### PR TITLE
sdl2-ttf: update to 2.22.0

### DIFF
--- a/runtime-multimedia/sdl2-ttf/spec
+++ b/runtime-multimedia/sdl2-ttf/spec
@@ -1,4 +1,4 @@
-VER=2.0.15
+VER=2.22.0
 SRCS="tbl::https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$VER.tar.gz"
-CHKSUMS="sha256::a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33"
+CHKSUMS="sha256::d48cbd1ce475b9e178206bf3b72d56b66d84d44f64ac05803328396234d67723"
 CHKUPDATE="anitya::id=4784"


### PR DESCRIPTION
Topic Description
-----------------

- sdl2-ttf: update to 2.22.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- sdl2-ttf: 2.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl2-ttf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
