### PR TITLE
grub: empty GRUB_CMDLINE_LINUX by default

### DIFF
--- a/app-admin/grub/autobuild/overrides/etc/default/grub
+++ b/app-admin/grub/autobuild/overrides/etc/default/grub
@@ -9,10 +9,10 @@ GRUB_TIMEOUT=5
 # GRUB distributor.
 GRUB_DISTRIBUTOR="AOSC OS"
 
-# Linux boot parameters for non-Recoveray boots.
+# Linux boot parameters for non-Recovery boots.
 GRUB_CMDLINE_LINUX_DEFAULT="quiet rd.auto rd.auto=1 splash"
 # Linux boot parameters for all boot modes.
-GRUB_CMDLINE_LINUX="quiet rd.auto rd.auto=1 splash"
+GRUB_CMDLINE_LINUX=""
 
 # Preload both GPT and MBR modules so that they are not missed.
 GRUB_PRELOAD_MODULES="part_gpt part_msdos"

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=16.0.01
 RETROFONTVER=20200402
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=1
+REL=2
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftp.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: empty GRUB_CMDLINE_LINUX by default
    In util/grub.d/10_linux.in, non-Recovery entries always have GRUB_CMDLINE_LINUX_DEFAULT appended, and Recovery Mode is disabled by us, so there's no point to repeat the same parameters in GRUB_CMDLINE_LINUX.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont16.0.01-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
