### PR TITLE
 fcitx5-pinyin-moegirl: update to 20241211

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20241109
+VER=20241211
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::560d4ac7fee6d603442407b76e1c68228817b0d57c234358ca11adf52bea7cce \
-         sha256::067a6fee2a933d13674a267a669cdc4172d991b15b6749d0830d9df88c9364e4 \
+CHKSUMS="sha256::c89610ff31c51f67538e464c1f868cd54e910cd1a58e097c881dc4ab953063d4 \
+         sha256::9806b6b1e22a07312023032891f53797203f1b0c03541be35dac778b697eaa6f \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20241211

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20241211
- rime-pinyin-moegirl: 20241211

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
