### PR TITLE
maturin: update to 1.7.4

### DIFF
--- a/lang-python/maturin/spec
+++ b/lang-python/maturin/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
+VER=1.7.4
 SRCS="git::commit=v${VER}::https://github.com/PyO3/maturin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=42653"


### PR DESCRIPTION
Topic Description
-----------------

- maturin: update to 1.7.4
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- maturin: 1.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit maturin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
