### PR TITLE
dnsdiag: update to 2.6.0

### DIFF
--- a/app-network/dnsdiag/spec
+++ b/app-network/dnsdiag/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
+VER=2.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/farrokhi/dnsdiag"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16297"

--- a/lang-python/dnspython/spec
+++ b/lang-python/dnspython/spec
@@ -1,4 +1,4 @@
-VER=2.6.1
-SRCS="tbl::https://pypi.io/packages/source/d/dnspython/dnspython-$VER.tar.gz"
-CHKSUMS="sha256::e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
+VER=2.7.0
+SRCS="pypi::version=$VER::dnspython"
+CHKSUMS="sha256::ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"
 CHKUPDATE="anitya::id=13190"


### PR DESCRIPTION
Topic Description
-----------------

- dnspython: update to 2.7.0
- dnsdiag: update to 2.6.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- dnsdiag: 2.6.0
- dnspython: 2.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnspython dnsdiag
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
