### PR TITLE
Rework postrm for multi-version packages

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -15,7 +15,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm $LLVM_SUFFIX || true
+    update-alternatives --remove-all llvm || true
 fi
 EOF
 

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=1
+REL=2
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -15,7 +15,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm $LLVM_SUFFIX || true
+    update-alternatives --remove-all llvm || true
 fi
 EOF
 

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,4 +1,5 @@
 VER=19.1.5
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::bd8445f554aae33d50d3212a15e993a667c0ad1b694ac1977f3463db3338e542"

--- a/lang-js/nodejs-20/autobuild/beyond
+++ b/lang-js/nodejs-20/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node$NODE_SUFFIX || true
+    update-alternatives --remove-all node || true
 fi
 EOF
 

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,4 +1,5 @@
 VER=20.18.1
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::91df43f8ab6c3f7be81522d73313dbdd5634bbca228ef0e6d9369fe0ab8cccd0"
 CHKUPDATE="anitya::id=369796"

--- a/lang-js/nodejs-22/autobuild/beyond
+++ b/lang-js/nodejs-22/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node$NODE_SUFFIX || true
+    update-alternatives --remove-all node || true
 fi
 EOF
 

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.12.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::fe1bc4be004dc12721ea2cb671b08a21de01c6976960ef8a1248798589679e16"
 CHKUPDATE="anitya::id=374342"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: drop unused _SUFFIX in postrm
    This should fix errors whilst attempting to remove multi-version packages.
- nodejs-20: drop unused _SUFFIX in postrm
    This should fix errors whilst attempting to remove multi-version packages.
- llvm-19: drop unused _SUFFIX in postrm
    This should fix errors whilst attempting to remove multi-version packages.
- llvm-18: drop unused _SUFFIX in postrm
    This should fix errors whilst attempting to remove multi-version packages.

Package(s) Affected
-------------------

- llvm-18: 18.1.8-2
- llvm-19: 19.1.5-1
- llvm-runtime-18: 18.1.8-2
- llvm-runtime-19: 19.1.5-1
- nodejs-20: 20.18.1-1
- nodejs-22: 22.12.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-20 nodejs-22 llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
