### PR TITLE
Linux Firmware Survey 20241114

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=20241029
+UPSTREAM_VER=20241113
 DEBIANVER=20240909-2
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 REL=2
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=3c9f887a81aea0a69a3ec141602fef15603b56f4::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=6e4e94b02da0357ed7db03b2120b02e378c403e0::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update...
    - Update Linux Firmware to current HEAD 6e4e94b02da0357ed7db03b2120b02e378c403e0...
    - Changelog below...
    - AMD
    - Update DMCUB for DCN351 to 9.0.10.0.
    - Chips&Media
    - Update firmware for WAVE521C for K3 devices to 1.0.6.
    - Cirrus
    - Update Cirrus CS35L54 and CS35L56 firmwares for some Dell and HP laptops.
    - Intel
    - Update Bluetooth firmware for Intel BlazarI core (AX211/BE201), build BT_BlazarI_S_REL64160_23.70.24233.64160.
    - Update DMC API/APB to 2.23 for Xe2LPD.
    - MediaTek
    - Update WHENCE to include sof-tolg for MT8195, version 0.4.3.
    - Update firmwares for MT7925, WLAN version 20241104132949a and 20241104132855, Bluetooth version 20241104133214.
    - Update firmwares for MT7922, WLAN version 20241106163228a and 20241106163156, Bluetooth version 20241106163512.
    - Update firmwares for MT7921, WLAN version 20241106151007a and 20241106150855, Bluetooth version 20241106151414.
    - Update firmwares for MT7920, WLAN version 20241104091014a and 20241104090857, Bluetooth version 20241104091246.
    - Qualcomm
    - Add secure GPU firmware for QCS615, version 0.21.
    - Create link for QCS6490 GPU firmware.
    - Update aic100 firmware for Qualcomm Cloud AI 100, version 1.18.2.0.
    - Add firmware for Qualcomm 5G DU X100.
    - Add QCA Bluetooth firmwares for QCA2066, version 2.1.0-00641.
    - Update venus firmware for SC7280, version VIDEO.VPU.2.0-00055-PROD-1.
    - Add venus firmware for QCS615.
    - Realtek
    - Add rtw88 firmware for RTL8812AU, version 52.14.0.
    - Update rtw89 firmware for RTL8852A, version 0.13.36.2.
    - Update RTL8852BT/RTL8852BE-VT BT USB I/F firmware, version 0x04D7_63F7.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20241113+debian20240909+2-2
- firmware-nonfree: 20241113+debian20240909+2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
