### PR TITLE
id3: update to 0.81

### DIFF
--- a/app-utils/id3/spec
+++ b/app-utils/id3/spec
@@ -1,5 +1,4 @@
-VER=0.80
+VER=0.81
 SRCS="tbl::https://github.com/squell/id3/releases/download/$VER/id3-$VER.tar.gz"
-CHKSUMS="sha256::aa61735c5806ed77b71de1408a78371d04add8c8c9b1532a055949081e5a35e2"
-REL=1
+CHKSUMS="sha256::5eda41e277e67492bfe0116d24962c24c47ead56a925a00f05f724bcc7687b0c"
 CHKUPDATE="anitya::id=231597"


### PR DESCRIPTION
Topic Description
-----------------

- id3: update to 0.81
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- id3: 0.81

Security Update?
----------------

No

Build Order
-----------

```
#buildit id3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
