### PR TITLE
stunnel: update to 5.73

### DIFF
--- a/app-network/stunnel/spec
+++ b/app-network/stunnel/spec
@@ -1,5 +1,4 @@
-VER=5.56
+VER=5.73
 SRCS="tbl::https://ftp.osuosl.org/pub/blfs/conglomeration/stunnel/stunnel-$VER.tar.gz"
-CHKSUMS="sha256::7384bfb356b9a89ddfee70b5ca494d187605bb516b4fff597e167f97e2236b22"
-REL=2
+CHKSUMS="sha256::bc917c3bcd943a4d632360c067977a31e85e385f5f4845f69749bce88183cb38"
 CHKUPDATE="anitya::id=4901"


### PR DESCRIPTION
Topic Description
-----------------

- stunnel: update to 5.73
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- stunnel: 5.73

Security Update?
----------------

No

Build Order
-----------

```
#buildit stunnel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
