### PR TITLE
vscodium: update to 1.95.3.24321

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -13,12 +13,14 @@ export OS_NAME=linux
 export RELEASE_VERSION="$PKGVER"
 export DISABLE_UPDATE=yes
 
-if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
-  export VSCODE_ARCH="x64"
-elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
-  export VSCODE_ARCH="arm64"
+if ab_match_arch amd64; then
+    export VSCODE_ARCH="x64"
+elif ab_match_arch arm64; then
+    export VSCODE_ARCH="arm64"
+elif ab_match_arch loongarch64; then
+    export VSCODE_ARCH="loong64"
 else
-  aberr "Platform not supported" && exit 1
+    aberr "Platform not supported" && exit 1
 fi
 
 abinfo "Building .."

--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME="vscodium"
 PKGSEC="devel"
-PKGDES="Visual Studio Code - Open Source"
-PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
+PKGDES="Visual Studio Code without Microsoft branding, telemetry, and licensing"
+PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf \
+        libnotify libsecret nss x11-lib"
 BUILDDEP="gcc make pkg-config jq nodejs"
 PKGPROV="codium"
 
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
 ABSPLITDBG=0

--- a/app-editors/vscodium/autobuild/prepare
+++ b/app-editors/vscodium/autobuild/prepare
@@ -1,4 +1,2 @@
-acbs_copy_git
-
 abinfo "Prevent Corepack from showing the URL ..."
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.95.2.24313
-SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
+VER=1.95.3.24321
+SRCS="git::rename=vscodium;commit=tags/$VER;copy-repo=true::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.95.3.24321
    - Enable loongarch64 (loong64) build.
    - Use copy-repo=true instead of the deprecated acbs_copy_git function.
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vscodium: 1.95.3.24321

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
