### PR TITLE
nettle: update to 3.10

### DIFF
--- a/runtime-cryptography/nettle/spec
+++ b/runtime-cryptography/nettle/spec
@@ -1,4 +1,4 @@
-VER=3.7.2
+VER=3.10
 SRCS="tbl::https://ftp.gnu.org/gnu/nettle/nettle-$VER.tar.gz"
-CHKSUMS="sha256::8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162"
+CHKSUMS="sha256::b4c518adb174e484cb4acea54118f02380c7133771e7e9beb98a0787194ee47c"
 CHKUPDATE="anitya::id=2073"


### PR DESCRIPTION
Topic Description
-----------------

- nettle: update to 3.10
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- nettle: 3.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit nettle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
