### PR TITLE
systemtap: update to 5.1

### DIFF
--- a/app-utils/systemtap/spec
+++ b/app-utils/systemtap/spec
@@ -1,5 +1,4 @@
-VER=4.4
-REL=3
+VER=5.1
 SRCS="tbl::https://www.sourceware.org/pub/systemtap/releases/systemtap-$VER.tar.gz"
-CHKSUMS="sha256::ca70b6107537162ce401f8965a7e315950c1292c02ea50a490e77bd6fde5638c"
+CHKSUMS="sha256::1db8c1d65bb13b65bc3f30e4cee2f7e174d517e908d994bb0fcde0051f181b40"
 CHKUPDATE="anitya::id=4934"


### PR DESCRIPTION
Topic Description
-----------------

- systemtap: update to 5.1

Package(s) Affected
-------------------

- systemtap: 5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemtap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
