### PR TITLE
papirus-icon-theme: update to 20240501

### DIFF
--- a/desktop-themes/papirus-icon-theme/spec
+++ b/desktop-themes/papirus-icon-theme/spec
@@ -1,4 +1,4 @@
-VER=20240201
-# FIXME: HTTP 400 whilst fetching a Git snapshot.
-SRCS="tbl::https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/$VER.tar.gz"
-CHKSUMS="sha256::8ff3caded7862e5e6f531dbae54b213ff1cd3666d26f23357c6183173856f380"
+VER=20240501
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/PapirusDevelopmentTeam/papirus-icon-theme.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=18645"


### PR DESCRIPTION
Topic Description
-----------------

- papirus-icon-theme: update to 20240501

Package(s) Affected
-------------------

- papirus-icon-theme: 20240501

Security Update?
----------------

No

Build Order
-----------

```
#buildit papirus-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
