### PR TITLE
fantasque-sans-mono-nerd-fonts: update to 3.3.0

### DIFF
--- a/desktop-fonts/fantasque-sans-mono-nerd-fonts/spec
+++ b/desktop-fonts/fantasque-sans-mono-nerd-fonts/spec
@@ -1,4 +1,4 @@
-VER=3.2.1
+VER=3.3.0
 SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/FantasqueSansMono.zip"
-CHKSUMS="sha256::8ea52f3ee930a64a086b0ca95f1cc1553034de7431f4c1813d239bf6b65532df"
+CHKSUMS="sha256::849a660ce68cfba5b63dd8ee9cf90ed572f50579b8a098c2a2218559e6293fe5"
 CHKUPDATE="anitya::id=227412"


### PR DESCRIPTION
Topic Description
-----------------

- fantasque-sans-mono-nerd-fonts: update to 3.3.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fantasque-sans-mono-nerd-fonts: 3.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fantasque-sans-mono-nerd-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
