### PR TITLE
alacritty: update to 0.14.0

### DIFF
--- a/app-utils/alacritty/spec
+++ b/app-utils/alacritty/spec
@@ -1,4 +1,4 @@
-VER=0.13.2
+VER=0.14.0
 SRCS="git::commit=tags/v$VER::https://github.com/alacritty/alacritty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141678"


### PR DESCRIPTION
Topic Description
-----------------

- alacritty: update to 0.14.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- alacritty: 0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit alacritty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
