### PR TITLE
rosegarden: update to 24.12

### DIFF
--- a/app-creativity/rosegarden/spec
+++ b/app-creativity/rosegarden/spec
@@ -1,4 +1,4 @@
-VER=24.06
+VER=24.12
 SRCS="tbl::https://downloads.sourceforge.net/project/rosegarden/rosegarden/$VER/rosegarden-${VER}.tar.xz"
-CHKSUMS="sha256::866cd4297c128a68208edd28a37808f278f630219533fff32441ad6647e09c27"
+CHKSUMS="sha256::7f3f66136b09af14bd9998e4ade4d6204d458afd1694788fd6dcb3a96ebf15cc"
 CHKUPDATE="anitya::id=8939"


### PR DESCRIPTION
Topic Description
-----------------

- rosegarden: update to 24.12
    Co-authored-by: Icenowy Zheng (@Icenowy) <uwu@icenowy.me>

Package(s) Affected
-------------------

- rosegarden: 24.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit rosegarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
