### PR TITLE
vscode: update to 1.96.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.96.0
+VER=1.96.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::fbc5026ea43b81e08f1526bd6a75629cad6dec6111049f967aa45a9e36737749"
-CHKSUMS__ARM64="sha256::bcf71f03263200f5973fbef4ecd22592f0d5f2c29300077408963b6a63478541"
+CHKSUMS__AMD64="sha256::80974294fb37f3ac49e2c1c847a0479db9de96bfd5fb75b05207f93f238b9634"
+CHKSUMS__ARM64="sha256::2fad93f48c58e2dca7d3faf4673fd715042ae30ccaa3f974a393098f3106eab5"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.96.1
    Co-authored-by: yidaduizuoye (@CAB233)

Package(s) Affected
-------------------

- vscode: 1.96.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
