### PR TITLE
moonlight-qt: update to 6.1.0

### DIFF
--- a/app-multimedia/moonlight-qt/autobuild/build
+++ b/app-multimedia/moonlight-qt/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Configuring moonlight-qt"
+qmake-qt6 PREFIX="$PKGDIR"/usr moonlight-qt.pro
+
+abinfo "Building moonlight-qt"
+make
+
+abinfo "Installing moonlight-qt"
+make install

--- a/app-multimedia/moonlight-qt/autobuild/defines
+++ b/app-multimedia/moonlight-qt/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=moonlight-qt
 PKGDES="An open source PC client for NVIDIA GameStream"
-PKGDEP="qt-5 libdrm wayland libglvnd libva libvdpau ffmpeg openssl sdl2 sdl2-ttf opus"
+PKGDEP="qt-6 libdrm wayland libglvnd libva libvdpau ffmpeg openssl sdl2 sdl2-ttf opus"
 BUILDDEP__AMD64="ffnvcodec"
 PKGSEC=video
 
-ABTYPE=qtproj

--- a/app-multimedia/moonlight-qt/spec
+++ b/app-multimedia/moonlight-qt/spec
@@ -1,6 +1,3 @@
-VER=4.3.0
-REL=2
-SRCS="tbl::https://github.com/moonlight-stream/moonlight-qt/releases/download/v4.3.0/MoonlightSrc-4.3.0.tar.gz"
-CHKSUMS="sha256::6ad2e1d9d32758505bb770fe581b84ebc86f63b12ab7002a1ac10d136ec8b747"
-# Weird upstream package...
-SUBDIR="."
+VER=6.1.0
+SRCS="git::commit=tags/v${VER}::https://github.com/moonlight-stream/moonlight-qt.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- moonlight-qt: update to 6.1.0

Package(s) Affected
-------------------

- moonlight-qt: 6.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit moonlight-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
