### PR TITLE
os-prober: fix /var/lib/os-prober/mount not exist

### DIFF
--- a/app-utils/os-prober/autobuild/beyond
+++ b/app-utils/os-prober/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Creating /var/lib/os-prober ..."
+mkdir -pv "$PKGDIR"/var/lib/os-prober

--- a/app-utils/os-prober/spec
+++ b/app-utils/os-prober/spec
@@ -1,5 +1,5 @@
 VER=1.81
-REL=2
+REL=3
 SRCS="tbl::http://http.debian.net/debian/pool/main/o/os-prober/os-prober_$VER.tar.xz"
 CHKSUMS="sha256::2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883"
 CHKUPDATE="anitya::id=2574"


### PR DESCRIPTION
Topic Description
-----------------

- os-prober: fix `/var/lib/os-prober/mount` not exist

Package(s) Affected
-------------------

- os-prober: 1.81-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit os-prober
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
