### PR TITLE
xf86-video-mach64: update to 6.10.0

### DIFF
--- a/runtime-display/xf86-video-mach64/spec
+++ b/runtime-display/xf86-video-mach64/spec
@@ -1,5 +1,4 @@
-VER=6.9.7
-REL=0retro2
+VER=6.10.0
 SRCS="tbl::http://xorg.freedesktop.org/releases/individual/driver/xf86-video-mach64-$VER.tar.gz"
-CHKSUMS="sha256::1ddd2bfb6595397b7985c1d47cc5e47c4172c67d58bae5e3b792aa69890758a4"
+CHKSUMS="sha256::d7bc8a5e66a12bf9c04845b46b4c91190a1925bf128e722e922505057d7ade85"
 CHKUPDATE="anitya::id=5225"


### PR DESCRIPTION
Topic Description
-----------------

- xf86-video-mach64: update to 6.10.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xf86-video-mach64: 6.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-video-mach64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
