### PR TITLE
zerotier-one: update to 1.14.2

### DIFF
--- a/app-network/zerotier-one/spec
+++ b/app-network/zerotier-one/spec
@@ -1,4 +1,4 @@
-VER=1.14.1
+VER=1.14.2
 SRCS="git::commit=tags/$VER::https://github.com/zerotier/ZeroTierOne"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17578"


### PR DESCRIPTION
Topic Description
-----------------

- zerotier-one: update to 1.14.2
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- zerotier-one: 1.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zerotier-one
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
