### PR TITLE
hyperfine: update to 1.19.0

### DIFF
--- a/app-devel/hyperfine/spec
+++ b/app-devel/hyperfine/spec
@@ -1,4 +1,4 @@
-VER=1.18.0
+VER=1.19.0
 SRCS="git::commit=tags/v$VER::https://github.com/sharkdp/hyperfine"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18526"


### PR DESCRIPTION
Topic Description
-----------------

- hyperfine: update to 1.19.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- hyperfine: 1.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hyperfine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
