### PR TITLE
zellij: update to 0.41.1

### DIFF
--- a/app-utils/zellij/autobuild/defines
+++ b/app-utils/zellij/autobuild/defines
@@ -6,4 +6,8 @@ PKGDES="A terminal workspace and a terminal multiplexer"
 
 USECLANG=1
 ABSPLITDBG=0
-FAIL_ARCH="!(amd64|arm64)"
+
+# FIXME: `cranelift-codegen` does not support ISA for other architectures.
+# More information:
+# https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/codegen/meta/src/isa/mod.rs
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.40.1
+VER=0.41.1
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.41.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.41.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
