### PR TITLE
fwupd: update to 2.0.2

### DIFF
--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=1.9.25
+VER=2.0.2
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/runtime-common/libxmlb/spec
+++ b/runtime-common/libxmlb/spec
@@ -1,4 +1,4 @@
-VER=0.3.15
-SRCS="tbl::https://github.com/hughsie/libxmlb/archive/$VER.tar.gz"
-CHKSUMS="sha256::68ee69002cc2b792fca250d7a7df2a8e3f8e43ccd6ab7b14c8481407b95e7087"
+VER=0.3.21
+SRCS="git::commit=tags/$VER::https://github.com/hughsie/libxmlb"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179028"


### PR DESCRIPTION
Topic Description
-----------------

- libxmlb: update to 0.3.21
    - Lest fwupd attempts to bundle libxmlb via wrap and breaks gtk-doc.
    - Use Git tag.
- fwupd: update to 2.0.2
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- fwupd: 2.0.2
- libxmlb: 0.3.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxmlb fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
