### PR TITLE
mihomo-party: fix

### DIFF
--- a/app-network/mihomo-party/autobuild/build
+++ b/app-network/mihomo-party/autobuild/build
@@ -1,19 +1,8 @@
 abinfo "Fetching dependencies and prepare ..."
 pnpm install
-if ab_match_arch amd64; then
-    pnpm add @mihomo-party/sysproxy-linux-x64-gnu
-    pnpm prepare --x64
-elif ab_match_arch arm64; then
-    pnpm add @mihomo-party/sysproxy-linux-arm64-gnu
-    pnpm prepare --arm64
-fi
 
 abinfo "Building Mihomo-Party ..."
-if ab_match_arch amd64; then
-    pnpm build:linux --x64 --dir
-elif ab_match_arch arm64; then
-    pnpm build:linux --arm64 --dir
-fi
+pnpm build:linux --dir
 
 
 abinfo "Installing Mihomo Party ..."

--- a/app-network/mihomo-party/autobuild/build
+++ b/app-network/mihomo-party/autobuild/build
@@ -1,6 +1,4 @@
 abinfo "Fetching dependencies and prepare ..."
-# Resolve the need for manual validation in automation scripts
-export CI=true  
 pnpm install
 if ab_match_arch amd64; then
     pnpm add @mihomo-party/sysproxy-linux-x64-gnu

--- a/app-network/mihomo-party/autobuild/defines
+++ b/app-network/mihomo-party/autobuild/defines
@@ -4,7 +4,5 @@ PKGDEP="gtk-3 mihomo nss libsecret libnotify xdg-utils at-spi2-core"
 BUILDDEP="nodejs"
 PKGDES="Graphical interface for managing Mihomo subscriptions, profiles, and settings"
 
-PKGPROV="mihomo-party"
-
-# mihomo-party/sysproxy not supported on loongson3, riscv64, loongarch64.
+# electron only supported on amd64, arm64.
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
+++ b/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
@@ -1,7 +1,7 @@
 From 3b3150e66b1e813aac5d1f1051aeda302d1b4a56 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 24 Nov 2024 17:58:46 +0800
-Subject: [PATCH 1/2] Keep old productName on linux
+Subject: [PATCH 1/6] Keep old productName on linux
 
 ---
  electron-builder.yml | 2 +-
@@ -19,5 +19,5 @@ index e8d6002..f252e76 100644
    buildResources: build
  files:
 -- 
-2.47.0
+2.47.1
 

--- a/app-network/mihomo-party/autobuild/patches/0002-Remove-check-update-UI.patch
+++ b/app-network/mihomo-party/autobuild/patches/0002-Remove-check-update-UI.patch
@@ -1,7 +1,7 @@
 From 14c8061df0c089241d9ecb0f71823d204f0d91f4 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 24 Nov 2024 17:50:25 +0800
-Subject: [PATCH 2/2] Remove check update UI
+Subject: [PATCH 2/6] Remove check update UI
 
 ---
  src/main/utils/template.ts                    |  2 +-
@@ -95,5 +95,5 @@ index c595074..f74e4c9 100644
            <Switch
              size="sm"
 -- 
-2.47.0
+2.47.1
 

--- a/app-network/mihomo-party/autobuild/patches/0003-Drop-clash-meta-alpha-support.patch
+++ b/app-network/mihomo-party/autobuild/patches/0003-Drop-clash-meta-alpha-support.patch
@@ -1,0 +1,34 @@
+From 3d99502cbe440786627f104a76443adc73fe4d8b Mon Sep 17 00:00:00 2001
+From: miwu04 <mail@alanlin.icu>
+Date: Tue, 17 Dec 2024 00:01:33 +0800
+Subject: [PATCH 3/6] Drop clash-meta-alpha support
+
+---
+ src/renderer/src/pages/mihomo.tsx | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/renderer/src/pages/mihomo.tsx b/src/renderer/src/pages/mihomo.tsx
+index 9f24eaa..d4d1d5b 100644
+--- a/src/renderer/src/pages/mihomo.tsx
++++ b/src/renderer/src/pages/mihomo.tsx
+@@ -19,8 +19,7 @@ import InterfaceModal from '@renderer/components/mihomo/interface-modal'
+ import { MdDeleteForever } from 'react-icons/md'
+ 
+ const CoreMap = {
+-  mihomo: '稳定版',
+-  'mihomo-alpha': '预览版'
++  mihomo: '稳定版'
+ }
+ 
+ const Mihomo: React.FC = () => {
+@@ -127,7 +126,6 @@ const Mihomo: React.FC = () => {
+               }}
+             >
+               <SelectItem key="mihomo">{CoreMap['mihomo']}</SelectItem>
+-              <SelectItem key="mihomo-alpha">{CoreMap['mihomo-alpha']}</SelectItem>
+             </Select>
+           </SettingItem>
+           <SettingItem title="混合端口" divider>
+-- 
+2.47.1
+

--- a/app-network/mihomo-party/autobuild/patches/0004-Remove-upgrade-mihomo-UI.patch
+++ b/app-network/mihomo-party/autobuild/patches/0004-Remove-upgrade-mihomo-UI.patch
@@ -1,0 +1,56 @@
+From a358491aa6a6455c8d2a6cb9339dc7a1a6f4c62b Mon Sep 17 00:00:00 2001
+From: miwu04 <mail@alanlin.icu>
+Date: Tue, 17 Dec 2024 00:04:04 +0800
+Subject: [PATCH 4/6] Remove upgrade mihomo UI
+
+---
+ src/renderer/src/pages/mihomo.tsx | 33 -------------------------------
+ 1 file changed, 33 deletions(-)
+
+diff --git a/src/renderer/src/pages/mihomo.tsx b/src/renderer/src/pages/mihomo.tsx
+index d4d1d5b..02b05d0 100644
+--- a/src/renderer/src/pages/mihomo.tsx
++++ b/src/renderer/src/pages/mihomo.tsx
+@@ -74,39 +74,6 @@ const Mihomo: React.FC = () => {
+         <SettingCard>
+           <SettingItem
+             title="内核版本"
+-            actions={
+-              <Button
+-                size="sm"
+-                isIconOnly
+-                title="升级内核"
+-                variant="light"
+-                isLoading={upgrading}
+-                onPress={async () => {
+-                  try {
+-                    setUpgrading(true)
+-                    await mihomoUpgrade()
+-                    setTimeout(() => {
+-                      PubSub.publish('mihomo-core-changed')
+-                    }, 2000)
+-                    if (platform !== 'win32') {
+-                      new Notification('内核权限丢失', {
+-                        body: '内核升级成功，若要使用虚拟网卡（Tun），请到虚拟网卡页面重新手动授权内核'
+-                      })
+-                    }
+-                  } catch (e) {
+-                    if (typeof e === 'string' && e.includes('already using latest version')) {
+-                      new Notification('已经是最新版本')
+-                    } else {
+-                      alert(e)
+-                    }
+-                  } finally {
+-                    setUpgrading(false)
+-                  }
+-                }}
+-              >
+-                <IoMdCloudDownload className="text-lg" />
+-              </Button>
+-            }
+             divider
+           >
+             <Select
+-- 
+2.47.1
+

--- a/app-network/mihomo-party/autobuild/patches/0005-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
+++ b/app-network/mihomo-party/autobuild/patches/0005-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
@@ -1,0 +1,34 @@
+From fc1abf809fc2a50ea6262f567954dd9abd1a21d4 Mon Sep 17 00:00:00 2001
+From: miwu04 <mail@alanlin.icu>
+Date: Tue, 17 Dec 2024 00:10:02 +0800
+Subject: [PATCH 5/6] Do not fetch Mihomo (Clash Meta) binaries We use a system
+ copy for this purpose.
+
+---
+ scripts/prepare.mjs | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/scripts/prepare.mjs b/scripts/prepare.mjs
+index fec61a9..56862c6 100644
+--- a/scripts/prepare.mjs
++++ b/scripts/prepare.mjs
+@@ -345,16 +345,6 @@ const resolveFont = async () => {
+ }
+ 
+ const tasks = [
+-  {
+-    name: 'mihomo-alpha',
+-    func: () => getLatestAlphaVersion().then(() => resolveSidecar(MihomoAlpha())),
+-    retry: 5
+-  },
+-  {
+-    name: 'mihomo',
+-    func: () => getLatestReleaseVersion().then(() => resolveSidecar(mihomo())),
+-    retry: 5
+-  },
+   { name: 'mmdb', func: resolveMmdb, retry: 5 },
+   { name: 'metadb', func: resolveMetadb, retry: 5 },
+   { name: 'geosite', func: resolveGeosite, retry: 5 },
+-- 
+2.47.1
+

--- a/app-network/mihomo-party/autobuild/patches/0006-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
+++ b/app-network/mihomo-party/autobuild/patches/0006-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
@@ -1,0 +1,26 @@
+From 44875d2bc54dcb4225a22f4ff17a7482570e223c Mon Sep 17 00:00:00 2001
+From: miwu04 <mail@alanlin.icu>
+Date: Tue, 17 Dec 2024 00:54:50 +0800
+Subject: [PATCH 6/6] Do not find Mihomo(Clash Meta) binary in sidecar dir
+
+---
+ src/main/utils/dirs.ts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/main/utils/dirs.ts b/src/main/utils/dirs.ts
+index 0ea3566..8ba99d4 100644
+--- a/src/main/utils/dirs.ts
++++ b/src/main/utils/dirs.ts
+@@ -58,7 +58,8 @@ export function themesDir(): string {
+ }
+ 
+ export function mihomoCoreDir(): string {
+-  return path.join(resourcesDir(), 'sidecar')
++  const isLinux = process.platform === 'linux'
++  return isLinux ? '/usr/bin' : path.join(resourcesDir(), 'sidecar')
+ }
+ 
+ export function mihomoCorePath(core: string): string {
+-- 
+2.47.1
+

--- a/app-network/mihomo-party/autobuild/prepare
+++ b/app-network/mihomo-party/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Prevent Corepack from showing the URL ..."
-export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-network/mihomo-party/autobuild/prepare
+++ b/app-network/mihomo-party/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Prevent Corepack from showing the URL ..."
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/app-network/mihomo-party/spec
+++ b/app-network/mihomo-party/spec
@@ -3,5 +3,3 @@ REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mihomo-party-org/mihomo-party.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375292"
-ENVREQ__ARM64="total_mem_per_core=3"
-ENVREQ__AMD64="total_mem_per_core=3"

--- a/app-network/mihomo-party/spec
+++ b/app-network/mihomo-party/spec
@@ -1,4 +1,5 @@
 VER=1.5.12
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mihomo-party-org/mihomo-party.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375292"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo-party: optimize redundant code
- Remove pnpm add mihomo-party/sysproxy-linux-{arch}-gnu as it is optional.
- Remove pnpm prepare as it's redundant with pnpm install.
- No need to manage the distribution of automatic construction equipment.
- mihomo-party: remove Mihomo upgrade interface and use system Mihomo
- Remove UI entry to upgrade Mihomo.
- Use system mihomo executable instead of the bundled copy.
- Drop support for mihomo-alpha as we do not ship it.
- mihomo-party: fix build script

Package(s) Affected
-------------------

- mihomo-party: 1.5.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo-party
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
