### PR TITLE
xdg-desktop-portal: update to 1.18.4

### DIFF
--- a/app-admin/xdg-desktop-portal/spec
+++ b/app-admin/xdg-desktop-portal/spec
@@ -1,5 +1,4 @@
-VER=1.16.0
-REL=1
+VER=1.18.4
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
-CHKSUMS="sha256::5b41a5915c11851493d8c33b9783f147a0a6f419db80ad760e84cd3420fd8c19"
+CHKSUMS="sha256::b858aa1e74e80c862790dbb912906e6eab8b1e4db9339cd759473af62b461e65"
 CHKUPDATE="anitya::id=11089"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal: update to 1.18.4
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- xdg-desktop-portal: 1.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
