### PR TITLE
qt-5: rebuild for Spiral markers

### DIFF
--- a/runtime-desktop/qt-5/01-runtime/defines
+++ b/runtime-desktop/qt-5/01-runtime/defines
@@ -45,4 +45,5 @@ PKGREP="qtvirtualkeyboard<=5.11.2 qtchooser<=1:64 qt-5-doc<=1:5.12.2+wk5.212.0 q
 # Note: Extra Provides for Spiral (Debian compatibility).
 PKGPROV="libqt5sql5-mysql_spiral libqt5sql5-odbc_spiral \
          libqt5sql5-psql_spiral libqt5sql5-sqlite_spiral libqt5core5a_spiral \
-         qt5-image-formats-plugins_spiral"
+         qt5-image-formats-plugins_spiral qml-module-qtquick2_spiral \
+         qml-module-qtquick-window2_spiral qml-module-qtquick-controls_spiral"

--- a/runtime-desktop/qt-5/01-runtime/patches/0022-Fedora-QtWebKit-Fix-build-with-GCC-14.patch
+++ b/runtime-desktop/qt-5/01-runtime/patches/0022-Fedora-QtWebKit-Fix-build-with-GCC-14.patch
@@ -1,0 +1,15 @@
+diff --git a/qtwebkit/Source/WebCore/page/csp/ContentSecurityPolicy.cpp b/qtwebkit/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+index 9e726d5..4876f0f 100644
+--- a/qtwebkit/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
++++ b/qtwebkit/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+@@ -231,8 +231,9 @@ bool isAllowedByAllWithHashFromContent(const CSPDirectiveListVector& policies, c
+         auto cryptoDigest = CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
+         cryptoDigest->addBytes(contentCString.data(), contentCString.length());
+         Vector<uint8_t> digest = cryptoDigest->computeHash();
++        ContentSecurityPolicyHash hash = std::make_pair(algorithm, digest);
+         for (auto& policy : policies) {
+-            if ((policy.get()->*allowed)(std::make_pair(algorithm, digest)))
++            if ((policy.get()->*allowed)(hash))
+                 return true;
+         }
+     }

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=5.15.13
 VER=${UPSTREAM_VER}+webengine5.15.16+webkit5.212.0+kde20240408
-REL=8
+REL=9
 SRCS="https://repo.aosc.io/aosc-repacks/qt-5-$VER.tar.xz"
 CHKSUMS="sha256::48b528491c345c32760a0554c1f99c9c3fbd5bc8d8200bf1b28f008d3c3e600a"
 SUBDIR="qt-${VER:0:1}"


### PR DESCRIPTION
Topic Description
-----------------

- qt-5: rebuild for Spiral markers

Package(s) Affected
-------------------

- qt-5: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-9
- qt-5-doc: 1:5.15.13+webengine5.15.16+webkit5.212.0+kde20240408-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
