### PR TITLE
abbs-update-checksum: update to 0.3.0

### DIFF
--- a/app-devel/abbs-update-checksum/spec
+++ b/app-devel/abbs-update-checksum/spec
@@ -1,4 +1,4 @@
-VER=0.2.4
+VER=0.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/abbs-update-checksum"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372823"


### PR DESCRIPTION
Topic Description
-----------------

- abbs-update-checksum: update to 0.3.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- abbs-update-checksum: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit abbs-update-checksum
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
