### PR TITLE
mpd: update to 0.23.16

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,5 +1,4 @@
-VER=0.23.15
-REL=6
+VER=0.23.16
 SRCS="tbl::http://www.musicpd.org/download/mpd/${VER%.*}/mpd-${VER}.tar.xz"
-CHKSUMS="sha256::550132239ad1acf82ccf8905b56cc13dc2c81a4489b96fba7731b3049907661a"
+CHKSUMS="sha256::9668e36df80de485683c962d02845bf314d8a08e6141af7afeff76401e32b2c1"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.23.16
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- mpd: 0.23.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
