### PR TITLE
stress-ng: update to 0.18.06

### DIFF
--- a/app-benchmarks/stress-ng/spec
+++ b/app-benchmarks/stress-ng/spec
@@ -1,4 +1,4 @@
-VER=0.18.04
+VER=0.18.06
 SRCS="git::commit=tags/V${VER}::https://github.com/ColinIanKing/stress-ng.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12538"

--- a/runtime-cryptography/intel-ipsec-mb/autobuild/beyond
+++ b/runtime-cryptography/intel-ipsec-mb/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo "Installing manual pages ..."
-mkdir -pv "${PKGDIR}"/usr/share
-mv -v "${PKGDIR}"/usr/man "${PKGDIR}"/usr/share/

--- a/runtime-cryptography/intel-ipsec-mb/spec
+++ b/runtime-cryptography/intel-ipsec-mb/spec
@@ -1,4 +1,4 @@
-VER=1.5
+VER=2.0
 SRCS="git::commit=tags/v${VER}::https://github.com/intel/intel-ipsec-mb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373794"


### PR DESCRIPTION
Topic Description
-----------------

- stress-ng: update to 0.18.06
- intel-ipsec-mb: update to 2.0
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- intel-ipsec-mb: 2.0
- stress-ng: 0.18.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ipsec-mb stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
