### PR TITLE
znc: update to 1.9.1

### DIFF
--- a/app-web/znc/autobuild/defines
+++ b/app-web/znc/autobuild/defines
@@ -1,12 +1,15 @@
 PKGNAME=znc
 PKGSEC=web
-PKGDEP="cyrus-sasl icu openssl python-3 tcl"
-BUILDDEP="perl python-3 swig tcl"
+PKGDEP="cyrus-sasl icu openssl python-3 perl tcl argon2 boost"
+BUILDDEP="swig gettext"
 PKGDES="An IRC bouncer with modules & scripts support"
 
-AUTOTOOLS_AFTER="--enable-cyrus \
-                 --enable-python \
-                 --enable-perl \
-                 --enable-tcl \
-                 --with-systemdsystemunitdir=/usr/lib/systemd/system"
-ABSHADOW=0
+ABTYPE=cmake
+CMAKE_AFTER="-DWANT_CYRUS=YES \
+	     -DWANT_PYTHON=YES \
+	     -DWANT_PERL=YES \
+	     -DWANT_TCL=YES \
+	     -DWANT_OPENSSL=YES \
+	     -DWANT_ARGON=YES \
+	     -DWANT_I18N=YES \
+	     -DWANT_SYSTEMD=YES"

--- a/app-web/znc/autobuild/patches/0001-Install-systemd-unit-to-correct-location.patch
+++ b/app-web/znc/autobuild/patches/0001-Install-systemd-unit-to-correct-location.patch
@@ -1,0 +1,37 @@
+From d7b9a04381bbf969f1c23811bb2ce4804e71719c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Thu, 21 Nov 2024 17:02:13 -0800
+Subject: [PATCH] Install systemd unit to correct location
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ CMakeLists.txt | 12 +-----------
+ 1 file changed, 1 insertion(+), 11 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a38513d9..559dd4bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -373,18 +373,8 @@ install(DIRECTORY man/
+ set(WANT_SYSTEMD false CACHE BOOL "Install znc.service to systemd")
+ if(WANT_SYSTEMD)
+ 	configure_file("znc.service.in" "znc.service")
+-	set(SYSTEMD_DIR "" CACHE PATH "Path to systemd units")
+-	if(SYSTEMD_DIR STREQUAL "" AND PKG_CONFIG_EXECUTABLE)
+-		execute_process(COMMAND "${PKG_CONFIG_EXECUTABLE}"
+-			--variable=systemdsystemunitdir systemd
+-			OUTPUT_VARIABLE SYSTEMD_DIR)
+-	endif()
+-	if(SYSTEMD_DIR STREQUAL "")
+-		message(FATAL_ERROR "Systemd is enabled, "
+-			"but the unit dir can't be found.")
+-	endif()
+ 	install(FILES "${PROJECT_BINARY_DIR}/znc.service"
+-		DESTINATION "${SYSTEMD_DIR}")
++		DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/system")
+ endif()
+ 
+ # On cygwin, if to link modules against znc.exe directly, modperl can't call
+-- 
+2.47.0
+

--- a/app-web/znc/spec
+++ b/app-web/znc/spec
@@ -1,5 +1,4 @@
-VER=1.8.2
-REL=3
+VER=1.9.1
 SRCS="git::commit=tags/znc-$VER::https://github.com/znc/znc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5305"


### PR DESCRIPTION
Topic Description
-----------------

- znc: update to 1.9.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- znc: 1.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit znc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
