### PR TITLE
kakasi: new, 2.3.6

### DIFF
--- a/app-i18n/kakasi/autobuild/defines
+++ b/app-i18n/kakasi/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=kakasi
+PKGSEC=localization
+PKGDEP="glibc"
+PKGDES="A language processing filter to convert Kanji characters to Hiragana, Katakana or Romaji"
+
+ABTYPE=autotools
+ABSHADOW=0

--- a/app-i18n/kakasi/spec
+++ b/app-i18n/kakasi/spec
@@ -1,0 +1,4 @@
+VER=2.3.6
+SRCS="tbl::http://kakasi.namazu.org/stable/kakasi-$VER.tar.gz"
+CHKSUMS="sha256::004276fd5619c003f514822d82d14ae83cd45fb9338e0cb56a44974b44961893"
+CHKUPDATE="anitya::id=1487"


### PR DESCRIPTION
Topic Description
-----------------

- kakasi: new, 2.3.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- kakasi: 2.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit kakasi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
