### PR TITLE
hmcl: update to 3.5.9.257

### DIFF
--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,5 @@
-VER=3.5.9
-SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
+VER=3.5.9.257
+SRCS="git::commit=tags/v$VER::https://github.com/HMCL-dev/HMCL"
 CHKSUMS=SKIP
-CHKUPDATE="github::repo=HMCL-dev/HMCL"
+CHKUPDATE="anitya::id=371893"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.5.9.257

Package(s) Affected
-------------------

- hmcl: 3.5.9.257

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
