### PR TITLE
libinput: fix touchpad on Lenovo ThinkBook 14 G7+ ASP

### DIFF
--- a/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
@@ -1,7 +1,8 @@
 From 8c50678f14d193b0f36ef85d083bc223d7200259 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Sep 2024 00:10:11 +0800
-Subject: [PATCH] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by default
+Subject: [PATCH 1/2] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by
+ default
 
 As we know, most touchpads these days come with no buttons *and*, more
 importantly, decent palm rejection and tap zones/recognition. The original
@@ -81,5 +82,5 @@ index 299cd554..576d71d3 100644
  
  static enum libinput_config_tap_state
 -- 
-2.46.0
+2.47.0
 

--- a/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
+++ b/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
@@ -1,0 +1,36 @@
+From 6258cef9b0b8157231606957477dc607ad9936cf Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 12 Nov 2024 11:29:27 +0800
+Subject: [PATCH 2/2] quirks: add pressure pad quirk for Lenovo ThinkBook 14
+ G7+ ASP
+
+Some Lenovo ThinkBook 14 G7+ ASP models ship with pressure pads (nominally
+"Force Pad"). However, they do not appear to be declared as such by the
+firmware.
+
+Add a quirk to make them work.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-lenovo.quirks | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/quirks/50-system-lenovo.quirks b/quirks/50-system-lenovo.quirks
+index 852eba01..15825426 100644
+--- a/quirks/50-system-lenovo.quirks
++++ b/quirks/50-system-lenovo.quirks
+@@ -376,3 +376,11 @@ MatchName=ITE Tech. Inc. ITE Device(8910) Keyboard
+ MatchUdevType=keyboard
+ MatchDMIModalias=dmi:*svnLENOVO:*
+ AttrKeyboardIntegration=internal
++
++# Some ThinkBook 14 G7+ ASP models come with pressure pads that were not
++# correctly declared as such.
++[Lenovo ThinkBook 14 G7+ ASP touchpad]
++MatchName=*GXTP5100*
++MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook14G7+ASP*:*
++MatchUdevType=touchpad
++ModelPressurePad=1
+-- 
+2.47.0
+

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,5 +1,5 @@
 VER=1.26.2
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: fix touchpad on Lenovo ThinkBook 14 G7+ ASP
    Some Lenovo ThinkBook 14 G7+ ASP models ship with pressure pads (nominally
    "Force Pad"). However, they do not appear to be declared as such by the
    firmware.
    Add a quirk to make them work.
    Link: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1079

Package(s) Affected
-------------------

- libinput: 1.26.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
