### PR TITLE
dae: update to 0.9.0

### DIFF
--- a/app-network/dae/autobuild/defines
+++ b/app-network/dae/autobuild/defines
@@ -8,6 +8,5 @@ BUILDDEP="go llvm"
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0
 # Go module "github.com/sirupsen/logrus" does not support loongson3 and loongarch64
-# and build error on ppc64el and riscv64.
-# See: https://github.com/daeuniverse/dae/issues/696
-FAIL_ARCH="!(amd64|arm64)"
+# and build error on ppc64el.
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-network/dae/spec
+++ b/app-network/dae/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=0.9.0
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/daeuniverse/dae.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369479"


### PR DESCRIPTION
Topic Description
-----------------

- dae: update to 0.9.0

Package(s) Affected
-------------------

- dae: 0.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dae
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
