### PR TITLE
iosevka-fonts: update to 32.2.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=32.2.0
+VER=32.2.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::81651ba2e9b5402f3298094532cb3c3a00d7f2189dc8d831cb18a5eecbb6da8e \
-         sha256::a0a6c1471661322fe927dc01d8f69a87057ea568c0bf8443ed292f7cff02f6f0 \
-         sha256::02752bd7cca7557e917a24a51ff994f42b71b6169bc5de811b937ee9e71a0e8f \
-         sha256::267e5726620aaa2242ae20c98611b3b28ba9e982ac27160de498f9a7816813e6 \
-         sha256::29b5f4f0c5c044fa4ffe94941fa1b3a6255296e7beb0ee3132ed1bd44211827f \
-         sha256::2d75250cf1cbdb90b14e778a5b6b7742784c50f20ec076354a38540903adcdaf \
-         sha256::5932988c975bccdf55be836a9b0672e15601f5f920c57d19c7b9a149e0cbc708 \
-         sha256::8de34b157c8845753d000278d8e848d89fd9c12b183c23d70b47cfa56d068ca1 \
-         sha256::ed1929858bc94f75f0a76bededf73fa497d7509c155457b4da027e20b065f304 \
-         sha256::269c61c50621c377d63cd2c40e279169fb960157eccb5aa1cf92fdd02919c80f \
-         sha256::c92c940824a8651b4803ae88470d174f8e2044c0c79e7d4aa70477e99632601f \
-         sha256::f25d051436365ea988cfb292bab130879a885f242fc247d6edd86e1bc91eb85a \
-         sha256::cff79f1a93745743fa0346e4a52fe3b237318825d233c963a158d7a528bcb9d6 \
-         sha256::b63f1e89a85888537825587b8af45b6c8ff3ab31447cdd939286a92137dfe81e \
-         sha256::a87256eda1af8d6c3a33b545106a07777efbcf9529dee92938725c7bec16fc6b \
-         sha256::40478d7cc3e92e997956bd64efa13a050af386889d641f3397f3746b2d2d6625 \
-         sha256::27174082a971eac9c85c1414db626b832a99461e8044bd41bf4e0bc003a34dc0 \
-         sha256::62cbf1ffe88283a977cacb778dd1af6249954131918c1fe83aeb620f939236a1 \
-         sha256::cc874585420530e49a2e43e20e6453a4f975a4e3e4f99154128589df1c416993 \
-         sha256::715f7c10d1650a853ede45d71116c330f44f4f39d5addeeae82d67e188716465 \
-         sha256::9f483b0b484cd7fe3caef2a7b1a9cec8f8e4551fccfa9ffa9db6ad8943344ebe \
-         sha256::c5c8d87a134a58f826b10e4d02672febb4393e7f7dbc6f0bc5bf84c599c3ba47 \
-         sha256::e0f52b760984880fa20f8ed00f6482af8dc682a6af6f899521ab3f2f2bcea1b5 \
-         sha256::a60a58779941453309a2c83c58f624e05415369c4301bd3ead94e52435643719 \
+CHKSUMS="sha256::0456fca7cdba4497131c41db8896e6dd418521593e736c3411ae918cfb439283 \
+         sha256::fb0d3f56b5524107f7c5f1d03eaedf0083644756783300b88a811f3977820ce4 \
+         sha256::f2aa2b435cefcaba2edefe0556a385d6634ab4f05b18410353214e341f45d0cb \
+         sha256::8cd09bfc4a6e4eee0595ea5731265e8b8e2fb0f9d4622a604a8c6aaf3cd7cad8 \
+         sha256::ea6c4c0d7873ec02d16591efddf622f6a00b51cc5e1c175b47df2276b383dd0f \
+         sha256::8d06ad8bcca54a7a63e15c9197c859cd2f57438b0c3c44c28d6f643ca1f16483 \
+         sha256::d5974e5946d4f04582ad72a4cded508fe245cf5bc1af0d1166445b7f6adfe046 \
+         sha256::8bcc97cf9fb3089bdecd919f732228966761e22691b6b2b9b4f371f0138052f0 \
+         sha256::9f17c91d7d7bbc9c80c81022f7566e6a983988658a92c402a4569f4dcf7d1236 \
+         sha256::3eac838d04b723f70e78f93f460be4d3afd4f4e487ed3fafd19f82cec1c113a5 \
+         sha256::c6a7079da3960584cf8005a0a595f5aba7f46af83ff82907841f97e92696b1b4 \
+         sha256::889527a81d8e8b378d9f3dff8fd354fca737c08bf6155a571fd033d3face804f \
+         sha256::000dc74ed94f41847fde532e699421a7da169e5c90f813b865f4764024a05d57 \
+         sha256::71b090f3f4f7b84e3ee15dd471bc3b130440431b68f3d26bcd8c4b008a752370 \
+         sha256::c95388297197be02834d1db54df5228fc4c920d2a70d7c2b9cb49cc47e2378b9 \
+         sha256::ce0002e5e63bf3e9e1095d8239b711c05a30607c34c554771d66ba57f0a517c3 \
+         sha256::66c8280694301bdf89663625c74df90f720fa69a9d969ce00fc131fd790c0edc \
+         sha256::f7edad901ee46eb2ae6296b809e81aa2ea02ea56f5990b1e1625f62b1a7f89fa \
+         sha256::877d39ad6fdd8bda327ad26faa3bf734daaa7fe7a7795af8b1fb6d87c07ef77b \
+         sha256::3ac5c3f07c7b6f9e01e32006504e18febdeea18a0d9b061a425806c713f14792 \
+         sha256::2f5e8a44fc48821d7011f0ba79a85e834a79adf8353387bfc5c6ba6c13d62165 \
+         sha256::e05179f430aa6a806d72702327a74efe0eb2569e50ee5da5fa5b2258cc229b29 \
+         sha256::7978ad1ae6a809ee020cee56aea2a2a291e97521424fa9012e2b6a285e8ae320 \
+         sha256::91fb7e144e4270ab3f6eaaf037021f12be7134ce010d1b7835dbe51eef62800c \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 32.2.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 32.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
