### PR TITLE
xz: update to 5.6.3

### DIFF
--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,5 +1,4 @@
-VER=5.6.2
+VER=5.6.3
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf"
+CHKSUMS="sha256::db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a"
 CHKUPDATE="anitya::id=5277"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- xz: update to 5.6.3
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- xz: 5.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
