### PR TITLE
wayland-protocols: update to 1.39

### DIFF
--- a/app-devel/wayland-protocols/spec
+++ b/app-devel/wayland-protocols/spec
@@ -1,4 +1,4 @@
-VER=1.38
+VER=1.39
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland-protocols"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13997"


### PR DESCRIPTION
Topic Description
-----------------

- wayland-protocols: update to 1.39
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- wayland-protocols: 1.39

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland-protocols
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
