### PR TITLE
plymouth: disable kernel log streaming

### DIFF
--- a/app-admin/plymouth/autobuild/patches/0001-main-Go-back-to-text-mode-when-quitting-if-appropria.patch
+++ b/app-admin/plymouth/autobuild/patches/0001-main-Go-back-to-text-mode-when-quitting-if-appropria.patch
@@ -1,7 +1,7 @@
 From ad8236ef35d5645a373e77637d8188c8ac552a0f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 1 Sep 2024 00:15:17 +0800
-Subject: [PATCH 1/2] main: Go back to text mode when quitting (if appropriate)
+Subject: [PATCH 1/3] main: Go back to text mode when quitting (if appropriate)
 
 Since commit 48881ba2ef3d25fd27fd150d4d5957d4df9868e0 plymouth
 goes into GRAPHICS mode early on. Unfortunately, there are cases
@@ -16,7 +16,7 @@ Ref: https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/d2ab367e12423646d
  1 file changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/src/main.c b/src/main.c
-index 33fe51e..5916ddc 100644
+index 33fe51e0..5916ddcd 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -1223,10 +1223,8 @@ hide_splash (state_t *state)
@@ -33,5 +33,5 @@ index 33fe51e..5916ddc 100644
          if (state->local_console_terminal != NULL) {
                  ply_terminal_set_mode (state->local_console_terminal, PLY_TERMINAL_MODE_TEXT);
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/app-admin/plymouth/autobuild/patches/0002-main-Correctly-switch-back-to-text-mode-if-the-splas.patch
+++ b/app-admin/plymouth/autobuild/patches/0002-main-Correctly-switch-back-to-text-mode-if-the-splas.patch
@@ -1,7 +1,7 @@
 From 5323b33eb5073cfeb0086939993129bac14fd1a9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 1 Sep 2024 00:16:10 +0800
-Subject: [PATCH 2/2] main: Correctly switch back to text mode if the splash is
+Subject: [PATCH 2/3] main: Correctly switch back to text mode if the splash is
  requested, but never shown
 
 Co-authored-by: filip-hejsek
@@ -12,7 +12,7 @@ Ref: https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/1e206268df99d28e9
  1 file changed, 4 insertions(+)
 
 diff --git a/src/main.c b/src/main.c
-index 5916ddc..44486ac 100644
+index 5916ddcd..44486ac3 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -1457,6 +1457,10 @@ on_quit (state_t       *state,
@@ -27,5 +27,5 @@ index 5916ddc..44486ac 100644
          }
  }
 -- 
-2.46.0.windows.1
+2.47.0
 

--- a/app-admin/plymouth/autobuild/patches/0003-ply-kmsg-reader-disable-completely.patch
+++ b/app-admin/plymouth/autobuild/patches/0003-ply-kmsg-reader-disable-completely.patch
@@ -1,0 +1,126 @@
+From 2ca060a481ccccb7cda5aa2e1743e68e531e9e8e Mon Sep 17 00:00:00 2001
+From: Cyan <cyan@cyano.uk>
+Date: Tue, 5 Nov 2024 15:03:52 +0800
+Subject: [PATCH] ply-kmsg-reader: disable completely
+
+Currently it does nothing useful, since we already have kernel message
+printed to the console. It spams the terminal if kernel log level is
+verbose.
+---
+ src/libply-splash-core/meson.build            |  2 --
+ .../ply-console-viewer.c                      |  1 -
+ src/main.c                                    | 31 -------------------
+ 3 files changed, 34 deletions(-)
+
+diff --git a/src/libply-splash-core/meson.build b/src/libply-splash-core/meson.build
+index cd22345c..0a7a6c5b 100644
+--- a/src/libply-splash-core/meson.build
++++ b/src/libply-splash-core/meson.build
+@@ -2,7 +2,6 @@ libply_splash_core_sources = files(
+   'ply-boot-splash.c',
+   'ply-device-manager.c',
+   'ply-input-device.c',
+-  'ply-kmsg-reader.c',
+   'ply-keyboard.c',
+   'ply-pixel-buffer.c',
+   'ply-pixel-display.c',
+@@ -57,7 +56,6 @@ libply_splash_core_headers = files(
+   'ply-boot-splash.h',
+   'ply-device-manager.h',
+   'ply-input-device.h',
+-  'ply-kmsg-reader.h',
+   'ply-keyboard.h',
+   'ply-pixel-buffer.h',
+   'ply-pixel-display.h',
+diff --git a/src/libply-splash-graphics/ply-console-viewer.c b/src/libply-splash-graphics/ply-console-viewer.c
+index fe25089d..d8453465 100644
+--- a/src/libply-splash-graphics/ply-console-viewer.c
++++ b/src/libply-splash-graphics/ply-console-viewer.c
+@@ -25,7 +25,6 @@
+ #include "ply-array.h"
+ #include "ply-pixel-display.h"
+ #include "ply-image.h"
+-#include "ply-kmsg-reader.h"
+ #include "ply-console-viewer.h"
+ #include "ply-rich-text.h"
+ 
+diff --git a/src/main.c b/src/main.c
+index 44486ac3..c2a7c6c6 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -54,7 +54,6 @@
+ #include "ply-trigger.h"
+ #include "ply-utils.h"
+ #include "ply-progress.h"
+-#include "ply-kmsg-reader.h"
+ 
+ #define BOOT_DURATION_FILE     PLYMOUTH_TIME_DIRECTORY "/boot-duration"
+ #define SHUTDOWN_DURATION_FILE PLYMOUTH_TIME_DIRECTORY "/shutdown-duration"
+@@ -81,7 +80,6 @@ typedef struct
+         ply_event_loop_t       *loop;
+         ply_boot_server_t      *boot_server;
+         ply_boot_splash_t      *boot_splash;
+-        ply_kmsg_reader_t      *kmsg_reader;
+         ply_terminal_session_t *session;
+         ply_buffer_t           *boot_buffer;
+         ply_progress_t         *progress;
+@@ -161,8 +159,6 @@ static void on_backspace (state_t *state);
+ static void on_quit (state_t       *state,
+                      bool           retain_splash,
+                      ply_trigger_t *quit_trigger);
+-static void on_new_kmsg_message (state_t        *state,
+-                                 kmsg_message_t *kmsg_message);
+ static bool sh_is_init (state_t *state);
+ static void cancel_pending_delayed_show (state_t *state);
+ static void prepare_logging (state_t *state);
+@@ -1465,18 +1461,6 @@ on_quit (state_t       *state,
+         }
+ }
+ 
+-void
+-on_new_kmsg_message (state_t        *state,
+-                     kmsg_message_t *kmsg_message)
+-{
+-        ply_buffer_append (state->boot_buffer, "%s\n", kmsg_message->message);
+-
+-        if (state->boot_splash != NULL) {
+-                ply_boot_splash_update_output (state->boot_splash, kmsg_message->message, strlen (kmsg_message->message));
+-                ply_boot_splash_update_output (state->boot_splash, "\n", 1);
+-        }
+-}
+-
+ static bool
+ on_has_active_vt (state_t *state)
+ {
+@@ -1903,18 +1887,6 @@ attach_to_running_session (state_t *state)
+                 return false;
+         }
+ 
+-        if (state->kmsg_reader == NULL) {
+-                ply_trace ("Creating new kmsg reader");
+-                state->kmsg_reader = ply_kmsg_reader_new ();
+-
+-                ply_kmsg_reader_watch_for_messages (state->kmsg_reader,
+-                                                    (ply_kmsg_reader_message_handler_t)
+-                                                    on_new_kmsg_message,
+-                                                    state);
+-        }
+-
+-        ply_kmsg_reader_start (state->kmsg_reader);
+-
+ #ifdef PLY_ENABLE_SYSTEMD_INTEGRATION
+         tell_systemd_to_print_details (state);
+ #endif
+@@ -1939,9 +1911,6 @@ detach_from_running_session (state_t *state)
+         tell_systemd_to_stop_printing_details (state);
+ #endif
+ 
+-        ply_trace ("stopping kmsg reader");
+-        ply_kmsg_reader_stop (state->kmsg_reader);
+-
+         ply_trace ("detaching from terminal session");
+         ply_terminal_session_detach (state->session);
+         state->is_redirected = false;
+-- 
+2.47.0
+

--- a/app-admin/plymouth/autobuild/patches/0003-ply-kmsg-reader-disable-completely.patch
+++ b/app-admin/plymouth/autobuild/patches/0003-ply-kmsg-reader-disable-completely.patch
@@ -1,7 +1,7 @@
 From 2ca060a481ccccb7cda5aa2e1743e68e531e9e8e Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Tue, 5 Nov 2024 15:03:52 +0800
-Subject: [PATCH] ply-kmsg-reader: disable completely
+Subject: [PATCH 3/3] ply-kmsg-reader: disable completely
 
 Currently it does nothing useful, since we already have kernel message
 printed to the console. It spams the terminal if kernel log level is

--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,5 +1,5 @@
 VER=24.004.60
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- plymouth: disable kmsg streaming completely
    Currently it does nothing useful, since we already have kernel messages
    printed to the console. It spams the terminal if kernel log level is
    verbose. Disabling it to stop kernel messages from being printed out
    more than once.

Package(s) Affected
-------------------

- plymouth: 2:24.004.60-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
