### PR TITLE
opencl-registry-api: update to 2024.10.24

### DIFF
--- a/app-devel/opencl-registry-api/spec
+++ b/app-devel/opencl-registry-api/spec
@@ -1,4 +1,4 @@
-VER=2024.05.08
+VER=2024.10.24
 SRCS="git::commit=tags/v$VER;rename=OpenCL-Headers::https://github.com/KhronosGroup/OpenCL-Headers \
       git::commit=tags/v$VER;rename=OpenCL-CLHPP::https://github.com/KhronosGroup/OpenCL-CLHPP"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- opencl-registry-api: update to 2024.10.24
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- opencl-registry-api: 2024.10.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencl-registry-api
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
