### PR TITLE
libjpeg-turbo: update to 3.0.4

### DIFF
--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -1,4 +1,4 @@
-VER=3.0.3
+VER=3.0.4
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"


### PR DESCRIPTION
Topic Description
-----------------

- libjpeg-turbo: update to 3.0.4
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libjpeg-turbo: 2:3.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
