### PR TITLE
asahi-fwextract: update to 0.7.8

### DIFF
--- a/app-utils/asahi-fwextract/spec
+++ b/app-utils/asahi-fwextract/spec
@@ -1,4 +1,4 @@
-VER=0.6.21
+VER=0.7.8
 SRCS="git::commit=tags/v$VER::https://github.com/AsahiLinux/asahi-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=290641"


### PR DESCRIPTION
Topic Description
-----------------

- asahi-fwextract: update to 0.7.8
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- asahi-fwextract: 0.7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit asahi-fwextract
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
