### PR TITLE
unzip: fix man path

### DIFF
--- a/app-utils/unzip/autobuild/build
+++ b/app-utils/unzip/autobuild/build
@@ -12,5 +12,5 @@ abinfo "Installing unzip ..."
 make install \
      -f "$SRCDIR"/unix/Makefile \
      BINDIR="$PKGDIR"/usr/bin \
-     MANDIR="$PKGDIR"/usr/share/man \
+     MANDIR="$PKGDIR"/usr/share/man/man1 \
      STRIP=/usr/bin/true

--- a/app-utils/unzip/spec
+++ b/app-utils/unzip/spec
@@ -1,5 +1,5 @@
 VER=6.0
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/infozip/unzip${VER//./}.tar.gz"
 CHKSUMS="sha256::036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37"
 CHKUPDATE="anitya::id=8684"


### PR DESCRIPTION
Topic Description
-----------------

- unzip: fix man path /usr/share/man => /usr/share/man/man1

Package(s) Affected
-------------------

- unzip: 2:6.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit unzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
