### PR TITLE
wireless-regdb: update to 2024.10.07

### DIFF
--- a/app-network/wireless-regdb/spec
+++ b/app-network/wireless-regdb/spec
@@ -1,4 +1,4 @@
-VER=2024.07.04
+VER=2024.10.07
 SRCS="tbl::https://www.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-$VER.tar.xz"
-CHKSUMS="sha256::9832a14e1be24abff7be30dee3c9a1afb5fdfcf475a0d91aafef039f8d85f5eb"
+CHKSUMS="sha256::f76f2bd79a653e9f9dd50548d99d03a4a4eb157da056dfd5892f403ec28fb3d5"
 CHKUPDATE="anitya::id=15257"


### PR DESCRIPTION
Topic Description
-----------------

- wireless-regdb: update to 2024.10.07
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireless-regdb: 2024.10.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireless-regdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
