### PR TITLE
just: update to 1.37.0

### DIFF
--- a/app-devel/just/spec
+++ b/app-devel/just/spec
@@ -1,4 +1,4 @@
-VER=1.36.0
+VER=1.37.0
 SRCS="git::commit=tags/$VER::https://github.com/casey/just"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141393"


### PR DESCRIPTION
Topic Description
-----------------

- just: update to 1.37.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- just: 1.37.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit just
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
