### PR TITLE
bash: update to 5.2.37

### DIFF
--- a/app-shells/bash/autobuild/patches/0027-bash52-027.patch
+++ b/app-shells/bash/autobuild/patches/0027-bash52-027.patch
@@ -1,0 +1,63 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-027
+
+Bug-Reported-by:	Emanuel Haupt <ehaupt@FreeBSD.org>
+Bug-Reference-ID:	<20221001123841.27e1bfb3bf3ed58ab32ea2b5@FreeBSD.org>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2022-10/msg00000.html
+
+Bug-Description:
+
+The configure test for the presence of strtoimax(3) is inverted.
+
+Patch (apply with `patch -p0'):
+
+
+*** ../bash-5.2-patched/m4/strtoimax.m4	Mon Apr 11 16:31:52 2022
+--- m4/strtoimax.m4	Tue Apr  9 11:12:36 2024
+***************
+*** 30,34 ****
+  ])
+  AC_MSG_RESULT($bash_cv_func_strtoimax)
+! if test $bash_cv_func_strtoimax = yes; then
+  AC_LIBOBJ(strtoimax)
+  fi
+--- 30,34 ----
+  ])
+  AC_MSG_RESULT($bash_cv_func_strtoimax)
+! if test $bash_cv_func_strtoimax = no; then
+  AC_LIBOBJ(strtoimax)
+  fi
+*** ..//bash-5.2-patched/configure	Fri Sep 23 10:13:22 2022
+--- configure	Tue Apr  9 11:13:21 2024
+***************
+*** 20444,20448 ****
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $bash_cv_func_strtoimax" >&5
+  printf "%s\n" "$bash_cv_func_strtoimax" >&6; }
+! if test $bash_cv_func_strtoimax = yes; then
+  case " $LIBOBJS " in
+    *" strtoimax.$ac_objext "* ) ;;
+--- 20444,20448 ----
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $bash_cv_func_strtoimax" >&5
+  printf "%s\n" "$bash_cv_func_strtoimax" >&6; }
+! if test $bash_cv_func_strtoimax = no; then
+  case " $LIBOBJS " in
+    *" strtoimax.$ac_objext "* ) ;;
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 26
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 27
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0028-bash52-028.patch
+++ b/app-shells/bash/autobuild/patches/0028-bash52-028.patch
@@ -1,0 +1,49 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-028
+
+Bug-Reported-by:	Mark March <march@systempad.cloud>
+Bug-Reference-ID:	<834896722.6304071.1718744118467@mail.yahoo.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2024-06/msg00122.html
+
+Bug-Description:
+
+A DEBUG trap in an asynchronous process can steal the controlling terminal
+away from the calling shell, causing it to exit.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20240609/trap.c	Fri May  3 12:12:38 2024
+--- trap.c	Wed Jun 26 10:41:40 2024
+***************
+*** 1217,1221 ****
+        restore_pgrp_pipe (save_pipe);
+  #  endif
+!       if (pipeline_pgrp > 0 && ((subshell_environment & (SUBSHELL_ASYNC|SUBSHELL_PIPE)) == 0))
+  	give_terminal_to (pipeline_pgrp, 1);
+  
+--- 1217,1223 ----
+        restore_pgrp_pipe (save_pipe);
+  #  endif
+!       /* If the trap command gave the terminal to another process group,
+! 	 restore it. XXX - check running_in_background? */
+!       if (job_control && pipeline_pgrp > 0 && ((subshell_environment & (SUBSHELL_ASYNC|SUBSHELL_PIPE)) == 0))
+  	give_terminal_to (pipeline_pgrp, 1);
+  
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 27
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 28
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0029-bash52-029.patch
+++ b/app-shells/bash/autobuild/patches/0029-bash52-029.patch
@@ -1,0 +1,137 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-029
+
+Bug-Reported-by:	Grisha Levit <grishalevit@gmail.com>
+Bug-Reference-ID:	<CAMu=Brp9QHvLh8vbY45hRgCVaQUNSnU7n8EVjsWKajT7c99K8Q@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-04/msg00072.html
+
+Bug-Description:
+
+There are problems with recovery after parser errors when parsing compound
+assignments. For instance, the `local' builtin reports an error but never
+cleans up the function context.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20230427/parse.y	Fri Apr 14 11:50:29 2023
+--- parse.y	Mon May  1 16:25:14 2023
+***************
+*** 6471,6478 ****
+      {
+        set_exit_status (EXECUTION_FAILURE);
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	jump_to_top_level (DISCARD);
+      }
+  
+--- 6471,6483 ----
+      {
+        set_exit_status (EXECUTION_FAILURE);
++       current_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	{
+! 	  if (executing && parse_and_execute_level == 0)
+! 	    top_level_cleanup ();
+! 	  jump_to_top_level (DISCARD);
+! 	}
+      }
+  
+***************
+*** 6538,6546 ****
+      {
+        set_exit_status (EXECUTION_FAILURE);
+!       last_read_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	jump_to_top_level (DISCARD);
+      }
+  
+--- 6543,6555 ----
+      {
+        set_exit_status (EXECUTION_FAILURE);
+!       last_read_token = current_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	{
+! 	  if (executing && parse_and_execute_level == 0)
+! 	    top_level_cleanup ();
+! 	  jump_to_top_level (DISCARD);
+! 	}
+      }
+  
+
+*** ../bash-20230427/y.tab.c	Tue Jul 30 15:19:31 2024
+--- y.tab.c	Tue Jul 30 15:20:21 2024
+***************
+*** 8786,8793 ****
+      {
+        set_exit_status (EXECUTION_FAILURE);
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	jump_to_top_level (DISCARD);
+      }
+  
+--- 8786,8798 ----
+      {
+        set_exit_status (EXECUTION_FAILURE);
++       current_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	{
+! 	  if (executing && parse_and_execute_level == 0)
+! 	    top_level_cleanup ();
+! 	  jump_to_top_level (DISCARD);
+! 	}
+      }
+  
+***************
+*** 8853,8861 ****
+      {
+        set_exit_status (EXECUTION_FAILURE);
+!       last_read_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	jump_to_top_level (DISCARD);
+      }
+  
+--- 8858,8870 ----
+      {
+        set_exit_status (EXECUTION_FAILURE);
+!       last_read_token = current_token = '\n';	/* XXX */
+        if (interactive_shell == 0 && posixly_correct)
+  	jump_to_top_level (FORCE_EOF);
+        else
+! 	{
+! 	  if (executing && parse_and_execute_level == 0)
+! 	    top_level_cleanup ();
+! 	  jump_to_top_level (DISCARD);
+! 	}
+      }
+  
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 28
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 29
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0030-bash52-030.patch
+++ b/app-shells/bash/autobuild/patches/0030-bash52-030.patch
@@ -1,0 +1,130 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-030
+
+Bug-Reported-by:	Steven Pelley <stevenpelley@gmail.com>
+Bug-Reference-ID:	<CAGOYURh6CKaE-D0Z8puP-tQknavCQNRHo02vpvgMQqaTG3_cRw@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2024-01/msg00104.html
+
+Bug-Description:
+
+`wait -n' can fail to return some jobs if they exit due to signals the shell
+does not report to the user.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/jobs.c	Thu Nov  9 14:59:14 2023
+--- jobs.c	Tue Jul 30 15:27:44 2024
+***************
+*** 4275,4279 ****
+  		((DEADJOB (job) && IS_FOREGROUND (job) == 0) || STOPPED (job)))
+  	    continue;
+! 	  
+  	  /* If job control is disabled, don't print the status messages.
+  	     Mark dead jobs as notified so that they get cleaned up.  If
+--- 4288,4312 ----
+  		((DEADJOB (job) && IS_FOREGROUND (job) == 0) || STOPPED (job)))
+  	    continue;
+! 
+! 	  /* Do the same thing and don't print anything or mark as notified
+! 	     for the signals we're not going to report on. This is the opposite
+! 	     of the first two cases under case JDEAD below. */
+! 	  else if (interactive_shell == 0 && DEADJOB (job) && IS_FOREGROUND (job) == 0 &&
+! 		WIFSIGNALED (s) && (termsig == SIGINT
+! #if defined (DONT_REPORT_SIGTERM)
+! 		|| termsig == SIGTERM
+! #endif
+! #if defined (DONT_REPORT_SIGPIPE)
+! 		|| termsig == SIGPIPE
+! #endif
+! 		|| signal_is_trapped (termsig)))
+! 	    continue;
+! 
+! 	  /* hang onto the status if the shell is running -c command */
+! 	  else if (startup_state == 2 && subshell_environment == 0 &&
+! 		WIFSIGNALED (s) == 0 &&
+! 		((DEADJOB (job) && IS_FOREGROUND (job) == 0) || STOPPED (job)))
+! 	    continue;
+! 
+  	  /* If job control is disabled, don't print the status messages.
+  	     Mark dead jobs as notified so that they get cleaned up.  If
+***************
+*** 4298,4302 ****
+  	  /* Print info on jobs that are running in the background,
+  	     and on foreground jobs that were killed by anything
+! 	     except SIGINT (and possibly SIGPIPE). */
+  	  switch (JOBSTATE (job))
+  	    {
+--- 4331,4335 ----
+  	  /* Print info on jobs that are running in the background,
+  	     and on foreground jobs that were killed by anything
+! 	     except SIGINT (and possibly SIGTERM and SIGPIPE). */
+  	  switch (JOBSTATE (job))
+  	    {
+***************
+*** 4318,4321 ****
+--- 4351,4355 ----
+  	      else if (IS_FOREGROUND (job))
+  		{
++ 		  /* foreground jobs, interactive and non-interactive shells */
+  #if !defined (DONT_REPORT_SIGPIPE)
+  		  if (termsig && WIFSIGNALED (s) && termsig != SIGINT)
+***************
+*** 4331,4337 ****
+  		      fprintf (stderr, "\n");
+  		    }
+  		}
+! 	      else if (job_control)	/* XXX job control test added */
+  		{
+  		  if (dir == 0)
+  		    dir = current_working_directory ();
+--- 4365,4375 ----
+  		      fprintf (stderr, "\n");
+  		    }
++ 		  /* foreground jobs that exit cleanly */
++ 		  jobs[job]->flags |= J_NOTIFIED;
+  		}
+! 	      else if (job_control)
+  		{
++ 		  /* background jobs with job control, interactive and
++ 		     non-interactive shells */
+  		  if (dir == 0)
+  		    dir = current_working_directory ();
+***************
+*** 4342,4346 ****
+  		}
+  
+! 	      jobs[job]->flags |= J_NOTIFIED;
+  	      break;
+  
+--- 4380,4391 ----
+  		}
+  
+! 	      /* Interactive shells without job control enabled are handled
+! 		 above. */
+! 	      /* XXX - this is a catch-all in case we missed a state */
+! 	      else
+! {
+! internal_debug("notify_of_job_status: catch-all setting J_NOTIFIED on job %d (%d), startup state = %d", job, jobs[job]->flags, startup_state);
+! 		jobs[job]->flags |= J_NOTIFIED;
+! }
+  	      break;
+  
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 29
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 30
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0031-bash52-031.patch
+++ b/app-shells/bash/autobuild/patches/0031-bash52-031.patch
@@ -1,0 +1,46 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-031
+
+Bug-Reported-by:	Grisha Levit <grishalevit@gmail.com>
+Bug-Reference-ID:	<CAMu=BrrD52xxF7C9Ke1fosAurHq1kz82t7FcHsrPBw9CbAst6A@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-06/msg00045.html
+
+Bug-Description:
+
+There is a memory leak in the code that implements the optimized $(<file)
+expansion for some code paths.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/builtins/evalstring.c	Tue Dec 13 12:53:21 2022
+--- builtins/evalstring.c	Tue Nov 28 17:25:39 2023
+***************
+*** 763,766 ****
+--- 773,779 ----
+    if (fnp)
+      *fnp = fn;
++   else
++     free (fn);
++ 
+    return fd;
+  }
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 30
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 31
+  
+  #endif /* _PATCHLEVEL_H_ */
+

--- a/app-shells/bash/autobuild/patches/0032-bash52-032.patch
+++ b/app-shells/bash/autobuild/patches/0032-bash52-032.patch
@@ -1,0 +1,51 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-032
+
+Bug-Reported-by:	Albert Akchurin <ackbeat@gmail.com>
+Bug-Reference-ID:	Mon, 11 Dec 2023 20:41:58 +0600
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-12/msg00047.html
+
+Bug-Description:
+
+Patch (apply with `patch -p0'):
+
+When printing functions containing coprocesses, the displayed coproc command
+has the word COPROC inserted unconditionally, resulting in function bodies
+that cannot be re-read as input.
+
+*** ../bash-5.2-patched/print_cmd.c	Mon Aug 21 16:09:44 2023
+--- print_cmd.c	Mon Dec 11 15:34:30 2023
+***************
+*** 357,361 ****
+  
+  	case cm_coproc:
+! 	  cprintf ("coproc %s ", command->value.Coproc->name);
+  	  skip_this_indent++;
+  	  make_command_string_internal (command->value.Coproc->command);
+--- 357,363 ----
+  
+  	case cm_coproc:
+! 	  cprintf ("coproc ");
+! 	  if (command->value.Coproc->command->type != cm_simple)
+! 	    cprintf ("%s ", command->value.Coproc->name);
+  	  skip_this_indent++;
+  	  make_command_string_internal (command->value.Coproc->command);
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 31
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 32
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0033-bash52-033.patch
+++ b/app-shells/bash/autobuild/patches/0033-bash52-033.patch
@@ -1,0 +1,80 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-033
+
+Bug-Reported-by:	Florian Weimer <fweimer@redhat.com>
+Bug-Reference-ID:	<87leasmvoo.fsf@oldenburg.str.redhat.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-11/msg00104.html
+
+Bug-Description:
+
+A typo in the autoconf test for strtold causes false negatives for strtold
+being available and working when compiled with gcc-14.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/configure.ac	Fri Aug 11 14:52:31 2023
+--- configure.ac	Tue Nov 21 12:00:25 2023
+***************
+*** 899,903 ****
+  		[AC_LANG_PROGRAM(
+  		[[#include <stdlib.h>]],
+! 		[[long double r; char *foo, bar; r = strtold(foo, &bar);]]
+  	)],
+  	[bash_cv_strtold_broken=no],[bash_cv_strtold_broken=yes])
+--- 900,904 ----
+  		[AC_LANG_PROGRAM(
+  		[[#include <stdlib.h>]],
+! 		[[long double r; char *foo, *bar; r = strtold(foo, &bar);]]
+  	)],
+  	[bash_cv_strtold_broken=no],[bash_cv_strtold_broken=yes])
+
+*** ../bash-5.2-patched/configure	Fri Aug 18 16:27:53 2023
+--- configure	Tue Nov 21 12:00:30 2023
+***************
+*** 15923,15927 ****
+  main (void)
+  {
+! long double r; char *foo, bar; r = strtold(foo, &bar);
+  
+    ;
+--- 15932,15936 ----
+  main (void)
+  {
+! long double r; char *foo, *bar; r = strtold(foo, &bar);
+  
+    ;
+
+*** ../bash-5.2-patched/builtins/printf.def	Fri Jun 24 10:09:50 2022
+--- builtins/printf.def	Tue Aug 13 10:36:55 2024
+***************
+*** 710,714 ****
+  
+  		    p = getfloatmax ();
+! 		    f = mklong (start, "L", 1);
+  		    PF (f, p);
+  		  }
+--- 710,714 ----
+  
+  		    p = getfloatmax ();
+! 		    f = mklong (start, FLOATMAX_CONV, USE_LONG_DOUBLE);
+  		    PF (f, p);
+  		  }
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 32
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 33
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0034-bash52-034.patch
+++ b/app-shells/bash/autobuild/patches/0034-bash52-034.patch
@@ -1,0 +1,143 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-034
+
+Bug-Reported-by:	Wiley Young <wyeth2485@gmail.com>
+Bug-Reference-ID:	<CAGnujaPrPV9hgbvdtG=fOs+L1zVGEahT9d3Aw0e1y3Qj8D8stw@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00146.html
+
+Bug-Description:
+
+If we parse a compound assignment during an alias expansion, it's possible
+to have the current input string popped out from underneath the parse. In
+this case, we should not restore the input we were using when we began to
+parse the compound assignment.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/parse.y	Fri May 26 16:57:03 2023
+--- parse.y	Thu Jun  1 16:30:19 2023
+***************
+*** 6854,6860 ****
+  {
+    WORD_LIST *wl, *rl;
+!   int tok, orig_line_number, assignok;
+    sh_parser_state_t ps;
+    char *ret;
+  
+    orig_line_number = line_number;
+--- 6858,6865 ----
+  {
+    WORD_LIST *wl, *rl;
+!   int tok, orig_line_number, assignok, ea, restore_pushed_strings;
+    sh_parser_state_t ps;
+    char *ret;
++   STRING_SAVER *ss;
+  
+    orig_line_number = line_number;
+***************
+*** 6879,6882 ****
+--- 6884,6893 ----
+    esacs_needed_count = expecting_in_token = 0;
+  
++   /* We're not pushing any new input here, we're reading from the current input
++      source. If that's an alias, we have to be prepared for the alias to get
++      popped out from underneath us. */
++   ss = (ea = expanding_alias ()) ? pushed_string_list : (STRING_SAVER *)NULL;
++   restore_pushed_strings = 0;
++     
+    while ((tok = read_token (READ)) != ')')
+      {
+***************
+*** 6902,6906 ****
+--- 6913,6926 ----
+      }
+  
++   /* Check whether or not an alias got popped out from underneath us and
++      fix up after restore_parser_state. */
++   if (ea && ss && ss != pushed_string_list)
++     {
++       restore_pushed_strings = 1;
++       ss = pushed_string_list;
++     }
+    restore_parser_state (&ps);
++   if (restore_pushed_strings)
++     pushed_string_list = ss;
+  
+    if (wl == &parse_string_error)
+*** ../bash-5.2-patched/y.tab.c	Mon Sep 23 10:02:46 2024
+--- y.tab.c	Mon Sep 23 10:02:49 2024
+***************
+*** 8804,8812 ****
+       int *retlenp;
+  {
+    WORD_LIST *wl, *rl;
+!   int tok, orig_line_number, assignok;
+    sh_parser_state_t ps;
+    char *ret;
+  
+    orig_line_number = line_number;
+    save_parser_state (&ps);
+--- 8804,8813 ----
+       int *retlenp;
+  {
+    WORD_LIST *wl, *rl;
+!   int tok, orig_line_number, assignok, ea, restore_pushed_strings;
+    sh_parser_state_t ps;
+    char *ret;
++   STRING_SAVER *ss;
+  
+    orig_line_number = line_number;
+    save_parser_state (&ps);
+***************
+*** 8829,8834 ****
+--- 8830,8841 ----
+  
+    esacs_needed_count = expecting_in_token = 0;
+  
++   /* We're not pushing any new input here, we're reading from the current input
++      source. If that's an alias, we have to be prepared for the alias to get
++      popped out from underneath us. */
++   ss = (ea = expanding_alias ()) ? pushed_string_list : (STRING_SAVER *)NULL;
++   restore_pushed_strings = 0;
++     
+    while ((tok = read_token (READ)) != ')')
+      {
+        if (tok == '\n')			/* Allow newlines in compound assignments */
+***************
+*** 8852,8858 ****
+--- 8859,8874 ----
+        wl = make_word_list (yylval.word, wl);
+      }
+  
++   /* Check whether or not an alias got popped out from underneath us and
++      fix up after restore_parser_state. */
++   if (ea && ss && ss != pushed_string_list)
++     {
++       restore_pushed_strings = 1;
++       ss = pushed_string_list;
++     }
+    restore_parser_state (&ps);
++   if (restore_pushed_strings)
++     pushed_string_list = ss;
+  
+    if (wl == &parse_string_error)
+      {
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 33
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 34
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0035-bash52-035.patch
+++ b/app-shells/bash/autobuild/patches/0035-bash52-035.patch
@@ -1,0 +1,129 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-035
+
+Bug-Reported-by:	Henry Bent <henry.r.bent@gmail.com>
+Bug-Reference-ID:	<CAEdTPBdD0WOW2n0-y-XyZ_VwhbiG-oS3bXfGkOPPG617rGH-Ww@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2022-11/msg00044.html
+
+Bug-Description:
+
+There are systems that supply one of select or pselect, but not both.
+
+Patch (apply with `patch -p0'):
+
+https://lists.gnu.org/archive/html/bug-bash/2022-11/msg00058.html
+
+*** ../bash/bash-5.2-patched/lib/readline/input.c	2022-04-08 15:43:24.000000000 -0400
+--- lib/readline/input.c	2022-11-16 09:10:41.000000000 -0500
+***************
+*** 152,156 ****
+--- 152,158 ----
+  int _rl_timeout_init (void);
+  int _rl_timeout_sigalrm_handler (void);
++ #if defined (RL_TIMEOUT_USE_SELECT)
+  int _rl_timeout_select (int, fd_set *, fd_set *, fd_set *, const struct timeval *, const sigset_t *);
++ #endif
+  
+  static void _rl_timeout_handle (void);
+***************
+*** 249,253 ****
+    int chars_avail, k;
+    char input;
+! #if defined(HAVE_SELECT)
+    fd_set readfds, exceptfds;
+    struct timeval timeout;
+--- 251,255 ----
+    int chars_avail, k;
+    char input;
+! #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
+    fd_set readfds, exceptfds;
+    struct timeval timeout;
+***************
+*** 806,810 ****
+    unsigned char c;
+    int fd;
+! #if defined (HAVE_PSELECT)
+    sigset_t empty_set;
+    fd_set readfds;
+--- 808,812 ----
+    unsigned char c;
+    int fd;
+! #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
+    sigset_t empty_set;
+    fd_set readfds;
+*** ../bash-5.2-patched/lib/sh/input_avail.c	2021-05-24 11:16:33.000000000 -0400
+--- lib/sh/input_avail.c	2022-11-16 09:12:48.000000000 -0500
+***************
+*** 34,40 ****
+  #endif /* HAVE_SYS_FILE_H */
+  
+! #if defined (HAVE_PSELECT)
+! #  include <signal.h>
+! #endif
+  
+  #if defined (HAVE_UNISTD_H)
+--- 34,38 ----
+  #endif /* HAVE_SYS_FILE_H */
+  
+! #include <signal.h>
+  
+  #if defined (HAVE_UNISTD_H)
+***************
+*** 108,115 ****
+  {
+    int result, chars_avail;
+- #if defined(HAVE_SELECT)
+-   fd_set readfds, exceptfds;
+- #endif
+  #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
+    sigset_t set, oset;
+  #endif
+--- 106,111 ----
+  {
+    int result, chars_avail;
+  #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
++   fd_set readfds, exceptfds;
+    sigset_t set, oset;
+  #endif
+***************
+*** 122,132 ****
+    chars_avail = 0;
+  
+! #if defined (HAVE_SELECT)
+    FD_ZERO (&readfds);
+    FD_ZERO (&exceptfds);
+    FD_SET (fd, &readfds);
+    FD_SET (fd, &exceptfds);
+- #endif
+- #if defined (HAVE_SELECT) || defined (HAVE_PSELECT)
+    sigprocmask (SIG_BLOCK, (sigset_t *)NULL, &set);
+  #  ifdef SIGCHLD
+--- 115,123 ----
+    chars_avail = 0;
+  
+! #if defined (HAVE_PSELECT) || defined (HAVE_SELECT)
+    FD_ZERO (&readfds);
+    FD_ZERO (&exceptfds);
+    FD_SET (fd, &readfds);
+    FD_SET (fd, &exceptfds);
+    sigprocmask (SIG_BLOCK, (sigset_t *)NULL, &set);
+  #  ifdef SIGCHLD
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 34
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 35
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0036-bash52-036.patch
+++ b/app-shells/bash/autobuild/patches/0036-bash52-036.patch
@@ -1,0 +1,237 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-036
+
+Bug-Reported-by:        Grisha Levit <grishalevit@gmail.com>
+Bug-Reference-ID:       <CAMu=Brrv5qKY6LPfw8PxqNXNO8rNsZo0Fb=BcFb-uHObWPqnrw@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2023-04/msg00082.html
+
+Bug-Description:
+
+When readline is accumulating bytes until it reads a complete multibyte
+character, reading a byte that makes the multibyte character invalid can
+result in discarding the bytes in the partial character.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/lib/readline/text.c	Mon May  1 09:37:52 2023
+--- lib/readline/text.c	Mon May 29 12:22:29 2023
+***************
+*** 86,90 ****
+  rl_insert_text (const char *string)
+  {
+!   register int i, l;
+  
+    l = (string && *string) ? strlen (string) : 0;
+--- 86,91 ----
+  rl_insert_text (const char *string)
+  {
+!   register int i;
+!   size_t l;
+  
+    l = (string && *string) ? strlen (string) : 0;
+***************
+*** 705,709 ****
+  /* Insert the character C at the current location, moving point forward.
+     If C introduces a multibyte sequence, we read the whole sequence and
+!    then insert the multibyte char into the line buffer. */
+  int
+  _rl_insert_char (int count, int c)
+--- 706,714 ----
+  /* Insert the character C at the current location, moving point forward.
+     If C introduces a multibyte sequence, we read the whole sequence and
+!    then insert the multibyte char into the line buffer.
+!    If C == 0, we immediately insert any pending partial multibyte character,
+!    assuming that we have read a character that doesn't map to self-insert.
+!    This doesn't completely handle characters that are part of a multibyte
+!    character but map to editing functions. */
+  int
+  _rl_insert_char (int count, int c)
+***************
+*** 719,727 ****
+  #endif
+  
+    if (count <= 0)
+      return 0;
+  
+! #if defined (HANDLE_MULTIBYTE)
+!   if (MB_CUR_MAX == 1 || rl_byte_oriented)
+      {
+        incoming[0] = c;
+--- 724,749 ----
+  #endif
+  
++ #if !defined (HANDLE_MULTIBYTE)
+    if (count <= 0)
+      return 0;
++ #else
++   if (count < 0)
++     return 0;
++   if (count == 0)
++     {
++       if (pending_bytes_length == 0)
++ 	return 0;
++       if (stored_count <= 0)
++ 	stored_count = count;
++       else
++ 	count = stored_count;
+  
+!       memcpy (incoming, pending_bytes, pending_bytes_length);
+!       incoming[pending_bytes_length] = '\0';
+!       incoming_length = pending_bytes_length;
+!       pending_bytes_length = 0;
+!       memset (&ps, 0, sizeof (mbstate_t));
+!     }
+!   else if (MB_CUR_MAX == 1 || rl_byte_oriented)
+      {
+        incoming[0] = c;
+***************
+*** 731,734 ****
+--- 753,759 ----
+    else if (_rl_utf8locale && (c & 0x80) == 0)
+      {
++       if (pending_bytes_length)
++ 	_rl_insert_char (0, 0);
++ 
+        incoming[0] = c;
+        incoming[1] = '\0';
+***************
+*** 765,769 ****
+  	  incoming_length = 1;
+  	  pending_bytes_length--;
+! 	  memmove (pending_bytes, pending_bytes + 1, pending_bytes_length);
+  	  /* Clear the state of the byte sequence, because in this case the
+  	     effect of mbstate is undefined. */
+--- 790,795 ----
+  	  incoming_length = 1;
+  	  pending_bytes_length--;
+! 	  if (pending_bytes_length)
+! 	    memmove (pending_bytes, pending_bytes + 1, pending_bytes_length);
+  	  /* Clear the state of the byte sequence, because in this case the
+  	     effect of mbstate is undefined. */
+***************
+*** 828,832 ****
+--- 854,862 ----
+        xfree (string);
+  
++ #if defined (HANDLE_MULTIBYTE)
++       return (pending_bytes_length != 0);
++ #else
+        return 0;
++ #endif
+      }
+  
+***************
+*** 861,864 ****
+--- 891,896 ----
+        incoming_length = 0;
+        stored_count = 0;
++ 
++       return (pending_bytes_length != 0);
+  #else /* !HANDLE_MULTIBYTE */
+        char str[TEXT_COUNT_MAX+1];
+***************
+*** 874,880 ****
+  	  count -= decreaser;
+  	}
+- #endif /* !HANDLE_MULTIBYTE */
+  
+        return 0;
+      }
+  
+--- 906,912 ----
+  	  count -= decreaser;
+  	}
+  
+        return 0;
++ #endif /* !HANDLE_MULTIBYTE */
+      }
+  
+***************
+*** 904,910 ****
+        stored_count = 0;
+      }
+! #endif
+! 
+    return 0;
+  }
+  
+--- 936,944 ----
+        stored_count = 0;
+      }
+!   
+!   return (pending_bytes_length != 0);
+! #else
+    return 0;
++ #endif
+  }
+  
+***************
+*** 984,987 ****
+--- 1018,1026 ----
+      }
+  
++   /* If we didn't insert n and there are pending bytes, we need to insert
++      them if _rl_insert_char didn't do that on its own. */
++   if (r == 1 && rl_insert_mode == RL_IM_INSERT)
++     r = _rl_insert_char (0, 0);		/* flush partial multibyte char */
++ 
+    if (n != (unsigned short)-2)		/* -2 = sentinel value for having inserted N */
+      {
+***************
+*** 1055,1058 ****
+--- 1094,1099 ----
+  rl_quoted_insert (int count, int key)
+  {
++   int r;
++ 
+    /* Let's see...should the callback interface futz with signal handling? */
+  #if defined (HANDLE_SIGNALS)
+***************
+*** 1073,1085 ****
+    if (count < 0)
+      {
+-       int r;
+- 
+        do
+  	r = _rl_insert_next (1);
+        while (r == 0 && ++count < 0);
+-       return r;
+      }
+  
+!   return _rl_insert_next (count);
+  }
+  
+--- 1114,1128 ----
+    if (count < 0)
+      {
+        do
+  	r = _rl_insert_next (1);
+        while (r == 0 && ++count < 0);
+      }
++   else
++     r = _rl_insert_next (count);
+  
+!   if (r == 1)
+!     _rl_insert_char (0, 0);	/* insert partial multibyte character */
+! 
+!   return r;
+  }
+  
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 35
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 36
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/autobuild/patches/0037-bash52-037.patch
+++ b/app-shells/bash/autobuild/patches/0037-bash52-037.patch
@@ -1,0 +1,71 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-037
+
+Bug-Reported-by:        Martin Castillo <castilma@uni-bremen.de>
+Bug-Reference-ID:       <2d42153b-cf65-caba-dff1-cd3bc6268c7e@uni-bremen.de>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-readline/2023-01/msg00000.html
+
+Bug-Description:
+
+Fix the case where text to be completed from the line buffer (quoted) is
+compared to the common prefix of the possible matches (unquoted) and the
+quoting makes the former appear to be longer than the latter. Readline
+assumes the match doesn't add any characters to the word and doesn't display
+multiple matches.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/lib/readline/complete.c	Tue Apr  5 10:47:06 2022
+--- lib/readline/complete.c	Sat Jan  7 14:19:45 2023
+***************
+*** 2032,2038 ****
+    text = rl_copy_text (start, end);
+    matches = gen_completion_matches (text, start, end, our_func, found_quote, quote_char);
+    /* nontrivial_lcd is set if the common prefix adds something to the word
+       being completed. */
+!   nontrivial_lcd = matches && compare_match (text, matches[0]) != 0;
+    if (what_to_do == '!' || what_to_do == '@')
+      tlen = strlen (text);
+--- 2038,2060 ----
+    text = rl_copy_text (start, end);
+    matches = gen_completion_matches (text, start, end, our_func, found_quote, quote_char);
++   /* If TEXT contains quote characters, it will be dequoted as part of
++      generating the matches, and the matches will not contain any quote
++      characters. We need to dequote TEXT before performing the comparison.
++      Since compare_match performs the dequoting, and we only want to do it
++      once, we don't call compare_matches after dequoting TEXT; we call
++      strcmp directly. */
+    /* nontrivial_lcd is set if the common prefix adds something to the word
+       being completed. */
+!   if (rl_filename_completion_desired && rl_filename_quoting_desired &&
+!       rl_completion_found_quote && rl_filename_dequoting_function)
+!     {
+!       char *t;
+!       t = (*rl_filename_dequoting_function) (text, rl_completion_quote_character);
+!       xfree (text);
+!       text = t;
+!       nontrivial_lcd = matches && strcmp (text, matches[0]) != 0;
+!     }
+!   else
+!     nontrivial_lcd = matches && strcmp (text, matches[0]) != 0;
+    if (what_to_do == '!' || what_to_do == '@')
+      tlen = strlen (text);
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 36
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 37
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/app-shells/bash/spec
+++ b/app-shells/bash/spec
@@ -1,5 +1,4 @@
-VER=5.2.26
+VER=5.2.37
 SRCS="https://ftp.gnu.org/gnu/bash/bash-${VER%.*}.tar.gz"
 CHKSUMS="sha256::a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb"
 CHKUPDATE="anitya::id=166"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- bash: update to 5.2.37
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- bash: 5.2.37

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
