### PR TITLE
mesa: update to 24.2.6+dxheaders1.614.1

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=24.2.5
+UPSTREAM_VER=24.2.6
 DXHEADERS_VER=1.614.1
 VER=${UPSTREAM_VER}+dxheaders${DXHEADERS_VER}
 
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::733d0bea242ed6a5bb5c806fe836792ce7f092d45a2f115b7b7e15897c9dd96f \
+CHKSUMS="sha256::2b68c4a6f204c1999815a457299f81c41ba7bf48c4674b0b2d1d8864f41f3709 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.2.6+dxheaders1.614.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mesa: 1:24.2.6+dxheaders1.614.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
