### PR TITLE
flask: update to 3.0.3

### DIFF
--- a/lang-python/blinker/autobuild/defines
+++ b/lang-python/blinker/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=blinker
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+BUILDDEP="setuptools flit-core"
 PKGDES="Fast, simple object-to-object and broadcast signaling"
 
 ABHOST=noarch

--- a/lang-python/blinker/spec
+++ b/lang-python/blinker/spec
@@ -1,5 +1,4 @@
-VER=1.4
-REL=5
-SRCS="tbl::https://pypi.io/packages/source/b/blinker/blinker-$VER.tar.gz"
-CHKSUMS="sha256::471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+VER=1.8.2
+SRCS="pypi::version=$VER::blinker"
+CHKSUMS="sha256::8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"
 CHKUPDATE="anitya::id=20042"

--- a/lang-python/click/autobuild/defines
+++ b/lang-python/click/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=click
 PKGSEC=python
-PKGDEP="python-3 python-2"
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="Command Line Interface Creation Kit"
 
-ABTYPE=python
+NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/click/spec
+++ b/lang-python/click/spec
@@ -1,5 +1,4 @@
-VER=7.1.2
-SRCS="https://github.com/pallets/click/archive/$VER.tar.gz"
-CHKSUMS="sha256::da626c7e5fa918a8c9bf9b5c0c0255b55469ca6b0c3cb2318ea0dc7eb05a56c3"
+VER=8.1.7
+SRCS="pypi::version=$VER::click"
+CHKSUMS="sha256::ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
 CHKUPDATE="anitya::id=3802"
-REL=2

--- a/lang-python/flask-login/autobuild/defines
+++ b/lang-python/flask-login/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="flask"
 PKGDES="User session management for Flask"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/flask-login/spec
+++ b/lang-python/flask-login/spec
@@ -1,5 +1,4 @@
-VER=0.4.1
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/F/Flask-Login/Flask-Login-$VER.tar.gz"
-CHKSUMS="sha256::c815c1ac7b3e35e2081685e389a665f2c74d7e077cb93cecabaea352da4752ec"
+VER=0.6.3
+SRCS="pypi::version=$VER::Flask-Login"
+CHKSUMS="sha256::5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333"
 CHKUPDATE="anitya::id=3868"

--- a/lang-python/flask-mail/autobuild/defines
+++ b/lang-python/flask-mail/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=flask-mail
 PKGSEC=python
 PKGDEP="flask"
+BUILDDEP="flit-core"
 PKGDES="Flask extension for sending email"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/flask-mail/spec
+++ b/lang-python/flask-mail/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-REL=4
-SRCS="tbl::https://pypi.io/packages/source/F/Flask-Mail/Flask-Mail-$VER.tar.gz"
-CHKSUMS="sha256::22e5eb9a940bf407bcf30410ecc3708f3c56cc44b29c34e1726fe85006935f41"
+VER=0.10.0
+SRCS="pypi::version=$VER::flask_mail"
+CHKSUMS="sha256::44083e7b02bbcce792209c06252f8569dd5a325a7aaa76afe7330422bd97881d"
 CHKUPDATE="anitya::id=19595"

--- a/lang-python/flask-wtf/autobuild/defines
+++ b/lang-python/flask-wtf/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=flask-wtf
 PKGSEC=python
 PKGDEP="flask werkzeug wtforms"
-BUILDDEP="setuptools sphinx"
+BUILDDEP="setuptools sphinx hatchling"
 PKGDES="Simple integration of Flask and WTForms"
 
 ABHOST=noarch

--- a/lang-python/flask-wtf/spec
+++ b/lang-python/flask-wtf/spec
@@ -1,5 +1,4 @@
-VER=0.14
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/F/Flask-WTF/Flask-WTF-$VER.tar.gz"
-CHKSUMS="sha256::a938bfabc450b61e2d76f8b32288b65d0cd43ce33c2de496e1b28152c5d141cf"
+VER=1.2.2
+SRCS="pypi::version=$VER::flask_wtf"
+CHKSUMS="sha256::79d2ee1e436cf570bccb7d916533fa18757a2f18c290accffab1b9a0b684666b"
 CHKUPDATE="anitya::id=70870"

--- a/lang-python/flask/autobuild/build
+++ b/lang-python/flask/autobuild/build
@@ -1,6 +1,0 @@
-python3 setup.py build
-python3 setup.py install --prefix=/usr --root="$PKGDIR" --optimize=1
-mv "$PKGDIR"/usr/bin/flask{,3}
-
-python2 setup.py build
-python2 setup.py install --prefix=/usr --root="$PKGDIR" --optimize=1

--- a/lang-python/flask/autobuild/defines
+++ b/lang-python/flask/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=flask
 PKGEPOCH=1
 PKGSEC=python
-PKGDEP="werkzeug jinja2 itsdangerous click markupsafe"
+PKGDEP="werkzeug jinja2 itsdangerous click markupsafe blinker"
+BUILDDEP="flit-core"
 PKGDES="Micro webdevelopment framework for Python"
 
-NOPYTHON3=1
 ABHOST=noarch

--- a/lang-python/flask/spec
+++ b/lang-python/flask/spec
@@ -1,5 +1,4 @@
-VER=1.1.2
-SRCS="tbl::https://github.com/mitsuhiko/flask/archive/$VER.tar.gz"
-CHKSUMS="sha256::6da812f0fb52ad1ccfb5b3868b1dd20e420cc6e77379c2a4ecbaccd3eceb8923"
+VER=3.0.3
+SRCS="pypi::version=$VER::flask"
+CHKSUMS="sha256::ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"
 CHKUPDATE="anitya::id=3867"
-REL=1

--- a/lang-python/itsdangerous/autobuild/defines
+++ b/lang-python/itsdangerous/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=itsdangerous
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
+BUILDDEP="flit-core"
 PKGDES="Various helpers to pass trusted data to untrusted environments"
 
-ABTYPE=python
 ABHOST=noarch

--- a/lang-python/itsdangerous/spec
+++ b/lang-python/itsdangerous/spec
@@ -1,5 +1,4 @@
-VER=1.1.0
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/i/itsdangerous/itsdangerous-$VER.tar.gz"
-CHKSUMS="sha256::321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"
+VER=2.2.0
+SRCS="pypi::version=$VER::itsdangerous"
+CHKSUMS="sha256::e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
 CHKUPDATE="anitya::id=3892"

--- a/lang-python/jinja2/autobuild/defines
+++ b/lang-python/jinja2/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=jinja2
 PKGSEC=python
-PKGDEP="setuptools markupsafe"
+PKGDEP="markupsafe"
+BUILDDEP="setuptools flit-core"
 PKGDES="A simple pythonic template language written in Python"
 
 ABHOST=noarch
-ABTYPE=python
 
 NOPYTHON2=1

--- a/lang-python/jinja2/spec
+++ b/lang-python/jinja2/spec
@@ -1,4 +1,4 @@
-VER=3.1.2
-SRCS="tbl::https://files.pythonhosted.org/packages/source/J/Jinja2/Jinja2-$VER.tar.gz"
-CHKSUMS="sha256::31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"
+VER=3.1.4
+SRCS="pypi::version=$VER::jinja2"
+CHKSUMS="sha256::4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"
 CHKUPDATE="anitya::id=3894"

--- a/lang-python/markupsafe/spec
+++ b/lang-python/markupsafe/spec
@@ -1,5 +1,4 @@
-VER=2.1.1
-REL=1
-SRCS="tbl::https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-$VER.tar.gz"
-CHKSUMS="sha256::7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"
+VER=3.0.2
+SRCS="pypi::version=$VER::markupsafe"
+CHKSUMS="sha256::ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
 CHKUPDATE="anitya::id=3918"

--- a/lang-python/werkzeug/autobuild/defines
+++ b/lang-python/werkzeug/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=werkzeug
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="pytest requests setuptools"
+PKGDEP="python-3"
+BUILDDEP="pytest requests setuptools flit-core"
 PKGDES="Swiss Army knife of Python web development"
 
-ABTYPE=python
 ABHOST=noarch

--- a/lang-python/werkzeug/spec
+++ b/lang-python/werkzeug/spec
@@ -1,5 +1,4 @@
-VER=1.0.1
-SRCS="tbl::https://pypi.io/packages/source/W/Werkzeug/Werkzeug-$VER.tar.gz"
-CHKSUMS="sha256::6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+VER=3.0.6
+SRCS="pypi::version=$VER::werkzeug"
+CHKSUMS="sha256::a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d"
 CHKUPDATE="anitya::id=4092"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- flask-wtf: update to 1.2.2
- flask-mail: update to 0.10.0
- flask-login: update to 0.6.3
- flask: update to 3.0.3
- itsdangerous: update to 2.2.0
- jinja2: update to 3.1.4
- markupsafe: update to 3.0.2
- click: update to 8.1.7
- blinker: update to 1.8.2
- werkzeug: update to 3.0.6

Package(s) Affected
-------------------

- blinker: 1.8.2
- click: 8.1.7
- flask: 1:3.0.3
- flask-login: 0.6.3
- flask-mail: 0.10.0
- flask-wtf: 1.2.2
- itsdangerous: 2.2.0
- jinja2: 3.1.4
- markupsafe: 3.0.2
- werkzeug: 3.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit markupsafe werkzeug blinker click jinja2 itsdangerous flask flask-login flask-mail flask-wtf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
