### PR TITLE
greetd-tuigreet: recommend xinit as used as default xsession wrapper

### DIFF
--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/defines
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=greetd-tuigreet
 PKGSEC=x11
 PKGDEP="greetd"
 BUILDDEP="rustc llvm scdoc"
+PKGRECOM="xinit"
 PKGDES="A graphical console greeter for greetd"
 
 USECLANG=1

--- a/desktop-displaymanagers/greetd-tuigreet/spec
+++ b/desktop-displaymanagers/greetd-tuigreet/spec
@@ -1,4 +1,5 @@
 VER=0.9.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/apognu/tuigreet"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=266462"


### PR DESCRIPTION
Topic Description
-----------------

- greetd-tuigreet: recommend xinit as used as default xsession wrapper
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- greetd-tuigreet: 0.9.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit greetd-tuigreet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
