### PR TITLE
filezilla: update to 3.60.2

### DIFF
--- a/app-network/filezilla/spec
+++ b/app-network/filezilla/spec
@@ -1,4 +1,4 @@
-VER=3.66.4
+VER=3.60.2
 SRCS="tbl::https://download.filezilla-project.org/client/FileZilla_${VER}_src.tar.xz"
-CHKSUMS="sha256::a40f04e02efaae7b50d1515ee1c36c4b0e445818566c450e440bfd6c70e9b203"
+CHKSUMS="sha256::885205fa91917783501da1755823fce6ca8af59b4689cbbb0527f290e00ffcf8"
 CHKUPDATE="anitya::id=809"


### PR DESCRIPTION
Topic Description
-----------------

- filezilla: update to 3.60.2
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- filezilla: 3.60.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit filezilla
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
