### PR TITLE
i3status-rust: update to 0.33.2

### DIFF
--- a/desktop-wm/i3status-rust/spec
+++ b/desktop-wm/i3status-rust/spec
@@ -1,4 +1,4 @@
-VER=0.33.1
+VER=0.33.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/greshake/i3status-rust"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231979"


### PR DESCRIPTION
Topic Description
-----------------

- i3status-rust: update to 0.33.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- i3status-rust: 0.33.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3status-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
