### PR TITLE
aoscbootstrap: update to 0.7.4

### DIFF
--- a/app-utils/aoscbootstrap/spec
+++ b/app-utils/aoscbootstrap/spec
@@ -1,4 +1,4 @@
-VER=0.7.3
+VER=0.7.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

- aoscbootstrap: update to 0.7.4
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- aoscbootstrap: 0.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
