### PR TITLE
readymedia: new, 1.3.3

### DIFF
--- a/app-multimedia/readymedia/autobuild/beyond
+++ b/app-multimedia/readymedia/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Installing config file to /etc ..."
+install -D -m 644 -v "$SRCDIR"/minidlna.conf -t "$PKGDIR"/etc/
+abinfo "Installing manual files..."
+install -D -m 644 -v "$SRCDIR"/minidlna.conf.5 -t "$PKGDIR"/usr/share/man/man5/
+install -D -m 644 -v "$SRCDIR"/minidlnad.8 -t "$PKGDIR"/usr/share/man/man8/

--- a/app-multimedia/readymedia/autobuild/conffiles
+++ b/app-multimedia/readymedia/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/minidlna.conf

--- a/app-multimedia/readymedia/autobuild/defines
+++ b/app-multimedia/readymedia/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=readymedia
+PKGSEC=sound
+PKGDEP="ffmpeg libexif"
+PKGDES="A DLNA media server formerly known as minidlna"
+
+ABSHADOW=0

--- a/app-multimedia/readymedia/autobuild/overrides/usr/lib/systemd/system/readymedia.service
+++ b/app-multimedia/readymedia/autobuild/overrides/usr/lib/systemd/system/readymedia.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ReadyMedia DLNA/UPnP-AV server
+After=network-online.target syslog.target local-fs.target
+Wants=network-online.target
+
+[Service]
+User=readymedia
+Group=readymedia
+Type=simple
+ExecStart=/usr/bin/minidlnad -S
+
+[Install]
+WantedBy=multi-user.target

--- a/app-multimedia/readymedia/autobuild/overrides/usr/lib/sysusers.d/readymedia.conf
+++ b/app-multimedia/readymedia/autobuild/overrides/usr/lib/sysusers.d/readymedia.conf
@@ -1,0 +1,2 @@
+u readymedia - "ReadyMedia Server"
+g readymedia -

--- a/app-multimedia/readymedia/autobuild/overrides/usr/lib/tmpfiles.d/readymedia.conf
+++ b/app-multimedia/readymedia/autobuild/overrides/usr/lib/tmpfiles.d/readymedia.conf
@@ -1,0 +1,3 @@
+d /srv/readymedia 0775 readymedia readymedia -
+d /run/minidlna 0770 readymedia readymedia -
+d /var/cache/minidlna 0700 readymedia readymedia -

--- a/app-multimedia/readymedia/autobuild/patches/0001-libav-api-fix.patch
+++ b/app-multimedia/readymedia/autobuild/patches/0001-libav-api-fix.patch
@@ -1,0 +1,11 @@
+--- minidlna-1.3.3/libav.h
++++ minidlna-1.3.3/libav.h
+@@ -174,7 +174,7 @@ lav_get_interlaced(AVStream *s)
+ #define lav_codec_tag(s) s->codecpar->codec_tag
+ #define lav_sample_rate(s) s->codecpar->sample_rate
+ #define lav_bit_rate(s) s->codecpar->bit_rate
+-#define lav_channels(s) s->codecpar->channels
++#define lav_channels(s) s->codecpar->ch_layout.nb_channels
+ #define lav_width(s) s->codecpar->width
+ #define lav_height(s) s->codecpar->height
+ #define lav_profile(s) s->codecpar->profile

--- a/app-multimedia/readymedia/autobuild/postinst
+++ b/app-multimedia/readymedia/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers readymedia.conf
+systemd-tmpfiles --create readymedia.conf

--- a/app-multimedia/readymedia/spec
+++ b/app-multimedia/readymedia/spec
@@ -1,0 +1,4 @@
+VER=1.3.3
+SRCS="tbl::https://sourceforge.net/projects/minidlna/files/minidlna/${VER}/minidlna-${VER}.tar.gz/download"
+CHKSUMS="sha256::39026c6d4a139b9180192d1c37225aa3376fdf4f1a74d7debbdbb693d996afa4"
+CHKUPDATE="anitya::id=12598"


### PR DESCRIPTION
Topic Description
-----------------

- readymedia: new 1.3.3

Package(s) Affected
-------------------

- readymedia: 1.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit readymedia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
