### PR TITLE
libsixel: update to 1.10.3

### DIFF
--- a/runtime-imaging/libsixel/autobuild/defines
+++ b/runtime-imaging/libsixel/autobuild/defines
@@ -3,17 +3,14 @@ PKGSEC=libs
 PKGDEP="curl gdk-pixbuf libgd libjpeg-turbo libpng python-3"
 PKGDES="A SIXEL (terminal graphics and printing format by DEC) codec implementation"
 
-AUTOTOOLS_AFTER=(
-    '--disable-img2sixel'
-    '--disable-sixel2png'
-    '--enable-python'
-    '--disable-debug'
-    '--disable-gcov'
-    '--disable-tests'
-    '--with-gdk-pixbuf2'
-    '--with-gd'
-    '--with-libcurl'
-    '--with-jpeg'
-    '--with-png'
-    'PYTHON=/usr/bin/python3'
+# FIXME: Python support is broken upstream
+MESON_AFTER=(
+    '-Dimg2sixel=disabled'
+    '-Dsixel2png=disabled'
+    '-Dtests=disabled'
+    '-Dgdk-pixbuf2=enabled'
+    '-Dgd=enabled'
+    '-Dlibcurl=enabled'
+    '-Djpeg=enabled'
+    '-Dpng=enabled'
 )

--- a/runtime-imaging/libsixel/spec
+++ b/runtime-imaging/libsixel/spec
@@ -1,4 +1,4 @@
-VER=1.8.6
-SRCS="git::commit=tags/v$VER::https://github.com/saitoha/libsixel"
+VER=1.10.5
+SRCS="git::commit=tags/v$VER::https://github.com/libsixel/libsixel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243242"


### PR DESCRIPTION
Topic Description
-----------------

- libsixel: update to 1.10.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libsixel: 1.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsixel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
