### PR TITLE
oma: update to 1.12.6

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -41,4 +41,4 @@ install -Dvm644 "$SRCDIR"/data/apt.conf.d/50oma.conf \
 
 abinfo "Installing D-Bus config file ..."
 install -Dvm644 "$SRCDIR"/data/dbus/oma-dbus.conf \
-	-t "$PKGDIR"/usr/share/dbus-1/
+	-t "$PKGDIR"/usr/share/dbus-1/system.d

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.12.4
+VER=1.12.6
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.12.6

Package(s) Affected
-------------------

- oma: 1.12.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



