### PR TITLE
synaptic: update to 0.91.3

### DIFF
--- a/app-admin/synaptic/spec
+++ b/app-admin/synaptic/spec
@@ -1,4 +1,4 @@
-VER=0.90.2
+VER=0.91.3
 SRCS="https://deb.debian.org/debian/pool/main/s/synaptic/synaptic_$VER.tar.xz"
-CHKSUMS="sha256::9e88f69e3c7dd1aa024ea4e20dce683ac3697e19360c7663bc2ff54f7b657ea6"
+CHKSUMS="sha256::e2ed206d8d5af86417eafbeff349b99cde29b31008e21a6327f4a49a7951ed33"
 CHKUPDATE="anitya::id=16196"


### PR DESCRIPTION
Topic Description
-----------------

- synaptic: update to 0.91.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- synaptic: 0.91.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit synaptic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
