### PR TITLE
symbols-nerd-font: add fontconfig config

### DIFF
--- a/desktop-fonts/symbols-nerd-font/autobuild/build
+++ b/desktop-fonts/symbols-nerd-font/autobuild/build
@@ -1,2 +1,13 @@
 abinfo "Installing Symbols Nerd Font ..."
 install -Dvm644 -t "$PKGDIR"/usr/share/fonts/TTF "$SRCDIR"/*.ttf
+
+abinfo "Installing fontconfig file for Nerd Font"
+install -Dvm644 \
+  "$SRCDIR"/symbols-nerd-font-3.2.1-1.conf \
+  "$PKGDIR"/etc/fonts/conf.avail/10-nerd-font-symbols.conf
+
+abinfo "Enabling fontconfig file for Nerd Font"
+mkdir -v -p "$PKGDIR"/etc/fonts/conf.d
+ln -v -s -t \
+  "$PKGDIR"/etc/fonts/conf.d \
+  /etc/fonts/conf.avail/10-nerd-font-symbols.conf

--- a/desktop-fonts/symbols-nerd-font/spec
+++ b/desktop-fonts/symbols-nerd-font/spec
@@ -1,4 +1,7 @@
 VER=3.2.1
-SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/NerdFontsSymbolsOnly.zip"
-CHKSUMS="sha256::bc59c2ea74d022a6262ff9e372fde5c36cd5ae3f82a567941489ecfab4f03d66"
+REL=1
+SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/NerdFontsSymbolsOnly.zip \
+      file::https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v$VER/10-nerd-font-symbols.conf"
+CHKSUMS="sha256::bc59c2ea74d022a6262ff9e372fde5c36cd5ae3f82a567941489ecfab4f03d66 \
+         sha256::6601e431c5c43d80dfce375147b297df0b36bb4d465948f8f2178c1da89ace76"
 CHKUPDATE="anitya::id=227412"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This fontconfig file from upstream is required for nerd font glyphs to be rendered in most terminal emulators.

Package(s) Affected
-------------------

- symbols-nerd-font

Security Update?
----------------

No


Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch` -->