### PR TITLE
docker: fix systemd service

### DIFF
--- a/app-containers/docker/autobuild/overrides/etc/conf.d/docker
+++ b/app-containers/docker/autobuild/overrides/etc/conf.d/docker
@@ -1,8 +1,0 @@
-# /etc/conf.d/docker
-
-# Modify these options if you want to change the way the docker daemon runs
-OPTIONS="--log-driver=journald \
-         --live-restore \
-         --default-ulimit nofile=1024:1024 \
-         --init-path /usr/libexec/docker/docker-init \
-         --userland-proxy-path /usr/libexec/docker/docker-proxy"

--- a/app-containers/docker/autobuild/overrides/usr/lib/systemd/system/docker.service
+++ b/app-containers/docker/autobuild/overrides/usr/lib/systemd/system/docker.service
@@ -1,38 +1,46 @@
 [Unit]
-Description=Docker Daemon
+Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=docker.socket network-online.target firewalld.service
+After=network-online.target docker.socket firewalld.service containerd.service time-set.target
+Wants=network-online.target containerd.service
 Requires=docker.socket
-Wants=network-online.target
 
 [Service]
 Type=notify
-EnvironmentFile=-/etc/conf.d/docker
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd \
-          --host=fd:// \
-          --exec-opt native.cgroupdriver=systemd \
-          $OPTIONS
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
 ExecReload=/bin/kill -s HUP $MAINPID
+TimeoutStartSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
-# Uncomment TasksMax if your systemd version supports it.
-# Only systemd 226 and above support this version.
-#TasksMax=infinity
-TimeoutStartSec=0
+
+# Comment TasksMax if your systemd version does not support it.
+# Only systemd 226 and above support this option.
+TasksMax=infinity
+
 # set delegate yes so that systemd does not reset the cgroups of docker containers
-#Delegate=yes
+Delegate=yes
+
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
-# restart the docker process if it exits prematurely
-Restart=on-failure
-StartLimitBurst=3
-StartLimitInterval=60s
+OOMScoreAdjust=-500
 
 [Install]
 WantedBy=multi-user.target

--- a/app-containers/docker/autobuild/postrm
+++ b/app-containers/docker/autobuild/postrm
@@ -1,10 +1,3 @@
-systemd-sysusers docker.conf
-
-# Note: Only call preset during installation.
-if [[ "$1" = "install" ]]; then
-	systemctl preset docker.service
-fi
-
 # Remove /etc/conf.d/docker 
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
     dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"

--- a/app-containers/docker/autobuild/preinst
+++ b/app-containers/docker/autobuild/preinst
@@ -1,10 +1,3 @@
-systemd-sysusers docker.conf
-
-# Note: Only call preset during installation.
-if [[ "$1" = "install" ]]; then
-	systemctl preset docker.service
-fi
-
 # Remove /etc/conf.d/docker 
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
     dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -13,3 +13,4 @@ CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=11719"
 SUBDIR="moby"
+REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
docker:  fix systemd service

Drop `/etc/conf.d/docker` and to allow Docker honor user settings from the default configuration file `/etc/docker/daemon.json`.
Copy docker.service file from Debian.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
docker

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
