### PR TITLE
dracut-ng: update to 105

### DIFF
--- a/app-admin/dracut-ng/autobuild/build
+++ b/app-admin/dracut-ng/autobuild/build
@@ -15,6 +15,7 @@ abinfo "Configuring..."
     ${CONFIG_OPTS}
 
 abinfo "Making..."
+export enable_test=no
 make $ABMK
 
 abinfo "Installing..."

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,4 +1,4 @@
-VER=103
+VER=105
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: update to 105
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dracut-ng: 105

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
