### PR TITLE
forgejo: update to 9.0.0

### DIFF
--- a/app-web/forgejo/autobuild/patches/0001-edit-systemd-service-file-to-met-need-of-AOSC-OS.patch
+++ b/app-web/forgejo/autobuild/patches/0001-edit-systemd-service-file-to-met-need-of-AOSC-OS.patch
@@ -1,4 +1,4 @@
-From f8f45cece720e0d87dac22f5842c6af8a048e563 Mon Sep 17 00:00:00 2001
+From 6cfffc107a070c8602a6512d426cd5ec28614d90 Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Tue, 6 Aug 2024 17:19:57 +0000
 Subject: [PATCH] edit systemd service file to met need of AOSC OS
@@ -10,7 +10,7 @@ change user and group name to 'forgejo'
  1 file changed, 14 insertions(+), 17 deletions(-)
 
 diff --git a/contrib/systemd/forgejo.service b/contrib/systemd/forgejo.service
-index 04ef69adc0..191f6fd6d8 100644
+index ee019e11ea78..6fa5b497e1eb 100644
 --- a/contrib/systemd/forgejo.service
 +++ b/contrib/systemd/forgejo.service
 @@ -5,22 +5,19 @@ After=network.target
@@ -61,11 +61,13 @@ index 04ef69adc0..191f6fd6d8 100644
 -ExecStart=/usr/local/bin/forgejo web --config /etc/forgejo/app.ini
 +ExecStart=/usr/bin/forgejo web --config /etc/forgejo/app.ini
  Restart=always
--Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/var/lib/forgejo
-+Environment=USER=forgejo HOME=/home/forgejo GITEA_WORK_DIR=/var/lib/forgejo
+-Environment=USER=git HOME=/home/git FORGEJO_WORK_DIR=/var/lib/forgejo
++Environment=USER=forgejo HOME=/home/forgejo FORGEJO_WORK_DIR=/var/lib/forgejo
  # If you install Git to directory prefix other than default PATH (which happens
  # for example if you install other versions of Git side-to-side with
  # distribution version), uncomment below line and add that prefix to PATH
+
+base-commit: 12a277ed65220cc152419242280f426e84ba0e61
 -- 
-2.46.0
+2.47.0
 

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,4 +1,4 @@
-VER=8.0.3
+VER=9.0.0
 # Note: copy-repo required by auto version detection
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- forgejo: update to 9.0.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- forgejo: 9.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
