### PR TITLE
samtools: update to 1.21

### DIFF
--- a/app-scientific/htslib/autobuild/defines
+++ b/app-scientific/htslib/autobuild/defines
@@ -3,6 +3,12 @@ PKGSEC=science
 PKGDEP="curl"
 PKGDES="C library for high-throughput sequencing data formats"
 
-AUTOTOOLS_AFTER="--enable-libcurl --enable-plugins"
-MAKE_AFTER="LIB_PERM=755"
 ABSHADOW=no
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--enable-plugins"
+    "--enable-libcurl"
+)
+MAKE_AFTER=(
+    "LIB_PERM=755"
+)

--- a/app-scientific/htslib/spec
+++ b/app-scientific/htslib/spec
@@ -1,5 +1,4 @@
-VER=1.20
+VER=1.21
 SRCS="tbl::https://github.com/samtools/htslib/releases/download/$VER/htslib-$VER.tar.bz2"
-CHKSUMS="sha256::e52d95b14da68e0cfd7d27faf56fef2f88c2eaf32a2be51c72e146e3aa928544"
-
+CHKSUMS="sha256::84b510e735f4963641f26fd88c8abdee81ff4cb62168310ae716636aac0f1823"
 CHKUPDATE="anitya::id=13500"

--- a/app-scientific/samtools/autobuild/defines
+++ b/app-scientific/samtools/autobuild/defines
@@ -2,5 +2,10 @@ PKGNAME=samtools
 PKGSEC=science
 PKGDES="Tools (written in C using htslib) for manipulating next-generation sequencing data"
 PKGDEP="htslib ncurses"
+
 ABSHADOW=no
-AUTOTOOLS_AFTER="--with-htslib=system --with-ncurses"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-htslib=system"
+    "--with-ncurses"
+)

--- a/app-scientific/samtools/spec
+++ b/app-scientific/samtools/spec
@@ -1,4 +1,4 @@
-VER=1.20
+VER=1.21
 SRCS="tbl::https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER.tar.bz2"
-CHKSUMS="sha256::c71be865e241613c2ca99679c074f1a0daeb55288af577db945bdabe3eb2cf10"
+CHKSUMS="sha256::05724b083a6b6f0305fcae5243a056cc36cf826309c3cb9347a6b89ee3fc5ada"
 CHKUPDATE="anitya::id=4759"


### PR DESCRIPTION
Topic Description
-----------------

- htslib: update to 1.21
- samtools: update to 1.21
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- htslib: 1.21
- samtools: 1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit htslib samtools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
