### PR TITLE
autobuild4: update to 4.6.4

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.6.3
+VER=4.6.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.6.4
    This release fixes an issue where `-march=la64v1.0' may be specified for
    compilers that do not support this flag (GCC < 14, Clang < 19).

Package(s) Affected
-------------------

- autobuild4: 4.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
