### PR TITLE
cdrdao: update to 1.2.5

### DIFF
--- a/app-multimedia/cdrdao/spec
+++ b/app-multimedia/cdrdao/spec
@@ -1,4 +1,4 @@
-VER=1.2.4
+VER=1.2.5
 SRCS="tbl::https://sourceforge.net/projects/cdrdao/files/cdrdao-$VER.tar.bz2"
-CHKSUMS="sha256::358d9cb83370ceaecdc60564cbf14c2ea2636eac60a966e2461c011ba09853b4"
+CHKSUMS="sha256::d19b67c853c5dba2406afaab6cd788e77f35eebe634cac4679528477c7be01b6"
 CHKUPDATE="anitya::id=263"


### PR DESCRIPTION
Topic Description
-----------------

- cdrdao: update to 1.2.5
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cdrdao: 1.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit cdrdao
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
