### PR TITLE
libjxl: update to 0.11.1

### DIFF
--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,4 +1,4 @@
-VER=0.10.2
+VER=0.11.1
 SRCS="git::commit=tags/v$VER::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"


### PR DESCRIPTION
Topic Description
-----------------

- libjxl: update to 0.11.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libjxl: 0.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjxl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
