### PR TITLE
git-absorb: update to 0.6.16

### DIFF
--- a/app-devel/git-absorb/spec
+++ b/app-devel/git-absorb/spec
@@ -1,5 +1,4 @@
-VER=0.6.15
-REL=1
+VER=0.6.16
 SRCS="git::commit=tags/$VER::https://github.com/tummychow/git-absorb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328525"


### PR DESCRIPTION
Topic Description
-----------------

- git-absorb: update to 0.6.16
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- git-absorb: 0.6.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-absorb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
