### PR TITLE
zathura-pdf-mupdf: new, 0.4.4

### DIFF
--- a/app-doc/zathura-pdf-mupdf/autobuild/defines
+++ b/app-doc/zathura-pdf-mupdf/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=zathura-pdf-mupdf
+PKGSEC=doc
+PKGDEP="mupdf zathura girara"
+PKGDES="MuPDF PDF backend support for Zathura"
+
+ABTYPE=meson

--- a/app-doc/zathura-pdf-mupdf/autobuild/patches/0001-Arch-Linux-Remove-mupdf-linking-detection.patch
+++ b/app-doc/zathura-pdf-mupdf/autobuild/patches/0001-Arch-Linux-Remove-mupdf-linking-detection.patch
@@ -1,0 +1,82 @@
+From e91e5ad64d20eb4a7df377effc12ec21ba6f5f7c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johannes=20L=C3=B6thberg?= <johannes@kyriasis.com>
+Date: Fri, 18 Mar 2022 00:02:43 +0100
+Subject: [PATCH] Remove mupdf linking detection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>
+---
+ meson.build | 40 ++++++++++++++--------------------------
+ 1 file changed, 14 insertions(+), 26 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 2d1c6a2..9e34214 100644
+--- a/meson.build
++++ b/meson.build
+@@ -22,8 +22,6 @@ zathura = dependency('zathura', version: '>=0.5.2')
+ girara = dependency('girara-gtk3')
+ glib = dependency('glib-2.0')
+ cairo = dependency('cairo')
+-mupdf = dependency('mupdf', required: false, version: '>=@0@.@1@'.format(mupdf_required_version_major, mupdf_required_version_minor))
+-mupdfthird = cc.find_library('mupdf-third')
+ 
+ build_dependencies = [
+   zathura,
+@@ -32,43 +30,20 @@ build_dependencies = [
+   cairo,
+ ]
+ 
+-if not mupdf.found()
+-  # normal build of mupdf
+-  mupdf = cc.find_library('mupdf', has_headers: ['mupdf/fitz/version.h', 'mupdf/fitz.h', 'mupdf/pdf.h'], required: true)
+-  version_check = '''
+-#include <mupdf/fitz/version.h>
++mupdf = cc.find_library('mupdf')
+ 
+-#if FZ_VERSION_MAJOR < @0@ || (FZ_VERSION_MAJOR == @0@ && FZ_VERSION_MINOR < @1@)
+-#error "mupdf @0@.@1@ or newer is requried"
+-#endif
+-'''.format(mupdf_required_version_major, mupdf_required_version_minor)
+-  if not cc.compiles(version_check, dependencies: [mupdf])
+-    error('mupdf @0@.@1@ or newer is required'.format(mupdf_required_version_major, mupdf_required_version_minor))
+-  endif
++libjpeg = dependency('libjpeg')
++libjbig2dec = cc.find_library('jbig2dec')
++libopenjp2 = dependency('libopenjp2')
++gumbo = dependency('gumbo')
+ 
+-  build_dependencies += [mupdf, mupdfthird]
+-else
+-  # build from Debian's libmupdf-dev
+-  build_dependencies += [mupdf, mupdfthird]
+-
+-  libjpeg = dependency('libjpeg')
+-  libjbig2dec = cc.find_library('jbig2dec')
+-  libopenjp2 = dependency('libopenjp2')
+-  gumbo = dependency('gumbo')
+-  tesseract = dependency('tesseract')
+-  leptonica = dependency('lept')
+-  mujs = dependency('mujs')
+-
+-  build_dependencies += [
+-    libjpeg,
+-    libjbig2dec,
+-    libopenjp2,
+-    gumbo,
+-    tesseract,
+-    leptonica,
+-    mujs
+-  ]
+-endif
++build_dependencies += [
++  mupdf,
++  libjpeg,
++  libjbig2dec,
++  libopenjp2,
++  gumbo,
++]
+ 
+ if get_option('plugindir') == ''
+   plugindir = zathura.get_variable(pkgconfig: 'plugindir')

--- a/app-doc/zathura-pdf-mupdf/spec
+++ b/app-doc/zathura-pdf-mupdf/spec
@@ -1,0 +1,4 @@
+VER=0.4.4
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-mupdf"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=14847"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-pdf-mupdf: new, 0.4.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- zathura-pdf-mupdf: 0.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura-pdf-mupdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
