### PR TITLE
podman: update to 5.2.5+vsock0.7.5

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=5.2.4
+UPSTREAM_VER=5.2.5
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
@@ -7,7 +7,7 @@ GVISOR_TAP_VSOCK_VER=0.7.5
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
 SRCS="git::commit=v${UPSTREAM_VER};rename=podman-${UPSTREAM_VER}::https://github.com/containers/podman \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
-CHKSUMS="SKIP\
+CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=93284"
 SUBDIR="podman-$UPSTREAM_VER"


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.2.5+vsock0.7.5
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- podman: 5.2.5+vsock0.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
