### PR TITLE
cmake: update to 3.30.5

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,4 @@
-VER=3.30.4
+VER=3.30.5
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::c759c97274f1e7aaaafcb1f0d261f9de9bf3a5d6ecb7e2df616324a46fe704b2"
+CHKSUMS="sha256::9f55e1a40508f2f29b7e065fa08c29f82c402fa0402da839fffe64a25755a86d"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 3.30.5
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- cmake: 3.30.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
