### PR TITLE
systemd: update to 256

### DIFF
--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,4 @@
-VER=256.7
+VER=256
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: update to 256
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- systemd: 1:256

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
