### PR TITLE
svt-av1: update to 2.3.0

### DIFF
--- a/runtime-multimedia/svt-av1/spec
+++ b/runtime-multimedia/svt-av1/spec
@@ -1,4 +1,4 @@
-VER=2.2.1
+VER=2.3.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/AOMediaCodec/SVT-AV1"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=24271"


### PR DESCRIPTION
Topic Description
-----------------

- svt-av1: update to 2.3.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- svt-av1: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit svt-av1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
