### PR TITLE
gtkwave: update to 3.3.121

### DIFF
--- a/app-electronics/gtkwave/spec
+++ b/app-electronics/gtkwave/spec
@@ -1,4 +1,4 @@
-VER=3.3.120
+VER=3.3.121
 SRCS="tbl::https://gtkwave.sourceforge.net/gtkwave-$VER.tar.gz"
-CHKSUMS="sha256::803a1893b473132b2672beac30e90f13333534d0b2a1078979fd965a6dc1de8d"
+CHKSUMS="sha256::5b05b6469bca675d9c9de60cf7ce8ad33afe13ef71aa29777898ced2ffe88397"
 CHKUPDATE="anitya::id=8813"


### PR DESCRIPTION
Topic Description
-----------------

- gtkwave: update to 3.3.121
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- gtkwave: 3.3.121

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkwave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
