### PR TITLE
android-udev: update to 20240829

### DIFF
--- a/runtime-devices/android-udev/spec
+++ b/runtime-devices/android-udev/spec
@@ -1,4 +1,4 @@
-VER=20240625
+VER=20240829
 SRCS="git::commit=tags/$VER::https://github.com/M0Rf30/android-udev-rules"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226909"


### PR DESCRIPTION
Topic Description
-----------------

- android-udev: update to 20240829
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- android-udev: 1:20240829

Security Update?
----------------

No

Build Order
-----------

```
#buildit android-udev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
