### PR TITLE
binutils+w64: update to 2.43.1

### DIFF
--- a/runtime-optenvw64/binutils+w64/spec
+++ b/runtime-optenvw64/binutils+w64/spec
@@ -1,4 +1,4 @@
-VER=2.43
-SRCS="git::commit=binutils-${VER/./_}::https://sourceware.org/git/binutils-gdb.git"
+VER=2.43.1
+SRCS="git::commit=binutils-${VER//./_}::https://sourceware.org/git/binutils-gdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils+w64: update to 2.43.1

Package(s) Affected
-------------------

- binutils+w64: 2.43.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils+w64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
