### PR TITLE
pygments: update to 2.18.0

### DIFF
--- a/lang-python/pygments/autobuild/defines
+++ b/lang-python/pygments/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=pygments
 PKGSEC=python
-PKGDEP="setuptools"
+PKGDEP="python-3"
+BUILDDEP="setuptools hatchling"
 PKGDES="Python syntax highlighter"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pygments/spec
+++ b/lang-python/pygments/spec
@@ -1,5 +1,4 @@
-VER=2.10.0
-REL=1
-SRCS="tbl::https://files.pythonhosted.org/packages/source/P/Pygments/Pygments-$VER.tar.gz"
-CHKSUMS="sha256::f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
+VER=2.18.0
+SRCS="tbl::https://pypi.python.org/packages/source/p/pygments/pygments-$VER.tar.gz"
+CHKSUMS="sha256::786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"
 CHKUPDATE="anitya::id=3986"


### PR DESCRIPTION
Topic Description
-----------------

- pygments: update to 2.18.0

Package(s) Affected
-------------------

- pygments: 2.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pygments
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
