### PR TITLE
qcef: update to 1.1.8

### DIFF
--- a/runtime-desktop/qcef/spec
+++ b/runtime-desktop/qcef/spec
@@ -1,9 +1,8 @@
-VER=1.1.6
-REL=2
+VER=1.1.8
 CEFCOMMIT=fecf00339545d2819224333cc506d5aa22ae8008
 SRCS="tbl::https://github.com/linuxdeepin/qcef/archive/$VER.tar.gz \
       tbl::https://github.com/linuxdeepin/cef-binary/archive/$CEFCOMMIT.tar.gz"
 SUBDIR="qcef-$VER"
-CHKSUMS="sha256::d8c3e266b3034ce785a23acb200bf46ee4ba72946e69bc8134a0e9dd48288326 \
+CHKSUMS="sha256::7e16c9166251f0c74a585dccb8fdca572274b948128eb6a607d4ef866c771ebf \
          sha256::20aabc7b3d9995a5df5a75244f392f205ef8bd12cfa3dc2490a8915dcedda62c"
 CHKUPDATE="anitya::id=230516"


### PR DESCRIPTION
Topic Description
-----------------

- qcef: update to 1.1.8
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qcef: 1.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit qcef
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
