### PR TITLE
audacious: update to 4.4.2

### DIFF
--- a/app-multimedia/audacious/spec
+++ b/app-multimedia/audacious/spec
@@ -1,7 +1,7 @@
-VER=4.4.1
+VER=4.4.2
 SRCS="tbl::https://distfiles.audacious-media-player.org/audacious-$VER.tar.bz2 \
       git::rename=audacious-plugins-$VER;commit=tags/audacious-plugins-$VER::https://github.com/audacious-media-player/audacious-plugins"
-CHKSUMS="sha256::260d988d168e558f041bbb56692e24c535a96437878d60dfd01efdf6b1226416 \
+CHKSUMS="sha256::34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \
          SKIP"
 CHKUPDATE="anitya::id=138"
 SUBDIR="audacious-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- audacious: update to 4.4.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- audacious: 4.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit audacious
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
