### PR TITLE
neovim: update to 0.10.2

### DIFF
--- a/app-devel/tree-sitter/autobuild/beyond
+++ b/app-devel/tree-sitter/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Building the executable ..."
+cd "$SRCDIR"/cli
+cargo build --release
+
+abinfo "Installing the executable ..."
+install -Dv "$SRCDIR"/target/release/tree-sitter -t "$PKGDIR"/usr/bin

--- a/app-devel/tree-sitter/autobuild/defines
+++ b/app-devel/tree-sitter/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=tree-sitter
-PKGSEC=libs
+PKGSEC=devel
 PKGDES="An incremental parsing system for programming tools"
 
-BUILDDEP="rustc"
+BUILDDEP="rustc llvm"
 
 ABTYPE=plainmake
+NOLTO=1

--- a/app-devel/tree-sitter/spec
+++ b/app-devel/tree-sitter/spec
@@ -1,4 +1,4 @@
-VER=0.22.6
+VER=0.24.3
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=142464"

--- a/app-editors/neovim/autobuild/beyond
+++ b/app-editors/neovim/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Symlinking tree-sitter parsers for Neovim to detect ..."
+ln -sv /usr/lib/tree_sitter "$PKGDIR"/usr/share/nvim/runtime/parser

--- a/app-editors/neovim/autobuild/defines
+++ b/app-editors/neovim/autobuild/defines
@@ -4,7 +4,7 @@ PKGDES="Vim-fork focused on extensibility and usability"
 
 PKGEPOCH=1
 
-PKGDEP="luajit msgpack-c tree-sitter unibilium libvterm libuv libtermkey libluv lpeg"
+PKGDEP="luajit msgpack-c tree-sitter tree-sitter-c tree-sitter-lua tree-sitter-markdown tree-sitter-query tree-sitter-vim tree-sitter-vimdoc unibilium libvterm libuv libtermkey libluv lpeg"
 BUILDDEP="lua-mpack"
 
 CMAKE_AFTER="-DUSE_BUNDLED=OFF"

--- a/app-editors/neovim/autobuild/defines
+++ b/app-editors/neovim/autobuild/defines
@@ -4,7 +4,9 @@ PKGDES="Vim-fork focused on extensibility and usability"
 
 PKGEPOCH=1
 
-PKGDEP="luajit msgpack-c tree-sitter tree-sitter-c tree-sitter-lua tree-sitter-markdown tree-sitter-query tree-sitter-vim tree-sitter-vimdoc unibilium libvterm libuv libtermkey libluv lpeg"
+PKGDEP="luajit msgpack-c tree-sitter tree-sitter-c tree-sitter-lua \
+        tree-sitter-markdown tree-sitter-query tree-sitter-vim \
+        tree-sitter-vimdoc unibilium libvterm libuv libtermkey libluv lpeg"
 BUILDDEP="lua-mpack"
 
 CMAKE_AFTER="-DUSE_BUNDLED=OFF"

--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -1,4 +1,4 @@
-VER=0.10.0
+VER=0.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"

--- a/runtime-editors/tree-sitter-c/autobuild/beyond
+++ b/runtime-editors/tree-sitter-c/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/libtree-sitter-c.so "$PKGDIR"/usr/lib/tree_sitter/c.so

--- a/runtime-editors/tree-sitter-c/autobuild/defines
+++ b/runtime-editors/tree-sitter-c/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-c
+PKGSEC=libs
+PKGDES="C grammar for tree-sitter"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-c/spec
+++ b/runtime-editors/tree-sitter-c/spec
@@ -1,0 +1,4 @@
+VER=0.23.1
+SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter-c"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242273"

--- a/runtime-editors/tree-sitter-lua/autobuild/beyond
+++ b/runtime-editors/tree-sitter-lua/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/lib"$PKGNAME".so "$PKGDIR"/usr/lib/tree_sitter/"${PKGNAME/tree-sitter-//}".so

--- a/runtime-editors/tree-sitter-lua/autobuild/defines
+++ b/runtime-editors/tree-sitter-lua/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-lua
+PKGSEC=libs
+PKGDES="Lua grammar for tree-sitter"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-lua/spec
+++ b/runtime-editors/tree-sitter-lua/spec
@@ -1,0 +1,4 @@
+VER=0.2.0
+SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-lua"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=334876"

--- a/runtime-editors/tree-sitter-markdown/autobuild/beyond
+++ b/runtime-editors/tree-sitter-markdown/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/lib"$PKGNAME".so "$PKGDIR"/usr/lib/tree_sitter/"${PKGNAME/tree-sitter-//}".so

--- a/runtime-editors/tree-sitter-markdown/autobuild/defines
+++ b/runtime-editors/tree-sitter-markdown/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-markdown
+PKGSEC=libs
+PKGDES="Markdown grammar for tree-sitter"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-markdown/spec
+++ b/runtime-editors/tree-sitter-markdown/spec
@@ -1,0 +1,4 @@
+VER=0.3.2
+SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-markdown"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371613"

--- a/runtime-editors/tree-sitter-query/autobuild/beyond
+++ b/runtime-editors/tree-sitter-query/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/libtree-sitter-query.so "$PKGDIR"/usr/lib/tree_sitter/query.so

--- a/runtime-editors/tree-sitter-query/autobuild/defines
+++ b/runtime-editors/tree-sitter-query/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-query
+PKGSEC=libs
+PKGDES="TS query grammar for tree-sitter"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-query/spec
+++ b/runtime-editors/tree-sitter-query/spec
@@ -1,4 +1,4 @@
 VER=0.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-query"
 CHKSUMS="SKIP"
-CHKUPDATE="github::repo=tree-sitter-grammars/tree-sitter-query"
+CHKUPDATE="anitya::id=375139"

--- a/runtime-editors/tree-sitter-query/spec
+++ b/runtime-editors/tree-sitter-query/spec
@@ -1,0 +1,4 @@
+VER=0.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-query"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=tree-sitter-grammars/tree-sitter-query"

--- a/runtime-editors/tree-sitter-vim/autobuild/beyond
+++ b/runtime-editors/tree-sitter-vim/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/lib"$PKGNAME".so "$PKGDIR"/usr/lib/tree_sitter/"${PKGNAME/tree-sitter-//}".so

--- a/runtime-editors/tree-sitter-vim/autobuild/defines
+++ b/runtime-editors/tree-sitter-vim/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-vim
+PKGSEC=libs
+PKGDES="Vimscript grammar for tree-sitter"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-vim/spec
+++ b/runtime-editors/tree-sitter-vim/spec
@@ -1,4 +1,4 @@
 VER=0.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-vim"
 CHKSUMS="SKIP"
-CHKUPDATE="github::repo=tree-sitter-grammars/tree-sitter-vim"
+CHKUPDATE="anitya::id=375138"

--- a/runtime-editors/tree-sitter-vim/spec
+++ b/runtime-editors/tree-sitter-vim/spec
@@ -1,0 +1,4 @@
+VER=0.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-vim"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=tree-sitter-grammars/tree-sitter-vim"

--- a/runtime-editors/tree-sitter-vimdoc/autobuild/beyond
+++ b/runtime-editors/tree-sitter-vimdoc/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Symlinking the library ..."
+
+install -dv "$PKGDIR"/usr/lib/tree_sitter
+ln -sv /usr/lib/libtree-sitter-vimdoc.so "$PKGDIR"/usr/lib/tree_sitter/vimdoc.so

--- a/runtime-editors/tree-sitter-vimdoc/autobuild/defines
+++ b/runtime-editors/tree-sitter-vimdoc/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=tree-sitter-vimdoc
+PKGSEC=libs
+PKGDES="Tree-sitter parser for Vim help files"
+
+PKGDEP="tree-sitter"
+
+ABTYPE=plainmake

--- a/runtime-editors/tree-sitter-vimdoc/spec
+++ b/runtime-editors/tree-sitter-vimdoc/spec
@@ -1,0 +1,4 @@
+VER=3.0.0
+SRCS="git::commit=tags/v$VER::https://github.com/neovim/tree-sitter-vimdoc"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=neovim/tree-sitter-vimdoc"

--- a/runtime-editors/tree-sitter-vimdoc/spec
+++ b/runtime-editors/tree-sitter-vimdoc/spec
@@ -1,4 +1,4 @@
 VER=3.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/tree-sitter-vimdoc"
 CHKSUMS="SKIP"
-CHKUPDATE="github::repo=neovim/tree-sitter-vimdoc"
+CHKUPDATE="anitya::id=375140"


### PR DESCRIPTION
Topic Description
-----------------

- neovim: update to 0.10.2
    Co-authored-by: Suyun (@Suyun114)

Package(s) Affected
-------------------

- neovim: 1:0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree-sitter tree-sitter-c tree-sitter-lua tree-sitter-markdown tree-sitter-query tree-sitter-vim tree-sitter-vimdoc neovim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
