### PR TITLE
mdbook: update to 0.4.40

### DIFF
--- a/app-doc/mdbook/autobuild/defines
+++ b/app-doc/mdbook/autobuild/defines
@@ -5,3 +5,5 @@ BUILDDEP="llvm rustc"
 PKGDES="Create books from Markdown files"
 
 USECLANG=1
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/app-doc/mdbook/spec
+++ b/app-doc/mdbook/spec
@@ -1,4 +1,4 @@
-VER=0.4.14
-SRCS="tbl::https://github.com/rust-lang/mdBook/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::59fd3e417e9d09deac89e20467194dd9f93854c2f1a87e845816c5cec676765c"
+VER=0.4.40
+SRCS="git::commit=tags/v$VER::https://github.com/rust-lang/mdBook"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241825"


### PR DESCRIPTION
Topic Description
-----------------

- mdbook: update to 0.4.40
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- mdbook: 0.4.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit mdbook
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
