### PR TITLE
git-filter-repo: update to 2.47.0

### DIFF
--- a/app-devel/git-filter-repo/spec
+++ b/app-devel/git-filter-repo/spec
@@ -1,5 +1,4 @@
-VER=2.45.0
-REL=1
+VER=2.47.0
 SRCS="tbl::https://github.com/newren/git-filter-repo/releases/download/v$VER/git-filter-repo-$VER.tar.xz"
-CHKSUMS="sha256::430a2c4a5d6f010ebeafac6e724e3d8d44c83517f61ea2b2d0d07ed8a6fc555a"
+CHKSUMS="sha256::4662cbe5918196a9f1b5b3e1211a32e61cff1812419c21df4f47c5439f09e902"
 CHKUPDATE="anitya::id=63454"


### PR DESCRIPTION
Topic Description
-----------------

- git-filter-repo: update to 2.47.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- git-filter-repo: 2.47.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-filter-repo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
