### PR TITLE
ffmpeg: enable libwebp support

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/build
+++ b/app-multimedia/ffmpeg/autobuild/build
@@ -67,7 +67,8 @@ CONFIGURE_OPTIONS=" \
     --enable-vaapi \
     --enable-libaom \
     --enable-libsmbclient \
-    --enable-libsvtav1"
+    --enable-libsvtav1 \
+    --enable-libwebp"
 
 # FIXME: lto1: fatal error: target specific builtin not available
 # Potentially a compiler bug?

--- a/app-multimedia/ffmpeg/autobuild/defines
+++ b/app-multimedia/ffmpeg/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass \
         libbluray libmodplug pulseaudio libssh libtheora libvdpau libvorbis \
         libvpx libxcb x264 x265 opencore-amr opus schroedinger sdl speex \
         v4l-utils xvidcore zlib soxr libva sdl2 numactl ladspa-sdk xz aom \
-        samba dav1d avisynthplus svt-av1"
+        samba dav1d avisynthplus svt-av1 libwebp"
 PKGDEP__AMD64="${PKGDEP} intel-media-sdk"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec llvm"
 BUILDDEP_ARM64="${BUILDDEP} yasm"

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=2
+REL=3
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: enable libwebp
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- ffmpeg: 7.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
