### PR TITLE
mstflint: update to 4.29.0-1

### DIFF
--- a/app-admin/mstflint/spec
+++ b/app-admin/mstflint/spec
@@ -1,4 +1,4 @@
-VER=4.28.0+1
+VER=4.29.0-1
 SRCS="tbl::https://github.com/Mellanox/mstflint/releases/download/v${VER/+/-}/mstflint-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::cef08373ff7002a4f75c123d03990ea6b9e79b9d8493ca067b625eddd287b62d"
+CHKSUMS="sha256::1bd048146f1fe0493d4770b244b02e32981b49caed068fd96a22700103220654"
 CHKUPDATE="anitya::id=13357"


### PR DESCRIPTION
Topic Description
-----------------

- mstflint: update to 4.29.0-1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mstflint: 4.29.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mstflint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
