### PR TITLE
ruby: update to 3.3.6

### DIFF
--- a/lang-ruby/ruby/spec
+++ b/lang-ruby/ruby/spec
@@ -1,5 +1,6 @@
-VER=3.2.2
+VER=3.3.6
 REL=1
 SRCS="tbl::https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.xz"
-CHKSUMS="sha256::4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23"
+CHKSUMS="sha256::540975969d1af42190d26ff629bc93b1c3f4bffff4ab253e245e125085e66266
+"
 CHKUPDATE="anitya::id=4223"


### PR DESCRIPTION
Topic Description
-----------------

- ruby: update to 3.3.6


Package(s) Affected
-------------------

- ruby: 3.36

Security Update?
----------------

No

Build Order
-----------

```
#buildit stunnel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`


