### PR TITLE
rpcbind: update to 1.2.7

### DIFF
--- a/app-network/rpcbind/autobuild/patches/0001-Change-servname-to-sunrpc-following-IANA-ports-assig.patch
+++ b/app-network/rpcbind/autobuild/patches/0001-Change-servname-to-sunrpc-following-IANA-ports-assig.patch
@@ -1,0 +1,26 @@
+From 9d4c1c496b40c06a9bfd2a1006337137d10eec07 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Fri, 6 Dec 2024 11:04:30 +0800
+Subject: [PATCH] Change `servname` to sunrpc, following IANA ports assignation
+ table
+
+---
+ src/rpcbind.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpcbind.c b/src/rpcbind.c
+index ecebe97..a4e07a4 100644
+--- a/src/rpcbind.c
++++ b/src/rpcbind.c
+@@ -132,7 +132,7 @@ char *tcptrans;		/* Name of TCP transport */
+ char *udp_uaddr;	/* Universal UDP address */
+ char *tcp_uaddr;	/* Universal TCP address */
+ #endif
+-static char servname[] = "rpcbind";
++static char servname[] = "sunrpc";
+ static char superuser[] = "superuser";
+ 
+ int main(int, char *[]);
+-- 
+2.47.1
+

--- a/app-network/rpcbind/spec
+++ b/app-network/rpcbind/spec
@@ -1,4 +1,4 @@
-VER=1.2.6
+VER=1.2.7
 SRCS="tbl::https://downloads.sourceforge.net/rpcbind/rpcbind-$VER.tar.bz2"
-CHKSUMS="sha256::5613746489cae5ae23a443bb85c05a11741a5f12c8f55d2bb5e83b9defeee8de"
+CHKSUMS="sha256::f6edf8cdf562aedd5d53b8bf93962d61623292bfc4d47eedd3f427d84d06f37e"
 CHKUPDATE="anitya::id=4212"


### PR DESCRIPTION
Topic Description
-----------------

- rpcbind: update to 1.2.7
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rpcbind: 1.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit rpcbind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
