### PR TITLE
gnupg: update to 2.4.6

### DIFF
--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,4 @@
-VER=2.4.5
+VER=2.4.6
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
-CHKSUMS="sha256::f68f7d75d06cb1635c336d34d844af97436c3f64ea14bcb7c869782f96f44277"
+CHKSUMS="sha256::95acfafda7004924a6f5c901677f15ac1bda2754511d973bb4523e8dd840e17a"
 CHKUPDATE="anitya::id=1215"


### PR DESCRIPTION
Topic Description
-----------------

- gnupg: update to 2.4.6
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- gnupg: 1:2.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnupg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
