### PR TITLE
srain: drop, orphaned

### DIFF
--- a/app-web/srain/autobuild/defines
+++ b/app-web/srain/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=srain
-PKGSEC=web
-PKGDEP="gtk-3 libconfig libsoup-3 libsecret"
-BUILDDEP="sphinx"
-PKGDES="An graphical IRC (Internet Relay Chat) client"
-
-MESON_AFTER="-Dbuildtype=release \
-             -Dapp_indicator=false"

--- a/app-web/srain/spec
+++ b/app-web/srain/spec
@@ -1,4 +1,0 @@
-VER=1.7.0
-SRCS="git::commit=tags/$VER::https://github.com/SrainApp/srain"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=27553"


### PR DESCRIPTION
Topic Description
-----------------

- srain: drop, orphaned
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
