### PR TITLE
xray: update to 24.11.21

### DIFF
--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,4 @@
-VER=24.11.11
+VER=24.11.21
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/XTLS/Xray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- xray: update to 24.11.21
    Co-authored-by: yidaduizuoye (@CAB233)

Package(s) Affected
-------------------

- xray: 24.11.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
