### PR TITLE
geant4: update to 11.3.0

### DIFF
--- a/app-productivity/geant4/spec
+++ b/app-productivity/geant4/spec
@@ -1,4 +1,0 @@
-VER=11.2.2
-SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
-CHKSUMS="sha256::d24f65735b8a0a039c00f9434991e99ef119b86c510d0f2ab21155db82a3491d"
-CHKUPDATE="github::repo=Geant4/geant4"

--- a/app-scientific/geant4/autobuild/beyond
+++ b/app-scientific/geant4/autobuild/beyond
@@ -1,0 +1,12 @@
+abinfo "Creating geant4.sh"
+mkdir -pv "$PKGDIR"/etc/profile.d
+# geant4.sh will be overridden
+touch "$PKGDIR"/etc/profile.d/geant4.sh
+
+abinfo "Creating symbolic link to geant4.sh in bashrc.d ..."
+mkdir -pv "$PKGDIR"/etc/bashrc.d
+ln -sv ../../etc/profile.d/geant4.sh "$PKGDIR"/etc/bashrc.d/geant4.sh
+
+abinfo "Creating symbolic link to geant4.sh in zshrc.d ..."
+mkdir -pv "$PKGDIR"/etc/zsh/zshrc.d
+ln -sv ../../../etc/profile.d/geant4.sh "$PKGDIR"/etc/zsh/zshrc.d/geant4.sh

--- a/app-scientific/geant4/autobuild/defines
+++ b/app-scientific/geant4/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=geant4
 PKGDES="A toolkit for the simulation of the passage of particles through matter"
-PKGSEC=utils
+PKGSEC=science
 PKGDEP="cmake make llvm xerces-c zlib expat motif coin soqt qt-6 python-3 boost"
 BUILDDEP="extra-cmake-modules"
 ABTYPE=cmake

--- a/app-scientific/geant4/autobuild/overrides/etc/profile.d/geant4.sh
+++ b/app-scientific/geant4/autobuild/overrides/etc/profile.d/geant4.sh
@@ -1,0 +1,3 @@
+# Resolve OpenGL compatibility issues with some GPUs by using a specified graphics system
+# Ref: https://geant4-userdoc.web.cern.ch/UsersGuides/AllGuides/html/ForApplicationDevelopers/Visualization/visdrivers.html
+export G4VIS_DEFAULT_DRIVER=TSG

--- a/app-scientific/geant4/spec
+++ b/app-scientific/geant4/spec
@@ -1,0 +1,4 @@
+VER=11.3.0
+SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
+CHKSUMS="sha256::1da4318b3f96f87f4d47558a32dab269b8f3fc956708038c28e72a180b0efba6"
+CHKUPDATE="anitya::id=375805"


### PR DESCRIPTION
Topic Description
-----------------

- geant4: update to 11.3.0
    - Resolve OpenGL compatibility issue with some GPUs
    - Move to app-scientific
    - Use anitya to check for updates

Package(s) Affected
-------------------

- geant4: 11.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit geant4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
