### PR TITLE
linux-firmware: update to 20241122

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=20241113
+UPSTREAM_VER=20241122
 DEBIANVER=20240909-2
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 REL=2
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=6e4e94b02da0357ed7db03b2120b02e378c403e0::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=3ed524d5c15373883390b0fc49a425076f823a25::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20241122
    - Update Linux Firmware to current (20241122) HEAD 3ed524d5c15373883390b0fc49a425076f823a25...
    - Changelog below...
    - AMD
    - Update AMD CPU microcode for processor family 17h and 19h to version 2024-11-21.
    - Update DMCUB for DCN314 to version 9.0.10.0.
    - Intel
    - Update iwlwifi firmwares for Bz-gf devices to build Core_manual_signed_core91-69.
    - Update i915 firmware for ADL-P, DG1, DG2, MTL, TGL GUC to version 70.36.0.
    - Update xe firmware for BMG, LNL GUC to version 70.36.0.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20241122+debian20240909+2-2
- firmware-nonfree: 20241122+debian20240909+2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
