### PR TITLE
tor: update to 0.4.8.13

### DIFF
--- a/app-network/tor/spec
+++ b/app-network/tor/spec
@@ -1,4 +1,4 @@
-VER=0.4.8.12
+VER=0.4.8.13
 SRCS="tbl::https://www.torproject.org/dist/tor-$VER.tar.gz"
-CHKSUMS="sha256::ca7cc735d98e3747b58f2f3cc14f804dd789fa0fb333a84dcb6bd70adbb8c874"
+CHKSUMS="sha256::9baf26c387a2820b3942da572146e6eb77c2bc66862af6297cd02a074e6fba28"
 CHKUPDATE="anitya::id=4991"


### PR DESCRIPTION
Topic Description
-----------------

- tor: update to 0.4.8.13
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- tor: 0.4.8.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit tor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
