### PR TITLE
sing-box: update to 1.10.2

### DIFF
--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,5 +1,4 @@
-VER=1.10.1
-REL=1
+VER=1.10.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.10.2
    Co-authored-by: yidaduizuoye (@CAB233)

Package(s) Affected
-------------------

- sing-box: 1.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
