### PR TITLE
nodejs-22: update to 22.11.0

### DIFF
--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,6 +1,6 @@
-VER=22.10.0
+VER=22.11.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::3180710d3130ad9df01466abf010e408d41b374be54301d1480d10eca73558e0"
+CHKSUMS="sha256::bbf0297761d53aefda9d7855c57c7d2c272b83a7b5bad4fea9cb29006d8e1d35"
 CHKUPDATE="anitya::id=374342"
 # Note: Node.js currently requires large memory to build. 
 #       Prefer 3C5000 (or faster) build hosts.


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: update to 22.11.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- nodejs-22: 22.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
