### PR TITLE
pcp: update to 6.3.2

### DIFF
--- a/app-utils/pcp/autobuild/defines
+++ b/app-utils/pcp/autobuild/defines
@@ -2,8 +2,9 @@ PKGNAME=pcp
 PKGSEC=util
 PKGDEP="avahi chan hdrhistogram-c inetutils jsonpointer libmicrohttpd libnsl2 \
         libpfm libuv libvarlink libwww-perl lxml openpyxl perl perl-dbd-mysql \
-        perl-file-slurp perl-json perl-net-snmp perl-xml-libxml \
-        perl-yaml-libyaml procps psycopg2 python-3 requests six systemtap"
+        perl-file-slurp perl-json perl-net-snmp perl-spreadsheet-read perl-xml-libxml \
+        perl-xml-tokeparser perl-yaml-libyaml procps psycopg2 python-3 \
+        requests six systemtap"
 BUILDDEP="libvirt-python qt-5"
 PKGDES="System performance and analysis framework"
 

--- a/app-utils/pcp/autobuild/patches/0001-Arch-Linux-fix-LTO.patch
+++ b/app-utils/pcp/autobuild/patches/0001-Arch-Linux-fix-LTO.patch
@@ -1,12 +1,24 @@
+From b77e1513e8c5feb3d69790be7651c6889e045dc4 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Mon, 9 Dec 2024 15:10:25 +0800
+Subject: [PATCH] Arch Linux fix LTO
+
+---
+ src/libpcp/src/check-statics | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/src/libpcp/src/check-statics b/src/libpcp/src/check-statics
-index 8db3aac..9a7e5c1 100755
+index 29dcb868a..3bc3ed808 100755
 --- a/src/libpcp/src/check-statics
 +++ b/src/libpcp/src/check-statics
-@@ -680,6 +680,7 @@ do
+@@ -721,6 +721,7 @@ do
  		    -e 's/b \([_a-zA-Z][_a-zA-Z0-9]*\)\.[0-9]*.[0b]$/b \1/' \
  		    -e 's/\([bds] \).*\.\([_a-zA-Z]\)/\1\2/' \
  		    -e 's/s _glib_relative_date\./s /' \
 +		    -e '/ B __gnu_lto_slim/d' \
  		    -e '/ s EH_/d' \
+ 		    -e '/ s str\.[0-9][0-9]*$/d' \
  		    -e '/ b \.bss/d' \
- 		    -e '/ d \.data/d' \
+-- 
+2.34.1
+

--- a/app-utils/pcp/spec
+++ b/app-utils/pcp/spec
@@ -1,5 +1,4 @@
-VER=6.0.1
-SRCS="tbl::https://github.com/performancecopilot/pcp/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::c74708cce473566f9ce8caae933f7c78c0c2f0733abb23bd2af79b0f5a7eaf82"
+VER=6.3.2
+SRCS="git::commit=tags/$VER::https://github.com/performancecopilot/pcp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231628"
-REL=1

--- a/lang-perl/perl-data-peek/autobuild/defines
+++ b/lang-perl/perl-data-peek/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=perl-data-peek
+PKGSEC=perl
+PKGDEP="perl"
+PKGDES="A collection of low-level debug facilities"

--- a/lang-perl/perl-data-peek/spec
+++ b/lang-perl/perl-data-peek/spec
@@ -1,0 +1,4 @@
+VER=0.52
+SRCS="tbl::https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/Data-Peek-$VER.tgz"
+CHKSUMS="sha256::6b78ae513c068bd1ed629d08531283c12a9888f61e96ffbdf166d6ab51e277d0"
+CHKUPDATE="anitya::id=2770"

--- a/lang-perl/perl-spreadsheet-read/autobuild/defines
+++ b/lang-perl/perl-spreadsheet-read/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-spreadsheet-read
+PKGSEC=perl
+PKGDEP="perl perl-data-peek perl-tk perl-tk-tablematrix"
+PKGDES="Meta-Wrapper for reading spreadsheet data"
+
+ABHOST=noarch

--- a/lang-perl/perl-spreadsheet-read/spec
+++ b/lang-perl/perl-spreadsheet-read/spec
@@ -1,0 +1,4 @@
+VER=0.91
+SRCS="git::commit=tags/$VER::https://github.com/Tux/Spreadsheet-Read.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375908"

--- a/lang-perl/perl-tk-tablematrix/autobuild/build
+++ b/lang-perl/perl-tk-tablematrix/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Generating Makefile from Makefile.PL ..."
+PERL_MM_USE_DEFAULT=1 \
+  perl -I"$SRCDIR" Makefile.PL INSTALLDIRS=vendor
+
+abinfo "Building perl-tk-tablematrix ..."
+make V=1 VERBOSE=1 "${MAKE_AFTER[@]}"
+
+abinfo "Installing perl-tk-tablematrix ..."
+make V=1 VERBOSE=1 DESTDIR="$PKGDIR" install
+
+abinfo "Deleting conflicting files ..."
+rm "$PKGDIR"/usr/lib/perl5/vendor_perl/Tk/TableMatrix.pod
+rm "$PKGDIR"/usr/lib/perl5/vendor_perl/auto/Tk/pTk/extralibs.ld

--- a/lang-perl/perl-tk-tablematrix/autobuild/defines
+++ b/lang-perl/perl-tk-tablematrix/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=perl-tk-tablematrix
+PKGSEC=perl
+PKGDEP="perl perl-tk"
+PKGDES="Display data in TableSpreadsheet format"

--- a/lang-perl/perl-tk-tablematrix/spec
+++ b/lang-perl/perl-tk-tablematrix/spec
@@ -1,0 +1,4 @@
+VER=1.29
+SRCS="tbl::https://cpan.metacpan.org/authors/id/C/CA/CAC/Tk-TableMatrix-$VER.tar.gz"
+CHKSUMS="sha256::d31708b8bbfddce9034540522b2e4ec58e70f2eb5b23ac593d2421ea90dbd0d6"
+CHKUPDATE="anitya::id=14404"

--- a/lang-perl/perl-xml-tokeparser/autobuild/defines
+++ b/lang-perl/perl-xml-tokeparser/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-xml-tokeparser
+PKGSEC=perl
+PKGDEP="perl-xml-parser"
+PKGDES="Perl module to XML::TokeParser"
+
+ABHOST=noarch

--- a/lang-perl/perl-xml-tokeparser/spec
+++ b/lang-perl/perl-xml-tokeparser/spec
@@ -1,0 +1,4 @@
+VER=0.05
+SRCS="tbl::https://cpan.metacpan.org/authors/id/P/PO/PODMASTER/XML-TokeParser-$VER.tar.gz"
+CHKSUMS="sha256::8539b4f98436b1a6d088341a8b4530b7922acd651f3f29377f8b1948c7e2d7c2"
+CHKUPDATE="anitya::id=16103"


### PR DESCRIPTION
Topic Description
-----------------

- perl-tk-tablematrix: new, 1.29, needed by perl-spreadsheet-read
- perl-data-peek: new, 0.52, needed by perl-spreadsheet-read
- perl-spreadsheet-read: new, 0.91, needed by pcp
- perl-xml-tokeparser: new, 0.05, needed by pcp
    Fix 'Can't locate XML/TokeParser.pm in @INC' when run /usr/bin/sheet2pcp
- pcp: update to 6.3.2
    Track the patch at AOSC-Tracking/pcp @ aosc/6.3.2

Package(s) Affected
-------------------

- pcp: 6.3.2
- perl-data-peek: 0.52
- perl-spreadsheet-read: 0.91
- perl-tk-tablematrix: 1.29
- perl-xml-tokeparser: 0.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-xml-tokeparser perl-data-peek perl-tk-tablematrix perl-spreadsheet-read pcp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
