### PR TITLE
deskflow: new, 1.17.1

### DIFF
--- a/app-utils/deskflow/autobuild/defines
+++ b/app-utils/deskflow/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=deskflow
+PKGSEC=utils
+PKGDES="Share mouse and keyboard between multiple devices"
+PKGDEP="glib pugixml qt-6 libei libtomlplusplus libportal libnotify"

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -1,0 +1,4 @@
+VER=1.17.1
+SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375452"

--- a/runtime-common/libtomlplusplus/autobuild/defines
+++ b/runtime-common/libtomlplusplus/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libtomlplusplus
+PKGSEC=libs
+PKGDES="Header-only TOML config file parser and serializer library for C++17"
+PKGDEP="glibc"
+
+ABTYPE=meson
+MESON_AFTER="-Dbuild_lib=true"

--- a/runtime-common/libtomlplusplus/spec
+++ b/runtime-common/libtomlplusplus/spec
@@ -1,0 +1,4 @@
+VER=3.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/marzer/tomlplusplus.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=370466"

--- a/runtime-desktop/libei/autobuild/defines
+++ b/runtime-desktop/libei/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libei
+PKGDES="Library for handling Emulated Input (EI)"
+PKGSEC=libs
+PKGDEP="glibc libxkbcommon libevdev systemd"
+BUILDDEP="attrs jinja2"
+
+MESON_AFTER="-Dsd-bus-provider=libsystemd -Dliboeffis=enabled"

--- a/runtime-desktop/libei/spec
+++ b/runtime-desktop/libei/spec
@@ -1,0 +1,4 @@
+VER=1.3.0
+SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libei.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=350087"


### PR DESCRIPTION
Topic Description
-----------------

- deskflow: new, 1.17.1
- libtomlplusplus: new, 3.4.0
- libei: new, 1.3.0

Package(s) Affected
-------------------

- deskflow: 1.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
