### PR TITLE
numactl: update to 2.0.19

### DIFF
--- a/app-admin/numactl/spec
+++ b/app-admin/numactl/spec
@@ -1,5 +1,4 @@
-VER=2.0.14
-REL=3
+VER=2.0.19
 SRCS="tbl::https://github.com/numactl/numactl/archive/v$VER.tar.gz"
-CHKSUMS="sha256::1ee27abd07ff6ba140aaf9bc6379b37825e54496e01d6f7343330cf1a4487035"
+CHKSUMS="sha256::8b84ffdebfa0d730fb2fc71bb7ec96bb2d38bf76fb67246fde416a68e04125e4"
 CHKUPDATE="anitya::id=2507"


### PR DESCRIPTION
Topic Description
-----------------

- numactl: update to 2.0.19
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- numactl: 2.0.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit numactl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
