### PR TITLE
intel-ipsec-mb: add pkgbreak

### DIFF
--- a/runtime-cryptography/intel-ipsec-mb/autobuild/defines
+++ b/runtime-cryptography/intel-ipsec-mb/autobuild/defines
@@ -7,3 +7,5 @@ PKGDES="Software implementations of the core cryptographic processing for IPsec 
 ABTYPE=cmakeninja
 
 FAIL_ARCH="!(amd64)"
+
+PKGBREAK="stress-ng<=0.18.04"

--- a/runtime-cryptography/intel-ipsec-mb/spec
+++ b/runtime-cryptography/intel-ipsec-mb/spec
@@ -2,3 +2,4 @@ VER=2.0
 SRCS="git::commit=tags/v${VER}::https://github.com/intel/intel-ipsec-mb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373794"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- intel-ipsec-mb: add pkgbreak

Package(s) Affected
-------------------

- intel-ipsec-mb: 2.0-1
- stress-ng: 0.18.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ipsec-mb stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
