### PR TITLE
mcomix: update to 3.1.0

### DIFF
--- a/app-utils/mcomix/autobuild/build
+++ b/app-utils/mcomix/autobuild/build
@@ -1,9 +1,0 @@
-export PYTHONPATH="$PKGDIR/usr/lib/python2.7/site-packages"
-mkdir -p "$PYTHONPATH"
-
-python2 setup.py install --prefix=/usr --optimize=1 \
-    --single-version-externally-managed --root="$PKGDIR"
-
-install -Dm755 mime/comicthumb "$PKGDIR"/usr/bin/comicthumb
-install -Dm644 mime/comicthumb.1.gz "$PKGDIR"/usr/share/man/man1/comicthumb.1.gz
-install -Dm644 mime/comicthumb.thumbnailer "$PKGDIR"/usr/share/thumbnailers/comicthumb.thumbnailer

--- a/app-utils/mcomix/autobuild/defines
+++ b/app-utils/mcomix/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=mcomix
 PKGSEC=utils
 PKGDEP="desktop-file-utils hicolor-icon-theme mupdf p7zip pillow pygtk unrar xdg-utils"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools python-installer python-build wheel"
 PKGDES="GTK+ comic book viewer"
 
 ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/app-utils/mcomix/spec
+++ b/app-utils/mcomix/spec
@@ -1,4 +1,4 @@
-VER=1.2.1
-SRCS="tbl::https://sourceforge.net/projects/mcomix/files/MComix-$VER/mcomix-$VER.tar.bz2"
-CHKSUMS="sha256::7e43159dc585bc9bc31970a44bd2b4e42c303660c4c8cf7f0eda413a6f72fa3b"
+VER=3.1.0
+SRCS="tbl::https://sourceforge.net/projects/mcomix/files/MComix-$VER/mcomix-$VER.tar.gz"
+CHKSUMS="sha256::f9286eba7ffbc3ce9528135a9939823c425f3bbe9f74a639f8706fcc28b4c427"
 CHKUPDATE="anitya::id=8886"


### PR DESCRIPTION
Topic Description
-----------------

- mcomix: update to 3.1.0
    - Specify pep517 ABTYPE
    - Remove unnecessary build file

Package(s) Affected
-------------------

- mcomix: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mcomix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
