### PR TITLE
zed: update to 0.161.2

### DIFF
--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,8 @@
-VER=0.160.7
+VER=0.161.2
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"
+
+# LTO consumes more memory
+ENVREQ__AMD64="total_mem_per_core=3"
+ENVREQ__ARM64="total_mem_per_core=3"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.161.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- zed: 0.161.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
