### PR TITLE
remmina: update to 1.4.36

### DIFF
--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,4 +1,4 @@
-VER=1.4.35
+VER=1.4.36
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::a4ee127d2414b6891dbd46c73d6af3bfdc55863909460145bf0343c897792109"
+CHKSUMS="sha256::631248f047a1006c57c1f178c560b26cbd8f6caa6c0e251019abd8d54d1c63f3"
 CHKUPDATE="anitya::id=4188"


### PR DESCRIPTION
Topic Description
-----------------

- remmina: update to 1.4.36
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- remmina: 1.4.36

Security Update?
----------------

No

Build Order
-----------

```
#buildit remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
