### PR TITLE
util-linux: update to 2.40.2

### DIFF
--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,4 @@
-VER=2.40.1
+VER=2.40.2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f"
+CHKSUMS="sha256::d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3"
 CHKUPDATE="anitya::id=8179"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: update to 2.40.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- util-linux: 2.40.2
- util-linux-runtime: 2.40.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
