### PR TITLE
rng-tools: update to 6.17

### DIFF
--- a/app-utils/rng-tools/spec
+++ b/app-utils/rng-tools/spec
@@ -1,4 +1,4 @@
-VER=6.16
-SRCS="tbl::https://github.com/nhorman/rng-tools/archive/v$VER.tar.gz"
-CHKSUMS="sha256::17666c4745fb635d91df293be188daf94b9e465d51d8503c0195fa3beb390894"
+VER=6.17
+SRCS="git::commit=tags/v$VER::https://github.com/nhorman/rng-tools"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4202"


### PR DESCRIPTION
Topic Description
-----------------

- rng-tools: update to 6.17
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rng-tools: 6.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit rng-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
