### PR TITLE
nodejs-*: fix postrm

### DIFF
--- a/lang-js/nodejs-20/autobuild/beyond
+++ b/lang-js/nodejs-20/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node $NODE_SUFFIX || true
+    update-alternatives --remove-all node$NODE_SUFFIX || true
 fi
 EOF
 

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,4 +1,5 @@
 VER=20.18.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::7d9433e91fd88d82ba8de86e711ec41907638e227993d22e95126b02f6cd714a"
 CHKUPDATE="anitya::id=369796"

--- a/lang-js/nodejs-22/autobuild/beyond
+++ b/lang-js/nodejs-22/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node $NODE_SUFFIX || true
+    update-alternatives --remove-all node$NODE_SUFFIX || true
 fi
 EOF
 

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.11.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::bbf0297761d53aefda9d7855c57c7d2c272b83a7b5bad4fea9cb29006d8e1d35"
 CHKUPDATE="anitya::id=374342"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: fix postrm
    Drop an extraneous space between node and $NODE_SUFFIX in postrm.
- nodejs-20: fix postrm
    Drop an extraneous space between node and $NODE_SUFFIX in postrm.

Package(s) Affected
-------------------

- nodejs-20: 20.18.0-1
- nodejs-22: 22.10.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-20 nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
