### PR TITLE
curl, curl+32: update to 8.11.0

### DIFF
--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,4 +1,4 @@
-VER=8.10.1
+VER=8.11.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee"
+CHKSUMS="sha256::db59cf0d671ca6e7f5c2c5ec177084a33a79e04c97e71cf183a5cdea235054eb"
 CHKUPDATE="anitya::id=381"

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,4 @@
-VER=8.10.1
+VER=8.11.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee"
+CHKSUMS="sha256::db59cf0d671ca6e7f5c2c5ec177084a33a79e04c97e71cf183a5cdea235054eb"
 CHKUPDATE="anitya::id=381"


### PR DESCRIPTION
Topic Description
-----------------

- curl+32: update to 8.11.0
- curl: update to 8.11.0

Package(s) Affected
-------------------

- curl: 8.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
