### PR TITLE
bitwarden: update to 2024.11.2

### DIFF
--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2024.11.1
+VER=2024.11.2
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2024.11.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- bitwarden: 2024.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
