### PR TITLE
darktable: update to 5.0.0

### DIFF
--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -10,6 +10,7 @@ BUILDDEP="cmake gnome-doc-utils intltool po4a llvm sphinx doxygen"
 PKGDES="Utility to organize and develop raw images"
 
 CMAKE_AFTER=(
+	-DPROJECT_VERSION=$PKGVER
 	-DBINARY_PACKAGE_BUILD=ON
 	-DBUILD_BATTERY_INDICATOR=ON
 	-DBUILD_CURVE_TOOLS=ON

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,4 +1,4 @@
-VER=4.8.1
+VER=5.0.0
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: update to 5.0.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- darktable: 1:5.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
