### PR TITLE
nvme-cli: update to 2.11

### DIFF
--- a/app-admin/nvme-cli/spec
+++ b/app-admin/nvme-cli/spec
@@ -1,4 +1,4 @@
-VER=2.9.1
+VER=2.11
 SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/nvme-cli.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9074"

--- a/runtime-devices/libnvme/spec
+++ b/runtime-devices/libnvme/spec
@@ -1,4 +1,4 @@
-VER=1.9
+VER=1.11
 SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/libnvme.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242763"


### PR DESCRIPTION
Topic Description
-----------------

- libnvme: update to 1.11
- nvme-cli: update to 2.11
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- libnvme: 1.11
- nvme-cli: 2.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnvme nvme-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
