### PR TITLE
steam: update to 1.0.0.82

### DIFF
--- a/app-games/steam/autobuild/patches/0001-fix-steam.desktop-make-sure-Steam-recognises-our-32-.patch
+++ b/app-games/steam/autobuild/patches/0001-fix-steam.desktop-make-sure-Steam-recognises-our-32-.patch
@@ -1,4 +1,4 @@
-From ae9f69121e5b47010d7b3d6432f9f99b7fa8e4bd Mon Sep 17 00:00:00 2001
+From 90ccc0b2d57b004f032dbeb7e1162f4a3792a22f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 4 Mar 2024 14:59:34 +0800
 Subject: [PATCH 1/2] fix(steam.desktop): make sure Steam recognises our 32-bit
@@ -22,5 +22,5 @@ index 77314e0..bdaea30 100644
  Terminal=false
  Type=Application
 -- 
-2.46.2
+2.47.1
 

--- a/app-games/steam/autobuild/patches/0002-hack-fix-IME-input-text.patch
+++ b/app-games/steam/autobuild/patches/0002-hack-fix-IME-input-text.patch
@@ -1,4 +1,4 @@
-From 9271c715f151af9d4cb99f99d5dd23a8f5322382 Mon Sep 17 00:00:00 2001
+From 4a202ecebbe140985d20378d933f1eda1557845a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 5 Jul 2024 21:21:23 +0800
 Subject: [PATCH 2/2] hack: fix IME input text
@@ -8,10 +8,10 @@ Subject: [PATCH 2/2] hack: fix IME input text
  1 file changed, 6 insertions(+)
 
 diff --git a/bin_steam.sh b/bin_steam.sh
-index 91d2519..eabc1ae 100755
+index 49f9d8a..04e6be0 100755
 --- a/bin_steam.sh
 +++ b/bin_steam.sh
-@@ -229,4 +229,10 @@ fi
+@@ -303,4 +303,10 @@ fi
  # go to the install directory and run the client
  cd "$LAUNCHSTEAMDIR"
  
@@ -21,7 +21,7 @@ index 91d2519..eabc1ae 100755
 +export QT5_IM_MODULE=fcitx5
 +export XMODIFIERS=@im=fcitx5
 +
- exec "$LAUNCHSTEAMDIR/$STEAMBOOTSTRAP" "$@"
+ exec "$LAUNCHSTEAMDIR/$STEAMBOOTSTRAP" ${log_opened+-srt-logger-opened} "$@"
 -- 
-2.46.2
+2.47.1
 

--- a/app-games/steam/spec
+++ b/app-games/steam/spec
@@ -1,4 +1,4 @@
-VER=1.0.0.81
+VER=1.0.0.82
 SRCS="tbl::https://repo.steampowered.com/steam/pool/steam/s/steam/steam_$VER.tar.gz"
-CHKSUMS="sha256::1a26b9d7cdace09e04dc86b511e0b9923257f664a5b6cafe6fed5e46d117b4f9"
+CHKSUMS="sha256::afa2f1dd6271fd2b645ba30b8f3ab40afd3654e354241a31cbd51000f7e6fc77"
 CHKUPDATE="anitya::id=12318"


### PR DESCRIPTION
Topic Description
-----------------

- steam: update to 1.0.0.82
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- steam: 1.0.0.82

Security Update?
----------------

No

Build Order
-----------

```
#buildit steam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
