### PR TITLE
webkit2gtk: update to 2.46.5

### DIFF
--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=webkit2gtk
 PKGSEC=gnome
 PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 gtk-4 hyphen icu \
         libavif libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
-        openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy"
+        openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy sysprof"
 BUILDDEP="gi-docgen gobject-introspection gperf gtk-doc ruby unifdef vim"
 PKGDES="A WebKit rendering engine port for GTK"
 

--- a/runtime-web/webkit2gtk/autobuild/patches/0001-Enable-THREADS_PREFER_PTHREAD_FLAG.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0001-Enable-THREADS_PREFER_PTHREAD_FLAG.patch
@@ -1,4 +1,4 @@
-From cb0139175d8ea3c43cbb6c0f9752891f811c0405 Mon Sep 17 00:00:00 2001
+From 5054e33f49c0b2794f4930a1a9b6c2c95b1296c9 Mon Sep 17 00:00:00 2001
 From: Alberto Garcia <berto@igalia.com>
 Date: Thu, 23 May 2024 19:48:05 +0800
 Subject: [PATCH 1/2] Enable THREADS_PREFER_PTHREAD_FLAG
@@ -14,20 +14,20 @@ Origin: https://trac.webkit.org/changeset/231843
  2 files changed, 3 insertions(+)
 
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 781267de..13b00f8c 100644
+index 10fded8d..d88f6842 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
-@@ -13,6 +13,8 @@ endif ()
+@@ -7,6 +7,8 @@ SET_PROJECT_VERSION(2 46 5)
  
  set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
  
 +set(THREADS_PREFER_PTHREAD_FLAG ON)
 +
  find_package(Cairo 1.16.0 REQUIRED)
- find_package(Fontconfig 2.13.0 REQUIRED)
- find_package(Freetype 2.9.0 REQUIRED)
+ find_package(LibGcrypt 1.7.0 REQUIRED)
+ find_package(Libtasn1 REQUIRED)
 diff --git a/Source/cmake/OptionsJSCOnly.cmake b/Source/cmake/OptionsJSCOnly.cmake
-index 31e353de..7bed31f4 100644
+index b5b4f01f..810c2657 100644
 --- a/Source/cmake/OptionsJSCOnly.cmake
 +++ b/Source/cmake/OptionsJSCOnly.cmake
 @@ -1,3 +1,4 @@
@@ -36,5 +36,5 @@ index 31e353de..7bed31f4 100644
  
  if (MSVC)
 -- 
-2.45.1
+2.47.1
 

--- a/runtime-web/webkit2gtk/autobuild/patches/0002-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0002-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
@@ -1,4 +1,4 @@
-From f131f15361f90dd11248d980f7e1c148030765c2 Mon Sep 17 00:00:00 2001
+From 89b0067d8b11820ba0efc262c48c800ecc73821a Mon Sep 17 00:00:00 2001
 From: Alberto Garcia <berto@igalia.com>
 Date: Thu, 23 May 2024 19:48:44 +0800
 Subject: [PATCH 2/2] Description: Use WTF_CPU_UNKNOWN when building for
@@ -16,7 +16,7 @@ Bug: https://bugs.webkit.org/show_bug.cgi?id=271371
  2 files changed, 10 deletions(-)
 
 diff --git a/Source/WTF/wtf/PlatformCPU.h b/Source/WTF/wtf/PlatformCPU.h
-index 166262f8..5f7d2c89 100644
+index ca328a20..c88b16a2 100644
 --- a/Source/WTF/wtf/PlatformCPU.h
 +++ b/Source/WTF/wtf/PlatformCPU.h
 @@ -285,14 +285,6 @@
@@ -35,7 +35,7 @@ index 166262f8..5f7d2c89 100644
  #define WTF_CPU_UNKNOWN 1
  #endif
 diff --git a/Source/cmake/WebKitCommon.cmake b/Source/cmake/WebKitCommon.cmake
-index f20a8d06..108a001c 100644
+index 38ac0c47..9d7873e2 100644
 --- a/Source/cmake/WebKitCommon.cmake
 +++ b/Source/cmake/WebKitCommon.cmake
 @@ -125,8 +125,6 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
@@ -48,5 +48,5 @@ index f20a8d06..108a001c 100644
          set(WTF_CPU_LOONGARCH64 1)
      else ()
 -- 
-2.45.1
+2.47.1
 

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,7 +1,6 @@
-VER=2.44.2
+VER=2.46.5
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521b"
+CHKSUMS="sha256::bad4020bb0cfb3e740df3082c2d9cbf67cf4095596588a56aecdde6702137805"
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.46.5
    - Track patches at AOSC-Tracking/webkit2gtk @ aosc/v2.46.5
    (HEAD: 89b0067d8b11820ba0efc262c48c800ecc73821a).
    - Add sysprof dep.
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.46.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
