### PR TITLE
sing-box: update to 1.10.1

### DIFF
--- a/app-network/sing-box/autobuild/build
+++ b/app-network/sing-box/autobuild/build
@@ -5,7 +5,7 @@ go get "${SRCDIR}"
 
 abinfo "Building exec binary..."
 go build -v \
-    -ldflags "-s -w -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/autobuild3/specs/hardened-ld'" \
+    -ldflags "-s -w -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/autobuild3/specs/hardened-ld' -X 'github.com/sagernet/sing-box/constant.Version=$PKGVER'" \
     -tags "with_gvisor,with_quic,with_wireguard,with_grpc,with_ech,with_utls,with_reality_server,with_acme,with_dhcp,with_clash_api,with_v2ray_api" \
     ../cmd/sing-box
 

--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,5 +1,4 @@
-VER=1.9.4
-SRCS="git::commit=tags/v$VER::https://github.com/SagerNet/sing-box"
+VER=1.10.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.10.1

Package(s) Affected
-------------------

- sing-box: 1.10.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
