### PR TITLE
[WIP] libqapt: new, 3.0.5

### DIFF
--- a/desktop-kde/libqapt/autobuild/defines
+++ b/desktop-kde/libqapt/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=libqapt
+PKGSEC=kde
+PKGDEP="apt debconf-kde glib kauth kcoreaddons ki18n kiconthemes kio krunner \
+        ktextwidgets kwidgetsaddons kwindowsystem polkit-qt-1 xapian-core"
+BUILDDEP="extra-cmake-modules"
+PKGDES="Qt frontend library and utilities for APT"
+
+CMAKE_AFTER="-DBUILD_WITH_QT6=OFF"

--- a/desktop-kde/libqapt/autobuild/patches/0001-Debian-fix-missing-include-for-GCC-12.patch
+++ b/desktop-kde/libqapt/autobuild/patches/0001-Debian-fix-missing-include-for-GCC-12.patch
@@ -1,0 +1,38 @@
+From 3fa82bf348c4ec749858fb5f112d03b014b9eb02 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 21 Feb 2024 21:40:07 +0800
+Subject: [PATCH] [Debian] fix missing include for GCC >= 12
+
+---
+ src/worker/aptlock.cpp   | 2 ++
+ src/worker/aptworker.cpp | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/src/worker/aptlock.cpp b/src/worker/aptlock.cpp
+index 93b4f6b..7a90a17 100644
+--- a/src/worker/aptlock.cpp
++++ b/src/worker/aptlock.cpp
+@@ -23,6 +23,8 @@
+ #include <apt-pkg/error.h>
+ #include <QDebug>
+ 
++#include <unistd.h>
++
+ AptLock::AptLock(const QString &path)
+     : m_path(path.toUtf8())
+     , m_fd(-1)
+diff --git a/src/worker/aptworker.cpp b/src/worker/aptworker.cpp
+index e08c993..d9ead49 100644
+--- a/src/worker/aptworker.cpp
++++ b/src/worker/aptworker.cpp
+@@ -47,6 +47,7 @@
+ // System includes
+ #include <sys/statvfs.h>
+ #include <sys/statfs.h>
++#include <unistd.h>
+ #define RAMFS_MAGIC     0x858458f6
+ 
+ // Own includes
+-- 
+2.47.0
+

--- a/desktop-kde/libqapt/spec
+++ b/desktop-kde/libqapt/spec
@@ -1,0 +1,13 @@
+VER=3.0.5
+# FIXME: Upstream released but never tagged v3.0.5.
+#
+#   Author: Harald Sitter <sitter@kde.org>
+#   Date:   Wed Apr 1 14:26:44 2020 +0200
+#
+#      bump version to 3.0.5
+#    
+#      in preparation of release
+#
+SRCS="git::commit=3f73b48371fa2a7faf3d0555ea90bcbb66097ed0::https://github.com/KDE/libqapt"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371536"


### PR DESCRIPTION
Topic Description
-----------------

- libqapt: new, 3.0.5

Package(s) Affected
-------------------

- libqapt: 3.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libqapt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
