### PR TITLE
upower: update to 1.90.6

### DIFF
--- a/app-admin/upower/autobuild/defines
+++ b/app-admin/upower/autobuild/defines
@@ -18,6 +18,7 @@ MESON_AFTER="-Dman=true \
              -Dintrospection=enabled \
              -Dos_backend=linux \
              -Didevice=enabled \
+             -Dpolkit=enabled \
              -Dinstalled_tests=false"
 MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \

--- a/app-admin/upower/autobuild/patches/0001-build-Make-installation-of-tests-optional.patch
+++ b/app-admin/upower/autobuild/patches/0001-build-Make-installation-of-tests-optional.patch
@@ -1,4 +1,4 @@
-From f056d758240ea88d2c9b476054441888916e7c18 Mon Sep 17 00:00:00 2001
+From 8910ab1caa680ddef8b3fd7ca585e7a9f3c4c169 Mon Sep 17 00:00:00 2001
 From: Luciano Santos <luc14n0@opensuse.org>
 Date: Fri, 4 Aug 2023 22:21:20 -0300
 Subject: [PATCH] build: Make installation of tests optional
@@ -11,22 +11,22 @@ what they want.
  2 files changed, 23 insertions(+), 16 deletions(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
-index eec3659..ef3f03d 100644
+index 82b6af0..a0683f9 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -33,3 +33,7 @@ option('idevice',
-        type : 'feature',
-        value : 'auto',
-        description : 'Build with libimobiledevice')
+@@ -40,3 +40,7 @@ option('polkit',
+        type: 'feature',
+        value: 'auto',
+        description: 'PolKit support in daemon')
 +option('installed_tests',
 +       type : 'boolean',
 +       value : 'true',
 +       description : 'Install integration tests')
 diff --git a/src/meson.build b/src/meson.build
-index f072328..0701a12 100644
+index e4ed974..7aa1c66 100644
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -143,20 +143,23 @@ if os_backend == 'linux' and gobject_introspection.found()
+@@ -146,20 +146,23 @@ if os_backend == 'linux' and gobject_introspection.found()
              )
      endforeach
  
@@ -67,5 +67,5 @@ index f072328..0701a12 100644
 +    endif
  endif
 -- 
-2.43.4
+2.47.1
 

--- a/app-admin/upower/spec
+++ b/app-admin/upower/spec
@@ -1,5 +1,4 @@
-VER=1.90.4
-REL=1
+VER=1.90.6
 SRCS="tbl::https://gitlab.freedesktop.org/upower/upower/-/archive/v$VER/upower-v$VER.tar.gz"
-CHKSUMS="sha256::cd194dd278bd8d058b4728efd1d0a91cdf017378f025b558beb6f60a86af4781"
+CHKSUMS="sha256::7e367c2619ca0f26d5bfc085b46bad9657b2774cc3eaffbf310b607df6e21377"
 CHKUPDATE="anitya::id=5056"


### PR DESCRIPTION
Topic Description
-----------------

- upower: update to 1.90.6
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- upower: 1.90.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit upower
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
