### PR TITLE
ciel: update to 3.5.2

### DIFF
--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.5.1
+VER=3.5.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: update to 3.5.2

Package(s) Affected
-------------------

- ciel: 3.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
