### PR TITLE
sof-firmware: update to 2024.09.1

### DIFF
--- a/runtime-kernel/sof-firmware/spec
+++ b/runtime-kernel/sof-firmware/spec
@@ -1,4 +1,4 @@
-VER=2024.06
+VER=2024.09.1
 SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-${VER}.tar.gz"
-CHKSUMS="sha256::581ca3285bb56837a8954953f629ebddce644152b673ecd4bbfae1504306d7d6"
+CHKSUMS="sha256::a9b94d96648ab139d8270c728522d0ad7470276bc6a30efaf3752650d21e84e6"
 CHKUPDATE="anitya::id=246473"


### PR DESCRIPTION
Topic Description
-----------------

- sof-firmware: update to 2024.09.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sof-firmware: 2024.09.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
