### PR TITLE
open-vm-tools: update to 12.5.0

### DIFF
--- a/app-virtualization/open-vm-tools/spec
+++ b/app-virtualization/open-vm-tools/spec
@@ -1,6 +1,6 @@
-VER=12.4.5
-BUILDNBR=23787635
+VER=12.5.0
+BUILDNBR=24276846
 SRCS="tbl::https://github.com/vmware/open-vm-tools/releases/download/stable-${VER}/open-vm-tools-${VER}-${BUILDNBR}.tar.gz"
-CHKSUMS="sha256::506e5677add62c938cdc6c340f1494de94f1988b9b6511f7b19f74344fcec9d9"
+CHKSUMS="sha256::7eefd632f10ed4afc48559bcae31a598501377e72dec4b9965cee53e8c4f47ce"
 SUDDIR="open-vm-tools-${VER}-${BUILDNBR}"
 CHKUPDATE="anitya::id=10998"


### PR DESCRIPTION
Topic Description
-----------------

- open-vm-tools: update to 12.5.0

Package(s) Affected
-------------------

- open-vm-tools: 12.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit open-vm-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
