### PR TITLE
virtualenvwrapper: new, 6.1.1

### DIFF
--- a/lang-python/setuptools-scm/autobuild/defines
+++ b/lang-python/setuptools-scm/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=setuptools-scm
 PKGSEC=python
 PKGDEP="setuptools packaging typing-extensions"
-PKGDES="Handles managing your python package versions in SCM metadata"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Python module to manage package versions in SCM metadata"
 
-NOPYTHON2=1
+ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/setuptools-scm/spec
+++ b/lang-python/setuptools-scm/spec
@@ -1,5 +1,4 @@
-VER=7.1.0
-REL=1
-SRCS="tbl::https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-$VER.tar.gz"
-CHKSUMS="sha256::6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"
+VER=8.1.0
+SRCS="pypi::version=$VER::setuptools_scm"
+CHKSUMS="sha256::42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7"
 CHKUPDATE="anitya::id=65053"

--- a/lang-python/virtualenv-clone/autobuild/defines
+++ b/lang-python/virtualenv-clone/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=virtualenv-clone
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Script to clone virtualenv environments"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/virtualenv-clone/spec
+++ b/lang-python/virtualenv-clone/spec
@@ -1,0 +1,4 @@
+VER=0.5.7
+SRCS="pypi::version=$VER::virtualenv-clone"
+CHKSUMS="sha256::418ee935c36152f8f153c79824bb93eaf6f0f7984bae31d3f48f350b9183501a"
+CHKUPDATE="anitya::id=5439"

--- a/lang-python/virtualenv/autobuild/defines
+++ b/lang-python/virtualenv/autobuild/defines
@@ -5,6 +5,4 @@ BUILDDEP="python-build python-installer wheel tomli hatch-vcs"
 PKGDES="A tool to create isolated Python environments"
 
 ABHOST=noarch
-
-NOPYTHON2=1
 ABTYPE=pep517

--- a/lang-python/virtualenv/spec
+++ b/lang-python/virtualenv/spec
@@ -1,4 +1,4 @@
-VER=20.25.0
-SRCS="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VER}.tar.gz"
-CHKSUMS="sha256::bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"
+VER=20.27.1
+SRCS="pypi::version=$VER::virtualenv"
+CHKSUMS="sha256::142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba"
 CHKUPDATE="anitya::id=6904"

--- a/lang-python/virtualenvwrapper/autobuild/defines
+++ b/lang-python/virtualenvwrapper/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=virtualenvwrapper
 PKGSEC=python
 PKGDEP="stevedore virtualenv"
-BUILDDEP="python-build python-installer wheel"
+BUILDDEP="python-build python-installer setuptools-scm wheel"
 PKGDES="Extension modules for virtualenv"
 
 ABTYPE=pep517

--- a/lang-python/virtualenvwrapper/autobuild/defines
+++ b/lang-python/virtualenvwrapper/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=virtualenvwrapper
+PKGSEC=python
+PKGDEP="stevedore virtualenv"
+BUILDDEP="python-build python-installer wheel"
+PKGDES="Extension modules for virtualenv"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/virtualenvwrapper/spec
+++ b/lang-python/virtualenvwrapper/spec
@@ -1,0 +1,4 @@
+VER=6.1.1
+SRCS="pypi::version=$VER::virtualenvwrapper"
+CHKSUMS="sha256::112e7ea34a9a3ce90aaea54182f0d3afef4d1a913eeb75e98a263b4978cd73c6"
+CHKUPDATE="anitya::id=4082"


### PR DESCRIPTION
Topic Description
-----------------

- virtualenvwrapper: new, 6.1.1
- virtualenv-clone: new, 0.5.7
- virtualenv: update to 20.27.1
- setuptools-scm: update to 8.1.0

Package(s) Affected
-------------------

- setuptools-scm: 8.1.0
- virtualenv: 20.27.1
- virtualenv-clone: 0.5.7
- virtualenvwrapper: 6.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit setuptools-scm virtualenv virtualenv-clone virtualenvwrapper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
