### PR TITLE
docker: fix dockerd version

### DIFF
--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -2,6 +2,22 @@
 abinfo "Creating build directory ..."
 mkdir -pv "$BLDDIR"/bin
 
+# Get build version.
+# https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2
+VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
+GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
+BUILDTIME=${BUILDTIME:-$(TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+
+case "$VERSION" in
+	refs/tags/v*) VERSION=${VERSION#refs/tags/v} ;;
+	refs/tags/*) VERSION=${VERSION#refs/tags/} ;;
+	refs/heads/*) VERSION=$(echo "${VERSION#refs/heads/}" | sed -r 's#/+#-#g') ;;
+	refs/pull/*) VERSION=pr-$(echo "$VERSION" | grep -o '[0-9]\+') ;;
+esac
+
+DOCKER_CE_GO_LDFLAGS="-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/docker/docker/dockerversion.Version=${VERSION}\""
+DOCKER_CLI_GO_LDFLAGS="-X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
+
 # Fedora: Build docker-proxy (libnetwork).
 abinfo "docker-proxy (libnetwork): Building ..."
 export GOPATH="$SRCDIR"
@@ -30,6 +46,7 @@ abinfo "Docker Engine: Building ..."
 # FIXME: go build does not allow absolute paths.
 go build \
     -o abbuild/bin/dockerd \
+    -ldflags "${DOCKER_CE_GO_LDFLAGS}" \
     github.com/docker/docker/cmd/dockerd
 	
 # Fedora: Build cli.
@@ -45,7 +62,6 @@ export BUILDTAGS="pkcs11"
 export GOBUILDTAGS="${BUILDTAGS}"
 
 abinfo "docker-cli: Building ..."
-. ./scripts/build/.variables
 # The variables script does `set -u`, which is incompatibbe with Autobuild4, revert it.
 # https://github.com/docker/cli/blob/9eb7b52189c4c233f7e7cee0ce8c1bcaf68f3c36/scripts/build/.variables#L2
 set +u
@@ -53,8 +69,7 @@ set +u
 # FIXME: go build does not allow absolute paths
 go build \
     -o ../moby/abbuild/bin/docker \
-    -tags "${GO_BUILDTAGS}" \
-    -ldflags "${GO_LDFLAGS}" \
+    -ldflags "${DOCKER_CLI_GO_LDFLAGS}" \
     ${GO_BUILDMODE} \
     github.com/docker/cli/cmd/docker
 

--- a/app-containers/docker/autobuild/postinst
+++ b/app-containers/docker/autobuild/postinst
@@ -6,6 +6,7 @@ if [[ "$1" = "install" ]]; then
 fi
 
 # Remove /etc/conf.d/docker 
+# Before 27.3.1+tini0.19.0-1, we shipped an systemd environment file (/etc/conf.d/docker) which rendered custom Docker configurations unusable. We removed this file in its next revision. Do not change this version.
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/autobuild/postrm
+++ b/app-containers/docker/autobuild/postrm
@@ -1,4 +1,5 @@
 # Remove /etc/conf.d/docker 
+# Before 27.3.1+tini0.19.0-1, we shipped an systemd environment file (/etc/conf.d/docker) which rendered custom Docker configurations unusable. We removed this file in its next revision. Do not change this version.
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/autobuild/preinst
+++ b/app-containers/docker/autobuild/preinst
@@ -1,4 +1,5 @@
 # Remove /etc/conf.d/docker 
+# Before 27.3.1+tini0.19.0-1, we shipped an systemd environment file (/etc/conf.d/docker) which rendered custom Docker configurations unusable. We removed this file in its next revision. Do not change this version.
 if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
-    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0~ -- "$@"
+    dpkg-maintscript-helper rm_conffile /etc/conf.d/docker 27.3.1+tini0.19.0-1~ -- "$@"
 fi

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -5,12 +5,12 @@ UPSTREAM_VER=27.3.1
 TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
-SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli;copy-repo=true::https://github.com/docker/cli \
-      git::commit=tags/v${UPSTREAM_VER};rename=moby::https://github.com/moby/moby \
+SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli::https://github.com/docker/cli \
+      git::commit=tags/v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=11719"
 SUBDIR="moby"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- docker: improve packaging
    - Change the way to get the build version.
    - Add ldflags to dockerd to fix dockerd version.
    - Modify dpkg-maintscript-helper script package version to fix remove config file failed version.

Package(s) Affected
-------------------

- docker: 27.3.1+tini0.19.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
