### PR TITLE
telegram-qt: drop, orphaned

### DIFF
--- a/runtime-web/telegram-qt/autobuild/defines
+++ b/runtime-web/telegram-qt/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=telegram-qt
-PKGSEC=libs
-PKGDEP="qt-5"
-PKGDES="Qt bindings for the Telegram/MTProto protocol"

--- a/runtime-web/telegram-qt/spec
+++ b/runtime-web/telegram-qt/spec
@@ -1,5 +1,0 @@
-VER=0.1.0
-REL=5
-SRCS="tbl::https://github.com/Kaffeine/telegram-qt/releases/download/telegram-qt-$VER/telegram-qt-$VER.tar.bz2"
-CHKSUMS="sha256::dfefa4b107455b37856728819bba0671f55ed46028cc90e534f90331299b8a86"
-CHKUPDATE="anitya::id=230547"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-qt: drop, orphaned
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- pulsectl: drop, orphaned
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
