### PR TITLE
libltc: update to 1.3.2

### DIFF
--- a/runtime-multimedia/libltc/spec
+++ b/runtime-multimedia/libltc/spec
@@ -1,4 +1,4 @@
-VER=1.3.1
+VER=1.3.2
 SRCS="tbl::https://github.com/x42/libltc/releases/download/v$VER/libltc-$VER.tar.gz"
-CHKSUMS="sha256::50e63eb3b767151bc0159a3cc5d426d03a42fd69029bc9b3b7c346555f4b709c"
+CHKSUMS="sha256::0a6d42cd6c21e925a27fa560dc45ac80057d275f23342102825909c02d3b1249"
 CHKUPDATE="anitya::id=1655"


### PR DESCRIPTION
Topic Description
-----------------

- libltc: update to 1.3.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libltc: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libltc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
