### PR TITLE
libdvdread: update to 6.1.3

### DIFF
--- a/runtime-multimedia/libdvdread/spec
+++ b/runtime-multimedia/libdvdread/spec
@@ -1,4 +1,4 @@
-VER=6.1.1
+VER=6.1.3
 SRCS="tbl::https://www.videolan.org/pub/videolan/libdvdread/$VER/libdvdread-$VER.tar.bz2"
-CHKSUMS="sha256::3e357309a17c5be3731385b9eabda6b7e3fa010f46022a06f104553bf8e21796"
+CHKSUMS="sha256::ce35454997a208cbe50e91232f0e73fb1ac3471965813a13b8730a8f18a15369"
 CHKUPDATE="anitya::id=5614"


### PR DESCRIPTION
Topic Description
-----------------

- libdvdread: update to 6.1.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libdvdread: 6.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdvdread
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
