### PR TITLE
intel-ucode: update to 20241029

### DIFF
--- a/runtime-data/intel-ucode/spec
+++ b/runtime-data/intel-ucode/spec
@@ -1,4 +1,4 @@
-VER=20240910
+VER=20241029
 SRCS="git::commit=tags/microcode-${VER}::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20614"


### PR DESCRIPTION
Topic Description
-----------------

- intel-ucode: update to 20241029
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- intel-ucode: 20241029

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ucode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
