### PR TITLE
acpica-unix: update to 20250404

### DIFF
--- a/app-devel/acpica-unix/autobuild/build
+++ b/app-devel/acpica-unix/autobuild/build
@@ -1,7 +1,10 @@
 abinfo "Building acpica-unix ..."
-make ${ABMK}
+make \
+    V=1 \
+    VERBOSE=1 \
 
 abinfo "Installing acpica-unix ..."
-mkdir -pv "$PKGDIR"/usr/bin
-install -vpD "$SRCDIR"/bin*/* \
-    "$PKGDIR"/usr/bin/
+make install \
+    V=1 \
+    VERBOSE=1 \
+    DESTDIR="$PKGDIR"

--- a/app-devel/acpica-unix/autobuild/defines
+++ b/app-devel/acpica-unix/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="glibc"
 PKGDES="Intel ACPI Source Language compiler"
 
 ABMK="OPT_CFLAGS=${CFLAGS} OPT_LDFLAGS=${LDFLAGS}"
+ABTYPE=self

--- a/app-devel/acpica-unix/autobuild/prepare
+++ b/app-devel/acpica-unix/autobuild/prepare
@@ -1,2 +1,6 @@
-abinfo "Appending -Wno-error=pointer-to-int-cast to CFLAGS to fix build"
-export CFLAGS="${CFLAGS} -Wno-error=pointer-to-int-cast"
+# FIXME: Build error on loongson3.
+# error: cast to pointer from integer of different size
+if ab_match_arch loongson3; then
+    abinfo "Appending -Wno-error=pointer-to-int-cast to CFLAGS to fix build ..."
+    export CFLAGS="${CFLAGS} -Wno-error=pointer-to-int-cast"
+fi

--- a/app-devel/acpica-unix/spec
+++ b/app-devel/acpica-unix/spec
@@ -1,5 +1,6 @@
-VER=20240322
-SRCS="git::commit=tags/G$VER::https://github.com/acpica/acpica"
-CHKSUMS="SKIP"
+VER=20250404
+__VER="${VER:0:4}_${VER:4:2}_${VER:6:2}"
+SRCS="tbl::https://github.com/acpica/acpica/releases/download/R${__VER}/acpica-unix-${VER}.tar.gz"
+CHKSUMS="sha256::c0895489e6cb2dc92e49dc60cdf94ac02b0d33602166354267b8f4b6586c2315"
 CHKUPDATE="anitya::id=18"
-SUBDIR="acpica-unix/generate/unix"
+SUBDIR="acpica-unix-${VER}/generate/unix"


### PR DESCRIPTION
Topic Description
-----------------

- acpica-unix: adjust build script
- acpica-unix: update to 20250404
    - Switch to tarball source.

Package(s) Affected
-------------------

- acpica-unix: 20250404

Security Update?
----------------

No

Build Order
-----------

```
#buildit acpica-unix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
