### PR TITLE
kexec-tools: update to 2.0.29

### DIFF
--- a/app-admin/kexec-tools/autobuild/patches/0001-RISC-V-Add-support-for-riscv-kexec-kdump-on-kexec-to.patch.riscv64
+++ b/app-admin/kexec-tools/autobuild/patches/0001-RISC-V-Add-support-for-riscv-kexec-kdump-on-kexec-to.patch.riscv64
@@ -1,67 +1,7 @@
-From mboxrd@z Thu Jan  1 00:00:00 1970
-Return-Path: <kexec-bounces+kexec=archiver.kernel.org@lists.infradead.org>
-X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
-	aws-us-west-2-korg-lkml-1.web.codeaurora.org
-Received: from bombadil.infradead.org (bombadil.infradead.org [198.137.202.133])
-	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
-	(No client certificate requested)
-	by smtp.lore.kernel.org (Postfix) with ESMTPS id 8C841C4332F
-	for <kexec@archiver.kernel.org>; Fri, 21 Oct 2022 13:54:21 +0000 (UTC)
-DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/relaxed;
-	d=lists.infradead.org; s=bombadil.20210309; h=Sender:
-	Content-Transfer-Encoding:Content-Type:MIME-Version:List-Subscribe:List-Help:
-	List-Post:List-Archive:List-Unsubscribe:List-Id:Message-Id:Date:Subject:Cc:To
-	:From:Reply-To:Content-ID:Content-Description:Resent-Date:Resent-From:
-	Resent-Sender:Resent-To:Resent-Cc:Resent-Message-ID:In-Reply-To:References:
-	List-Owner; bh=XlsHV8qPVaW0qsI3mLDVKzmXqjhVeqXYZ9waxBwfvRQ=; b=jqiE/dLj2tVLBd
-	bvZdcxnFVz1vVqKdAyU0R5oA5D3oOQH2Dvre4ZgAesWFeFkyid+2ceUSs1dPXbrqV6dj/BhNBzk09
-	EjAB4rNmpwlDGMyvWDyO5jXdG7GkWlz9yYw/zyhw3jAu0KnJpz2JGVJ2s8Hzyt0m+3dPmeuBabJxe
-	36CD18Ao9kBKqjQ96P2ixg0yLdwTYixH+syHA+F3CaXgOz+7UxF3lTt4eDnkhngBY3iKtIhr7khvh
-	zk2aZk/SUx8ZIhEPguwxkqhtMr3Ou1wKaPETaK62zQckzGw3WtHiOcoll4UPiGbFwlgcGmPNfE7Y1
-	uUJTib+HjhfyhYCiWVig==;
-Received: from localhost ([::1] helo=bombadil.infradead.org)
-	by bombadil.infradead.org with esmtp (Exim 4.94.2 #2 (Red Hat Linux))
-	id 1olsTX-008Jr3-Fw; Fri, 21 Oct 2022 13:54:15 +0000
-Received: from out30-56.freemail.mail.aliyun.com ([115.124.30.56])
-	by bombadil.infradead.org with esmtps (Exim 4.94.2 #2 (Red Hat Linux))
-	id 1olM2K-009qfv-FO
-	for kexec@lists.infradead.org; Thu, 20 Oct 2022 03:16:06 +0000
-X-Alimail-AntiSpam: AC=PASS;BC=-1|-1;BR=01201311R211e4;CH=green;DM=||false|;DS=||;FP=0|-1|-1|-1|0|-1|-1|-1;HT=ay29a033018046051;MF=xianting.tian@linux.alibaba.com;NM=1;PH=DS;RN=5;SR=0;TI=SMTPD_---0VSdKC-S_1666235749;
-Received: from localhost.localdomain(mailfrom:xianting.tian@linux.alibaba.com fp:SMTPD_---0VSdKC-S_1666235749)
-          by smtp.aliyun-inc.com;
-          Thu, 20 Oct 2022 11:15:57 +0800
-From: Xianting Tian <xianting.tian@linux.alibaba.com>
-To: horms@kernel.org,
-	kexec@lists.infradead.org,
-	mick@ics.forth.gr,
-	yixun.lan@gmail.com
-Cc: guoren@kernel.org
-Subject: [PATCH V2] RISC-V: Add support for riscv kexec/kdump on kexec-tools
-Date: Thu, 20 Oct 2022 11:15:48 +0800
-Message-Id: <20221020031548.47587-1-xianting.tian@linux.alibaba.com>
-X-Mailer: git-send-email 2.17.1
-X-CRM114-Version: 20100106-BlameMichelson ( TRE 0.8.0 (BSD) ) MR-646709E3 
-X-CRM114-CacheID: sfid-20221019_201601_091453_0CFD7E2A 
-X-CRM114-Status: GOOD (  34.75  )
-X-Mailman-Approved-At: Fri, 21 Oct 2022 06:53:57 -0700
-X-BeenThere: kexec@lists.infradead.org
-X-Mailman-Version: 2.1.34
-Precedence: list
-List-Id: <kexec.lists.infradead.org>
-List-Unsubscribe: <http://lists.infradead.org/mailman/options/kexec>,
- <mailto:kexec-request@lists.infradead.org?subject=unsubscribe>
-List-Archive: <http://lists.infradead.org/pipermail/kexec/>
-List-Post: <mailto:kexec@lists.infradead.org>
-List-Help: <mailto:kexec-request@lists.infradead.org?subject=help>
-List-Subscribe: <http://lists.infradead.org/mailman/listinfo/kexec>,
- <mailto:kexec-request@lists.infradead.org?subject=subscribe>
-MIME-Version: 1.0
-Content-Type: text/plain; charset="us-ascii"
-Content-Transfer-Encoding: 7bit
-Sender: "kexec" <kexec-bounces@lists.infradead.org>
-Errors-To: kexec-bounces+kexec=archiver.kernel.org@lists.infradead.org
-
+From 0677b06445cd434a5c5169e968611f4b772bffd7 Mon Sep 17 00:00:00 2001
 From: Nick Kossifidis <mick@ics.forth.gr>
+Date: Thu, 20 Oct 2022 11:15:48 +0800
+Subject: [PATCH 1/2] RISC-V: Add support for riscv kexec/kdump on kexec-tools
 
 This patch adds support for loading the ELF kernel image. It parses
 the current/provided device tree to determine the system's memory
@@ -81,11 +21,6 @@ Co-developed-by: Xianting Tian <xianting.tian@linux.alibaba.com>
 Co-developed-by: Yixun Lan <yixun.lan@gmail.com>
 Signed-off-by: Nick Kossifidis <mick@ics.forth.gr>
 ---
-Changes
-  V1 -> V2:
-  1, Rebase the patch to latest kexec code.
-  2, Set patch author Nick Kossifidis.
-
  configure.ac                            |   3 +
  include/elf.h                           |   1 +
  kexec/Makefile                          |   1 +
@@ -110,7 +45,7 @@ Changes
  create mode 100644 purgatory/arch/riscv/Makefile
 
 diff --git a/configure.ac b/configure.ac
-index d081c82..9204c37 100644
+index 46da85f..98edc74 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -61,6 +61,9 @@ case $target_cpu in
@@ -136,10 +71,10 @@ index 1c8d2cc..93a5ee5 100644
  #define EM_NUM		184
  
 diff --git a/kexec/Makefile b/kexec/Makefile
-index 8a52e8d..405864a 100644
+index 11682bf..69115a4 100644
 --- a/kexec/Makefile
 +++ b/kexec/Makefile
-@@ -88,6 +88,7 @@ include $(srcdir)/kexec/arch/mips/Makefile
+@@ -89,6 +89,7 @@ include $(srcdir)/kexec/arch/mips/Makefile
  include $(srcdir)/kexec/arch/cris/Makefile
  include $(srcdir)/kexec/arch/ppc/Makefile
  include $(srcdir)/kexec/arch/ppc64/Makefile
@@ -1537,10 +1472,10 @@ index 03659ce..3014205 100644
 +
  #endif
 diff --git a/kexec/kexec-syscall.h b/kexec/kexec-syscall.h
-index be6ccd5..4cdae84 100644
+index cc32c01..89591ad 100644
 --- a/kexec/kexec-syscall.h
 +++ b/kexec/kexec-syscall.h
-@@ -137,6 +137,7 @@ static inline long kexec_file_load(int kernel_fd, int initrd_fd,
+@@ -140,6 +140,7 @@ static inline long kexec_file_load(int kernel_fd, int initrd_fd,
  #define KEXEC_ARCH_MIPS_LE (10 << 16)
  #define KEXEC_ARCH_MIPS    ( 8 << 16)
  #define KEXEC_ARCH_CRIS    (76 << 16)
@@ -1548,7 +1483,7 @@ index be6ccd5..4cdae84 100644
  #define KEXEC_ARCH_LOONGARCH	(258 << 16)
  
  #define KEXEC_MAX_SEGMENTS 16
-@@ -184,5 +185,8 @@ static inline long kexec_file_load(int kernel_fd, int initrd_fd,
+@@ -187,5 +188,8 @@ static inline long kexec_file_load(int kernel_fd, int initrd_fd,
  #if defined(__loongarch__)
  #define KEXEC_ARCH_NATIVE	KEXEC_ARCH_LOONGARCH
  #endif
@@ -1583,11 +1518,5 @@ index 0000000..8bded71
 +
 +dist += purgatory/arch/sh/Makefile $(riscv_PURGATORY_SRCS)
 -- 
-2.17.1
-
-
-_______________________________________________
-kexec mailing list
-kexec@lists.infradead.org
-http://lists.infradead.org/mailman/listinfo/kexec
+2.47.0
 

--- a/app-admin/kexec-tools/autobuild/patches/0002-riscv-add-stubs-of-arch_do_exclude_segment.patch.riscv64
+++ b/app-admin/kexec-tools/autobuild/patches/0002-riscv-add-stubs-of-arch_do_exclude_segment.patch.riscv64
@@ -1,0 +1,25 @@
+From 054e3a75627ecad24e2bc7d39ed47570dba29709 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Sat, 12 Oct 2024 18:39:14 +0800
+Subject: [PATCH 2/2] riscv: add stubs of `arch_do_exclude_segment`
+
+---
+ kexec/arch/riscv/kexec-riscv.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/kexec/arch/riscv/kexec-riscv.c b/kexec/arch/riscv/kexec-riscv.c
+index fe5dd2d..a5bcd65 100644
+--- a/kexec/arch/riscv/kexec-riscv.c
++++ b/kexec/arch/riscv/kexec-riscv.c
+@@ -363,3 +363,8 @@ int arch_compat_trampoline(struct kexec_info *UNUSED(info))
+ void arch_update_purgatory(struct kexec_info *UNUSED(info))
+ {
+ }
++
++int arch_do_exclude_segment(struct kexec_info *UNUSED(info), struct kexec_segment *UNUSED(segment))
++{
++        return 0;
++}
+-- 
+2.47.0
+

--- a/app-admin/kexec-tools/spec
+++ b/app-admin/kexec-tools/spec
@@ -1,4 +1,4 @@
-VER=2.0.28
+VER=2.0.29
 SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12689"


### PR DESCRIPTION
Topic Description
-----------------

- kexec-tools: update to 2.0.29, treat RISCV's patch as platform-dependent

Package(s) Affected
-------------------

- kexec-tools: 2.0.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit kexec-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
