### PR TITLE
deb-installer: update to 0.1.4

### DIFF
--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,4 +1,4 @@
-VER=0.1.3
+VER=0.1.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: update to 0.1.4

Package(s) Affected
-------------------

- deb-installer: 0.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
