### PR TITLE
wallpaper-engine-kde-plugin: new, 0.5.4+git20240308

### DIFF
--- a/desktop-kde/wallpaper-engine-kde-plugin/autobuild/defines
+++ b/desktop-kde/wallpaper-engine-kde-plugin/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=wallpaper-engine-kde-plugin
+PKGSEC=kde
+PKGDEP="gstreamer plasma-workspace mpv websockets"
+BUILDDEP="extra-cmake-modules"
+PKGDES="Wallpaper Engine plugin for the KDE Plasma Desktop"

--- a/desktop-kde/wallpaper-engine-kde-plugin/spec
+++ b/desktop-kde/wallpaper-engine-kde-plugin/spec
@@ -1,0 +1,4 @@
+VER=0.5.4
+SRCS="git::commit=tags/v$VER::https://github.com/catsout/wallpaper-engine-kde-plugin"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=318568"


### PR DESCRIPTION
Topic Description
-----------------

- wallpaper-engine-kde-plugin: new, 0.5.4+git20240308

Package(s) Affected
-------------------

- wallpaper-engine-kde-plugin: 0.5.4+git20240308

Security Update?
----------------

No

Build Order
-----------

```
#buildit wallpaper-engine-kde-plugin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
