### PR TITLE
WeChat for Linux 4.0 fix

### DIFF
--- a/desktop-fonts/noto-fonts/01-noto/defines
+++ b/desktop-fonts/noto-fonts/01-noto/defines
@@ -4,7 +4,7 @@ PKGSEC=fonts
 PKGDEP="adobe-source-code-pro"
 PKGDES="A font family aiming to support all languages with a harmonious look"
 
-PKGREP="fonts-noto-cjk fonts-noto"
+PKGREP="fonts-noto"
 PKGPROV="ttf-noto"
 
 ABHOST=noarch

--- a/desktop-fonts/noto-fonts/02-cjk/defines
+++ b/desktop-fonts/noto-fonts/02-cjk/defines
@@ -4,8 +4,8 @@ PKGSEC=fonts
 PKGDEP="fontconfig"
 PKGDES="A font family aiming to support all languages with a harmonious look (Pan-CJK fonts)"
 
-PKGREP="fonts-noto-cjk fonts-noto"
-PKGPROV="ttf-noto-cjk"
+PKGREP="fonts-noto"
+PKGPROV="fonts-noto-cjk ttf-noto-cjk"
 
 ABHOST=noarch
 

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -5,6 +5,7 @@ EMOJI_VER=2.042
 CJKSANS_VER=2.004
 CJKSERIF_VER=2.003
 VER=${UPSTREAM_VER}+emoji${EMOJI_VER}+cjksans${CJKSANS_VER}+cjkserif${CJKSERIF_VER}
+REL=1
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}

--- a/meta-bases/desktop-base/autobuild/overrides/etc/bashrc.d/xdg-data-dirs-opt-apps.sh
+++ b/meta-bases/desktop-base/autobuild/overrides/etc/bashrc.d/xdg-data-dirs-opt-apps.sh
@@ -1,0 +1,1 @@
+../profile.d/xdg-data-dirs-opt-apps.sh

--- a/meta-bases/desktop-base/autobuild/overrides/etc/profile.d/xdg-data-dirs-opt-apps.sh
+++ b/meta-bases/desktop-base/autobuild/overrides/etc/profile.d/xdg-data-dirs-opt-apps.sh
@@ -1,0 +1,24 @@
+# Append deepin/openKylin/UOS-compatible desktop XDG data directories
+#
+# Per an unspoken rule, these distributions agreed on a pattern for XDG data
+# directories: /opt/apps/*/entries.
+#
+# Append them so that XDG-compliant AOSC OS desktop environments may discover
+# the application entries.
+
+# Do not allow non-matching globs to be appended to $XDG_DATA_DIRS.
+shopt -s nullglob
+
+# Fallback to /usr/local/share:/usr/share if $XDG_DATA_DIRS is empty.
+if [ -z "$XDG_DATA_DIRS" ]; then
+	export XDG_DATA_DIRS="/usr/local/share:/usr/share"
+fi
+
+# Append the aforementioned paths.
+for opt_apps_path in /opt/apps/*/entries; do
+	# Exclude paths already in $XDG_DATA_DIRS to avoid duplicates.
+	if [ -n "${XDG_DATA_DIRS##*${opt_apps_path}}" ] && \
+	   [ -n "${XDG_DATA_DIRS##*${opt_apps_path}:*}" ]; then
+		export XDG_DATA_DIRS="${XDG_DATA_DIRS}:${opt_apps_path}"
+	fi
+done

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,4 @@
-VER=12
+VER=13
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
-REL=1
+# FIXME: No release would be made from this repository.


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: (Spiral) provide Debian-compatible fonts-noto-cjk alias
    While `fonts-noto-cjk' was originally listed in PKGREP=, this packge name
    was never used (at least post-aosc-os-abbs), so remove it due to lack of
    record and preserve upgradability.
- desktop-base: append deepin/openKylin/UOS-compatible XDG data directories
    Per an unspoken rule, these distributions agreed on a pattern for XDG
    data directories: /opt/apps/*/entries.
    Append them so that XDG-compliant AOSC OS desktop environments may
    discover the application entries.

Package(s) Affected
-------------------

- desktop-base: 13
- noto-cjk-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.003-1
- noto-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.003-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
