### PR TITLE
dnscontrol: new, 4.14.3

### DIFF
--- a/app-network/dnscontrol/autobuild/beyond
+++ b/app-network/dnscontrol/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Generating shell completions ..."
+mkdir -vp "$PKGDIR"/usr/share/bash-completion/completions
+"$PKGDIR"/usr/bin/dnscontrol shell-completion bash \
+    >"$PKGDIR"/usr/share/bash-completion/completions/dnscontrol
+mkdir -vp "$PKGDIR"/usr/share/zsh/site-functions
+"$PKGDIR"/usr/bin/dnscontrol shell-completion zsh \
+    >"$PKGDIR"/usr/share/zsh/site-functions/_dnscontrol

--- a/app-network/dnscontrol/autobuild/defines
+++ b/app-network/dnscontrol/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=dnscontrol
+PKGSEC=net
+PKGDES="An Infrastructure as Code tool for DNS"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
+ABSPLITDBG=0
+
+GO_LDFLAGS=("-X main.version=$PKGVER")

--- a/app-network/dnscontrol/spec
+++ b/app-network/dnscontrol/spec
@@ -1,0 +1,4 @@
+VER=4.14.3
+SRCS="git::commit=tags/v$VER::https://github.com/StackExchange/dnscontrol.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375553"


### PR DESCRIPTION
Topic Description
-----------------

- dnscontrol: new, 4.14.3

Package(s) Affected
-------------------

- dnscontrol: 4.14.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnscontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
