### PR TITLE
bind: update to 9.20.2

### DIFF
--- a/app-network/bind/spec
+++ b/app-network/bind/spec
@@ -1,5 +1,4 @@
-VER=9.20.0
-REL=1
+VER=9.20.2
 SRCS="tbl::https://downloads.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUMS="sha256::cc580998017b51f273964058e8cb3aa5482bc785243dea71e5556ec565a13347"
+CHKSUMS="sha256::a31dba2aaa1b371902dd0474eb3963f47b7ffed2bd9ece7da4834e23210d6067"
 CHKUPDATE="anitya::id=14923"


### PR DESCRIPTION
Topic Description
-----------------

- bind: update to 9.20.2
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- bind: 1:9.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
