### PR TITLE
wheel: update to 0.45.0

### DIFF
--- a/lang-python/wheel/spec
+++ b/lang-python/wheel/spec
@@ -1,4 +1,4 @@
-VER=0.42.0
+VER=0.45.0
 SRCS="tbl::https://pypi.io/packages/source/w/wheel/wheel-$VER.tar.gz"
-CHKSUMS="sha256::c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"
+CHKSUMS="sha256::a57353941a3183b3d5365346b567a260a0602a0f8a635926a7dede41b94c674a"
 CHKUPDATE="anitya::id=11428"


### PR DESCRIPTION
Topic Description
-----------------

- wheel: update to 0.45.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wheel: 0.45.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wheel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
