### PR TITLE
xdg-user-dirs: update to 0.18

### DIFF
--- a/app-admin/xdg-user-dirs/spec
+++ b/app-admin/xdg-user-dirs/spec
@@ -1,5 +1,4 @@
-VER=0.17
-REL=1
+VER=0.18
 SRCS="tbl::https://user-dirs.freedesktop.org/releases/xdg-user-dirs-$VER.tar.gz"
-CHKSUMS="sha256::2a07052823788e8614925c5a19ef5b968d8db734fdee656699ea4f97d132418c"
+CHKSUMS="sha256::ec6f06d7495cdba37a732039f9b5e1578bcb296576fde0da40edb2f52220df3c"
 CHKUPDATE="anitya::id=8637"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-user-dirs: update to 0.18
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xdg-user-dirs: 0.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-user-dirs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
