### PR TITLE
dex: update to 0.10.1

### DIFF
--- a/app-utils/dex/spec
+++ b/app-utils/dex/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.1
 SRCS="git::commit=tags/v$VER::https://github.com/jceb/dex.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14547"


### PR DESCRIPTION
Topic Description
-----------------

- dex: update to 0.10.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dex: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
