### PR TITLE
binutils: add two patches for LoongArch ld

### DIFF
--- a/app-devel/binutils/01-main/patches/0003-FROMLIST-LoongArch-Fix-broken-DESC-IE-transition-for.patch
+++ b/app-devel/binutils/01-main/patches/0003-FROMLIST-LoongArch-Fix-broken-DESC-IE-transition-for.patch
@@ -1,0 +1,102 @@
+From 08460fc56c7db0f7a341005bc33340c95df64b14 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 19 Dec 2024 13:23:02 +0800
+Subject: [PATCH 3/4] FROMLIST: LoongArch: Fix broken DESC => IE transition for
+ 2.43 branch
+
+If code compiled with -fPIC -mtls-dialect=desc is linked into a PDE or
+PIE, and the code refers to external DSO symbols, we can produce broken
+link unit as check_relocs expects DESC => IE transition to happen and
+emits a TLS IE entry in the GOT, but a too early "continue" in
+relax_section actually jumps over the DESC => IE transition so the code
+sequence is unchanged and still expecting a TLS descriptor (instead of
+an IE entry) in the GOT.
+
+The bug is already fixed in master branch by commit 5c3d09c1855b
+("LoongArch: Optimize the relaxation process") so this fix is only
+needed for the 2.43 branch.
+
+Reported-by: Icenowy Zheng <uwu@icenowy.me>
+Closes: https://gcc.gnu.org/PR118114
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ bfd/elfnn-loongarch.c | 43 ++++++++++++++++++++++---------------------
+ 1 file changed, 22 insertions(+), 21 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index e8180fc2071..3b149fe62e5 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -5316,7 +5316,7 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+     {
+       char symtype;
+       bfd_vma symval;
+-      asection *sym_sec;
++      asection *sym_sec = NULL;
+       bool local_got = false;
+       Elf_Internal_Rela *rel = relocs + i;
+       struct elf_link_hash_entry *h = NULL;
+@@ -5408,14 +5408,33 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	      symval = h->root.u.def.value;
+ 	      sym_sec = h->root.u.def.section;
+ 	    }
+-	  else
+-	    continue;
+ 
+ 	  if (h && LARCH_REF_LOCAL (info, h))
+ 	    local_got = true;
+ 	  symtype = h->type;
+ 	}
+ 
++      /* If the conditions for tls type transition are met, type
++	 transition is performed instead of relax.
++	 During the transition from DESC->IE/LE, there are 2 situations
++	 depending on the different configurations of the relax/norelax
++	 option.
++	 If the -relax option is used, the extra nops will be removed,
++	 and this transition is performed in pass 0.
++	 If the --no-relax option is used, nop will be retained, and
++	 this transition is performed in pass 1.  */
++      if (IS_LOONGARCH_TLS_TRANS_RELOC (r_type)
++	  && (i + 1 != sec->reloc_count)
++	  && ELFNN_R_TYPE (rel[1].r_info) == R_LARCH_RELAX
++	  && loongarch_can_trans_tls (abfd, info, h, r_symndx, r_type))
++	{
++	  loongarch_tls_perform_trans (abfd, sec, rel, h, info);
++	  r_type = ELFNN_R_TYPE (rel->r_info);
++	}
++
++      if (!sym_sec)
++	continue;
++
+       if (sym_sec->sec_info_type == SEC_INFO_TYPE_MERGE
+ 	   && (sym_sec->flags & SEC_MERGE))
+ 	{
+@@ -5443,24 +5462,6 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 
+       symval += sec_addr (sym_sec);
+ 
+-      /* If the conditions for tls type transition are met, type
+-	 transition is performed instead of relax.
+-	 During the transition from DESC->IE/LE, there are 2 situations
+-	 depending on the different configurations of the relax/norelax
+-	 option.
+-	 If the -relax option is used, the extra nops will be removed,
+-	 and this transition is performed in pass 0.
+-	 If the --no-relax option is used, nop will be retained, and
+-	 this transition is performed in pass 1.  */
+-      if (IS_LOONGARCH_TLS_TRANS_RELOC (r_type)
+-	  && (i + 1 != sec->reloc_count)
+-	  && ELFNN_R_TYPE (rel[1].r_info) == R_LARCH_RELAX
+-	  && loongarch_can_trans_tls (abfd, info, h, r_symndx, r_type))
+-	{
+-	  loongarch_tls_perform_trans (abfd, sec, rel, h, info);
+-	  r_type = ELFNN_R_TYPE (rel->r_info);
+-	}
+-
+       switch (r_type)
+ 	{
+ 	case R_LARCH_ALIGN:
+-- 
+2.47.1
+

--- a/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Add-elfNN_loongarch_mkobject-to-i.patch
+++ b/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Add-elfNN_loongarch_mkobject-to-i.patch
@@ -1,0 +1,44 @@
+From d3d8bd394bfdd8be15ced1f406a5231444801df1 Mon Sep 17 00:00:00 2001
+From: Xin Wang <yw987194828@gmail.com>
+Date: Fri, 6 Sep 2024 09:00:12 +0800
+Subject: [PATCH 4/4] BACKPORT: LoongArch: Add elfNN_loongarch_mkobject to
+ initialize LoongArch tdata
+
+LoongArch: Add elfNN_loongarch_mkobject to initialize LoongArch tdata.
+
+(cherry picked from commit 28489a70d4660d67e71d75e82286a6e1a7003b93)
+---
+ bfd/elfnn-loongarch.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index 3b149fe62e5..ea480d74695 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -84,6 +84,14 @@ struct _bfd_loongarch_elf_obj_tdata
+    && elf_tdata (bfd) != NULL						\
+    && elf_object_id (bfd) == LARCH_ELF_DATA)
+ 
++static bool
++elfNN_loongarch_object (bfd *abfd)
++{
++  return bfd_elf_allocate_object (abfd,
++				  sizeof (struct _bfd_loongarch_elf_obj_tdata),
++				  LARCH_ELF_DATA);
++}
++
+ struct relr_entry
+ {
+   asection *sec;
+@@ -6146,6 +6154,8 @@ elf_loongarch64_hash_symbol (struct elf_link_hash_entry *h)
+ #define bfd_elfNN_bfd_reloc_name_lookup loongarch_reloc_name_lookup
+ #define elf_info_to_howto_rel NULL /* Fall through to elf_info_to_howto.  */
+ #define elf_info_to_howto loongarch_info_to_howto_rela
++#define bfd_elfNN_mkobject						  \
++  elfNN_loongarch_object
+ #define bfd_elfNN_bfd_merge_private_bfd_data				  \
+   elfNN_loongarch_merge_private_bfd_data
+ 
+-- 
+2.47.1
+

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,4 +1,5 @@
 VER=2.43.1
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: add two patches for LoongArch ld
    The ld in 2.43 has some problems for the LoongArch part.
    Pick two patches, one from binutils-2_41-branch, another from mailing
    list, to fix some linking problems at least for Mesa.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- binutils: 2.43.1-1
- binutils+cross-amd64: 2.43.1-1
- binutils+cross-arm64: 2.43.1-1
- binutils+cross-loongarch64: 2.43.1-1
- binutils+cross-loongson3: 2.43.1-1
- binutils+cross-mips64r6el: 2.43.1-1
- binutils+cross-ppc64el: 2.43.1-1
- binutils+cross-riscv64: 2.43.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
