### PR TITLE
openssl (OpenSSL): update to 3.4.0

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.3.2
+VER=3.4.0
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
+CHKSUMS="sha256::e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.3.2
+VER=3.4.0
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
+CHKSUMS="sha256::e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl+32: update to 3.4.0
- openssl: update to 3.4.0

Package(s) Affected
-------------------

- openssl: 3.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
