### PR TITLE
git: update to 2.48.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,11 +1,12 @@
-VER=2.47.1
-REL=1
+VER=2.48.0
+
 # Use this for stable releases.
-SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
+#REL=1
+#SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-#RC=1
-#SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
+RC=0
+SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::f4c4e98667800585d218dfdf415eb72f73baa7abcac4569e2ce497970f8d6665"
+CHKSUMS="sha256::38125be2af1a4be145c1b6b08dfaa3167c09206e8554b80ea74dd635e297bea9"
 CHKUPDATE="anitya::id=5350"

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -5,8 +5,8 @@ VER=2.48.0
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-RC=1
+RC=2
 SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::be6df7354fc6ced1c0d05ecf44273000e137bd9710c9a5f165fd50eb2f571d82"
+CHKSUMS="sha256::770fe0f6215404087e24725c3ce483a10217649f8a4583bbdf26a6f92a7b5e15"
 CHKUPDATE="anitya::id=5350"

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -2,11 +2,12 @@ VER=2.48.0
 
 # Use this for stable releases.
 #REL=1
-#SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
+SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-RC=2
-SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
+#RC=2
+#REL=0.${RC}
+#SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::770fe0f6215404087e24725c3ce483a10217649f8a4583bbdf26a6f92a7b5e15"
+CHKSUMS="sha256::430c94c0927a6fe5a2b57072060db545e2b151944e00180694cf301c9eb0a859"
 CHKUPDATE="anitya::id=5350"

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -5,8 +5,8 @@ VER=2.48.0
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
-RC=0
+RC=1
 SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::38125be2af1a4be145c1b6b08dfaa3167c09206e8554b80ea74dd635e297bea9"
+CHKSUMS="sha256::be6df7354fc6ced1c0d05ecf44273000e137bd9710c9a5f165fd50eb2f571d82"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.48.0
- git: update to 2.48.0-rc2
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
- git: update to 2.48.0-rc1
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
- git: update to 2.48.0-rc0
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- git: 2.48.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
