### PR TITLE
git-cliff: update to 2.7.0

### DIFF
--- a/app-vcs/git-cliff/spec
+++ b/app-vcs/git-cliff/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.7.0
 SRCS="git::commit=tags/v$VER::https://github.com/orhun/git-cliff"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368021"


### PR DESCRIPTION
Topic Description
-----------------

- git-cliff: update to 2.7.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- git-cliff: 2.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-cliff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
