### PR TITLE
rio: new, 0.2.2

### DIFF
--- a/app-utils/rio/autobuild/beyond
+++ b/app-utils/rio/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Installing .desktop file ..."
+install -Dm644 "$SRCDIR"/misc/rio.desktop "$PKGDIR"/usr/share/applications/rio.desktop

--- a/app-utils/rio/autobuild/defines
+++ b/app-utils/rio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=rio
+PKGSEC=utils
+BUILDDEP="rustc llvm"
+PKGDES="A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers."
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1
+NOLTO__MIPS64R6EL=1

--- a/app-utils/rio/autobuild/patches/0001-Fix-LoongSon3-Termios-Error.patch.loongson3
+++ b/app-utils/rio/autobuild/patches/0001-Fix-LoongSon3-Termios-Error.patch.loongson3
@@ -1,0 +1,19 @@
+diff --git a/teletypewriter/src/unix/mod.rs b/teletypewriter/src/unix/mod.rs
+index 18336b263..bbd6baedf 100644
+--- a/teletypewriter/src/unix/mod.rs
++++ b/teletypewriter/src/unix/mod.rs
+@@ -278,14 +278,6 @@ pub fn create_termp(utf8: bool) -> libc::termios {
+             | libc::ECHOKE
+             | libc::ECHOCTL,
+         c_cc: Default::default(),
+-        #[cfg(not(target_env = "musl"))]
+-        c_ispeed: Default::default(),
+-        #[cfg(not(target_env = "musl"))]
+-        c_ospeed: Default::default(),
+-        #[cfg(target_env = "musl")]
+-        __c_ispeed: Default::default(),
+-        #[cfg(target_env = "musl")]
+-        __c_ospeed: Default::default(),
+         c_line: 0,
+     };
+ 

--- a/app-utils/rio/spec
+++ b/app-utils/rio/spec
@@ -1,0 +1,4 @@
+VER=0.2.2
+SRCS="git::commit=tags/v$VER::https://github.com/raphamorim/rio"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375035"


### PR DESCRIPTION
Topic Description
-----------------

- rio: new, 0.2.2

Package(s) Affected
-------------------

- rio: 0.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
