### PR TITLE
gnupg: update to 2.5.1

### DIFF
--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,4 @@
-VER=2.4.6
+VER=2.5.1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
-CHKSUMS="sha256::95acfafda7004924a6f5c901677f15ac1bda2754511d973bb4523e8dd840e17a"
+CHKSUMS="sha256::8a34bb318499867962c939e156666ada93ed81f01926590ac68f3ff79178375e"
 CHKUPDATE="anitya::id=1215"


### PR DESCRIPTION
Topic Description
-----------------

- gnupg: update to 2.5.1
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- gnupg: 1:2.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnupg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
