### PR TITLE
xf86-video-fbdev: update to 0.5.1

### DIFF
--- a/runtime-display/xf86-video-fbdev/spec
+++ b/runtime-display/xf86-video-fbdev/spec
@@ -1,5 +1,4 @@
-VER=0.5.0
-REL=5
+VER=0.5.1
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/driver/xf86-video-fbdev-$VER.tar.gz"
-CHKSUMS="sha256::a31f62db237a5c25bb087713a22a867a9b7680833ce3b644ecd712887b7b1d62"
+CHKSUMS="sha256::5e73c01f6ede09ddbc1f553fecdf35dd8efe76b44c7ed263de786a5968c5116f"
 CHKUPDATE="anitya::id=5218"


### PR DESCRIPTION
Topic Description
-----------------

- xf86-video-fbdev: update to 0.5.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xf86-video-fbdev: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-video-fbdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
