### PR TITLE
pngquant: update to 3.0.3

### DIFF
--- a/app-utils/pngquant/autobuild/beyond
+++ b/app-utils/pngquant/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Installing manpage and LICENSE ..."
+install -Dm644 "$SRCDIR"/pngquant.1 \
+        "$PKGDIR"/usr/share/man/man1/pngquant.1
+install -Dm644 "$SRCDIR"/COPYRIGHT \
+        "$PKGDIR"/usr/share/licenses/pngquant/LICENSE

--- a/app-utils/pngquant/autobuild/defines
+++ b/app-utils/pngquant/autobuild/defines
@@ -1,8 +1,11 @@
 PKGNAME=pngquant
 PKGSEC=utils
 PKGDEP="lcms2 libpng zlib"
+BUILDDEP="llvm rustc"
 PKGDES="Command-line utility to quantize PNGs down to 8-bit paletted PNGs"
 
-AUTOTOOLS_AFTER="--with-openmp"
-ABSHADOW=0
-RECONF=0
+ABTYPE=rust
+# FIXME: There is no Cargo.lock file in the repository.
+NOCARGOAUDIT=1
+# FIXME: LTO breaks build with undefined symbols.
+NOLTO=1

--- a/app-utils/pngquant/spec
+++ b/app-utils/pngquant/spec
@@ -1,4 +1,4 @@
-VER=2.18.0
+VER=3.0.3
 SRCS="git::commit=tags/$VER::https://github.com/kornelski/pngquant"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3674"


### PR DESCRIPTION
Topic Description
-----------------

- pngquant: update to 3.0.3
    Add BUILDDEP due to the changed build methods

Package(s) Affected
-------------------

- pngquant: 3.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pngquant
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
