### PR TITLE
hashcat: fix undefined symbol caused by unrar

### DIFF
--- a/app-penetration/hashcat/autobuild/build
+++ b/app-penetration/hashcat/autobuild/build
@@ -1,0 +1,12 @@
+abinfo "Building hashcat ..."
+make \
+    SHARED=1 \
+    USE_SYSTEM_OPENCL=1 \
+    USE_SYSTEM_UNRAR=0 \
+    USE_SYSTEM_XXHASH=1 \
+    USE_SYSTEM_ZLIB=1
+
+abinfo "Installing hashcat ..."
+make install \
+    DESTDIR="${PKGDIR}" \
+    PREFIX=/usr

--- a/app-penetration/hashcat/autobuild/defines
+++ b/app-penetration/hashcat/autobuild/defines
@@ -1,14 +1,10 @@
 PKGNAME=hashcat
 PKGSEC=utils
-PKGDEP="libcl minizip unrar xxhash zlib"
+PKGDEP="libcl minizip opencl-registry-api xxhash zlib"
 BUILDDEP="opencl-registry-api"
 PKGDES="Multithreaded, advanced password recovery utility"
 
-MAKE_AFTER="SHARED=1 \
-            VERSION_TAG=$PKGVER \
-            USE_SYSTEM_OPENCL=1 \
-            USE_SYSTEM_UNRAR=1 \
-            USE_SYSTEM_XXHASH=1 \
-            USE_SYSTEM_ZLIB=1"
-AB_FLAGS_O3=1
+ABTYPE=self
+
+# It's not buildable on big endian arches.
 FAIL_ARCH="(powerpc|ppc64)"

--- a/app-penetration/hashcat/spec
+++ b/app-penetration/hashcat/spec
@@ -1,4 +1,5 @@
 VER=6.2.6
-SRCS="tbl::https://fossies.org/linux/privat/hashcat-$VER.tar.gz"
-CHKSUMS="sha256::b25e1077bcf34908cc8f18c1a69a2ec98b047b2cbcf0f51144dcf3ba1e0b7b2a"
+SRCS="git::commit=tags/v$VER::https://github.com/hashcat/hashcat.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14448"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- hashcat: fix undefined symbol caused by unrar

Package(s) Affected
-------------------

- hashcat: 6.2.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hashcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`
