### PR TITLE
cryptsetup: update to 2.7.5

### DIFF
--- a/app-admin/cryptsetup/spec
+++ b/app-admin/cryptsetup/spec
@@ -1,4 +1,4 @@
-VER=2.7.0
+VER=2.7.5
 SRCS="https://www.kernel.org/pub/linux/utils/cryptsetup/v${VER:0:3}/cryptsetup-$VER.tar.xz"
-CHKSUMS="sha256::94003a00cd5a81944f45e8dc529e0cfd2a6ff629bd2cd21cf5e574e465daf795"
+CHKSUMS="sha256::d2be4395b8f503b0ebf4b2d81db90c35a97050a358ee21fe62a0dfb66e5d5522"
 CHKUPDATE="anitya::id=13709"


### PR DESCRIPTION
Topic Description
-----------------

- cryptsetup: update to 2.7.5
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cryptsetup: 2.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit cryptsetup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
