### PR TITLE
simh: fix strange executable paths

### DIFF
--- a/app-emulation/simh/autobuild/build
+++ b/app-emulation/simh/autobuild/build
@@ -8,7 +8,7 @@ make \
 abinfo "Installing SimH ..."
 for i in "$SRCDIR"/BIN/*; do
     install -Dvm755 $i \
-        "$PKGDIR/usr/bin/simh-$i"
+        "$PKGDIR/usr/bin/simh-$(basename "$i")"
 done
 
 abinfo "Installing VAX binaries ..."

--- a/app-emulation/simh/spec
+++ b/app-emulation/simh/spec
@@ -1,5 +1,5 @@
 VER=3.11+1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/simh/simh/archive/v${VER/+/-}.tar.gz"
 CHKSUMS="sha256::c8a2fc62bfa9369f75935950512a4cac204fd813ce6a9a222b2c6a76503befdb"
 CHKUPDATE="anitya::id=9653"


### PR DESCRIPTION
Topic Description
-----------------

- simh: fix wrong binary path
    The executables of SIMH is wrongly put to a strange position because of
    miswritten build script.
    Fix it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- simh: 3.11+1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit simh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
