### PR TITLE
bitwarden: fix description in the desktop entry

### DIFF
--- a/app-utils/bitwarden/autobuild/overrides/usr/share/applications/bitwarden.desktop
+++ b/app-utils/bitwarden/autobuild/overrides/usr/share/applications/bitwarden.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Bitwarden
-Comment=A music player client for self-hosted streaming services
+Comment=Client for the Bitwarden password manager
 Comment[zh_CN]=Bitwarden 密码管理器客户端
 Comment[zh_TW]=Bitwarden 密碼管理器用户端
 Exec=/usr/bin/bitwarden %U

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,5 @@
 VER=2024.10.1
+REL=1
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: fix description in the desktop entry

Package(s) Affected
-------------------

- bitwarden: 2024.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
