### PR TITLE
yt-dlp: update to 2024.10.07

### DIFF
--- a/app-multimedia/yt-dlp/spec
+++ b/app-multimedia/yt-dlp/spec
@@ -1,4 +1,4 @@
-VER=2024.09.27
+VER=2024.10.07
 SRCS="git::commit=tags/$VER::https://github.com/yt-dlp/yt-dlp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143399"


### PR DESCRIPTION
Topic Description
-----------------

- yt-dlp: update to 2024.10.07
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- yt-dlp: 2024.10.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit yt-dlp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
