### PR TITLE
vscodium: update to 1.96.2.24355

### DIFF
--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.96.0.24347
+VER=1.96.2.24355
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.96.2.24355
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- vscodium: 1.96.2.24355

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
