### PR TITLE
MATE Desktop Survey (November, 2024)

### DIFF
--- a/desktop-mate/engrampa/spec
+++ b/desktop-mate/engrampa/spec
@@ -1,4 +1,4 @@
-VER=1.28.1
+VER=1.28.2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/engrampa-$VER.tar.xz"
-CHKSUMS="sha256::9c5c4c9bcf8b08eeaa8f275538d24b4c955089d58aec0331e89c02b84d85386a"
+CHKSUMS="sha256::1e9977c23745bf8843a37f315171d9af97814a0971aeac3d774f017650ac09ef"
 CHKUPDATE="anitya::id=230601"

--- a/desktop-mate/mate-control-center/spec
+++ b/desktop-mate/mate-control-center/spec
@@ -1,4 +1,5 @@
-VER=1.28.0
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-control-center-$VER.tar.xz"
-CHKSUMS="sha256::ebf2c704fd5248dc2f9836ff29028869ef29d5054907cc615734b6383a7914bc"
+VER=1.28.1
+# FIXME: Upstream tagged v1.28.1 but never uploaded the tarball.
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/mate-control-center"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230610"

--- a/desktop-mate/mate-notification-daemon/spec
+++ b/desktop-mate/mate-notification-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.28.0
+VER=1.28.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-notification-daemon-$VER.tar.xz"
-CHKSUMS="sha256::a4310348ead866cbcb9b4c463f4d265cc6a96a1a782a9411a08b23bd65dbb2e0"
+CHKSUMS="sha256::fffef553bea15becff5ed40d64e18c23d3b649c4599cc1eb1e82f70533853b34"
 CHKUPDATE="anitya::id=230618"

--- a/desktop-mate/mate-panel/spec
+++ b/desktop-mate/mate-panel/spec
@@ -1,4 +1,4 @@
-VER=1.28.1
+VER=1.28.4
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-panel-$VER.tar.xz"
-CHKSUMS="sha256::5133c64f5969ae8eeebe6e8bba450dea792cb0be06d9ae1c36e8569d2f8524ba"
+CHKSUMS="sha256::02f09eb0314c2ac197b6f089950a571cdba39bfd03d6c3a0b8fd77252a968874"
 CHKUPDATE="anitya::id=230619"


### PR DESCRIPTION
Topic Description
-----------------

- mate-notification-daemon: update to 1.28.1
- mate-control-center: update to 1.28.1
- engrampa: update to 1.28.2
- mate-panel: update to 1.28.4

Package(s) Affected
-------------------

- engrampa: 1:1.28.2
- mate-control-center: 1.28.1
- mate-notification-daemon: 1:1.28.1
- mate-panel: 1:1.28.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mate-panel engrampa mate-control-center mate-notification-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
