### PR TITLE
pulsectl: drop, orphaned

### DIFF
--- a/lang-python/pulsectl/autobuild/defines
+++ b/lang-python/pulsectl/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=pulsectl
-PKGSEC=python
-PKGDES="Python binding for PulseAudio"
-PKGDEP="python-2 python-3 pulseaudio"
-
-ABHOST=noarch
-ABTYPE=python

--- a/lang-python/pulsectl/spec
+++ b/lang-python/pulsectl/spec
@@ -1,5 +1,0 @@
-VER=20.5.1
-SRCS="https://pypi.org/packages/source/p/pulsectl/pulsectl-${VER}.tar.gz"
-CHKSUMS="sha256::39b0a0e7974a7d6468d826a838822f78b00ac9c3803f0d7bfa9b1cad08ee22db"
-CHKUPDATE="anitya::id=21291"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pulsectl: drop, orphaned
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
