### PR TITLE
intel-oneapi-basekit: update to 2025.0.1

### DIFF
--- a/app-devel/intel-oneapi-basekit/autobuild/defines
+++ b/app-devel/intel-oneapi-basekit/autobuild/defines
@@ -6,9 +6,3 @@ PKGDES="Intel oneAPI base toolkit"
 FAIL_ARCH="!(amd64)"
 ABSTRIP=0
 NOSTATIC=0
-
-# FIXME: currently an OpenMP GPU program compiled with "-g" flag will trigger a runtime error:
-# InvalidBuiltinSetName: Expects OpenCL12, OpenCL20. Actual is NonSemantic.Shader.DebugInfo.200 [Src: /var/cache/acbs/build/acbs.kjwza1v_/intel-graphics-compiler/IGC/AdaptorOCL/SPIRV/libSPIRV/SPIRVModule.cpp:565 SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet) ]
-# terminate called after throwing an instance of 'std::runtime_error'
-#   what():  internal compiler error
-# Aborted (core dumped)

--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2025.0.0
-PKG_URL=96aa5993-5b22-4a9b-91ab-da679f422594
-PKG_CODE=885
+VER=2025.0.1
+PKG_URL=dfc4a434-838c-4450-a6fe-2fa903b75aa7
+PKG_CODE=46
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha256::b379986e96a70d4d8c64b46eaecec73f14916ba39438ff167cb5f4f5fffc66de"
+CHKSUMS="sha384::8f315562c26104eea7790e1fba868d63562f0fd1888623f0f4a286a234ec799beefefe78ffa904bd71dc6b8fb479df79"
 CHKUPDATE="anitya::id=372585"


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.0.1

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
