### PR TITLE
libxnvctrl: update to 565.57.01

### DIFF
--- a/runtime-display/libxnvctrl/spec
+++ b/runtime-display/libxnvctrl/spec
@@ -1,5 +1,5 @@
-VER=545.23.06
-SRCS="tbl::https://github.com/NVIDIA/nvidia-settings/archive/${VER}.tar.gz"
-CHKSUMS="sha256::a4e0045c77406678c0d6c52433398b74d51f58cf19d350682b6408e154d7b6e8"
+VER=565.57.01
+SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"
-SUBDIR="nvidia-settings-${VER}/src/libXNVCtrl"
+SUBDIR="libxnvctrl/src/libXNVCtrl"

--- a/runtime-optenv32/libxnvctrl+32/autobuild/build
+++ b/runtime-optenv32/libxnvctrl+32/autobuild/build
@@ -1,7 +1,4 @@
 abinfo "Building libXNVCtrl.so ..."
-export PATH=/opt/32/bin:$PATH
-export CC=i686-pc-linux-gnu-gcc
-
 make
 
 abinfo "Installing libXNVCtrl.so ..."

--- a/runtime-optenv32/libxnvctrl+32/autobuild/defines
+++ b/runtime-optenv32/libxnvctrl+32/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="x11-lib+32"
 BUILDDEP="32subsystem"
 PKGDES="X extension for the NVIDIA NV-CONTROL API (optenv32)"
 
-ABHOST=noarch
+ABHOST=optenv32

--- a/runtime-optenv32/libxnvctrl+32/spec
+++ b/runtime-optenv32/libxnvctrl+32/spec
@@ -1,5 +1,5 @@
-VER=545.23.06
-SRCS="tbl::https://github.com/NVIDIA/nvidia-settings/archive/${VER}.tar.gz"
-CHKSUMS="sha256::a4e0045c77406678c0d6c52433398b74d51f58cf19d350682b6408e154d7b6e8"
+VER=565.57.01
+SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"
-SUBDIR="nvidia-settings-${VER}/src/libXNVCtrl"
+SUBDIR="libxnvctrl+32/src/libXNVCtrl"


### PR DESCRIPTION
Topic Description
-----------------

- libxnvctrl+32: update to 565.57.01
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libxnvctrl: update to 565.57.01
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libxnvctrl: 565.57.01
- libxnvctrl+32: 565.57.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxnvctrl libxnvctrl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
