### PR TITLE
opensc: update to 0.25.1

### DIFF
--- a/app-devices/opensc/spec
+++ b/app-devices/opensc/spec
@@ -1,5 +1,4 @@
-VER=0.22.0
-SRCS="tbl::https://github.com/OpenSC/OpenSC/releases/download/$VER/opensc-$VER.tar.gz"
-CHKSUMS="sha256::8d4e5347195ebea332be585df61dcc470331c26969e4b0447c851fb0844c7186"
+VER=0.25.1
+SRCS="git::commit=tags/$VER::https://github.com/OpenSC/OpenSC"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2559"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- opensc: update to 0.25.1

Package(s) Affected
-------------------

- opensc: 0.25.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opensc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
