### PR TITLE
perl-term-readkey: rework for missing rebuild

### DIFF
--- a/lang-perl/perl-term-readkey/spec
+++ b/lang-perl/perl-term-readkey/spec
@@ -1,5 +1,5 @@
 VER=2.37
-REL=4
+REL=5
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/J/JS/JSTOWE/TermReadKey-$VER.tar.gz"
 CHKSUMS="sha256::4a9383cf2e0e0194668fe2bd546e894ffad41d556b41d2f2f577c8db682db241"
 CHKUPDATE="anitya::id=3372"


### PR DESCRIPTION
Topic Description
-----------------

- perl-term-readkey: rework for missing rebuild

Package(s) Affected
-------------------

- perl-term-readkey: 2.37-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-term-readkey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
