### PR TITLE
vscodium: update to 1.96.2

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -8,7 +8,13 @@ abinfo "Getting vscode repo ..."
 abinfo "Setting build var ..."
 export SKIP_LINUX_PACKAGES="True"
 export SHOULD_BUILD=yes
-export CI_BUILD=no
+
+if [[ "${CROSS:-$ARCH}" = "loongarch64" ]]; then
+  export CI_BUILD=yes
+else
+  export CI_BUILD=no
+fi
+
 export OS_NAME=linux
 export RELEASE_VERSION="$PKGVER"
 export DISABLE_UPDATE=yes

--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -17,6 +17,8 @@ if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
   export VSCODE_ARCH="x64"
 elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
   export VSCODE_ARCH="arm64"
+elif [[ "${CROSS:-$ARCH}" = "loongarch64" ]]; then
+  export VSCODE_ARCH="loong64"
 else
   aberr "Platform not supported" && exit 1
 fi

--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -25,6 +25,7 @@ elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
   export VSCODE_ARCH="arm64"
 elif [[ "${CROSS:-$ARCH}" = "loongarch64" ]]; then
   export VSCODE_ARCH="loong64"
+  abinfo "111"
 else
   aberr "Platform not supported" && exit 1
 fi

--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -5,5 +5,5 @@ PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf lib
 BUILDDEP="gcc make pkg-config jq nodejs"
 PKGPROV="codium"
 
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
 ABSPLITDBG=0

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.96.0.24347
+VER=1.96.2.24355
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.96.2
    - Try to build on loongarch64

Package(s) Affected
-------------------

- vscodium: 1.96.2.24355

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
