### PR TITLE
Podman 5.3.0 Survey

### DIFF
--- a/app-admin/aardvark-dns/spec
+++ b/app-admin/aardvark-dns/spec
@@ -1,4 +1,4 @@
-VER=1.9.0
-SRCS="https://github.com/containers/aardvark-dns/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::d6b51743d334c42ec98ff229be044b5b2a5fedf8da45a005447809c4c1e9beea"
+VER=1.13.1
+SRCS="git::commit=tags/v${VER}::https://github.com/containers/aardvark-dns.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=327111"

--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,4 +1,4 @@
-VER=1.37.4
+VER=1.38.0
 SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14974"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=5.2.5
+UPSTREAM_VER=5.3.0
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,4 +1,4 @@
-VER=1.16.1
+VER=1.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"

--- a/app-network/passt/spec
+++ b/app-network/passt/spec
@@ -1,8 +1,8 @@
-UPSTREAM_VER=2024_09_06.6b38f07
+UPSTREAM_VER=2024_10_30.ee7d0b6
 # update this manually
 # if there are two releases in one day, add .1 suffix to version
-VER=2024.09.06
+VER=2024.10.30
 # FIXME: using Git sources causes passt.top network issues
 SRCS="tbl::https://passt.top/passt/snapshot/passt-${UPSTREAM_VER}.tar.zst"
-CHKSUMS="sha256::e724ff79ef3c6431cd1a20803006851abbd2c3df090aad6c236250b158a6c5cc"
+CHKSUMS="sha256::f35147d1473d44bb06cd1b77c57f4691a3a2ddc6d64f93d127d2d9732b8e85e9"
 CHKUPDATE="anitya::id=372091"

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,12 +1,12 @@
-UPSTREAM_VER=0.60.4
+UPSTREAM_VER=0.61.0
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-__IMAGE_VER=5.32.2
-__STORAGE_VER=1.55.0
+__IMAGE_VER=5.33.0
+__STORAGE_VER=1.56.0
 # FIXME: the following two dependencies are not in the go.sum file above.
 __SHORTNAMES_VER=2023.02.20
-__SKOPEO_VER=1.16.1
+__SKOPEO_VER=1.17.0
 
 VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
 __ORG_URL="https://github.com/containers"

--- a/runtime-containers/netavark/spec
+++ b/runtime-containers/netavark/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
-SRCS="https://github.com/containers/netavark/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::5b96e5a00a41a550d716f1e5c180df6e0ee5b0ce20961827ef17aff3d6a92f9c"
+VER=1.13.0
+SRCS="git::commit=tags/v${VER}::https://github.com/containers/netavark.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242639"


### PR DESCRIPTION
Topic Description
-----------------

- buildah: update to 1.38.0
- passt: update to 2024.10.30
- netavark: update to 1.13.0
- containers-common: update to 0.61.0+image5.33.0+shortnames2023.02.20+skopeo1.17.0+storage1.56.0
- skopeo: update to 1.17.0
- podman: update to 5.3.0+vsock0.7.5
- aardvark-dns: update to 1.13.1

Package(s) Affected
-------------------

- aardvark-dns: 1.13.1
- buildah: 1.38.0
- containers-common: 0.61.0+image5.33.0+shortnames2023.02.20+skopeo1.17.0+storage1.56.0
- netavark: 1.13.0
- passt: 2024.10.30
- podman: 5.3.0+vsock0.7.5
- skopeo: 1.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aardvark-dns netavark containers-common skopeo podman passt buildah
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
