### PR TITLE
mediainfo: update to 24.11

### DIFF
--- a/app-multimedia/mediainfo/spec
+++ b/app-multimedia/mediainfo/spec
@@ -1,5 +1,5 @@
-VER=24.06
+VER=24.11
 SRCS="https://mediaarea.net/download/source/mediainfo/$VER/mediainfo_$VER.tar.xz"
-CHKSUMS="sha256::32f4a82a31e386e177fdf6e4c237053e475b501089269ab2c729452a09313520"
+CHKSUMS="sha256::876a63a69d79dd1db6b6e69077a8a630421247751460b964381e3483835670fc"
 CHKUPDATE="anitya::id=8240"
 SUBDIR="MediaInfo/Project/GNU/CLI"

--- a/runtime-common/libzen/spec
+++ b/runtime-common/libzen/spec
@@ -1,5 +1,5 @@
-VER=0.4.38
-SRCS="tbl::https://old.mediaarea.net/download/source/libzen/$VER/libzen_$VER.tar.xz"
-CHKSUMS="sha256::b8825b3190b3a31d8d362547cfa26a3c10e8c063df2d87e4a05758d6b756c8ab"
+VER=0.4.41
+SRCS="tbl::https://mediaarea.net/download/source/libzen/$VER/libzen_$VER.tar.xz"
+CHKSUMS="sha256::933bad3b7ecd29dc6bdc88a83645c83dfd098c15b0b90d6177a37fa1536704e8"
 CHKUPDATE="anitya::id=1810"
 SUBDIR="ZenLib/Project/GNU/Library"

--- a/runtime-multimedia/libmediainfo/spec
+++ b/runtime-multimedia/libmediainfo/spec
@@ -1,5 +1,5 @@
-VER=22.06
+VER=24.11
 SRCS="tbl::https://mediaarea.net/download/source/libmediainfo/$VER/libmediainfo_$VER.tar.xz"
-CHKSUMS="sha256::b279a84f2f3bb353664c4e7d5feedbac98b1fd0d4d4131ab73317541f7fec2f6"
+CHKSUMS="sha256::96e44a617f90c8b63bb685ad53be6716b7df4221793c329780f02aea6e707aa1"
 CHKUPDATE="anitya::id=16249"
 SUBDIR="MediaInfoLib/Project/GNU/Library"


### PR DESCRIPTION
Topic Description
-----------------

- libzen: update to 0.4.41
- libmediainfo: update to 24.11
- mediainfo: update to 24.11
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- libmediainfo: 24.11
- libzen: 0.4.41
- mediainfo: 24.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit libzen libmediainfo mediainfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
