### PR TITLE
pugixml: update to 1.14

### DIFF
--- a/runtime-common/pugixml/spec
+++ b/runtime-common/pugixml/spec
@@ -1,5 +1,5 @@
-VER=1.11.4
+VER=1.14
 SRCS="tbl::https://github.com/zeux/pugixml/releases/download/v$VER/pugixml-$VER.tar.gz"
-CHKSUMS="sha256::8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716"
+CHKSUMS="sha256::2f10e276870c64b1db6809050a75e11a897a8d7456c4be5c6b2e35a11168a015"
 SUBDIR="pugixml-$VER"
 CHKUPDATE="anitya::id=3728"


### PR DESCRIPTION
Topic Description
-----------------

- pugixml: update to 1.14
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pugixml: 1.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit pugixml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
