### PR TITLE
btrfs-progs: update to 6.12

### DIFF
--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.11
+VER=6.12
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::ff9ae91521303a90d87e1c4be230f0121f39c44ddbe52c2aeae263c6fecfa099"
+CHKSUMS="sha256::9a7d9651ffd52fbe5212a8e4852a3cdb079e3d223fc5504e6a50b0ba96cd20a1"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 6.12
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- btrfs-progs: 6.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
