### PR TITLE
lsof: update to 4.99.3

### DIFF
--- a/app-utils/lsof/spec
+++ b/app-utils/lsof/spec
@@ -1,4 +1,4 @@
-VER=4.98.0
-SRCS="tbl::https://github.com/lsof-org/lsof/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::80308a614508814ac70eb2ae1ed2c4344dcf6076fa60afc7734d6b1a79e62b16"
+VER=4.99.3
+SRCS="git::commit=tags/$VER::https://github.com/lsof-org/lsof"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1844"


### PR DESCRIPTION
Topic Description
-----------------

- lsof: update to 4.99.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lsof: 4.99.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lsof
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
