### PR TITLE
openra: update to 20231010

### DIFF
--- a/app-games/openra/spec
+++ b/app-games/openra/spec
@@ -1,4 +1,4 @@
-VER=20210321
+VER=20231010
 SRCS="git::commit=tags/release-$VER::https://github.com/OpenRA/OpenRA"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12283"


### PR DESCRIPTION
Topic Description
-----------------

- openra: update to 20231010
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openra: 20231010

Security Update?
----------------

No

Build Order
-----------

```
#buildit openra
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
