### PR TITLE
wget: update to 1.25.0

### DIFF
--- a/app-web/wget/spec
+++ b/app-web/wget/spec
@@ -1,5 +1,4 @@
-VER=1.24.5
+VER=1.25.0
 SRCS="tbl::https://ftp.gnu.org/gnu/wget/wget-$VER.tar.lz"
-CHKSUMS="sha256::57a107151e4ef94fdf94affecfac598963f372f13293ed9c74032105390b36ee"
+CHKSUMS="sha256::19225cc756b0a088fc81148dc6a40a0c8f329af7fd8483f1c7b2fe50f4e08a1f"
 CHKUPDATE="anitya::id=5124"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- wget: update to 1.25.0
    Co-authored-by: billchenchina (@billchenchina) <billchenchina2001@gmail.com>

Package(s) Affected
-------------------

- wget: 1.25.0

Security Update?
----------------

Yes

https://jfrog.com/blog/cve-2024-10524-wget-zero-day-vulnerability/
https://www.mail-archive.com/oss-security@lists.openwall.com/msg00632.html

Build Order
-----------

```
#buildit wget
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
