### PR TITLE
weechat: update to 4.4.4

### DIFF
--- a/app-web/weechat/autobuild/defines
+++ b/app-web/weechat/autobuild/defines
@@ -15,6 +15,10 @@ CMAKE_AFTER="-DENABLE_PYTHON=ON \
              -DENABLE_DOC=ON \
              -DENABLE_TESTS=OFF \
              -DENABLE_JAVASCRIPT=OFF \
-	     -DENABLE_RUBY=OFF \
-	     -DENABLE_DOC_INCOMPLETE=ON \
+             -DENABLE_RUBY=OFF \
+             -DENABLE_DOC_INCOMPLETE=ON \
              -DCA_FILE=/etc/ssl/ca-bundle.crt"
+# FIXME: Similar to the above issue, asciidoctor causes FTBFS with illegal
+# instruction on riscv64
+CMAKE_AFTER__RISCV64="${CMAKE_AFTER} \
+                      -DENABLE_DOC=OFF"

--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.4.3
+VER=4.4.4
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::295612f8dc24af28c918257d3014eb53342a5d077d5e3d9a3eadf303bd8febfa"
+CHKSUMS="sha256::a8f4bb768c3d6ac3ea1eb4e6dc7a7bb2ee19b734a72cc58e063476dae8f3d077"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.4.4
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- weechat: 4.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
