### PR TITLE
geoclue: drop, orphaned

### DIFF
--- a/runtime-desktop/qt-6/autobuild/defines
+++ b/runtime-desktop/qt-6/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=qt-6
 PKGSEC=x11
 PKGDES="Qt version 6"
 PKGDEP="alsa-lib bluez cups dbus desktop-file-utils double-conversion ffmpeg \
-        fontconfig geoclue glib gst-plugins-base-1-0 harfbuzz \
+        fontconfig geoclue2 glib gst-plugins-base-1-0 harfbuzz \
         hicolor-icon-theme hyphen icu lcms2 libb2 libdrm libevent libinput \
         libglvnd libjpeg-turbo libmng libpng libproxy libvpx libwebp \
         libxkbcommon libxml2 libxslt mesa minizip opus pciutils pcre2 perl \
@@ -20,7 +20,7 @@ BUILDDEP__PPC64EL="${BUILDDEP__NOWEBENGINE}"
 BUILDDEP__RISCV64="${BUILDDEP__NOWEBENGINE}"
 
 PKGDEP__NOWEBENGINE="alsa-lib bluez cups dbus desktop-file-utils
-        double-conversion fontconfig geoclue gst-plugins-base-1-0 glib \
+        double-conversion fontconfig geoclue2 gst-plugins-base-1-0 glib \
         harfbuzz hicolor-icon-theme hyphen icu libb2 libdrm libinput \
         libglvnd libjpeg-turbo libmng libpng libproxy libxkbcommon libxslt \
         mesa pcre2 perl protobuf pulseaudio re2 snappy sqlite srtp systemd \
@@ -95,7 +95,8 @@ CMAKE_AFTER__MIPS64R6EL="${CMAKE_AFTER__NOWEBENGINE}"
 # FIXME: qtquick3dphysics' PhysX bindings is not supported on loongarch64, ppc*, riscv64.
 CMAKE_AFTER__LOONGARCH64=" \
                       ${CMAKE_AFTER} \
-                      -DBUILD_qtquick3dphysics=OFF"
+                      -DBUILD_qtquick3dphysics=OFF \
+                      -DQT_FEATURE_webengine_jumbo_build=OFF"
 CMAKE_AFTER__PPC64EL="${CMAKE_AFTER__NOWEBENGINE} \
                       -DBUILD_qtquick3dphysics=OFF"
 CMAKE_AFTER__RISCV64="${CMAKE_AFTER__NOWEBENGINE} \

--- a/runtime-desktop/qt-6/autobuild/patches/0013-Gentoo-qtwebengine-chroimum-fix-build-without-jumbo.patch
+++ b/runtime-desktop/qt-6/autobuild/patches/0013-Gentoo-qtwebengine-chroimum-fix-build-without-jumbo.patch
@@ -1,0 +1,17 @@
+Patch status: limbo, but should be fixed when GLX code is removed again
+
+chromium has removed some GLX code which Qt has temporarily(?)
+restored in [1]. This however seems to misses some headers and
+only works with some configurations and fails with others[2].
+So add the headers here as a quick fix for now.
+
+[1] https://github.com/qt/qtwebengine-chromium/commit/f2b407a61bea122d18a012f0049ba193725f0461
+[2] https://bugs.gentoo.org/928508
+--- a/qtwebengine/src/3rdparty/chromium/ui/gl/gl_context.h
++++ b/qtwebengine/src/3rdparty/chromium/ui/gl/gl_context.h
+@@ -24,4 +24,5 @@
+ #include "ui/gl/gl_workarounds.h"
+ #include "ui/gl/gpu_preference.h"
++#include "ui/gl/gl_surface.h"
+ 
+ namespace gl {

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,4 +1,5 @@
 VER=6.7.3
+REL=1
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::a3f1d257cbb14c6536585ffccf7c203ce7017418e1a0c2ed7c316c20c729c801"
 CHKUPDATE="anitya::id=7927"

--- a/runtime-gis/geoclue/autobuild/beyond
+++ b/runtime-gis/geoclue/autobuild/beyond
@@ -1,1 +1,0 @@
-rm -rfv "$PKGDIR"/usr/share/gtk-doc

--- a/runtime-gis/geoclue/autobuild/defines
+++ b/runtime-gis/geoclue/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=geoclue
-PKGDES="A modular geoinformation service built on top of the D-Bus messaging system"
-PKGDEP="dbus-glib dconf libxslt libsoup"
-BUILDDEP="gtk-doc"
-PKGSEC=libs
-
-AUTOTOOLS_AFTER="--enable-gpsd=no --disable-gtk-doc"
-ABSHADOW=0

--- a/runtime-gis/geoclue/autobuild/prepare
+++ b/runtime-gis/geoclue/autobuild/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-gis/geoclue/spec
+++ b/runtime-gis/geoclue/spec
@@ -1,5 +1,0 @@
-VER=0.12.99
-REL=3
-SRCS="tbl::https://freedesktop.org/~hadess/geoclue-$VER.tar.gz"
-CHKSUMS="sha256::fe396c91cb52de4219281f4d9223156338fc03670d34700281e86d1399b80a72"
-CHKUPDATE="anitya::id=229511"


### PR DESCRIPTION
Topic Description
-----------------

- geoclue: drop, orphaned
    As no package uses the legacy geoclue now, drop it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- qt-6: modify the geoclue dependency to geoclue2
    What QtPositioning uses is really GeoClue2 instead of legacy GeoClue.
    In addition, this dependency may be reduced to recommendation because
    the QtPositioning GeoClue2 plugin communicates with GeoClue2 via D-Bus
    instead of linking to it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- qt-6: 6.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
