### PR TITLE
gawk: update to 5.3.1

### DIFF
--- a/app-utils/gawk/spec
+++ b/app-utils/gawk/spec
@@ -1,5 +1,4 @@
-VER=5.3.0
+VER=5.3.1
 SRCS="tbl::https://ftp.gnu.org/gnu/gawk/gawk-$VER.tar.xz"
-CHKSUMS="sha256::ca9c16d3d11d0ff8c69d79dc0b47267e1329a69b39b799895604ed447d3ca90b"
+CHKSUMS="sha256::694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78"
 CHKUPDATE="anitya::id=868"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gawk: update to 5.3.1
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- gawk: 5.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gawk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
