### PR TITLE
networkmanager-pptp: update to 1.2.12

### DIFF
--- a/app-network/networkmanager-pptp/spec
+++ b/app-network/networkmanager-pptp/spec
@@ -1,4 +1,4 @@
-VER=1.2.10
+VER=1.2.12
 SRCS="tbl::https://download.gnome.org/sources/NetworkManager-pptp/${VER%.*}/NetworkManager-pptp-$VER.tar.xz"
-CHKSUMS="sha256::548cb1f87de81935e559ca3732d38fa4ca1eab077a17ba4f7a6cc5b0f94f0943"
+CHKSUMS="sha256::e5fa59fe46117f0ee86e9ca62c6943bc063884b04dd2396ccec38a2d1f414982"
 CHKUPDATE="anitya::id=230980"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager-pptp: update to 1.2.12
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- networkmanager-pptp: 1.2.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager-pptp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
