### PR TITLE
pngquant: update to 2.18.0

### DIFF
--- a/app-utils/pngquant/spec
+++ b/app-utils/pngquant/spec
@@ -1,5 +1,4 @@
-VER=2.12.6
-CHKSUMS="SKIP"
+VER=2.18.0
 SRCS="git::commit=tags/$VER::https://github.com/kornelski/pngquant"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3674"


### PR DESCRIPTION
Topic Description
-----------------

- pngquant: update to 2.18.0

Package(s) Affected
-------------------

- pngquant: 2.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pngquant
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
