### PR TITLE
mediainfo: update to 24.06

### DIFF
--- a/app-multimedia/mediainfo/spec
+++ b/app-multimedia/mediainfo/spec
@@ -1,5 +1,5 @@
-VER=22.06
+VER=24.06
 SRCS="https://mediaarea.net/download/source/mediainfo/$VER/mediainfo_$VER.tar.xz"
-CHKSUMS="sha256::986a300bcc273498a3e5da4e9701d7de6eee199ed36d42273dd3fe9ec7ac8b7d"
+CHKSUMS="sha256::32f4a82a31e386e177fdf6e4c237053e475b501089269ab2c729452a09313520"
 CHKUPDATE="anitya::id=8240"
 SUBDIR="MediaInfo/Project/GNU/CLI"


### PR DESCRIPTION
Topic Description
-----------------

- mediainfo: update to 24.06
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- mediainfo: 24.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit mediainfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
