### PR TITLE
mediainfo: update to 24.12

### DIFF
--- a/app-multimedia/mediainfo/spec
+++ b/app-multimedia/mediainfo/spec
@@ -1,5 +1,5 @@
-VER=24.11
+VER=24.12
 SRCS="https://mediaarea.net/download/source/mediainfo/$VER/mediainfo_$VER.tar.xz"
-CHKSUMS="sha256::876a63a69d79dd1db6b6e69077a8a630421247751460b964381e3483835670fc"
+CHKSUMS="sha256::3699ae650ce71893a932ce2eaa2a35f8da47e6f721f93d695b0beb0aad4e9997"
 CHKUPDATE="anitya::id=8240"
 SUBDIR="MediaInfo/Project/GNU/CLI"

--- a/runtime-multimedia/libmediainfo/spec
+++ b/runtime-multimedia/libmediainfo/spec
@@ -1,5 +1,5 @@
-VER=24.11
+VER=24.12
 SRCS="tbl::https://mediaarea.net/download/source/libmediainfo/$VER/libmediainfo_$VER.tar.xz"
-CHKSUMS="sha256::96e44a617f90c8b63bb685ad53be6716b7df4221793c329780f02aea6e707aa1"
+CHKSUMS="sha256::1f4986207f75deb290915e6bf0b33e3e455774305dd266ffe8997c01aad65b27"
 CHKUPDATE="anitya::id=16249"
 SUBDIR="MediaInfoLib/Project/GNU/Library"


### PR DESCRIPTION
Topic Description
-----------------

- libmediainfo: update to 24.12
- mediainfo: update to 24.12
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- libmediainfo: 24.12
- mediainfo: 24.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmediainfo mediainfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
