### PR TITLE
dpkg: update to 1.22.11

### DIFF
--- a/app-admin/dpkg/01-update-alternatives/patches/0001-HACK-feat-data-add-AOSC-OS-specific-armv4-architectu.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0001-HACK-feat-data-add-AOSC-OS-specific-armv4-architectu.patch
@@ -1,7 +1,7 @@
-From 72467c8121e6c25c2707ec9c6c64ff101f8934fc Mon Sep 17 00:00:00 2001
+From adb2a1cd428584e23b990d8fd69aff6182871fff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:42:36 -0700
-Subject: [PATCH 1/8] [HACK] feat(data): add AOSC OS-specific armv4
+Subject: [PATCH 1/9] [HACK] feat(data): add AOSC OS-specific armv4
  architecture
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 1/8] [HACK] feat(data): add AOSC OS-specific armv4
  1 file changed, 1 insertion(+)
 
 diff --git a/data/cputable b/data/cputable
-index 575c008e..72d065af 100644
+index 575c008e3..72d065af0 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -21,6 +21,7 @@
@@ -21,5 +21,5 @@ index 575c008e..72d065af 100644
  arm		arm		arm.*			32	little
  arm64		aarch64		aarch64			64	little
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0002-HACK-ARMV6HF-fix-data-rename-armhf-as-AOSC-OS-specif.patch.armv6hf
+++ b/app-admin/dpkg/01-update-alternatives/patches/0002-HACK-ARMV6HF-fix-data-rename-armhf-as-AOSC-OS-specif.patch.armv6hf
@@ -1,7 +1,7 @@
-From 5a5d8672a16863e4a33f0cfecbc4f245324d0355 Mon Sep 17 00:00:00 2001
+From 1ca82d9ba32d556eb76c3a6880118b27757f2e10 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:43:52 -0700
-Subject: [PATCH 2/8] [HACK] [ARMV6HF] fix(data): rename armhf as AOSC
+Subject: [PATCH 2/9] [HACK] [ARMV6HF] fix(data): rename armhf as AOSC
  OS-specific armv6hf
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 2/8] [HACK] [ARMV6HF] fix(data): rename armhf as AOSC
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/tupletable b/data/tupletable
-index ae9f2ddb..b91ace61 100644
+index ae9f2ddb4..b91ace617 100644
 --- a/data/tupletable
 +++ b/data/tupletable
 @@ -25,7 +25,7 @@ eabi-uclibc-linux-arm		uclibc-linux-armel
@@ -22,5 +22,5 @@ index ae9f2ddb..b91ace61 100644
  abin32-gnu-linux-mips64r6el	mipsn32r6el
  abin32-gnu-linux-mips64r6	mipsn32r6
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0002-HACK-ARMV7HF-fix-data-rename-armhf-as-AOSC-OS-specif.patch.armv7hf
+++ b/app-admin/dpkg/01-update-alternatives/patches/0002-HACK-ARMV7HF-fix-data-rename-armhf-as-AOSC-OS-specif.patch.armv7hf
@@ -1,9 +1,7 @@
-DERIVED FROM [ARMV6HF].
-
-From 5a5d8672a16863e4a33f0cfecbc4f245324d0355 Mon Sep 17 00:00:00 2001
+From 1ca82d9ba32d556eb76c3a6880118b27757f2e10 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:43:52 -0700
-Subject: [PATCH 2/8] [HACK] [ARMV7HF] fix(data): rename armhf as AOSC
+Subject: [PATCH 2/9] [HACK] [ARMV7HF] fix(data): rename armhf as AOSC
  OS-specific armv7hf
 
 ---
@@ -11,7 +9,7 @@ Subject: [PATCH 2/8] [HACK] [ARMV7HF] fix(data): rename armhf as AOSC
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/tupletable b/data/tupletable
-index ae9f2ddb..b91ace61 100644
+index ae9f2ddb4..b91ace617 100644
 --- a/data/tupletable
 +++ b/data/tupletable
 @@ -25,7 +25,7 @@ eabi-uclibc-linux-arm		uclibc-linux-armel
@@ -24,5 +22,5 @@ index ae9f2ddb..b91ace61 100644
  abin32-gnu-linux-mips64r6el	mipsn32r6el
  abin32-gnu-linux-mips64r6	mipsn32r6
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0003-HACK-fix-data-rename-i-86-as-AOSC-OS-specific-i486.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0003-HACK-fix-data-rename-i-86-as-AOSC-OS-specific-i486.patch
@@ -1,14 +1,14 @@
-From 9dae1bcd1943804a215c827c59a967325cfd1fdb Mon Sep 17 00:00:00 2001
+From e885e7dcc220bdf4df4a297d0b5ca9bfa1ca2dba Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:45:44 -0700
-Subject: [PATCH 3/8] [HACK] fix(data): rename i*86 as AOSC OS-specific i486
+Subject: [PATCH 3/9] [HACK] fix(data): rename i*86 as AOSC OS-specific i486
 
 ---
  data/cputable | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/cputable b/data/cputable
-index 72d065af..ca2d6b30 100644
+index 72d065af0..ca2d6b308 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -27,7 +27,7 @@ arm		arm		arm.*			32	little
@@ -21,5 +21,5 @@ index 72d065af..ca2d6b30 100644
  m68k		m68k		m68k			32	big
  mips		mips		mips(eb)?		32	big
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0004-HACK-fix-data-rename-loong64-as-AOSC-OS-specific-loo.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0004-HACK-fix-data-rename-loong64-as-AOSC-OS-specific-loo.patch
@@ -1,7 +1,7 @@
-From 6b32f345022c7bd409f723f9c3d2148db04f7c12 Mon Sep 17 00:00:00 2001
+From 7cad56d17c6202e092f6d160bc4c33c78d0ff02a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:46:13 -0700
-Subject: [PATCH 4/8] [HACK] fix(data): rename loong64 as AOSC OS-specific
+Subject: [PATCH 4/9] [HACK] fix(data): rename loong64 as AOSC OS-specific
  loongarch64
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 4/8] [HACK] fix(data): rename loong64 as AOSC OS-specific
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/cputable b/data/cputable
-index ca2d6b30..9d79de9a 100644
+index ca2d6b308..9d79de9a7 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -26,7 +26,7 @@ armeb		armeb		arm.*b			32	big
@@ -22,5 +22,5 @@ index ca2d6b30..9d79de9a 100644
  ia64		ia64		ia64			64	little
  m68k		m68k		m68k			32	big
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0005-HACK-LOONGSON2F-fix-data-rename-mips64el-as-AOSC-OS-.patch.loongson2f
+++ b/app-admin/dpkg/01-update-alternatives/patches/0005-HACK-LOONGSON2F-fix-data-rename-mips64el-as-AOSC-OS-.patch.loongson2f
@@ -1,16 +1,16 @@
-From af7861bcd35eba7746f04126dbefb8089ac3d635 Mon Sep 17 00:00:00 2001
+From b4e1cf8bd091914ebde9762d14f9a84ab0a712c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:47:00 -0700
-Subject: [PATCH 5/8] [HACK] [LOONGSON2F] fix(data): rename mips64el as AOSC
- OS-specific loongson2
+Subject: [PATCH 5/9] [HACK] [LOONGSON2F] fix(data): rename mips64el as AOSC
+ OS-specific loongson2f
 
 ---
  data/cputable   | 2 +-
- data/tupletable | 1 +
- 2 files changed, 2 insertions(+), 1 deletion(-)
+ data/tupletable | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/data/cputable b/data/cputable
-index 9d79de9a..f6e1a2d2 100644
+index 9d79de9a7..f6e1a2d26 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -35,7 +35,7 @@ mipsel		mipsel		mipsel			32	little
@@ -23,17 +23,18 @@ index 9d79de9a..f6e1a2d2 100644
  mips64r6el	mipsisa64r6el	mipsisa64r6el		64	little
  nios2		nios2		nios2			32	little
 diff --git a/data/tupletable b/data/tupletable
-index b91ace61..2e220f0f 100644
+index b91ace617..9ea7a2e4e 100644
 --- a/data/tupletable
 +++ b/data/tupletable
-@@ -35,6 +35,7 @@ abi64-gnu-linux-mips64r6el	mips64r6el
+@@ -33,7 +33,7 @@ abin32-gnu-linux-mips64el	mipsn32el
+ abin32-gnu-linux-mips64		mipsn32
+ abi64-gnu-linux-mips64r6el	mips64r6el
  abi64-gnu-linux-mips64r6	mips64r6
- abi64-gnu-linux-mips64el	mips64el
+-abi64-gnu-linux-mips64el	mips64el
++abi64-gnu-linux-mips64el	loongson2f
  abi64-gnu-linux-mips64		mips64
-+abi64-gnu-linux-loongson2f	loongson2f
  spe-gnu-linux-powerpc		powerpcspe
  x32-gnu-linux-amd64		x32
- base-gnu-linux-<cpu>		<cpu>
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0005-HACK-LOONGSON3-fix-data-rename-mips64el-as-AOSC-OS-.patch.loongson3
+++ b/app-admin/dpkg/01-update-alternatives/patches/0005-HACK-LOONGSON3-fix-data-rename-mips64el-as-AOSC-OS-.patch.loongson3
@@ -1,18 +1,16 @@
-Derived from [LOONGSON2F]
-
-From af7861bcd35eba7746f04126dbefb8089ac3d635 Mon Sep 17 00:00:00 2001
+From b4e1cf8bd091914ebde9762d14f9a84ab0a712c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:47:00 -0700
-Subject: [PATCH 5/8] [HACK] [LOONGSON3] fix(data): rename mips64el as AOSC
+Subject: [PATCH 5/9] [HACK] [LOONGSON3] fix(data): rename mips64el as AOSC
  OS-specific loongson3
 
 ---
  data/cputable   | 2 +-
- data/tupletable | 1 +
- 2 files changed, 2 insertions(+), 1 deletion(-)
+ data/tupletable | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/data/cputable b/data/cputable
-index 9d79de9a..f6e1a2d2 100644
+index 9d79de9a7..f6e1a2d26 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -35,7 +35,7 @@ mipsel		mipsel		mipsel			32	little
@@ -25,17 +23,18 @@ index 9d79de9a..f6e1a2d2 100644
  mips64r6el	mipsisa64r6el	mipsisa64r6el		64	little
  nios2		nios2		nios2			32	little
 diff --git a/data/tupletable b/data/tupletable
-index b91ace61..2e220f0f 100644
+index b91ace617..9ea7a2e4e 100644
 --- a/data/tupletable
 +++ b/data/tupletable
-@@ -35,6 +35,7 @@ abi64-gnu-linux-mips64r6el	mips64r6el
+@@ -33,7 +33,7 @@ abin32-gnu-linux-mips64el	mipsn32el
+ abin32-gnu-linux-mips64		mipsn32
+ abi64-gnu-linux-mips64r6el	mips64r6el
  abi64-gnu-linux-mips64r6	mips64r6
- abi64-gnu-linux-mips64el	mips64el
+-abi64-gnu-linux-mips64el	mips64el
++abi64-gnu-linux-mips64el	loongson3
  abi64-gnu-linux-mips64		mips64
-+abi64-gnu-linux-loongson3	loongson3
  spe-gnu-linux-powerpc		powerpcspe
  x32-gnu-linux-amd64		x32
- base-gnu-linux-<cpu>		<cpu>
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0006-feat-drop-multiarch-features-add-remove-architecture.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0006-feat-drop-multiarch-features-add-remove-architecture.patch
@@ -1,7 +1,7 @@
-From 73c78ce29d409fa2c765bde066201473de8b1d3b Mon Sep 17 00:00:00 2001
+From 0989dde2a112d9652c7757cd4a835c827bd79eed Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 5 May 2024 16:06:18 +0800
-Subject: [PATCH 6/8] feat: drop multiarch features
+Subject: [PATCH 6/9] feat: drop multiarch features
  (--{add,remove}-architectures)
 
 AOSC OS does not offer multiarch or any way to install foreign-architecture
@@ -18,7 +18,7 @@ Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 60 deletions(-)
 
 diff --git a/src/main/main.c b/src/main/main.c
-index ecaed5f3..1bc5eb6c 100644
+index ecaed5f32..1bc5eb6c4 100644
 --- a/src/main/main.c
 +++ b/src/main/main.c
 @@ -456,73 +456,17 @@ run_status_loggers(struct invoke_list *hook_list)
@@ -100,5 +100,5 @@ index ecaed5f3..1bc5eb6c 100644
  
  int execbackend(const char *const *argv) DPKG_ATTR_NORET;
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0007-po-update-translation-catalogue.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0007-po-update-translation-catalogue.patch
@@ -1,13 +1,14 @@
-From 1d8e3481a17c2825b7472e296d8c925ab34e644e Mon Sep 17 00:00:00 2001
-From: Kexy Biscuit <kexybiscuit@aosc.io>
-Date: Thu, 18 Jul 2024 06:02:26 +0800
-Subject: [PATCH 7/8] po: update translation catalogue
+From 8040dd538341634a6da5c913aa19447bc2e817ff Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 27 Nov 2024 22:37:27 +0800
+Subject: [PATCH 7/9] po: update translation catalogue
 
 This is done with `make update-po', re-generate this patch in future versions.
 
 DO NOT CHERRY-PICK.
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
+Co-authored-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
  dselect/po/bs.po        |  2 +-
  dselect/po/ca.po        |  2 +-
@@ -97,441 +98,441 @@ Co-authored-by: eatradish <sakiiily@aosc.io>
  85 files changed, 913 insertions(+), 970 deletions(-)
 
 diff --git a/dselect/po/bs.po b/dselect/po/bs.po
-index dbaaffb6..12d25077 100644
+index 05a3360fa..269150531 100644
 --- a/dselect/po/bs.po
 +++ b/dselect/po/bs.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-02-17 08:55+0200\n"
  "Last-Translator: Safir Šećerović <sapphire@linux.org.ba>\n"
  "Language-Team: Bosnian <lokal@linux.org.ba>\n"
 diff --git a/dselect/po/ca.po b/dselect/po/ca.po
-index 4babe456..c90e4838 100644
+index 8c37d8310..6f3e94992 100644
 --- a/dselect/po/ca.po
 +++ b/dselect/po/ca.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-12-17 19:34+0100\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
 diff --git a/dselect/po/cs.po b/dselect/po/cs.po
-index 7318cd96..ef23a288 100644
+index a15747b5b..3e99a7136 100644
 --- a/dselect/po/cs.po
 +++ b/dselect/po/cs.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-26 13:52+0100\n"
  "Last-Translator: Miroslav Kure <kurem@debian.cz>\n"
  "Language-Team: Czech <debian-l10n-czech@lists.debian.org>\n"
 diff --git a/dselect/po/da.po b/dselect/po/da.po
-index f30c430e..e7aca450 100644
+index 10c7ed16b..c6beee95c 100644
 --- a/dselect/po/da.po
 +++ b/dselect/po/da.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-11-27 02:33+0200\n"
  "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
  "Language-Team: Danish <debian-l10n-danish@lists.debian.org>\n"
 diff --git a/dselect/po/de.po b/dselect/po/de.po
-index 1e194088..907b59b1 100644
+index d73406f42..177f13a68 100644
 --- a/dselect/po/de.po
 +++ b/dselect/po/de.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0~\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-04-25 20:26+0200\n"
  "Last-Translator: Sven Joachim <svenjoac@gmx.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
 diff --git a/dselect/po/dselect.pot b/dselect/po/dselect.pot
-index 73a40ae0..bf03856a 100644
+index c08035ac8..9bdb22f3d 100644
 --- a/dselect/po/dselect.pot
 +++ b/dselect/po/dselect.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.7\n"
-+"Project-Id-Version: dpkg 1.22.7-6-g73c7\n"
+-"Project-Id-Version: dpkg 1.22.11\n"
++"Project-Id-Version: dpkg 1.22.11-6-g9e3c\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/dselect/po/el.po b/dselect/po/el.po
-index 10be82cc..b2cc6824 100644
+index 82f43788f..a32359ec0 100644
 --- a/dselect/po/el.po
 +++ b/dselect/po/el.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-02-17 08:56+0200\n"
  "Last-Translator: quad-nrg.net <galaxico@quad-nrg.net>\n"
  "Language-Team: Greek <debian-l10n-greek@lists.debian.org>\n"
 diff --git a/dselect/po/es.po b/dselect/po/es.po
-index a8f2b638..b0e10554 100644
+index 857a714ac..6df75a625 100644
 --- a/dselect/po/es.po
 +++ b/dselect/po/es.po
 @@ -40,7 +40,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-27 22:48+0100\n"
  "Last-Translator: Javier Fernández-Sanguino <jfs@debian.org>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
 diff --git a/dselect/po/et.po b/dselect/po/et.po
-index a9aea103..bd544129 100644
+index 28556321b..4c55428e2 100644
 --- a/dselect/po/et.po
 +++ b/dselect/po/et.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.14.5\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2007-07-13 08:22+0300\n"
  "Last-Translator: Ivar Smolin <okul@linux.ee>\n"
  "Language-Team: Estonian <et@li.org>\n"
 diff --git a/dselect/po/eu.po b/dselect/po/eu.po
-index 9dfccae7..d379ff09 100644
+index 28e035e62..875740553 100644
 --- a/dselect/po/eu.po
 +++ b/dselect/po/eu.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.16.8\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2012-09-01 12:21+0200\n"
  "Last-Translator: Iñaki Larrañaga Murgoitio <dooteo@zundan.com>\n"
  "Language-Team: Basque <debian-l10n-basque@lists.debian.org>\n"
 diff --git a/dselect/po/fr.po b/dselect/po/fr.po
-index 1d5d1fea..9d9367da 100644
+index 94b76c643..0783bfb6c 100644
 --- a/dselect/po/fr.po
 +++ b/dselect/po/fr.po
 @@ -49,7 +49,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-05 23:47+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
 diff --git a/dselect/po/gl.po b/dselect/po/gl.po
-index e68a9004..9478b3b9 100644
+index dac45a53c..1f5cc9ff7 100644
 --- a/dselect/po/gl.po
 +++ b/dselect/po/gl.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2008-12-27 15:56+0100\n"
  "Last-Translator: mvillarino <mvillarino@users.sourceforge.net>\n"
  "Language-Team: Galician <proxecto@trasno.net>\n"
 diff --git a/dselect/po/hu.po b/dselect/po/hu.po
-index 02d94ab8..b5b7e571 100644
+index 6a9e0e037..5cc8a894f 100644
 --- a/dselect/po/hu.po
 +++ b/dselect/po/hu.po
 @@ -4,7 +4,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-10-06 03:48+0100\n"
  "Last-Translator: SZERVÁC Attila <sas@321.hu>\n"
  "Language-Team: Hungarian <debian-l10n-hungarian@lists.debian.org>\n"
 diff --git a/dselect/po/id.po b/dselect/po/id.po
-index cd1b8f10..51e8a982 100644
+index 796f01e90..f5e3e66df 100644
 --- a/dselect/po/id.po
 +++ b/dselect/po/id.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-10-06 20:20+0700\n"
  "Last-Translator: Arief S Fitrianto <arief@gurame.fisika.ui.ac.id>\n"
  "Language-Team: Indonesian <debian-l10n-indonesian@lists.debian.org>\n"
 diff --git a/dselect/po/it.po b/dselect/po/it.po
-index 114254af..e81b77de 100644
+index b717e87b4..1f3b23440 100644
 --- a/dselect/po/it.po
 +++ b/dselect/po/it.po
 @@ -42,7 +42,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.10.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-10-06 22:01+0200\n"
  "Last-Translator: Stefano Canepa <sc@linux.it>\n"
  "Language-Team: Italian <debian-l10n-italian@lists.debian.org>\n"
 diff --git a/dselect/po/ja.po b/dselect/po/ja.po
-index a1ab7d97..eabdbc2e 100644
+index 62764aafb..987cf7a8c 100644
 --- a/dselect/po/ja.po
 +++ b/dselect/po/ja.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2016-03-31 12:44+0900\n"
  "Last-Translator: Takuma Yamada <tyamada@takumayamada.com>\n"
  "Language-Team: Japanese <debian-japanese@lists.debian.org>\n"
 diff --git a/dselect/po/ko.po b/dselect/po/ko.po
-index de40cecb..4a54b627 100644
+index 6673e4f0c..8165eb72a 100644
 --- a/dselect/po/ko.po
 +++ b/dselect/po/ko.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-29 11:18+0100\n"
  "Last-Translator: Sangdo Jun <sebuls@gmail.com>\n"
  "Language-Team: Korean <debian-l10n-korean@lists.debian.org>\n"
 diff --git a/dselect/po/nb.po b/dselect/po/nb.po
-index f5244866..8352f1a2 100644
+index 37d4b63bd..1d98e486b 100644
 --- a/dselect/po/nb.po
 +++ b/dselect/po/nb.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-12-05 13:25+0200\n"
  "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
  "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
 diff --git a/dselect/po/nl.po b/dselect/po/nl.po
-index f0647cdf..e928c671 100644
+index 0a9ca7405..a9d6bf09f 100644
 --- a/dselect/po/nl.po
 +++ b/dselect/po/nl.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-09-11 21:13+0200\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: Debian Dutch l10n Team <debian-l10n-dutch@lists.debian.org>\n"
 diff --git a/dselect/po/nn.po b/dselect/po/nn.po
-index bcea9e19..d3f765bc 100644
+index ef3bdfd2a..196463b35 100644
 --- a/dselect/po/nn.po
 +++ b/dselect/po/nn.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-02-17 08:57+0200\n"
  "Last-Translator: Håvard Korsvoll <korsvoll@skulelinux.no>\n"
  "Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
 diff --git a/dselect/po/pl.po b/dselect/po/pl.po
-index 794b0a43..039b94b6 100644
+index 6bb91c3b6..19f3e20bf 100644
 --- a/dselect/po/pl.po
 +++ b/dselect/po/pl.po
 @@ -14,7 +14,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.15.4\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-12-21 20:58+0100\n"
  "Last-Translator: Łukasz Dulny <bartekchom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
 diff --git a/dselect/po/pt.po b/dselect/po/pt.po
-index 0982a3aa..0e2b90fd 100644
+index de817fa44..7c198bd3b 100644
 --- a/dselect/po/pt.po
 +++ b/dselect/po/pt.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-11-30 13:28+0000\n"
  "Last-Translator: Miguel Figueiredo <elmig@debianpt.org>\n"
  "Language-Team: Portuguese <traduz@debianpt.org>\n"
 diff --git a/dselect/po/pt_BR.po b/dselect/po/pt_BR.po
-index 0bfa3491..3e98fafe 100644
+index d0815eac7..bfa1e0f49 100644
 --- a/dselect/po/pt_BR.po
 +++ b/dselect/po/pt_BR.po
 @@ -13,7 +13,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2008-06-09 02:53-0300\n"
  "Last-Translator: Felipe Augusto van de Wiel <faw@debian.org>\n"
  "Language-Team: Brazilian Portuguese <debian-l10n-portuguese@lists.debian."
 diff --git a/dselect/po/ro.po b/dselect/po/ro.po
-index da5ef47a..dae41b74 100644
+index 13f668667..0fdb83548 100644
 --- a/dselect/po/ro.po
 +++ b/dselect/po/ro.po
 @@ -18,7 +18,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-09-13 20:15+0200\n"
  "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
  "Language-Team: Romanian <debian-l10n-romanian@lists.debian.org>\n"
 diff --git a/dselect/po/ru.po b/dselect/po/ru.po
-index 29fbc1e1..a1041927 100644
+index a82696fda..53f894573 100644
 --- a/dselect/po/ru.po
 +++ b/dselect/po/ru.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-31 22:38+0100\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
 diff --git a/dselect/po/sk.po b/dselect/po/sk.po
-index c9105609..01b4c012 100644
+index d2a48728c..a487c90fc 100644
 --- a/dselect/po/sk.po
 +++ b/dselect/po/sk.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2012-07-03 01:09+0100\n"
  "Last-Translator: Ivan Masár <helix84@centrum.sk>\n"
  "Language-Team: Slovak <debian-l10n-slovak@lists.debian.org>\n"
 diff --git a/dselect/po/sv.po b/dselect/po/sv.po
-index 0032a9cf..717df525 100644
+index 1ca777156..a43031762 100644
 --- a/dselect/po/sv.po
 +++ b/dselect/po/sv.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-10-24 18:29+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 diff --git a/dselect/po/tl.po b/dselect/po/tl.po
-index 3de74ed7..a76e3347 100644
+index dc11154a8..30cbb15e1 100644
 --- a/dselect/po/tl.po
 +++ b/dselect/po/tl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2006-02-17 08:58+0200\n"
  "Last-Translator: Eric Pareja <xenos@upm.edu.ph>\n"
  "Language-Team: Tagalog <debian-tl@banwa.upm.edu.ph>\n"
 diff --git a/dselect/po/vi.po b/dselect/po/vi.po
-index 16e1d524..618c386d 100644
+index b196eeaa4..aa556c535 100644
 --- a/dselect/po/vi.po
 +++ b/dselect/po/vi.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-12-01 08:20+0700\n"
  "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
  "Language-Team: Vietnamese <debian-l10n-vietnamese@lists.debian.org>\n"
 diff --git a/dselect/po/zh_CN.po b/dselect/po/zh_CN.po
-index 4175e569..18e83b5c 100644
+index 6437ad454..af765bdcd 100644
 --- a/dselect/po/zh_CN.po
 +++ b/dselect/po/zh_CN.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-27 15:29-0500\n"
  "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
  "Language-Team: Chinese (simplified) <debian-l10n-chinese@lists.debian.org>\n"
 diff --git a/dselect/po/zh_TW.po b/dselect/po/zh_TW.po
-index e801038d..e243b1d8 100644
+index c826085db..1cf24663c 100644
 --- a/dselect/po/zh_TW.po
 +++ b/dselect/po/zh_TW.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-28 15:57+0800\n"
  "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
  "Language-Team: Chinese (traditional) <debian-l10n-chinese@lists.debian.org>\n"
 diff --git a/man/po/dpkg-man.pot b/man/po/dpkg-man.pot
-index d3b41b47..4dde58f6 100644
+index d39626f31..c94192596 100644
 --- a/man/po/dpkg-man.pot
 +++ b/man/po/dpkg-man.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg-man 1.22.7\n"
-+"Project-Id-Version: dpkg-man 1.22.7-6-g73c7\n"
+-"Project-Id-Version: dpkg-man 1.22.11\n"
++"Project-Id-Version: dpkg-man 1.22.11-6-g9e3c\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:58+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:36+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/po/ast.po b/po/ast.po
-index 16262350..d5c1294b 100644
+index b7a57c1d1..b19ff27b7 100644
 --- a/po/ast.po
 +++ b/po/ast.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.14.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:47+0200\n"
  "Last-Translator: Marcos Alvarez Costales <marcos.alvarez.costales@gmail."
  "com>\n"
-@@ -6205,29 +6205,15 @@ msgid "status logger"
+@@ -6199,29 +6199,15 @@ msgid "status logger"
  msgstr "estáu"
  
  #: src/main/main.c
@@ -567,7 +568,7 @@ index 16262350..d5c1294b 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7807,6 +7793,11 @@ msgstr ""
+@@ -7801,6 +7787,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -576,23 +577,23 @@ index 16262350..d5c1294b 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "nun se puede desaniciar el ficheru `%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "fallu al abrir el ficheru de desvíos"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/bs.po b/po/bs.po
-index a1b00fe8..9f51fcda 100644
+index f45596918..bb64895d7 100644
 --- a/po/bs.po
 +++ b/po/bs.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 10:02+0200\n"
  "Last-Translator: Safir Šećerović <sapphire@linux.org.ba>\n"
  "Language-Team: Bosnian <lokal@linux.org.ba>\n"
-@@ -5242,28 +5242,15 @@ msgid "status logger"
+@@ -5251,28 +5251,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -628,19 +629,19 @@ index a1b00fe8..9f51fcda 100644
  
  #: src/main/main.c
 diff --git a/po/ca.po b/po/ca.po
-index 9b9b5951..f2abf9bc 100644
+index 451a09778..20844778f 100644
 --- a/po/ca.po
 +++ b/po/ca.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.18\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
- "PO-Revision-Date: 2023-12-17 20:02+0100\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
+ "PO-Revision-Date: 2024-07-21 19:57+0200\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
-@@ -5774,29 +5774,16 @@ msgid "status logger"
+@@ -5786,29 +5786,16 @@ msgid "status logger"
  msgstr "registre d'estat"
  
  #: src/main/main.c
@@ -678,7 +679,7 @@ index 9b9b5951..f2abf9bc 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7223,6 +7210,28 @@ msgstr ""
+@@ -7235,6 +7222,28 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Es requereix autenticació per a executar update-alternatives"
  
@@ -704,23 +705,23 @@ index 9b9b5951..f2abf9bc 100644
 +#~ msgstr ""
 +#~ "no es pot esborrar l'arquitectura «%s» que és en ús a la base de dades"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "no s'ha pogut obrir el fitxer de desviacions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/cs.po b/po/cs.po
-index 33278c6e..98ecc60d 100644
+index 833013f44..84864cb3d 100644
 --- a/po/cs.po
 +++ b/po/cs.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-01 23:14+0100\n"
  "Last-Translator: Miroslav Kure <kurem@debian.cz>\n"
  "Language-Team: Czech <debian-l10n-czech@lists.debian.org>\n"
-@@ -5543,29 +5543,16 @@ msgid "status logger"
+@@ -5568,29 +5568,16 @@ msgid "status logger"
  msgstr "záznam stavů"
  
  #: src/main/main.c
@@ -758,7 +759,7 @@ index 33278c6e..98ecc60d 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6933,6 +6920,26 @@ msgstr "Spustí update-alternatives pro úpravu systémových alternativ"
+@@ -6958,6 +6945,26 @@ msgstr "Spustí update-alternatives pro úpravu systémových alternativ"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Pro spuštění update-alternatives je vyžadováno ověření"
  
@@ -782,23 +783,23 @@ index 33278c6e..98ecc60d 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "nelze odstranit aktuálně používanou architekturu „%s“"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "nelze otevřít soubor s odsuny"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/da.po b/po/da.po
-index 78d69391..b1bddcea 100644
+index 439a22d75..40964276c 100644
 --- a/po/da.po
 +++ b/po/da.po
 @@ -22,7 +22,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
  "Language-Team: Danish <debian-l10n-danish@lists.debian.org>\n"
-@@ -6005,29 +6005,16 @@ msgid "status logger"
+@@ -6002,29 +6002,16 @@ msgid "status logger"
  msgstr "statuslogger"
  
  #: src/main/main.c
@@ -836,7 +837,7 @@ index 78d69391..b1bddcea 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7471,6 +7458,26 @@ msgstr ""
+@@ -7468,6 +7455,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -860,23 +861,23 @@ index 78d69391..b1bddcea 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "kan ikke fjerne arkitektur '%s' aktuelt i brug af databasen"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "kunne ikke åbne omdirigeringsfil"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/de.po b/po/de.po
-index d56a4fdf..516c3676 100644
+index bf37e6df7..21b50e20c 100644
 --- a/po/de.po
 +++ b/po/de.po
 @@ -13,7 +13,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dpkg 1.22.7~\n"
+ "Project-Id-Version: dpkg 1.22.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
- "PO-Revision-Date: 2024-04-29 18:35+0200\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
+ "PO-Revision-Date: 2024-07-27 17:22+0200\n"
  "Last-Translator: Sven Joachim <svenjoac@gmx.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
-@@ -5733,31 +5733,16 @@ msgid "status logger"
+@@ -5720,31 +5720,16 @@ msgid "status logger"
  msgstr "Statuslogger"
  
  #: src/main/main.c
@@ -915,7 +916,7 @@ index d56a4fdf..516c3676 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7178,6 +7163,29 @@ msgstr ""
+@@ -7165,6 +7150,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Authentifizierung ist erforderlich, um update-alternatives auszuführen"
  
@@ -942,26 +943,26 @@ index d56a4fdf..516c3676 100644
 +#~ "Architektur »%s«, derzeit verwendet von der Datenbank, kann nicht "
 +#~ "entfernt werden"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "Öffnen der diversions-Datei fehlgeschlagen"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/dpkg.pot b/po/dpkg.pot
-index 69f98896..1b3255f6 100644
+index b6ba0a688..8275fab10 100644
 --- a/po/dpkg.pot
 +++ b/po/dpkg.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.7\n"
-+"Project-Id-Version: dpkg 1.22.7-6-g73c7\n"
+-"Project-Id-Version: dpkg 1.22.11\n"
++"Project-Id-Version: dpkg 1.22.11-6-g9e3c\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
-@@ -5018,28 +5018,15 @@ msgid "status logger"
+@@ -5012,28 +5012,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -997,19 +998,19 @@ index 69f98896..1b3255f6 100644
  
  #: src/main/main.c
 diff --git a/po/dz.po b/po/dz.po
-index d83a6c63..8728d5af 100644
+index 2daf753e3..fc5b3b4f5 100644
 --- a/po/dz.po
 +++ b/po/dz.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: Tshewang Norbu <bumthap2006@hotmail.com>\n"
  "Language-Team: Dzongkha <pgeyleg@dit.gov.bt>\n"
-@@ -5913,29 +5913,15 @@ msgid "status logger"
+@@ -5907,29 +5907,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1045,7 +1046,7 @@ index d83a6c63..8728d5af 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7405,6 +7391,11 @@ msgstr ""
+@@ -7399,6 +7385,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1054,23 +1055,23 @@ index d83a6c63..8728d5af 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "ཡིག་སྣོད་ `%.250s' རྩ་བསྐྲད་གཏང་མི་ཚུགས།"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "ཁ་སྒྱུར་ཡིག་སྣོད་ཁ་ཕྱེ་ནི་འཐུས་ཤོར་བྱུང་ཡོད།"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/el.po b/po/el.po
-index aec47b82..3337e371 100644
+index acb21704d..67ed0da08 100644
 --- a/po/el.po
 +++ b/po/el.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: quad-nrg.net <yodesy@quad-nrg.net>\n"
  "Language-Team: Greek <debian-l10n-greek@lists.debian.org>\n"
-@@ -6191,29 +6191,15 @@ msgid "status logger"
+@@ -6186,29 +6186,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1106,7 +1107,7 @@ index aec47b82..3337e371 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7768,6 +7754,11 @@ msgstr ""
+@@ -7763,6 +7749,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1115,23 +1116,23 @@ index aec47b82..3337e371 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "αδύνατη η αφαίρεση του αρχείου `%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "αποτυχία κατά το άνοιγμα του αρχείου diversions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/eo.po b/po/eo.po
-index ee6c7d2d..ac231c9c 100644
+index 2e2afe908..95bb06a47 100644
 --- a/po/eo.po
 +++ b/po/eo.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Felipe Castro <fefcas@gmail.com>\n"
  "Language-Team: Esperanto <debian-l10n-esperanto@lists.debian.org>\n"
-@@ -5965,29 +5965,16 @@ msgid "status logger"
+@@ -5962,29 +5962,16 @@ msgid "status logger"
  msgstr "stat-registrilo"
  
  #: src/main/main.c
@@ -1169,7 +1170,7 @@ index ee6c7d2d..ac231c9c 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7433,6 +7420,26 @@ msgstr ""
+@@ -7430,6 +7417,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1193,23 +1194,23 @@ index ee6c7d2d..ac231c9c 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "ne eblas forigi arkitekturon '%s', nune uzata de datumbazo"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "malsukcesis malfermi dosieron diversions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "malfermi elementon '%.255s' (en %.255s) malsukcesis neatendite"
 diff --git a/po/es.po b/po/es.po
-index 250054c4..f15d6be4 100644
+index 690a06496..6291752e3 100644
 --- a/po/es.po
 +++ b/po/es.po
 @@ -38,7 +38,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.16.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2017-11-08 00:59+0100\n"
  "Last-Translator: Javier Fernandez-Sanguino <jfs@debian.org>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
-@@ -6195,32 +6195,16 @@ msgid "status logger"
+@@ -6190,32 +6190,16 @@ msgid "status logger"
  msgstr "registro de estado"
  
  #: src/main/main.c
@@ -1248,7 +1249,7 @@ index 250054c4..f15d6be4 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7703,6 +7687,29 @@ msgstr ""
+@@ -7698,6 +7682,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Es necesario autenticarse para ejecutar `update-alternatives'"
  
@@ -1275,23 +1276,23 @@ index 250054c4..f15d6be4 100644
 +#~ "no se puede eliminar la arquitectura '%s' puesto que está en uso "
 +#~ "actualmente en la base de datos"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "fallo al abrir fichero de desvíos"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/et.po b/po/et.po
-index b337fa64..71d268f0 100644
+index 648944b63..883c31f37 100644
 --- a/po/et.po
 +++ b/po/et.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.14.5\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Ivar Smolin <okul@linux.ee>\n"
  "Language-Team: Estonian <et@li.org>\n"
-@@ -5550,28 +5550,15 @@ msgid "status logger"
+@@ -5546,28 +5546,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1327,19 +1328,19 @@ index b337fa64..71d268f0 100644
  
  #: src/main/main.c
 diff --git a/po/eu.po b/po/eu.po
-index 73a05385..a4ca94c3 100644
+index 5fa8cc725..eb94bd4c6 100644
 --- a/po/eu.po
 +++ b/po/eu.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Iñaki Larrañaga Murgoitio <dooteo@zundan.com>\n"
  "Language-Team: Basque <debian-l10n-basque@lists.debian.org>\n"
-@@ -6083,29 +6083,16 @@ msgid "status logger"
+@@ -6079,29 +6079,16 @@ msgid "status logger"
  msgstr "egoeraren egunkaria"
  
  #: src/main/main.c
@@ -1377,7 +1378,7 @@ index 73a05385..a4ca94c3 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7568,6 +7555,26 @@ msgstr ""
+@@ -7564,6 +7551,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1401,23 +1402,23 @@ index 73a05385..a4ca94c3 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "ezin da '%s' arkitektura kendu datu-baseak unean darabilelako"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "huts egin du desbideratzeen fitxategia irekitzean"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/fr.po b/po/fr.po
-index 4675a75e..72dc3b7e 100644
+index 4583dc934..4205bd5af 100644
 --- a/po/fr.po
 +++ b/po/fr.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-05 23:47+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
-@@ -5887,33 +5887,16 @@ msgid "status logger"
+@@ -5910,33 +5910,16 @@ msgid "status logger"
  msgstr "journaliseur de l'état"
  
  #: src/main/main.c
@@ -1457,7 +1458,7 @@ index 4675a75e..72dc3b7e 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7355,6 +7338,30 @@ msgstr ""
+@@ -7378,6 +7361,30 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Une authentification est requise pour exécuter update-alternatives"
  
@@ -1485,23 +1486,23 @@ index 4675a75e..72dc3b7e 100644
 +#~ "impossible de supprimer l'architecture « %s » actuellement utilisée dans "
 +#~ "la base de données"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "impossible d'ouvrir le fichier des détournements"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/gl.po b/po/gl.po
-index d35b584e..a18d286c 100644
+index 17503fb0f..0e75a7a32 100644
 --- a/po/gl.po
 +++ b/po/gl.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: mvillarino <mvillarino@users.sourceforge.net>\n"
  "Language-Team: Galician <proxecto@trasno.net>\n"
-@@ -6152,29 +6152,15 @@ msgid "status logger"
+@@ -6147,29 +6147,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1537,7 +1538,7 @@ index d35b584e..a18d286c 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7724,6 +7710,11 @@ msgstr ""
+@@ -7719,6 +7705,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1546,23 +1547,23 @@ index d35b584e..a18d286c 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "non se pode borrar o ficheiro \"%.250s\""
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "non se puido abrir o ficheiro de desvíos"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/hu.po b/po/hu.po
-index 2f3bf1ff..a3bc8709 100644
+index c0db30c7f..06152ccdc 100644
 --- a/po/hu.po
 +++ b/po/hu.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-05 23:44+0100\n"
  "Last-Translator: Nagy Elemér Károly <nagy.elemer.karoly@gmail.com>\n"
  "Language-Team: Hungarian <debian-l10n-hungarian@lists.debian.org>\n"
-@@ -5777,29 +5777,15 @@ msgid "status logger"
+@@ -5772,29 +5772,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1598,7 +1599,7 @@ index 2f3bf1ff..a3bc8709 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7224,6 +7210,11 @@ msgstr ""
+@@ -7219,6 +7205,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1607,23 +1608,23 @@ index 2f3bf1ff..a3bc8709 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "nem törölhető fájl: `%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "eltérítés fájl megnyitása sikertelen"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/id.po b/po/id.po
-index d5ebd29e..cf11b069 100644
+index 60f1f0d84..daa57b69d 100644
 --- a/po/id.po
 +++ b/po/id.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.15\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-06-26 16:12+0200\n"
  "Last-Translator: Arief S Fitrianto <arief@gurame.fisika.ui.ac.id>\n"
  "Language-Team: Indonesian <debian-l10n-indonesian@lists.debian.org>\n"
-@@ -6172,28 +6172,15 @@ msgid "status logger"
+@@ -6168,28 +6168,15 @@ msgid "status logger"
  msgstr "status"
  
  #: src/main/main.c
@@ -1659,19 +1660,19 @@ index d5ebd29e..cf11b069 100644
  
  #: src/main/main.c
 diff --git a/po/it.po b/po/it.po
-index d4e38739..4d859edb 100644
+index 6b43eacfd..e614e4612 100644
 --- a/po/it.po
 +++ b/po/it.po
 @@ -26,7 +26,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.19.3\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2018-12-04 12:15+0100\n"
  "Last-Translator: Milo Casagrande <milo@milo.name>\n"
  "Language-Team: Italian <tp@lists.linux.it>\n"
-@@ -6084,30 +6084,16 @@ msgid "status logger"
+@@ -6078,30 +6078,16 @@ msgid "status logger"
  msgstr "logger di stato"
  
  #: src/main/main.c
@@ -1709,7 +1710,7 @@ index d4e38739..4d859edb 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7580,6 +7566,28 @@ msgstr ""
+@@ -7574,6 +7560,28 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1735,23 +1736,23 @@ index d4e38739..4d859edb 100644
 +#~ "impossibile rimuovere l'architettura \"%s\" attualmente in uso dal "
 +#~ "database"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "apertura del file con le deviazioni non riuscita"
- 
+ # (ndt) non mi è molto chiara
+ # se fosse: il componente aperto ... ?
+ #, c-format
 diff --git a/po/ja.po b/po/ja.po
-index 19d1061c..6678e91e 100644
+index 9c5341639..95dd2c1dd 100644
 --- a/po/ja.po
 +++ b/po/ja.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.18.3\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2022-11-03 20:08+0100\n"
  "Last-Translator: Takuma Yamada <tyamada@takumayamada.com>\n"
  "Language-Team: Japanese <debian-japanese@lists.debian.org>\n"
-@@ -6018,29 +6018,16 @@ msgid "status logger"
+@@ -6013,29 +6013,16 @@ msgid "status logger"
  msgstr "状態記録"
  
  #: src/main/main.c
@@ -1789,7 +1790,7 @@ index 19d1061c..6678e91e 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7494,6 +7481,26 @@ msgstr ""
+@@ -7489,6 +7476,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1813,23 +1814,23 @@ index 19d1061c..6678e91e 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "データベースで現在使用中のアーキテクチャ '%s' を削除できません"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "diversions ファイルのオープンに失敗しました"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/km.po b/po/km.po
-index 89d7e350..b77bfdab 100644
+index 78f761be4..0935d6805 100644
 --- a/po/km.po
 +++ b/po/km.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
  "Language-Team: Khmer <support@khmeros.info>\n"
-@@ -5821,29 +5821,15 @@ msgid "status logger"
+@@ -5817,29 +5817,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1865,7 +1866,7 @@ index 89d7e350..b77bfdab 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7287,6 +7273,11 @@ msgstr ""
+@@ -7283,6 +7269,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1874,23 +1875,23 @@ index 89d7e350..b77bfdab 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "មិន​អាច​យក​ឯកសារ​ចេញ `%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​បើក​ឯកសារ​បង្វែរ"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "បើក​សមាសភាគ​`%.255s' (នៅ %.255s)​ បានបរាជ័យ​តាម​វិធី​ដែលមិន​បាន​រំពឹង​ទុក"
 diff --git a/po/ko.po b/po/ko.po
-index 083fb1e8..6403bd11 100644
+index 613f0fdd7..aa0f24fc5 100644
 --- a/po/ko.po
 +++ b/po/ko.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-06-26 16:12+0200\n"
  "Last-Translator: Changwoo Ryu <cwryu@debian.org>\n"
  "Language-Team: Korean <debian-l10n-korean@lists.debian.org>\n"
-@@ -6198,28 +6198,15 @@ msgid "status logger"
+@@ -6194,28 +6194,15 @@ msgid "status logger"
  msgstr "상태"
  
  #: src/main/main.c
@@ -1926,19 +1927,19 @@ index 083fb1e8..6403bd11 100644
  
  # fdopen() 실패 상황
 diff --git a/po/ku.po b/po/ku.po
-index b4c0891b..76686669 100644
+index 70810aa28..decc17ae4 100644
 --- a/po/ku.po
 +++ b/po/ku.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Erdal Ronahi <erdal.ronahi@gmail.com>\n"
  "Language-Team: Kurdish <ku@li.org>\n"
-@@ -5192,28 +5192,15 @@ msgid "status logger"
+@@ -5186,28 +5186,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1974,19 +1975,19 @@ index b4c0891b..76686669 100644
  
  #: src/main/main.c
 diff --git a/po/lt.po b/po/lt.po
-index cf953afd..38e60f98 100644
+index d49961a98..13a86124b 100644
 --- a/po/lt.po
 +++ b/po/lt.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Gintautas Miliauskas <gintas@akl.lt>\n"
  "Language-Team: Lithuanian <komp_lt@konferencijos.lt>\n"
-@@ -5707,28 +5707,15 @@ msgid "status logger"
+@@ -5703,28 +5703,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2022,19 +2023,19 @@ index cf953afd..38e60f98 100644
  
  #: src/main/main.c
 diff --git a/po/mr.po b/po/mr.po
-index d60fd60a..8bd87857 100644
+index dff0429fa..8f1777213 100644
 --- a/po/mr.po
 +++ b/po/mr.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Priti Patil <prithisd@gmail.com>\n"
  "Language-Team: Marathi <janabhaaratii@cdacmumbai.in>\n"
-@@ -5780,29 +5780,15 @@ msgid "status logger"
+@@ -5776,29 +5776,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2070,7 +2071,7 @@ index d60fd60a..8bd87857 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7263,6 +7249,11 @@ msgstr ""
+@@ -7259,6 +7245,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2079,23 +2080,23 @@ index d60fd60a..8bd87857 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "`%.250s' फाइल काढणे अशक्य"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "डाइव्हर्जन्स फाइल उघडण्यास अयशस्वी"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "चालू असलेला घटक `%.255s' (%.255s मधील) अनपेक्षित रित्या बंद पडला"
 diff --git a/po/nb.po b/po/nb.po
-index a085d9cc..8bf22c4c 100644
+index eb5b6d941..3ab811224 100644
 --- a/po/nb.po
 +++ b/po/nb.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
  "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
-@@ -6182,29 +6182,15 @@ msgid "status logger"
+@@ -6179,29 +6179,15 @@ msgid "status logger"
  msgstr "status"
  
  #: src/main/main.c
@@ -2131,7 +2132,7 @@ index a085d9cc..8bf22c4c 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7780,6 +7766,11 @@ msgstr ""
+@@ -7777,6 +7763,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2140,23 +2141,23 @@ index a085d9cc..8bf22c4c 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "klarte ikke fjerne fila «%.250s»"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "klarte ikke åpne omdirigeringsfil"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/ne.po b/po/ne.po
-index 5e699ad3..6a7c98fb 100644
+index 4831894d2..42d7d5404 100644
 --- a/po/ne.po
 +++ b/po/ne.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Nabin Gautam <nabin@mpp.org.np>\n"
  "Language-Team: Nepali <info@mpp.org.np>\n"
-@@ -5867,29 +5867,15 @@ msgid "status logger"
+@@ -5863,29 +5863,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2192,7 +2193,7 @@ index 5e699ad3..6a7c98fb 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7343,6 +7329,11 @@ msgstr ""
+@@ -7339,6 +7325,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2201,23 +2202,23 @@ index 5e699ad3..6a7c98fb 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "फाइल `%.250s' हटाउन सक्दैन"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "diversions फाइल खोल्न असफल"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "अवयव`%.255s' (in %.255s)खोल्न अप्रत्यासित रुपले असफल"
 diff --git a/po/nl.po b/po/nl.po
-index 4a5bdea0..4e3abf89 100644
+index 413699267..651ace8c2 100644
 --- a/po/nl.po
 +++ b/po/nl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.1\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-12-03 17:45+0100\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: Debian Dutch l10n Team <debian-l10n-dutch@lists.debian.org>\n"
-@@ -5699,33 +5699,16 @@ msgid "status logger"
+@@ -5723,33 +5723,16 @@ msgid "status logger"
  msgstr "statuslogger"
  
  #: src/main/main.c
@@ -2257,7 +2258,7 @@ index 4a5bdea0..4e3abf89 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7157,6 +7140,30 @@ msgstr ""
+@@ -7181,6 +7164,30 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Authenticatie is nodig voor het uitvoeren van update-alternatives"
  
@@ -2285,23 +2286,23 @@ index 4a5bdea0..4e3abf89 100644
 +#~ "kan architectuur '%s' die momenteel door de database gebruikt wordt, niet "
 +#~ "verwijderen"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "kon omleidingenbestand niet openen"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/nn.po b/po/nn.po
-index 81b0189c..f872f1a2 100644
+index 389f9360c..6a426fb6e 100644
 --- a/po/nn.po
 +++ b/po/nn.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Håvard Korsvoll <korsvoll@skulelinux.no>\n"
  "Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
-@@ -5732,29 +5732,15 @@ msgid "status logger"
+@@ -5725,29 +5725,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2337,7 +2338,7 @@ index 81b0189c..f872f1a2 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7140,6 +7126,11 @@ msgstr ""
+@@ -7133,6 +7119,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2346,23 +2347,23 @@ index 81b0189c..f872f1a2 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "klarte ikkje fjerna fila «%.250s»"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "klarte ikkje opna omdirigeringsfil"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/oc.po b/po/oc.po
-index da4b013c..e3896c7d 100644
+index e3ac91c02..5142a0a33 100644
 --- a/po/oc.po
 +++ b/po/oc.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-05 23:42+0100\n"
  "Last-Translator: Quentin PAGÈS <quentinantonin@free.fr>\n"
  "Language-Team: Occitan\n"
-@@ -5191,28 +5191,15 @@ msgid "status logger"
+@@ -5188,28 +5188,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2397,7 +2398,7 @@ index da4b013c..e3896c7d 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -6514,6 +6501,14 @@ msgstr ""
+@@ -6511,6 +6498,14 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2409,23 +2410,23 @@ index da4b013c..e3896c7d 100644
 +#~ msgid "architecture '%s' is reserved and cannot be added"
 +#~ msgstr "l'arquitectura « %s » es reservada e se pòt pas apondre"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "impossible de dobrir lo fichièr dels detornaments"
- 
+ #, c-format
+ #~ msgid "cannot open '%.255s' (in '%.255s')"
+ #~ msgstr "impossible de dobrir « %.255s » (dins « %.255s »)"
 diff --git a/po/pa.po b/po/pa.po
-index 61141da8..e3129afa 100644
+index 98f15d02c..382d3bc9c 100644
 --- a/po/pa.po
 +++ b/po/pa.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: A S Alam <apbrar@gmail.com>\n"
  "Language-Team: Punjabi <punjabi-users@lists.sf.net>\n"
-@@ -5455,28 +5455,15 @@ msgid "status logger"
+@@ -5451,28 +5451,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2461,19 +2462,19 @@ index 61141da8..e3129afa 100644
  
  #: src/main/main.c
 diff --git a/po/pl.po b/po/pl.po
-index fd3ffde2..035dff00 100644
+index e44d8ccf4..6b91b5838 100644
 --- a/po/pl.po
 +++ b/po/pl.po
 @@ -16,7 +16,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.20.7\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2021-04-24 19:50+0200\n"
  "Last-Translator: Łukasz Dulny <bartekchom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
-@@ -5885,30 +5885,16 @@ msgid "status logger"
+@@ -5880,30 +5880,16 @@ msgid "status logger"
  msgstr "status programu logującego"
  
  #: src/main/main.c
@@ -2511,7 +2512,7 @@ index fd3ffde2..035dff00 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7360,6 +7346,27 @@ msgstr "Uruchom update-alternatives, aby zmienić wybór alternatyw w systemie"
+@@ -7355,6 +7341,27 @@ msgstr "Uruchom update-alternatives, aby zmienić wybór alternatyw w systemie"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Uruchomienie update-alternatives wymaga uwierzytelnienia"
  
@@ -2536,23 +2537,23 @@ index fd3ffde2..035dff00 100644
 +#~ msgstr ""
 +#~ "nie można usunąć architektury \"%s\" używanej aktualnie przez bazę danych"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "nie można otworzyć listy ominiętych plików"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/pt.po b/po/pt.po
-index 52792e36..519d9963 100644
+index ad06b6576..874d6983b 100644
 --- a/po/pt.po
 +++ b/po/pt.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-04 14:11+0000\n"
  "Last-Translator: Miguel Figueiredo <elmig@debianpt.org>\n"
  "Language-Team: Portuguese <traduz@debianpt.org>\n"
-@@ -5683,32 +5683,16 @@ msgid "status logger"
+@@ -5708,32 +5708,16 @@ msgid "status logger"
  msgstr "registador de estado"
  
  #: src/main/main.c
@@ -2591,7 +2592,7 @@ index 52792e36..519d9963 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7113,6 +7097,29 @@ msgstr ""
+@@ -7138,6 +7122,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "É necessária autenticação para correr update-alternatives"
  
@@ -2618,23 +2619,23 @@ index 52792e36..519d9963 100644
 +#~ "nao pode remover a arquitectura '%s' actualmente em utilização pela base "
 +#~ "de dados"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "falhou abrir ficheiro diversions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/pt_BR.po b/po/pt_BR.po
-index 0d37f168..430a9087 100644
+index bfc8c1229..d95848e11 100644
 --- a/po/pt_BR.po
 +++ b/po/pt_BR.po
 @@ -14,7 +14,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:52+0200\n"
  "Last-Translator: Felipe Augusto van de Wiel (faw) <faw@debian.org>\n"
  "Language-Team: Brazilian Portuguese <debian-l10n-portuguese@lists.debian."
-@@ -6128,29 +6128,15 @@ msgid "status logger"
+@@ -6122,29 +6122,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2670,7 +2671,7 @@ index 0d37f168..430a9087 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7692,6 +7678,11 @@ msgstr ""
+@@ -7686,6 +7672,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2679,23 +2680,23 @@ index 0d37f168..430a9087 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "não foi possível remover arquivo '%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "falhou ao abrir arquivo de desvios"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/ro.po b/po/ro.po
-index c8887f81..fb51f694 100644
+index 083b1a6d8..35f06ab93 100644
 --- a/po/ro.po
 +++ b/po/ro.po
 @@ -23,7 +23,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-10-04 11:08+0200\n"
  "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
  "Language-Team: Romanian <debian-l10n-romanian@lists.debian.org>\n"
-@@ -6019,30 +6019,16 @@ msgid "status logger"
+@@ -6043,30 +6043,16 @@ msgid "status logger"
  msgstr "jurnalul de stare"
  
  #: src/main/main.c
@@ -2733,7 +2734,7 @@ index c8887f81..fb51f694 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7474,6 +7460,27 @@ msgstr ""
+@@ -7498,6 +7484,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Autentificarea este necesară pentru a rula «update-alternatives»"
  
@@ -2758,23 +2759,23 @@ index c8887f81..fb51f694 100644
 +#~ msgstr ""
 +#~ "nu se poate elimina arhitectura „%s” folosită în prezent de baza de date"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "eșec la deschiderea fișierului de redirecționări"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/ru.po b/po/ru.po
-index 66b5e43f..fc427a24 100644
+index f46c31a6a..a2d5de19b 100644
 --- a/po/ru.po
 +++ b/po/ru.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-06 00:01+0100\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
-@@ -5710,31 +5710,16 @@ msgid "status logger"
+@@ -5734,31 +5734,16 @@ msgid "status logger"
  msgstr "протоколировщик состояния"
  
  #: src/main/main.c
@@ -2813,7 +2814,7 @@ index 66b5e43f..fc427a24 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7133,6 +7118,29 @@ msgstr ""
+@@ -7157,6 +7142,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Для запуска update-alternatives требуется аутентификация"
  
@@ -2840,23 +2841,23 @@ index 66b5e43f..fc427a24 100644
 +#~ "невозможно удалить архитектуру «%s», которая в данный момент используется "
 +#~ "в базе данных"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "не удалось открыть файл diversions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/sk.po b/po/sk.po
-index d03d28af..4fb5fce8 100644
+index 7044b824e..d47aab7aa 100644
 --- a/po/sk.po
 +++ b/po/sk.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 10:01+0200\n"
  "Last-Translator: Ivan Masár <helix84@centrum.sk>\n"
  "Language-Team: Slovak <debian-l10n-slovak@lists.debian.org>\n"
-@@ -6056,29 +6056,16 @@ msgid "status logger"
+@@ -6053,29 +6053,16 @@ msgid "status logger"
  msgstr "záznam stavu"
  
  #: src/main/main.c
@@ -2894,7 +2895,7 @@ index d03d28af..4fb5fce8 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7552,6 +7539,27 @@ msgstr ""
+@@ -7549,6 +7536,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2919,23 +2920,23 @@ index d03d28af..4fb5fce8 100644
 +#~ msgstr ""
 +#~ "nemožno odstrániť architektúru „%s“, ktorú momentálne používa databáza"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "zlyhalo otvorenie súboru s odchýlkami"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "otvorenie zložky „%.255s“ (v %.255s) zlyhalo neočakávaným spôsobom"
 diff --git a/po/sv.po b/po/sv.po
-index 884255e7..8bb29e8f 100644
+index bf53769f9..649c2c894 100644
 --- a/po/sv.po
 +++ b/po/sv.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2024-04-28 14:30+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Svenska <tp-sv@listor.tp-sv.se>\n"
-@@ -5551,30 +5551,16 @@ msgid "status logger"
+@@ -5575,30 +5575,16 @@ msgid "status logger"
  msgstr "statusloggare"
  
  #: src/main/main.c
@@ -2973,11 +2974,10 @@ index 884255e7..8bb29e8f 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6946,3 +6932,24 @@ msgstr "Kör update-alternatives för att ändra systemets val av alternativ"
- #: utils/update-alternatives.polkit.in
+@@ -6971,6 +6957,27 @@ msgstr "Kör update-alternatives för att ändra systemets val av alternativ"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Autentisering krävs för att köra update-alternatives"
-+
+ 
 +#, c-format
 +#~ msgid "architecture '%s' is illegal: %s"
 +#~ msgstr "arkitekturen ”%s” är ogiltig: %s"
@@ -2998,20 +2998,24 @@ index 884255e7..8bb29e8f 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr ""
 +#~ "kan inte ta bort arkitekturen ”%s” som för närvarande används av databasen"
++
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/th.po b/po/th.po
-index 37f3d759..5227dc10 100644
+index 1d1b8bc11..7420795d6 100644
 --- a/po/th.po
 +++ b/po/th.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-05 23:45+0100\n"
  "Last-Translator: Theppitak Karoonboonyanan <thep@debian.org>\n"
  "Language-Team: Thai <thai-l10n@googlegroups.com>\n"
-@@ -5472,29 +5472,16 @@ msgid "status logger"
+@@ -5497,29 +5497,16 @@ msgid "status logger"
  msgstr "เครื่องมือบันทึกปูมของสถานะ"
  
  #: src/main/main.c
@@ -3049,7 +3053,7 @@ index 37f3d759..5227dc10 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6838,6 +6825,26 @@ msgstr "เรียก update-alternatives เพื่อเปลี่ยน
+@@ -6863,6 +6850,26 @@ msgstr "เรียก update-alternatives เพื่อเปลี่ยน
  msgid "Authentication is required to run update-alternatives"
  msgstr "ต้องยืนยันตัวบุคคลเพื่อเรียกทำงาน update-alternatives"
  
@@ -3073,23 +3077,23 @@ index 37f3d759..5227dc10 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "ไม่สามารถลบสถาปัตยกรรม '%s' ซึ่งกำลังใช้งานอยู่ในฐานข้อมูล"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "ไม่สามารถเปิดแฟ้ม diversions"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "เปิดองค์ประกอบ '%.255s' (ใน %.255s) ไม่สำเร็จ โดยได้ผลลัพธ์ที่ไม่คาดคิด"
 diff --git a/po/tl.po b/po/tl.po
-index 4efe7573..d63cf7d4 100644
+index b9deae92c..eae80c054 100644
 --- a/po/tl.po
 +++ b/po/tl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 09:53+0200\n"
  "Last-Translator: Eric Pareja <xenos@upm.edu.ph>\n"
  "Language-Team: Tagalog <debian-tl@banwa.upm.edu.ph>\n"
-@@ -5857,29 +5857,15 @@ msgid "status logger"
+@@ -5850,29 +5850,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -3125,7 +3129,7 @@ index 4efe7573..d63cf7d4 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7288,6 +7274,11 @@ msgstr ""
+@@ -7281,6 +7267,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3134,23 +3138,23 @@ index 4efe7573..d63cf7d4 100644
 +#~ msgid "cannot remove non-foreign architecture '%s'"
 +#~ msgstr "hindi matanggal ang talaksang `%.250s'"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "bigo sa pagbukas ng talaksang dibersyon"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/tr.po b/po/tr.po
-index 9faf7a9e..1f136904 100644
+index f572fd658..e6eeecb0a 100644
 --- a/po/tr.po
 +++ b/po/tr.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2018-01-03 16:44+0300\n"
  "Last-Translator: Mert Dirik <mertdirik@gmail.com>\n"
  "Language-Team: Turkish <debian-l10n-turkish@lists.debian.org>\n"
-@@ -5982,30 +5982,16 @@ msgid "status logger"
+@@ -5977,30 +5977,16 @@ msgid "status logger"
  msgstr "durum günlükçüsü"
  
  #: src/main/main.c
@@ -3188,7 +3192,7 @@ index 9faf7a9e..1f136904 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7472,6 +7458,27 @@ msgid "Authentication is required to run update-alternatives"
+@@ -7467,6 +7453,27 @@ msgid "Authentication is required to run update-alternatives"
  msgstr ""
  "update-alternatives komutunu çalıştırmak için kimlik doğrulama gerekmektedir"
  
@@ -3213,23 +3217,23 @@ index 9faf7a9e..1f136904 100644
 +#~ msgstr ""
 +#~ "veritabanı tarafından hâlâ kullanılmakta olan '%s' mimarisi kaldırılamıyor"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "yönlendirme dosyası açılamadı"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/vi.po b/po/vi.po
-index 5710e861..0191f110 100644
+index 4aceb3c92..d9087a320 100644
 --- a/po/vi.po
 +++ b/po/vi.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.18.2\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2016-01-14 08:22+0700\n"
  "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
  "Language-Team: Vietnamese <debian-l10n-vietnamese@lists.debian.org>\n"
-@@ -6032,30 +6032,16 @@ msgid "status logger"
+@@ -6029,30 +6029,16 @@ msgid "status logger"
  msgstr "bộ ghi nhật ký trạng thái"
  
  #: src/main/main.c
@@ -3267,7 +3271,7 @@ index 5710e861..0191f110 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7490,6 +7476,27 @@ msgstr ""
+@@ -7487,6 +7473,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3292,23 +3296,23 @@ index 5710e861..0191f110 100644
 +#~ msgstr ""
 +#~ "không thể gỡ bỏ kiến trúc “%s” hiện tại đang được dùng bởi cơ sở dữ liệu"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "lỗi mở tập tin diversions (sự trệch đi)"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr ""
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index 74bf30e1..79493ed6 100644
+index c4ef0412f..976970f5e 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
 @@ -16,7 +16,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-01-27 15:39-0500\n"
  "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
  "Language-Team: Chinese (simplified) <debian-l10n-chinese@lists.debian.org>\n"
-@@ -5457,29 +5457,16 @@ msgid "status logger"
+@@ -5482,29 +5482,16 @@ msgid "status logger"
  msgstr "状态日志记录器"
  
  #: src/main/main.c
@@ -3346,7 +3350,7 @@ index 74bf30e1..79493ed6 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6819,6 +6806,26 @@ msgstr "运行 update-alternatives 工具以修改系统可选项的选择情况
+@@ -6844,6 +6831,26 @@ msgstr "运行 update-alternatives 工具以修改系统可选项的选择情况
  msgid "Authentication is required to run update-alternatives"
  msgstr "需要认证后才能执行 update-alternatives"
  
@@ -3370,23 +3374,23 @@ index 74bf30e1..79493ed6 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "无法移除体系结构 %s ，当前它仍被数据库使用"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "无法打开转移文件"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "打开组件 %.255s (于 %.255s 目录)出乎意料地失败"
 diff --git a/po/zh_TW.po b/po/zh_TW.po
-index 279a488e..bd677900 100644
+index 432e89fdb..fd9dc417b 100644
 --- a/po/zh_TW.po
 +++ b/po/zh_TW.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:09+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2018-04-15 07:06+0800\n"
  "Last-Translator: 林博仁 <Buo.Ren.Lin@gmail.com>\n"
  "Language-Team: Chinese (traditional) <debian-l10n-chinese@lists.debian.org>\n"
-@@ -5808,29 +5808,16 @@ msgid "status logger"
+@@ -5805,29 +5805,16 @@ msgid "status logger"
  msgstr "狀態記錄器"
  
  #: src/main/main.c
@@ -3424,7 +3428,7 @@ index 279a488e..bd677900 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7237,6 +7224,26 @@ msgstr ""
+@@ -7234,6 +7221,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3448,142 +3452,142 @@ index 279a488e..bd677900 100644
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr "無法移除資料庫正在使用的 '%s' 硬體平台"
 +
- #~ msgid "failed to open diversions file"
- #~ msgstr "無法開啟移轉檔"
- 
+ #, c-format
+ #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
+ #~ msgstr "在開啟元件 `%.255s'（位於 %.255s）時以意想不到的方式失敗了"
 diff --git a/scripts/po/ca.po b/scripts/po/ca.po
-index 8a958fd4..4a83db94 100644
+index 9f14f8ae7..22cedb146 100644
 --- a/scripts/po/ca.po
 +++ b/scripts/po/ca.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.18\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
- "PO-Revision-Date: 2023-12-17 20:30+0100\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
+ "PO-Revision-Date: 2024-07-21 19:57+0200\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
 diff --git a/scripts/po/de.po b/scripts/po/de.po
-index 9b11a8e8..a7c98d93 100644
+index 8ff6bc8b7..4e78d2acb 100644
 --- a/scripts/po/de.po
 +++ b/scripts/po/de.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dpkg-dev 1.22.6\n"
+ "Project-Id-Version: dpkg-dev 1.22.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
- "PO-Revision-Date: 2024-07-03 21:25+0200\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
+ "PO-Revision-Date: 2024-07-27 14:36+0200\n"
  "Last-Translator: Helge Kreutzmann <debian@helgefjell.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
 diff --git a/scripts/po/dpkg-dev.pot b/scripts/po/dpkg-dev.pot
-index 5b7f1d13..a9de079b 100644
+index 753ac7be4..8f1e30982 100644
 --- a/scripts/po/dpkg-dev.pot
 +++ b/scripts/po/dpkg-dev.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.7\n"
-+"Project-Id-Version: dpkg 1.22.7-6-g73c7\n"
+-"Project-Id-Version: dpkg 1.22.11\n"
++"Project-Id-Version: dpkg 1.22.11-6-g9e3c\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/scripts/po/es.po b/scripts/po/es.po
-index a6695b4c..e4b5fddc 100644
+index 38a10e63f..fffdb7491 100644
 --- a/scripts/po/es.po
 +++ b/scripts/po/es.po
 @@ -31,7 +31,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.16.8\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2014-12-02 20:24+0100\n"
  "Last-Translator: Omar Campagne <ocampagne@gmail.com>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
 diff --git a/scripts/po/fr.po b/scripts/po/fr.po
-index 2b9bb545..2d137113 100644
+index f1ff576ce..cf523fd42 100644
 --- a/scripts/po/fr.po
 +++ b/scripts/po/fr.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-10 02:16+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
 diff --git a/scripts/po/nl.po b/scripts/po/nl.po
-index 4d856760..f73d59e7 100644
+index 578392b92..4ba97ea63 100644
 --- a/scripts/po/nl.po
 +++ b/scripts/po/nl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.19\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-02-02 17:51+0100\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: \n"
 diff --git a/scripts/po/pl.po b/scripts/po/pl.po
-index 595de07b..27ac5cdc 100644
+index 973e83d70..32b81a7b6 100644
 --- a/scripts/po/pl.po
 +++ b/scripts/po/pl.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.15.4\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 07:05+0200\n"
  "Last-Translator: Łukasz Dulny <BartekChom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
 diff --git a/scripts/po/pt.po b/scripts/po/pt.po
-index 6be16187..9123b809 100644
+index 16f1ba9d2..3f2e637d7 100644
 --- a/scripts/po/pt.po
 +++ b/scripts/po/pt.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2023-03-08 22:31+0000\n"
  "Last-Translator: Américo Monteiro <a_monteiro@gmx.com>\n"
  "Language-Team: Portuguese <>\n"
 diff --git a/scripts/po/ru.po b/scripts/po/ru.po
-index dc62f1f4..18453063 100644
+index 8ef5f0ee6..cbe09d4ab 100644
 --- a/scripts/po/ru.po
 +++ b/scripts/po/ru.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.17.23\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2015-04-07 07:02+0200\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
 diff --git a/scripts/po/sv.po b/scripts/po/sv.po
-index 163f373c..420acb08 100644
+index b8b69e0b0..a72bc2d5d 100644
 --- a/scripts/po/sv.po
 +++ b/scripts/po/sv.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2024-07-17 01:10+0200\n"
-+"POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-08-01 12:38+0200\n"
++"POT-Creation-Date: 2024-11-27 22:35+0800\n"
  "PO-Revision-Date: 2024-04-28 14:34+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Svenska <tp-sv@listor.tp-sv.se>\n"
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0008-po-add-translation-for-AOSC-OS-add-remove-architectu.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0008-po-add-translation-for-AOSC-OS-add-remove-architectu.patch
@@ -1,23 +1,25 @@
-From 80bd92d033a562475512265da50f1f3aba13803b Mon Sep 17 00:00:00 2001
+From 10d211f595683df6ac7ac900fe9b44469e2bfaf9 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 7 May 2024 17:55:11 +0800
-Subject: [PATCH 8/8] po: add translation for AOSC OS
+Subject: [PATCH 8/9] po: add translation for AOSC OS
  --{add,remove}-architecture options
 
 Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- po/zh_CN.po | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
+ po/zh_CN.po | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index 79493ed6..6083334c 100644
+index 976970f5e..022fc5867 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
-@@ -17,7 +17,7 @@ msgstr ""
+@@ -16,8 +16,8 @@ msgid ""
+ msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
- "POT-Creation-Date: 2024-07-18 05:55+0800\n"
+-"POT-Creation-Date: 2024-11-27 22:35+0800\n"
 -"PO-Revision-Date: 2023-01-27 15:39-0500\n"
++"POT-Creation-Date: 2024-07-18 05:55+0800\n"
 +"PO-Revision-Date: 2024-05-07 03:09-0700\n"
  "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
  "Language-Team: Chinese (simplified) <debian-l10n-chinese@lists.debian.org>\n"
@@ -31,7 +33,7 @@ index 79493ed6..6083334c 100644
  
  #: lib/dpkg/ar.c
  msgid "failed to fstat archive"
-@@ -5461,12 +5461,15 @@ msgid ""
+@@ -5486,12 +5486,15 @@ msgid ""
  "--add-architecture is not supported in AOSC OS. Please contact AOSC OS "
  "maintainers for any problems encountered."
  msgstr ""
@@ -48,5 +50,5 @@ index 79493ed6..6083334c 100644
  #: src/main/main.c
  #, c-format
 -- 
-2.45.2
+2.48.1
 

--- a/app-admin/dpkg/01-update-alternatives/patches/0009-AOSCOS-add-architecture-alias-mapping.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0009-AOSCOS-add-architecture-alias-mapping.patch
@@ -1,0 +1,64 @@
+From 8eea17eb1da6da755eb19033c56bc633c7664314 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 19 Jan 2025 23:25:59 +0800
+Subject: [PATCH 9/9] AOSCOS: add architecture alias mapping
+
+With AOSC OS, we use a few architecture names that are different to what
+dpkg defines internally:
+
+- LoongArch ("new-world" ABI 2.0): we use loongarch64 (old-world naming),
+  whereas Debian uses loong64.
+- MIPS Loongson ports (for 2F and 3-series): we use loongson2f/loongson3
+  to reflect the fact that we do introduce LoongISA optimisation, but
+  Debian (and most software vendors) uses mips64el for at least the latter
+  (most Loongson 2F targetted distros were 32-bit to "save on RAM").
+- 80486: We use i486 whereas Debian uses i386 (when in fact the binaries
+  targetted i686).
+- ARMv4T: We use armv4 whereas Debian uses armel (for v4T, v5, and soft-
+  float v6).
+- ARMv6, Hard-Float: We use armv6hf whereas Debian uses armv6hf.
+- ARMv7, Hard-Float, NEON: We use armv7hf whereas Debian uses armv7hf.
+
+Introduce alias mapping, as inspired by how Loongnix 25 marked loongarch64
+packages as compatible via their abi-compat infrastructure.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ lib/dpkg/arch.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/lib/dpkg/arch.c b/lib/dpkg/arch.c
+index 9409f5a5e..06d713668 100644
+--- a/lib/dpkg/arch.c
++++ b/lib/dpkg/arch.c
+@@ -146,6 +146,27 @@ dpkg_arch_find(const char *name)
+ 	for (arch = arch_head; arch; arch = arch->next) {
+ 		if (strcmp(arch->name, name) == 0)
+ 			return arch;
++		if (strcmp(arch->name, "loongarch64") == 0 &&
++		    strcmp(name, "loong64") == 0)
++			return arch;
++		if (strcmp(arch->name, "loongson3") == 0 &&
++		    strcmp(name, "mips64el") == 0)
++			return arch;
++		if (strcmp(arch->name, "armv4") == 0 &&
++		    strcmp(name, "armel") == 0)
++			return arch;
++		if (strcmp(arch->name, "armv6hf") == 0 &&
++		    strcmp(name, "armhf") == 0)
++			return arch;
++		if (strcmp(arch->name, "armv7hf") == 0 &&
++		    strcmp(name, "armhf") == 0)
++			return arch;
++		if (strcmp(arch->name, "i486") == 0 &&
++		    strcmp(name, "i386") == 0)
++			return arch;
++		if (strcmp(arch->name, "loongson2f") == 0 &&
++		   strcmp(name, "mips64el") == 0)
++			return arch;
+ 		last_arch = arch;
+ 	}
+ 
+-- 
+2.48.1
+

--- a/app-admin/dpkg/spec
+++ b/app-admin/dpkg/spec
@@ -1,5 +1,4 @@
-VER=1.22.7
+VER=1.22.11
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- dpkg: update to 1.22.11
    \- Track patches at AOSC\-Tracking/dpkg @ aosc/1.22.11
    \(HEAD: 8cb3821489ed56b46136f3d1a95d03e741126201\).
    \- Introduce Debian\-compatible architecture alias mapping, see below:
    With AOSC OS, we use a few architecture names that are different to what
    dpkg defines internally:
    \- LoongArch \("new\-world" ABI 2.0\): we use loongarch64 \(old\-world naming\),
    whereas Debian uses loong64.
    \- MIPS Loongson ports \(for 2F and 3\-series\): we use loongson2f/loongson3
    to reflect the fact that we do introduce LoongISA optimisation, but
    Debian \(and most software vendors\) uses mips64el for at least the latter
    \(most Loongson 2F targetted distros were 32\-bit to "save on RAM"\).
    \- 80486: We use i486 whereas Debian uses i386 \(when in fact the binaries
    targetted i686\).
    \- ARMv4T: We use armv4 whereas Debian uses armel \(for v4T, v5, and soft\-
    float v6\).
    \- ARMv6, Hard\-Float: We use armv6hf whereas Debian uses armv6hf.
    \- ARMv7, Hard\-Float, NEON: We use armv7hf whereas Debian uses armv7hf.
    Introduce alias mapping, as inspired by how Loongnix 25 marked loongarch64
    packages as compatible via their abi\-compat infrastructure.

Package(s) Affected
-------------------

- dpkg: 1.22.11
- update-alternatives: 1.22.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit dpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
