### PR TITLE
librsvg: update to 2.59.2

### DIFF
--- a/runtime-imaging/librsvg/autobuild/beyond
+++ b/runtime-imaging/librsvg/autobuild/beyond
@@ -1,4 +1,4 @@
 # Ensure than programs depending on GTK 3 is not shipped.
 if [ -e "$PKGDIR"/usr/bin/rsvg-view-3 ]; then
-	rm "$PKGDIR"/usr/bin/rsvg-view-3
+    rm -v "$PKGDIR"/usr/bin/rsvg-view-3
 fi

--- a/runtime-imaging/librsvg/autobuild/defines
+++ b/runtime-imaging/librsvg/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=librsvg
 PKGDES="SVG rendering and manipulation library"
 PKGSEC=libs
-PKGDEP="libcroco pango gdk-pixbuf"
-BUILDDEP="gobject-introspection gtk-doc intltool vala vim rustc llvm gi-docgen docutils"
-BUILDDEP__RETRO="llvm rustc"
+PKGDEP="cairo pango gdk-pixbuf dav1d glib freetype libxml2"
+BUILDDEP="gobject-introspection vala rustc llvm gi-docgen docutils cargo-c"
+BUILDDEP__RETRO="llvm rustc cargo-c"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
@@ -13,22 +13,13 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--enable-vala"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-vala \
-                 --disable-introspection"
+MESON_AFTER="-Dvala=enabled -Ddocs=enabled"
+MESON_AFTER__RETRO="-Dvala=disabled \
+		    -Dintrospection=disabled
+                    -Ddocs=disabled"
 ABSHADOW=0
-RECONF=0
-
 USECLANG=1
-USECLANG__LOONGSON3=0
-USECLANG__RISCV64=0
-USECLANG__MIPS64R6EL=0
-NOLTO__LOONGSON3=1
-NOLTO__RISCV64=1
-NOLTO__MIPS64R6EL=1
-ABSPLITDBG=0
 
-# FIXME: ld.lld not yet available for loongarch64.
-NOLTO__LOONGARCH64=1
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local
+# symbol; recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/runtime-imaging/librsvg/autobuild/prepare
+++ b/runtime-imaging/librsvg/autobuild/prepare
@@ -1,11 +1,12 @@
-if [[ "${CROSS:-$ARCH}" != "loongson3" && "${CROSS:-$ARCH}" != "riscv64" && "${CROSS:-$ARCH} != "mips64r6el" ]]; then
+if ! ab_match_arch loongson3 && ! ab_match_arch riscv64; then
     abinfo "Adjusting flags for Rust LLVM LTO ..."
     export CFLAGS="${CFLAGS} -fuse-ld=lld"
     export LDFLAGS="${LDFLAGS} -ldl"
 fi
+
 # FIXME: multiple lse.o is contained in the LLVM compiler_builtins-aarch64.a
 # libtool will bug out when this happens
-if [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
+if ab_match_arch arm64; then
     BUILD_READY() {
         abinfo "Hacking libtool to workaround a libtool bug ..."
         sed -i 's/| sort -uc//' libtool

--- a/runtime-imaging/librsvg/spec
+++ b/runtime-imaging/librsvg/spec
@@ -1,4 +1,4 @@
-VER=2.56.1
+VER=2.59.2
 SRCS="tbl::https://download.gnome.org/sources/librsvg/${VER:0:4}/librsvg-$VER.tar.xz"
-CHKSUMS="sha256::1685aeacae9a441dcb12c0c3ec63706172a2f52705dafbefb8e7311d4d5e430b"
+CHKSUMS="sha256::ecd293fb0cc338c170171bbc7bcfbea6725d041c95f31385dc935409933e4597"
 CHKUPDATE="anitya::id=5420"


### PR DESCRIPTION
Topic Description
-----------------

- librsvg: update to 2.59.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- librsvg: 2.59.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit librsvg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
