### PR TITLE
 fcitx5-pinyin-moegirl: update to 20241009

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20240909
+VER=20241009
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::f9ee1acc45876128771b2f576be63c13b7fbac003c6255a56ef6ef6bd90d5c22 \
-         sha256::19e9bd5be47e8d621900ec88755090464c62c50063436413f1c24c1e4b72f477 \
+CHKSUMS="sha256::b5bf99ee36bac86ee7e837314af74584cab6c5336cea627aa5d3df10a791530c \
+         sha256::1bde8120ba2b3162fa417b790d89f2299885fbd547acc542a8de2ba85250dbfa \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20241009

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20241009
- rime-pinyin-moegirl: 20241009

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
