### PR TITLE
libinput: update to 1.27.0

### DIFF
--- a/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-fix-evdev-mt-touchpad-tap.c-enable-tap-to-click-by-d.patch
@@ -1,4 +1,4 @@
-From 8c50678f14d193b0f36ef85d083bc223d7200259 Mon Sep 17 00:00:00 2001
+From 453c30492f2ce20c4631db16fea6757672685df6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Sep 2024 00:10:11 +0800
 Subject: [PATCH 1/3] fix(evdev-mt-touchpad-tap.c): enable tap-to-click by
@@ -53,10 +53,10 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 17 deletions(-)
 
 diff --git a/src/evdev-mt-touchpad-tap.c b/src/evdev-mt-touchpad-tap.c
-index 299cd554..576d71d3 100644
+index 3c76c3d6..7f912276 100644
 --- a/src/evdev-mt-touchpad-tap.c
 +++ b/src/evdev-mt-touchpad-tap.c
-@@ -1419,23 +1419,7 @@ tp_tap_config_is_enabled(struct libinput_device *device)
+@@ -1420,23 +1420,7 @@ tp_tap_config_is_enabled(struct libinput_device *device)
  static enum libinput_config_tap_state
  tp_tap_default(struct evdev_device *evdev)
  {
@@ -82,5 +82,5 @@ index 299cd554..576d71d3 100644
  
  static enum libinput_config_tap_state
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
+++ b/runtime-devices/libinput/autobuild/patches/0002-quirks-add-pressure-pad-quirk-for-Lenovo-ThinkBook-1.patch
@@ -1,36 +1,31 @@
-From 6258cef9b0b8157231606957477dc607ad9936cf Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.io>
-Date: Tue, 12 Nov 2024 11:29:27 +0800
+From 21e0bc0e62b25fd904d0d15fece5c44555cf872c Mon Sep 17 00:00:00 2001
+From: xzl <xiangzelong@deepin.org>
+Date: Thu, 28 Nov 2024 15:41:42 +0800
 Subject: [PATCH 2/3] quirks: add pressure pad quirk for Lenovo ThinkBook 14
- G7+ ASP
+ G6+ IMH
 
-Some Lenovo ThinkBook 14 G7+ ASP models ship with pressure pads (nominally
-"Force Pad"). However, they do not appear to be declared as such by the
-firmware.
+The ThinkBook 14 G6+ IMH also has the same issue as the ThinkBook 14 G7+ ASP.
 
-Add a quirk to make them work.
-
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1083>
 ---
- quirks/50-system-lenovo.quirks | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ quirks/50-system-lenovo.quirks | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git a/quirks/50-system-lenovo.quirks b/quirks/50-system-lenovo.quirks
-index 852eba01..15825426 100644
+index 6abbd368..30a79fc7 100644
 --- a/quirks/50-system-lenovo.quirks
 +++ b/quirks/50-system-lenovo.quirks
-@@ -376,3 +376,11 @@ MatchName=ITE Tech. Inc. ITE Device(8910) Keyboard
- MatchUdevType=keyboard
- MatchDMIModalias=dmi:*svnLENOVO:*
- AttrKeyboardIntegration=internal
+@@ -384,3 +384,10 @@ MatchName=*GXTP5100*
+ MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook14G7+ASP*:*
+ MatchUdevType=touchpad
+ ModelPressurePad=1
 +
-+# Some ThinkBook 14 G7+ ASP models come with pressure pads that were not
-+# correctly declared as such.
-+[Lenovo ThinkBook 14 G7+ ASP touchpad]
++# The ThinkBook 14 G6+ IMH also has a similar issue as the G7+ mentioned above.
++[Lenovo ThinkBook 14 G6+ IMH]
 +MatchName=*GXTP5100*
-+MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook14G7+ASP*:*
++MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook14G6+IMH*:*
 +MatchUdevType=touchpad
 +ModelPressurePad=1
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-devices/libinput/autobuild/patches/0003-quirks-lower-AttrTrackpointMultiplier-for-ThinkPad-X.patch
+++ b/runtime-devices/libinput/autobuild/patches/0003-quirks-lower-AttrTrackpointMultiplier-for-ThinkPad-X.patch
@@ -1,23 +1,13 @@
-From e6db1131ac58ab7056c82c44d14b71be584dece9 Mon Sep 17 00:00:00 2001
+From 1d2d6b032566060eb9791d677fc9cee4e0b368bc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
-Date: Thu, 14 Nov 2024 21:57:52 +0800
+Date: Sun, 1 Dec 2024 22:56:20 +0800
 Subject: [PATCH 3/3] quirks: lower AttrTrackpointMultiplier for ThinkPad
- X200/201 to 0.25
+ X200s/201s to 0.25
 
-Upstream commit 43cd2cbf83e0 ("data: add the dell trackpoint multipliers")
-broke the default acceleration profile on Lenovo ThinkPad X200/201, where
-the cursor speeds became so quick that it was practically impossible to
-control. Merely dragging on the TrackPoint lightly would result in the
-cursor flying from corner-to-corner.
-
-I have tested on a Lenovo ThinkPad X201 to find
-`AttrTrackpointMultiplier=0.25' the most reasonable and closest to the
-default behaviour on Windows 7 with Lenovo's driver.
-
-Not sure about ThinkPad X200s/201s, but I suspect that they would have
-similar issues (with the multiplier set to 1.25). I have just ordered both
-models to experiment with and will report back with another patch if I
-find similar issue.
+Follow commit 65b53f82ff9f ("quirks: lower AttrTrackpointMultiplier for
+ThinkPad X200/201 to 0.25") and lower this multiplier for Lenovo ThinkPad
+X200s/201s models, as I found the identical issue as the one previously
+quirked for ThinkPad X200/201.
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
@@ -25,22 +15,22 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/quirks/50-system-lenovo.quirks b/quirks/50-system-lenovo.quirks
-index 15825426..6abbd368 100644
+index 30a79fc7..404efa20 100644
 --- a/quirks/50-system-lenovo.quirks
 +++ b/quirks/50-system-lenovo.quirks
-@@ -62,10 +62,10 @@ MatchName=Elan Touchpad
- MatchDMIModalias=dmi:*svnLENOVO:*:pvrThinkPadL380*
- AttrInputProp=+INPUT_PROP_BUTTONPAD
- 
--[Lenovo X200 Trackpoint]
-+[Lenovo X200/201 Trackpoint]
- MatchName=*TPPS/2 IBM TrackPoint
+@@ -67,10 +67,10 @@ MatchName=*TPPS/2 IBM TrackPoint
  MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkPadX20?:*
+ AttrTrackpointMultiplier=0.25
+ 
+-[Lenovo X200x Trackpoint]
++[Lenovo X200s/201s Trackpoint]
+ MatchName=*TPPS/2 IBM TrackPoint
+ MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkPadX20??:*
 -AttrTrackpointMultiplier=1.25
 +AttrTrackpointMultiplier=0.25
  
- [Lenovo X200x Trackpoint]
+ [Lenovo X230 Trackpoint]
  MatchName=*TPPS/2 IBM TrackPoint
 -- 
-2.47.0
+2.47.1
 

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,5 +1,4 @@
-VER=1.26.2
-REL=3
+VER=1.27.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: update to 1.27.0
    - Track patches at AOSC-Tracking/libinput @ aosc/1.27.0
    (HEAD: 1d2d6b032566060eb9791d677fc9cee4e0b368bc).
    - Backport a fix for pressure pads on ThinkPad 14 G6+ IMH models.
    - Backport a fix for exceedingly fast trackpoints on ThinkPad X200s/201s.
    Link: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1083
    Link: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1084

Package(s) Affected
-------------------

- libinput: 1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
