### PR TITLE
adcli: new, 0.9.2

### DIFF
--- a/app-admin/adcli/autobuild/defines
+++ b/app-admin/adcli/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=adcli
+PKGSEC=admin
+PKGDES="Command-line tool for managing Active Directory domains"
+PKGDEP="openldap krb5 cyrus-sasl"
+BUILDDEP="libxslt xmlto docbook-xsl"
+
+# FIXME: build in SRCDIR because of generated Makefile for docs/manpage
+ABSHADOW=0

--- a/app-admin/adcli/spec
+++ b/app-admin/adcli/spec
@@ -1,0 +1,4 @@
+VER=0.9.2
+SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/realmd/adcli.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=21"

--- a/app-network/realmd/autobuild/defines
+++ b/app-network/realmd/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="realmd"
 PKGDES="DBus service for configuring kerberos and other online identities"
-PKGDEP="glib polkit systemd krb5 openldap samba dbus"
+PKGDEP="glib polkit systemd krb5 openldap samba dbus adcli"
 BUILDDEP="xmlto docbook-xsl"
 PKGSEC="admin"
 

--- a/app-network/realmd/spec
+++ b/app-network/realmd/spec
@@ -1,5 +1,5 @@
 VER="0.17.1"
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/realmd/realmd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4175"


### PR DESCRIPTION
Topic Description
-----------------

- realmd: add dependency `adcli`, bump rel
- adcli: new, 0.9.2

Package(s) Affected
-------------------

- adcli: 0.9.2
- realmd: 0.17.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit adcli realmd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
