### PR TITLE
vscode: update to 1.95.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.95.0
+VER=1.95.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::f7aebec8a01756cbbbeca044b8b696289193b5647efa7c3b30047423d49c3046"
-CHKSUMS__ARM64="sha256::5763a842e0d30be16199a4266baf7a3662a0764514a7ce695b05faa1f84d2b40"
+CHKSUMS__AMD64="sha256::b6bbcfa09acb9727b0c42701a4682c1f1446d5ab161be786b3996fab914c24a0"
+CHKSUMS__ARM64="sha256::fb70e0bd58c915f41aff4b6d2171d75af73611e8008bce627865cf25aec55ad2"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.95.1
    Co-authored-by: Alan Lin (@miwu04) <mail@alanlin.icu>

Package(s) Affected
-------------------

- vscode: 1.95.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
