### PR TITLE
binutils: update to 2.43.1

### DIFF
--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,4 @@
-VER=2.43
-REL=1
+VER=2.43.1
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
-CHKSUMS="sha256::b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365"
+CHKSUMS="sha256::13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: update to 2.43.1
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- binutils: 2.43.1
- binutils+cross-amd64: 2.43.1
- binutils+cross-arm64: 2.43.1
- binutils+cross-loongarch64: 2.43.1
- binutils+cross-loongson3: 2.43.1
- binutils+cross-mips64r6el: 2.43.1
- binutils+cross-ppc64el: 2.43.1
- binutils+cross-riscv64: 2.43.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
