### PR TITLE
mimalloc: update to 2.1.7

### DIFF
--- a/runtime-common/mimalloc/spec
+++ b/runtime-common/mimalloc/spec
@@ -1,5 +1,4 @@
-VER=2.1.2
+VER=2.1.7
 SRCS="git::commit=tags/v$VER::https://github.com/microsoft/mimalloc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=233872"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- mimalloc: update to 2.1.7
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mimalloc: 2.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit mimalloc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
