### PR TITLE
spake2: update to 0.9

### DIFF
--- a/lang-python/spake2/autobuild/defines
+++ b/lang-python/spake2/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=spake2
 PKGSEC=python
-PKGDEP="hkdf"
+PKGDEP="hkdf python-3"
 BUILDDEP="setuptools"
 PKGDES="Implements the SPAKE2 password-authenticated key exchange for Python"
 
 ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/spake2/spec
+++ b/lang-python/spake2/spec
@@ -1,5 +1,4 @@
-VER=0.8
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/s/spake2/spake2-$VER.tar.gz"
-CHKSUMS="sha256::c17a614b29ee4126206e22181f70a406c618d3c6c62ca6d6779bce95e9c926f4"
+VER=0.9
+SRCS="pypi::version=$VER::spake2"
+CHKSUMS="sha256::421fc4a8d5ac395af7af0206ffd9e6cdf188c105cb1b883d9d683312bb5a9334"
 CHKUPDATE="anitya::id=19872"


### PR DESCRIPTION
Topic Description
-----------------

- spake2: update to 0.9
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- spake2: 0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit spake2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
