### PR TITLE
iosevka-fonts: update to 31.9.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=31.8.0
+VER=31.9.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::e50fec11065acda7b39ec69a5c8cbad61064d64037596961d3d30b74750a239b \
-         sha256::a0b5e4b10337080a14131acaef950c81ffd6927d1ea46875d4df33751e6e92f3 \
-         sha256::1ee228437e621056a46845586136d2db0cbcea337851d1d450d5bdfe30e41cf0 \
-         sha256::0c9ab25d2798354780434b4fc4339b4732cceddc8aa20c993e27083abaf8262b \
-         sha256::ca5b55798ee94a518b86f2aaaf907ad7f658bf4347df7fb03538033fdba62205 \
-         sha256::dcb3f5766cb5e71017417e35541172dc260a9ece9e533f7e8d234ee16c708b2d \
-         sha256::d6ce032db2d4c27972ee5e4c19bea5d0723f2a4245ad74fecf1c8a78a9af5b0b \
-         sha256::bf889bef1c62c719c2cc3aa2842d0730df12175000d0a61d1eb6b1b989b8ee93 \
-         sha256::3287001dd8a09f9192c0ab5213108829f490bd0b1a7e58573bba99a474596d72 \
-         sha256::7280f8d24ee5714a2e8e99f6145154c5f6a7aa5ff2aaafc79a8cc6f879b80d77 \
-         sha256::13d1eaefa9de0cfee56623f595c80c8373818a59896f74930b5d557f3dad5a81 \
-         sha256::f6855e9aa2d5cf43d9deeac4f6ba199a97086fc4527a993098b58bd35fdfc0f7 \
-         sha256::510a0dad258194aadea85118c2e70284bff410774dc432d83cb88fb10a4cf2d8 \
-         sha256::59c6539a37cc936b7871a50ae056a9d3fe6286667911794354e8fbd3ac5ff2da \
-         sha256::6d4f2c966799b90b94ba606f0b1989eb26d56c43ae7ffbeed54f8391dca64899 \
-         sha256::5402c11fe71d5b2950f22161e97ffdaaa6851a5bf6824d6a308bd3b32de843c5 \
-         sha256::693991880134ec629b401bbbb69f8e65c0024e8c6d3f1f454a95f6821cdadd26 \
-         sha256::0928730699188f26db621e96e204868fabaf5f8eca60775348f220c00d0058e7 \
-         sha256::73f3eed86743876555cb74333346c869a62e86092839c3c60469135632408a8e \
-         sha256::4f12c44954344602370a63700b954766e588542dedcdd702fc65457701ec22b9 \
-         sha256::edb5c492f48ba4b677ba13ce6fd6e37b0b22232ad7bfdf3a67ca93765433ea31 \
-         sha256::fe0efcb9080d6d80464804b2ac3f1b463d9788e66eab8d3468e1f366e275ab3c \
-         sha256::126b5aae677110354a89247a2d0bcb2f1c8f71e16371ae269b1085bef9466e3f \
-         sha256::a65acbb6e5a2ef763f42c032ba11acc03475641fdcf675cb70e48d085e509c13 \
+CHKSUMS="sha256::fab599f41be6a3931812b4da4876f6c9032e7b5bc5fdf7704a7662f707bcd151 \
+         sha256::7c2720875cc7e9a0224ffadd4ff17bb2a0e71037479a05ae35bd6115bc369522 \
+         sha256::a1622aa363a64718f75db19df9d34727b4d3596fee47564fcf94048d857b05d0 \
+         sha256::948ff6ccf75834e8630b4a827fb75320b9b0cca6978adb4a99b0d96ea49dacb0 \
+         sha256::fdf7f4ee2499b53ecde53927ca4c34a9d0aa72823165dba54a1283df1ffa2609 \
+         sha256::4beabd9bc6e496fe47c26e6b6d4b1a7588502383c1662dd062eab001227addb5 \
+         sha256::07c89a857c08f8620e33f3e76e51b13358c0474561f05be63dae3b1db46a0fe2 \
+         sha256::b4f5e9c122ad4cedd062398009145f72f32636d586bc03ef599f7dd5dbc11c10 \
+         sha256::6167c5c2b9fa9a3f0471fb4349b0451fb406e6e34377f88edc83bd21eb0baac6 \
+         sha256::a7a0ebd86f1e825a148a43ef12ed695d5689cb735613c2c0c95ee7d44e622f3a \
+         sha256::bbc38c978b49b4720a63c6362642179173455398f2d62d754abd9e54af61764e \
+         sha256::dee2299547448de222f6772cb5a397aff8e2b725cbe2c9588ffb200b4fdf2c25 \
+         sha256::414f20b2db21aeff8edb8858e48ea4c586622b1c27c65d3a4d35eabf898e8d2d \
+         sha256::31647d2bde55e17a1f33eacfbd7db359d3c485c5824f6ff75b95299530dffdd8 \
+         sha256::678489161cfb4edee128b809a13a1bbb11f9359dfbd0049effa7c415edf38056 \
+         sha256::035ce15a0ae08d8697ea716bd5fc5414430aef0be33ce42457bb029bbade4a8f \
+         sha256::610a5652c7ca172551e9b56ea4652eeffcd0ae328d9666919745e20ebf94ab2e \
+         sha256::338371fdff3cb9f5faf7b9e3f2a5863093e8a998f2d743eb45be113b5a956d1e \
+         sha256::f5ad65107259644a1e8d549ecca0bad23ae0e58d16d5d6d060ed9cb32e079799 \
+         sha256::40a0f92fa401dd2e8d40833e414179c8f96e38745121119d620aee93015cab14 \
+         sha256::405e784b355706ddeddeda8d5726d010f8fe81a213d08aea060ac22e7129224b \
+         sha256::71f6cfdab8af2b37e9e965cea03cf27cee3c363a47e82fa0340d7caa84f5f22c \
+         sha256::cf7da1ddec77286ad506baf96ad4ce648ea4a5ed31133043f4d840ce8274a43f \
+         sha256::82659495e411d1bbd8123c76d9162e678b62394952fbafe4174076ecbd87763d \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 31.9.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 31.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
