### PR TITLE
aom: update to 3.11.0

### DIFF
--- a/runtime-multimedia/aom/spec
+++ b/runtime-multimedia/aom/spec
@@ -1,4 +1,4 @@
-VER=3.9.1
+VER=3.11.0
 SRCS="git::commit=tags/v$VER::https://aomedia.googlesource.com/aom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17628"


### PR DESCRIPTION
Topic Description
-----------------

- aom: update to 3.11.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aom: 3.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
