### PR TITLE
npth: update to 1.8

### DIFF
--- a/runtime-common/npth/spec
+++ b/runtime-common/npth/spec
@@ -1,5 +1,4 @@
-VER=1.6
-REL=1
+VER=1.8
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/npth/npth-$VER.tar.bz2"
-CHKSUMS="sha256::1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1"
+CHKSUMS="sha256::8bd24b4f23a3065d6e5b26e98aba9ce783ea4fd781069c1b35d149694e90ca3e"
 CHKUPDATE="anitya::id=2505"


### PR DESCRIPTION
Topic Description
-----------------

- npth: update to 1.8
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- npth: 1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit npth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
