### PR TITLE
pipewire: fix pw-jack record finish crash

### DIFF
--- a/app-multimedia/pipewire/autobuild/patches/0001-BACKPORT-jack-actually-clear-the-mix-io.patch
+++ b/app-multimedia/pipewire/autobuild/patches/0001-BACKPORT-jack-actually-clear-the-mix-io.patch
@@ -1,0 +1,36 @@
+From 885f8ab517365295e1c0651702a85c1324eb35db Mon Sep 17 00:00:00 2001
+From: Wim Taymans <wtaymans@redhat.com>
+Date: Sun, 6 Oct 2024 12:36:18 +0200
+Subject: [PATCH] jack: actually clear the mix io
+
+When we are asked to clear the mix io areas, actually do it, otherwise
+the process thread might still be accessing the old memory and crash.
+
+Also check that we have set io on the port before we decrement the
+counter with active io or else we have a negative value and cause
+problems later. This can happen when we susupend and set io to NULL but
+there was never any io set on the port.
+
+Fixes #4337
+---
+ pipewire-jack/src/pipewire-jack.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pipewire-jack/src/pipewire-jack.c b/pipewire-jack/src/pipewire-jack.c
+index 1adfa2225..ccca29006 100644
+--- a/pipewire-jack/src/pipewire-jack.c
++++ b/pipewire-jack/src/pipewire-jack.c
+@@ -600,7 +600,9 @@ do_mix_set_io(struct spa_loop *loop, bool async, uint32_t seq,
+ 			port->global_mix->io[1] = &port->io[1];
+ 		}
+ 	} else {
+-		if (--port->n_mix == 0 && port->global_mix != NULL) {
++		info->mix->io[0] = NULL;
++		info->mix->io[1] = NULL;
++		if (port->n_mix > 0 && --port->n_mix == 0 && port->global_mix != NULL) {
+ 			port->global_mix->io[0] = NULL;
+ 			port->global_mix->io[1] = NULL;
+ 		}
+-- 
+2.46.2
+

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.2.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: backport a patch to fix pw-jack record finish crash
    Backport a patch (from upstream 1.2 branch) to fix Audacity (when using
    PW fake JACK) crashing when stopping audio record.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- pipewire: 1.2.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
