### PR TITLE
vim: update to 9.1.0880

### DIFF
--- a/app-editors/vim/01-vim/defines
+++ b/app-editors/vim/01-vim/defines
@@ -1,6 +1,7 @@
 PKGNAME=vim
 PKGSEC=editors
-PKGDEP="gpm ruby lua python-2 python-3 tk tcl acl"
+PKGDEP="gpm ruby lua python-2 python-3 tk tcl acl ncurses x11-lib libsodium \
+        perl"
 PKGDEP__RETRO="gpm acl"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-editors/vim/02-gvim/defines
+++ b/app-editors/vim/02-gvim/defines
@@ -1,6 +1,7 @@
 PKGNAME=gvim
 PKGSEC=editor
-PKGDEP="gpm ruby lua python-2 python-3 tk tcl acl gtk-3"
+PKGDEP="gpm ruby lua python-2 python-3 tk tcl acl gtk-3 ncurses x11-lib \
+        libsodium perl"
 PKGDES="VI Improved (with GTK frontend)"
 
 PKGBREAK="vim<=9.0.0859 gvim<=8.1.1968 vim-nox<=8.1.1968 vim-runtime<=8.1.1968"

--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.1.0794
+VER=9.1.0880
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.1.0880
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gvim: 9.1.0880
- vim: 9.1.0880

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
