### PR TITLE
lfortran: new, 0.42.0

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -1,0 +1,23 @@
+PKGNAME=lfortran
+PKGSEC=devel
+PKGDEP="gcc-runtime glibc llvm ncurses python-3"
+BUILDDEP="fmt llvm python-3 re2c zlib-static zstd-static"
+PKGDES="Interactive LLVM-based Fortran compiler"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DWITH_FMT=ON \
+    -DWITH_LLVM=ON \
+    -DWITH_RUNTIME_LIBRARY=ON \
+    -DWITH_RUNTIME_STACKTRACE=ON
+    -DWITH_STACKTRACE=ON \
+    -DWITH_TARGET_WASM=OFF \
+    -DWITH_UNWIND=ON \
+    -DWITH_WHEREAMI=ON \
+    -DWITH_ZLIB=ON \
+"
+
+# FIXME: operations on real data type may cause segfault or incorrect results on loongarch64.
+# GitHub issue link: https://github.com/lfortran/lfortran/issues/5405
+FAIL_ARCH="loongarch64"

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,0 +1,4 @@
+VER=0.42.0
+SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
+CHKSUMS="sha256::3144abce88da2bcfd39e2c5c655b1bc977c429f3e7dae58afbe45c0237f07298"
+CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: new, 0.42.0

Package(s) Affected
-------------------

- lfortran: 0.42.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
