### PR TITLE
wpa-supplicant: Fix connection issues on brcmfmac hardware

### DIFF
--- a/app-network/wpa-supplicant/autobuild/patches/0001-Revert-Mark-authorization-completed-on-driver-indica.patch
+++ b/app-network/wpa-supplicant/autobuild/patches/0001-Revert-Mark-authorization-completed-on-driver-indica.patch
@@ -1,0 +1,50 @@
+From 81c34734007e53a57ef1ae6f1d99278d979c08fa Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Mon, 25 Nov 2024 20:10:08 +0800
+Subject: [PATCH] Revert "Mark authorization completed on driver indication
+ during 4-way HS offload"
+
+This reverts commit 41638606054a09867fe3f9a2b5523aa4678cbfa5.
+---
+ wpa_supplicant/events.c | 25 ++++++++-----------------
+ 1 file changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/wpa_supplicant/events.c b/wpa_supplicant/events.c
+index a7c56f771..4e28b5239 100644
+--- a/wpa_supplicant/events.c
++++ b/wpa_supplicant/events.c
+@@ -4449,23 +4449,14 @@ static void wpa_supplicant_event_assoc(struct wpa_supplicant *wpa_s,
+ 		eapol_sm_notify_eap_success(wpa_s->eapol, true);
+ 	} else if ((wpa_s->drv_flags & WPA_DRIVER_FLAGS_4WAY_HANDSHAKE_PSK) &&
+ 		   wpa_key_mgmt_wpa_psk(wpa_s->key_mgmt)) {
+-		if (already_authorized) {
+-			/*
+-			 * We are done; the driver will take care of RSN 4-way
+-			 * handshake.
+-			 */
+-			wpa_supplicant_cancel_auth_timeout(wpa_s);
+-			wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
+-			eapol_sm_notify_portValid(wpa_s->eapol, true);
+-			eapol_sm_notify_eap_success(wpa_s->eapol, true);
+-		} else {
+-			/* Update port, WPA_COMPLETED state from the
+-			 * EVENT_PORT_AUTHORIZED handler when the driver is done
+-			 * with the 4-way handshake.
+-			 */
+-			wpa_msg(wpa_s, MSG_DEBUG,
+-				"ASSOC INFO: wait for driver port authorized indication");
+-		}
++		/*
++		 * We are done; the driver will take care of RSN 4-way
++		 * handshake.
++		 */
++		wpa_supplicant_cancel_auth_timeout(wpa_s);
++		wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
++		eapol_sm_notify_portValid(wpa_s->eapol, true);
++		eapol_sm_notify_eap_success(wpa_s->eapol, true);
+ 	} else if ((wpa_s->drv_flags & WPA_DRIVER_FLAGS_4WAY_HANDSHAKE_8021X) &&
+ 		   wpa_key_mgmt_wpa_ieee8021x(wpa_s->key_mgmt)) {
+ 		/*
+-- 
+2.47.0
+

--- a/app-network/wpa-supplicant/spec
+++ b/app-network/wpa-supplicant/spec
@@ -1,5 +1,5 @@
 VER=2.11
-REL=2
+REL=3
 SRCS="tbl::https://w1.fi/releases/wpa_supplicant-$VER.tar.gz"
 CHKSUMS="sha256::912ea06f74e30a8e36fbb68064d6cdff218d8d591db0fc5d75dee6c81ac7fc0a"
 CHKUPDATE="anitya::id=5146"


### PR DESCRIPTION
Topic Description
-----------------

- wpa-supplicant: fix association timeout on brcmfmac hardware
    - Some clients with Broadcom WiFi cards may find it unable to connect to
    any Wi-Fi network despite it can scan networks.
    - They may find it work after using iwd (manually or using iwd backend
    for NetworkManager).
    - According to [1], the bug is introduced in a commit that intended to
    fix some race conditions (for their hardware supporting 4-way hanshake
    offloading).
    - According to [1], reverting this commit fixes the issue.
    - Tested working on Raspberry Pi 5 Model B. Other hardware using
    BCM43455 SDIO cards may also benefits from this change.
    [1]: https://lists.infradead.org/pipermail/hostap/2024-August/042893.html
- double-conversion: update to 3.3.0
    Signed-off-by: 某亚瑟 <mouyase@aosc.io>

Package(s) Affected
-------------------

- wpa-supplicant: 1:2.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit wpa-supplicant
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
