### PR TITLE
neomutt: update to 20241114

### DIFF
--- a/app-web/neomutt/spec
+++ b/app-web/neomutt/spec
@@ -1,5 +1,4 @@
-VER=20200619
-SRCS="tbl::https://github.com/neomutt/neomutt/archive/$VER.tar.gz"
-CHKSUMS="sha256::4449d43b3586a730ead151c66afc6af37e3ea15b3e72065e579a9e9884146acc"
+VER=20241114
+SRCS="git::commit=tags/$VER::https://github.com/neomutt/neomutt"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10882"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- neomutt: update to 20241114
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- neomutt: 20241114

Security Update?
----------------

No

Build Order
-----------

```
#buildit neomutt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
