### PR TITLE
zellij: update to 0.41.2

### DIFF
--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.41.1
+VER=0.41.2
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.41.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.41.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
