### PR TITLE
metasploit: new, 6.4.40

### DIFF
--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# 设置 Ruby 的 GEM 默认目录
+GEMDIR=$(ruby -e 'puts Gem.default_dir')
+
+# 设置 Bundler 配置
+abinfo "设置 Bundler 配置..."
+sed -e '/BUNDLED WITH/,+1d' -i Gemfile.lock
+
+# 对 Nokogiri 使用系统库
+bundle config build.nokogiri --use-system-libraries
+# 启用部署模式
+bundle config set --local deployment 'true'
+# 禁用缓存
+bundle config set --local no-cache 'true'
+# 设置 Bundler 路径为目标安装路径
+bundle config set path "$PKGDIR$GEMDIR"
+
+# 修改 gemspec 以支持 find 替代 git ls-files
+sed 's|git ls-files|find -type f|' -i metasploit-framework.gemspec
+
+# 安装依赖
+abinfo "正在使用 Bundler 安装依赖..."
+bundle install -j"$(nproc)" --no-cache
+
+# 调整文件权限
+abinfo "调整文件权限..."
+find "$PKGDIR$GEMDIR" -exec chmod o+r '{}' \;
+
+# 创建可执行文件脚本
+abinfo "创建可执行文件脚本..."
+for script in msfconsole msfvenom msfrpc msfrpcd msfd; do
+  # 如果目标目录不存在，创建它
+  mkdir -p "$PKGDIR/usr/bin"
+
+  # 创建脚本
+  script_path="$PKGDIR/usr/bin/$script"
+  echo -e "#!/bin/bash\nBUNDLE_GEMFILE=$PKGDIR/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$script \"\$@\"" > "$script_path"
+  chmod 755 "$script_path"
+done
+
+# 处理 tools 脚本
+abinfo "设置工具脚本..."
+
+tools_dir="$PKGDIR/opt/metasploit/"
+
+# 创建目标目录
+mkdir -p "$tools_dir"
+
+# 使用 rsync 复制文件并排除 $PKGDIR
+rsync -a --exclude="$PKGDIR" "$SRCDIR/" "$tools_dir"
+
+
+abinfo "脚本执行完成。"

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -20,7 +20,8 @@ abinfo "正在使用 Bundler 安装依赖..."
 bundle install -j"$(nproc)" --no-cache
 
 abinfo "调整文件权限..."
-chmod -R 777 "$PKGDIR" 
+chmod -R 777 "$PKGDIR"
+chmod -R 777 "$SRCDIR"
 
 
 abinfo "创建可执行文件脚本..."
@@ -31,7 +32,7 @@ for script in msfconsole msfvenom msfrpc msfrpcd msfd; do
 
   script_path="$PKGDIR/usr/bin/$script"
   echo -e "#!/bin/bash\nBUNDLE_GEMFILE=/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$script \"\$@\"" > "$script_path"
-  chmod 777 "$script_path"
+  chmod 777 "$PKGDIR"
 done
 
 

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -1,54 +1,51 @@
 #!/bin/bash
 
-# 设置 Ruby 的 GEM 默认目录
+
 GEMDIR=$(ruby -e 'puts Gem.default_dir')
 
-# 设置 Bundler 配置
+
 abinfo "设置 Bundler 配置..."
 sed -e '/BUNDLED WITH/,+1d' -i Gemfile.lock
 
-# 对 Nokogiri 使用系统库
+
 bundle config build.nokogiri --use-system-libraries
-# 启用部署模式
 bundle config set --local deployment 'true'
-# 禁用缓存
 bundle config set --local no-cache 'true'
-# 设置 Bundler 路径为目标安装路径
 bundle config set path "$PKGDIR$GEMDIR"
 
-# 修改 gemspec 以支持 find 替代 git ls-files
+
 sed 's|git ls-files|find -type f|' -i metasploit-framework.gemspec
 
-# 安装依赖
 abinfo "正在使用 Bundler 安装依赖..."
 bundle install -j"$(nproc)" --no-cache
 
-# 调整文件权限
+abinfo "调整文件权限..."
+
+chmod -R 775 $SRCDIR/*
+
+
 abinfo "调整文件权限..."
 find "$PKGDIR$GEMDIR" -exec chmod o+r '{}' \;
 
-# 创建可执行文件脚本
+
 abinfo "创建可执行文件脚本..."
 for script in msfconsole msfvenom msfrpc msfrpcd msfd; do
-  # 如果目标目录不存在，创建它
+
   mkdir -p "$PKGDIR/usr/bin"
 
-  # 创建脚本
+
   script_path="$PKGDIR/usr/bin/$script"
-  echo -e "#!/bin/bash\nBUNDLE_GEMFILE=$PKGDIR/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$script \"\$@\"" > "$script_path"
+  echo -e "#!/bin/bash\nBUNDLE_GEMFILE=/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$script \"\$@\"" > "$script_path"
   chmod 755 "$script_path"
 done
 
-# 处理 tools 脚本
+
 abinfo "设置工具脚本..."
 
 tools_dir="$PKGDIR/opt/metasploit/"
 
-# 创建目标目录
+
 mkdir -p "$tools_dir"
 
-# 使用 rsync 复制文件并排除 $PKGDIR
+
 rsync -a --exclude="$PKGDIR" "$SRCDIR/" "$tools_dir"
-
-
-abinfo "脚本执行完成。"

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -21,9 +21,6 @@ bundle install -j"$(nproc)" --no-cache
 
 abinfo "调整文件权限..."
 
-chmod -R 775 $PKGDIR/*
-
-
 abinfo "调整文件权限..."
 find "$PKGDIR$GEMDIR" -exec chmod o+r '{}' \;
 
@@ -49,3 +46,5 @@ mkdir -p "$tools_dir"
 
 
 rsync -a --exclude="$PKGDIR" "$SRCDIR/" "$tools_dir"
+
+chmod -R 775 $PKGDIR/*

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -20,7 +20,7 @@ abinfo "正在使用 Bundler 安装依赖..."
 bundle install -j"$(nproc)" --no-cache
 
 abinfo "调整文件权限..."
-chmod -R 777 "PKGDIR" 
+chmod -R 777 "$PKGDIR" 
 
 
 abinfo "创建可执行文件脚本..."

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -20,9 +20,7 @@ abinfo "正在使用 Bundler 安装依赖..."
 bundle install -j"$(nproc)" --no-cache
 
 abinfo "调整文件权限..."
-
-abinfo "调整文件权限..."
-find "$PKGDIR$GEMDIR" -exec chmod o+r '{}' \;
+chmod -R 777 "PKGDIR" 
 
 
 abinfo "创建可执行文件脚本..."
@@ -33,7 +31,7 @@ for script in msfconsole msfvenom msfrpc msfrpcd msfd; do
 
   script_path="$PKGDIR/usr/bin/$script"
   echo -e "#!/bin/bash\nBUNDLE_GEMFILE=/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$script \"\$@\"" > "$script_path"
-  chmod 755 "$script_path"
+  chmod 777 "$script_path"
 done
 
 
@@ -46,5 +44,3 @@ mkdir -p "$tools_dir"
 
 
 rsync -a --exclude="$PKGDIR" "$SRCDIR/" "$tools_dir"
-
-chmod -R 775 $PKGDIR/*

--- a/app-utils/metasploit/autobuild/build
+++ b/app-utils/metasploit/autobuild/build
@@ -21,7 +21,7 @@ bundle install -j"$(nproc)" --no-cache
 
 abinfo "调整文件权限..."
 
-chmod -R 775 $SRCDIR/*
+chmod -R 775 $PKGDIR/*
 
 
 abinfo "调整文件权限..."

--- a/app-utils/metasploit/autobuild/defines
+++ b/app-utils/metasploit/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=metasploit
+PKGDES="Advanced open-source platform for developing, testing, and using exploit code"
+PKGSEC=utils
+PKGDEP="ruby ruby-bundler libpcap postgresql sqlite libxslt libxml2 inetutils git"
+
+ABSTRIP=0
+ABSPLITDBG=0

--- a/app-utils/metasploit/spec
+++ b/app-utils/metasploit/spec
@@ -1,0 +1,4 @@
+VER=6.4.40
+SRCS="git::commit=tags/$VER::https://github.com/rapid7/metasploit-framework.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=190993"


### PR DESCRIPTION
Topic Description
-----------------

metasploit: new, 6.4.40

Package(s) Affected
-------------------


Security Update?
----------------

No

Build Order
-----------

```
#buildit metasploit
```


Test Build(s) Done
------------------

**Primary Architectures**



- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`


**Secondary Architectures**



Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`


