### PR TITLE
xf86-video-loongson: new, 0+git20230305

### DIFF
--- a/runtime-display/xf86-video-loongson/autobuild/defines
+++ b/runtime-display/xf86-video-loongson/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=xf86-video-loongson
+PKGDES="XF86 driver for LS7A1000/2000 GPUs"
+PKGDEP="xorg-server libdrm"
+PKGSEC=x11
+
+# Note: Only provide Vivante (7A1000) support for now, as 7A2000 users
+# would be better served by LoongGPU.
+AUTOTOOLS_AFTER=(
+    '--disable-gsgpu'
+)
+
+# Note: Only useful for loongson3, (and much less for) loongarch64.
+FAIL_ARCH="!(loongarch64|loongson3)"
+
+AB_FLAGS_RRO=0
+AB_FLAGS_NOW=0

--- a/runtime-display/xf86-video-loongson/spec
+++ b/runtime-display/xf86-video-loongson/spec
@@ -1,0 +1,4 @@
+VER=0+git20230305
+SRCS="git::commit=7c23fb46899c34fa1aff27751ede5d42f7619f07::https://github.com/suijingfeng/xf86-video-loongson"
+CHKSUMS="SKIP"
+# FIXME: No release/tag yet.


### PR DESCRIPTION
Topic Description
-----------------

- xf86-video-loongson: new, 0+git20230305

Package(s) Affected
-------------------

- xf86-video-loongson: 0+git20230305

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-video-loongson
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
