### PR TITLE
blinker: update to 1.9.0

### DIFF
--- a/lang-python/blinker/spec
+++ b/lang-python/blinker/spec
@@ -1,4 +1,4 @@
-VER=1.8.2
+VER=1.9.0
 SRCS="pypi::version=$VER::blinker"
-CHKSUMS="sha256::8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"
+CHKSUMS="sha256::b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"
 CHKUPDATE="anitya::id=20042"


### PR DESCRIPTION
Topic Description
-----------------

- blinker: update to 1.9.0
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- blinker: 1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit blinker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
