### PR TITLE
networkmanager: enable iwd backend

### DIFF
--- a/app-network/networkmanager/autobuild/defines
+++ b/app-network/networkmanager/autobuild/defines
@@ -53,7 +53,7 @@ MESON_AFTER="-Dsession_tracking_consolekit=false \
              -Dlibaudit=no \
              -Dwext=true \
              -Dwifi=true \
-             -Diwd=false \
+             -Diwd=true \
              -Dppp=true \
              -Dmodem_manager=true \
              -Dofono=true \

--- a/app-network/networkmanager/spec
+++ b/app-network/networkmanager/spec
@@ -1,5 +1,5 @@
 VER=1.40.6
-REL=3
+REL=4
 SRCS="https://download.gnome.org/sources/NetworkManager/${VER:0:4}/NetworkManager-$VER.tar.xz"
 CHKSUMS="sha256::2f025b2d5af7de593bbf47c17e4d98a2b9608ea90a8260fb08080be97439534e"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager: enable iwd backend
    Some may find iwd backend useful under specific circumstances (e.g.
    something on wpa_supplicant breaks).
- double-conversion: update to 3.3.0
    Signed-off-by: 某亚瑟 <mouyase@aosc.io>

Package(s) Affected
-------------------

- networkmanager: 1.40.6-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
