### PR TITLE
rustc: update to 1.83.0

### DIFF
--- a/lang-rust/rustc/autobuild/defines
+++ b/lang-rust/rustc/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=rustc
 PKGEPOCH=1
 PKGSEC=devel
-PKGDEP="gcc-runtime llvm-runtime http-parser"
-BUILDDEP="cmake curl libffi llvm ninja rustc"
+PKGDEP="gcc-runtime llvm-runtime-19 http-parser"
+BUILDDEP="cmake curl libffi llvm-19 ninja rustc"
 PKGDES="General purpose, multi-paradigm programming language (compiler and runtime)"
 
 NOLTO=1

--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 1e21011f5612a2ae77e363217060513572b379f6 Mon Sep 17 00:00:00 2001
+From ba28fdb727b883690a37ebc1b23e42dbbc88255c Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 607eeac7cc..6278e69006 100644
+index 82e11a3afc..1c813d903b 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1542,6 +1542,7 @@ supported_targets! {
+@@ -1622,6 +1622,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -23,18 +23,18 @@ index 607eeac7cc..6278e69006 100644
      ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
 diff --git a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 new file mode 100644
-index 0000000000..a11fbecc3c
+index 0000000000..a57ef97626
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 @@ -0,0 +1,8 @@
 +use crate::spec::Target;
 +
-+pub fn target() -> Target {
++pub(crate) fn target() -> Target {
 +    let mut base = super::i686_unknown_linux_gnu::target();
 +    base.cpu = "i486".into();
 +    base.llvm_target = "i486-unknown-linux-gnu".into();
 +    base
 +}
 -- 
-2.46.0
+2.47.1
 

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,4 +1,4 @@
-From 9f944a0e2c7ee6a5fee1ff41c793291712a482bf Mon Sep 17 00:00:00 2001
+From ac98d84d26ce1305335275bb75bf3d55beed4870 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
 Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys
@@ -90,5 +90,5 @@ index e8fd86d03d..f3eb03ca3c 100644
  
  impl Default for ffi_cif {
 -- 
-2.46.0
+2.47.1
 

--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -35,6 +35,7 @@ abinfo "Generating config.toml ..."
 cat > "$SRCDIR"/config.toml <<EOF
 [llvm]
 link-shared = true
+download-ci-llvm = false
 ninja = true
 
 [build]
@@ -47,12 +48,39 @@ vendor = true
 print-step-timings = true
 EOF
 
-abinfo "Using system rustc for bootstrapping ..."
-cat >> "$SRCDIR"/config.toml << EOF
-cargo = "/usr/bin/cargo"
-rustc = "/usr/bin/rustc"
-rustfmt = "/usr/bin/rustfmt"
+# FIXME: Uncomment this if we have the last version built and ready.
+#
+#abinfo "Using system rustc for bootstrapping ..."
+#cat >> "$SRCDIR"/config.toml << EOF
+#cargo = "/usr/bin/cargo"
+#rustc = "/usr/bin/rustc"
+#rustfmt = "/usr/bin/rustfmt"
+#EOF
+
+# FIXME: Using local bootstrap tarball as we missed a release - rustc needs
+# to bootstrap from an adjacent release.
+if ab_match_arch loongson3; then
+    SRC_PARENT="$(realpath $SRCDIR/..)"
+
+    abinfo "Extracting bootstrapped Stage 1 Rust toolchain..."
+    bsdtar xf "$SRC_PARENT"/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}.tar.xz \
+        -C "$SRC_PARENT"
+
+    abinfo "Copying bootstrapped Stage 1 Rust toolchain ..."
+    cp -rv "$SRC_PARENT"/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH} \
+        /opt
+
+    if [ ! -e /opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustc ] ; then
+        abdie "Help! Stage 1 Rust toolchain does not exist in the desired directory."
+    fi
+
+    abinfo "Using local bootstrap binaries ..."
+    cat >> "$SRCDIR"/config.toml << EOF
+cargo = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/cargo"
+rustc = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustc"
+rustfmt = "/opt/rustc-bootstrap-${PKGVER}-${CROSS:-$ARCH}/bin/rustfmt"
 EOF
+fi
 
 if ab_match_arch i486; then
     cat >> "$SRCDIR"/config.toml << EOF
@@ -100,22 +128,22 @@ channel = "stable"
 rpath = false
 
 [target.${rust_target}]
-llvm-config = "/usr/bin/llvm-config"
+llvm-config = "/usr/lib/llvm-19/bin/llvm-config"
 EOF
 
 if ab_match_arch i486; then
     cat >> "$SRCDIR"/config.toml << EOF
 [target.i686-unknown-linux-gnu]
-llvm-config = "/usr/bin/llvm-config"
+llvm-config = "/usr/lib/llvm-19/bin/llvm-config"
 EOF
 fi
 
 if ab_match_arch armv7hf; then
     cat >> "$SRCDIR"/config.toml << EOF
 [target.thumbv7neon-unknown-linux-gnueabihf]
-llvm-config = "/usr/bin/llvm-config"
+llvm-config = "/usr/lib/llvm-19/bin/llvm-config"
 
 [target.armv7-unknown-linux-gnueabihf]
-llvm-config = "/usr/bin/llvm-config"
+llvm-config = "/usr/lib/llvm-19/bin/llvm-config"
 EOF
 fi

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,17 @@
-VER=1.81.0
-SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::36217ef7e32f40a180e3d79bd666b4dfdaed49dd381023a5fb765fd12d0092ce"
+VER=1.83.0
+
+# Note: Uncomment this if we have the last version built and ready.
+#SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
+#CHKSUMS="sha256::7b11d4242dab0921a7d54758ad3fe805153c979c144625fecde11735760f97df"
+
+# FIXME: Using local bootstrap tarball as we missed a release - rustc needs
+# to bootstrap from an adjacent release.
+#
+# Comment the following segment if this is not the case.
+SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz \
+      tbl::rename=rustc-bootstrap-${VER}-loongson3.tar.xz::https://repo.aosc.io/aosc-repacks/rust-loongson3/rustc-bootstrap-${VER}-loongson3.tar.xz"
+CHKSUMS="sha256::7b11d4242dab0921a7d54758ad3fe805153c979c144625fecde11735760f97df \
+         sha256::c8bad5abe44f459fd7983a66337543952fea756fcfa73ddd10a869c4c753c336"
+
 CHKUPDATE="anitya::id=7635"
+SUBDIR="rustc-${VER}-src"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.83.0
    - Track patches at AOSC-Tracking/rust @ aosc/v1.83.0
    (HEAD: 68757f859f724374107416d1c0b212ce9126aa71).
    - FIXME: Using local bootstrap tarball as we missed a release - rustc needs
    to bootstrap from an adjacent release.

Package(s) Affected
-------------------

- rustc: 1:1.83.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
