### PR TITLE
x264: update to master HEAD 20241027

### DIFF
--- a/runtime-multimedia/x264/autobuild/defines
+++ b/runtime-multimedia/x264/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
 BUILDDEP__I486="nasm"
-PKGDES="H264 encoding library"
+PKGDES="An H.264 encoder"
 
 AUTOTOOLS_AFTER="--enable-shared \
                  --enable-pic"

--- a/runtime-multimedia/x264/autobuild/prepare
+++ b/runtime-multimedia/x264/autobuild/prepare
@@ -1,7 +1,2 @@
 abinfo "Appending -ffat-lto-objects to avoid endianess test failure when LTO is enabled ..."
 export CFLAGS="${CFLAGS} -ffat-lto-objects"
-
-if ab_match_arch mips64r6el; then
-    # FIXME: flag hack to pass configure (i6400/6500 should support MSA).
-    export CFLAGS="${CFLAGS} -mmsa"
-fi

--- a/runtime-multimedia/x264/spec
+++ b/runtime-multimedia/x264/spec
@@ -1,4 +1,4 @@
-VER=0+git20240305
-SRCS="git::commit=7ed753b10a61d0be95f683289dfb925b800b0676::https://git.videolan.org/git/x264.git"
+VER=0+git20241027
+SRCS="git::commit=da14df5535fd46776fb1c9da3130973295c87aca::https://git.videolan.org/git/x264.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15280"


### PR DESCRIPTION
Topic Description
-----------------

- x264: update to master HEAD 20241027

Package(s) Affected
-------------------

- x264: 1:0+git20241027

Security Update?
----------------

No

Build Order
-----------

```
#buildit x264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
