### PR TITLE
nuclei: new, 3.3.7

### DIFF
--- a/app-utils/nuclei/autobuild/build
+++ b/app-utils/nuclei/autobuild/build
@@ -4,4 +4,4 @@ go build -v -o "nuclei" "$SRCDIR"/cmd/nuclei
 abinfo "Installing nuclei ..."
 install -Dvm755 "$SRCDIR"/nuclei -t "$PKGDIR"/usr/bin
 install -Dvm644 "$SRCDIR"/README*.md "$SRCDIR"/LICENSE.md \
-    -t "$PKGDIR"/usr/share/doc/nuclei/
+	-t "$PKGDIR"/usr/share/doc/nuclei/

--- a/app-utils/nuclei/autobuild/build
+++ b/app-utils/nuclei/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building nuclei ..."
+go build -v -o "nuclei" "$SRCDIR"/cmd/nuclei
+
+abinfo "Installing nuclei ..."
+install -Dvm755 "$SRCDIR"/nuclei -t "$PKGDIR"/usr/bin
+install -Dvm644 "$SRCDIR"/README*.md -t "$PKGDIR"/usr/share/doc/nuclei
+install -Dvm644 "$SRCDIR"/LICENSE.md "$PKGDIR"/usr/share/doc/nuclei/LINCENSE.md

--- a/app-utils/nuclei/autobuild/build
+++ b/app-utils/nuclei/autobuild/build
@@ -3,5 +3,5 @@ go build -v -o "nuclei" "$SRCDIR"/cmd/nuclei
 
 abinfo "Installing nuclei ..."
 install -Dvm755 "$SRCDIR"/nuclei -t "$PKGDIR"/usr/bin
-install -Dvm644 "$SRCDIR"/README*.md -t "$PKGDIR"/usr/share/doc/nuclei
-install -Dvm644 "$SRCDIR"/LICENSE.md "$PKGDIR"/usr/share/doc/nuclei/LINCENSE.md
+install -Dvm644 "$SRCDIR"/README*.md "$SRCDIR"/LICENSE.md \
+    -t "$PKGDIR"/usr/share/doc/nuclei/

--- a/app-utils/nuclei/autobuild/defines
+++ b/app-utils/nuclei/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=nuclei
+PKGDES="template-based vulnerability scanner"
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="go"
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.\
+ABSPLITDBG=0

--- a/app-utils/nuclei/autobuild/defines
+++ b/app-utils/nuclei/autobuild/defines
@@ -3,5 +3,6 @@ PKGDES="template-based vulnerability scanner"
 PKGSEC=utils
 PKGDEP="glibc"
 BUILDDEP="go"
-# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.\
+
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0

--- a/app-utils/nuclei/spec
+++ b/app-utils/nuclei/spec
@@ -1,0 +1,4 @@
+VER=3.3.7
+SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/nuclei.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=106029"


### PR DESCRIPTION
Topic Description
-----------------

nuclei: new, 3.3.7

Package(s) Affected
-------------------
- nuclei 3.3.7

Security Update?
----------------

No 

Build Order
-----------

```
#buildit nuclei
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`