### PR TITLE
xcb-util-cursor: update to 0.1.5

### DIFF
--- a/runtime-display/xcb-util-cursor/spec
+++ b/runtime-display/xcb-util-cursor/spec
@@ -1,4 +1,4 @@
-VER=0.1.4
+VER=0.1.5
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-cursor-$VER.tar.xz"
-CHKSUMS="sha256::28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb"
+CHKSUMS="sha256::0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57"
 CHKUPDATE="anitya::id=5166"


### PR DESCRIPTION
Topic Description
-----------------

- xcb-util-cursor: update to 0.1.5
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- xcb-util-cursor: 0.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcb-util-cursor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
