### PR TITLE
pcre: update to 8.45

### DIFF
--- a/runtime-common/pcre/spec
+++ b/runtime-common/pcre/spec
@@ -1,5 +1,4 @@
-VER=8.44
-REL=2
+VER=8.45
 SRCS="tbl::https://ftp.exim.org/pub/pcre/pcre-$VER.tar.gz"
-CHKSUMS="sha256::aecafd4af3bd0f3935721af77b889d9024b2e01d96b58471bd91a3063fb47728"
+CHKSUMS="sha256::4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09"
 CHKUPDATE="anitya::id=2610"


### PR DESCRIPTION
Topic Description
-----------------

- pcre: update to 8.45
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pcre: 8.45

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcre
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
