### PR TITLE
libarchive: update to 3.7.6

### DIFF
--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,4 @@
-VER=3.7.4
+VER=3.7.6
 SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
-CHKSUMS="sha256::7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8"
+CHKSUMS="sha256::b4071807367b15b72777c2eaac80f42c8ea2d20212ab279514a19fe1f6f96ef4"
 CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- libarchive: update to 3.7.6
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- libarchive: 1:3.7.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
