### PR TITLE
typst: update to 0.12.0

### DIFF
--- a/app-doc/typst/spec
+++ b/app-doc/typst/spec
@@ -1,4 +1,4 @@
-VER=0.11.1
-SRCS="tbl::https://github.com/typst/typst/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::b1ba054e821073daafd90675c4822bcd8166f33fe2e3acba87ba1451a0d1fc56"
+VER=0.12.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/typst/typst"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=332526"


### PR DESCRIPTION
Topic Description
-----------------

- typst: update to 0.12.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- typst: 1:0.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit typst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
