### PR TITLE
nestopia: update to 1.52.1

### DIFF
--- a/app-games/nestopia/spec
+++ b/app-games/nestopia/spec
@@ -1,4 +1,4 @@
-VER=1.51.0
-SRCS="tbl::https://github.com/0ldsk00l/nestopia/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::9dd3253629a05f68fb730e5bc59148cd5498cea359eff2cbf4202d1e1329bce9"
+VER=1.52.1
+SRCS="git::commit=tags/$VER::https://github.com/0ldsk00l/nestopia"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17534"


### PR DESCRIPTION
Topic Description
-----------------

- nestopia: update to 1.52.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nestopia: 1.52.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nestopia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
