### PR TITLE
i3: update to 4.24

### DIFF
--- a/desktop-wm/i3/autobuild/beyond
+++ b/desktop-wm/i3/autobuild/beyond
@@ -1,2 +1,3 @@
-mkdir -p "$PKGDIR"/usr/share/man/man1/
-cp man/*.1 "$PKGDIR"/usr/share/man/man1/
+abinfo "Installing manpages ..."
+install -Dvm644 "$SRCDIR"/man/*.1 \
+    -t "$PKGDIR"/usr/share/man/man1/

--- a/desktop-wm/i3/spec
+++ b/desktop-wm/i3/spec
@@ -1,5 +1,4 @@
-VER=4.23
-REL=1
+VER=4.24
 SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.xz"
-CHKSUMS="sha256::61026a7196c9139d0f3aadd27197e8b320c576e3a450e01d74c1aca484044c46"
+CHKSUMS="sha256::5baefd0e5e78f1bafb7ac85deea42bcd3cbfe65f1279aa96f7e49661637ac981"
 CHKUPDATE="anitya::id=1348"


### PR DESCRIPTION
Topic Description
-----------------

- i3: update to 4.24
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- i3: 4.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
