### PR TITLE
vscode: update to 1.96.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.96.1
+VER=1.96.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::80974294fb37f3ac49e2c1c847a0479db9de96bfd5fb75b05207f93f238b9634"
-CHKSUMS__ARM64="sha256::2fad93f48c58e2dca7d3faf4673fd715042ae30ccaa3f974a393098f3106eab5"
+CHKSUMS__AMD64="sha256::ff58dfdb0e5674d8e42e1f3907be75a36587b1ca45e586ac06353e97869474e7"
+CHKSUMS__ARM64="sha256::4205d715b583d12841c11aa32fd4a1b0fa2d1fe472949ffd30ea04c71e3176cc"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.96.2
    Co-authored-by: Alan Lin (@miwu04) <mail@alanlin.icu>

Package(s) Affected
-------------------

- vscode: 1.96.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
