### PR TITLE
geant4: NOLTO on loongson3

### DIFF
--- a/app-scientific/geant4/autobuild/defines
+++ b/app-scientific/geant4/autobuild/defines
@@ -20,3 +20,6 @@ CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
              -DGEANT4_USE_PYTHON=ON \
              -DGEANT4_INSTALL_DATA=ON \
              -DGEANT4_INSTALL_DATASETS_TENDL=ON"
+
+# FIXME: ABI change for returning aggregates with empty bases in GCC 12.1
+NOLTO__LOONGSON3=1

--- a/app-scientific/geant4/spec
+++ b/app-scientific/geant4/spec
@@ -1,4 +1,5 @@
 VER=11.3.0
+REL=1
 SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
 CHKSUMS="sha256::1da4318b3f96f87f4d47558a32dab269b8f3fc956708038c28e72a180b0efba6"
 CHKUPDATE="anitya::id=375805"


### PR DESCRIPTION
Topic Description
-----------------

- geant4: NOLTO on loongson3

Package(s) Affected
-------------------

- geant4: 11.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit geant4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
