### PR TITLE
jellyfish: update to 1.1.1

### DIFF
--- a/lang-python/jellyfish/autobuild/defines
+++ b/lang-python/jellyfish/autobuild/defines
@@ -10,5 +10,12 @@ ABTYPE=pep517
 ABSPLITDBG=0
 NOPYTHON2=1
 
-# FIXME: ld.lld: error: unknown relocation against symbol .Lla-relax-align
-NOLTO__LOONGARCH64=1
+# FIXME
+# error: linking with `clang` failed: exit status: 1
+#   |
+#   = note: (command-line)
+#   = note: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
+#           >>> defined in /usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libstd-933bbba4e9638d9f.rlib(std-933bbba4e9638d9f.std.cb7dec0cc09f6f49-cgu.0.rcgu.o)
+#           >>> referenced by std.cb7dec0cc09f6f49-cgu.0
+#           >>>               std-933bbba4e9638d9f.std.cb7dec0cc09f6f49-cgu.0.rcgu.o:(.eh_frame+0x416B) in archive /usr/lib64/rustlib/mips64el-unknown-linux-gnuabi64/lib/libstd-933bbba4e9638d9f.rlib
+NOLTO__LOONGSON3=1

--- a/lang-python/jellyfish/spec
+++ b/lang-python/jellyfish/spec
@@ -1,4 +1,4 @@
-VER=1.0.4
+VER=1.1.1
 SRCS="git::commit=tags/v$VER::https://github.com/jamesturk/jellyfish"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6587"


### PR DESCRIPTION
Topic Description
-----------------

- jellyfish: update to 1.1.1
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- jellyfish: 1:1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit jellyfish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
