### PR TITLE
intel-gpu-tools: update to 1.29

### DIFF
--- a/app-admin/intel-gpu-tools/spec
+++ b/app-admin/intel-gpu-tools/spec
@@ -1,4 +1,4 @@
-VER=1.28
+VER=1.29
 SRCS="tbl::https://www.x.org/archive/individual/app/igt-gpu-tools-$VER.tar.xz"
-CHKSUMS="sha256::ffcbdf61bd495803d9ae9dfa83e2fe04b8f583a2296fe059c1d5dd135a8a3b15"
+CHKSUMS="sha256::e0fe0d0f088cb50090b212f28b8960fb1e6160c681f5bea0654973aaa9909d8f"
 CHKUPDATE="anitya::id=12378"


### PR DESCRIPTION
Topic Description
-----------------

- intel-gpu-tools: update to 1.29
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- intel-gpu-tools: 1.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gpu-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
