### PR TITLE
dae: add support for loongarch64 and ppc64el

### DIFF
--- a/app-network/dae/autobuild/defines
+++ b/app-network/dae/autobuild/defines
@@ -7,6 +7,5 @@ BUILDDEP="go llvm"
 
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0
-# Go module "github.com/sirupsen/logrus" does not support loongson3 and loongarch64
-# and build error on ppc64el.
-FAIL_ARCH="!(amd64|arm64|riscv64)"
+# FIXME: Missing vmlinux.h file for loongson3
+FAIL_ARCH="loongson3"

--- a/app-network/dae/spec
+++ b/app-network/dae/spec
@@ -1,4 +1,6 @@
 VER=0.9.0
-SRCS="git::commit=v$VER;copy-repo=true::https://github.com/daeuniverse/dae.git"
-CHKSUMS="SKIP"
+REL=1
+SRCS="tbl::https://github.com/daeuniverse/dae/releases/download/v$VER/dae-full-src.zip"
+CHKSUMS="sha256::b631e2cc729f28410f5ccf584de18cf6a839c4a313d694df5e326377f6435ab1"
 CHKUPDATE="anitya::id=369479"
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- dae: add support for loongarch64 and ppc64el

Package(s) Affected
-------------------

- dae: 0.9.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dae
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
