### PR TITLE
llvm-18, llvm-19: rework to fix lldb

### DIFF
--- a/app-devel/llvm-18/01-runtime/build
+++ b/app-devel/llvm-18/01-runtime/build
@@ -39,7 +39,7 @@ cmake "$SRCDIR" \
     -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
     -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
     -DCMAKE_SKIP_RPATH=NO \
-    -DCMAKE_SKIP_INSTALL_RPATH=YES
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
 
 # FIXME: LLVM builds break with Ninja due to an unidentified race condition.
 # Fallback to GNU Make for now.

--- a/app-devel/llvm-18/01-runtime/build.stage2
+++ b/app-devel/llvm-18/01-runtime/build.stage2
@@ -15,9 +15,9 @@ cmake "$SRCDIR" \
     -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
     -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
     -DCMAKE_SKIP_RPATH=NO \
-    -DCMAKE_SKIP_INSTALL_RPATH=YES
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
 
-# FIXME: LLVM builds break with Ninja due to an unidentified race condition.    
+# FIXME: LLVM builds break with Ninja due to an unidentified race condition.
 # Fallback to GNU Make for now.
 #
 # Ref: https://github.com/llvm/llvm-project/issues/87553

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=2
+REL=3
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/01-runtime/build
+++ b/app-devel/llvm-19/01-runtime/build
@@ -39,7 +39,7 @@ cmake "$SRCDIR" \
     -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
     -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
     -DCMAKE_SKIP_RPATH=NO \
-    -DCMAKE_SKIP_INSTALL_RPATH=YES
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
 
 # FIXME: LLVM builds break with Ninja due to an unidentified race condition.
 # Fallback to GNU Make for now.

--- a/app-devel/llvm-19/01-runtime/build.stage2
+++ b/app-devel/llvm-19/01-runtime/build.stage2
@@ -15,7 +15,7 @@ cmake "$SRCDIR" \
     -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
     -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
     -DCMAKE_SKIP_RPATH=NO \
-    -DCMAKE_SKIP_INSTALL_RPATH=YES
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
 
 # FIXME: LLVM builds break with Ninja due to an unidentified race condition.    
 # Fallback to GNU Make for now.

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,4 +1,5 @@
 VER=19.1.6
+REL=1
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-18: enable install RPATH
    This will allow pre-installed tools (lldb, etc.) to work again.
- llvm-19: enable install RPATH
    This will allow pre-installed tools (lldb, etc.) to work again.

Package(s) Affected
-------------------

- llvm-18: 18.1.8-3
- llvm-19: 19.1.6-1
- llvm-runtime-18: 18.1.8-3
- llvm-runtime-19: 19.1.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
