### PR TITLE
aoscbootstrap: update to 0.7.6

### DIFF
--- a/app-utils/aoscbootstrap/spec
+++ b/app-utils/aoscbootstrap/spec
@@ -1,4 +1,4 @@
-VER=0.7.5
+VER=0.7.6
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

- aoscbootstrap: update to 0.7.6
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aoscbootstrap: 0.7.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
