### PR TITLE
linyaps: fix ll-cli search API

### DIFF
--- a/app-admin/linyaps/autobuild/patches/0001-fix-repo-ll-cli-search-result-is-abnormal.patch
+++ b/app-admin/linyaps/autobuild/patches/0001-fix-repo-ll-cli-search-result-is-abnormal.patch
@@ -1,0 +1,28 @@
+From cfc28fd05f4d8414659660438aa24faa11fe86e8 Mon Sep 17 00:00:00 2001
+From: dengbo11 <dengbo@deepin.org>
+Date: Sat, 12 Oct 2024 17:46:16 +0800
+Subject: [PATCH] fix(repo): ll-cli search result is abnormal
+
+PackageInfoV2 packageInfoV2Module is not assignment when construction
+PackageInfoV2.
+
+Log: fix ll-cli search abnormally
+---
+ libs/linglong/src/linglong/repo/ostree_repo.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libs/linglong/src/linglong/repo/ostree_repo.cpp b/libs/linglong/src/linglong/repo/ostree_repo.cpp
+index 5ae933cc..84ec991a 100644
+--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
++++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
+@@ -1239,6 +1239,7 @@ OSTreeRepo::listRemote(const package::FuzzyReference &fuzzyRef) const noexcept
+           .description = item->description,
+           .id = item->app_id,
+           .kind = item->kind,
++          .packageInfoV2Module = item->module,
+           .name = item->name,
+           .runtime = item->runtime,
+           .size = item->size,
+-- 
+2.47.0
+

--- a/app-admin/linyaps/spec
+++ b/app-admin/linyaps/spec
@@ -1,4 +1,5 @@
 VER=1.6.3
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/OpenAtom-Linyaps/linyaps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372461"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps: backport a patch to fix search API
    This should fix the local store's installation and version list interface.
    Ref: https://github.com/OpenAtom-Linyaps/linyaps/commit/e2e33e7392aa2d9683c779eb03b248c93815a721

Package(s) Affected
-------------------

- linyaps: 1.6.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
