### PR TITLE
ethtool: update to 6.11

### DIFF
--- a/app-network/ethtool/spec
+++ b/app-network/ethtool/spec
@@ -1,4 +1,4 @@
-VER=6.9
+VER=6.11
 SRCS="tbl::https://www.kernel.org/pub/software/network/ethtool/ethtool-$VER.tar.xz"
-CHKSUMS="sha256::a71b0354010661c5cf178bc606ed50fcb91805cf1897ad0eb2818387a5fd0cd9"
+CHKSUMS="sha256::8d91f5c72ae3f25b7e88d4781279dcb320f71e30058914370b1c574c96b31202"
 CHKUPDATE="anitya::id=763"


### PR DESCRIPTION
Topic Description
-----------------

- ethtool: update to 6.11
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ethtool: 6.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit ethtool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
