### PR TITLE
docker:  fix dockerd version

### DIFF
--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -2,6 +2,20 @@
 abinfo "Creating build directory ..."
 mkdir -pv "$BLDDIR"/bin
 
+VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
+GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
+BUILDTIME=${BUILDTIME:-$(TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+
+case "$VERSION" in
+	refs/tags/v*) VERSION=${VERSION#refs/tags/v} ;;
+	refs/tags/*) VERSION=${VERSION#refs/tags/} ;;
+	refs/heads/*) VERSION=$(echo "${VERSION#refs/heads/}" | sed -r 's#/+#-#g') ;;
+	refs/pull/*) VERSION=pr-$(echo "$VERSION" | grep -o '[0-9]\+') ;;
+esac
+
+DOCKER_CE_GO_LDFLAGS="-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/docker/docker/dockerversion.Version=${VERSION}\""
+DOCKER_CLI_GO_LDFLAGS="-X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
+
 # Fedora: Build docker-proxy (libnetwork).
 abinfo "docker-proxy (libnetwork): Building ..."
 export GOPATH="$SRCDIR"
@@ -30,6 +44,7 @@ abinfo "Docker Engine: Building ..."
 # FIXME: go build does not allow absolute paths.
 go build \
     -o abbuild/bin/dockerd \
+    -ldflags "${DOCKER_CE_GO_LDFLAGS}" \
     github.com/docker/docker/cmd/dockerd
 	
 # Fedora: Build cli.
@@ -45,7 +60,6 @@ export BUILDTAGS="pkcs11"
 export GOBUILDTAGS="${BUILDTAGS}"
 
 abinfo "docker-cli: Building ..."
-. ./scripts/build/.variables
 # The variables script does `set -u`, which is incompatibbe with Autobuild4, revert it.
 # https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2
 set +u
@@ -54,7 +68,7 @@ set +u
 go build \
     -o ../moby/abbuild/bin/docker \
     -tags "${GO_BUILDTAGS}" \
-    -ldflags "${GO_LDFLAGS}" \
+    -ldflags "${DOCKER_CLI_GO_LDFLAGS}" \
     ${GO_BUILDMODE} \
     github.com/docker/cli/cmd/docker
 

--- a/app-containers/docker/autobuild/postinst
+++ b/app-containers/docker/autobuild/postinst
@@ -7,5 +7,5 @@ fi
 
 # Remove /etc/conf.d/docker 
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/autobuild/postrm
+++ b/app-containers/docker/autobuild/postrm
@@ -1,4 +1,4 @@
 # Remove /etc/conf.d/docker 
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/autobuild/preinst
+++ b/app-containers/docker/autobuild/preinst
@@ -1,4 +1,4 @@
 # Remove /etc/conf.d/docker 
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -6,11 +6,11 @@ TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli;copy-repo=true::https://github.com/docker/cli \
-      git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
+      git::commit=tags/v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=11719"
 SUBDIR="moby"
-REL=1
+REL=2


### PR DESCRIPTION
Modification dpkg-maintscript-helper script package version. Change the way to get the version, add ldflags to dockerd.

<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

docker:  fix dockerd version, change the way to get the version
Co-authored-by: 某亚瑟 (@mouyase) [mouyase@aosc.io](mailto:mouyase@aosc.io)

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- docker: 27.3.1

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
#buildit docker
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
