### PR TITLE
gnutls: update to 3.8.7

### DIFF
--- a/runtime-cryptography/gnutls/spec
+++ b/runtime-cryptography/gnutls/spec
@@ -1,4 +1,4 @@
-VER=3.8.4
+VER=3.8.7
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::2bea4e154794f3f00180fa2a5c51fe8b005ac7a31cd58bd44cdfa7f36ebc3a9b"
+CHKSUMS="sha256::fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477"
 CHKUPDATE="anitya::id=1221"


### PR DESCRIPTION
Topic Description
-----------------

- gnutls: update to 3.8.7
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gnutls: 3.8.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnutls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
