### PR TITLE
archlinux-keyring: update to 20241015

### DIFF
--- a/app-admin/archlinux-keyring/spec
+++ b/app-admin/archlinux-keyring/spec
@@ -1,4 +1,4 @@
-VER=20240709
+VER=20241015
 SRCS="git::commit=tags/$VER::https://gitlab.archlinux.org/archlinux/archlinux-keyring"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=103"


### PR DESCRIPTION
Topic Description
-----------------

- archlinux-keyring: update to 20241015
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- archlinux-keyring: 20241015

Security Update?
----------------

No

Build Order
-----------

```
#buildit archlinux-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
