### PR TITLE
mihomo-party: update to 1.5.11

### DIFF
--- a/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
+++ b/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
@@ -1,4 +1,4 @@
-From 0048046bb7eede8ba9b13dffbe1466c1ace5f6a5 Mon Sep 17 00:00:00 2001
+From 2c47220f7a580fd2014073a6283074ed3277851b Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 5 Nov 2024 01:18:49 +0800
 Subject: [PATCH 1/2] Keep old productName on linux

--- a/app-network/mihomo-party/autobuild/patches/0002-Remove-auto-update-feature.patch
+++ b/app-network/mihomo-party/autobuild/patches/0002-Remove-auto-update-feature.patch
@@ -1,4 +1,4 @@
-From 338205bda2373490b4300abb47dea674fa36aad5 Mon Sep 17 00:00:00 2001
+From 33d9af438ebdde08b483ac37d4533b01c4738718 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 5 Nov 2024 01:19:03 +0800
 Subject: [PATCH 2/2] Remove auto update feature
@@ -165,7 +165,7 @@ index dd3b9a5..fbcf359 100644
    ipcMain.handle('platform', () => process.platform)
    ipcMain.handle('openUWPTool', ipcErrorWrapper(openUWPTool))
 diff --git a/src/main/utils/template.ts b/src/main/utils/template.ts
-index 26f2db1..b150312 100644
+index 91e390f..7ef5735 100644
 --- a/src/main/utils/template.ts
 +++ b/src/main/utils/template.ts
 @@ -11,7 +11,6 @@ export const defaultConfig: IAppConfig = {
@@ -177,7 +177,7 @@ index 26f2db1..b150312 100644
    useNameserverPolicy: false,
    controlDns: true,
 diff --git a/src/renderer/src/App.tsx b/src/renderer/src/App.tsx
-index 39397d2..d44568a 100644
+index aef0099..87b03c6 100644
 --- a/src/renderer/src/App.tsx
 +++ b/src/renderer/src/App.tsx
 @@ -26,7 +26,6 @@ import ConnCard from '@renderer/components/sider/conn-card'
@@ -488,10 +488,10 @@ index 1097967..646f312 100644
    return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('getVersion'))
  }
 diff --git a/src/shared/types.d.ts b/src/shared/types.d.ts
-index e8c59a5..fe67640 100644
+index 4644c00..f034d9a 100644
 --- a/src/shared/types.d.ts
 +++ b/src/shared/types.d.ts
-@@ -248,7 +248,6 @@ interface IAppConfig {
+@@ -258,7 +258,6 @@ interface IAppConfig {
    siderWidth: number
    appTheme: AppTheme
    customTheme?: string

--- a/app-network/mihomo-party/spec
+++ b/app-network/mihomo-party/spec
@@ -1,4 +1,4 @@
-VER=1.5.6
+VER=1.5.11
 SRCS="git::commit=tags/v$VER::https://github.com/mihomo-party-org/mihomo-party.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375292"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo-party: update to 1.5.11

Package(s) Affected
-------------------

- mihomo-party: 1.5.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo-party
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
