### PR TITLE
OpenJDK Survey (Oct. 2024)

### DIFF
--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=11.0.24-ga
+UPSTREAM_VER=11.0.25-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=17.0.12-ga
+UPSTREAM_VER=17.0.13-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235001"

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=21.0.4-ga
+UPSTREAM_VER=21.0.5-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369281"

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,5 +1,5 @@
 MAJOR_VER=23
-UPSTREAM_VER=23-ga
+UPSTREAM_VER=23.0.1-ga
 VER=${UPSTREAM_VER/-/+}
 REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=8u422-ga
+UPSTREAM_VER=8u432-ga
 VER=${UPSTREAM_VER/-/+}
-REL=2
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17307"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-23: update to 23.0.1+ga
    - Track patches @ AOSC-Tracking/jdk aosc/23/23.0.1-ga
    - Ported upstream changes:
    Crash fixes:
    - 8340313: Crash due to invalid oop in nm
    - 8342701: [PPC64] TestOSRLotsOfLocals.java crashes
    - 8342496: C2/Shenandoah: SEGV in compiled code when running jcstress
    Feature fixes:
    - 8338751: ConfigureNotify behavior has changed in KWin 6.2
    tzdata update:
    - 8339803: Acknowledge case insensitive unambiguous keywords in tzdata files
    - 8340073: Support "%z" time zone abbreviation format in TZ files
    - 8339644: Improve parsing of Day/Month in tzdata rules
    - 8339637: (tz) Update Timezone Data to 2024b
    Other changes:
    - 8324672: Update jdk/java/time/tck/java/time/TCKInstant.java now() to be more robust
    - 8335267: [XWayland] move screencast tokens from .awt to .java folder
- openjdk-21: update to 21.0.5-ga
    - Track patches @ AOSC-Tracking/jdk aosc/21/21.0.5-ga
    - Merged changes from loongson/jdk21u
- openjdk-17: update to 17.0.13+ga
    - Track patches @ AOSC-Tracking/jdk aosc/17/17.0.13-ga
    - Merged changes from loongson/jdk17u
    - Added a patch to fix building on musl from Alpine
    Link: https://github.com/AOSC-Tracking/jdk/commit/c67d2e1402f8946ba213c640ed6d6d8b8c744902
- openjdk-11: update to 11.0.25+ga
    - Track patches @ AOSC-Tracking/jdk aosc/11/11.0.25-ga/base
    - Merged changes from github.com/openjdk/riscv-port-jdk11u
- openjdk-8: update to 8u432+ga
    - Track patches @ AOSC-Tracking/jdk aosc/8/8u432-ga
    - Merged changes from loongson/jdk8u

Package(s) Affected
-------------------

- openjdk-11: 3:11.0.25+ga
- openjdk-17: 3:17.0.13+ga
- openjdk-21: 3:21.0.5+ga
- openjdk-23: 3:23.0.1+ga-1
- openjdk-8: 3:8u432+ga

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjdk-8 openjdk-11 openjdk-17 openjdk-21 openjdk-23
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
