### PR TITLE
uboot-tools: update to 2024.10

### DIFF
--- a/app-utils/uboot-tools/spec
+++ b/app-utils/uboot-tools/spec
@@ -1,5 +1,4 @@
-VER=2022.10
+VER=2024.10
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"
+CHKSUMS="sha256::b28daf4ac17e43156363078bf510297584137f6df50fced9b12df34f61a92fb0"
 CHKUPDATE="anitya::id=5022"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- uboot-tools: update to 2024.10
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uboot-tools: 2024.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit uboot-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
