### PR TITLE
gh: update to 2.59.0

### DIFF
--- a/app-devel/gh/spec
+++ b/app-devel/gh/spec
@@ -1,4 +1,4 @@
-VER=2.58.0
+VER=2.59.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/cli/cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235195"


### PR DESCRIPTION
Topic Description
-----------------

- gh: update to 2.59.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- gh: 2.59.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
