### PR TITLE
Fix manpage paths

### DIFF
--- a/app-utils/progress/autobuild/build
+++ b/app-utils/progress/autobuild/build
@@ -1,0 +1,12 @@
+# Note: Leverage UNAME=Darwin to make sure `progress' links to -lncurses.
+#
+# From the Makefile:
+#
+#   ifeq ($(UNAME), Darwin)
+#	  override LDFLAGS += -lncurses
+#   endif
+abinfo "Installing progress ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    PREFIX=/usr \
+    UNAME=Darwin

--- a/app-utils/progress/autobuild/defines
+++ b/app-utils/progress/autobuild/defines
@@ -2,6 +2,3 @@ PKGNAME=progress
 PKGSEC=utils
 PKGDEP="glibc"
 PKGDES="A tool to show progress for various command-line programs"
-
-ABTYPE=plainmake
-MAKE_AFTER="UNAME=Darwin"

--- a/app-utils/progress/spec
+++ b/app-utils/progress/spec
@@ -1,4 +1,5 @@
 VER=0.16
-SRCS="tbl::https://github.com/Xfennec/progress/archive/v$VER.tar.gz"
-CHKSUMS="sha256::59944ee35f8ae6d62ed4f9b643eee2ae6d03825da288d9779dc43de41164c834"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/Xfennec/progress"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16242"

--- a/runtime-common/xxhash/autobuild/build
+++ b/runtime-common/xxhash/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building xxHash ..."
+make
+
+abinfo "Installing xxhash ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    PREFIX=/usr

--- a/runtime-common/xxhash/autobuild/defines
+++ b/runtime-common/xxhash/autobuild/defines
@@ -1,3 +1,3 @@
 PKGNAME=xxhash
-PKGDES="Extremely fast non-cryptographic hash algorithm"
+PKGDES="Non-cryptographic hash algorithm"
 PKGSEC=libs

--- a/runtime-common/xxhash/spec
+++ b/runtime-common/xxhash/spec
@@ -1,4 +1,4 @@
-VER=0.8.1
+VER=0.8.2
 SRCS="git::commit=tags/v$VER::https://github.com/Cyan4973/xxHash"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17583"


### PR DESCRIPTION
Topic Description
-----------------

- progress: fix man path
    - Use a build script as plainmake is now deprecated.
    - Use default MANDIR (previously, plainmake sets MANDIR=/usr/share/man,
    but here it expects MANDIR=/usr/share/man/man1).
- xxhash: update to 0.8.2
    - Fix man path /usr/share/man => /usr/share/man/man1.
    - Use a build script as plainmake is now deprecated.
    - Use default MANDIR (previously, plainmake sets MANDIR=/usr/share/man,
    but here it expects MANDIR=/usr/share/man/man1).

Package(s) Affected
-------------------

- progress: 0.16-1
- xxhash: 0.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xxhash progress
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
