### PR TITLE
docker-buildx: new, 0.18.0

### DIFF
--- a/app-containers/docker-buildx/autobuild/build
+++ b/app-containers/docker-buildx/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building docker-buildx..."
+cd "$SRCDIR"
+make build
+
+abinfo "Installing docker-buildx ..."
+install -Dvm755 "$SRCDIR"/bin/build/docker-buildx "$PKGDIR"/usr/libexec/docker/cli-plugins/docker-buildx

--- a/app-containers/docker-buildx/autobuild/defines
+++ b/app-containers/docker-buildx/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=docker-buildx
+PKGDES="Docker CLI plugin for extended build capabilities"
+PKGSEC=admin
+PKGDEP="docker"
+BUILDDEP="go"
+
+# FIXME: Missing criu support
+FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+ABSPLITDBG=0

--- a/app-containers/docker-buildx/spec
+++ b/app-containers/docker-buildx/spec
@@ -1,0 +1,4 @@
+VER=0.18.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/docker/buildx"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=325723"


### PR DESCRIPTION
Topic Description
-----------------

- docker-buildx: new, 0.18.0

Package(s) Affected
-------------------

- docker-buildx: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-buildx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
