### PR TITLE
pstate-frequency: update to 3.15.2

### DIFF
--- a/app-admin/pstate-frequency/spec
+++ b/app-admin/pstate-frequency/spec
@@ -1,5 +1,4 @@
-VER=3.11.0
-REL=1
-SRCS="https://github.com/pyamsoft/pstate-frequency/archive/$VER.tar.gz"
-CHKSUMS="sha256::df232f57de91c6527958a89fc06010d8ed9bffd686f1f682ebf9ef30bd5078d4"
+VER=3.15.2
+SRCS="git::commit=tags/$VER::https://github.com/pyamsoft/pstate-frequency"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226793"


### PR DESCRIPTION
Topic Description
-----------------

- pstate-frequency: update to 3.15.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pstate-frequency: 3.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pstate-frequency
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
