### PR TITLE
iwd: update to 3.0

### DIFF
--- a/app-network/iwd/spec
+++ b/app-network/iwd/spec
@@ -1,4 +1,4 @@
-VER=1.20
+VER=3.0
 SRCS="tbl::https://mirrors.edge.kernel.org/pub/linux/network/wireless/iwd-$VER.tar.xz"
-CHKSUMS="sha256::7d51e2ccabe7c500e44061ac725dbd4f6b0fb518b5e3de1681063d0f15d3050f"
+CHKSUMS="sha256::bd167ab368b6ba302b6c948a4f41f02d233a12e20d5094b1c0393325309f8a60"
 CHKUPDATE="anitya::id=18380"


### PR DESCRIPTION
Topic Description
-----------------

- iwd: update to 3.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- iwd: 3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iwd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
