### PR TITLE
thunderbird: rebuild for libvpx 1.15.0

### DIFF
--- a/app-web/thunderbird/spec
+++ b/app-web/thunderbird/spec
@@ -1,4 +1,5 @@
 VER=128.3.0esr
+REL=1
 CHKUPDATE="anitya::id=4967"
 SRCS="https://archive.mozilla.org/pub/thunderbird/releases/$VER/source/thunderbird-$VER.source.tar.xz \
       file::rename=af.xpi::https://archive.mozilla.org/pub/thunderbird/releases/$VER/linux-x86_64/xpi/af.xpi \

--- a/groups/libvpx-rebuilds
+++ b/groups/libvpx-rebuilds
@@ -8,4 +8,6 @@ app-multimedia/handbrake
 app-multimedia/vlc
 app-web/toxcore
 app-network/xpra
+runtime-desktop/qt-5
 app-web/telegram-desktop
+app-web/thunderbird


### PR DESCRIPTION
Topic Description
-----------------

- groups/libvpx-rebuilds: add thunderbird
- thunderbird: rebuild for libvpx 1.15.0

Package(s) Affected
-------------------

- thunderbird: 128.3.0esr-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit thunderbird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
