### PR TITLE
rustdesk: rebuild for Spiral markers

### DIFF
--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -9,6 +9,9 @@ PKGRECOM="pipewire-jack"
 
 BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
 
+# FIXME: Autobuild is not yet capable of generating Spiral markers for gstreamer1.0-* modules.
+PKGPROV="gstreamer1.0-pipewire_spiral"
+
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say
 ABTYPE=meson

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,5 @@
 VER=1.2.7
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/runtime-multimedia/libvdpau/spec
+++ b/runtime-multimedia/libvdpau/spec
@@ -1,4 +1,5 @@
 VER=1.5
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/vdpau/libvdpau"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1755"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: rebuild for Spiral markers
- libvdpau: rebuild for Spiral markers

Package(s) Affected
-------------------

- libvdpau: 1.5-1
- pipewire: 1.2.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire libvdpau
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
