### PR TITLE
intel-compute-runtime: update to 24.39.31294.12

### DIFF
--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,8 +1,8 @@
-VER=1.0.17537.20
+VER=1.0.17791.9
 LLVM_VER=15.0.7
 OPENCL_CLANG_VER=15.0.0
 SPIRV_LLVM_TRANSLATOR_VER=15.0.3
-VS_INTRINSICS_VER=0.20.0
+VS_INTRINSICS_VER=0.20.1
 SPIRV_TOOLS_VER=1.3.290.0
 
 SRCS="git::commit=tags/igc-$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.17.42
-SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero"
+VER=1.18.3
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"

--- a/runtime-devices/igsc/spec
+++ b/runtime-devices/igsc/spec
@@ -1,4 +1,4 @@
-VER=0.9.3
+VER=0.9.4
 SRCS="git::commit=tags/V$VER::https://github.com/intel/igsc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229526"

--- a/runtime-devices/metee/spec
+++ b/runtime-devices/metee/spec
@@ -1,4 +1,4 @@
-VER=4.2.0
+VER=4.2.1
 SRCS="git::commit=tags/$VER::https://github.com/intel/metee.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230452"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.35.30872.22
+VER=24.39.31294.12
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 24.39.31294.12
- intel-graphics-compiler: update to 1.0.17791.9
- level-zero: update to 1.18.3
- igsc: update to 0.9.4
- metee: update to 4.2.1

Package(s) Affected
-------------------

- igsc: 0.9.4
- intel-compute-runtime: 24.39.31294.12
- intel-graphics-compiler: 1.0.17791.9
- level-zero: 1.18.3
- metee: 4.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit metee igsc level-zero intel-graphics-compiler intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
