### PR TITLE
cdrdao: fixes TOC reading failure

### DIFF
--- a/app-multimedia/cdrdao/autobuild/patches/0001-PR-21-Fix-uninitialized-TOC-data-file-name.patch
+++ b/app-multimedia/cdrdao/autobuild/patches/0001-PR-21-Fix-uninitialized-TOC-data-file-name.patch
@@ -1,0 +1,23 @@
+From 251a40ab42305c412674c7c2d391374d91e91c95 Mon Sep 17 00:00:00 2001
+From: Ole Bertram <git@bertr.am>
+Date: Thu, 23 Mar 2023 17:08:48 +0100
+Subject: [PATCH] Fix uninitialized TOC data file name
+
+This caused spurious garbled TOC files and/or segfaults when not using
+the `--datafile` option.
+---
+ dao/main.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dao/main.cc b/dao/main.cc
+index 8bf4590..d09fc69 100644
+--- a/dao/main.cc
++++ b/dao/main.cc
+@@ -219,6 +219,7 @@ DaoCommandLine::DaoCommandLine() :
+     fullBurn(false), withCddb(false), taoSource(false), keepImage(false), overburn(false),
+     writeSpeedControl(false), keep(false), printQuery(false), no_utf8(false)
+ {
++    dataFilename = NULL;
+     readingSpeed = -1;
+     writingSpeed = -1;
+     command = UNKNOWN;

--- a/app-multimedia/cdrdao/autobuild/patches/0002-PR-25-Fix-version-command.patch
+++ b/app-multimedia/cdrdao/autobuild/patches/0002-PR-25-Fix-version-command.patch
@@ -1,0 +1,26 @@
+From ada9f82dbab5b07da49ca47e0b799b456d696b1a Mon Sep 17 00:00:00 2001
+From: Daniel Foster <daniel@amesite.me>
+Date: Fri, 13 Oct 2023 05:51:48 +0000
+Subject: [PATCH] Fix version command
+
+---
+ dao/main.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/dao/main.cc b/dao/main.cc
+index 8bf4590..4fd447f 100644
+--- a/dao/main.cc
++++ b/dao/main.cc
+@@ -2489,8 +2489,10 @@ int main(int argc, char **argv)
+     options.commitSettings(settings, settingsPath);
+ 
+     // Just show version ? We're done.
+-    if (options.command == SHOW_VERSION)
+-	goto fail;
++    if (options.command == SHOW_VERSION) {
++        printVersion();
++        goto fail;
++    }
+ 
+     errPrintParams.no_utf8 = options.no_utf8;
+     filePrintParams.no_utf8 = options.no_utf8;

--- a/app-multimedia/cdrdao/spec
+++ b/app-multimedia/cdrdao/spec
@@ -1,4 +1,5 @@
 VER=1.2.5
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/cdrdao/files/cdrdao-$VER.tar.bz2"
 CHKSUMS="sha256::d19b67c853c5dba2406afaab6cd788e77f35eebe634cac4679528477c7be01b6"
 CHKUPDATE="anitya::id=263"


### PR DESCRIPTION
Topic Description
-----------------

- cdrdao: pull 2 pull requests to fix some issues
    The debian packaging of cdrdao pulles 2 patches from pull requests of
    the upstream github repository, #21 and #25, to fix two issues,
    including SEGV when reading TOC and version subcommand fails to display
    the version number.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- cdrdao: 1.2.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cdrdao
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
