### PR TITLE
netease-cloud-music-gtk: update to 2.5.0

### DIFF
--- a/app-multimedia/netease-cloud-music-gtk/autobuild/defines
+++ b/app-multimedia/netease-cloud-music-gtk/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=netease-cloud-music-gtk
 PKGDES="An unofficial client for Netease Cloud Music"
 PKGDEP="openssl curl gstreamer at-spi2-core gdk-pixbuf osdlyrics gtk-4 \
         libadwaita"
-BUILDDEP="cargo llvm"
+BUILDDEP="cargo llvm gtk-update-icon-cache"
 PKGSEC="sound"
 
 USECLANG=1

--- a/app-multimedia/netease-cloud-music-gtk/spec
+++ b/app-multimedia/netease-cloud-music-gtk/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.5.0
 SRCS="git::commit=tags/$VER::https://github.com/gmg137/netease-cloud-music-gtk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230942"


### PR DESCRIPTION
Topic Description
-----------------

- netease-cloud-music-gtk: update to 2.5.0
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- netease-cloud-music-gtk: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit netease-cloud-music-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
