### PR TITLE
docker: update to 27.3.1+tini0.19.0

### DIFF
--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -46,6 +46,7 @@ export GOBUILDTAGS="${BUILDTAGS}"
 
 abinfo "docker-cli: Building ..."
 # FIXME: go build does not allow absolute paths
+. ./scripts/build/.variables
 go build \
     -o ../moby/abbuild/bin/docker \
     github.com/docker/cli/cmd/docker

--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -47,11 +47,15 @@ export GOBUILDTAGS="${BUILDTAGS}"
 abinfo "docker-cli: Building ..."
 . ./scripts/build/.variables
 # The variables script does `set -u`, which is incompatibbe with Autobuild4, revert it.
-# https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2C1-L2C8
+# https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2
 set +u
+# https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/binary#L27
 # FIXME: go build does not allow absolute paths
 go build \
     -o ../moby/abbuild/bin/docker \
+    -tags "${GO_BUILDTAGS}" \
+    -ldflags "${GO_LDFLAGS}" \
+    ${GO_BUILDMODE} \
     github.com/docker/cli/cmd/docker
 
 #abinfo "docker-cli: Building man pages ..."

--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -45,8 +45,11 @@ export BUILDTAGS="pkcs11"
 export GOBUILDTAGS="${BUILDTAGS}"
 
 abinfo "docker-cli: Building ..."
-# FIXME: go build does not allow absolute paths
 . ./scripts/build/.variables
+# The variables script does `set -u`, which is incompatibbe with Autobuild4, revert it.
+# https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2C1-L2C8
+set +u
+# FIXME: go build does not allow absolute paths
 go build \
     -o ../moby/abbuild/bin/docker \
     github.com/docker/cli/cmd/docker

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -6,7 +6,7 @@ TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli;copy-repo=true::https://github.com/docker/cli \
-      git::commit=tags/v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
+      git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -6,7 +6,7 @@ TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli;copy-repo=true::https://github.com/docker/cli \
-      git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
+      git::commit=tags/v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=27.2.1
+UPSTREAM_VER=27.3.1
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$PKGVER/hack/dockerfile/install/tini.installer

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -5,7 +5,7 @@ UPSTREAM_VER=27.3.1
 TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
-SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli::https://github.com/docker/cli \
+SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli;copy-repo=true::https://github.com/docker/cli \
       git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- docker: update to 27.3.1+tini0.19.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- docker: 27.3.1+tini0.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
