### PR TITLE
giflib: update to 5.2.2

### DIFF
--- a/runtime-imaging/giflib/autobuild/build
+++ b/runtime-imaging/giflib/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building giflib ..."
+make V=1 VERBOSE=1
+
+abinfo "Installing giflib ..."
+make install V=1 VERBOSE=1 \
+        PREFIX=/usr DESTDIR="$PKGDIR"

--- a/runtime-imaging/giflib/autobuild/defines
+++ b/runtime-imaging/giflib/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=giflib
 PKGDES="A library for reading and writing GIF images"
 PKGDEP="glibc"
-BUILDDEP="xmlto docbook-xsl"
+BUILDDEP="xmlto docbook-xsl imagemagick"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -12,3 +12,5 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGSEC=libs
+
+ABTYPE=self

--- a/runtime-imaging/giflib/autobuild/patches/0001-FROM-ARCHLINUX-Install-the-actual-man-pages-instead-of-the-sources.patch
+++ b/runtime-imaging/giflib/autobuild/patches/0001-FROM-ARCHLINUX-Install-the-actual-man-pages-instead-of-the-sources.patch
@@ -1,0 +1,46 @@
+From 0c73525023b821bb46afb6ae52567b2ddb352dce Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 13 Apr 2025 18:46:51 +0800
+Subject: [PATCH] Install the actual man pages instead of the sources
+
+---
+ Makefile | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 87966a9..75d9a63 100644
+--- a/Makefile
++++ b/Makefile
+@@ -64,13 +64,13 @@ UTILS = $(INSTALLABLE) \
+ LDLIBS=libgif.a -lm
+ 
+ MANUAL_PAGES = \
+-	doc/gif2rgb.xml \
+-	doc/gifbuild.xml \
+-	doc/gifclrmp.xml \
+-	doc/giffix.xml \
+-	doc/giflib.xml \
+-	doc/giftext.xml \
+-	doc/giftool.xml
++	doc/gif2rgb.1 \
++	doc/gifbuild.1 \
++	doc/gifclrmp.1 \
++	doc/giffix.1 \
++	doc/giflib.7 \
++	doc/giftext.1 \
++	doc/giftool.1
+ 
+ SOEXTENSION	= so
+ LIBGIFSO	= libgif.$(SOEXTENSION)
+@@ -180,7 +180,7 @@ EXTRAS =     README \
+ 	     doc/gifstandard \
+ 
+ DSOURCES = Makefile *.[ch]
+-DOCS = doc/*.xml doc/*.1 doc/*.7 doc/*.html doc/index.html.in doc/00README doc/Makefile
++DOCS = doc/*.1 doc/*.1 doc/*.7 doc/*.html doc/index.html.in doc/00README doc/Makefile
+ ALL =  $(DSOURCES) $(DOCS) tests pic $(EXTRAS)
+ giflib-$(VERSION).tar.gz: $(ALL)
+ 	$(TAR) --transform='s:^:giflib-$(VERSION)/:' -czf giflib-$(VERSION).tar.gz $(ALL)
+-- 
+2.49.0
+

--- a/runtime-imaging/giflib/spec
+++ b/runtime-imaging/giflib/spec
@@ -1,5 +1,4 @@
-VER=5.1.8
-REL=1
+VER=5.2.2
 SRCS="tbl::https://sourceforge.net/projects/giflib/files/giflib-$VER.tar.gz"
-CHKSUMS="sha256::d105a905df34a7822172d13657cdae3d4b0c8e8c7067ccf05e39a40044f8ca53"
+CHKSUMS="sha256::be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb"
 CHKUPDATE="anitya::id=1158"

--- a/runtime-imaging/giflib/spec
+++ b/runtime-imaging/giflib/spec
@@ -1,4 +1,4 @@
 VER=5.2.2
-SRCS="tbl::https://sourceforge.net/projects/giflib/files/giflib-$VER.tar.gz"
+SRCS="tbl::https://sourceforge.net/projects/giflib/files/giflib-$VER.tar.gz/download"
 CHKSUMS="sha256::be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb"
 CHKUPDATE="anitya::id=1158"


### PR DESCRIPTION
Topic Description
-----------------

- giflib: update to 5.2.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- giflib: 5.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit giflib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
