### PR TITLE
musescore: re-check CMAKE_AFTER, fixing Jack audio output and disabling Crashpad

### DIFF
--- a/app-creativity/musescore/autobuild/beyond
+++ b/app-creativity/musescore/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Removing bundled files ..."
-rm -rv "$PKGDIR"/usr/{bin/crashpad_handler,include,lib}
+rm -rv "$PKGDIR"/usr/{include,lib}

--- a/app-creativity/musescore/autobuild/defines
+++ b/app-creativity/musescore/autobuild/defines
@@ -1,27 +1,18 @@
 PKGNAME=musescore
 PKGSEC=sound
-PKGDEP="lame portaudio pulseaudio qt-5 shared-mime-info"
+PKGDEP="lame portaudio pulseaudio qt-5 shared-mime-info flac freetype"
 BUILDDEP="doxygen gtk-2"
 PKGDES="Create, play and print beautiful sheet music"
 
-CMAKE_AFTER="-DMSCORE_INSTALL_SUFFIX= \
-        -DMUSESCORE_LABEL=Alpha \
-        -DMUSESCORE_BUILD_CONFIG=release \
-        -DMUSESCORE_REVISION= \
-        -DTELEMETRY_TRACK_ID= \
-        -DCRASH_REPORT_URL= \
-        -DBUILD_JACK=ON \
-        -DBUILD_WEBENGINE=OFF \
-        -DDOWNLOAD_SOUNDFONT=ON \
-        -DUSE_SYSTEM_FREETYPE=ON \
-        -DBUILD_UNIT_TESTS=OFF \
-        -DMUSESCORE_BUILD_MODE=release \
-        -DCMAKE_SKIP_RPATH=OFF"
+CMAKE_AFTER="-DMUSESCORE_BUILD_MODE=release \
+             -DMUE_ENABLE_AUDIO_JACK=ON \
+             -DMUE_DOWNLOAD_SOUNDFONT=OFF \
+             -DMUE_COMPILE_USE_SYSTEM_FLAC=ON \
+             -DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON \
+             -DMUE_BUILD_UNIT_TESTS=OFF \
+             -DMUE_BUILD_CRASHPAD_CLIENT=OFF"
 
 # FIXME: No data signature found in rcc
 # See https://bugreports.qt.io/browse/QTBUG-73834
 # & https://bugs.gentoo.org/908808
 NOLTO=1
-
-# FIXME: crashpad only support these architectures
-FAIL_ARCH="!(amd64|arm64|loongson3)"

--- a/app-creativity/musescore/spec
+++ b/app-creativity/musescore/spec
@@ -1,4 +1,5 @@
 VER=4.3.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/musescore/MuseScore"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6093"


### PR DESCRIPTION
Topic Description
-----------------

- musescore: re-check CMAKE_AFTER
    MuseScore tends to change CMake option names.
    This commit tries to fix as many CMake option names as possible, and
    disables crashpad, which should enhance this package's architecture
    compatibility.
    In addition, updating the soundfont when building is disabled for
    enhancing reproducibility and preventing Internet access during build.
    This package couldn't currently be updated because upstream 4.4.x
    versions dropped support for Qt5, and do not support Qt6 newer than 6.5.
    When the support for newer Qt6 gets fixed and the package is being
    updated, CMAKE_AFTER should be investigated again because 4.4.x has
    some known option name changes again. (sigh)
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- musescore: 4.3.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit musescore
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
