### PR TITLE
forgejo: update to 9.0.3

### DIFF
--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,4 +1,4 @@
-VER=9.0.0
+VER=9.0.3
 # Note: copy-repo required by auto version detection
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- forgejo: update to 9.0.3
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- forgejo: 9.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
