### PR TITLE
linyaps: add linyaps-web-store-installer

### DIFF
--- a/app-admin/linglong/autobuild/defines
+++ b/app-admin/linglong/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=linglong
 PKGSEC=admin
-PKGDEP="linyaps"
-PKGDES="Transitional package for linglong"
+PKGDEP="linyaps linyaps-web-store-installer"
+PKGDES="Meta package for Linyaps (Linglong) support"
 
 ABHOST=noarch
 ABTYPE=dummy

--- a/app-admin/linglong/spec
+++ b/app-admin/linglong/spec
@@ -1,2 +1,2 @@
-VER=0
+VER=1
 DUMMYSRC=1

--- a/app-admin/linyaps-web-store-installer/autobuild/defines
+++ b/app-admin/linyaps-web-store-installer/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=linyaps-web-store-installer
+PKGSEC=admin
+PKGDEP="qt-5"
+PKGDES="Package installer for Linyaps (Linglong) Web store"

--- a/app-admin/linyaps-web-store-installer/spec
+++ b/app-admin/linyaps-web-store-installer/spec
@@ -1,0 +1,5 @@
+VER=1.6.3
+# FIXME: A new tag needs to be made to reflect ll-installer sync.
+SRCS="git::commit=tags/v$VER::https://github.com/OpenAtom-Linyaps/linyaps-web-store-installer"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=374940"


### PR DESCRIPTION
Topic Description
-----------------

- linglong: add dependency to linyaps-web-store-installer
- linyaps-web-store-installer: new, 1.6.3

Package(s) Affected
-------------------

- linglong: 1:1
- linyaps-web-store-installer: 1.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps-web-store-installer linglong
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
