### PR TITLE
meson: update to 1.6.0

### DIFF
--- a/app-devel/meson/spec
+++ b/app-devel/meson/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.6.0
 SRCS="git::commit=tags/${VER}::https://github.com/mesonbuild/meson.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6472"


### PR DESCRIPTION
Topic Description
-----------------

- meson: update to 1.6.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- meson: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit meson
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
