### PR TITLE
picom: update to 12.3

### DIFF
--- a/desktop-wm/picom/spec
+++ b/desktop-wm/picom/spec
@@ -1,4 +1,4 @@
-VER=12.2
+VER=12.3
 SRCS="git::commit=tags/v${VER}::https://github.com/yshui/picom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=48078"


### PR DESCRIPTION
Topic Description
-----------------

- picom: update to 12.3
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- picom: 12.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit picom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
