### PR TITLE
kose-font: update to 3.113

### DIFF
--- a/desktop-fonts/kose-font/01-kose-font/build
+++ b/desktop-fonts/kose-font/01-kose-font/build
@@ -1,7 +1,7 @@
 abinfo "Installing kose-font..."
-install -dvm755 "$PKGDIR"/usr/share/fonts/TTF
-install -vm644 "$SRCDIR"/"TTF (Japanese)"/*.ttf "$PKGDIR"/usr/share/fonts/TTF
+install -Dvm644 "$SRCDIR"/"TTF (Japanese)"/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF/
 
 abinfo "Installing LICENSE..."
-install -dvm755 "$PKGDIR"/usr/share/doc/kose-font 
-install -vm644 "$SRCDIR"/SIL_Open_Font_License_1.1.txt "$PKGDIR"/usr/share/doc/kose-font
+install -Dvm644 "$SRCDIR"/License.txt \
+    "$PKGDIR"/usr/share/doc/kose-font/SIL_Open_Font_License_1.1.txt

--- a/desktop-fonts/kose-font/01-kose-font/defines
+++ b/desktop-fonts/kose-font/01-kose-font/defines
@@ -1,5 +1,5 @@
 PKGNAME="kose-font"
-PKGDES="A Kanji/Kana font derived from SetoFont / Naikai Font / cjkFonts-AllSeto (Japanese version)"
+PKGDES="A Kanji/Kana font derived from SetoFont/Naikai Font/cjkFonts-AllSeto (Japanese version)"
 PKGDEP="fontconfig"
 PKGSEC="fonts"
 

--- a/desktop-fonts/kose-font/02-xiaolai-font/build
+++ b/desktop-fonts/kose-font/02-xiaolai-font/build
@@ -1,7 +1,7 @@
 abinfo "Installing xiaolai-font..."
-install -dvm755 "$PKGDIR"/usr/share/fonts/TTF
-install -vm644 "$SRCDIR"/"TTF (Simplified Chinese)"/*.ttf "$PKGDIR"/usr/share/fonts/TTF
+install -Dvm644 "$SRCDIR"/../*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF/
 
 abinfo "Installing LICENSE..."
-install -dvm755 "$PKGDIR"/usr/share/doc/xiaolai-font
-install -vm644 "$SRCDIR"/SIL_Open_Font_License_1.1.txt "$PKGDIR"/usr/share/doc/xiaolai-font
+install -Dvm644 "$SRCDIR"/License.txt \
+    "$PKGDIR"/usr/share/doc/xiaolai-font/SIL_Open_Font_License_1.1.txt

--- a/desktop-fonts/kose-font/02-xiaolai-font/defines
+++ b/desktop-fonts/kose-font/02-xiaolai-font/defines
@@ -1,5 +1,5 @@
 PKGNAME="xiaolai-font"
-PKGDES="A Kanji/Kana font derived from SetoFont / Naikai Font / cjkFonts-AllSeto (Simplified Chinese version)"
+PKGDES="A Simplified Chinese font dervied from Kose Font"
 PKGDEP="fontconfig"
 PKGSEC="fonts"
 

--- a/desktop-fonts/kose-font/spec
+++ b/desktop-fonts/kose-font/spec
@@ -1,5 +1,8 @@
-# About version, see https://github.com/lxgw/kose-font/blob/master/history.md .
-VER=3.11
-SRCS="git::commit=c1a6ec8e3093b41bb936eeb8deb86c4a573a99a2::https://github.com/lxgw/kose-font"
-CHKSUMS="SKIP"
-REL=1
+VER=3.113
+SRCS="git::commit=tags/v$VER::https://github.com/lxgw/kose-font \
+      file::rename=XiaolaiMonoSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiMonoSC-Regular.ttf \
+      file::rename=XiaolaiSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiSC-Regular.ttf"
+CHKSUMS="SKIP \
+         sha256::95ecac13c3f8c69e3e80fa73864102f13730b5fd87e7438c23b96766ef458e41 \
+         sha256::b04eec580794279f6178644f6d7af090bd9bcbd3fb3b6873f3c714e21fa514fb"
+CHKUPDATE="anitya::id=374941"


### PR DESCRIPTION
Topic Description
-----------------

- kose-font: update to 3.113
    - Mark CHKUPDATE.
    - Improve PKGDES.
    - Lint build scripts.

Package(s) Affected
-------------------

- kose-font: 3.113
- xiaolai-font: 3.113

Security Update?
----------------

No

Build Order
-----------

```
#buildit kose-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
