### PR TITLE
hunspell: update to 1.7.2

### DIFF
--- a/app-i18n/hunspell/spec
+++ b/app-i18n/hunspell/spec
@@ -1,5 +1,4 @@
-VER=1.7.0
-REL=4
-SRCS="tbl::https://github.com/hunspell/hunspell/archive/v$VER.tar.gz"
-CHKSUMS="sha256::bb27b86eb910a8285407cf3ca33b62643a02798cf2eef468c0a74f6c3ee6bc8a"
+VER=1.7.2
+SRCS="git::commit=tags/v$VER::https://github.com/hunspell/hunspell.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1343"


### PR DESCRIPTION
Topic Description
-----------------

- hunspell: update to 1.7.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hunspell: 1.7.2
- hunspell-dicts: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hunspell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
