### PR TITLE
libburn: update to 1.5.6

### DIFF
--- a/runtime-devices/libburn/spec
+++ b/runtime-devices/libburn/spec
@@ -1,4 +1,4 @@
-VER=1.5.2
+VER=1.5.6
 SRCS="tbl::http://files.libburnia-project.org/releases/libburn-$VER.tar.gz"
-CHKSUMS="sha256::7b32db1719d7f6516cce82a9d00dfddfb3581725db732ea87d41ea8ef0ce5227"
+CHKSUMS="sha256::7295491b4be5eeac5e7a3fb2067e236e2955ffdc6bbd45f546466edee321644b"
 CHKUPDATE="anitya::id=1568"


### PR DESCRIPTION
Topic Description
-----------------

- libburn: update to 1.5.6
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libburn: 1.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libburn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
