### PR TITLE
xorg-server: allow the modesetting DDX to match Multimedia Video Controllers

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,7 +1,7 @@
 From db964f598a52652c6d3d674a81e577ef3f01b46d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
-Subject: [PATCH 1/5] Use intel ddx only on pre-gen4 hw, newer ones will fall
+Subject: [PATCH 1/6] Use intel ddx only on pre-gen4 hw, newer ones will fall
  back to modesetting
 
 Co-authored-by: Timo Aaltonen <tjaalton@debian.org>
@@ -40,5 +40,5 @@ index aeeed8be6..db705bf72 100644
  			break;
          }
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,7 +1,7 @@
 From d02162ee355de18fc02474a43226bed8777f734c Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
-Subject: [PATCH 2/5] xfree86: use modesetting driver by default on GeForce 8
+Subject: [PATCH 2/6] xfree86: use modesetting driver by default on GeForce 8
  and newer
 
 Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
@@ -49,5 +49,5 @@ index db705bf72..d2e78acaa 100644
  #endif
          driverList[idx++] = "nv";
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
 From 5c1585f201bc1b75eea3416ea7cff441509be526 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
-Subject: [PATCH 3/5] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 3/6] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85,5 +85,5 @@ index ad01b87ec..561087717 100644
      MODE_ERROR = -1             /* error condition */
  } ModeStatus;
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,7 +1,7 @@
 From b9010be23844651b133e09921993054ed9e5c1e8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
-Subject: [PATCH 4/5] xf86: Accept devices with the 'hyperv_drm' driver
+Subject: [PATCH 4/6] xf86: Accept devices with the 'hyperv_drm' driver
 
 Put in a workaround to accept devices of the kernel's hyperv_drm
 driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics
@@ -28,5 +28,5 @@ index 45028f7a6..071f44b2a 100644
                      if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
                          break;
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,7 +1,7 @@
 From e98bf06b4da1a8e5791290b45eca6cb73db08ba5 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
-Subject: [PATCH 5/5] Allows X to work on the Lemote Yeeloong laptop
+Subject: [PATCH 5/6] Allows X to work on the Lemote Yeeloong laptop
 
 ---
  hw/xfree86/common/compiler.h            | 64 ++++++++++++++++++++++++-
@@ -133,5 +133,5 @@ index fd83022f6..bacbe010b 100644
      if (ioBase == NULL) {
          ioBase = (volatile unsigned char *) mmap(0, 0x20000,
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,0 +1,32 @@
+From d57964fe30504a3618e0f4ea3f497552bb35fb5a Mon Sep 17 00:00:00 2001
+From: "Liu, Chang" <cl91tp@gmail.com>
+Date: Wed, 8 Nov 2023 13:02:10 +0800
+Subject: [PATCH 6/6] modesetting: match against Multimedia Video Controllers
+ as well
+
+Some GPU devices such as those found in the Loongson 7A2000 bridge
+chips and 2K2000 SOCs identify as Multimedia Video Controllers
+(PCI class 0x4 subclass 0x0). These have standard KMS drivers in
+the kernel and the modesetting driver works flawlessly, so match
+against these types of devices as well.
+---
+ hw/xfree86/drivers/modesetting/driver.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 535f49d1d..54eb42d84 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -96,6 +96,9 @@ static const struct pci_id_match ms_device_match[] = {
+     {
+      PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY,
+      0x00030000, 0x00ff0000, 0},
++    {
++     PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY,
++     0x00040000, 0x00ff0000, 0},
+ 
+     {0, 0, 0},
+ };
+-- 
+2.47.1
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,5 @@
 VER=21.1.14
+REL=1
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
 CHKSUMS="sha256::8f2102cebdc4747d1656c1099ef610f5063c7422c24a177e300de569b354ee35"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: allow the modesetting DDX to match Multimedia Video Controllers
    In the words of Chang Liu:
    Some GPU devices such as those found in the Loongson LS7A2000 bridge chips
    and the LS2K2000 SoCs identify themselves as Multimedia Video Controllers
    (PCI device class 0x4 subclass 0x0) rather than VGA-Compatible Controllers
    (PCI device class 0x3 subclass 0x0).
    This causes these DRM devices to be overlooked by the modesetting DDX's
    probing procedures and thereby fallback to a generic framebuffer, hurting
    performance. Patch the modesetting DDX to make it recognise Multimedia
    Video Controllers.
    Track patches at AOSC-Tracking/xserver @ aosc/xorg-server-21.1.14
    (HEAD: d57964fe30504a3618e0f4ea3f497552bb35fb5a).

Package(s) Affected
-------------------

- xorg-server: 21.1.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
