### PR TITLE
endless-sky: update to 0.10.10

### DIFF
--- a/app-games/endless-sky/autobuild/defines
+++ b/app-games/endless-sky/autobuild/defines
@@ -3,3 +3,6 @@ PKGSEC=games
 PKGDES="Space exploration, trading, and combat game"
 PKGDEP="sdl2 libpng zlib libjpeg-turbo openal-soft libmad util-linux-runtime \
         libglvnd glew gcc-runtime glibc x11-lib libxcb libxau libxdmcp"
+
+# Note: test require Catch2
+CMAKE_AFTER="-DBUILD_TESTING=OFF"

--- a/app-games/endless-sky/spec
+++ b/app-games/endless-sky/spec
@@ -1,4 +1,4 @@
-VER=0.10.8
+VER=0.10.10
 SRCS="git::commit=tags/v$VER::https://github.com/endless-sky/endless-sky.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10359"


### PR DESCRIPTION
Topic Description
-----------------

- endless-sky: update to 0.10.10
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- endless-sky: 0.10.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit endless-sky
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
