### PR TITLE
iosevka-fonts: update to 32.2.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=32.1.0
+VER=32.2.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::ac6325cb6dc455548a58babcdf8dcbd8b5333f3c97edd2d803341a563fa26cfb \
-         sha256::e4bf2e8169d1f1fb4e7f9cc5fb327ec59b0e890796e89e65992f3cf3c3b956c5 \
-         sha256::38776f5c2212e9d939b85b360e11b818c2b22dd696ab8b76d3727eb53e47b34e \
-         sha256::768a0a009bfcfef2299379b1225e5c01e019f9a7b9c06aa157e03c1c01a8621f \
-         sha256::42ae0fbf05824ac3d99b38daa796755c460cb7ba76862e67dbb2c85d7a3359b2 \
-         sha256::767fe668f67127dcae12431c292ec1152fa52caa2f11823b126344567fc08ba2 \
-         sha256::2dbca59c48888d5c2a35e0eeeeb3319c50aeadca830315595a199694ad717fee \
-         sha256::5260b525c3433c96906115fe0a09a0a0a7a9d74743ef2286b12ee01d501f2f83 \
-         sha256::bbf1262bd8c284f1f8ca8db357fd63f4cb5b826cd50a1218ce6a7d7f94927e07 \
-         sha256::21e0a19258426c33dd7c96adfc4a79993bf83799a982aee7e1249c9703b33feb \
-         sha256::8376ba654300b0064c9c5dd63310296f1086c3e17f28dca05c8a5248ca491d8d \
-         sha256::6465a6f1b3ec332c84b95e6b9f65a17e2f44e3e8fd8c0bef69c0f18b3698f9d0 \
-         sha256::181aff239f518a192c9d99dc7b8a55a8119e583aca3ebd5b154d1583a0eb2143 \
-         sha256::d4fe1357a5d95c413e08f3e428d24b57a3f5e67052a2520fc925cab0e53c896a \
-         sha256::95513c9c826b1733caae645bf959dd01caadb145348cf4ff40bdd2fc4e48c017 \
-         sha256::6be80e1c58050cea6f7c101823df5a602d98c5b184bc343e0e25a7647a9112eb \
-         sha256::a2610dd5389039ec11f13263649f788c2dd8ebb7c36b6b2d2c1cf1743fc0c5bf \
-         sha256::0020b05981d654d4b6bc55fb61b71cf8ff81dc684ab14b6f80e19f915ddaae55 \
-         sha256::c1db4cfa9752ae7fe6aa354359536b2c7cc54cc739d772ac7b8aec0d90777b74 \
-         sha256::17aa1e1eaff927c5b6fe1e3d93bb5776c16189980955f3f7f1c116d5463be8bb \
-         sha256::a85099f636bad42eda6937564925de4abaaa002588b639a3446df7c111b0ded7 \
-         sha256::63888613f760f5348ec0187b9350d15fbc4865d723faabc9245d862149ced8e1 \
-         sha256::112f12353563f162acc4d12bca9b1b2ec4712d066a3b97b05e3c8b60cae09499 \
-         sha256::9b854d0a78ceebc6b9b2ae3ad19704023e80822cbd7c848a2c8e2ec59c54d311 \
+CHKSUMS="sha256::81651ba2e9b5402f3298094532cb3c3a00d7f2189dc8d831cb18a5eecbb6da8e \
+         sha256::a0a6c1471661322fe927dc01d8f69a87057ea568c0bf8443ed292f7cff02f6f0 \
+         sha256::02752bd7cca7557e917a24a51ff994f42b71b6169bc5de811b937ee9e71a0e8f \
+         sha256::267e5726620aaa2242ae20c98611b3b28ba9e982ac27160de498f9a7816813e6 \
+         sha256::29b5f4f0c5c044fa4ffe94941fa1b3a6255296e7beb0ee3132ed1bd44211827f \
+         sha256::2d75250cf1cbdb90b14e778a5b6b7742784c50f20ec076354a38540903adcdaf \
+         sha256::5932988c975bccdf55be836a9b0672e15601f5f920c57d19c7b9a149e0cbc708 \
+         sha256::8de34b157c8845753d000278d8e848d89fd9c12b183c23d70b47cfa56d068ca1 \
+         sha256::ed1929858bc94f75f0a76bededf73fa497d7509c155457b4da027e20b065f304 \
+         sha256::269c61c50621c377d63cd2c40e279169fb960157eccb5aa1cf92fdd02919c80f \
+         sha256::c92c940824a8651b4803ae88470d174f8e2044c0c79e7d4aa70477e99632601f \
+         sha256::f25d051436365ea988cfb292bab130879a885f242fc247d6edd86e1bc91eb85a \
+         sha256::cff79f1a93745743fa0346e4a52fe3b237318825d233c963a158d7a528bcb9d6 \
+         sha256::b63f1e89a85888537825587b8af45b6c8ff3ab31447cdd939286a92137dfe81e \
+         sha256::a87256eda1af8d6c3a33b545106a07777efbcf9529dee92938725c7bec16fc6b \
+         sha256::40478d7cc3e92e997956bd64efa13a050af386889d641f3397f3746b2d2d6625 \
+         sha256::27174082a971eac9c85c1414db626b832a99461e8044bd41bf4e0bc003a34dc0 \
+         sha256::62cbf1ffe88283a977cacb778dd1af6249954131918c1fe83aeb620f939236a1 \
+         sha256::cc874585420530e49a2e43e20e6453a4f975a4e3e4f99154128589df1c416993 \
+         sha256::715f7c10d1650a853ede45d71116c330f44f4f39d5addeeae82d67e188716465 \
+         sha256::9f483b0b484cd7fe3caef2a7b1a9cec8f8e4551fccfa9ffa9db6ad8943344ebe \
+         sha256::c5c8d87a134a58f826b10e4d02672febb4393e7f7dbc6f0bc5bf84c599c3ba47 \
+         sha256::e0f52b760984880fa20f8ed00f6482af8dc682a6af6f899521ab3f2f2bcea1b5 \
+         sha256::a60a58779941453309a2c83c58f624e05415369c4301bd3ead94e52435643719 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 32.2.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 32.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
