### PR TITLE
clpeak: update to 1.1.3

### DIFF
--- a/app-benchmarks/clpeak/autobuild/defines
+++ b/app-benchmarks/clpeak/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=clpeak
 PKGDES="Benchmark tool to measure theortical peak performance of OpenCL devices"
 PKGDEP="libcl"
+BUILDDEP="opencl-registry-api"
 PKGSEC="utils"
 
 ABTYPE=cmakeninja

--- a/app-benchmarks/clpeak/spec
+++ b/app-benchmarks/clpeak/spec
@@ -1,4 +1,4 @@
-VER=1.1.2
+VER=1.1.3
 SRCS="git::commit=tags/${VER}::https://github.com/krrishnarraj/clpeak.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15180"


### PR DESCRIPTION
Topic Description
-----------------

- clpeak: update to 1.1.3
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- clpeak: 1.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit clpeak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
