### PR TITLE
vala: update to 0.56.17

### DIFF
--- a/app-devel/vala/spec
+++ b/app-devel/vala/spec
@@ -1,4 +1,4 @@
-VER=0.56.16
+VER=0.56.17
 SRCS="https://download.gnome.org/sources/vala/${VER:0:4}/vala-$VER.tar.xz"
-CHKSUMS="sha256::05487b5600f5d2f09e66a753cccd8f39c1bff9f148aea1b7774d505b9c8bca9b"
+CHKSUMS="sha256::26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a"
 CHKUPDATE="anitya::id=5065"


### PR DESCRIPTION
Topic Description
-----------------

- vala: update to 0.56.17
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vala: 0.56.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit vala
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
