### PR TITLE
xreader: update to 4.2.2

### DIFF
--- a/app-doc/xreader/autobuild/defines
+++ b/app-doc/xreader/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xreader
 PKGSEC=doc
 PKGDEP="djvulibre gtk-3 libgxps poppler libsecret libspectre webkit2gtk \
-        mathjax"
+        mathjax xapps"
 BUILDDEP="caja gobject-introspection libxslt mate-common nemo texlive \
           yelp-tools"
 PKGDES="A generic Document Reader"

--- a/app-doc/xreader/spec
+++ b/app-doc/xreader/spec
@@ -1,4 +1,4 @@
-VER=3.8.5
-SRCS="tbl::https://github.com/linuxmint/xreader/archive/$VER.tar.gz"
-CHKSUMS="sha256::7c949058a1da445053fa852fd0bc36d8ab1d994a06b9908da4cef556d2a21d33"
+VER=4.2.2
+SRCS="git::commit=tags/$VER::https://github.com/linuxmint/xreader"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15149"


### PR DESCRIPTION
Topic Description
-----------------

- xreader: update to 4.2.2

Package(s) Affected
-------------------

- xreader: 4.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xreader
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
