### PR TITLE
libfdk-aac: update to 2.0.3

### DIFF
--- a/runtime-multimedia/libfdk-aac/spec
+++ b/runtime-multimedia/libfdk-aac/spec
@@ -1,4 +1,4 @@
-VER=2.0.1
+VER=2.0.3
 SRCS="tbl::https://github.com/mstorsjo/fdk-aac/archive/v$VER.tar.gz"
-CHKSUMS="sha256::a4142815d8d52d0e798212a5adea54ecf42bcd4eec8092b37a8cb615ace91dc6"
+CHKSUMS="sha256::e25671cd96b10bad896aa42ab91a695a9e573395262baed4e4a2ff178d6a3a78"
 CHKUPDATE="anitya::id=16208"


### PR DESCRIPTION
Topic Description
-----------------

- libfdk-aac: update to 2.0.3
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- libfdk-aac: 2.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfdk-aac
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
