### PR TITLE
zvm: update to 0.7.9

### DIFF
--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,4 +1,4 @@
-VER=0.7.6
+VER=0.7.9
 SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=363557"


### PR DESCRIPTION
Topic Description
-----------------

- zvm: update to 0.7.9

Package(s) Affected
-------------------

- zvm: 0.7.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit zvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
