### PR TITLE
firefox: fix build on loongson3

### DIFF
--- a/app-web/firefox/autobuild/patches/0001-feat-netwerk-declare-AOSC-OS-in-user-agent-string.patch
+++ b/app-web/firefox/autobuild/patches/0001-feat-netwerk-declare-AOSC-OS-in-user-agent-string.patch
@@ -1,14 +1,14 @@
 From c05e8cec4bb814d60352df11ded2a8d2af93c070 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 5 Apr 2024 22:52:21 +0800
-Subject: [PATCH 01/10] feat(netwerk): declare AOSC OS in user agent string
+Subject: [PATCH 01/11] feat(netwerk): declare AOSC OS in user agent string
 
 ---
  netwerk/protocol/http/nsHttpHandler.cpp | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/netwerk/protocol/http/nsHttpHandler.cpp b/netwerk/protocol/http/nsHttpHandler.cpp
-index 42b2021e2c..da58d038d3 100644
+index 42b2021e2cba..da58d038d327 100644
 --- a/netwerk/protocol/http/nsHttpHandler.cpp
 +++ b/netwerk/protocol/http/nsHttpHandler.cpp
 @@ -874,6 +874,7 @@ void nsHttpHandler::BuildUserAgent() {

--- a/app-web/firefox/autobuild/patches/0002-Enable-VA-API-support-for-AMD-GPUs.patch
+++ b/app-web/firefox/autobuild/patches/0002-Enable-VA-API-support-for-AMD-GPUs.patch
@@ -1,14 +1,14 @@
 From b7fce5140f10495970384daba0bc33e9bf8dcf5e Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 14 Nov 2023 18:14:20 -0800
-Subject: [PATCH 02/10] Enable VA-API support for AMD GPUs
+Subject: [PATCH 02/11] Enable VA-API support for AMD GPUs
 
 ---
  widget/gtk/GfxInfo.cpp | 8 --------
  1 file changed, 8 deletions(-)
 
 diff --git a/widget/gtk/GfxInfo.cpp b/widget/gtk/GfxInfo.cpp
-index baf3fb452a..bd4a90605a 100644
+index baf3fb452abd..bd4a90605a8f 100644
 --- a/widget/gtk/GfxInfo.cpp
 +++ b/widget/gtk/GfxInfo.cpp
 @@ -1086,14 +1086,6 @@ const nsTArray<GfxDriverInfo>& GfxInfo::GetGfxDriverInfo() {

--- a/app-web/firefox/autobuild/patches/0003-Add-support-for-LoongArch64.patch
+++ b/app-web/firefox/autobuild/patches/0003-Add-support-for-LoongArch64.patch
@@ -1,7 +1,7 @@
 From f468b51a819405fb52fcd3e20d6270558bcdec74 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Sun, 22 Oct 2023 22:13:17 -0700
-Subject: [PATCH 03/10] Add support for LoongArch64
+Subject: [PATCH 03/11] Add support for LoongArch64
 
 Adapted from LoongArchLinux. Rebased to Firefox 130.0.0.
 
@@ -14,7 +14,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  2 files changed, 5 insertions(+)
 
 diff --git a/third_party/libwebrtc/build/build_config.h b/third_party/libwebrtc/build/build_config.h
-index c39ae9da50..28191de026 100644
+index c39ae9da50f9..28191de02654 100644
 --- a/third_party/libwebrtc/build/build_config.h
 +++ b/third_party/libwebrtc/build/build_config.h
 @@ -210,6 +210,10 @@
@@ -29,7 +29,7 @@ index c39ae9da50..28191de026 100644
  #error Please add support for your architecture in build/build_config.h
  #endif
 diff --git a/toolkit/components/telemetry/pingsender/pingsender.cpp b/toolkit/components/telemetry/pingsender/pingsender.cpp
-index 30f2907c72..e6645227a2 100644
+index 30f2907c720e..e6645227a294 100644
 --- a/toolkit/components/telemetry/pingsender/pingsender.cpp
 +++ b/toolkit/components/telemetry/pingsender/pingsender.cpp
 @@ -10,6 +10,7 @@

--- a/app-web/firefox/autobuild/patches/0004-update-gn_processor.py-to-support-linux-on-loong64.patch
+++ b/app-web/firefox/autobuild/patches/0004-update-gn_processor.py-to-support-linux-on-loong64.patch
@@ -1,7 +1,7 @@
 From d1ccb62c80e0a3fe8bea07444fab4ba92c56758c Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:38:04 +0800
-Subject: [PATCH 04/10] update gn_processor.py to support linux on loong64
+Subject: [PATCH 04/11] update gn_processor.py to support linux on loong64
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/python/mozbuild/mozbuild/gn_processor.py b/python/mozbuild/mozbuild/gn_processor.py
-index 3a9b9e7f3b..fc771a4e63 100644
+index 3a9b9e7f3bae..fc771a4e63fd 100644
 --- a/python/mozbuild/mozbuild/gn_processor.py
 +++ b/python/mozbuild/mozbuild/gn_processor.py
 @@ -182,6 +182,7 @@ def filter_gn_config(path, gn_result, sandbox_vars, input_vars, gn_target):

--- a/app-web/firefox/autobuild/patches/0005-Re-generate-libwebrtc-moz.build-files.patch
+++ b/app-web/firefox/autobuild/patches/0005-Re-generate-libwebrtc-moz.build-files.patch
@@ -1,7 +1,7 @@
 From 09f209d7dc25c48494d86ee1ad4eb0c8d3436dc6 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:46:09 +0800
-Subject: [PATCH 05/10] Re-generate libwebrtc moz.build files
+Subject: [PATCH 05/11] Re-generate libwebrtc moz.build files
 
 With the following invocation at project root:
 
@@ -484,7 +484,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  470 files changed, 1924 insertions(+)
 
 diff --git a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
-index 2dbd588158..b63b665289 100644
+index 2dbd5881583e..b63b665289b5 100644
 --- a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -499,7 +499,7 @@ index 2dbd588158..b63b665289 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/array_view_gn/moz.build b/third_party/libwebrtc/api/array_view_gn/moz.build
-index df2c86715c..0a60fd48bb 100644
+index df2c86715cac..0a60fd48bb19 100644
 --- a/third_party/libwebrtc/api/array_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/array_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -514,7 +514,7 @@ index df2c86715c..0a60fd48bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
-index 4d678a1de7..90dd37068d 100644
+index 4d678a1de7c9..90dd37068d14 100644
 --- a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -529,7 +529,7 @@ index 4d678a1de7..90dd37068d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
-index cbd6f2e6f0..785f61c7f9 100644
+index cbd6f2e6f0d5..785f61c7f9c3 100644
 --- a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -544,7 +544,7 @@ index cbd6f2e6f0..785f61c7f9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
-index 746585483f..b702e63d8d 100644
+index 746585483f96..b702e63d8d1c 100644
 --- a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -559,7 +559,7 @@ index 746585483f..b702e63d8d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
-index 9609692094..4b1e3244c5 100644
+index 9609692094c1..4b1e3244c5b7 100644
 --- a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -574,7 +574,7 @@ index 9609692094..4b1e3244c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
-index e2561db08f..5da158eb82 100644
+index e2561db08f06..5da158eb823a 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -589,7 +589,7 @@ index e2561db08f..5da158eb82 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
-index 7dd1c4b911..d33585f69f 100644
+index 7dd1c4b91100..d33585f69fe6 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -604,7 +604,7 @@ index 7dd1c4b911..d33585f69f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
-index 36d43783a3..f8d9e41c9a 100644
+index 36d43783a3e7..f8d9e41c9a37 100644
 --- a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -619,7 +619,7 @@ index 36d43783a3..f8d9e41c9a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
-index 7226d2a92a..a3ed2ed8a9 100644
+index 7226d2a92a40..a3ed2ed8a94d 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -634,7 +634,7 @@ index 7226d2a92a..a3ed2ed8a9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
-index d7629659d6..ede61bc1f9 100644
+index d7629659d6ba..ede61bc1f955 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -649,7 +649,7 @@ index d7629659d6..ede61bc1f9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
-index 06f43e7651..cc5e401aa4 100644
+index 06f43e765114..cc5e401aa4f8 100644
 --- a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -664,7 +664,7 @@ index 06f43e7651..cc5e401aa4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
-index 5811f4d932..f530738ade 100644
+index 5811f4d9321b..f530738ade2e 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -679,7 +679,7 @@ index 5811f4d932..f530738ade 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
-index f4fb06ef3f..452bc02291 100644
+index f4fb06ef3f09..452bc02291fb 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -694,7 +694,7 @@ index f4fb06ef3f..452bc02291 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
-index faed7e9b0f..c0e23d412a 100644
+index faed7e9b0f61..c0e23d412af5 100644
 --- a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -709,7 +709,7 @@ index faed7e9b0f..c0e23d412a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
-index 5de9c29607..d04a8351a0 100644
+index 5de9c2960769..d04a8351a0f6 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -724,7 +724,7 @@ index 5de9c29607..d04a8351a0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
-index 5ff7dfd0ff..dd8118bf09 100644
+index 5ff7dfd0ffd4..dd8118bf090a 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -739,7 +739,7 @@ index 5ff7dfd0ff..dd8118bf09 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
-index e1c8fa6a08..132315de16 100644
+index e1c8fa6a08bc..132315de16c5 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -754,7 +754,7 @@ index e1c8fa6a08..132315de16 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
-index 39513d15b3..12e706e63a 100644
+index 39513d15b310..12e706e63a9a 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -769,7 +769,7 @@ index 39513d15b3..12e706e63a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
-index cf9228dcab..4b5fab47cb 100644
+index cf9228dcab3c..4b5fab47cbee 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -784,7 +784,7 @@ index cf9228dcab..4b5fab47cb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
-index 3b1a814ac7..aab75ab622 100644
+index 3b1a814ac7b2..aab75ab622b2 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -799,7 +799,7 @@ index 3b1a814ac7..aab75ab622 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
-index 57bdfeaf74..bf6097f6d1 100644
+index 57bdfeaf74c0..bf6097f6d137 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -814,7 +814,7 @@ index 57bdfeaf74..bf6097f6d1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
-index ae2d4f5dc9..e89cb12925 100644
+index ae2d4f5dc9b4..e89cb12925c3 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -829,7 +829,7 @@ index ae2d4f5dc9..e89cb12925 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
-index 2ec1c97ea2..f97c0e70bb 100644
+index 2ec1c97ea240..f97c0e70bb9f 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -844,7 +844,7 @@ index 2ec1c97ea2..f97c0e70bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
-index ff9d947abb..f153ba6833 100644
+index ff9d947abb85..f153ba683381 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -859,7 +859,7 @@ index ff9d947abb..f153ba6833 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
-index 06926f2550..66ab66c8f3 100644
+index 06926f2550c6..66ab66c8f34b 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -874,7 +874,7 @@ index 06926f2550..66ab66c8f3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
-index a404176923..c25005f973 100644
+index a40417692306..c25005f9737a 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -889,7 +889,7 @@ index a404176923..c25005f973 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
-index a52b290d08..d131b519ff 100644
+index a52b290d08bc..d131b519ffd2 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -904,7 +904,7 @@ index a52b290d08..d131b519ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
-index 1847aa9f23..9952f0f04c 100644
+index 1847aa9f2334..9952f0f04c16 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -919,7 +919,7 @@ index 1847aa9f23..9952f0f04c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
-index b4ed20ad85..895171c2d1 100644
+index b4ed20ad8589..895171c2d11a 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -934,7 +934,7 @@ index b4ed20ad85..895171c2d1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
-index dc73c7abc3..8f4a2bf4f1 100644
+index dc73c7abc386..8f4a2bf4f154 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -949,7 +949,7 @@ index dc73c7abc3..8f4a2bf4f1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_options_api_gn/moz.build b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
-index 974d1dbdf2..0b52d3c781 100644
+index 974d1dbdf2c7..0b52d3c7819f 100644
 --- a/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -964,7 +964,7 @@ index 974d1dbdf2..0b52d3c781 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
-index 500eff54bb..0daeeeffac 100644
+index 500eff54bbfd..0daeeeffacee 100644
 --- a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -979,7 +979,7 @@ index 500eff54bb..0daeeeffac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/call_api_gn/moz.build b/third_party/libwebrtc/api/call_api_gn/moz.build
-index 372f0888fb..c694ed5d84 100644
+index 372f0888fbba..c694ed5d84f5 100644
 --- a/third_party/libwebrtc/api/call_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/call_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -994,7 +994,7 @@ index 372f0888fb..c694ed5d84 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
-index 2a9b6d96dd..640dde634d 100644
+index 2a9b6d96dd75..640dde634d16 100644
 --- a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1009,7 +1009,7 @@ index 2a9b6d96dd..640dde634d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
-index f1716e6b62..a2119ffc20 100644
+index f1716e6b6267..a2119ffc20e1 100644
 --- a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1024,7 +1024,7 @@ index f1716e6b62..a2119ffc20 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/options_gn/moz.build b/third_party/libwebrtc/api/crypto/options_gn/moz.build
-index fae93b1392..eb25f7ce47 100644
+index fae93b139253..eb25f7ce47a7 100644
 --- a/third_party/libwebrtc/api/crypto/options_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/options_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1039,7 +1039,7 @@ index fae93b1392..eb25f7ce47 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
-index 9388642ab5..6f3bff64f1 100644
+index 9388642ab5e6..6f3bff64f1a6 100644
 --- a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1054,7 +1054,7 @@ index 9388642ab5..6f3bff64f1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_gn/moz.build b/third_party/libwebrtc/api/environment/environment_gn/moz.build
-index 5b7b361ac3..59ebfd8ef9 100644
+index 5b7b361ac342..59ebfd8ef91d 100644
 --- a/third_party/libwebrtc/api/environment/environment_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1069,7 +1069,7 @@ index 5b7b361ac3..59ebfd8ef9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
-index 653eae8f23..49f4eede68 100644
+index 653eae8f233f..49f4eede6882 100644
 --- a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1084,7 +1084,7 @@ index 653eae8f23..49f4eede68 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
-index 76e121ec9f..ea669bd624 100644
+index 76e121ec9f5e..ea669bd624c7 100644
 --- a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1099,7 +1099,7 @@ index 76e121ec9f..ea669bd624 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_view_gn/moz.build b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
-index a6ac64bf50..2a3e4ded29 100644
+index a6ac64bf50c6..2a3e4ded29f8 100644
 --- a/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1114,7 +1114,7 @@ index a6ac64bf50..2a3e4ded29 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
-index b79f531f5d..efe8806017 100644
+index b79f531f5def..efe880601783 100644
 --- a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1129,7 +1129,7 @@ index b79f531f5d..efe8806017 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/function_view_gn/moz.build b/third_party/libwebrtc/api/function_view_gn/moz.build
-index feea8c2c0b..8b1ff5ec3a 100644
+index feea8c2c0ba6..8b1ff5ec3a26 100644
 --- a/third_party/libwebrtc/api/function_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/function_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1144,7 +1144,7 @@ index feea8c2c0b..8b1ff5ec3a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
-index 6729abedf9..2e97c3bc61 100644
+index 6729abedf9bd..2e97c3bc61bc 100644
 --- a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1159,7 +1159,7 @@ index 6729abedf9..2e97c3bc61 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
-index f815d7da4e..084545fc52 100644
+index f815d7da4e62..084545fc52ea 100644
 --- a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1174,7 +1174,7 @@ index f815d7da4e..084545fc52 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/location_gn/moz.build b/third_party/libwebrtc/api/location_gn/moz.build
-index 706b1d5026..fe442cba8c 100644
+index 706b1d5026cc..fe442cba8c1b 100644
 --- a/third_party/libwebrtc/api/location_gn/moz.build
 +++ b/third_party/libwebrtc/api/location_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1189,7 +1189,7 @@ index 706b1d5026..fe442cba8c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
-index 6bedaf55cd..0b1eb1b16c 100644
+index 6bedaf55cd03..0b1eb1b16cff 100644
 --- a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 +++ b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1204,7 +1204,7 @@ index 6bedaf55cd..0b1eb1b16c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
-index 8cc4995908..75524f59d0 100644
+index 8cc4995908e8..75524f59d042 100644
 --- a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1219,7 +1219,7 @@ index 8cc4995908..75524f59d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
-index 5ffa4ac6c7..e26be50d5a 100644
+index 5ffa4ac6c78f..e26be50d5a96 100644
 --- a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 +++ b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1234,7 +1234,7 @@ index 5ffa4ac6c7..e26be50d5a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
-index 0486a791d1..ad94f63893 100644
+index 0486a791d10f..ad94f6389319 100644
 --- a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1249,7 +1249,7 @@ index 0486a791d1..ad94f63893 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
-index ec0207e6b8..ee453a5ba4 100644
+index ec0207e6b81a..ee453a5ba492 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1264,7 +1264,7 @@ index ec0207e6b8..ee453a5ba4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
-index 830a41cbcb..c896a2a549 100644
+index 830a41cbcb2f..c896a2a54931 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1279,7 +1279,7 @@ index 830a41cbcb..c896a2a549 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
-index 4f4101599f..782b2f92bf 100644
+index 4f4101599f07..782b2f92bf77 100644
 --- a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1294,7 +1294,7 @@ index 4f4101599f..782b2f92bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
-index 84ec637233..00f9a3ed0f 100644
+index 84ec63723306..00f9a3ed0f64 100644
 --- a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1309,7 +1309,7 @@ index 84ec637233..00f9a3ed0f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/priority_gn/moz.build b/third_party/libwebrtc/api/priority_gn/moz.build
-index e90b551e4d..15cd85663a 100644
+index e90b551e4d69..15cd85663ab5 100644
 --- a/third_party/libwebrtc/api/priority_gn/moz.build
 +++ b/third_party/libwebrtc/api/priority_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1324,7 +1324,7 @@ index e90b551e4d..15cd85663a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/ref_count_gn/moz.build b/third_party/libwebrtc/api/ref_count_gn/moz.build
-index b5ded03ae3..8ec15b650b 100644
+index b5ded03ae3a4..8ec15b650b3c 100644
 --- a/third_party/libwebrtc/api/ref_count_gn/moz.build
 +++ b/third_party/libwebrtc/api/ref_count_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1339,7 +1339,7 @@ index b5ded03ae3..8ec15b650b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/refcountedbase_gn/moz.build b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
-index 42e693bf02..87e00c5de1 100644
+index 42e693bf022a..87e00c5de1d3 100644
 --- a/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 +++ b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1354,7 +1354,7 @@ index 42e693bf02..87e00c5de1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_error_gn/moz.build b/third_party/libwebrtc/api/rtc_error_gn/moz.build
-index 1ff7960b4d..4bda31aba1 100644
+index 1ff7960b4dd0..4bda31aba12f 100644
 --- a/third_party/libwebrtc/api/rtc_error_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_error_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1369,7 +1369,7 @@ index 1ff7960b4d..4bda31aba1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
-index e478cf3e4c..e33d4042d5 100644
+index e478cf3e4c3c..e33d4042d5c3 100644
 --- a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1384,7 +1384,7 @@ index e478cf3e4c..e33d4042d5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_headers_gn/moz.build b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
-index 5b5cac9bf0..5effef5b2c 100644
+index 5b5cac9bf046..5effef5b2c4e 100644
 --- a/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1399,7 +1399,7 @@ index 5b5cac9bf0..5effef5b2c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
-index 7bd7a37fb3..0f24dd2a9b 100644
+index 7bd7a37fb361..0f24dd2a9bc4 100644
 --- a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1414,7 +1414,7 @@ index 7bd7a37fb3..0f24dd2a9b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
-index ada3bfe3a2..2355c94b66 100644
+index ada3bfe3a22b..2355c94b6639 100644
 --- a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1429,7 +1429,7 @@ index ada3bfe3a2..2355c94b66 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
-index 5b41bb13cb..9981f77bfc 100644
+index 5b41bb13cbbe..9981f77bfc6e 100644
 --- a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1444,7 +1444,7 @@ index 5b41bb13cb..9981f77bfc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
-index 89f5c0fcc1..46d09e7890 100644
+index 89f5c0fcc118..46d09e7890da 100644
 --- a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1459,7 +1459,7 @@ index 89f5c0fcc1..46d09e7890 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
-index c3b4e7f67e..0c0233a8e6 100644
+index c3b4e7f67e56..0c0233a8e64e 100644
 --- a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1474,7 +1474,7 @@ index c3b4e7f67e..0c0233a8e6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
-index bd244c29b5..10f1d42f76 100644
+index bd244c29b5cb..10f1d42f76b2 100644
 --- a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 +++ b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1489,7 +1489,7 @@ index bd244c29b5..10f1d42f76 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/sequence_checker_gn/moz.build b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
-index e129bf8a01..11c8e5391f 100644
+index e129bf8a010e..11c8e5391fa5 100644
 --- a/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 +++ b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1504,7 +1504,7 @@ index e129bf8a01..11c8e5391f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
-index 222193edde..e627311ebb 100644
+index 222193edde3f..e627311ebbf0 100644
 --- a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1519,7 +1519,7 @@ index 222193edde..e627311ebb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
-index 0d9947daa8..77f07de263 100644
+index 0d9947daa8ce..77f07de26370 100644
 --- a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1534,7 +1534,7 @@ index 0d9947daa8..77f07de263 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
-index e0e0b4688e..db1d874780 100644
+index e0e0b4688e62..db1d874780de 100644
 --- a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1549,7 +1549,7 @@ index e0e0b4688e..db1d874780 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
-index b3eb74837f..80617f24dd 100644
+index b3eb74837f20..80617f24dd39 100644
 --- a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1564,7 +1564,7 @@ index b3eb74837f..80617f24dd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
-index 0885f16a06..5dd6c3a3c1 100644
+index 0885f16a0655..5dd6c3a3c16e 100644
 --- a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1579,7 +1579,7 @@ index 0885f16a06..5dd6c3a3c1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
-index 2f22fa141f..bf3b4e7143 100644
+index 2f22fa141fe6..bf3b4e714361 100644
 --- a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1594,7 +1594,7 @@ index 2f22fa141f..bf3b4e7143 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
-index 42410686d0..5a3b31c116 100644
+index 42410686d0be..5a3b31c1162c 100644
 --- a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1609,7 +1609,7 @@ index 42410686d0..5a3b31c116 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
-index e0f8f02378..a4a27afce7 100644
+index e0f8f023787b..a4a27afce7db 100644
 --- a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1624,7 +1624,7 @@ index e0f8f02378..a4a27afce7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
-index 0b2e41f78c..c89e0728c5 100644
+index 0b2e41f78c7b..c89e0728c542 100644
 --- a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1639,7 +1639,7 @@ index 0b2e41f78c..c89e0728c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
-index 70efa923b7..5d52ad1d36 100644
+index 70efa923b78f..5d52ad1d3676 100644
 --- a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1654,7 +1654,7 @@ index 70efa923b7..5d52ad1d36 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/network_control_gn/moz.build b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
-index abbedfaee9..7dc37c6365 100644
+index abbedfaee9af..7dc37c636547 100644
 --- a/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1669,7 +1669,7 @@ index abbedfaee9..7dc37c6365 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
-index 16ec75fa01..777afccd30 100644
+index 16ec75fa0170..777afccd3065 100644
 --- a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1684,7 +1684,7 @@ index 16ec75fa01..777afccd30 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
-index 83c88e8037..c171d5eaae 100644
+index 83c88e8037fe..c171d5eaae72 100644
 --- a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1699,7 +1699,7 @@ index 83c88e8037..c171d5eaae 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
-index 51a16e295e..67f3481ac3 100644
+index 51a16e295eef..67f3481ac3f7 100644
 --- a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1714,7 +1714,7 @@ index 51a16e295e..67f3481ac3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport_api_gn/moz.build b/third_party/libwebrtc/api/transport_api_gn/moz.build
-index a726caad28..1583c32e67 100644
+index a726caad2813..1583c32e678d 100644
 --- a/third_party/libwebrtc/api/transport_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1729,7 +1729,7 @@ index a726caad28..1583c32e67 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_rate_gn/moz.build b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
-index 398b03d0a2..6e9d5a3220 100644
+index 398b03d0a231..6e9d5a322007 100644
 --- a/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1744,7 +1744,7 @@ index 398b03d0a2..6e9d5a3220 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_size_gn/moz.build b/third_party/libwebrtc/api/units/data_size_gn/moz.build
-index 8f61d01314..4be1545e6b 100644
+index 8f61d0131463..4be1545e6b24 100644
 --- a/third_party/libwebrtc/api/units/data_size_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_size_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1759,7 +1759,7 @@ index 8f61d01314..4be1545e6b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/frequency_gn/moz.build b/third_party/libwebrtc/api/units/frequency_gn/moz.build
-index 40a6bf2617..30b302563c 100644
+index 40a6bf261710..30b302563cde 100644
 --- a/third_party/libwebrtc/api/units/frequency_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/frequency_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1774,7 +1774,7 @@ index 40a6bf2617..30b302563c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/time_delta_gn/moz.build b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
-index d9ede8c812..fbc69252d8 100644
+index d9ede8c812f2..fbc69252d87c 100644
 --- a/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1789,7 +1789,7 @@ index d9ede8c812..fbc69252d8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/timestamp_gn/moz.build b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
-index 9e5ed8541e..b1ac1b772c 100644
+index 9e5ed8541e57..b1ac1b772c67 100644
 --- a/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1804,7 +1804,7 @@ index 9e5ed8541e..b1ac1b772c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
-index cafafadf44..a085a65795 100644
+index cafafadf4452..a085a657952c 100644
 --- a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1819,7 +1819,7 @@ index cafafadf44..a085a65795 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
-index d804e2fd36..f21f8b55cf 100644
+index d804e2fd3671..f21f8b55cf1c 100644
 --- a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1834,7 +1834,7 @@ index d804e2fd36..f21f8b55cf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
-index a444a71189..a3ef10fcda 100644
+index a444a71189b9..a3ef10fcda79 100644
 --- a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1849,7 +1849,7 @@ index a444a71189..a3ef10fcda 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
-index 01a33c4b81..8a7e83234f 100644
+index 01a33c4b813f..8a7e83234f24 100644
 --- a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1864,7 +1864,7 @@ index 01a33c4b81..8a7e83234f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
-index 4d6199a714..b0203be91a 100644
+index 4d6199a71433..b0203be91a91 100644
 --- a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1879,7 +1879,7 @@ index 4d6199a714..b0203be91a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
-index a0c4da6d58..15ae70c215 100644
+index a0c4da6d5809..15ae70c2156a 100644
 --- a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1894,7 +1894,7 @@ index a0c4da6d58..15ae70c215 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/resolution_gn/moz.build b/third_party/libwebrtc/api/video/resolution_gn/moz.build
-index e55dfe7d2c..fe470816b6 100644
+index e55dfe7d2c22..fe470816b693 100644
 --- a/third_party/libwebrtc/api/video/resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1909,7 +1909,7 @@ index e55dfe7d2c..fe470816b6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
-index c061e657ab..4788ea5e55 100644
+index c061e657ab8a..4788ea5e553c 100644
 --- a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1924,7 +1924,7 @@ index c061e657ab..4788ea5e55 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
-index 9581b4202a..9c1413b14f 100644
+index 9581b4202af9..9c1413b14f18 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1939,7 +1939,7 @@ index 9581b4202a..9c1413b14f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
-index 71a1a7f2dc..fe3788112d 100644
+index 71a1a7f2dc3e..fe3788112df3 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1954,7 +1954,7 @@ index 71a1a7f2dc..fe3788112d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
-index aecab75d2e..fea9f428f2 100644
+index aecab75d2eac..fea9f428f2be 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1969,7 +1969,7 @@ index aecab75d2e..fea9f428f2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
-index 1ff8d8117f..9b78d2d831 100644
+index 1ff8d8117fa6..9b78d2d8311f 100644
 --- a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1984,7 +1984,7 @@ index 1ff8d8117f..9b78d2d831 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
-index 37f7adf184..a44a5b3c64 100644
+index 37f7adf1843d..a44a5b3c6487 100644
 --- a/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1999,7 +1999,7 @@ index 37f7adf184..a44a5b3c64 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
-index 2b8bd493af..b2459fc0d7 100644
+index 2b8bd493aff9..b2459fc0d73a 100644
 --- a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2014,7 +2014,7 @@ index 2b8bd493af..b2459fc0d7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
-index 8b4bd96df2..2cd46e2244 100644
+index 8b4bd96df239..2cd46e22441c 100644
 --- a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2029,7 +2029,7 @@ index 8b4bd96df2..2cd46e2244 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
-index 3416d040b2..f5951d6e30 100644
+index 3416d040b2ea..f5951d6e30cd 100644
 --- a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2044,7 +2044,7 @@ index 3416d040b2..f5951d6e30 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
-index d9d7097f2f..e6f9710eda 100644
+index d9d7097f2f89..e6f9710eda5d 100644
 --- a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2059,7 +2059,7 @@ index d9d7097f2f..e6f9710eda 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
-index 7c696af228..609b8f3c20 100644
+index 7c696af228c6..609b8f3c2047 100644
 --- a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2074,7 +2074,7 @@ index 7c696af228..609b8f3c20 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
-index f54c465004..b7874ea832 100644
+index f54c46500445..b7874ea83217 100644
 --- a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2089,7 +2089,7 @@ index f54c465004..b7874ea832 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
-index b1bb1e3323..96630db641 100644
+index b1bb1e3323e8..96630db64121 100644
 --- a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2104,7 +2104,7 @@ index b1bb1e3323..96630db641 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
-index ca9c0f599a..8b4f3c069f 100644
+index ca9c0f599a99..8b4f3c069f58 100644
 --- a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2119,7 +2119,7 @@ index ca9c0f599a..8b4f3c069f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
-index b0c90b8ad2..bcec657a2e 100644
+index b0c90b8ad2ee..bcec657a2e8a 100644
 --- a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2134,7 +2134,7 @@ index b0c90b8ad2..bcec657a2e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
-index f3060e020a..b06f0a61bb 100644
+index f3060e020af9..b06f0a61bb83 100644
 --- a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2149,7 +2149,7 @@ index f3060e020a..b06f0a61bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
-index 3940914214..f404af52ff 100644
+index 394091421449..f404af52ff91 100644
 --- a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2164,7 +2164,7 @@ index 3940914214..f404af52ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
-index 636a3df69c..6c8dc9ed7b 100644
+index 636a3df69c9a..6c8dc9ed7bf3 100644
 --- a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2179,7 +2179,7 @@ index 636a3df69c..6c8dc9ed7b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/audio_gn/moz.build b/third_party/libwebrtc/audio/audio_gn/moz.build
-index 2888ef09bd..8cd43e9caa 100644
+index 2888ef09bd9b..8cd43e9caa67 100644
 --- a/third_party/libwebrtc/audio/audio_gn/moz.build
 +++ b/third_party/libwebrtc/audio/audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2194,7 +2194,7 @@ index 2888ef09bd..8cd43e9caa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
-index 315f691f3e..46997a10da 100644
+index 315f691f3e09..46997a10da7a 100644
 --- a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 +++ b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2209,7 +2209,7 @@ index 315f691f3e..46997a10da 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
-index 3dab96b5a3..16d001bc0f 100644
+index 3dab96b5a372..16d001bc0f42 100644
 --- a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2224,7 +2224,7 @@ index 3dab96b5a3..16d001bc0f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
-index 6ca0ee7739..ba943f674b 100644
+index 6ca0ee773997..ba943f674bdf 100644
 --- a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2239,7 +2239,7 @@ index 6ca0ee7739..ba943f674b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
-index 57adb400db..053203704d 100644
+index 57adb400db54..053203704dd3 100644
 --- a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2254,7 +2254,7 @@ index 57adb400db..053203704d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
-index 59f87d2fdf..d383801337 100644
+index 59f87d2fdf4d..d3838013378c 100644
 --- a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2269,7 +2269,7 @@ index 59f87d2fdf..d383801337 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_gn/moz.build b/third_party/libwebrtc/call/call_gn/moz.build
-index da452122ce..db896312b0 100644
+index da452122ce12..db896312b03e 100644
 --- a/third_party/libwebrtc/call/call_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2284,7 +2284,7 @@ index da452122ce..db896312b0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_interfaces_gn/moz.build b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
-index 3c7b6a05d3..a3f85dc6dc 100644
+index 3c7b6a05d3ab..a3f85dc6dc44 100644
 --- a/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2299,7 +2299,7 @@ index 3c7b6a05d3..a3f85dc6dc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
-index 0b3511082a..79a9228856 100644
+index 0b3511082a51..79a9228856cf 100644
 --- a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2314,7 +2314,7 @@ index 0b3511082a..79a9228856 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
-index f2fb2ab649..d138865b68 100644
+index f2fb2ab649bb..d138865b6812 100644
 --- a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2329,7 +2329,7 @@ index f2fb2ab649..d138865b68 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
-index 35c68ca336..e188943041 100644
+index 35c68ca3368d..e1889430418c 100644
 --- a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2344,7 +2344,7 @@ index 35c68ca336..e188943041 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_sender_gn/moz.build b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
-index c99d9d8e8a..d2ef2c26bf 100644
+index c99d9d8e8a66..d2ef2c26bf50 100644
 --- a/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2359,7 +2359,7 @@ index c99d9d8e8a..d2ef2c26bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/version_gn/moz.build b/third_party/libwebrtc/call/version_gn/moz.build
-index 50ff0cff2e..c048f48b99 100644
+index 50ff0cff2e55..c048f48b9985 100644
 --- a/third_party/libwebrtc/call/version_gn/moz.build
 +++ b/third_party/libwebrtc/call/version_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2374,7 +2374,7 @@ index 50ff0cff2e..c048f48b99 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/video_stream_api_gn/moz.build b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
-index 9aa475a12f..2f75e5afad 100644
+index 9aa475a12fc6..2f75e5afadd5 100644
 --- a/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 +++ b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2389,7 +2389,7 @@ index 9aa475a12f..2f75e5afad 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
-index 0827bbf31a..9c26089f8a 100644
+index 0827bbf31a41..9c26089f8ade 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 @@ -136,6 +136,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2404,7 +2404,7 @@ index 0827bbf31a..9c26089f8a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
-index 99cceabf29..247ada76ca 100644
+index 99cceabf2989..247ada76caf0 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 @@ -213,6 +213,16 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2425,7 +2425,7 @@ index 99cceabf29..247ada76ca 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
-index 1ab56ac809..7c54dfade5 100644
+index 1ab56ac80918..7c54dfade59b 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2440,7 +2440,7 @@ index 1ab56ac809..7c54dfade5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
-index 79a78f7837..c4e0d5b973 100644
+index 79a78f783794..c4e0d5b97304 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2455,7 +2455,7 @@ index 79a78f7837..c4e0d5b973 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
-index 2faac2a931..8ce1283652 100644
+index 2faac2a93134..8ce1283652b7 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2470,7 +2470,7 @@ index 2faac2a931..8ce1283652 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
-index af029033e7..66ffa7f1c4 100644
+index af029033e761..66ffa7f1c4d1 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2485,7 +2485,7 @@ index af029033e7..66ffa7f1c4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
-index 962dbed44b..fbe78886f9 100644
+index 962dbed44bf8..fbe78886f96f 100644
 --- a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2500,7 +2500,7 @@ index 962dbed44b..fbe78886f9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
-index 6245fdf7ef..60598ae2b1 100644
+index 6245fdf7ef93..60598ae2b108 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2515,7 +2515,7 @@ index 6245fdf7ef..60598ae2b1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
-index 7c2503bc9c..964be76261 100644
+index 7c2503bc9ccd..964be76261da 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2530,7 +2530,7 @@ index 7c2503bc9c..964be76261 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
-index ec09e725ff..424d4cd5b2 100644
+index ec09e725fff7..424d4cd5b263 100644
 --- a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 @@ -147,6 +147,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2549,7 +2549,7 @@ index ec09e725ff..424d4cd5b2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/common_video_gn/moz.build b/third_party/libwebrtc/common_video/common_video_gn/moz.build
-index fb64d190c3..02b32a6d4d 100644
+index fb64d190c30d..02b32a6d4daa 100644
 --- a/third_party/libwebrtc/common_video/common_video_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/common_video_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2564,7 +2564,7 @@ index fb64d190c3..02b32a6d4d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
-index 08c88c4702..b23c38bd68 100644
+index 08c88c4702cf..b23c38bd683c 100644
 --- a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2579,7 +2579,7 @@ index 08c88c4702..b23c38bd68 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
-index b16531fbf8..4c983cdd33 100644
+index b16531fbf8e2..4c983cdd3375 100644
 --- a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2594,7 +2594,7 @@ index b16531fbf8..4c983cdd33 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
-index 5e1ddc355d..f54ba694b9 100644
+index 5e1ddc355d5b..f54ba694b979 100644
 --- a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 +++ b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2609,7 +2609,7 @@ index 5e1ddc355d..f54ba694b9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
-index bf124013de..5ccc734ffb 100644
+index bf124013de2a..5ccc734ffb63 100644
 --- a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2624,7 +2624,7 @@ index bf124013de..5ccc734ffb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
-index c7c2a5f880..2b655652cf 100644
+index c7c2a5f88033..2b655652cf26 100644
 --- a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2639,7 +2639,7 @@ index c7c2a5f880..2b655652cf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
-index 630358f349..505d38c743 100644
+index 630358f34942..505d38c743e6 100644
 --- a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2654,7 +2654,7 @@ index 630358f349..505d38c743 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
-index 46e013a0d4..67413d361a 100644
+index 46e013a0d4d4..67413d361af9 100644
 --- a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2669,7 +2669,7 @@ index 46e013a0d4..67413d361a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
-index 4c491af396..22760a5762 100644
+index 4c491af3963c..22760a576252 100644
 --- a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2684,7 +2684,7 @@ index 4c491af396..22760a5762 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
-index aec4465f8a..4c8b44223c 100644
+index aec4465f8ac3..4c8b44223ce6 100644
 --- a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2699,7 +2699,7 @@ index aec4465f8a..4c8b44223c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
-index 3edc922b8f..bda2020ffe 100644
+index 3edc922b8f08..bda2020ffebb 100644
 --- a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2714,7 +2714,7 @@ index 3edc922b8f..bda2020ffe 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
-index 616e73dcf5..bcbf391a10 100644
+index 616e73dcf5ec..bcbf391a109f 100644
 --- a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2729,7 +2729,7 @@ index 616e73dcf5..bcbf391a10 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
-index 6fd95dde97..fa2bb3837f 100644
+index 6fd95dde97d0..fa2bb3837f81 100644
 --- a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2744,7 +2744,7 @@ index 6fd95dde97..fa2bb3837f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
-index 1cb4f853ab..bd46fcffc0 100644
+index 1cb4f853abba..bd46fcffc0b4 100644
 --- a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 +++ b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2759,7 +2759,7 @@ index 1cb4f853ab..bd46fcffc0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/codec_gn/moz.build b/third_party/libwebrtc/media/codec_gn/moz.build
-index cf10ada0cf..b749cab437 100644
+index cf10ada0cf66..b749cab4375c 100644
 --- a/third_party/libwebrtc/media/codec_gn/moz.build
 +++ b/third_party/libwebrtc/media/codec_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2774,7 +2774,7 @@ index cf10ada0cf..b749cab437 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_gn/moz.build b/third_party/libwebrtc/media/media_channel_gn/moz.build
-index fc0c50aa72..9449c00102 100644
+index fc0c50aa726b..9449c00102e3 100644
 --- a/third_party/libwebrtc/media/media_channel_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2789,7 +2789,7 @@ index fc0c50aa72..9449c00102 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
-index b7db93813a..5f0b214ebc 100644
+index b7db93813a60..5f0b214ebcd7 100644
 --- a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2804,7 +2804,7 @@ index b7db93813a..5f0b214ebc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_constants_gn/moz.build b/third_party/libwebrtc/media/media_constants_gn/moz.build
-index fb7440ec4a..08c077d934 100644
+index fb7440ec4a07..08c077d93411 100644
 --- a/third_party/libwebrtc/media/media_constants_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_constants_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2819,7 +2819,7 @@ index fb7440ec4a..08c077d934 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rid_description_gn/moz.build b/third_party/libwebrtc/media/rid_description_gn/moz.build
-index 22f56f08a7..c604820208 100644
+index 22f56f08a780..c604820208e3 100644
 --- a/third_party/libwebrtc/media/rid_description_gn/moz.build
 +++ b/third_party/libwebrtc/media/rid_description_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2834,7 +2834,7 @@ index 22f56f08a7..c604820208 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
-index eb9cb4e29d..4f7284c512 100644
+index eb9cb4e29d04..4f7284c512d5 100644
 --- a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2849,7 +2849,7 @@ index eb9cb4e29d..4f7284c512 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
-index 4b6ba11d76..2c88fd7135 100644
+index 4b6ba11d7681..2c88fd713531 100644
 --- a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2864,7 +2864,7 @@ index 4b6ba11d76..2c88fd7135 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
-index 10b08d64fb..e9691926eb 100644
+index 10b08d64fbe2..e9691926eb78 100644
 --- a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2879,7 +2879,7 @@ index 10b08d64fb..e9691926eb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
-index 1929dd6e93..21c90c7205 100644
+index 1929dd6e9399..21c90c720512 100644
 --- a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2894,7 +2894,7 @@ index 1929dd6e93..21c90c7205 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtp_utils_gn/moz.build b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
-index 22b3cc9d64..8bbe127ddb 100644
+index 22b3cc9d6461..8bbe127ddbb5 100644
 --- a/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2909,7 +2909,7 @@ index 22b3cc9d64..8bbe127ddb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/stream_params_gn/moz.build b/third_party/libwebrtc/media/stream_params_gn/moz.build
-index 67ed8e9a46..389484ae5a 100644
+index 67ed8e9a461d..389484ae5a68 100644
 --- a/third_party/libwebrtc/media/stream_params_gn/moz.build
 +++ b/third_party/libwebrtc/media/stream_params_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2924,7 +2924,7 @@ index 67ed8e9a46..389484ae5a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_adapter_gn/moz.build b/third_party/libwebrtc/media/video_adapter_gn/moz.build
-index 1ce6badaf8..8fbf5bde01 100644
+index 1ce6badaf84c..8fbf5bde01ee 100644
 --- a/third_party/libwebrtc/media/video_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_adapter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2939,7 +2939,7 @@ index 1ce6badaf8..8fbf5bde01 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
-index c1ebd4508d..0efea5fbdb 100644
+index c1ebd4508d5a..0efea5fbdb49 100644
 --- a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2954,7 +2954,7 @@ index c1ebd4508d..0efea5fbdb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_common_gn/moz.build b/third_party/libwebrtc/media/video_common_gn/moz.build
-index b99fdbd294..f8eb593f9d 100644
+index b99fdbd29446..f8eb593f9d78 100644
 --- a/third_party/libwebrtc/media/video_common_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2969,7 +2969,7 @@ index b99fdbd294..f8eb593f9d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_source_base_gn/moz.build b/third_party/libwebrtc/media/video_source_base_gn/moz.build
-index b74ce609e9..b5d0dba31c 100644
+index b74ce609e95f..b5d0dba31c19 100644
 --- a/third_party/libwebrtc/media/video_source_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_source_base_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2984,7 +2984,7 @@ index b74ce609e9..b5d0dba31c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
-index 495a5d8cac..fbaede458a 100644
+index 495a5d8cac13..fbaede458a8f 100644
 --- a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2999,7 +2999,7 @@ index 495a5d8cac..fbaede458a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
-index 995b2a2a3b..6e189825b8 100644
+index 995b2a2a3b31..6e189825b893 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3014,7 +3014,7 @@ index 995b2a2a3b..6e189825b8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
-index 470578709e..182b02b3ac 100644
+index 470578709e2f..182b02b3ac5b 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3029,7 +3029,7 @@ index 470578709e..182b02b3ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
-index e484426fd2..b6195f87e0 100644
+index e484426fd2ab..b6195f87e0fd 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3044,7 +3044,7 @@ index e484426fd2..b6195f87e0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
-index 1e7e932b55..87d4e2c3a3 100644
+index 1e7e932b55da..87d4e2c3a375 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3059,7 +3059,7 @@ index 1e7e932b55..87d4e2c3a3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
-index 92221fcca1..5a2f9abe58 100644
+index 92221fcca1a0..5a2f9abe5853 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3074,7 +3074,7 @@ index 92221fcca1..5a2f9abe58 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
-index cb6c943d7c..842e71ab1e 100644
+index cb6c943d7c37..842e71ab1e05 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3089,7 +3089,7 @@ index cb6c943d7c..842e71ab1e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
-index a0d24b9a5d..5254b2ec50 100644
+index a0d24b9a5d28..5254b2ec5016 100644
 --- a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3104,7 +3104,7 @@ index a0d24b9a5d..5254b2ec50 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
-index dcf3567d5c..81256b0baa 100644
+index dcf3567d5c55..81256b0baa34 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3119,7 +3119,7 @@ index dcf3567d5c..81256b0baa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
-index b6962f1786..67ffd22812 100644
+index b6962f1786ab..67ffd22812d3 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3134,7 +3134,7 @@ index b6962f1786..67ffd22812 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
-index 99188c0a58..99f4403cfc 100644
+index 99188c0a5833..99f4403cfc64 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3149,7 +3149,7 @@ index 99188c0a58..99f4403cfc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
-index 56ac627776..7c1e7e68d3 100644
+index 56ac627776c9..7c1e7e68d34c 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3164,7 +3164,7 @@ index 56ac627776..7c1e7e68d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
-index 9c374405df..f4cd791e9f 100644
+index 9c374405df33..f4cd791e9f31 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 @@ -222,6 +222,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3179,7 +3179,7 @@ index 9c374405df..f4cd791e9f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
-index f3546882a1..93cd8f1d5c 100644
+index f3546882a1a3..93cd8f1d5ce9 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3194,7 +3194,7 @@ index f3546882a1..93cd8f1d5c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
-index c0b5ae4a7a..8753166af0 100644
+index c0b5ae4a7a4c..8753166af027 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3209,7 +3209,7 @@ index c0b5ae4a7a..8753166af0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
-index 15040244a1..fe5c0c394e 100644
+index 15040244a118..fe5c0c394ec8 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3224,7 +3224,7 @@ index 15040244a1..fe5c0c394e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
-index c03333a319..beadda7e8a 100644
+index c03333a31981..beadda7e8a91 100644
 --- a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3239,7 +3239,7 @@ index c03333a319..beadda7e8a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
-index a017d70518..0f2809ec51 100644
+index a017d70518e7..0f2809ec51ba 100644
 --- a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 @@ -188,6 +188,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3254,7 +3254,7 @@ index a017d70518..0f2809ec51 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
-index 1e7a8e8f65..d994147596 100644
+index 1e7a8e8f6560..d9941475969b 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3269,7 +3269,7 @@ index 1e7a8e8f65..d994147596 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
-index 2a2a254233..2a25d44721 100644
+index 2a2a2542335b..2a25d447216c 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3284,7 +3284,7 @@ index 2a2a254233..2a25d44721 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
-index 02ef2ce08e..01928268a1 100644
+index 02ef2ce08e9c..01928268a17a 100644
 --- a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3299,7 +3299,7 @@ index 02ef2ce08e..01928268a1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
-index 02f3bf49e1..edb2870971 100644
+index 02f3bf49e1c1..edb2870971b3 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3314,7 +3314,7 @@ index 02f3bf49e1..edb2870971 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
-index 9665cd22c6..7e110948ff 100644
+index 9665cd22c68e..7e110948ffd5 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3329,7 +3329,7 @@ index 9665cd22c6..7e110948ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
-index 2d219b5cc0..b432e58ff9 100644
+index 2d219b5cc091..b432e58ff912 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 @@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3344,7 +3344,7 @@ index 2d219b5cc0..b432e58ff9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
-index 4c1faef881..2dace42c23 100644
+index 4c1faef88198..2dace42c235e 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3359,7 +3359,7 @@ index 4c1faef881..2dace42c23 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
-index acd3896de1..c093add857 100644
+index acd3896de105..c093add85735 100644
 --- a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3374,7 +3374,7 @@ index acd3896de1..c093add857 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
-index 24bd59bd53..eac3cf70bf 100644
+index 24bd59bd5356..eac3cf70bf93 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3389,7 +3389,7 @@ index 24bd59bd53..eac3cf70bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
-index c32088c064..9dc3a5f0b7 100644
+index c32088c064a8..9dc3a5f0b7d8 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3404,7 +3404,7 @@ index c32088c064..9dc3a5f0b7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
-index f994d264fc..b8abfc845a 100644
+index f994d264fc0d..b8abfc845a07 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3419,7 +3419,7 @@ index f994d264fc..b8abfc845a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
-index bfab3391fd..5199751374 100644
+index bfab3391fd95..5199751374e7 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3434,7 +3434,7 @@ index bfab3391fd..5199751374 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
-index 8c8af7ad02..44a5bc121e 100644
+index 8c8af7ad0246..44a5bc121e81 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3449,7 +3449,7 @@ index 8c8af7ad02..44a5bc121e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
-index f29e375961..af371904ec 100644
+index f29e37596167..af371904ec80 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3464,7 +3464,7 @@ index f29e375961..af371904ec 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
-index b984c66872..1560ad3e8c 100644
+index b984c66872a1..1560ad3e8cf3 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 @@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3479,7 +3479,7 @@ index b984c66872..1560ad3e8c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
-index 636d54205e..e87539fa35 100644
+index 636d54205ecc..e87539fa3525 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3494,7 +3494,7 @@ index 636d54205e..e87539fa35 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
-index 0399096915..4957767a97 100644
+index 0399096915b4..4957767a97d1 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3509,7 +3509,7 @@ index 0399096915..4957767a97 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
-index 52ec8e5f7d..59db026889 100644
+index 52ec8e5f7dfc..59db026889b3 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3524,7 +3524,7 @@ index 52ec8e5f7d..59db026889 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
-index 712a4c3571..84ab412231 100644
+index 712a4c357172..84ab4122315b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3539,7 +3539,7 @@ index 712a4c3571..84ab412231 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
-index 198f71db43..4feed4a459 100644
+index 198f71db4371..4feed4a45991 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3554,7 +3554,7 @@ index 198f71db43..4feed4a459 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
-index ad723168ab..e3aa1dd5a2 100644
+index ad723168abdc..e3aa1dd5a2a0 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3569,7 +3569,7 @@ index ad723168ab..e3aa1dd5a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
-index ef89571bee..bde87ed337 100644
+index ef89571beeca..bde87ed33792 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3584,7 +3584,7 @@ index ef89571bee..bde87ed337 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
-index fc1a743ada..83fc157f7d 100644
+index fc1a743ada41..83fc157f7dec 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 @@ -179,6 +179,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3603,7 +3603,7 @@ index fc1a743ada..83fc157f7d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
-index c365d82510..070881ded9 100644
+index c365d8251091..070881ded96b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3618,7 +3618,7 @@ index c365d82510..070881ded9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
-index 7f018adae5..8506cfbd59 100644
+index 7f018adae5f0..8506cfbd594b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3633,7 +3633,7 @@ index 7f018adae5..8506cfbd59 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
-index d129ca31f3..47ce5fd532 100644
+index d129ca31f30f..47ce5fd532fd 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3648,7 +3648,7 @@ index d129ca31f3..47ce5fd532 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
-index 1b5ce0bb90..c43e8fceb1 100644
+index 1b5ce0bb9058..c43e8fceb193 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3663,7 +3663,7 @@ index 1b5ce0bb90..c43e8fceb1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
-index 3015020227..aa570bdf4b 100644
+index 301502022710..aa570bdf4b9b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3678,7 +3678,7 @@ index 3015020227..aa570bdf4b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
-index fe132f5f69..da0e8c7f46 100644
+index fe132f5f694c..da0e8c7f4639 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3693,7 +3693,7 @@ index fe132f5f69..da0e8c7f46 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
-index ae1541ded6..b3a96fea24 100644
+index ae1541ded6d8..b3a96fea24c2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3708,7 +3708,7 @@ index ae1541ded6..b3a96fea24 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
-index 64f1d62c2d..9b5bddda30 100644
+index 64f1d62c2def..9b5bddda30f9 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3723,7 +3723,7 @@ index 64f1d62c2d..9b5bddda30 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
-index bc5907abea..ee5749e503 100644
+index bc5907abea35..ee5749e50363 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3738,7 +3738,7 @@ index bc5907abea..ee5749e503 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
-index ed716566a4..03ed3a3a29 100644
+index ed716566a46d..03ed3a3a293b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3753,7 +3753,7 @@ index ed716566a4..03ed3a3a29 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
-index 41cc418007..b5d89e4790 100644
+index 41cc41800770..b5d89e479085 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3768,7 +3768,7 @@ index 41cc418007..b5d89e4790 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
-index 9736df4522..a7fb934a34 100644
+index 9736df45221e..a7fb934a3473 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3783,7 +3783,7 @@ index 9736df4522..a7fb934a34 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
-index cd4bf21946..1d382745e8 100644
+index cd4bf219463d..1d382745e827 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3798,7 +3798,7 @@ index cd4bf21946..1d382745e8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
-index 59a2714924..355c585694 100644
+index 59a271492490..355c5856949e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3813,7 +3813,7 @@ index 59a2714924..355c585694 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
-index bce906f682..93406719a2 100644
+index bce906f682e9..93406719a2d0 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3828,7 +3828,7 @@ index bce906f682..93406719a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
-index 06d77c98fd..07f0840a6f 100644
+index 06d77c98fdb8..07f0840a6fc5 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3843,7 +3843,7 @@ index 06d77c98fd..07f0840a6f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
-index 9c27c5284f..89078be592 100644
+index 9c27c5284f73..89078be5920c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3858,7 +3858,7 @@ index 9c27c5284f..89078be592 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
-index c06de8a64d..5606c2a7f4 100644
+index c06de8a64d6b..5606c2a7f4e2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3873,7 +3873,7 @@ index c06de8a64d..5606c2a7f4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
-index 68a10c5f8c..f982772114 100644
+index 68a10c5f8ca5..f98277211489 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3888,7 +3888,7 @@ index 68a10c5f8c..f982772114 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
-index 8d629f368a..5f78b7c60b 100644
+index 8d629f368af1..5f78b7c60b0f 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3903,7 +3903,7 @@ index 8d629f368a..5f78b7c60b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
-index 89a8148e73..f255d2c334 100644
+index 89a8148e73b2..f255d2c3348c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3918,7 +3918,7 @@ index 89a8148e73..f255d2c334 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
-index a650860e3e..34cb04366a 100644
+index a650860e3ed1..34cb04366a07 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3933,7 +3933,7 @@ index a650860e3e..34cb04366a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
-index 33988b17e1..83d745b203 100644
+index 33988b17e143..83d745b20360 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3948,7 +3948,7 @@ index 33988b17e1..83d745b203 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
-index 1e27faa587..6be5b9b815 100644
+index 1e27faa5870d..6be5b9b81526 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3963,7 +3963,7 @@ index 1e27faa587..6be5b9b815 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
-index 6ffad46366..f9fdb45956 100644
+index 6ffad4636659..f9fdb459564c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3978,7 +3978,7 @@ index 6ffad46366..f9fdb45956 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
-index d3bb22b9a5..08e88e9d82 100644
+index d3bb22b9a525..08e88e9d8232 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3993,7 +3993,7 @@ index d3bb22b9a5..08e88e9d82 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
-index 271c46c540..b334441c85 100644
+index 271c46c540d7..b334441c8534 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4008,7 +4008,7 @@ index 271c46c540..b334441c85 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
-index cfb4bb8084..0d452573df 100644
+index cfb4bb80840a..0d452573df8c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4023,7 +4023,7 @@ index cfb4bb8084..0d452573df 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
-index 00e3216b45..b3e2fa8ad3 100644
+index 00e3216b4597..b3e2fa8ad395 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4038,7 +4038,7 @@ index 00e3216b45..b3e2fa8ad3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
-index 9b5e11e947..f0ba4e3ff1 100644
+index 9b5e11e947d9..f0ba4e3ff14a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4053,7 +4053,7 @@ index 9b5e11e947..f0ba4e3ff1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
-index 986ecc61c7..23f3f826ab 100644
+index 986ecc61c766..23f3f826ab1e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4068,7 +4068,7 @@ index 986ecc61c7..23f3f826ab 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
-index 894361b574..2bb4f4a1af 100644
+index 894361b57458..2bb4f4a1affc 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4083,7 +4083,7 @@ index 894361b574..2bb4f4a1af 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
-index 9f4a7293e3..52f325e274 100644
+index 9f4a7293e302..52f325e274e5 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4098,7 +4098,7 @@ index 9f4a7293e3..52f325e274 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
-index 4acaa7f014..6856373c6a 100644
+index 4acaa7f014eb..6856373c6aa8 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4113,7 +4113,7 @@ index 4acaa7f014..6856373c6a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
-index ba09010585..2a9087fbc8 100644
+index ba0901058580..2a9087fbc863 100644
 --- a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4128,7 +4128,7 @@ index ba09010585..2a9087fbc8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
-index 2fd9b99a64..840899c2bd 100644
+index 2fd9b99a64df..840899c2bdc2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4143,7 +4143,7 @@ index 2fd9b99a64..840899c2bd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
-index 09d5dc9882..3a7c0d3e7e 100644
+index 09d5dc988247..3a7c0d3e7ef9 100644
 --- a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4158,7 +4158,7 @@ index 09d5dc9882..3a7c0d3e7e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
-index 93c673ef17..ca0192aff9 100644
+index 93c673ef1703..ca0192aff911 100644
 --- a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4173,7 +4173,7 @@ index 93c673ef17..ca0192aff9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
-index 0af06a9c35..b8e2e57e63 100644
+index 0af06a9c3544..b8e2e57e63dd 100644
 --- a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4188,7 +4188,7 @@ index 0af06a9c35..b8e2e57e63 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
-index 8b21dc34fd..40e4d2abad 100644
+index 8b21dc34fd6c..40e4d2abaddc 100644
 --- a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4203,7 +4203,7 @@ index 8b21dc34fd..40e4d2abad 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
-index f3ccbefcdb..c60ead6c16 100644
+index f3ccbefcdb8e..c60ead6c16a1 100644
 --- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4218,7 +4218,7 @@ index f3ccbefcdb..c60ead6c16 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
-index 0ec5dcb6c5..1d397b8332 100644
+index 0ec5dcb6c535..1d397b833271 100644
 --- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4233,7 +4233,7 @@ index 0ec5dcb6c5..1d397b8332 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
-index 50a6a9d55c..8125425cc9 100644
+index 50a6a9d55ce5..8125425cc94f 100644
 --- a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4248,7 +4248,7 @@ index 50a6a9d55c..8125425cc9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
-index f1b3493b7a..362afb2cd8 100644
+index f1b3493b7a96..362afb2cd88c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4263,7 +4263,7 @@ index f1b3493b7a..362afb2cd8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
-index 12b385e2e9..161fa3204e 100644
+index 12b385e2e905..161fa3204ef5 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4278,7 +4278,7 @@ index 12b385e2e9..161fa3204e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
-index f1e1bc555a..ebad818492 100644
+index f1e1bc555af4..ebad818492f3 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4293,7 +4293,7 @@ index f1e1bc555a..ebad818492 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
-index 4794a478e8..9832d3f220 100644
+index 4794a478e8a0..9832d3f2206c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4308,7 +4308,7 @@ index 4794a478e8..9832d3f220 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
-index 614d8e5ebc..0cca179347 100644
+index 614d8e5ebc43..0cca1793474a 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4323,7 +4323,7 @@ index 614d8e5ebc..0cca179347 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
-index 2a3d216e40..9ebbf45b41 100644
+index 2a3d216e40c0..9ebbf45b41e0 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4338,7 +4338,7 @@ index 2a3d216e40..9ebbf45b41 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
-index 4cb60b5d0d..59c695d21f 100644
+index 4cb60b5d0dc7..59c695d21ff4 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4353,7 +4353,7 @@ index 4cb60b5d0d..59c695d21f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
-index ad88ce9e60..da6f910c12 100644
+index ad88ce9e6090..da6f910c12cf 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
 @@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4368,7 +4368,7 @@ index ad88ce9e60..da6f910c12 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
-index 6b0c296616..c8422932df 100644
+index 6b0c2966167e..c8422932dfda 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4383,7 +4383,7 @@ index 6b0c296616..c8422932df 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
-index d229d732df..9c497d39ff 100644
+index d229d732df78..9c497d39ff31 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4398,7 +4398,7 @@ index d229d732df..9c497d39ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
-index bdf6228cc4..560dff5cd4 100644
+index bdf6228cc4e1..560dff5cd49f 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4413,7 +4413,7 @@ index bdf6228cc4..560dff5cd4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
-index 72c625902c..17370f7475 100644
+index 72c625902ca3..17370f74758c 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4428,7 +4428,7 @@ index 72c625902c..17370f7475 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
-index cb2bc83d28..33ec90a9bf 100644
+index cb2bc83d2850..33ec90a9bf5e 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4443,7 +4443,7 @@ index cb2bc83d28..33ec90a9bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
-index af00c01323..445de1ab79 100644
+index af00c0132302..445de1ab7939 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4458,7 +4458,7 @@ index af00c01323..445de1ab79 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
-index 0314d2e9f7..b37ac1a79e 100644
+index 0314d2e9f767..b37ac1a79e61 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4473,7 +4473,7 @@ index 0314d2e9f7..b37ac1a79e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
-index 9226c07dda..81fa66ddf6 100644
+index 9226c07dda23..81fa66ddf642 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4488,7 +4488,7 @@ index 9226c07dda..81fa66ddf6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
-index c2b8fead8d..a82b18fa5c 100644
+index c2b8fead8d15..a82b18fa5cd4 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4503,7 +4503,7 @@ index c2b8fead8d..a82b18fa5c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
-index a4fb8b3162..ee039ce2e3 100644
+index a4fb8b3162bd..ee039ce2e38a 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 @@ -277,6 +277,35 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4543,7 +4543,7 @@ index a4fb8b3162..ee039ce2e3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
-index 927926f3e9..e60f2879d7 100644
+index 927926f3e987..e60f2879d718 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 @@ -132,6 +132,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4559,7 +4559,7 @@ index 927926f3e9..e60f2879d7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_gn/moz.build b/third_party/libwebrtc/modules/module_api_gn/moz.build
-index 9b77a009fa..80236e4efb 100644
+index 9b77a009fa9e..80236e4efbbf 100644
 --- a/third_party/libwebrtc/modules/module_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4574,7 +4574,7 @@ index 9b77a009fa..80236e4efb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_public_gn/moz.build b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
-index 474dec6123..634cf27e15 100644
+index 474dec612359..634cf27e15f0 100644
 --- a/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4589,7 +4589,7 @@ index 474dec6123..634cf27e15 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
-index b69c69c311..3b3b0dbc5c 100644
+index b69c69c3118c..3b3b0dbc5cb3 100644
 --- a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4604,7 +4604,7 @@ index b69c69c311..3b3b0dbc5c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
-index 2e3ab3d987..9af23bc939 100644
+index 2e3ab3d9878e..9af23bc93919 100644
 --- a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4619,7 +4619,7 @@ index 2e3ab3d987..9af23bc939 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
-index d7aa189ef3..bf250e4433 100644
+index d7aa189ef37b..bf250e443318 100644
 --- a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4634,7 +4634,7 @@ index d7aa189ef3..bf250e4433 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
-index fa0e8cc1c8..3c46ab0e53 100644
+index fa0e8cc1c8f2..3c46ab0e5395 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4649,7 +4649,7 @@ index fa0e8cc1c8..3c46ab0e53 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
-index 121be23bf8..e1c4de4256 100644
+index 121be23bf87b..e1c4de4256d6 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4664,7 +4664,7 @@ index 121be23bf8..e1c4de4256 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
-index 9e1e50f3e0..f4c69ab37c 100644
+index 9e1e50f3e0e2..f4c69ab37ca5 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4679,7 +4679,7 @@ index 9e1e50f3e0..f4c69ab37c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
-index d939608111..285c0ccef4 100644
+index d9396081112f..285c0ccef4c2 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4694,7 +4694,7 @@ index d939608111..285c0ccef4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
-index 6e1dfd18c0..f1eb5b14cd 100644
+index 6e1dfd18c099..f1eb5b14cde1 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4709,7 +4709,7 @@ index 6e1dfd18c0..f1eb5b14cd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
-index d3c4652d07..8ed135c2a2 100644
+index d3c4652d07e2..8ed135c2a2f4 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4724,7 +4724,7 @@ index d3c4652d07..8ed135c2a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
-index ef12380474..932c1ce369 100644
+index ef123804746a..932c1ce369ee 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 @@ -197,6 +197,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4739,7 +4739,7 @@ index ef12380474..932c1ce369 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
-index 18691e659a..e1da5490fd 100644
+index 18691e659af3..e1da5490fdfa 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
 @@ -209,6 +209,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4754,7 +4754,7 @@ index 18691e659a..e1da5490fd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
-index bdee5bedc6..a78ffabadd 100644
+index bdee5bedc6db..a78ffabadd3e 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4769,7 +4769,7 @@ index bdee5bedc6..a78ffabadd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
-index 9afa4154ee..fc523a328e 100644
+index 9afa4154ee37..fc523a328e9f 100644
 --- a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4784,7 +4784,7 @@ index 9afa4154ee..fc523a328e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
-index 2fa1910cc8..6c2d50e960 100644
+index 2fa1910cc844..6c2d50e96027 100644
 --- a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4799,7 +4799,7 @@ index 2fa1910cc8..6c2d50e960 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
-index d1ff3aaad3..57fc6a12af 100644
+index d1ff3aaad348..57fc6a12afa5 100644
 --- a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4814,7 +4814,7 @@ index d1ff3aaad3..57fc6a12af 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/utility/utility_gn/moz.build b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
-index 97d828d64f..dafae21d5f 100644
+index 97d828d64fc1..dafae21d5fbd 100644
 --- a/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4829,7 +4829,7 @@ index 97d828d64f..dafae21d5f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
-index 6af27f618b..68ef46df66 100644
+index 6af27f618bcd..68ef46df66f2 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 @@ -185,6 +185,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4844,7 +4844,7 @@ index 6af27f618b..68ef46df66 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
-index 145e549286..b5c52722f7 100644
+index 145e54928644..b5c52722f750 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4859,7 +4859,7 @@ index 145e549286..b5c52722f7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
-index 065cf604b5..f2e93630b2 100644
+index 065cf604b5d3..f2e93630b268 100644
 --- a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4874,7 +4874,7 @@ index 065cf604b5..f2e93630b2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
-index 53a7fc384c..9bb894a49e 100644
+index 53a7fc384c3d..9bb894a49e45 100644
 --- a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4889,7 +4889,7 @@ index 53a7fc384c..9bb894a49e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
-index b9784482e9..674553fda2 100644
+index b9784482e9bd..674553fda2f8 100644
 --- a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4904,7 +4904,7 @@ index b9784482e9..674553fda2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
-index a086f7cb0b..c8c63c182b 100644
+index a086f7cb0b6f..c8c63c182bc7 100644
 --- a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4919,7 +4919,7 @@ index a086f7cb0b..c8c63c182b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
-index e8fdf3750a..78f33ae389 100644
+index e8fdf3750a0c..78f33ae389f0 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4934,7 +4934,7 @@ index e8fdf3750a..78f33ae389 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
-index ecd9c1dd8d..f0fde86029 100644
+index ecd9c1dd8d37..f0fde86029d8 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4949,7 +4949,7 @@ index ecd9c1dd8d..f0fde86029 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
-index b92c2ed528..03978f5726 100644
+index b92c2ed52823..03978f572637 100644
 --- a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4964,7 +4964,7 @@ index b92c2ed528..03978f5726 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
-index 92267a7c58..385ac6b02c 100644
+index 92267a7c583f..385ac6b02c51 100644
 --- a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4979,7 +4979,7 @@ index 92267a7c58..385ac6b02c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
-index 187cf6089c..8d44f9aa21 100644
+index 187cf6089c53..8d44f9aa2177 100644
 --- a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4994,7 +4994,7 @@ index 187cf6089c..8d44f9aa21 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
-index 09929b1d48..6565818521 100644
+index 09929b1d482a..65658185219d 100644
 --- a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5009,7 +5009,7 @@ index 09929b1d48..6565818521 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
-index 6986843464..3699238b44 100644
+index 698684346412..3699238b4492 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5024,7 +5024,7 @@ index 6986843464..3699238b44 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
-index 88f469760f..40515fd26f 100644
+index 88f469760f7f..40515fd26fcd 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5039,7 +5039,7 @@ index 88f469760f..40515fd26f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
-index d09a4aed3a..bd11fa819a 100644
+index d09a4aed3ab5..bd11fa819a39 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5054,7 +5054,7 @@ index d09a4aed3a..bd11fa819a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
-index 2bd3634ba9..cc86bd5298 100644
+index 2bd3634ba957..cc86bd52980d 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5069,7 +5069,7 @@ index 2bd3634ba9..cc86bd5298 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
-index 9c48932149..b177a6c6af 100644
+index 9c48932149b9..b177a6c6af3c 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5084,7 +5084,7 @@ index 9c48932149..b177a6c6af 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
-index 0e5991cffd..a1eda8e0e1 100644
+index 0e5991cffd44..a1eda8e0e10d 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5099,7 +5099,7 @@ index 0e5991cffd..a1eda8e0e1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
-index a311c4a802..8c81383d44 100644
+index a311c4a8024c..8c81383d449b 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5114,7 +5114,7 @@ index a311c4a802..8c81383d44 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
-index 6d87c74bd7..02fc5944f0 100644
+index 6d87c74bd732..02fc5944f0d6 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5129,7 +5129,7 @@ index 6d87c74bd7..02fc5944f0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
-index e05eebc11f..188f88c23c 100644
+index e05eebc11f52..188f88c23cf8 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5144,7 +5144,7 @@ index e05eebc11f..188f88c23c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
-index 10e36ea24c..033dfbfbe5 100644
+index 10e36ea24cf2..033dfbfbe578 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5159,7 +5159,7 @@ index 10e36ea24c..033dfbfbe5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
-index 2ab95ef629..cd036f90bb 100644
+index 2ab95ef62991..cd036f90bb3b 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5174,7 +5174,7 @@ index 2ab95ef629..cd036f90bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
-index 0e18b1aeca..3c0c4d1b83 100644
+index 0e18b1aecaed..3c0c4d1b8372 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5189,7 +5189,7 @@ index 0e18b1aeca..3c0c4d1b83 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
-index 01a6429d0c..813a0d6734 100644
+index 01a6429d0cdf..813a0d673454 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5204,7 +5204,7 @@ index 01a6429d0c..813a0d6734 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
-index 75698c304f..143d8016cc 100644
+index 75698c304f78..143d8016cc7a 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 @@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5219,7 +5219,7 @@ index 75698c304f..143d8016cc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
-index ce59cc861c..fbdbc2bcf8 100644
+index ce59cc861c99..fbdbc2bcf8f5 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5234,7 +5234,7 @@ index ce59cc861c..fbdbc2bcf8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
-index 352458cf8e..72e24edaa1 100644
+index 352458cf8e21..72e24edaa1e7 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5249,7 +5249,7 @@ index 352458cf8e..72e24edaa1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
-index 0338ba659e..b1519e2f17 100644
+index 0338ba659e01..b1519e2f179a 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5264,7 +5264,7 @@ index 0338ba659e..b1519e2f17 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
-index d7ae0d5805..6a4d3fcf8f 100644
+index d7ae0d5805b3..6a4d3fcf8fcb 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5279,7 +5279,7 @@ index d7ae0d5805..6a4d3fcf8f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
-index c0d16a8e51..9fab25c590 100644
+index c0d16a8e5163..9fab25c59070 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5294,7 +5294,7 @@ index c0d16a8e51..9fab25c590 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
-index 6abd453136..dd71c3be6b 100644
+index 6abd453136c9..dd71c3be6b35 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5309,7 +5309,7 @@ index 6abd453136..dd71c3be6b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
-index be3997a5c6..042ba845fd 100644
+index be3997a5c6c4..042ba845fdfc 100644
 --- a/third_party/libwebrtc/moz.build
 +++ b/third_party/libwebrtc/moz.build
 @@ -697,6 +697,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
@@ -5327,7 +5327,7 @@ index be3997a5c6..042ba845fd 100644
  
      DIRS += [
 diff --git a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
-index 415f09cfd1..8e39a6815b 100644
+index 415f09cfd1fe..8e39a6815b5c 100644
 --- a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5342,7 +5342,7 @@ index 415f09cfd1..8e39a6815b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
-index 9f3ce4d4b6..7d05708ab2 100644
+index 9f3ce4d4b600..7d05708ab2f3 100644
 --- a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5357,7 +5357,7 @@ index 9f3ce4d4b6..7d05708ab2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
-index 70a2aa730b..5a18fc4971 100644
+index 70a2aa730b19..5a18fc497148 100644
 --- a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5372,7 +5372,7 @@ index 70a2aa730b..5a18fc4971 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
-index 3dfd3b19d2..a269686bc3 100644
+index 3dfd3b19d24b..a269686bc379 100644
 --- a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5387,7 +5387,7 @@ index 3dfd3b19d2..a269686bc3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
-index 7b1ba50f99..13166faba8 100644
+index 7b1ba50f99cf..13166faba84f 100644
 --- a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5402,7 +5402,7 @@ index 7b1ba50f99..13166faba8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
-index c82c4c9965..48329129ba 100644
+index c82c4c9965bf..48329129ba16 100644
 --- a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5417,7 +5417,7 @@ index c82c4c9965..48329129ba 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
-index 5e5d11ff6f..23fccce8d5 100644
+index 5e5d11ff6f7e..23fccce8d58a 100644
 --- a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5432,7 +5432,7 @@ index 5e5d11ff6f..23fccce8d5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
-index 89a2c9e84e..fa6463f7dc 100644
+index 89a2c9e84e1c..fa6463f7dc2e 100644
 --- a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5447,7 +5447,7 @@ index 89a2c9e84e..fa6463f7dc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
-index b95d149625..edb05a89f3 100644
+index b95d149625ed..edb05a89f393 100644
 --- a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5462,7 +5462,7 @@ index b95d149625..edb05a89f3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/checks_gn/moz.build b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
-index f147bdc64b..ade028b3e1 100644
+index f147bdc64bd9..ade028b3e124 100644
 --- a/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5477,7 +5477,7 @@ index f147bdc64b..ade028b3e1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
-index 711466336e..15d74c507a 100644
+index 711466336e15..15d74c507a3e 100644
 --- a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5492,7 +5492,7 @@ index 711466336e..15d74c507a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
-index fa4fdc8739..fbb9672971 100644
+index fa4fdc873993..fbb9672971b5 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5507,7 +5507,7 @@ index fa4fdc8739..fbb9672971 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
-index 7c9b3edd16..b96ccfa67d 100644
+index 7c9b3edd1676..b96ccfa67d80 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5522,7 +5522,7 @@ index 7c9b3edd16..b96ccfa67d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
-index 02d364fe30..d4c7825e81 100644
+index 02d364fe30a5..d4c7825e8131 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5537,7 +5537,7 @@ index 02d364fe30..d4c7825e81 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
-index dd687b90f3..2fdd6c24f6 100644
+index dd687b90f3ff..2fdd6c24f6db 100644
 --- a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5552,7 +5552,7 @@ index dd687b90f3..2fdd6c24f6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
-index d860667eb5..ee5683a297 100644
+index d860667eb591..ee5683a29711 100644
 --- a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5567,7 +5567,7 @@ index d860667eb5..ee5683a297 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
-index 5946a30db4..cd02618cca 100644
+index 5946a30db45f..cd02618cca9b 100644
 --- a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5582,7 +5582,7 @@ index 5946a30db4..cd02618cca 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
-index fd82b23b98..89e4a04d02 100644
+index fd82b23b98e3..89e4a04d02e5 100644
 --- a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5597,7 +5597,7 @@ index fd82b23b98..89e4a04d02 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
-index 2ea470772f..0632f47c6f 100644
+index 2ea470772f4b..0632f47c6f3f 100644
 --- a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5612,7 +5612,7 @@ index 2ea470772f..0632f47c6f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
-index 09174a3a20..0223129834 100644
+index 09174a3a20ab..022312983408 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5627,7 +5627,7 @@ index 09174a3a20..0223129834 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
-index 233c203847..1bbb729d23 100644
+index 233c203847c4..1bbb729d23bc 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5642,7 +5642,7 @@ index 233c203847..1bbb729d23 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
-index 9866a74964..892b9d5894 100644
+index 9866a74964c7..892b9d589482 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5657,7 +5657,7 @@ index 9866a74964..892b9d5894 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
-index 520c4db65a..63192262a0 100644
+index 520c4db65a2b..63192262a02f 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5672,7 +5672,7 @@ index 520c4db65a..63192262a0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
-index 397f0dd3ce..c3778a2228 100644
+index 397f0dd3ce6f..c3778a222896 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5687,7 +5687,7 @@ index 397f0dd3ce..c3778a2228 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
-index 5cd3bb4a2b..0d11a128d3 100644
+index 5cd3bb4a2bf0..0d11a128d359 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5702,7 +5702,7 @@ index 5cd3bb4a2b..0d11a128d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
-index 9c3e585bf9..9f41518b20 100644
+index 9c3e585bf972..9f41518b202d 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5717,7 +5717,7 @@ index 9c3e585bf9..9f41518b20 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
-index d1b4330a18..9c69480dda 100644
+index d1b4330a18db..9c69480dda61 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5732,7 +5732,7 @@ index d1b4330a18..9c69480dda 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
-index 8e75fbc3b0..411e1effc5 100644
+index 8e75fbc3b032..411e1effc53a 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5747,7 +5747,7 @@ index 8e75fbc3b0..411e1effc5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
-index 0051ac37f9..f7be521b76 100644
+index 0051ac37f9e8..f7be521b76bf 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5762,7 +5762,7 @@ index 0051ac37f9..f7be521b76 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
-index 2c239310fc..5724d0c3a2 100644
+index 2c239310fc08..5724d0c3a2c0 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5777,7 +5777,7 @@ index 2c239310fc..5724d0c3a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
-index 87a5e335eb..eb2b13a9d5 100644
+index 87a5e335eb06..eb2b13a9d544 100644
 --- a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5792,7 +5792,7 @@ index 87a5e335eb..eb2b13a9d5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
-index 03bb1071f6..863c831e74 100644
+index 03bb1071f60c..863c831e74a0 100644
 --- a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5807,7 +5807,7 @@ index 03bb1071f6..863c831e74 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
-index 3f7a2c1ffa..c8feb06ebe 100644
+index 3f7a2c1ffa1f..c8feb06ebe2a 100644
 --- a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5822,7 +5822,7 @@ index 3f7a2c1ffa..c8feb06ebe 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
-index 06009fc866..6928e5a8d0 100644
+index 06009fc8668e..6928e5a8d0e3 100644
 --- a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5837,7 +5837,7 @@ index 06009fc866..6928e5a8d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
-index c2f9eb412b..9be9bef95f 100644
+index c2f9eb412bca..9be9bef95fc2 100644
 --- a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5852,7 +5852,7 @@ index c2f9eb412b..9be9bef95f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/logging_gn/moz.build b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
-index 2b47ed986c..3caf6f1644 100644
+index 2b47ed986c72..3caf6f16444e 100644
 --- a/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5867,7 +5867,7 @@ index 2b47ed986c..3caf6f1644 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
-index 7a54f63695..f0797ee8f7 100644
+index 7a54f6369568..f0797ee8f7d2 100644
 --- a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5882,7 +5882,7 @@ index 7a54f63695..f0797ee8f7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
-index 06a17077bb..21579b6836 100644
+index 06a17077bb82..21579b6836f3 100644
 --- a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5897,7 +5897,7 @@ index 06a17077bb..21579b6836 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
-index ea25143a15..bc55301f35 100644
+index ea25143a15aa..bc55301f3556 100644
 --- a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5912,7 +5912,7 @@ index ea25143a15..bc55301f35 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
-index 967e6e28ba..ee61c961c6 100644
+index 967e6e28ba29..ee61c961c6ef 100644
 --- a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5927,7 +5927,7 @@ index 967e6e28ba..ee61c961c6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
-index 7c0cfcf806..afcce9669e 100644
+index 7c0cfcf806a7..afcce9669ea0 100644
 --- a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5942,7 +5942,7 @@ index 7c0cfcf806..afcce9669e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
-index 9fb05f529e..fd974325cd 100644
+index 9fb05f529e15..fd974325cd73 100644
 --- a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5957,7 +5957,7 @@ index 9fb05f529e..fd974325cd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
-index 604cb9a5e8..9720569e9f 100644
+index 604cb9a5e8c8..9720569e9f45 100644
 --- a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5972,7 +5972,7 @@ index 604cb9a5e8..9720569e9f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
-index eacf185197..d86cc1dfdd 100644
+index eacf18519786..d86cc1dfdd32 100644
 --- a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5987,7 +5987,7 @@ index eacf185197..d86cc1dfdd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
-index 2ae8cf3c38..29577a4ef1 100644
+index 2ae8cf3c3837..29577a4ef101 100644
 --- a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6002,7 +6002,7 @@ index 2ae8cf3c38..29577a4ef1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
-index da5eb5b497..0115b8aa67 100644
+index da5eb5b49753..0115b8aa67a4 100644
 --- a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6017,7 +6017,7 @@ index da5eb5b497..0115b8aa67 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
-index 4de80444be..ba09c026e1 100644
+index 4de80444bef4..ba09c026e1a6 100644
 --- a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6032,7 +6032,7 @@ index 4de80444be..ba09c026e1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
-index 8c259b6765..702a66b048 100644
+index 8c259b6765c4..702a66b0487c 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6047,7 +6047,7 @@ index 8c259b6765..702a66b048 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
-index 09d6147ce1..044a2a040a 100644
+index 09d6147ce17d..044a2a040a92 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6062,7 +6062,7 @@ index 09d6147ce1..044a2a040a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
-index c2b0d4ce2f..77ed1ccd5d 100644
+index c2b0d4ce2f3a..77ed1ccd5d15 100644
 --- a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6077,7 +6077,7 @@ index c2b0d4ce2f..77ed1ccd5d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
-index 1fef37a2ba..646c506f7b 100644
+index 1fef37a2babc..646c506f7bda 100644
 --- a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6092,7 +6092,7 @@ index 1fef37a2ba..646c506f7b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/random_gn/moz.build b/third_party/libwebrtc/rtc_base/random_gn/moz.build
-index 6c9b369317..b244cf3c63 100644
+index 6c9b369317a5..b244cf3c63f9 100644
 --- a/third_party/libwebrtc/rtc_base/random_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/random_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6107,7 +6107,7 @@ index 6c9b369317..b244cf3c63 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
-index 586fc513dc..2383278249 100644
+index 586fc513dc7e..238327824942 100644
 --- a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6122,7 +6122,7 @@ index 586fc513dc..2383278249 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
-index 76d4f9d980..89fc7b6c88 100644
+index 76d4f9d980ae..89fc7b6c88d8 100644
 --- a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6137,7 +6137,7 @@ index 76d4f9d980..89fc7b6c88 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
-index c381e91cdc..93793d6d9d 100644
+index c381e91cdc55..93793d6d9d69 100644
 --- a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6152,7 +6152,7 @@ index c381e91cdc..93793d6d9d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
-index 4059c66e71..1d99acfc98 100644
+index 4059c66e7135..1d99acfc987a 100644
 --- a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6167,7 +6167,7 @@ index 4059c66e71..1d99acfc98 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
-index c8e14d5996..624ceec102 100644
+index c8e14d5996e0..624ceec10253 100644
 --- a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6182,7 +6182,7 @@ index c8e14d5996..624ceec102 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
-index a1b2840da3..8dd1830b2c 100644
+index a1b2840da3ea..8dd1830b2ccc 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6197,7 +6197,7 @@ index a1b2840da3..8dd1830b2c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
-index 6bcce7ecf5..fab2c2acf1 100644
+index 6bcce7ecf591..fab2c2acf14b 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6212,7 +6212,7 @@ index 6bcce7ecf5..fab2c2acf1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
-index 1e381892f3..1d20d4b9a8 100644
+index 1e381892f367..1d20d4b9a883 100644
 --- a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6227,7 +6227,7 @@ index 1e381892f3..1d20d4b9a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
-index f409a38347..5de066b506 100644
+index f409a3834780..5de066b506b9 100644
 --- a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6242,7 +6242,7 @@ index f409a38347..5de066b506 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
-index 31299792eb..a702ead459 100644
+index 31299792ebeb..a702ead45989 100644
 --- a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6257,7 +6257,7 @@ index 31299792eb..a702ead459 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
-index 0657de77c1..7387bc5630 100644
+index 0657de77c15b..7387bc563099 100644
 --- a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6272,7 +6272,7 @@ index 0657de77c1..7387bc5630 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
-index dcdcffdd8e..81c8160cff 100644
+index dcdcffdd8ef4..81c8160cff54 100644
 --- a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6287,7 +6287,7 @@ index dcdcffdd8e..81c8160cff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
-index 2e5c00378a..61b9d40f4d 100644
+index 2e5c00378acd..61b9d40f4d36 100644
 --- a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6302,7 +6302,7 @@ index 2e5c00378a..61b9d40f4d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
-index 572b2f62b0..65a197c457 100644
+index 572b2f62b08c..65a197c45742 100644
 --- a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6317,7 +6317,7 @@ index 572b2f62b0..65a197c457 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
-index 4b08aeb0de..7108719168 100644
+index 4b08aeb0de91..710871916811 100644
 --- a/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6332,7 +6332,7 @@ index 4b08aeb0de..7108719168 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
-index d4654af6fc..fbf7baddff 100644
+index d4654af6fc1f..fbf7baddffa2 100644
 --- a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6347,7 +6347,7 @@ index d4654af6fc..fbf7baddff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
-index 66251b8e86..73f5db2033 100644
+index 66251b8e86a1..73f5db2033e9 100644
 --- a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6362,7 +6362,7 @@ index 66251b8e86..73f5db2033 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
-index 5016b4fce0..3bd638067b 100644
+index 5016b4fce059..3bd638067b05 100644
 --- a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6377,7 +6377,7 @@ index 5016b4fce0..3bd638067b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
-index b84cec9997..05d7538439 100644
+index b84cec9997f3..05d753843959 100644
 --- a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6392,7 +6392,7 @@ index b84cec9997..05d7538439 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
-index c1704d2629..6b346305bb 100644
+index c1704d262949..6b346305bbc0 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6407,7 +6407,7 @@ index c1704d2629..6b346305bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
-index e4f72d3635..c3cf0e6275 100644
+index e4f72d363530..c3cf0e6275aa 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6422,7 +6422,7 @@ index e4f72d3635..c3cf0e6275 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
-index 98232a67bd..6c775aa652 100644
+index 98232a67bd39..6c775aa65228 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6437,7 +6437,7 @@ index 98232a67bd..6c775aa652 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
-index 40dcd7ba2f..0c08d9e2ba 100644
+index 40dcd7ba2f70..0c08d9e2ba30 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6452,7 +6452,7 @@ index 40dcd7ba2f..0c08d9e2ba 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
-index 1d1555984f..7c795caae7 100644
+index 1d1555984fb0..7c795caae78c 100644
 --- a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6467,7 +6467,7 @@ index 1d1555984f..7c795caae7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
-index 807f4726e1..0055ebd41f 100644
+index 807f4726e102..0055ebd41ff0 100644
 --- a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6482,7 +6482,7 @@ index 807f4726e1..0055ebd41f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
-index 7a5b332574..42561daf57 100644
+index 7a5b33257453..42561daf5711 100644
 --- a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6497,7 +6497,7 @@ index 7a5b332574..42561daf57 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
-index 7df25c5644..06e4935660 100644
+index 7df25c5644f1..06e4935660aa 100644
 --- a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6512,7 +6512,7 @@ index 7df25c5644..06e4935660 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
-index 17a93fe6bf..6d1e015fed 100644
+index 17a93fe6bf50..6d1e015fede3 100644
 --- a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6527,7 +6527,7 @@ index 17a93fe6bf..6d1e015fed 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
-index e0c1fd16dc..396a651192 100644
+index e0c1fd16dc3e..396a651192e5 100644
 --- a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6542,7 +6542,7 @@ index e0c1fd16dc..396a651192 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
-index 11c7d7e1a9..7e5d26eabf 100644
+index 11c7d7e1a9c3..7e5d26eabfb2 100644
 --- a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6557,7 +6557,7 @@ index 11c7d7e1a9..7e5d26eabf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
-index 72142098bf..94e93e2c94 100644
+index 72142098bf1c..94e93e2c9474 100644
 --- a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6572,7 +6572,7 @@ index 72142098bf..94e93e2c94 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
-index b6057410da..e6ac836fe8 100644
+index b6057410da79..e6ac836fe84e 100644
 --- a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6587,7 +6587,7 @@ index b6057410da..e6ac836fe8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
-index cd7049d1e1..ff094d9427 100644
+index cd7049d1e1ad..ff094d942773 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6602,7 +6602,7 @@ index cd7049d1e1..ff094d9427 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
-index b4ca57145c..be9d399baf 100644
+index b4ca57145cff..be9d399baf38 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6617,7 +6617,7 @@ index b4ca57145c..be9d399baf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/threading_gn/moz.build b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
-index 53ae39a124..679258f514 100644
+index 53ae39a12405..679258f514dd 100644
 --- a/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6632,7 +6632,7 @@ index 53ae39a124..679258f514 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
-index 55044da704..54b8976af8 100644
+index 55044da704f0..54b8976af8d0 100644
 --- a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6647,7 +6647,7 @@ index 55044da704..54b8976af8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
-index 6e5a6266c9..bd1429ccb8 100644
+index 6e5a6266c98d..bd1429ccb868 100644
 --- a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6662,7 +6662,7 @@ index 6e5a6266c9..bd1429ccb8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
-index 144e5ff789..d96430b2e7 100644
+index 144e5ff789f9..d96430b2e780 100644
 --- a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6677,7 +6677,7 @@ index 144e5ff789..d96430b2e7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
-index 1a73da55be..ab73c96ec8 100644
+index 1a73da55be6d..ab73c96ec8a8 100644
 --- a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6692,7 +6692,7 @@ index 1a73da55be..ab73c96ec8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
-index 24bcc6accf..2f76d89047 100644
+index 24bcc6accf79..2f76d89047de 100644
 --- a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6707,7 +6707,7 @@ index 24bcc6accf..2f76d89047 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
-index 3cb03f6879..9a3495582c 100644
+index 3cb03f687969..9a3495582c7a 100644
 --- a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6722,7 +6722,7 @@ index 3cb03f6879..9a3495582c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
-index cd0bc1b144..6bfcafef69 100644
+index cd0bc1b144b8..6bfcafef69be 100644
 --- a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6737,7 +6737,7 @@ index cd0bc1b144..6bfcafef69 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
-index 30aa20ae3e..1a9247571a 100644
+index 30aa20ae3ede..1a9247571a3b 100644
 --- a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6752,7 +6752,7 @@ index 30aa20ae3e..1a9247571a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
-index 2347fbcbac..64db8cecaa 100644
+index 2347fbcbacf5..64db8cecaa80 100644
 --- a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6767,7 +6767,7 @@ index 2347fbcbac..64db8cecaa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
-index 161fe336d9..65d379234a 100644
+index 161fe336d913..65d379234a18 100644
 --- a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6782,7 +6782,7 @@ index 161fe336d9..65d379234a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
-index 26939945bf..9ccc1b5e02 100644
+index 26939945bfb9..9ccc1b5e02f2 100644
 --- a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 +++ b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6797,7 +6797,7 @@ index 26939945bf..9ccc1b5e02 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
-index 5a0d4a3984..4ea4016ab1 100644
+index 5a0d4a3984ef..4ea4016ab1fc 100644
 --- a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 +++ b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6812,7 +6812,7 @@ index 5a0d4a3984..4ea4016ab1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
-index 696c19c0a0..8fe6e8be01 100644
+index 696c19c0a090..8fe6e8be0139 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6827,7 +6827,7 @@ index 696c19c0a0..8fe6e8be01 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
-index 376a6873a7..e6157f2d3e 100644
+index 376a6873a7de..e6157f2d3e2b 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6842,7 +6842,7 @@ index 376a6873a7..e6157f2d3e 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
-index 1dbf8b3037..7cf1035a0b 100644
+index 1dbf8b303711..7cf1035a0bf2 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6857,7 +6857,7 @@ index 1dbf8b3037..7cf1035a0b 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
-index c74d13c51a..04eb10e737 100644
+index c74d13c51a7f..04eb10e73716 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6872,7 +6872,7 @@ index c74d13c51a..04eb10e737 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
-index 5cd792ccd5..f01a3d7920 100644
+index 5cd792ccd5d2..f01a3d7920fa 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6887,7 +6887,7 @@ index 5cd792ccd5..f01a3d7920 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
-index 26296e769d..8e63fb471e 100644
+index 26296e769d53..8e63fb471ea1 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6902,7 +6902,7 @@ index 26296e769d..8e63fb471e 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
-index 284ba12620..25693df8ca 100644
+index 284ba1262009..25693df8caa1 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6917,7 +6917,7 @@ index 284ba12620..25693df8ca 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
-index f152e046ce..bcbd06dea2 100644
+index f152e046ce64..bcbd06dea262 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6932,7 +6932,7 @@ index f152e046ce..bcbd06dea2 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
-index 67100a4772..bc4df9942b 100644
+index 67100a47728f..bc4df9942bdf 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6947,7 +6947,7 @@ index 67100a4772..bc4df9942b 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
-index 06b91ef80d..c89bb5e994 100644
+index 06b91ef80d22..c89bb5e99493 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6962,7 +6962,7 @@ index 06b91ef80d..c89bb5e994 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
-index 8ed66c3ce2..ca4101d72c 100644
+index 8ed66c3ce2c6..ca4101d72c10 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6977,7 +6977,7 @@ index 8ed66c3ce2..ca4101d72c 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
-index 0f3944e348..0e30135bbb 100644
+index 0f3944e348c4..0e30135bbb61 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -6992,7 +6992,7 @@ index 0f3944e348..0e30135bbb 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
-index 758e27e19b..ebac3923d8 100644
+index 758e27e19bdf..ebac3923d884 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7007,7 +7007,7 @@ index 758e27e19b..ebac3923d8 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
-index 0aeeb25380..8095e437b2 100644
+index 0aeeb25380b2..8095e437b243 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7022,7 +7022,7 @@ index 0aeeb25380..8095e437b2 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
-index 3b6744eda7..8c6de006b5 100644
+index 3b6744eda733..8c6de006b5c3 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7037,7 +7037,7 @@ index 3b6744eda7..8c6de006b5 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
-index 63e6206cdf..2af18da4ca 100644
+index 63e6206cdfb4..2af18da4caf1 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7052,7 +7052,7 @@ index 63e6206cdf..2af18da4ca 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
-index c26f1ed6a4..64f2808f3c 100644
+index c26f1ed6a481..64f2808f3c90 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7067,7 +7067,7 @@ index c26f1ed6a4..64f2808f3c 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
-index 398b663a3d..6e8505c311 100644
+index 398b663a3d1e..6e8505c31178 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7082,7 +7082,7 @@ index 398b663a3d..6e8505c311 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
-index 6d2e55152f..67080088dd 100644
+index 6d2e55152f52..67080088dd35 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7097,7 +7097,7 @@ index 6d2e55152f..67080088dd 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
-index 765dc92eb6..3aaddd05a8 100644
+index 765dc92eb6d3..3aaddd05a899 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7112,7 +7112,7 @@ index 765dc92eb6..3aaddd05a8 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
-index 0d1a183aba..f6a72bb07e 100644
+index 0d1a183abaf9..f6a72bb07e57 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7127,7 +7127,7 @@ index 0d1a183aba..f6a72bb07e 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
-index 4002fa6263..62943daaa9 100644
+index 4002fa626303..62943daaa989 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7142,7 +7142,7 @@ index 4002fa6263..62943daaa9 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
-index 8105bb2f27..789fb9bc7c 100644
+index 8105bb2f27d1..789fb9bc7cd6 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
 @@ -106,6 +106,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7157,7 +7157,7 @@ index 8105bb2f27..789fb9bc7c 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
-index 25164c3e5f..2c5d7f3de3 100644
+index 25164c3e5f91..2c5d7f3de36b 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7172,7 +7172,7 @@ index 25164c3e5f..2c5d7f3de3 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
-index 83007237aa..448a79a6f9 100644
+index 83007237aa43..448a79a6f908 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
 @@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7187,7 +7187,7 @@ index 83007237aa..448a79a6f9 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
-index 890fa95dc8..b399b73c72 100644
+index 890fa95dc850..b399b73c72bc 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7202,7 +7202,7 @@ index 890fa95dc8..b399b73c72 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
-index 438c3e8f7c..f64a2b73bf 100644
+index 438c3e8f7ca6..f64a2b73bf2a 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7217,7 +7217,7 @@ index 438c3e8f7c..f64a2b73bf 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
-index b548c0214b..dc3a973fe5 100644
+index b548c0214b55..dc3a973fe547 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7232,7 +7232,7 @@ index b548c0214b..dc3a973fe5 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
-index c47e664912..6738c524bc 100644
+index c47e6649127c..6738c524bc3a 100644
 --- a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
 @@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
@@ -7247,7 +7247,7 @@ index c47e664912..6738c524bc 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
-index a3038e0c4a..b7f3404ef0 100644
+index a3038e0c4a61..b7f3404ef0e7 100644
 --- a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 @@ -133,6 +133,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7262,7 +7262,7 @@ index a3038e0c4a..b7f3404ef0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
-index 836a04a7c7..dc7c06ffc2 100644
+index 836a04a7c723..dc7c06ffc21f 100644
 --- a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 @@ -105,6 +105,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7278,7 +7278,7 @@ index 836a04a7c7..dc7c06ffc2 100644
  
      DEFINES["PFFFT_SIMD_DISABLE"] = True
 diff --git a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
-index b10b4c330e..2dfd79a68c 100644
+index b10b4c330ef8..2dfd79a68cf7 100644
 --- a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 @@ -104,6 +104,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7293,7 +7293,7 @@ index b10b4c330e..2dfd79a68c 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
-index 54334034a2..a361d16f18 100644
+index 54334034a290..a361d16f1813 100644
 --- a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7308,7 +7308,7 @@ index 54334034a2..a361d16f18 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
-index 605a6b14f7..dfe435da93 100644
+index 605a6b14f7f5..dfe435da93a7 100644
 --- a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7323,7 +7323,7 @@ index 605a6b14f7..dfe435da93 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/streams_config_gn/moz.build b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
-index 3014de4682..83fb010b0b 100644
+index 3014de468204..83fb010b0b8a 100644
 --- a/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7338,7 +7338,7 @@ index 3014de4682..83fb010b0b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
-index c1ae808ab1..ff744edf9a 100644
+index c1ae808ab1bb..ff744edf9a7e 100644
 --- a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 +++ b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7353,7 +7353,7 @@ index c1ae808ab1..ff744edf9a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
-index 6e073f2e20..e0c3d716a8 100644
+index 6e073f2e20c8..e0c3d716a817 100644
 --- a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7368,7 +7368,7 @@ index 6e073f2e20..e0c3d716a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
-index dfe1ecd08c..4f39955e9f 100644
+index dfe1ecd08c0c..4f39955e9f38 100644
 --- a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7383,7 +7383,7 @@ index dfe1ecd08c..4f39955e9f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
-index f1b85291c7..2754fa11c1 100644
+index f1b85291c770..2754fa11c163 100644
 --- a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7398,7 +7398,7 @@ index f1b85291c7..2754fa11c1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
-index 001433ce9f..9338f84a50 100644
+index 001433ce9ffe..9338f84a50f2 100644
 --- a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7413,7 +7413,7 @@ index 001433ce9f..9338f84a50 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
-index a3bf0c641a..27a5d945de 100644
+index a3bf0c641a1d..27a5d945deab 100644
 --- a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7428,7 +7428,7 @@ index a3bf0c641a..27a5d945de 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
-index 42488b31f3..721ef67ace 100644
+index 42488b31f3f8..721ef67ace64 100644
 --- a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7443,7 +7443,7 @@ index 42488b31f3..721ef67ace 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
-index 24bd462a0c..c4709991ec 100644
+index 24bd462a0c8e..c4709991ec74 100644
 --- a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7458,7 +7458,7 @@ index 24bd462a0c..c4709991ec 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
-index d1ee8ffccb..1bae2bfe1b 100644
+index d1ee8ffccb72..1bae2bfe1b1f 100644
 --- a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7473,7 +7473,7 @@ index d1ee8ffccb..1bae2bfe1b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
-index b0eb431cfb..636f41f80f 100644
+index b0eb431cfba7..636f41f80f9e 100644
 --- a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 +++ b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7488,7 +7488,7 @@ index b0eb431cfb..636f41f80f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_gn/moz.build b/third_party/libwebrtc/video/video_gn/moz.build
-index 09826d37f9..3ca669afab 100644
+index 09826d37f927..3ca669afab8b 100644
 --- a/third_party/libwebrtc/video/video_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_gn/moz.build
 @@ -174,6 +174,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7503,7 +7503,7 @@ index 09826d37f9..3ca669afab 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
-index d24bf03a59..f29c6509d4 100644
+index d24bf03a5991..f29c6509d473 100644
 --- a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7518,7 +7518,7 @@ index d24bf03a59..f29c6509d4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
-index b99c992d49..bb35fd9f65 100644
+index b99c992d4953..bb35fd9f657a 100644
 --- a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7533,7 +7533,7 @@ index b99c992d49..bb35fd9f65 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
-index a51248556a..7e4144879d 100644
+index a51248556ab1..7e4144879dd4 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7548,7 +7548,7 @@ index a51248556a..7e4144879d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
-index 7eeb5d9f42..e56f626416 100644
+index 7eeb5d9f4203..e56f626416bc 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7563,7 +7563,7 @@ index 7eeb5d9f42..e56f626416 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/webrtc_gn/moz.build b/third_party/libwebrtc/webrtc_gn/moz.build
-index 0a5908916a..4ba08802c6 100644
+index 0a5908916a50..4ba08802c685 100644
 --- a/third_party/libwebrtc/webrtc_gn/moz.build
 +++ b/third_party/libwebrtc/webrtc_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":

--- a/app-web/firefox/autobuild/patches/0006-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
+++ b/app-web/firefox/autobuild/patches/0006-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
@@ -1,7 +1,7 @@
 From 397d25f77597ecc38883743406821c33af2ee535 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:39:18 +0800
-Subject: [PATCH 06/10] enable webrtc for loongarch64 in toolkit/moz.configure
+Subject: [PATCH 06/11] enable webrtc for loongarch64 in toolkit/moz.configure
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 1 insertion(+)
 
 diff --git a/toolkit/moz.configure b/toolkit/moz.configure
-index 011eee093d..0559658ab2 100644
+index 011eee093dcf..0559658ab2ba 100644
 --- a/toolkit/moz.configure
 +++ b/toolkit/moz.configure
 @@ -1480,6 +1480,7 @@ def webrtc_default(target):

--- a/app-web/firefox/autobuild/patches/0007-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
+++ b/app-web/firefox/autobuild/patches/0007-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
@@ -1,7 +1,7 @@
 From 05fd9866c7c1f36bd7a3fbe5ed652cf2c4e2579b Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:47:26 +0800
-Subject: [PATCH 07/10] Fix libyuv unified-source and LoongArch SIMD build
+Subject: [PATCH 07/11] Fix libyuv unified-source and LoongArch SIMD build
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  3 files changed, 32 insertions(+)
 
 diff --git a/media/libyuv/libyuv/libyuv.gypi b/media/libyuv/libyuv/libyuv.gypi
-index 1fd1be71e3..fbe35fc42e 100644
+index 1fd1be71e341..fbe35fc42e6d 100644
 --- a/media/libyuv/libyuv/libyuv.gypi
 +++ b/media/libyuv/libyuv/libyuv.gypi
 @@ -80,11 +80,14 @@
@@ -38,7 +38,7 @@ index 1fd1be71e3..fbe35fc42e 100644
        'source/scale_rgb.cc',
        'source/scale_uv.cc',
 diff --git a/media/libyuv/libyuv/source/row_lasx.cc b/media/libyuv/libyuv/source/row_lasx.cc
-index 6d49aa5e8b..52fbde9c85 100644
+index 6d49aa5e8b39..52fbde9c854b 100644
 --- a/media/libyuv/libyuv/source/row_lasx.cc
 +++ b/media/libyuv/libyuv/source/row_lasx.cc
 @@ -2000,11 +2000,13 @@ void NV21ToARGBRow_LASX(const uint8_t* src_y,
@@ -82,7 +82,7 @@ index 6d49aa5e8b..52fbde9c85 100644
  }  // extern "C"
  }  // namespace libyuv
 diff --git a/media/libyuv/libyuv/source/row_lsx.cc b/media/libyuv/libyuv/source/row_lsx.cc
-index fa088c9e78..c32c718c78 100644
+index fa088c9e78a9..c32c718c78fe 100644
 --- a/media/libyuv/libyuv/source/row_lsx.cc
 +++ b/media/libyuv/libyuv/source/row_lsx.cc
 @@ -2769,11 +2769,13 @@ void HalfFloatRow_LSX(const uint16_t* src,

--- a/app-web/firefox/autobuild/patches/0008-Fix-missing-loongarch-subdir-in-libpng-moz.yaml.patch
+++ b/app-web/firefox/autobuild/patches/0008-Fix-missing-loongarch-subdir-in-libpng-moz.yaml.patch
@@ -1,7 +1,7 @@
 From 0c802396428178e63f001628597847b0ce80216f Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:45:05 +0800
-Subject: [PATCH 08/10] Fix missing loongarch subdir in libpng moz.yaml
+Subject: [PATCH 08/11] Fix missing loongarch subdir in libpng moz.yaml
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 1 insertion(+)
 
 diff --git a/media/libpng/moz.yaml b/media/libpng/moz.yaml
-index 4d193089ac..e3c63908cc 100644
+index 4d193089acd2..e3c63908cc35 100644
 --- a/media/libpng/moz.yaml
 +++ b/media/libpng/moz.yaml
 @@ -37,6 +37,7 @@ vendoring:

--- a/app-web/firefox/autobuild/patches/0009-Vendor-missing-loongarch-files-of-libpng.patch
+++ b/app-web/firefox/autobuild/patches/0009-Vendor-missing-loongarch-files-of-libpng.patch
@@ -1,7 +1,7 @@
 From 14315545094e38b9cc84883e64fb0eaa9cda2179 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:50:54 +0800
-Subject: [PATCH 09/10] Vendor missing loongarch files of libpng
+Subject: [PATCH 09/11] Vendor missing loongarch files of libpng
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -13,7 +13,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 
 diff --git a/media/libpng/loongarch/filter_lsx_intrinsics.c b/media/libpng/loongarch/filter_lsx_intrinsics.c
 new file mode 100644
-index 0000000000..af6cc763a0
+index 000000000000..af6cc763a078
 --- /dev/null
 +++ b/media/libpng/loongarch/filter_lsx_intrinsics.c
 @@ -0,0 +1,412 @@
@@ -431,7 +431,7 @@ index 0000000000..af6cc763a0
 +#endif /* PNG_READ_SUPPORTED */
 diff --git a/media/libpng/loongarch/loongarch_lsx_init.c b/media/libpng/loongarch/loongarch_lsx_init.c
 new file mode 100644
-index 0000000000..2c80fe81b6
+index 000000000000..2c80fe81b687
 --- /dev/null
 +++ b/media/libpng/loongarch/loongarch_lsx_init.c
 @@ -0,0 +1,65 @@

--- a/app-web/firefox/autobuild/patches/0010-Enable-LoongArch-LSX-optimization-for-libpng.patch
+++ b/app-web/firefox/autobuild/patches/0010-Enable-LoongArch-LSX-optimization-for-libpng.patch
@@ -1,7 +1,7 @@
 From 2a188e790e599122a70f2dec039c17a11dd8ea07 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:51:22 +0800
-Subject: [PATCH 10/10] Enable LoongArch LSX optimization for libpng
+Subject: [PATCH 10/11] Enable LoongArch LSX optimization for libpng
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  2 files changed, 14 insertions(+)
 
 diff --git a/media/libpng/moz.build b/media/libpng/moz.build
-index 663eb929fe..4ff8fa8841 100644
+index 663eb929fe2a..4ff8fa884115 100644
 --- a/media/libpng/moz.build
 +++ b/media/libpng/moz.build
 @@ -50,6 +50,13 @@ if CONFIG['INTEL_ARCHITECTURE']:
@@ -28,7 +28,7 @@ index 663eb929fe..4ff8fa8841 100644
      DEFINES['MOZ_PNG_USE_MIPS_MSA'] = True
      UNIFIED_SOURCES += [
 diff --git a/media/libpng/pnglibconf.h b/media/libpng/pnglibconf.h
-index 1cbb828436..8ef91386ff 100644
+index 1cbb828436de..8ef91386ffe4 100644
 --- a/media/libpng/pnglibconf.h
 +++ b/media/libpng/pnglibconf.h
 @@ -54,6 +54,13 @@

--- a/app-web/firefox/autobuild/patches/0011-Remove-references-to-private-members-for-MIPS.patch
+++ b/app-web/firefox/autobuild/patches/0011-Remove-references-to-private-members-for-MIPS.patch
@@ -1,0 +1,34 @@
+From 386b0d7d38162dbdf21ee833aea015c1b6aaf409 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Sat, 12 Oct 2024 10:57:33 +0800
+Subject: [PATCH 11/11] Remove references to private members for MIPS
+
+---
+ js/src/jit/mips-shared/AtomicOperations-mips-shared.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/js/src/jit/mips-shared/AtomicOperations-mips-shared.h b/js/src/jit/mips-shared/AtomicOperations-mips-shared.h
+index 5ef11fd8c27f..f48a4b6deba9 100644
+--- a/js/src/jit/mips-shared/AtomicOperations-mips-shared.h
++++ b/js/src/jit/mips-shared/AtomicOperations-mips-shared.h
+@@ -385,7 +385,7 @@ template <>
+ inline uint8_clamped js::jit::AtomicOperations::loadSafeWhenRacy(
+     uint8_clamped* addr) {
+   uint8_t v;
+-  __atomic_load(&addr->val, &v, __ATOMIC_RELAXED);
++  __atomic_load((uint8_t*)addr, &v, __ATOMIC_RELAXED);
+   return uint8_clamped(v);
+ }
+ 
+@@ -431,7 +431,7 @@ inline void js::jit::AtomicOperations::storeSafeWhenRacy(uint64_t* addr,
+ template <>
+ inline void js::jit::AtomicOperations::storeSafeWhenRacy(uint8_clamped* addr,
+                                                          uint8_clamped val) {
+-  __atomic_store(&addr->val, &val.val, __ATOMIC_RELAXED);
++  __atomic_store((uint8_t*)addr, (uint8_t*)&val, __ATOMIC_RELAXED);
+ }
+ 
+ template <>
+-- 
+2.47.0
+

--- a/app-web/firefox/autobuild/prepare
+++ b/app-web/firefox/autobuild/prepare
@@ -1,9 +1,3 @@
-abinfo "Tweaking CXXFLAGS ..."
-# FIXME: clang: error: unknown argument: '-fira-loop-pressure'
-export CXXFLAGS="${CXXFLAGS/-fira-loop-pressure/}"
-export CXXFLAGS="${CXXFLAGS/-fira-hoist-pressure/}"
-export CXXFLAGS="${CXXFLAGS/-fdeclone-ctor-dtor/}"
-
 abinfo "Preparing mozconfig ..."
 sed -e "s,@HOST@,${ARCH_TARGET[${CROSS:-ARCH}]},g" \
     -i "$SRCDIR"/autobuild/mozconfig

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=131.0.2
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- firefox: fix build on loongson3
    ... and remove CXXFLAGS hacks because autobuild4 no longer
    adds these gcc-exclusive flags when USECLANG is true.

Package(s) Affected
-------------------

- firefox: 131.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
