### PR TITLE
Fcitx 5 Survey 20241101

### DIFF
--- a/app-i18n/fcitx5-anthy/spec
+++ b/app-i18n/fcitx5-anthy/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
-SRCS="tbl::https://github.com/fcitx/fcitx5-anthy/archive/$VER.tar.gz"
-CHKSUMS="sha256::c7c3c5d3f40f8dd7ee8433d0c37f7f450e19e008e56caf73e30f1531ca7ab4ae"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-anthy"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174357"

--- a/app-i18n/fcitx5-chewing/spec
+++ b/app-i18n/fcitx5-chewing/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
-SRCS="tbl::https://github.com/fcitx/fcitx5-chewing/archive/$VER.tar.gz"
-CHKSUMS="sha256::252c5662fd1fb543cfd4f99b467766f235b1ddc0fe60839c10af900337a047c8"
+VER=5.1.6
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chewing"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138243"

--- a/app-i18n/fcitx5-chinese-addons/spec
+++ b/app-i18n/fcitx5-chinese-addons/spec
@@ -1,7 +1,7 @@
-VER=5.1.6
-SRCS="tbl::https://github.com/fcitx/fcitx5-chinese-addons/archive/$VER.tar.gz \
+VER=5.1.7
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chinese-addons \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.zst"
-CHKSUMS="sha256::b276eefb572c3d8d06702a052c7321804b394078f49d66d100a0ebed1c8f831b \
-         sha256::b3c0229a29c46eae0d711bab8876bcd6cd3fb1a1be9d134e792fdd34daffce4b"
+CHKSUMS="SKIP \
+         sha256::920ec6fb6abc93f80514eff3f7e64fce822dbd820a98afd816fe5039459520b3"
 CHKUPDATE="anitya::id=138238"
 SUBDIR="fcitx5-chinese-addons-$VER"

--- a/app-i18n/fcitx5-configtool/spec
+++ b/app-i18n/fcitx5-configtool/spec
@@ -1,4 +1,4 @@
-VER=5.1.6
-SRCS="tbl::https://github.com/fcitx/fcitx5-configtool/archive/$VER.tar.gz"
-CHKSUMS="sha256::bb2ed52aa0ebb881a5b19a5f2d93f9759ce0c56bcf1c555062ffe039e2539221"
+VER=5.1.7
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-configtool"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138233"

--- a/app-i18n/fcitx5-hangul/spec
+++ b/app-i18n/fcitx5-hangul/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
-SRCS="tbl::https://github.com/fcitx/fcitx5-hangul/archive/$VER.tar.gz"
-CHKSUMS="sha256::49404de5de38f4b182e487e7a51a4a68fdb5b8acef531d27ba328aca552b9009"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-hangul"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174360"

--- a/app-i18n/fcitx5-kkc/spec
+++ b/app-i18n/fcitx5-kkc/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
-SRCS="tbl::https://github.com/fcitx/fcitx5-kkc/archive/$VER.tar.gz"
-CHKSUMS="sha256::63552fa94dd81a929c3f562b4ecec99e12022147979afdbd49790625c141db44"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-kkc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138241"

--- a/app-i18n/fcitx5-libthai/spec
+++ b/app-i18n/fcitx5-libthai/spec
@@ -1,4 +1,4 @@
-VER=5.1.3
-SRCS="tbl::https://github.com/fcitx/fcitx5-libthai/archive/$VER.tar.gz"
-CHKSUMS="sha256::dd28290b43a9eabb8957cf6d655d3e4c999adcf27d08d50bb19e1d3f2f73a1ba"
+VER=5.1.4
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-libthai"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174358"

--- a/app-i18n/fcitx5-m17n/spec
+++ b/app-i18n/fcitx5-m17n/spec
@@ -1,4 +1,4 @@
-VER=5.1.1
-SRCS="tbl::https://github.com/fcitx/fcitx5-m17n/archive/$VER.tar.gz"
-CHKSUMS="sha256::d4481a907ef3eb3c544753d6b949d8b8caedfc000acbf3ea22381c9b0d88d119"
+VER=5.1.2
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-m17n"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174359"

--- a/app-i18n/fcitx5-qt/spec
+++ b/app-i18n/fcitx5-qt/spec
@@ -1,5 +1,4 @@
-VER=5.1.6
+VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-qt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138234"
-REL=1

--- a/app-i18n/fcitx5-rime/spec
+++ b/app-i18n/fcitx5-rime/spec
@@ -1,4 +1,4 @@
-VER=5.1.8
-SRCS="tbl::https://github.com/fcitx/fcitx5-rime/archive/$VER.tar.gz"
-CHKSUMS="sha256::773db664e7aeb12bf376cfa755fba0f65470af4c9884b1dc7fb64bfd0c0a4864"
+VER=5.1.9
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-rime"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138239"

--- a/app-i18n/fcitx5-skk/spec
+++ b/app-i18n/fcitx5-skk/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
-SRCS="tbl::https://github.com/fcitx/fcitx5-skk/archive/$VER.tar.gz"
-CHKSUMS="sha256::a965cc7c46ad667ac440fee4640f9f1b6090fc1fc1ba18539222ceb4143d7a60"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-skk"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138240"

--- a/app-i18n/fcitx5-unikey/spec
+++ b/app-i18n/fcitx5-unikey/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
-SRCS="tbl::https://github.com/fcitx/fcitx5-unikey/archive/$VER.tar.gz"
-CHKSUMS="sha256::d3598ba7be924ae05c6c5e750cde6bc4a40f30e6ec0803b6fb51c66e354b732c"
+VER=5.1.5
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-unikey"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180082"

--- a/app-i18n/fcitx5/spec
+++ b/app-i18n/fcitx5/spec
@@ -1,8 +1,7 @@
-VER=5.1.10
-REL=1
-SRCS="tbl::https://github.com/fcitx/fcitx5/archive/$VER.tar.gz \
+VER=5.1.11
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5 \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.zst"
-CHKSUMS="sha256::a33f71e60a840b37fed7b04d2dcc7544a89bda78e4f4b2df7946ff358032a903 \
-         sha256::1aff414eeb244a7f9aa4af480f3b97420db5fff258fe70580f49885a6c21aae9"
+CHKSUMS="SKIP \
+         sha256::6d16ce1eea7a86eacbb8e738329b924469c93fee954e8851ec58aed906577d89"
 CHKUPDATE="anitya::id=138232"
 SUBDIR="fcitx5-$VER"

--- a/runtime-i18n/libime/spec
+++ b/runtime-i18n/libime/spec
@@ -1,7 +1,7 @@
-VER=1.1.8
+VER=1.1.9
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
       tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \
-         sha256::706afaa76202e8293c4d3dad1e161adbe868eae4bcbc5c6e4e51703340b44258"
+         sha256::d128cdf13393722ee5c2ae9a5f74530d43dbfb19539fc32522be7dd239c78389"
 CHKUPDATE="anitya::id=138236"
 SUBDIR="libime-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-unikey: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-skk: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-rime: update to 5.1.9
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-qt: update to 5.1.8
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-m17n: update to 5.1.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-libthai: update to 5.1.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-kkc: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-hangul: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-chewing: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-anthy: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

... and 4 more commits

Package(s) Affected
-------------------

- fcitx5: 1:5.1.11
- fcitx5-anthy: 1:5.1.5
- fcitx5-chewing: 5.1.6
- fcitx5-chinese-addons: 1:5.1.7
- fcitx5-configtool: 1:5.1.7
- fcitx5-hangul: 5.1.5
- fcitx5-kkc: 1:5.1.5
- fcitx5-libthai: 5.1.4
- fcitx5-m17n: 5.1.2
- fcitx5-migrator: 1:5.1.7
- fcitx5-qt: 1:5.1.8
- fcitx5-rime: 1:5.1.9
- fcitx5-skk: 5.1.5
- fcitx5-unikey: 5.1.5
- libime: 1:1.1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5 libime fcitx5-chinese-addons fcitx5-configtool fcitx5-anthy fcitx5-chewing fcitx5-hangul fcitx5-kkc fcitx5-libthai fcitx5-m17n fcitx5-qt fcitx5-rime fcitx5-skk fcitx5-unikey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
