### PR TITLE
devscripts: update to 2.24.5

### DIFF
--- a/app-devel/devscripts/autobuild/defines
+++ b/app-devel/devscripts/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=devscripts
 PKGSEC=utils
 PKGDES="Utility scripts for Debian developers"
+PKGDEP="sensible-utils"
 BUILDDEP="libxslt po4a docbook-xsl"
 
 ABHOST=noarch

--- a/app-devel/devscripts/spec
+++ b/app-devel/devscripts/spec
@@ -1,4 +1,4 @@
-VER=2.24.2
+VER=2.24.5
 SRCS="git::commit=tags/v$VER::https://salsa.debian.org/debian/devscripts.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5419"

--- a/app-devel/devscripts/spec
+++ b/app-devel/devscripts/spec
@@ -1,4 +1,4 @@
-VER=2.23.7
+VER=2.24.2
 SRCS="git::commit=tags/v$VER::https://salsa.debian.org/debian/devscripts.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5419"

--- a/app-utils/sensible-utils/autobuild/defines
+++ b/app-utils/sensible-utils/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=sensible-utils
+PKGSEC=utils
+PKGDES="Utilities for sensible alternative selection"
+
+ABHOST=noarch

--- a/app-utils/sensible-utils/autobuild/defines
+++ b/app-utils/sensible-utils/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=sensible-utils
 PKGSEC=utils
-PKGDES="Utilities for sensible alternative selection"
+PKGDES="Utilities for configuring common utility alternatives"
 BUILDDEP="po4a"
 
 ABHOST=noarch

--- a/app-utils/sensible-utils/autobuild/defines
+++ b/app-utils/sensible-utils/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=sensible-utils
 PKGSEC=utils
 PKGDES="Utilities for sensible alternative selection"
+BUILDDEP="po4a"
 
 ABHOST=noarch

--- a/app-utils/sensible-utils/spec
+++ b/app-utils/sensible-utils/spec
@@ -1,0 +1,4 @@
+VER=0.0.24
+SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/debian/sensible-utils.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375729"


### PR DESCRIPTION
Topic Description
-----------------

- sensible-utils: add po4a to build Depends
- devscripts: update to 2.24.5
    Now Depends on sensible-utils.
- sensible-utils: new, 0.0.24
- devscripts: update to 2.24.2
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- devscripts: 2.24.5
- sensible-utils: 0.0.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit sensible-utils devscripts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
