### PR TITLE
libdecor: update to 0.2.2

### DIFF
--- a/runtime-desktop/libdecor/autobuild/defines
+++ b/runtime-desktop/libdecor/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=libdecor
 PKGSEC=libs
-PKGDEP="wayland cairo pango cairo glib mesa"
+PKGDEP="wayland cairo pango cairo glib mesa gtk-3"
 BUILDDEP="wayland-protocols dbus"
 PKGDES="A client-side decorations library for Wayland client"
 
 MESON_AFTER=(
-	-Ddemo=false
-	-Ddbus=enabled
-	-Dinstall_demo=false
+        -Ddemo=false
+        -Ddbus=enabled
+        -Dinstall_demo=false
+        -Dgtk=enabled
 )

--- a/runtime-desktop/libdecor/spec
+++ b/runtime-desktop/libdecor/spec
@@ -1,4 +1,4 @@
-VER=0.1.1
-SRCS="https://gitlab.freedesktop.org/libdecor/libdecor/uploads/ee5ef0f2c3a4743e8501a855d61cb397/libdecor-${VER}.tar.xz"
-CHKSUMS="sha256::fa95d892bd7941616f8d20aa665cd6f5745e2e8188a26a60e2a7390f21402708"
+VER=0.2.2
+SRCS="tbl::https://gitlab.freedesktop.org/libdecor/libdecor/-/releases/$VER/downloads/libdecor-$VER.tar.xz"
+CHKSUMS="sha256::16a288e24354d461b20dda9cf38e68543569134f04e4b7fa2914aa647907dfac"
 CHKUPDATE="anitya::id=312806"


### PR DESCRIPTION
Topic Description
-----------------

- libdecor: update to 0.2.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libdecor: 0.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdecor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
