### PR TITLE
sing-box: add completion files

### DIFF
--- a/app-network/sing-box/autobuild/build
+++ b/app-network/sing-box/autobuild/build
@@ -1,16 +1,11 @@
-cd "$BLDDIR"
-
-abinfo "Fetching go modules..."
-go get "${SRCDIR}"
-
-abinfo "Building exec binary..."
+abinfo "Building exec binary ..."
 go build -v \
-    -ldflags "-s -w -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/autobuild3/specs/hardened-ld' -X 'github.com/sagernet/sing-box/constant.Version=$PKGVER'" \
+    -ldflags "-s -w -buildid= -linkmode=external -X 'github.com/sagernet/sing-box/constant.Version=$PKGVER'" \
     -tags "with_gvisor,with_quic,with_wireguard,with_grpc,with_ech,with_utls,with_reality_server,with_acme,with_dhcp,with_clash_api,with_v2ray_api" \
-    ../cmd/sing-box
+    ./cmd/sing-box
 
 abinfo "Installing sing-box executables ..."
-install -Dvm755 "$BLDDIR"/sing-box \
+install -Dvm755 "$SRCDIR"/sing-box \
     -t "$PKGDIR"/usr/bin/
 
 abinfo "Installing systemd services..."
@@ -20,3 +15,11 @@ install -Dvm644 "$SRCDIR"/release/config/sing-box@.service \
     -t "$PKGDIR"/usr/lib/systemd/system
 install -Dvm644 "$SRCDIR"/release/config/config.json \
     -t "$PKGDIR"/etc/sing-box
+
+abinfo "Installing completion files ..."
+install -Dvm644 "$SRCDIR"/release/completions/sing-box.bash \
+    -T "$PKGDIR"/usr/share/bash-completion/completions/sing-box
+install -Dvm644 "$SRCDIR"/release/completions/sing-box.zsh \
+    -T "$PKGDIR"/usr/share/zsh/site-functions/_sing-box
+install -Dvm644 "$SRCDIR"/release/completions/sing-box.fish \
+    -T "$PKGDIR"/usr/share/fish/vendor_completions.d/sing-box.fish

--- a/app-network/sing-box/autobuild/defines
+++ b/app-network/sing-box/autobuild/defines
@@ -4,6 +4,4 @@ PKGDES="A universal proxy platform"
 PKGDEP="glibc"
 BUILDDEP="go"
 
-FAIL_ARCH="(mips64r6el)"
-
 ABSPLITDBG=0

--- a/app-network/sing-box/autobuild/prepare
+++ b/app-network/sing-box/autobuild/prepare
@@ -1,4 +1,10 @@
-abinfo "Setting up build environment..."
-export GOPATH="$SRCDIR"/abgopath
-mkdir -v "$BLDDIR"
-mkdir -v "$GOPATH"
+abinfo "Enabling trimpath for a reproducible build ..."
+export GOFLAGS="${GOFLAGS} -trimpath"
+
+abinfo "Setting other GOFLAGS ..."
+export GOFLAGS="${GOFLAGS} -mod=readonly -modcacherw"
+
+if ! ab_match_arch loongson3; then
+    abinfo "Enabling buildmode=pie ..."
+    export GOFLAGS="${GOFLAGS} -buildmode=pie"
+fi

--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,4 +1,5 @@
 VER=1.10.1
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: add completion files
    - Remove outdated FAIL_ARCH.
    - Enable reproducible tag and other GOFLAGS.
    - Clean up prepare and build.

Package(s) Affected
-------------------

- sing-box: 1.10.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
