### PR TITLE
syncthing: update to 1.28.0

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,6 +1,5 @@
-VER=1.27.12
+VER=1.28.0
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::5531f0e1bb81b824a2ab62f070e745c142e1328a15229de47b0cb596b5bae417"
+CHKSUMS="sha256::73b4030f9fca381f58f4966db48cc135cd8232fe9e8853b5651de0f0bf4cfbf7"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 1.28.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- syncthing: 1.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
