### PR TITLE
tesseract: update to 5.5.0

### DIFF
--- a/app-i18n/crow-translate/spec
+++ b/app-i18n/crow-translate/spec
@@ -1,5 +1,5 @@
 VER=2.11.1
-REL=2
+REL=3
 SRCS="tbl::https://github.com/crow-translate/crow-translate/releases/download/$VER/crow-translate-${VER}-source.tar.gz"
 CHKSUMS="sha256::74591a350892594946b36b198d981826a0756326a1a7991b942fccb7971ec95d"
 CHKUPDATE="anitya::id=232133"

--- a/app-utils/tesseract/autobuild/defines
+++ b/app-utils/tesseract/autobuild/defines
@@ -5,4 +5,4 @@ PKGDES="An OCR program"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON -DTESSDATA_PREFIX=/usr/share"
-PKGBREAK="crow-translate<=2.11.1 opencv<=4.7.0-2 skanpage<=22.08.5"
+PKGBREAK="crow-translate<=2.11.1-2 opencv<=4.9.0-4 skanpage<=23.08.5-2"

--- a/app-utils/tesseract/spec
+++ b/app-utils/tesseract/spec
@@ -1,4 +1,4 @@
-VER=5.4.1
+VER=5.5.0
 FASTVER=4.1.0
 SRCS="git::commit=tags/$VER::https://github.com/tesseract-ocr/tesseract \
       git::commit=tags/$FASTVER;rename=tessdata_fast::https://github.com/tesseract-ocr/tessdata_fast"
@@ -6,4 +6,3 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="tesseract"
 CHKUPDATE="anitya::id=4954"
-REL=2

--- a/desktop-kde/skanpage/spec
+++ b/desktop-kde/skanpage/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/skanpage-$VER.tar.xz"
 CHKSUMS="sha256::38e2300e1466c43bb531989c29d11221ebcaa2e3e8bb062a814c1f03270b72bb"
 CHKUPDATE="anitya::id=8763"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.9.0
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- tesseract: update to 5.5.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- tesseract: 5.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tesseract:-pkgbreak crow-translate opencv skanpage tesseract
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
