### PR TITLE
libinput: fix TrackPoint acceleration on ThinkPad X200/201

### DIFF
--- a/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
@@ -1,7 +1,7 @@
 From 8c50678f14d193b0f36ef85d083bc223d7200259 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Sep 2024 00:10:11 +0800
-Subject: [PATCH 1/2] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by
+Subject: [PATCH 1/3] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by
  default
 
 As we know, most touchpads these days come with no buttons *and*, more

--- a/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
+++ b/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
@@ -1,7 +1,7 @@
 From 6258cef9b0b8157231606957477dc607ad9936cf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Nov 2024 11:29:27 +0800
-Subject: [PATCH 2/2] quirks: add pressure pad quirk for Lenovo ThinkBook 14
+Subject: [PATCH 2/3] quirks: add pressure pad quirk for Lenovo ThinkBook 14
  G7+ ASP
 
 Some Lenovo ThinkBook 14 G7+ ASP models ship with pressure pads (nominally

--- a/runtime-devices/libinput/autobuild/patches/0003-quirks-lower-AttrTrackpointMultiplier-for-ThinkPad-X.patch
+++ b/runtime-devices/libinput/autobuild/patches/0003-quirks-lower-AttrTrackpointMultiplier-for-ThinkPad-X.patch
@@ -1,0 +1,46 @@
+From e6db1131ac58ab7056c82c44d14b71be584dece9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 14 Nov 2024 21:57:52 +0800
+Subject: [PATCH 3/3] quirks: lower AttrTrackpointMultiplier for ThinkPad
+ X200/201 to 0.25
+
+Upstream commit 43cd2cbf83e0 ("data: add the dell trackpoint multipliers")
+broke the default acceleration profile on Lenovo ThinkPad X200/201, where
+the cursor speeds became so quick that it was practically impossible to
+control. Merely dragging on the TrackPoint lightly would result in the
+cursor flying from corner-to-corner.
+
+I have tested on a Lenovo ThinkPad X201 to find
+`AttrTrackpointMultiplier=0.25' the most reasonable and closest to the
+default behaviour on Windows 7 with Lenovo's driver.
+
+Not sure about ThinkPad X200s/201s, but I suspect that they would have
+similar issues (with the multiplier set to 1.25). I have just ordered both
+models to experiment with and will report back with another patch if I
+find similar issue.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-lenovo.quirks | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/quirks/50-system-lenovo.quirks b/quirks/50-system-lenovo.quirks
+index 15825426..6abbd368 100644
+--- a/quirks/50-system-lenovo.quirks
++++ b/quirks/50-system-lenovo.quirks
+@@ -62,10 +62,10 @@ MatchName=Elan Touchpad
+ MatchDMIModalias=dmi:*svnLENOVO:*:pvrThinkPadL380*
+ AttrInputProp=+INPUT_PROP_BUTTONPAD
+ 
+-[Lenovo X200 Trackpoint]
++[Lenovo X200/201 Trackpoint]
+ MatchName=*TPPS/2 IBM TrackPoint
+ MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkPadX20?:*
+-AttrTrackpointMultiplier=1.25
++AttrTrackpointMultiplier=0.25
+ 
+ [Lenovo X200x Trackpoint]
+ MatchName=*TPPS/2 IBM TrackPoint
+-- 
+2.47.0
+

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,5 +1,5 @@
 VER=1.26.2
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

libinput: fix TrackPoint acceleration on ThinkPad X200/201

Upstream commit 43cd2cbf ("data: add the dell trackpoint multipliers") broke the default acceleration profile on Lenovo ThinkPad X200/201, where the cursor speeds became so quick that it was practically impossible to control. Merely dragging on the TrackPoint lightly would result in the cursor flying from corner-to-corner.

I have tested on a Lenovo ThinkPad X201 to find `AttrTrackpointMultiplier=0.25' the most reasonable and closest to the default behaviour on Windows 7 with Lenovo's driver.

Package(s) Affected
-------------------

- libinput: 1.26.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
