### PR TITLE
fprintd: update to 1.94.4

### DIFF
--- a/app-admin/fprintd/autobuild/beyond
+++ b/app-admin/fprintd/autobuild/beyond
@@ -1,5 +1,2 @@
 abinfo "Creating fprint data directory ..."
 mkdir -pv "$PKGDIR"/var/lib/fprint
-abinfo "Moving misplaced pam so files ..."
-mv -v "$PKGDIR"/lib/security "$PKGDIR"/usr/lib/
-rmdir -v "$PKGDIR"/lib

--- a/app-admin/fprintd/spec
+++ b/app-admin/fprintd/spec
@@ -1,4 +1,4 @@
-VER=1.94.3
-SRCS="tbl::https://gitlab.freedesktop.org/libfprint/fprintd/-/archive/v$VER/fprintd-v$VER.tar.gz"
-CHKSUMS="sha256::2413ec9c0be24f6852afde31baa275a2d7fe3a9ee03973af9362ddb97231aedd"
+VER=1.94.4
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/libfprint/fprintd.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=835"


### PR DESCRIPTION
Topic Description
-----------------

- fprintd: update to 1.94.4
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fprintd: 1.94.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit fprintd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
