### PR TITLE
docker-compose: update to 2.30.3

### DIFF
--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,4 +1,4 @@
-VER=2.29.2
+VER=2.30.3
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"


### PR DESCRIPTION
Topic Description
-----------------

- docker-compose: update to 2.30.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docker-compose: 2.30.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-compose
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
