### PR TITLE
[SECURITY] X.Org Server survey 20241030

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,7 +1,7 @@
-From 95c6d97ec82594d8ff6b471d08d39354a4846664 Mon Sep 17 00:00:00 2001
+From db964f598a52652c6d3d674a81e577ef3f01b46d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
-Subject: [PATCH 1/4] Use intel ddx only on pre-gen4 hw, newer ones will fall
+Subject: [PATCH 1/5] Use intel ddx only on pre-gen4 hw, newer ones will fall
  back to modesetting
 
 Co-authored-by: Timo Aaltonen <tjaalton@debian.org>
@@ -40,5 +40,5 @@ index aeeed8be6..db705bf72 100644
  			break;
          }
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,7 +1,7 @@
-From b7cfb88af84da6ae993a61783a4838e472ce625d Mon Sep 17 00:00:00 2001
+From d02162ee355de18fc02474a43226bed8777f734c Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
-Subject: [PATCH 2/4] xfree86: use modesetting driver by default on GeForce 8
+Subject: [PATCH 2/5] xfree86: use modesetting driver by default on GeForce 8
  and newer
 
 Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
@@ -49,5 +49,5 @@ index db705bf72..d2e78acaa 100644
  #endif
          driverList[idx++] = "nv";
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
-From 9a8b8ae9b796543fdf72cfe5300252dcd0cf54a9 Mon Sep 17 00:00:00 2001
+From 5c1585f201bc1b75eea3416ea7cff441509be526 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
-Subject: [PATCH 3/4] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 3/5] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -29,7 +29,7 @@ Ref: https://gitlab.freedesktop.org/xorg/xserver/-/commit/f59871587ea678d4c49887
  3 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/hw/xfree86/common/xf86Mode.c b/hw/xfree86/common/xf86Mode.c
-index ef3be84c3..b275ce9d8 100644
+index eb0885571..fec60a957 100644
 --- a/hw/xfree86/common/xf86Mode.c
 +++ b/hw/xfree86/common/xf86Mode.c
 @@ -230,6 +230,8 @@ xf86ModeStatusToString(ModeStatus status)
@@ -85,5 +85,5 @@ index ad01b87ec..561087717 100644
      MODE_ERROR = -1             /* error condition */
  } ModeStatus;
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,7 +1,7 @@
-From 6e32dfb23c242504e6a3cd60c5333f334cd22423 Mon Sep 17 00:00:00 2001
+From b9010be23844651b133e09921993054ed9e5c1e8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
-Subject: [PATCH 4/4] xf86: Accept devices with the 'hyperv_drm' driver
+Subject: [PATCH 4/5] xf86: Accept devices with the 'hyperv_drm' driver
 
 Put in a workaround to accept devices of the kernel's hyperv_drm
 driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics
@@ -28,5 +28,5 @@ index 45028f7a6..071f44b2a 100644
                      if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
                          break;
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,7 +1,7 @@
-From 4d915610a0da35cbfba1430ea9ab844c89238bba Mon Sep 17 00:00:00 2001
+From e98bf06b4da1a8e5791290b45eca6cb73db08ba5 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
-Subject: [PATCH] Allows X to work on the Lemote Yeeloong laptop
+Subject: [PATCH 5/5] Allows X to work on the Lemote Yeeloong laptop
 
 ---
  hw/xfree86/common/compiler.h            | 64 ++++++++++++++++++++++++-
@@ -10,19 +10,16 @@ Subject: [PATCH] Allows X to work on the Lemote Yeeloong laptop
  3 files changed, 70 insertions(+), 3 deletions(-)
 
 diff --git a/hw/xfree86/common/compiler.h b/hw/xfree86/common/compiler.h
-index 2b2008b3f..478111a27 100644
+index eb788d3fd..88b33553a 100644
 --- a/hw/xfree86/common/compiler.h
 +++ b/hw/xfree86/common/compiler.h
-@@ -519,12 +519,73 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
+@@ -518,9 +518,70 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
+     barrier();
  }
  
- #elif defined(__mips__) || (defined(__arm32__) && !defined(__linux__))
--#if defined(__arm32__) || defined(__mips64)
-+#if defined(__arm32__) || (defined(__mips64) && !defined(_MIPS_TUNE_LOONGSON2F))
+-#elif defined(__arm32__) && !defined(__linux__)
++#elif defined(__mips__) || (defined(__arm32__) && !defined(__linux__))
  #define PORT_SIZE long
- #else
- #define PORT_SIZE short
- #endif
  
 +#ifdef _MIPS_TUNE_LOONGSON2F
 +extern _X_EXPORT volatile unsigned char *ioBase;      /* Memory mapped I/O port area */
@@ -53,7 +50,7 @@ index 2b2008b3f..478111a27 100644
 +outl(unsigned PORT_SIZE port, unsigned int val)
 +{
 +    if (ioBase == MAP_FAILED)
-+        return;
++	        return;
 +    *(volatile unsigned int *) (((unsigned PORT_SIZE) (port)) + ioBase) =
 +        val;
 +}
@@ -85,10 +82,10 @@ index 2b2008b3f..478111a27 100644
 +                                       ioBase);
 +}
 +#else // !_MIPS_TUNE_LOONGSON2F
- _X_EXPORT unsigned int IOPortBase;      /* Memory mapped I/O port area */
+ extern _X_EXPORT unsigned int IOPortBase;      /* Memory mapped I/O port area */
  
  static __inline__ void
-@@ -568,6 +629,7 @@ inl(unsigned PORT_SIZE port)
+@@ -564,6 +625,7 @@ inl(unsigned PORT_SIZE port)
      return *(volatile unsigned int *) (((unsigned PORT_SIZE) (port)) +
                                         IOPortBase);
  }
@@ -110,7 +107,7 @@ index 1bef2421e..5b96e9f48 100644
  #define SAREA_MAX			0x10000 /* 64kB */
  #else
 diff --git a/hw/xfree86/os-support/linux/lnx_video.c b/hw/xfree86/os-support/linux/lnx_video.c
-index 04e45092a..5b3fab1c9 100644
+index fd83022f6..bacbe010b 100644
 --- a/hw/xfree86/os-support/linux/lnx_video.c
 +++ b/hw/xfree86/os-support/linux/lnx_video.c
 @@ -79,7 +79,7 @@ xf86OSInitVidMem(VidMemInfoPtr pVidMem)
@@ -136,5 +133,5 @@ index 04e45092a..5b3fab1c9 100644
      if (ioBase == NULL) {
          ioBase = (volatile unsigned char *) mmap(0, 0x20000,
 -- 
-2.28.0
+2.47.0
 

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,5 +1,4 @@
-VER=21.1.13
-REL=2
+VER=21.1.14
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
+CHKSUMS="sha256::8f2102cebdc4747d1656c1099ef610f5063c7422c24a177e300de569b354ee35"
 CHKUPDATE="anitya::id=5250"

--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.1
+VER=24.1.4
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::7125bee0b10335805d7f5ba57dfaa359a7850af1a68524f1d97b362741a51832"
+CHKSUMS="sha256::d96a78dbab819f55750173444444995b5031ebdcc15b77afebbd8dbc02af34f4"
 CHKUPDATE="anitya::id=180949"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 24.1.4
- xorg-server: update to 21.1.4
    Track patches at AOSC-Tracking/xserver @ aosc/xorg-server-21.1.4
    (HEAD: 6fad5ce33f0c668b01aa51d5e5bbbe2575481b75).

Package(s) Affected
-------------------

- xorg-server: 21.1.14
- xwayland: 24.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
