### PR TITLE
minetest: add postgresql dep

### DIFF
--- a/app-games/minetest/autobuild/defines
+++ b/app-games/minetest/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=minetest
 PKGDES="A sandbox game inspired by Minecraft"
 PKGSEC=games
-PKGDEP="openal-soft libvorbis libogg luajit zstd"
+PKGDEP="openal-soft libvorbis libogg luajit postgresql zstd"
 # FIXME: LuaJIT not available on these architectures.
 PKGDEP__LOONGARCH64="${PKGDEP/luajit/lua}"
 PKGDEP__MIPS64R6EL="${PKGDEP/luajit/lua}"

--- a/app-games/minetest/spec
+++ b/app-games/minetest/spec
@@ -3,6 +3,7 @@ UPSTREAM_VER=5.7.0
 __GAMEVER="${UPSTREAM_VER}"
 __IRRLICHTVER=1.9.0mt10
 VER=${UPSTREAM_VER}+irrlicht${__IRRLICHTVER}
+REL=2
 SRCS="tbl::https://github.com/minetest/minetest/archive/${UPSTREAM_VER}.tar.gz \
       git::commit=tags/${UPSTREAM_VER};rename=minetest_game::https://github.com/minetest/minetest_game \
       git::commit=tags/${__IRRLICHTVER};rename=irrlichtmt::https://github.com/minetest/irrlicht"
@@ -11,4 +12,3 @@ CHKSUMS="sha256::0cd0fd48a97f76e337a2e1284599a054f8f92906a84a4ef2122ed321e1b75fa
          SKIP"
 CHKUPDATE="anitya::id=1978"
 SUBDIR="minetest-${__GAMEVER}"
-REL=1

--- a/groups/postgresql-rebuilds
+++ b/groups/postgresql-rebuilds
@@ -21,3 +21,4 @@ runtime-desktop/qt-4
 runtime-desktop/qt-6
 app-productivity/libreoffice
 app-admin/p-vector
+app-games/minetest


### PR DESCRIPTION
Topic Description
-----------------

- minetest: add postgresql dep

Package(s) Affected
-------------------

- minetest: 5.7.0+irrlicht1.9.0mt10-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit minetest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
