### PR TITLE
weechat: update to 4.4.3

### DIFF
--- a/app-web/weechat/autobuild/defines
+++ b/app-web/weechat/autobuild/defines
@@ -1,14 +1,20 @@
 PKGNAME=weechat
 PKGSEC=net
-PKGDEP="gnutls curl libgcrypt"
-BUILDDEP="asciidoctor source-highlight cmake pkg-config \
-          perl python-3 lua tcl ruby aspell guile php7"
+PKGDEP="gnutls curl libgcrypt cjson"
+BUILDDEP="asciidoctor source-highlight cmake pkg-config perl python-3 lua tcl \
+          aspell guile php7 zstd"
 PKGDES="A fast, light and extensible chat client"
 
 ABTYPE=cmakeninja
-CMAKE_AFTER="-DENABLE_PYTHON3=ON \
+
+# FIXME: Disabling Ruby plugin due to SIGSEGV when building WeeChat on
+# loongson3, loongarch64, arm64, and SIGABRT during runtime on other
+# architectures.
+CMAKE_AFTER="-DENABLE_PYTHON=ON \
              -DENABLE_MAN=ON \
              -DENABLE_DOC=ON \
              -DENABLE_TESTS=OFF \
              -DENABLE_JAVASCRIPT=OFF \
+	     -DENABLE_RUBY=OFF \
+	     -DENABLE_DOC_INCOMPLETE=ON \
              -DCA_FILE=/etc/ssl/ca-bundle.crt"

--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.2.2
+VER=4.4.3
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::20968b22c7f0f50df9cf6ff8598dd1bd017c5759b2c94593f5d9ed7b24ebb941"
+CHKSUMS="sha256::295612f8dc24af28c918257d3014eb53342a5d077d5e3d9a3eadf303bd8febfa"
 CHKUPDATE="anitya::id=5122"

--- a/runtime-common/cjson/autobuild/defines
+++ b/runtime-common/cjson/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=cjson
+PKGDES="JSON parser in ANSI C"
+PKGSEC=libs
+PKGDEP="glibc"
+
+ABTYPE=cmakeninja

--- a/runtime-common/cjson/spec
+++ b/runtime-common/cjson/spec
@@ -1,0 +1,4 @@
+VER=1.7.18
+SRCS="git::commit=tags/v$VER::https://github.com/DaveGamble/cJSON.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=21330"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.4.3
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- weechat: 4.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cjson weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
