### PR TITLE
intel-ucode: update to 20241112

### DIFF
--- a/runtime-data/intel-ucode/spec
+++ b/runtime-data/intel-ucode/spec
@@ -1,4 +1,4 @@
-VER=20241029
+VER=20241112
 SRCS="git::commit=tags/microcode-${VER}::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20614"


### PR DESCRIPTION
Topic Description
-----------------

- intel-ucode: update to 20241112
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- intel-ucode: 20241112

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-ucode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
