### PR TITLE
telegram-desktop: rebuild for libvpx 1.15.0

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.7.1
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=8198c4d8b91e22d68eb5c7327fd408e3b6abcc79
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \

--- a/groups/libvpx-rebuilds
+++ b/groups/libvpx-rebuilds
@@ -8,3 +8,4 @@ app-multimedia/handbrake
 app-multimedia/vlc
 app-web/toxcore
 app-network/xpra
+app-web/telegram-desktop


### PR DESCRIPTION
Topic Description
-----------------

- groups/libvpx-rebuilds: add telegram-desktop
- telegram-desktop: rebuild for libvpx 1.15.0

Package(s) Affected
-------------------

- telegram-desktop: 5.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
