### PR TITLE
inetutils: update to 2.5

### DIFF
--- a/app-utils/inetutils/autobuild/patches/0001-build-Disable-GFDL-info-files-and-useless-man-pages.patch
+++ b/app-utils/inetutils/autobuild/patches/0001-build-Disable-GFDL-info-files-and-useless-man-pages.patch
@@ -1,4 +1,4 @@
-From e9c9f36b09a62d14dbf574ee854e8f8de4ab92db Mon Sep 17 00:00:00 2001
+From 656fc126ec68a9e9d32dd7edb728a8f831e89dd4 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 9 Jun 2010 03:56:08 +0200
 Subject: [PATCH 1/4] build: Disable GFDL info files and useless man pages
@@ -13,12 +13,12 @@ Instead we ship our own proper man pages.
 
 Not forwarded upstream due to GNU policies regarding man pages.
 ---
- Makefile.am    | 1 -
- configure.ac   | 3 ---
+ Makefile.am  | 1 -
+ configure.ac | 3 ---
  2 files changed, 4 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 055e2c5e..0119255c 100644
+index 5db056b9..a5b5d28f 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -23,7 +23,6 @@ EXTRA_DIST = paths ChangeLog.0 ChangeLog.1 summary.sh.in CHECKLIST
@@ -30,7 +30,7 @@ index 055e2c5e..0119255c 100644
  
  DISTCLEANFILES = pathdefs.make paths.defs
 diff --git a/configure.ac b/configure.ac
-index 56520853..d20bcdb2 100644
+index bbbb1986..a70d5c2f 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -141,7 +141,6 @@ AC_PROG_RANLIB
@@ -51,5 +51,5 @@ index 56520853..d20bcdb2 100644
  confpaths.h:confpaths.h.in
  ])
 -- 
-2.37.2
+2.47.0
 

--- a/app-utils/inetutils/autobuild/patches/0002-build-Use-runstatedir-for-run-directory.patch
+++ b/app-utils/inetutils/autobuild/patches/0002-build-Use-runstatedir-for-run-directory.patch
@@ -1,4 +1,4 @@
-From e75e151fa4ed7905fe43a86c4b4773046a9d2183 Mon Sep 17 00:00:00 2001
+From 4c984652e5cb7c23b42aedafa3528aa1573447ba Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Sun, 5 Sep 2021 05:00:23 +0200
 Subject: [PATCH 2/4] build: Use runstatedir for /run directory
@@ -8,7 +8,7 @@ Subject: [PATCH 2/4] build: Use runstatedir for /run directory
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/paths b/paths
-index 12efee42..0070432b 100644
+index 6cdd79d1..84d4c1a2 100644
 --- a/paths
 +++ b/paths
 @@ -77,12 +77,12 @@ PATH_FTPLOGINMESG /etc/motd
@@ -38,5 +38,5 @@ index 12efee42..0070432b 100644
  PATH_RLOGIN	x $(bindir)/rlogin
  PATH_RSH	x $(bindir)/rsh
 -- 
-2.37.2
+2.47.0
 

--- a/app-utils/inetutils/autobuild/patches/0003-inetd-Change-protocol-semantics-in-inetd.conf.patch
+++ b/app-utils/inetutils/autobuild/patches/0003-inetd-Change-protocol-semantics-in-inetd.conf.patch
@@ -1,4 +1,4 @@
-From 9d091c7fbdb510ec8ef567a521e208688e237885 Mon Sep 17 00:00:00 2001
+From eb8580d06cb41780f0c1345a2d2813b2de80e5ba Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Mon, 6 Sep 2010 10:52:27 +0200
 Subject: [PATCH 3/4] inetd: Change protocol semantics in inetd.conf
@@ -11,30 +11,21 @@ and "udp". Change "tcp6" and "udp6" to support IPv4 mapped addresses.
 
 Fixes: commit a12021ee959a88b48cd16e947c671f8f59e29c9d
 ---
- src/inetd.c | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+ src/inetd.c | 1 -
+ 1 file changed, 1 deletion(-)
 
 diff --git a/src/inetd.c b/src/inetd.c
-index 9d0d62f8..2f5dbb3f 100644
+index eed7cc76..2c5448ae 100644
 --- a/src/inetd.c
 +++ b/src/inetd.c
-@@ -1107,7 +1107,7 @@ getconfigent (FILE *fconfig, const char *file, size_t *line)
-       sep->se_proto = newstr (argv[INETD_PROTOCOL]);
- 
- #ifdef IPV6
--      /* We default to IPv4. */
-+      /* We default to IPv4.  */
-       sep->se_family = AF_INET;
-       sep->se_v4mapped = 1;
- 
-@@ -1117,7 +1117,6 @@ getconfigent (FILE *fconfig, const char *file, size_t *line)
+@@ -1112,7 +1112,6 @@ getconfigent (FILE *fconfig, const char *file, size_t *line)
  	  if (sep->se_proto[3] == '6')
  	    {
  	      sep->se_family = AF_INET6;
 -	      sep->se_v4mapped = 0;
  	      /* Check for tcp6only and udp6only.  */
  	      if (strcmp (&sep->se_proto[3], "6only") == 0)
- 	        sep->se_v4mapped = 0;
+ 		sep->se_v4mapped = 0;
 -- 
-2.37.2
+2.47.0
 

--- a/app-utils/inetutils/autobuild/patches/0004-Use-krb5_auth_con_getsendsubkey-instead-of-krb5_auth.patch
+++ b/app-utils/inetutils/autobuild/patches/0004-Use-krb5_auth_con_getsendsubkey-instead-of-krb5_auth.patch
@@ -1,4 +1,4 @@
-From dd9528410865ed43112a8cbca50e83fa84397427 Mon Sep 17 00:00:00 2001
+From fe968a508e2b300e79f195648b1db627004c3bce Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 10 Aug 2022 01:57:24 +0200
 Subject: [PATCH 4/4] Use krb5_auth_con_getsendsubkey() instead of
@@ -10,10 +10,10 @@ The latter is not exposed in the headers anymore.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libinetutils/kerberos5.c b/libinetutils/kerberos5.c
-index 37764847..cedb943a 100644
+index 5df12e77..f77bc412 100644
 --- a/libinetutils/kerberos5.c
 +++ b/libinetutils/kerberos5.c
-@@ -156,7 +156,7 @@ kerberos_auth (krb5_context *ctx, int verbose, char **cname,
+@@ -154,7 +154,7 @@ kerberos_auth (krb5_context *ctx, int verbose, char **cname,
    krb5_data_free (&cksum_data);
  # endif
  
@@ -23,5 +23,5 @@ index 37764847..cedb943a 100644
    /* send size of AP-REQ to the server */
  
 -- 
-2.37.2
+2.47.0
 

--- a/app-utils/inetutils/spec
+++ b/app-utils/inetutils/spec
@@ -1,4 +1,4 @@
-VER=2.4
+VER=2.5
 SRCS="tbl::https://ftp.gnu.org/gnu/inetutils/inetutils-$VER.tar.gz"
-CHKSUMS="sha256::76aee0c2f0954728600d510955d697a4ec29324318e784848db606ee3c09e365"
+CHKSUMS="sha256::fa043bbbc426eae1869070d2b6e29a98069615ac00681cdb92e20911d9292260"
 CHKUPDATE="anitya::id=13805"


### PR DESCRIPTION
Topic Description
-----------------

- inetutils: update to 2.5
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- inetutils: 2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit inetutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
