### PR TITLE
sunshine: let hardware decoding support by default

### DIFF
--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -2,19 +2,34 @@ PKGNAME=sunshine
 PKGDES="A Gamestream host for Moonlight"
 PKGSEC=video
 PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg miniupnpc \
-        libnotify libappindicator"
+        libnotify libappindicator libvdpau mesa"
+PKGDEP__AMD64="${PKGDEP} intel-media-driver"
 PKGRECOM="avahi"
-BUILDDEP="nodejs"
+BUILDDEP="nodejs ffnvcodec"
+BUILDDEP__AMD64="${BUILDDEP} cuda"
+BUILDDEP__ARM64="${BUILDDEP} cuda"
+PKGSUG__AMD64="cuda"
+PKGSUG__ARM64="cuda"
 
 ABTYPE=cmakeninja
 
 # SUNSHINE_ASSETS_DIR is set to make data files follow FHS, otherwise it will
 # come at /usr/assets
-CMAKE_AFTER="-DSUNSHINE_ENABLE_CUDA=OFF \
-             -DSUNSHINE_ENABLE_DRM=ON \
+CMAKE_AFTER="-DSUNSHINE_ENABLE_DRM=ON \
              -DSUNSHINE_ENABLE_X11=ON \
              -DSUNSHINE_ENABLE_WAYLAND=ON \
              -DSUNSHINE_ASSETS_DIR=share/sunshine"
+
+CMAKE_AFTER__AMD64="${CMAKE_AFTER} \
+                -DSUNSHINE_ENABLE_CUDA=ON \
+                -DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc"
+
+CMAKE_AFTER__ARM64="${CMAKE_AFTER} \
+                -DSUNSHINE_ENABLE_CUDA=ON \
+                -DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc"
+
+CMAKE_AFTER__PPC64EL="${CMAKE_AFTER} \
+                -DSUNSHINE_ENABLE_CUDA=OFF"
 
 # FIXME: Links against bundled FFmpeg binaries.
 FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/app-multimedia/sunshine/spec
+++ b/app-multimedia/sunshine/spec
@@ -1,4 +1,5 @@
 VER=0.23.1
+REL=1
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/LizardByte/Sunshine"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236300"


### PR DESCRIPTION
Topic Description
-----------------

- sunshine: let hardware decoding support by default

Package(s) Affected
-------------------

- sunshine: 0.23.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sunshine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
