### PR TITLE
Update lua-5.4 to 5.4.7, fix missing linux features

### DIFF
--- a/lang-lua/lua-5.4/autobuild/patches/0001-lua-5.4-dyn-linkage.patch
+++ b/lang-lua/lua-5.4/autobuild/patches/0001-lua-5.4-dyn-linkage.patch
@@ -1,7 +1,14 @@
-diff -Naur lua-5.4.3/Makefile lua-5.4.3-modded/Makefile
---- lua-5.4.3/Makefile	2021-03-02 14:04:35.000000000 -0600
-+++ lua-5.4.3-modded/Makefile	2021-12-31 00:13:04.118544819 -0600
-@@ -10,7 +10,7 @@
+diff -Naur lua-5.4.7/Makefile lua-5.4.7.modded/Makefile
+--- lua-5.4.7/Makefile	2024-05-08 17:47:12.000000000 -0400
++++ lua-5.4.7.modded/Makefile	2024-11-26 23:06:53.742748505 -0500
+@@ -4,13 +4,13 @@
+ # == CHANGE THE SETTINGS BELOW TO SUIT YOUR ENVIRONMENT =======================
+ 
+ # Your platform. See PLATS for possible values.
+-PLAT= guess
++PLAT= linux-readline
+ 
+ # Where to install. The installation starts in the src and doc directories,
  # so take care if INSTALL_TOP is not an absolute path. See the local target.
  # You may want to make INSTALL_LMOD and INSTALL_CMOD consistent with
  # LUA_ROOT, LUA_LDIR, and LUA_CDIR in luaconf.h.
@@ -12,11 +19,11 @@ diff -Naur lua-5.4.3/Makefile lua-5.4.3-modded/Makefile
  INSTALL_LIB= $(INSTALL_TOP)/lib
 @@ -38,21 +38,21 @@
  # Convenience platforms targets.
- PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
  
 +# Lua version and release.
 +V= 5.4
-+R= $V.3
++R= $V.7
 +
  # What to install.
 -TO_BIN= lua luac
@@ -27,7 +34,7 @@ diff -Naur lua-5.4.3/Makefile lua-5.4.3-modded/Makefile
  
 -# Lua version and release.
 -V= 5.4
--R= $V.3
+-R= $V.7
 -
  # Targets start here.
  all:	$(PLAT)
@@ -38,30 +45,21 @@ diff -Naur lua-5.4.3/Makefile lua-5.4.3-modded/Makefile
  
  install: dummy
  	cd src && $(MKDIR) $(INSTALL_BIN) $(INSTALL_INC) $(INSTALL_LIB) $(INSTALL_MAN) $(INSTALL_LMOD) $(INSTALL_CMOD)
-diff -Naur lua-5.4.3/src/luaconf.h lua-5.4.3-modded/src/luaconf.h
---- lua-5.4.3/src/luaconf.h	2021-03-15 08:32:52.000000000 -0500
-+++ lua-5.4.3-modded/src/luaconf.h	2021-12-30 23:39:43.804832558 -0600
-@@ -217,7 +217,7 @@
+diff -Naur lua-5.4.7/src/Makefile lua-5.4.7.modded/src/Makefile
+--- lua-5.4.7/src/Makefile	2023-02-03 05:43:14.000000000 -0500
++++ lua-5.4.7.modded/src/Makefile	2024-11-26 23:11:33.629701214 -0500
+@@ -4,27 +4,18 @@
+ # == CHANGE THE SETTINGS BELOW TO SUIT YOUR ENVIRONMENT =======================
  
- #else			/* }{ */
- 
--#define LUA_ROOT	"/usr/local/"
-+#define LUA_ROOT	"/usr/"
- #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
- #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
- 
-diff -Naur lua-5.4.3/src/Makefile lua-5.4.3-modded/src/Makefile
---- lua-5.4.3/src/Makefile	2021-02-09 12:47:17.000000000 -0600
-+++ lua-5.4.3-modded/src/Makefile	2021-12-31 00:14:54.715708198 -0600
-@@ -7,24 +7,14 @@
- PLAT= guess
+ # Your platform. See PLATS for possible values.
+-PLAT= guess
++PLAT= linux-readline
  
  CC= gcc -std=gnu99
 -CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS)
--LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
--LIBS= -lm $(SYSLIBS) $(MYLIBS)
-+CFLAGS += -O2 -Wall -Wextra -DLUA_COMPAT_5_3 -fPIC
-+LIBS= -lm
++CFLAGS += -O2 -Wall -Wextra -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS) -fPIC
+ LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
+ LIBS= -lm $(SYSLIBS) $(MYLIBS)
  
  AR= ar rcu
  RANLIB= ranlib
@@ -81,10 +79,10 @@ diff -Naur lua-5.4.3/src/Makefile lua-5.4.3-modded/src/Makefile
  CMCFLAGS= 
  
 @@ -33,18 +23,19 @@
- PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+ PLATS= guess aix bsd c89 freebsd generic ios linux linux-readline macosx mingw posix solaris
  
  LUA_A=	liblua.a
-+LUA_SO = liblua-$(V).so
++LUA_SO= liblua-$(V).so
  CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
  LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
  BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
@@ -112,4 +110,16 @@ diff -Naur lua-5.4.3/src/Makefile lua-5.4.3-modded/src/Makefile
 +
  $(LUA_T): $(LUA_O) $(LUA_A)
  	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+ 
+diff -Naur lua-5.4.7/src/luaconf.h lua-5.4.7.modded/src/luaconf.h
+--- lua-5.4.7/src/luaconf.h	2024-06-13 18:15:10.000000000 -0400
++++ lua-5.4.7.modded/src/luaconf.h	2024-11-26 23:08:13.097377930 -0500
+@@ -223,7 +223,7 @@
+ 
+ #else			/* }{ */
+ 
+-#define LUA_ROOT	"/usr/local/"
++#define LUA_ROOT	"/usr/"
+ #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+ #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
  

--- a/lang-lua/lua-5.4/autobuild/prepare
+++ b/lang-lua/lua-5.4/autobuild/prepare
@@ -1,3 +1,3 @@
 abinfo "Set LIBS and luac_LDADD..."
-export LIBS="-lm -ldl"
-export luac_LDADD="liblua.la -lm -ldl"
+export LIBS="-lm -ldl -lreadline"
+export luac_LDADD="liblua.la -lm -ldl -lreadline"

--- a/lang-lua/lua-5.4/spec
+++ b/lang-lua/lua-5.4/spec
@@ -1,4 +1,4 @@
-VER=5.4.3
+VER=5.4.7
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
-CHKSUMS="sha256::f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb"
+CHKSUMS="sha256::9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30"
 CHKUPDATE="anitya::id=230572"


### PR DESCRIPTION
Topic Description
-----------------

- lua-5.4: fix missing LUA_USE_LINUX features

Package(s) Affected
-------------------

- lua-5.4: 5.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit lua-5.4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
