### PR TITLE
scrcpy: update to 3.0

### DIFF
--- a/app-devices/scrcpy/spec
+++ b/app-devices/scrcpy/spec
@@ -1,8 +1,7 @@
-VER=2.6.1
-REL=1
+VER=3.0
 SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
       file::rename=scrcpy-server::https://github.com/Genymobile/scrcpy/releases/download/v$VER/scrcpy-server-v$VER"
 CHKSUMS="SKIP \
-         sha256::ca7ab50b2e25a0e5af7599c30383e365983fa5b808e65ce2e1c1bba5bfe8dc3b"
+         sha256::800044c62a94d5fc16f5ab9c86d45b1050eae3eb436514d1b0d2fe2646b894ea"
 SUBDIR="scrcpy"
 CHKUPDATE="anitya::id=226924"


### PR DESCRIPTION
Topic Description
-----------------

- scrcpy: update to 3.0

Package(s) Affected
-------------------

- scrcpy: 3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scrcpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
