### PR TITLE
libxslt: update to 1.1.42

### DIFF
--- a/runtime-common/libxslt/autobuild/defines
+++ b/runtime-common/libxslt/autobuild/defines
@@ -10,17 +10,15 @@ PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGSEC=libs
-PKGDES="Extensible Stylesheet Language Transformations(XSLT) C library developed for the GNOME project"
+PKGDES="C library for eXtensible Stylesheet Language Transformations (XSLT)"
 
-AUTOTOOLS_AFTER="--with-python=/usr/bin/python3"
-AUTOTOOLS_AFTER__RETRO="--without-crypto --without-python"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--with-python=/usr/bin/python3'
+    'PYTHON=/usr/bin/python3'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    '--without-crypto'
+    '--without-python'
+)
 
 AB_FLAGS_O3=1

--- a/runtime-common/libxslt/spec
+++ b/runtime-common/libxslt/spec
@@ -1,5 +1,4 @@
-VER=1.1.34
-REL=3
-SRCS="tbl::http://xmlsoft.org/sources/libxslt-$VER.tar.gz"
-CHKSUMS="SHA256::98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
+VER=1.1.42
+SRCS="git::commit=tags/v$VER::https://github.com/GNOME/libxslt.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13301"


### PR DESCRIPTION
Topic Description
-----------------

- libxslt: update to 1.1.42
    - Clean up AUTOTOOLS_AFTER and specify PYTHON=/usr/bin/python3.
    - Improve PKGDES.

Package(s) Affected
-------------------

- libxslt: 1.1.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxslt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
