### PR TITLE
spdx-licenses: update to 3.25.0

### DIFF
--- a/runtime-data/spdx-licenses/spec
+++ b/runtime-data/spdx-licenses/spec
@@ -1,4 +1,4 @@
-VER=3.24.0
+VER=3.25.0
 SRCS="git::commit=tags/v$VER::https://github.com/spdx/license-list-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226644"


### PR DESCRIPTION
Topic Description
-----------------

- spdx-licenses: update to 3.25.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- spdx-licenses: 1:3.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit spdx-licenses
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
