### PR TITLE
linux-firmware: update to 20241128

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=20241122
+UPSTREAM_VER=20241128
 DEBIANVER=20240909-2
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 REL=2
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=3ed524d5c15373883390b0fc49a425076f823a25::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=e6c08272f15b6802bd9832a364074ec7e8a37166::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20241128
    - Update Linux Firmware to current (20241128) HEAD e6c08272f15b6802bd9832a364074ec7e8a37166...
    - Changelog below...
    - AMD
    - Add and update lots of AMDGPU firmwares...
    - GC...
    - 9.4.3
    - 9.4.4
    - 11.0.0
    - 11.0.1
    - 11.0.2
    - 11.0.3
    - 11.0.4
    - 11.5.0
    - 11.5.1
    - 11.5.2
    - PSP...
    - 13.0.0
    - 13.0.4
    - 13.0.5
    - 13.0.6
    - 13.0.7
    - 13.0.8
    - 13.0.10
    - 13.0.11
    - 13.0.14
    - 14.0.0
    - 14.0.1
    - 14.0.4
    - SDMA...
    - 4.4.2
    - 4.4.5
    - 6.0.3
    - SMU...
    - 13.0.0
    - 13.0.10
    - 13.0.14
    - VCN...
    - 3.1.2
    - 4.0.0
    - 4.0.2
    - 4.0.4
    - 4.0.5
    - 4.0.6
    - VPE...
    - 6.1.1
    - Aldebaran / Arctutus / Beige Goby / Dimgrey Cavefish / Navy Flounder / Renoir / Sienna Cichlid / Vangogh
    - Navi10/Navi12/Navi14
    - Vega10/Vega12/Vega20
    - Cirrus
    - Add the firmware files for the Cirrus CS35L56 smart amplifier used in various Dell laptops.
    - Intel
    - Update ice DDP package file to the latest version: ice-1.3.41.0
    - Add iwlwifi firmwares for Bz-gf devices to build Core_manual_signed_core89-91.
    - Update i915 Xe2LPD DMC to version 2.24.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20241128+debian20240909+2-2
- firmware-nonfree: 20241128+debian20240909+2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
