### PR TITLE
vscode: update to 1.94.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.94.1
+VER=1.94.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::0c867923b3de247a0b1b0cf3b1a756db5ccb462095dc1fa40f5c579a6b43898e"
-CHKSUMS__ARM64="sha256::14375bf922cdba34a1e3fa9fc271c5c46b4e067d77db5150b6ce49fe4450d238"
+CHKSUMS__AMD64="sha256::dd67b44062197e067a8b241240e70b4be42ffa9a27eee147541f70d8cd8710b6"
+CHKSUMS__ARM64="sha256::6c9f727e617a902140577006cbad0c177b6af3274adb790a5310bdc536762045"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.94.2
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.94.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
