### PR TITLE
frp: update to 0.61.0

### DIFF
--- a/app-network/frp/spec
+++ b/app-network/frp/spec
@@ -1,4 +1,4 @@
-VER=0.60.0
+VER=0.61.0
 SRCS="git::commit=tags/v$VER::https://github.com/fatedier/frp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230969"


### PR DESCRIPTION
Topic Description
-----------------

- frp: update to 0.61.0

Package(s) Affected
-------------------

- frp: 0.61.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit frp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
