### PR TITLE
muse: new, 4.2.1

### DIFF
--- a/app-creativity/muse/autobuild/defines
+++ b/app-creativity/muse/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=muse
+PKGDEP="qt-5 libsndfile libsamplerate jack alsa-lib \
+        fluidsynth dssi rtaudio gtkmm lilv sord serd \
+        liblo lash liblrdf"
+PKGRECOM="pyqt5 dssi-vst"
+BUILDDEP="ladspa-sdk extra-cmake-modules"
+PKGSEC=sound
+PKGDES="A multi-track DAW focusing on MIDI sequencing"
+
+ABTYPE=cmakeninja
+
+# TODO: package libinstpatch and let MusE use it for automatic additional
+#       drum kit listing.
+CMAKE_AFTER="-DENABLE_INSTPATCH=OFF \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF \
+             -DLIB_INSTALL_DIR=/usr/lib"

--- a/app-creativity/muse/autobuild/patches/0001-BACKPORT-Force-the-use-of-in-window-menu.patch
+++ b/app-creativity/muse/autobuild/patches/0001-BACKPORT-Force-the-use-of-in-window-menu.patch
@@ -1,0 +1,27 @@
+From 9c80fd3513991ca56cd2b006efa4fe45e161d64f Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Mon, 2 Dec 2024 16:23:21 +0800
+Subject: [PATCH] Force the use of in-window menu
+
+KDE global menu with MusE sucks.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/muse/main.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/muse/main.cpp b/muse/main.cpp
+index a9f3e493..e60b7338 100644
+--- a/muse/main.cpp
++++ b/muse/main.cpp
+@@ -836,6 +836,7 @@ int main(int argc, char* argv[])
+           MusEGlobal::config.startSong = "";
+         }
+ 
++	app.instance()->setAttribute(Qt::AA_DontUseNativeMenuBar, true);
+         app.instance()->setAttribute(Qt::AA_DontShowIconsInMenus, !MusEGlobal::config.showIconsInMenus);
+         app.instance()->setAttribute(Qt::AA_DontUseNativeDialogs, !MusEGlobal::config.useNativeStandardDialogs);
+ 
+-- 
+2.47.1
+

--- a/app-creativity/muse/autobuild/patches/0002-BACKPORT-Fix-build-with-ninja-1.12.0-fix-1276.patch
+++ b/app-creativity/muse/autobuild/patches/0002-BACKPORT-Fix-build-with-ninja-1.12.0-fix-1276.patch
@@ -1,0 +1,51 @@
+From db237697b31efe7c51b2ae7064c3c6b072e93f6a Mon Sep 17 00:00:00 2001
+From: "Jason E. Hale" <jhale@FreeBSD.org>
+Date: Mon, 6 May 2024 03:43:04 -0400
+Subject: [PATCH 1/2] Fix build with ninja 1.12.0, fix #1276
+
+---
+ muse/components/confmport.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/muse/components/confmport.cpp b/muse/components/confmport.cpp
+index d01fb7de..c4744f98 100644
+--- a/muse/components/confmport.cpp
++++ b/muse/components/confmport.cpp
+@@ -44,8 +44,7 @@
+ #include "arranger.h"
+ #include "midiport.h"
+ #include "mididev.h"
+-#include "midisyncimpl.h"
+-#include "midifilterimpl.h"
++#include "midisyncimpl.
+ #include "ctrlcombo.h"
+ #include "minstrument.h"
+ #include "synth.h"
+-- 
+2.47.1
+
+From 61312213c9b12d51ef1cbaaf3347c2f25cbfaf94 Mon Sep 17 00:00:00 2001
+From: "Jason E. Hale" <jhale@FreeBSD.org>
+Date: Mon, 6 May 2024 03:53:29 -0400
+Subject: [PATCH 2/2] Stupid GitHub ui fix.
+
+---
+ muse/components/confmport.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/muse/components/confmport.cpp b/muse/components/confmport.cpp
+index c4744f98..828fe2b5 100644
+--- a/muse/components/confmport.cpp
++++ b/muse/components/confmport.cpp
+@@ -44,7 +44,7 @@
+ #include "arranger.h"
+ #include "midiport.h"
+ #include "mididev.h"
+-#include "midisyncimpl.
++#include "midisyncimpl.h"
+ #include "ctrlcombo.h"
+ #include "minstrument.h"
+ #include "synth.h"
+-- 
+2.47.1
+

--- a/app-creativity/muse/spec
+++ b/app-creativity/muse/spec
@@ -1,0 +1,4 @@
+VER=4.2.1
+SRCS="tbl::https://github.com/muse-sequencer/muse/releases/download/${VER}/muse-${VER}.tar.gz"
+CHKSUMS="sha256::05b896a885c0fcb5e48f17475516f8f3f8346d4c6425718f011ce7e409e1c5b0"
+CHKUPDATE="anitya::id=9808"


### PR DESCRIPTION
Topic Description
-----------------

- muse: new, 4.2.1
    - Backport a patch to prevent broken global menu on KDE.
    - As MusE uses plugins in /usr/lib/muse-4.2/ and dynamically link to
    them, preserve RPATH for it.
    - Set LIB_INSTALL_DIR to absolution path to allow the project's
    CMakeLists to generate proper RPATH (instead of a broken relative
    one).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- muse: 4.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit muse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
