### PR TITLE
[SECURITY] postgresql: update to 13.17

### DIFF
--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,5 +1,4 @@
-VER=13.16
-REL=1
+VER=13.17
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::c9cbbb6129f02328204828066bb3785c00a85c8ca8fd329c2a8a53c1f5cd8865"
+CHKSUMS="sha256::022b0a6e7bc374a777eece33708895d7b60cae07d492b286b296a49d7395d78b"
 CHKUPDATE="anitya::id=5601"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: update to 13.17

Package(s) Affected
-------------------

- postgresql: 1:13.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
