### PR TITLE
noto-fonts: fix some Qt program cannot display emoji


### DIFF
--- a/desktop-fonts/noto-fonts/01-noto/overrides/etc/fonts/conf.avail/66-google-noto-color-emoji.conf
+++ b/desktop-fonts/noto-fonts/01-noto/overrides/etc/fonts/conf.avail/66-google-noto-color-emoji.conf
@@ -1,17 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <alias>
-    <family>fantasy</family>
-    <prefer>
-      <family>Noto Color Emoji</family>
-    </prefer>
-  </alias>
-  <alias>
-    <family>Noto Color Emoji</family>
-    <default>
-      <family>fantasy</family>
-    </default>
-  </alias>
+  <match target="font">
+    <test name="family" qual="first">
+      <string>Noto Color Emoji</string>
+    </test>
+    <edit mode="assign" name="antialias">
+      <bool>false</bool>
+    </edit>
+  </match>
+  <match target="font">
+    <test name="family" qual="first">
+      <string>Noto Color Emoji</string>
+    </test>
+    <edit mode="assign" name="hinting">
+      <bool>true</bool>
+    </edit>
+  </match>
 </fontconfig>
-

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -5,7 +5,7 @@ EMOJI_VER=2.042
 CJKSANS_VER=2.004
 CJKSERIF_VER=2.003
 VER=${UPSTREAM_VER}+emoji${EMOJI_VER}+cjksans${CJKSANS_VER}+cjkserif${CJKSERIF_VER}
-REL=1
+REL=2
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: fix some Qt program cannot display emoji

Package(s) Affected
-------------------

- noto-cjk-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.003-2
- noto-fonts: 2:24.8.1+emoji2.042+cjksans2.004+cjkserif2.003-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
