### PR TITLE
libmypaint: rebuild for broken json-c abi version on riscv64

### DIFF
--- a/runtime-creativity/libmypaint/spec
+++ b/runtime-creativity/libmypaint/spec
@@ -1,5 +1,5 @@
 VER=1.6.1
-REL=2
+REL=3
 SRCS="tbl::https://github.com/mypaint/libmypaint/releases/download/v$VER/libmypaint-$VER.tar.xz"
 CHKSUMS="sha256::741754f293f6b7668f941506da07cd7725629a793108bb31633fb6c3eae5315f"
 CHKUPDATE="anitya::id=12974"


### PR DESCRIPTION
Topic Description
-----------------

- libmypaint: rebuild for broken json-c abi version on riscv64
    On riscv64, current libmypaint binary built depends on outdated
    libjson-c.so.4 while json-c is providing .5 ABI version.
    Rebuild libmypaint to solve this issue.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- libmypaint: 1.6.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmypaint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
