### PR TITLE
lighttpd: move mariadb from Depends to Suggests

### DIFF
--- a/app-network/lighttpd/autobuild/defines
+++ b/app-network/lighttpd/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lighttpd
 PKGSEC=net
-PKGDEP="libxml2 lua mariadb openldap pcre2 sqlite systemd util-linux"
+PKGDEP="libxml2 lua openldap pcre2 sqlite systemd util-linux"
 PKGDEP__RETRO="libxml2 lua pcre2 sqlite systemd util-linux"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -10,6 +10,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
+PKGSUG="mariadb"
 PKGDES="A secure, fast, compliant and very flexible web server"
 
 AUTOTOOLS_STRICT=0

--- a/app-network/lighttpd/spec
+++ b/app-network/lighttpd/spec
@@ -1,5 +1,5 @@
 VER=1.4.76
+REL=2
 SRCS="tbl::https://download.lighttpd.net/lighttpd/releases-${VER%.*}.x/lighttpd-$VER.tar.xz"
 CHKSUMS="sha256::8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011"
 CHKUPDATE="anitya::id=1817"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- lighttpd: move mariadb from Depends to Suggests

Package(s) Affected
-------------------

- lighttpd: 1.4.76-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lighttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
