### PR TITLE
intel-oneapi-basekit: update to 2025.0.0

### DIFF
--- a/app-devel/intel-oneapi-basekit/autobuild/build
+++ b/app-devel/intel-oneapi-basekit/autobuild/build
@@ -1,4 +1,4 @@
-PKG_FILENAME=$(ls | grep -oP 'l_BaseKit_p_.+(?=\.sh)')
+PKG_FILENAME=$(ls | grep -oP 'intel-oneapi-base-toolkit-.+(?=\.sh)')
 
 abinfo "Extracting Intel oneAPI Base Toolkit package ..."
 sh "${SRCDIR}"/"${PKG_FILENAME}".sh \

--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,7 +1,6 @@
-VER=2024.2.1
-PKG_URL=e6ff8e9c-ee28-47fb-abd7-5c524c983e1c
-PKG_CODE=100
-SRCS="file::rename=l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/l_BaseKit_p_"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha256::bfd0b61db946549f72104cda11af01790142b371b17340f3a7cd45fe0c900cba"
+VER=2025.0.0
+PKG_URL=96aa5993-5b22-4a9b-91ab-da679f422594
+PKG_CODE=885
+SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
+CHKSUMS="sha256::b379986e96a70d4d8c64b46eaecec73f14916ba39438ff167cb5f4f5fffc66de"
 CHKUPDATE="anitya::id=372585"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.0.0

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
