### PR TITLE
lzip: update to 1.24.1

### DIFF
--- a/app-utils/lzip/spec
+++ b/app-utils/lzip/spec
@@ -1,4 +1,4 @@
-VER=1.23
+VER=1.24.1
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/lzip-$VER.tar.gz"
-CHKSUMS="sha256::4792c047ddf15ef29d55ba8e68a1a21e0cb7692d87ecdf7204419864582f280d"
+CHKSUMS="sha256::30c9cb6a0605f479c496c376eb629a48b0a1696d167e3c1e090c5defa481b162"
 CHKUPDATE="anitya::id=1866"


### PR DESCRIPTION
Topic Description
-----------------

- lzip: update to 1.24.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lzip: 1.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
