### PR TITLE
openh264: update to 2.5.0+gmp114+2

### DIFF
--- a/app-multimedia/openh264/spec
+++ b/app-multimedia/openh264/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2.4.1
+UPSTREAM_VER=2.5.0
 GMPVER=114_2
 VER=${UPSTREAM_VER}+gmp${GMPVER/_/+}
 SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/cisco/openh264 \


### PR DESCRIPTION
Topic Description
-----------------

- openh264: update to 2.5.0+gmp114+2
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- openh264: 2.5.0+gmp114+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openh264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
