### PR TITLE
srain: update to 1.8.0

### DIFF
--- a/app-web/srain/spec
+++ b/app-web/srain/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
+VER=1.8.0
 SRCS="git::commit=tags/$VER::https://github.com/SrainApp/srain"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=27553"


### PR DESCRIPTION
Topic Description
-----------------

- srain: update to 1.8.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- srain: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit srain
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
