### PR TITLE
podman: update to 5.2.4+vsock0.7.5

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=5.2.3
-REL=1
+UPSTREAM_VER=5.2.4
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.2.4+vsock0.7.5
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- podman: 5.2.4+vsock0.7.5

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/8285

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
