### PR TITLE
paprefs: update to 1.2

### DIFF
--- a/app-multimedia/paprefs/spec
+++ b/app-multimedia/paprefs/spec
@@ -1,5 +1,4 @@
-VER=1.1
-REL=1
+VER=1.2
 SRCS="git::commit=6b50202f3f11bc5c016e41b8f0c529860a6baabb::git://anongit.freedesktop.org/pulseaudio/paprefs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2591"


### PR DESCRIPTION
Topic Description
-----------------

- paprefs: update to 1.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- paprefs: 1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit paprefs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
