### PR TITLE
scrcpy: update to 3.1

### DIFF
--- a/app-devices/scrcpy/spec
+++ b/app-devices/scrcpy/spec
@@ -1,7 +1,7 @@
-VER=3.0
+VER=3.1
 SRCS="git::commit=tags/v$VER::https://github.com/Genymobile/scrcpy \
       file::rename=scrcpy-server::https://github.com/Genymobile/scrcpy/releases/download/v$VER/scrcpy-server-v$VER"
 CHKSUMS="SKIP \
-         sha256::800044c62a94d5fc16f5ab9c86d45b1050eae3eb436514d1b0d2fe2646b894ea"
+         sha256::958f0944a62f23b1f33a16e9eb14844c1a04b882ca175a738c16d23cb22b86c0"
 SUBDIR="scrcpy"
 CHKUPDATE="anitya::id=226924"


### PR DESCRIPTION
Topic Description
-----------------

- scrcpy: update to 3.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- scrcpy: 3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit scrcpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
