### PR TITLE
 v2ray-rules-dat: update to 202411072211

### DIFF
--- a/runtime-data/v2ray-rules-dat/spec
+++ b/runtime-data/v2ray-rules-dat/spec
@@ -1,6 +1,6 @@
-VER=202411012212
+VER=202411072211
 SRCS="file::rename=geoip.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geoip.dat \
       file::rename=geosite.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geosite.dat"
-CHKSUMS="SHA256::ad0e48044a70a85173385ec401f66dfaffafef577d269b0015e79e511a8df09e \
-         SHA256::20d0e74f99185aee5bb458bf223a3c8ebc84de28d94f915df9676ccca21571f6"
-CHKUPDATE="github::repo=Loyalsoldier/v2ray-rules-dat"
+CHKSUMS="sha256::224a9b8a3c8296478231a28e1eb8f8bdcba49af81a0873ed556fa1d9cdd59128 \
+         sha256::87ee7c4f4545881042e313349191082b3d13b411fffee3df7e2297a96fa25f17"
+CHKUPDATE="anitya::id=375331"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray-rules-dat: update to 202411072211

Package(s) Affected
-------------------

- v2ray-rules-dat: 202411072211

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray-rules-dat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
