### PR TITLE
glm: disable library building

### DIFF
--- a/runtime-scientific/glm/autobuild/defines
+++ b/runtime-scientific/glm/autobuild/defines
@@ -14,4 +14,5 @@ ABTYPE=cmakeninja
 CMAKE_AFTER="-DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/usr \
              -DCMAKE_INSTALL_DATAROOTDIR=/usr/lib/cmake \
+             -DGLM_BUILD_LIBRARY=OFF \
              -W no-dev"

--- a/runtime-scientific/glm/spec
+++ b/runtime-scientific/glm/spec
@@ -1,4 +1,5 @@
 VER=1.0.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/g-truc/glm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1181"


### PR DESCRIPTION
Topic Description
-----------------

- glm: keep static archives

Package(s) Affected
-------------------

- glm: 1:1.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
