### PR TITLE
rustc: update to 1.82.0

### DIFF
--- a/lang-rust/rustc/autobuild/defines
+++ b/lang-rust/rustc/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=rustc
 PKGEPOCH=1
 PKGSEC=devel
-PKGDEP="gcc-runtime llvm-runtime http-parser"
-BUILDDEP="cmake curl libffi llvm ninja rustc"
+PKGDEP="gcc-runtime llvm-runtime-19 http-parser"
+BUILDDEP="cmake curl libffi llvm-19 ninja rustc"
 PKGDES="General purpose, multi-paradigm programming language (compiler and runtime)"
 
 NOLTO=1

--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,7 +1,7 @@
-From 1e21011f5612a2ae77e363217060513572b379f6 Mon Sep 17 00:00:00 2001
+From 6dfb63cb3d31e7ccff3893e417c411f6d3100f1e Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
-Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
+Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
 
 ---
  compiler/rustc_target/src/spec/mod.rs                     | 1 +
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 607eeac7cc..6278e69006 100644
+index d5f227a84a..32e01bad6a 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1542,6 +1542,7 @@ supported_targets! {
+@@ -1545,6 +1545,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -36,5 +36,5 @@ index 0000000000..a11fbecc3c
 +    base
 +}
 -- 
-2.46.0
+2.47.0
 

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,7 +1,7 @@
-From 9f944a0e2c7ee6a5fee1ff41c793291712a482bf Mon Sep 17 00:00:00 2001
+From 93896c7954036ce393f7364583b75f557f44465c Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
-Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys
+Subject: [PATCH 2/3] Add MIPS definitions to vendored libffi-sys
 
 ---
  vendor/libffi-sys-2.3.0/.cargo-checksum.json |  2 +-
@@ -90,5 +90,5 @@ index e8fd86d03d..f3eb03ca3c 100644
  
  impl Default for ffi_cif {
 -- 
-2.46.0
+2.47.0
 

--- a/lang-rust/rustc/autobuild/patches/0003-Revert-Add-f16-f128-handling-in-a-couple-places.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-Revert-Add-f16-f128-handling-in-a-couple-places.patch
@@ -1,0 +1,57 @@
+From 84386164e3c2c6ac5348040bb2b662310127134e Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 18 Oct 2024 14:51:44 +0800
+Subject: [PATCH 3/3] Revert "Add f16/f128 handling in a couple places"
+
+The f16/f128 handling introduced as part of rust-lang/rustc#125016 (Update
+compiler_builtins to 0.1.114) broke compilation on LoongArch and RISC-V:
+
+error: internal compiler error: compiler/rustc_codegen_llvm/src/abi.rs:
+126:22: unsupported float: Reg { kind: Float, size: Size(2 bytes) }
+
+thread 'rustc' panicked at compiler/rustc_codegen_llvm/src/abi.rs:126:22:
+Box<dyn Any>
+
+This should be resolved with LLVM 19, but we are still on LLVM 18.
+
+Revert 99e6a28804eac57faa37134d61a2bb17069996a2 as a temporary workaround.
+
+Ref: https://github.com/rust-lang/rust/pull/125016
+---
+ compiler/rustc_codegen_llvm/src/abi.rs    | 2 --
+ compiler/rustc_target/src/abi/call/mod.rs | 2 --
+ 2 files changed, 4 deletions(-)
+
+diff --git a/compiler/rustc_codegen_llvm/src/abi.rs b/compiler/rustc_codegen_llvm/src/abi.rs
+index dea574a53c..6d1bfb42e4 100644
+--- a/compiler/rustc_codegen_llvm/src/abi.rs
++++ b/compiler/rustc_codegen_llvm/src/abi.rs
+@@ -120,10 +120,8 @@ impl LlvmType for Reg {
+         match self.kind {
+             RegKind::Integer => cx.type_ix(self.size.bits()),
+             RegKind::Float => match self.size.bits() {
+-                16 => cx.type_f16(),
+                 32 => cx.type_f32(),
+                 64 => cx.type_f64(),
+-                128 => cx.type_f128(),
+                 _ => bug!("unsupported float: {:?}", self),
+             },
+             RegKind::Vector => cx.type_vector(cx.type_i8(), self.size.bytes()),
+diff --git a/compiler/rustc_target/src/abi/call/mod.rs b/compiler/rustc_target/src/abi/call/mod.rs
+index 082c169b21..78a8de9813 100644
+--- a/compiler/rustc_target/src/abi/call/mod.rs
++++ b/compiler/rustc_target/src/abi/call/mod.rs
+@@ -238,10 +238,8 @@ impl Reg {
+                 _ => panic!("unsupported integer: {self:?}"),
+             },
+             RegKind::Float => match self.size.bits() {
+-                16 => dl.f16_align.abi,
+                 32 => dl.f32_align.abi,
+                 64 => dl.f64_align.abi,
+-                128 => dl.f128_align.abi,
+                 _ => panic!("unsupported float: {self:?}"),
+             },
+             RegKind::Vector => dl.vector_align(self.size).abi,
+-- 
+2.47.0
+

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,4 @@
-VER=1.81.0
+VER=1.82.0
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::36217ef7e32f40a180e3d79bd666b4dfdaed49dd381023a5fb765fd12d0092ce"
+CHKSUMS="sha256::1276a0bb8fa12288ba6fa96597d28b40e74c44257c051d3bc02c2b049bb38210"
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.82.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.82.0.

Package(s) Affected
-------------------

- rustc: 1:1.82.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
