### PR TITLE
qt-5: rebuild for libvpx

### DIFF
--- a/groups/libvpx-rebuilds
+++ b/groups/libvpx-rebuilds
@@ -11,3 +11,4 @@ app-network/xpra
 runtime-desktop/qt-5
 app-web/telegram-desktop
 app-web/thunderbird
+app-web/firefox

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=5.15.13
 VER=${UPSTREAM_VER}+webengine5.15.16+webkit5.212.0+kde20240408
-REL=7
+REL=8
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::48b528491c345c32760a0554c1f99c9c3fbd5bc8d8200bf1b28f008d3c3e600a"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

- groups/libvpx-rebuilds: add qt-5
- qt-5: rebuild for libvpx 1.15.0

Package(s) Affected
-------------------

- qt-5: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-8
- qt-5-doc: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
