### PR TITLE
pycuda: update to 2024.1.2

### DIFF
--- a/lang-python/pycuda/spec
+++ b/lang-python/pycuda/spec
@@ -1,4 +1,4 @@
-VER=2022.2.2
+VER=2024.1.2
 SRCS="tbl::https://github.com/inducer/pycuda/archive/v$VER.tar.gz"
-CHKSUMS="sha256::6e1988c53b8d1fb5f779bef7447a12da6eec39730ea974d078166664167dc635"
+CHKSUMS="sha256::b685602f97485cd39ec7f1cb2afa2aa80ea12816edc0c3a0be8fb7038eb3712b"
 CHKUPDATE="anitya::id=187675"


### PR DESCRIPTION
Topic Description
-----------------

- pycuda: update to 2024.1.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pycuda: 2024.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
