### PR TITLE
perl-dbd-sqlite: rebuild against lastest perl

### DIFF
--- a/lang-perl/perl-dbd-sqlite/spec
+++ b/lang-perl/perl-dbd-sqlite/spec
@@ -1,5 +1,5 @@
 VER=1.63+03
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/DBD-SQLite-${VER/+/_}.tar.gz"
 CHKSUMS="sha256::04740f7f8a62b562f74a329f5c4760981e1fca823f497acd7fd07908cd690950"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=2810"


### PR DESCRIPTION
Topic Description
-----------------

- perl-dbd-sqlite: bump REL due to perl update

Package(s) Affected
-------------------

- perl-dbd-sqlite: 1.63+03-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-dbd-sqlite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
