### PR TITLE
termcolor: update to 2.5.0

### DIFF
--- a/lang-python/termcolor/autobuild/defines
+++ b/lang-python/termcolor/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=termcolor
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="hatch-vcs hatchling python-build python-installer wheel"
 PKGDES="ANSII Color formatting for output in terminal"
-BUILDDEP="python-3 python-2"
-PKGSEC="python"
 
+ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/termcolor/spec
+++ b/lang-python/termcolor/spec
@@ -1,5 +1,4 @@
-VER=1.1.0
-REL=3
-SRCS="tbl::https://pypi.python.org/packages/source/t/termcolor/termcolor-$VER.tar.gz"
-CHKSUMS="sha256::1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+VER=2.5.0
+SRCS="pypi::version=$VER::termcolor"
+CHKSUMS="sha256::998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f"
 CHKUPDATE="anitya::id=12029"


### PR DESCRIPTION
Topic Description
-----------------

- termcolor: update to 2.5.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- termcolor: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit termcolor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
