### PR TITLE
snapper: update to 0.12.0

### DIFF
--- a/app-admin/snapper/spec
+++ b/app-admin/snapper/spec
@@ -1,4 +1,4 @@
-VER=0.11.2
+VER=0.12.0
 SRCS="git::commit=tags/v${VER}::https://github.com/openSUSE/snapper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4843"


### PR DESCRIPTION
Topic Description
-----------------

- snapper: update to 0.12.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- snapper: 0.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
