### PR TITLE
zstandard: update to 0.23.0

### DIFF
--- a/lang-python/zstandard/autobuild/defines
+++ b/lang-python/zstandard/autobuild/defines
@@ -4,5 +4,8 @@ PKGDES="Zstandard binding for Python"
 PKGDEP="python-3"
 BUILDDEP="setuptools cffi"
 
-ABTYPE=pep517
+# FIXME: https://github.com/indygreg/python-zstandard/blob/e27f2f49f187f5f698e0a6004bee2aed80fe39e3/pyproject.toml#L5
+# https://github.com/pypa/pip/issues/11859#issuecomment-2132287974
+#ABTYPE=pep517
+ABTYPE=python
 NOPYTHON2=1

--- a/lang-python/zstandard/autobuild/defines
+++ b/lang-python/zstandard/autobuild/defines
@@ -4,5 +4,5 @@ PKGDES="Zstandard binding for Python"
 PKGDEP="python-3"
 BUILDDEP="setuptools cffi"
 
+ABTYPE=pep517
 NOPYTHON2=1
-ABTYPE=python

--- a/lang-python/zstandard/spec
+++ b/lang-python/zstandard/spec
@@ -1,4 +1,4 @@
-VER=0.22.0
+VER=0.23.0
 SRCS="https://pypi.io/packages/source/z/zstandard/zstandard-$VER.tar.gz"
-CHKSUMS="sha256::8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"
+CHKSUMS="sha256::b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09"
 CHKUPDATE="anitya::id=159551"

--- a/lang-python/zstandard/spec
+++ b/lang-python/zstandard/spec
@@ -1,4 +1,4 @@
 VER=0.23.0
-SRCS="https://pypi.io/packages/source/z/zstandard/zstandard-$VER.tar.gz"
+SRCS="pypi::version=$VER::zstandard"
 CHKSUMS="sha256::b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09"
 CHKUPDATE="anitya::id=159551"


### PR DESCRIPTION
Topic Description
-----------------

- zstandard: update to 0.23.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- zstandard: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zstandard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
