### PR TITLE
libnotify: rebuild for Spiral markers

### DIFF
--- a/runtime-desktop/libnotify/autobuild/defines
+++ b/runtime-desktop/libnotify/autobuild/defines
@@ -4,6 +4,9 @@ PKGSEC=libs
 PKGDEP="gtk-3"
 BUILDDEP="gtk-doc xmlto gobject-introspection gnome-common"
 
+# FIXME: Binary tool split packages not detected in Spiral LUT.
+PKGPROV="libnotify-bin_spiral"
+
 PKGDEP__RETRO="gtk-2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/runtime-desktop/libnotify/spec
+++ b/runtime-desktop/libnotify/spec
@@ -1,5 +1,5 @@
 VER=0.7.9
-REL=5
+REL=6
 SRCS="tbl::https://download.gnome.org/sources/libnotify/${VER:0:3}/libnotify-$VER.tar.xz"
 CHKSUMS="sha256::66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
 CHKUPDATE="anitya::id=13149"


### PR DESCRIPTION
Topic Description
-----------------

- libnotify: rebuild for Spiral markers

Package(s) Affected
-------------------

- libnotify: 0.7.9-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libnotify
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
