### PR TITLE
libportal: update to 0.8.1

### DIFF
--- a/runtime-desktop/libportal/autobuild/defines
+++ b/runtime-desktop/libportal/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=libportal
 PKGSEC=libs
 PKGDEP="glibc glib"
-BUILDDEP="gi-docgen gobject-introspection gtk-3 gtk-4 gtk-doc qt-5 vala"
+BUILDDEP="gi-docgen gobject-introspection gtk-3 gtk-4 gtk-doc qt-5 qt-6 vala"
 PKGDES="A library for GIO-style async APIs for Flatpak portals"
 
-MESON_AFTER="-Dbackends=gtk3,gtk4,qt5 \
+MESON_AFTER="-Dbackend-gtk3=enabled \
+             -Dbackend-gtk4=enabled \
+             -Dbackend-qt5=enabled \
+             -Dbackend-qt6=enabled \
              -Dportal-tests=false \
              -Dintrospection=true \
              -Dvapi=true \

--- a/runtime-desktop/libportal/spec
+++ b/runtime-desktop/libportal/spec
@@ -1,4 +1,4 @@
-VER=0.6
+VER=0.8.1
 SRCS="tbl::https://github.com/flatpak/libportal/releases/download/$VER/libportal-$VER.tar.xz"
-CHKSUMS="sha256::88a12c3ba71bc31acff7238c280de697d609cebc50830c3766776ec35abc6566"
+CHKSUMS="sha256::281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac"
 CHKUPDATE="anitya::id=230124"


### PR DESCRIPTION
Topic Description
-----------------

- libportal: update to 0.8.1
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- libportal: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libportal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
