### PR TITLE
zathura: update to 0.5.9

### DIFF
--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.8
+VER=0.5.9
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"

--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=0.4.4
+VER=0.4.5
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 0.5.9
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- zathura: 0.5.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara zathura
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
