### PR TITLE
FTBFS fixing survey 20241216

### DIFF
--- a/app-network/krb5/autobuild/prepare
+++ b/app-network/krb5/autobuild/prepare
@@ -1,3 +1,4 @@
+abinfo "Adding extra build flags ..."
 export CFLAGS="${CFLAGS} -fno-strict-aliasing"
 export CPPFLAGS="${CPPFLAGS} -I/usr/include/et"
 
@@ -5,3 +6,6 @@ export CPPFLAGS+=" -D_REENTRANT=1"
 export CFLAGS+=" -D_REENTRANT=1"
 export CXXFLAGS+=" -D_REENTRANT=1"
 export LDFLAGS+=" -D_REENTRANT=1"
+
+abinfo "Overriding krb5_cv_attr_constructor_destructor ..."
+export krb5_cv_attr_constructor_destructor=yes,yes

--- a/app-network/krb5/spec
+++ b/app-network/krb5/spec
@@ -1,5 +1,5 @@
 VER=1.17.1
-REL=8
+REL=9
 SRCS="tbl::https://web.mit.edu/kerberos/dist/krb5/${VER%.*}/krb5-$VER.tar.gz"
 CHKSUMS="sha256::3706d7ec2eaa773e0e32d3a87bf742ebaecae7d064e190443a3acddfd8afb181"
 CHKUPDATE="anitya::id=13287"

--- a/runtime-common/libffi/autobuild/defines
+++ b/runtime-common/libffi/autobuild/defines
@@ -5,7 +5,6 @@ PKGSEC=libs
 
 AUTOTOOLS_AFTER="--enable-pax_emutramp \
                  --enable-static"
-ABSHADOW=0
 
 NOSTATIC=0
 NOSTATIC__RETRO=1

--- a/runtime-common/libffi/autobuild/patches/0001-BACKPORT-MIPS-add-.note.GNU-stack-section-to-assembly-sources.patch
+++ b/runtime-common/libffi/autobuild/patches/0001-BACKPORT-MIPS-add-.note.GNU-stack-section-to-assembly-sources.patch
@@ -1,0 +1,46 @@
+From f515eac04cf8e5f594d5d9dee5fb7dfc3a186a4c Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 13 Dec 2024 18:36:02 +0800
+Subject: [PATCH] MIPS: add .note.GNU-stack section to assembly sources (#872)
+
+To build ELF shared libraries that do not require executable stack on
+MIPS, every object file linked should have a .note.GNU-stack section,
+otherwise the linker defaults to executable stack.
+
+As libffi shouldn't require executable stack, add the .note.GNU-stack
+section to the assembly source files under src/mips, like other
+architectures.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/mips/n32.S | 4 ++++
+ src/mips/o32.S | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/src/mips/n32.S b/src/mips/n32.S
+index df58e80..08cbb95 100644
+--- a/src/mips/n32.S
++++ b/src/mips/n32.S
+@@ -821,3 +821,7 @@ cls_epilogue:
+ #endif /* __GNUC__ */	
+ 	
+ #endif
++
++#if defined __ELF__ && defined __linux__
++	.section .note.GNU-stack,"",%progbits
++#endif
+diff --git a/src/mips/o32.S b/src/mips/o32.S
+index 78517be..03ceed5 100644
+--- a/src/mips/o32.S
++++ b/src/mips/o32.S
+@@ -559,3 +559,7 @@ $LASFDE2:
+ $LEFDE2:
+ 
+ #endif
++
++#if defined __ELF__ && defined __linux__
++	.section .note.GNU-stack,"",%progbits
++#endif
+-- 
+2.47.1
+

--- a/runtime-common/libffi/spec
+++ b/runtime-common/libffi/spec
@@ -1,4 +1,4 @@
-VER=3.4.4
-SRCS="tbl::https://github.com/libffi/libffi/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::828639972716ed18833df7b659b32060591fe0eb625a8d34078920d33c2dc867"
+VER=3.4.6
+SRCS="tbl::https://github.com/libffi/libffi/releases/download/v${VER}/libffi-${VER}.tar.gz"
+CHKSUMS="sha256::b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
 CHKUPDATE="anitya::id=1611"

--- a/runtime-display/libxau/autobuild/defines
+++ b/runtime-display/libxau/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libxau
 PKGDEP="glibc x11-proto"
 PKGSEC=x11
 PKGDES="X11 Authorization Library"
+
+ABTYPE=autotools

--- a/runtime-display/libxau/autobuild/prepare
+++ b/runtime-display/libxau/autobuild/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-display/libxau/spec
+++ b/runtime-display/libxau/spec
@@ -1,4 +1,4 @@
-VER=1.0.11
+VER=1.0.12
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/lib/libXau-$VER.tar.xz"
-CHKSUMS="sha256::f3fa3282f5570c3f6bd620244438dbfbdd580fc80f02f549587a0f8ab329bbeb"
+CHKSUMS="sha256::74d0e4dfa3d39ad8939e99bda37f5967aba528211076828464d2777d477fc0fb"
 CHKUPDATE="anitya::id=1765"

--- a/runtime-display/libxcb/autobuild/defines
+++ b/runtime-display/libxcb/autobuild/defines
@@ -5,15 +5,6 @@ PKGSEC=x11
 PKGDES="XCB library"
 AUTOTOOLS_AFTER="--enable-xinput \
                  --enable-xkb \
-                 PYTHON=/usr/bin/python3" 
+                 PYTHON=/usr/bin/python3"
 
-# FIXME: Spiral does not handle sonames with multiple dashes correctly.
-PKGPROV="libxcb-composite0_spiral libxcb-damage0_spiral libxcb-dbe0_spiral \
-         libxcb-dpms0_spiral libxcb-dri2-0_spiral libxcb-dri3-0_spiral \
-         libxcb-glx0_spiral libxcb-present0_spiral libxcb-randr0_spiral \
-         libxcb-record0_spiral libxcb-render0_spiral libxcb-res0_spiral \
-         libxcb-screensaver0_spiral libxcb-shape0_spiral libxcb-shm0_spiral \
-         libxcb1_spiral libxcb-sync1_spiral libxcb-xf86dri0_spiral \
-         libxcb-xfixes0_spiral libxcb-xinerama0_spiral libxcb-xinput0_spiral \
-         libxcb-xkb1_spiral libxcb-xtest0_spiral libxcb-xvmc0_spiral \
-         libxcb-xv0_spiral"
+ABTYPE=autotools

--- a/runtime-display/libxcb/autobuild/prepare
+++ b/runtime-display/libxcb/autobuild/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-display/libxcb/spec
+++ b/runtime-display/libxcb/spec
@@ -1,4 +1,4 @@
-VER=1.16.1
+VER=1.17.0
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/lib/libxcb-$VER.tar.gz"
-CHKSUMS="sha256::830c58758d814213e338fd1bb454be3787a7ef2aff9b9e4b721d9adef2662536"
+CHKSUMS="sha256::2c69287424c9e2128cb47ffe92171e10417041ec2963bceafb65cb3fcf8f0b85"
 CHKUPDATE="anitya::id=1767"

--- a/runtime-display/libxdmcp/autobuild/defines
+++ b/runtime-display/libxdmcp/autobuild/defines
@@ -3,3 +3,5 @@ PKGDES="The X Display Manager Control Protocol Library"
 PKGSEC=x11
 PKGDEP="glibc libbsd"
 BUILDDEP="x11-proto"
+
+ABTYPE=autotools

--- a/runtime-display/libxdmcp/autobuild/prepare
+++ b/runtime-display/libxdmcp/autobuild/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-display/libxdmcp/spec
+++ b/runtime-display/libxdmcp/spec
@@ -1,4 +1,5 @@
 VER=1.1.5
+REL=1
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/lib/libXdmcp-$VER.tar.xz"
 CHKSUMS="sha256::d8a5222828c3adab70adf69a5583f1d32eb5ece04304f7f8392b6a353aa2228c"
 CHKUPDATE="anitya::id=1772"

--- a/runtime-display/xcb-proto/spec
+++ b/runtime-display/xcb-proto/spec
@@ -1,4 +1,4 @@
-VER=1.16.0
+VER=1.17.0
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-$VER.tar.gz"
-CHKSUMS="sha256::d9c7f010b1105fc3858bf07b5169b2dd8e7493c6652b1fe45f3321d874f291d7"
+CHKSUMS="sha256::392d3c9690f8c8202a68fdb89c16fd55159ab8d65000a6da213f4a1576e97a16"
 CHKUPDATE="anitya::id=13646"

--- a/runtime-scientific/fftw/autobuild/prepare
+++ b/runtime-scientific/fftw/autobuild/prepare
@@ -8,6 +8,6 @@ for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
     # FIXME: hard-coded automake version.
     # Adapted from redhat-rpm-config.
     # https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_192
-        cp -v "/usr/share/automake-1.16/$(basename "$i")" "$i" \
+        cp -v "/usr/bin/$(basename "$i")" "$i" \
             || abdie "Failed to copy replacement $i: $?."; \
 done

--- a/runtime-scientific/fftw/spec
+++ b/runtime-scientific/fftw/spec
@@ -1,4 +1,5 @@
 VER=3.3.10
+REL=1
 SRCS="tbl::http://www.fftw.org/fftw-${VER/+/-}.tar.gz"
 CHKSUMS="sha256::56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
 CHKUPDATE="anitya::id=803"


### PR DESCRIPTION
Topic Description
-----------------

- krb5: fix FTBFS because of GCC 14
    GCC 14 defaults to -Werror=implicit-function-declaration, which breaks
    the detection of krb5_cv_attr_constructor_destructor in configure
    script (which uses unlink() w/o including unistd.h).
    As these compiler attributes are known to be properly working on GCC +
    Linux, override the result to "yes,yes" to prevent the broken detection.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- libxcb: update to 1.17.0
    - Dropped manual replacement of config.*, which leads to build failure
    because of hardcoding path to /usr/share/automake-1.16 . ABTYPE is
    explicitly set to autotools to ensure Autobuild replacing config.* .
    - Dropped manual PKGPROV for Spiral because the issue that preventing it
    from being generated automatically is already fixed.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- xcb-proto: update to 1.17.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- libxdmcp: fix FTBFS because of hardcoding /usr/share/automake-1.16
    - Manually config.* replacement is dropped and ABTYPE is set explicitly
    to autotools to ensure the automatic config.* scripts replacement by
    autobuild.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- libxau: update to 1.0.12
    - Dropped manual replacement of config.* scripts (which do not work now
    because of hardcoded automake version) and explicitly set ABTYPE to
    autotools.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- fftw: fix FTBFS because of hardcoding /usr/share/automake-1.16
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- libffi: update to 3.4.6
    - Switched tarball from the GitHub-generated one to the
    manually-uploaded one in GitHub Releases.
    - Backported a patch to fix executable stack on MIPS.
    - Drop ABSHADOW to fix FTBFS (newest libffi will try to do a broken
    shadow build when we don't do it).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- fftw: 3.3.10-1
- krb5: 1.17.1-9
- libffi: 3.4.6
- libxau: 1.0.12
- libxcb: 1.17.0
- libxdmcp: 1.1.5-1
- xcb-proto: 1:1.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libffi fftw libxau libxdmcp xcb-proto libxcb krb5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
