### PR TITLE
php: update to 8.3.13

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,4 @@
-VER=8.3.11
+VER=8.3.13
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::b862b098a08ab9bf4b36ed12c7d0d9f65353656b36fb0e3c5344093aceb35802"
+CHKSUMS="sha256::89adb978cca209124fe53fd6327bc4966ca21213a7fa2e9504f854e340873018"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.3.13
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- php: 1:8.3.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
