### PR TITLE
sof-tools: update to 2.11.2

### DIFF
--- a/app-multimedia/alsa-utils/spec
+++ b/app-multimedia/alsa-utils/spec
@@ -1,4 +1,4 @@
-VER=1.2.12
+VER=1.2.13
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-${VER}.tar.bz2"
-CHKSUMS="sha256::98bc6677d0c0074006679051822324a0ab0879aea558a8f68b511780d30cd924"
+CHKSUMS="sha256::1702a6b1cdf9ba3e996ecbc1ddcf9171e6808f5961d503d0f27e80ee162f1daa"
 CHKUPDATE="anitya::id=37"

--- a/app-multimedia/sof-tools/autobuild/prepare
+++ b/app-multimedia/sof-tools/autobuild/prepare
@@ -1,2 +1,2 @@
 abinfo "Symlinking license file"
-ln -vs ../LICENCE ./
+ln -vs ../LICENCE "$SRCDIR"/

--- a/app-multimedia/sof-tools/spec
+++ b/app-multimedia/sof-tools/spec
@@ -1,4 +1,4 @@
-VER=2.10
+VER=2.11.2
 SRCS="git::commit=tags/v$VER::https://github.com/thesofproject/sof"
 CHKSUMS="SKIP"
 SUBDIR="sof-tools/tools"

--- a/runtime-multimedia/alsa-lib/spec
+++ b/runtime-multimedia/alsa-lib/spec
@@ -1,4 +1,4 @@
-VER=1.2.12
+VER=1.2.13
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2"
+CHKSUMS="sha256::8c4ff37553cbe89618e187e4c779f71a9bb2a8b27b91f87ed40987cc9233d8f6"
 CHKUPDATE="anitya::id=38"


### PR DESCRIPTION
Topic Description
-----------------

- sof-tools: use absolute path in prepare per the Styling Manual
- alsa-utils: update to 1.2.13
- alsa-lib: update to 1.2.13
- sof-tools: update to 2.11.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- alsa-lib: 1.2.13
- alsa-utils: 1.2.13
- sof-tools: 2.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-lib alsa-utils sof-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
