### PR TITLE
hwdata: update to 0.388

### DIFF
--- a/runtime-data/hwdata/spec
+++ b/runtime-data/hwdata/spec
@@ -1,4 +1,4 @@
-VER=0.384
+VER=0.388
 SRCS="git::commit=tags/v$VER::https://github.com/vcrhonek/hwdata"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13577"


### PR DESCRIPTION
Topic Description
-----------------

- hwdata: update to 0.388
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hwdata: 0.388

Security Update?
----------------

No

Build Order
-----------

```
#buildit hwdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
