### PR TITLE
direnv: update to 2.35.0

### DIFF
--- a/app-utils/direnv/spec
+++ b/app-utils/direnv/spec
@@ -1,5 +1,4 @@
-VER=2.34.0
-REL=4
+VER=2.35.0
 SRCS="git::commit=tags/v$VER::https://github.com/direnv/direnv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11598"


### PR DESCRIPTION
Topic Description
-----------------

- direnv: update to 2.35.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- direnv: 2.35.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit direnv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
