### PR TITLE
plasma-desktop: drop possible mis-set Flat mouse acceleration profile

### DIFF
--- a/desktop-kde/plasma-desktop/autobuild/patches/0001-Revert-If-no-config-option-for-accel-profile-is-sele.patch
+++ b/desktop-kde/plasma-desktop/autobuild/patches/0001-Revert-If-no-config-option-for-accel-profile-is-sele.patch
@@ -1,0 +1,122 @@
+From 86f759380ea4990d4c05cb940cce82d7c433c541 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 21 Nov 2024 14:56:43 +0800
+Subject: [PATCH 1/2] Revert "If no config option for accel profile is
+ selected, use default from Xorg"
+
+With libinput 1.26.2, a "Flat" acceleration profile was set by default for
+all input devices. This is probably not correct as libinput still
+indicates that "Adaptive" is the default.
+
+Having a "Flat" default makes TrackPoints painfully unusable after login
+(whereas in SDDM they work as expected).
+
+This reverts commit fb8a655a73769351370abd2aa88ecf2d54583c42.
+---
+ .../backends/x11/x11_libinput_backend.cpp     |  2 -
+ .../backends/x11/x11_libinput_dummydevice.cpp | 47 ++-----------------
+ .../backends/x11/x11_libinput_dummydevice.h   |  2 -
+ 3 files changed, 4 insertions(+), 47 deletions(-)
+
+diff --git a/kcms/mouse/backends/x11/x11_libinput_backend.cpp b/kcms/mouse/backends/x11/x11_libinput_backend.cpp
+index a3dcce7d0..ec1ec5096 100644
+--- a/kcms/mouse/backends/x11/x11_libinput_backend.cpp
++++ b/kcms/mouse/backends/x11/x11_libinput_backend.cpp
+@@ -36,8 +36,6 @@ bool X11LibinputBackend::isChangedConfig() const
+ 
+ void X11LibinputBackend::kcmInit()
+ {
+-    static_cast<X11LibinputDummyDevice *>(m_device)->getDefaultConfigFromX();
+-
+     getConfig();
+     applyConfig();
+     X11Backend::kcmInit();
+diff --git a/kcms/mouse/backends/x11/x11_libinput_dummydevice.cpp b/kcms/mouse/backends/x11/x11_libinput_dummydevice.cpp
+index e41731a2a..21dff2dc4 100644
+--- a/kcms/mouse/backends/x11/x11_libinput_dummydevice.cpp
++++ b/kcms/mouse/backends/x11/x11_libinput_dummydevice.cpp
+@@ -150,9 +150,8 @@ X11LibinputDummyDevice::X11LibinputDummyDevice(QObject *parent, Display *dpy)
+     m_supportsPointerAccelerationProfileAdaptive.val = true;
+     m_supportsPointerAccelerationProfileFlat.val = true;
+ 
+-    auto x11DefaultFlat = m_settings->load(QStringLiteral("X11LibInputXAccelProfileFlat"), false);
+-    m_defaultPointerAccelerationProfileFlat.val = x11DefaultFlat;
+-    m_defaultPointerAccelerationProfileAdaptive.val = !x11DefaultFlat;
++    m_defaultPointerAccelerationProfileAdaptive.val = true;
++    m_defaultPointerAccelerationProfileFlat.val = false;
+ 
+     m_supportsNaturalScroll.val = true;
+     m_naturalScrollEnabledByDefault.val = false;
+@@ -175,10 +174,9 @@ bool X11LibinputDummyDevice::getConfig()
+ 
+     reset(m_middleEmulation, false);
+     reset(m_naturalScroll, false);
+-    auto flatDefault = m_defaultPointerAccelerationProfileFlat.val;
+-    reset(m_pointerAccelerationProfileFlat, flatDefault);
++    reset(m_pointerAccelerationProfileFlat, false);
+ 
+-    m_pointerAccelerationProfileAdaptive.reset(!m_settings->load(m_pointerAccelerationProfileFlat.cfgName, flatDefault));
++    m_pointerAccelerationProfileAdaptive.reset(!m_settings->load(m_pointerAccelerationProfileFlat.cfgName, false));
+     m_pointerAcceleration.reset(m_settings->load(m_pointerAcceleration.cfgName, 0.));
+ 
+     return true;
+@@ -209,43 +207,6 @@ bool X11LibinputDummyDevice::applyConfig()
+     return true;
+ }
+ 
+-void X11LibinputDummyDevice::getDefaultConfigFromX()
+-{
+-    // The user can override certain values in their X configuration. We want to
+-    // account for those in our default values, but if we just read this when
+-    // loading the KCM, we end up reading the current settings which may already
+-    // have been modified by us. So instead, read these defaults during startup
+-    // and write them to config, so we can later on read them again to know the
+-    // system-wide defaults.
+-    bool flatProfile = true;
+-    XIForallPointerDevices(m_dpy, [&](XDeviceInfo *info) {
+-        Atom property = m_pointerAccelerationProfileFlat.atom;
+-        Atom type_return;
+-        int format_return;
+-        unsigned long num_items_return;
+-        unsigned long bytes_after_return;
+-        unsigned char *_data = nullptr;
+-
+-        auto status =
+-            XIGetProperty(m_dpy, info->id, property, 0, 1, False, XA_INTEGER, &type_return, &format_return, &num_items_return, &bytes_after_return, &_data);
+-        if (status != Success) {
+-            return;
+-        }
+-
+-        QScopedArrayPointer<unsigned char, ScopedXDeleter> data(_data);
+-        _data = nullptr;
+-
+-        if (type_return != XA_INTEGER || !data || format_return != 8 || num_items_return != 2) {
+-            return;
+-        }
+-
+-        if (data[0] == 1 && data[1] == 0) {
+-            flatProfile = false;
+-        }
+-    });
+-    m_settings->save(QStringLiteral("X11LibInputXAccelProfileFlat"), flatProfile);
+-}
+-
+ template<typename T>
+ bool X11LibinputDummyDevice::valueWriter(Prop<T> &prop)
+ {
+diff --git a/kcms/mouse/backends/x11/x11_libinput_dummydevice.h b/kcms/mouse/backends/x11/x11_libinput_dummydevice.h
+index ad5bc46b8..5084d80f5 100644
+--- a/kcms/mouse/backends/x11/x11_libinput_dummydevice.h
++++ b/kcms/mouse/backends/x11/x11_libinput_dummydevice.h
+@@ -70,8 +70,6 @@ public:
+     bool applyConfig();
+     bool isChangedConfig() const;
+ 
+-    void getDefaultConfigFromX();
+-
+     //
+     // general
+     QString name() const
+-- 
+2.47.0
+

--- a/desktop-kde/plasma-desktop/autobuild/patches/0002-AOSCOS-feat-kickoff-set-default-applications-for-AOS.patch
+++ b/desktop-kde/plasma-desktop/autobuild/patches/0002-AOSCOS-feat-kickoff-set-default-applications-for-AOS.patch
@@ -1,6 +1,18 @@
---- a/applets/kickoff/package/contents/config/main.xml	2022-02-03 22:38:13.000000000 +0800
-+++ b/applets/kickoff/package/contents/config/main.xml	2022-02-09 16:38:59.607107961 +0800
-@@ -11,7 +11,7 @@
+From 791a49d3ebdfa3787a6d52ecbb52ea4ce21c4101 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 21 Nov 2024 15:06:45 +0800
+Subject: [PATCH 2/2] AOSCOS: feat(kickoff): set default applications for AOSC
+ OS
+
+---
+ applets/kickoff/package/contents/config/main.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/applets/kickoff/package/contents/config/main.xml b/applets/kickoff/package/contents/config/main.xml
+index 536943cee..05eadc692 100644
+--- a/applets/kickoff/package/contents/config/main.xml
++++ b/applets/kickoff/package/contents/config/main.xml
+@@ -15,7 +15,7 @@
          </entry>
          <entry name="favorites" type="StringList">
              <label>List of general favorites. Supported values are menu id's (usually .desktop file names), special URLs that expand into default applications (e.g. preferred://browser), document URLs and KPeople contact URIs.</label>
@@ -9,3 +21,6 @@
          </entry>
          <entry name="systemFavorites" type="StringList">
              <label>List of system action favorites.</label>
+-- 
+2.47.0
+

--- a/desktop-kde/plasma-desktop/spec
+++ b/desktop-kde/plasma-desktop/spec
@@ -1,5 +1,5 @@
 VER=5.27.11
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/plasma/${VER}/plasma-desktop-$VER.tar.xz"
 CHKSUMS="sha256::d09f1e576251e7b4b6fde20407bdbfb018e495eba604487b0a05f4f011fc44a3"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

plasma-desktop: drop possible mis-set Flat mouse acceleration profile

Revert upstream commit fb8a655a7376 ("If no config option for accel profile is selected, use default from Xorg").

With libinput 1.26.2, a "flat" acceleration profile was set by default for all input devices. This is probably not correct as libinput still indicates that "adaptive" is the default.

Having a "flat" default makes TrackPoints painfully unusable after login (whereas in SDDM they work as expected).

The user may still select a "flat" profile via the KCM module, save for the issue where their X configuration may not match with that of KDE's on first boot (before this reverted commit). This is really much less of a problem for most users.

Package(s) Affected
-------------------

- plasma-desktop: 5.27.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
