### PR TITLE
lldpd: update to 1.0.18

### DIFF
--- a/app-network/lldpd/spec
+++ b/app-network/lldpd/spec
@@ -1,4 +1,4 @@
-VER=1.0.17
-SRCS="tbl::https://github.com/lldpd/lldpd/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::8ea4115e061e0dceac59761b84d21e025c48d424e632d09d1201cfdf79309bff"
+VER=1.0.18
+SRCS="git::commit=tags/$VER::https://github.com/lldpd/lldpd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14019"


### PR DESCRIPTION
Topic Description
-----------------

- lldpd: update to 1.0.18
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lldpd: 1.0.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit lldpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
