### PR TITLE
libpng: update to 1.6.44

### DIFF
--- a/runtime-imaging/libpng/spec
+++ b/runtime-imaging/libpng/spec
@@ -1,5 +1,4 @@
-VER=1.6.43
+VER=1.6.44
 SRCS="git::commit=tags/v$VER::https://github.com/pnggroup/libpng"
 CHKSUMS="SKIP"
-REL=1
 CHKUPDATE="anitya::id=1705"


### PR DESCRIPTION
Topic Description
-----------------

- libpng: update to 1.6.44
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libpng: 1.6.44

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
