### PR TITLE
jsoncpp: update to 1.9.6

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,5 @@
 VER=3.31.2
+REL=1
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
 CHKSUMS="sha256::42abb3f48f37dbd739cdfeb19d3712db0c5935ed5c2aef6c340f9ae9114238a2"
 CHKUPDATE="anitya::id=306"

--- a/app-games/minetest/spec
+++ b/app-games/minetest/spec
@@ -3,7 +3,7 @@ UPSTREAM_VER=5.7.0
 __GAMEVER="${UPSTREAM_VER}"
 __IRRLICHTVER=1.9.0mt10
 VER=${UPSTREAM_VER}+irrlicht${__IRRLICHTVER}
-REL=2
+REL=3
 SRCS="tbl::https://github.com/minetest/minetest/archive/${UPSTREAM_VER}.tar.gz \
       git::commit=tags/${UPSTREAM_VER};rename=minetest_game::https://github.com/minetest/minetest_game \
       git::commit=tags/${__IRRLICHTVER};rename=irrlichtmt::https://github.com/minetest/irrlicht"

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.3.0
-REL=2
+REL=3
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"

--- a/app-utils/polybar/spec
+++ b/app-utils/polybar/spec
@@ -1,4 +1,5 @@
 VER=3.7.1
+REL=1
 SRCS="https://github.com/polybar/polybar/releases/download/$VER/polybar-$VER.tar.gz"
 CHKSUMS="sha256::5de6ad385ba09dc453a4e5ec7054749a4882b5b21a62c17ae40bf7c90613ff0f"
 CHKUPDATE="anitya::id=231634"

--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,4 +1,5 @@
 VER=0.11.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"

--- a/runtime-common/jsoncpp/autobuild/defines
+++ b/runtime-common/jsoncpp/autobuild/defines
@@ -8,17 +8,8 @@ CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
              -DBUILD_STATIC_LIBS=ON \
              -DCMAKE_SKIP_RPATH=OFF \
              -DJSONCPP_WITH_TESTS=OFF"
-PKGBREAK="avogadrolibs<=1.90.0 cmake<=3.11.1 kopete<=17.08.3 pingus<=20180327-1"
-
-PKGBREAK="""
-cmake<=3.26.3
-freecad<=0.21.1-1
-minetest<=5.6.1
-pcl<=1.12.0-2
-polybar<=3.6.3
-stepmania<=1:5.0.12+git20210814
-vtk<=9.2.6-1
-"""
+PKGBREAK="cmake<=3.31.2 minetest<=5.7.0+irrlicht1.9.0mt10-2 \
+          polybar<=3.7.1 vtk<=9.3.0-2 waybar<=0.11.0"
 
 NOSTATIC=0
 NOSTATIC__RETRO=1

--- a/runtime-common/jsoncpp/spec
+++ b/runtime-common/jsoncpp/spec
@@ -1,4 +1,4 @@
-VER=1.9.5
-SRCS="tbl::https://github.com/open-source-parsers/jsoncpp/archive/$VER.tar.gz"
-CHKSUMS="sha256::f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2"
+VER=1.9.6
+SRCS="git::commit=tags/$VER::https://github.com/open-source-parsers/jsoncpp.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7483"


### PR DESCRIPTION
Topic Description
-----------------

- jsoncpp: update to 1.9.6
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- jsoncpp: 1.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit jsoncpp:-pkgbreak cmake minetest polybar vtk waybar jsoncpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
