### PR TITLE
sndio: update to 1.10.0

### DIFF
--- a/app-multimedia/sndio/spec
+++ b/app-multimedia/sndio/spec
@@ -1,4 +1,4 @@
-VER=1.9.0
+VER=1.10.0
 SRCS="tbl::http://www.sndio.org/sndio-$VER.tar.gz"
-CHKSUMS="sha256::f30826fc9c07e369d3924d5fcedf6a0a53c0df4ae1f5ab50fe9cf280540f699a"
+CHKSUMS="sha256::bebd3bfd01c50c9376cf3e7814b9379bed9e17d0393b5113b7eb7a3d0d038c54"
 CHKUPDATE="anitya::id=230954"


### PR DESCRIPTION
Topic Description
-----------------

- sndio: update to 1.10.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- sndio: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sndio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
