### PR TITLE
xray: update to 24.11.11

### DIFF
--- a/app-network/xray/autobuild/prepare
+++ b/app-network/xray/autobuild/prepare
@@ -4,7 +4,7 @@ export GOFLAGS="${GOFLAGS} -trimpath"
 abinfo "Setting other GOFLAGS ..."
 export GOFLAGS="${GOFLAGS} -mod=readonly -modcacherw"
 
-if [[ "${CROSS:-$ARCH}" != "loongson3" ]]; then
+if ! ab_match_arch loongson3; then
     abinfo "Enabling buildmode=pie ..."
     export GOFLAGS="${GOFLAGS} -buildmode=pie"
 fi

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,4 @@
-VER=24.11.5
+VER=24.11.11
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/XTLS/Xray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- xray: update to 24.11.11
    Co-authored-by: yidaduizuoye (@CAB233)

Package(s) Affected
-------------------

- xray: 24.11.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
