### PR TITLE
valgrind: update to 3.24.0

### DIFF
--- a/app-devel/valgrind/autobuild/defines
+++ b/app-devel/valgrind/autobuild/defines
@@ -42,4 +42,4 @@ AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
 
 # configure: error: Unsupported host architecture. Sorry
-FAIL_ARCH="loongarch64"
+FAIL_ARCH="(loongarch64|riscv64)"

--- a/app-devel/valgrind/autobuild/patches/0001-AOSCOS-cachegrind-improvements.patch
+++ b/app-devel/valgrind/autobuild/patches/0001-AOSCOS-cachegrind-improvements.patch
@@ -1,8 +1,9 @@
-From d9592f0877af8e3edcb49cb7ee2071e0d4ffdb25 Mon Sep 17 00:00:00 2001
+From b8b4c0ee4ba348344c356b6256db2eac02d47e66 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:18:56 +0800
-Subject: [PATCH 1/4] cachegrind improvements
+Subject: [PATCH 1/5] AOSCOS: cachegrind improvements
 
+Signed-off-by: Jiajie Chen <c@jia.je>
 ---
  cachegrind/cg_sim.c | 24 ++++++++++++------------
  1 file changed, 12 insertions(+), 12 deletions(-)
@@ -64,5 +65,5 @@ index c2ea3791b..67fd382e3 100644
  
  /* This attribute forces GCC to inline the function, getting rid of a
 -- 
-2.44.0
+2.47.1.windows.1
 

--- a/app-devel/valgrind/autobuild/patches/0002-AOSCOS-helgrind-race-supp.patch
+++ b/app-devel/valgrind/autobuild/patches/0002-AOSCOS-helgrind-race-supp.patch
@@ -1,17 +1,18 @@
-From f2f1f74c643f5af48090f6dbf10a245620cf94ce Mon Sep 17 00:00:00 2001
+From 0bea9b4f7d3d07908a9c85472ffe9563fe091d4f Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:19:17 +0800
-Subject: [PATCH 2/4] helgrind race supp
+Subject: [PATCH 2/5] AOSCOS: helgrind race supp
 
+Signed-off-by: Jiajie Chen <c@jia.je>
 ---
  glibc-2.X-helgrind.supp.in | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/glibc-2.X-helgrind.supp.in b/glibc-2.X-helgrind.supp.in
-index 62492c9aa..f39f60a88 100644
+index 9b1ef9ae4..c447b3a55 100644
 --- a/glibc-2.X-helgrind.supp.in
 +++ b/glibc-2.X-helgrind.supp.in
-@@ -109,6 +109,12 @@
+@@ -118,6 +118,12 @@
     fun:mythread_wrapper
     obj:@GLIBC_LIBPTHREAD_PATH@
  }
@@ -25,5 +26,5 @@ index 62492c9aa..f39f60a88 100644
     helgrind-glibc2X-103
     Helgrind:Race
 -- 
-2.44.0
+2.47.1.windows.1
 

--- a/app-devel/valgrind/autobuild/patches/0003-AOSCOS-ldso-supp.patch
+++ b/app-devel/valgrind/autobuild/patches/0003-AOSCOS-ldso-supp.patch
@@ -1,14 +1,15 @@
-From 56585938e9c79b32e623b689c7fb9f8a737e218c Mon Sep 17 00:00:00 2001
+From 1713d4dfcd0d075f634ff6bcbeafbcf26dcc594f Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:19:32 +0800
-Subject: [PATCH 3/4] ldso supp
+Subject: [PATCH 3/5] AOSCOS: ldso supp
 
+Signed-off-by: Jiajie Chen <c@jia.je>
 ---
  glibc-2.X.supp.in | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/glibc-2.X.supp.in b/glibc-2.X.supp.in
-index eeefa3935..408909882 100644
+index fc346d803..51b403ada 100644
 --- a/glibc-2.X.supp.in
 +++ b/glibc-2.X.supp.in
 @@ -124,7 +124,7 @@
@@ -38,5 +39,5 @@ index eeefa3935..408909882 100644
  
  {
 -- 
-2.44.0
+2.47.1.windows.1
 

--- a/app-devel/valgrind/autobuild/patches/0004-AOSCOS-some-Wl-z-now.patch
+++ b/app-devel/valgrind/autobuild/patches/0004-AOSCOS-some-Wl-z-now.patch
@@ -1,8 +1,9 @@
-From 783786c23250a23e11020943e6814745e28b9bb2 Mon Sep 17 00:00:00 2001
+From 7fb7bb9bf894199715f1c5eddd2b1e3342400791 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:20:18 +0800
-Subject: [PATCH 4/4] some -Wl,-z,now
+Subject: [PATCH 4/5] AOSCOS: some -Wl,-z,now
 
+Signed-off-by: Jiajie Chen <c@jia.je>
 ---
  auxprogs/Makefile.am  | 6 +++---
  coregrind/Makefile.am | 4 ++--
@@ -40,7 +41,7 @@ index 3a9709da6..bcbd3e0eb 100644
  getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_LDADD = $(LDADD) -ldl
  endif
 diff --git a/coregrind/Makefile.am b/coregrind/Makefile.am
-index 8a7f753a6..d305ac9fd 100644
+index e3e31a73b..509c17909 100644
 --- a/coregrind/Makefile.am
 +++ b/coregrind/Makefile.am
 @@ -62,7 +62,7 @@ RANLIB = ${LTO_RANLIB}
@@ -62,5 +63,5 @@ index 8a7f753a6..d305ac9fd 100644
  vgdb_CFLAGS    += -static
  endif
 -- 
-2.44.0
+2.47.1.windows.1
 

--- a/app-devel/valgrind/autobuild/patches/0005-AOSCOS-mips-detect-Loongson-CPU-model-names-without-.patch
+++ b/app-devel/valgrind/autobuild/patches/0005-AOSCOS-mips-detect-Loongson-CPU-model-names-without-.patch
@@ -1,0 +1,42 @@
+From a56d5d333376551e65eacf0866cac3bef9d3eaed Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 11 Dec 2024 17:24:20 +0800
+Subject: [PATCH 5/5] AOSCOS: mips: detect Loongson CPU model names without ICT
+
+There was a patch proposing to drop ICT in CPU model names
+("MIPS: Add __cpu_full_name[] to make CPU names more human-readable"),
+but never got its way into Linux kernel upstream. Never the less, since
+AOSC OS includes that patch, it's necessary for valgrind to detect
+Loongson CPU model names with or without ICT.
+
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ coregrind/m_machine.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/coregrind/m_machine.c b/coregrind/m_machine.c
+index 234efb312..ece336503 100644
+--- a/coregrind/m_machine.c
++++ b/coregrind/m_machine.c
+@@ -680,7 +680,8 @@ static Bool VG_(parse_cpuinfo)(void)
+    const char *search_Broadcom_str = "cpu model\t\t: Broadcom";
+    const char *search_Cavium_str= "cpu model\t\t: Cavium";
+    const char *search_Ingenic_str= "cpu model\t\t: Ingenic";
+-   const char *search_Loongson_str= "cpu model\t\t: ICT Loongson";
++   const char *search_Ict_Loongson_str= "cpu model\t\t: ICT Loongson";
++   const char *search_Loongson_str= "cpu model\t\t: Loongson";
+    const char *search_MIPS_str = "cpu model\t\t: MIPS";
+    const char *search_Netlogic_str = "cpu model\t\t: Netlogic";
+ 
+@@ -734,7 +735,7 @@ static Bool VG_(parse_cpuinfo)(void)
+        vai.hwcaps = VEX_PRID_COMP_MIPS;
+    else if (VG_(strstr)(file_buf, search_Ingenic_str) != NULL)
+        vai.hwcaps = VEX_PRID_COMP_INGENIC_E1;
+-   else if (VG_(strstr)(file_buf, search_Loongson_str) != NULL)
++   else if (VG_(strstr)(file_buf, search_Ict_Loongson_str) != NULL || VG_(strstr)(file_buf, search_Loongson_str) != NULL)
+        vai.hwcaps = (VEX_PRID_COMP_LEGACY | VEX_PRID_IMP_LOONGSON_64);
+    else {
+        /* Did not find string in the proc file. */
+-- 
+2.47.1.windows.1
+

--- a/app-devel/valgrind/spec
+++ b/app-devel/valgrind/spec
@@ -1,4 +1,4 @@
-VER=3.22.0
+VER=3.24.0
 SRCS="tbl::https://sourceware.org/pub/valgrind/valgrind-$VER.tar.bz2"
-CHKSUMS="sha256::c811db5add2c5f729944caf47c4e7a65dcaabb9461e472b578765dd7bf6d2d4c"
+CHKSUMS="sha256::71aee202bdef1ae73898ccf7e9c315134fa7db6c246063afc503aef702ec03bd"
 CHKUPDATE="anitya::id=13639"


### PR DESCRIPTION
Topic Description
-----------------

- valgrind: update to 3.24.0
    - Add patch to detect Loongson CPU model names without ICT.
    - Track patches at https://github.com/AOSC-Tracking/valgrind @ aosc/VALGRIND_3_24_0, current HEAD is a56d5d333376551e65eacf0866cac3bef9d3eaed.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- valgrind: 3.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit valgrind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
