### PR TITLE
system-config-printer: update to 1.5.18

### DIFF
--- a/app-admin/system-config-printer/spec
+++ b/app-admin/system-config-printer/spec
@@ -1,5 +1,4 @@
-VER=1.5.17
-REL=1
+VER=1.5.18
 SRCS="https://github.com/OpenPrinting/system-config-printer/releases/download/v$VER/system-config-printer-$VER.tar.xz"
-CHKSUMS="sha256::dc9c8ad03f7983962ddf0ef05621c948370bd1763cd90c3dcff672280aa2d6e6"
+CHKSUMS="sha256::b1a69e1b4ec2add569a87aeca811a37c5361ee6ae327ec852b79e64223e34bee"
 CHKUPDATE="anitya::id=8855"


### PR DESCRIPTION
Topic Description
-----------------

- system-config-printer: update to 1.5.18
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- system-config-printer: 1.5.18
- system-config-printer-runtime: 1.5.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit system-config-printer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
