### PR TITLE
libdatachannel: update to 0.22.2

### DIFF
--- a/app-multimedia/obs-studio/autobuild/patches/0003-obs-ffmpeg-Fix-deprecation-with-FFmpeg-7.1.patch
+++ b/app-multimedia/obs-studio/autobuild/patches/0003-obs-ffmpeg-Fix-deprecation-with-FFmpeg-7.1.patch
@@ -1,0 +1,149 @@
+From 463fabeda1ef8cc31e7c6f2cd25d6194bc717dca Mon Sep 17 00:00:00 2001
+From: tytan652 <tytan652@tytanium.xyz>
+Date: Mon, 11 Nov 2024 19:47:03 +0100
+Subject: [PATCH] obs-ffmpeg: Fix deprecation with FFmpeg 7.1
+
+---
+ .../obs-ffmpeg/obs-ffmpeg-audio-encoders.c    | 23 ++++++++---
+ plugins/obs-ffmpeg/obs-ffmpeg-output.c        | 41 ++++++++++++-------
+ 2 files changed, 45 insertions(+), 19 deletions(-)
+
+diff --git a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+index 49ee82dae..0cb0e9113 100644
+--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
++++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+@@ -290,11 +290,24 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
+ 
+ 	enc->context->sample_rate = audio_output_get_sample_rate(audio);
+ 
+-	if (enc->codec->sample_fmts) {
++	const enum AVSampleFormat *sample_fmts = NULL;
++	const int *supported_samplerates = NULL;
++
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
++	sample_fmts = enc->codec->sample_fmts;
++	supported_samplerates = enc->codec->supported_samplerates;
++#else
++	avcodec_get_supported_config(enc->context, enc->codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0,
++				     (const void **)&sample_fmts, NULL);
++	avcodec_get_supported_config(enc->context, enc->codec, AV_CODEC_CONFIG_SAMPLE_RATE, 0,
++				     (const void **)&supported_samplerates, NULL);
++#endif
++
++	if (sample_fmts) {
+ 		/* Check if the requested format is actually available for the specified
+ 		 * encoder. This may not always be the case due to FFmpeg changes or a
+ 		 * fallback being used (for example, when libopus is unavailable). */
+-		const enum AVSampleFormat *fmt = enc->codec->sample_fmts;
++		const enum AVSampleFormat *fmt = sample_fmts;
+ 		while (*fmt != AV_SAMPLE_FMT_NONE) {
+ 			if (*fmt == sample_format) {
+ 				enc->context->sample_fmt = *fmt;
+@@ -305,15 +318,15 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
+ 
+ 		/* Fall back to default if requested format was not found. */
+ 		if (enc->context->sample_fmt == AV_SAMPLE_FMT_NONE)
+-			enc->context->sample_fmt = enc->codec->sample_fmts[0];
++			enc->context->sample_fmt = sample_fmts[0];
+ 	} else {
+ 		/* Fall back to planar float if codec does not specify formats. */
+ 		enc->context->sample_fmt = AV_SAMPLE_FMT_FLTP;
+ 	}
+ 
+ 	/* check to make sure sample rate is supported */
+-	if (enc->codec->supported_samplerates) {
+-		const int *rate = enc->codec->supported_samplerates;
++	if (supported_samplerates) {
++		const int *rate = supported_samplerates;
+ 		int cur_rate = enc->context->sample_rate;
+ 		int closest = 0;
+ 
+diff --git a/plugins/obs-ffmpeg/obs-ffmpeg-output.c b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+index 899f5e2d0..94eb66141 100644
+--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
++++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+@@ -189,6 +189,7 @@ static bool create_video_stream(struct ffmpeg_data *data)
+ 	enum AVPixelFormat closest_format;
+ 	AVCodecContext *context;
+ 	struct obs_video_info ovi;
++	const enum AVPixelFormat *pix_fmts = NULL;
+ 
+ 	if (!obs_get_video_info(&ovi)) {
+ 		ffmpeg_log_error(LOG_WARNING, data, "No active video");
+@@ -200,14 +201,6 @@ static bool create_video_stream(struct ffmpeg_data *data)
+ 			data->config.video_encoder))
+ 		return false;
+ 
+-	closest_format = data->config.format;
+-	if (data->vcodec->pix_fmts) {
+-		const int has_alpha = closest_format == AV_PIX_FMT_BGRA;
+-		closest_format = avcodec_find_best_pix_fmt_of_list(
+-			data->vcodec->pix_fmts, closest_format, has_alpha,
+-			NULL);
+-	}
+-
+ 	context = avcodec_alloc_context3(data->vcodec);
+ 	context->bit_rate = (int64_t)data->config.video_bitrate * 1000;
+ 	context->width = data->config.scale_width;
+@@ -215,15 +208,28 @@ static bool create_video_stream(struct ffmpeg_data *data)
+ 	context->time_base = (AVRational){ovi.fps_den, ovi.fps_num};
+ 	context->framerate = (AVRational){ovi.fps_num, ovi.fps_den};
+ 	context->gop_size = data->config.gop_size;
+-	context->pix_fmt = closest_format;
+ 	context->color_range = data->config.color_range;
+ 	context->color_primaries = data->config.color_primaries;
+ 	context->color_trc = data->config.color_trc;
+ 	context->colorspace = data->config.colorspace;
+-	context->chroma_sample_location = determine_chroma_location(
+-		closest_format, data->config.colorspace);
+ 	context->thread_count = 0;
+ 
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
++	pix_fmts = data->vcodec->pix_fmts;
++#else
++	avcodec_get_supported_config(context, data->vcodec, AV_CODEC_CONFIG_PIX_FORMAT, 0, (const void **)&pix_fmts,
++				     NULL);
++#endif
++
++	closest_format = data->config.format;
++	if (pix_fmts) {
++		const int has_alpha = closest_format == AV_PIX_FMT_BGRA;
++		closest_format = avcodec_find_best_pix_fmt_of_list(pix_fmts, closest_format, has_alpha, NULL);
++	}
++
++	context->pix_fmt = closest_format;
++	context->chroma_sample_location = determine_chroma_location(closest_format, data->config.colorspace);
++
+ 	data->video->time_base = context->time_base;
+ 	data->video->avg_frame_rate = (AVRational){ovi.fps_num, ovi.fps_den};
+ 
+@@ -361,6 +367,7 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
+ 	AVStream *stream;
+ 	struct obs_audio_info aoi;
+ 	int channels;
++	const enum AVSampleFormat *sample_fmts = NULL;
+ 
+ 	if (!obs_get_audio_info(&aoi)) {
+ 		ffmpeg_log_error(LOG_WARNING, data, "No active audio");
+@@ -392,9 +399,15 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
+ 	if (aoi.speakers == SPEAKERS_4POINT1)
+ 		context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+ #endif
+-	context->sample_fmt = data->acodec->sample_fmts
+-				      ? data->acodec->sample_fmts[0]
+-				      : AV_SAMPLE_FMT_FLTP;
++
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
++	sample_fmts = data->acodec->sample_fmts;
++#else
++	avcodec_get_supported_config(context, data->acodec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0,
++				     (const void **)&sample_fmts, NULL);
++#endif
++
++	context->sample_fmt = sample_fmts ? sample_fmts[0] : AV_SAMPLE_FMT_FLTP;
+ 
+ 	stream->time_base = context->time_base;
+ 
+-- 
+2.47.0
+

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,5 +1,5 @@
 VER=30.2.3
-REL=1
+REL=2
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # FIXME: 126.x has https://github.com/chromiumembedded/cef/issues/3616#issuecomment-2158624330
 __OBS_CEF_VER="125.0.22+gc410c95+chromium-125.0.6422.142"

--- a/runtime-multimedia/libdatachannel/autobuild/defines
+++ b/runtime-multimedia/libdatachannel/autobuild/defines
@@ -4,6 +4,8 @@ PKGDEP="openssl libnice srtp usrsctp glib"
 BUILDDEP="cmake nlohmann-json plog"
 PKGDES="A C/C++ WebRTC network library"
 
+PKGBREAK="obs-studio<=30.2.3-1"
+
 ABTYPE=cmake
 CMAKE_AFTER="-DUSE_GNUTLS=ON \
             -DUSE_NICE=ON \

--- a/runtime-multimedia/libdatachannel/spec
+++ b/runtime-multimedia/libdatachannel/spec
@@ -1,4 +1,4 @@
-VER=0.21.2
+VER=0.22.2
 SRCS="git::commit=tags/v$VER::https://github.com/paullouisageneau/libdatachannel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369160"


### PR DESCRIPTION
Topic Description
-----------------

- libdatachannel: update to 0.22.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libdatachannel: 0.22.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdatachannel obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
