### PR TITLE
fish: update to 4.0.0

### DIFF
--- a/app-shells/fish/autobuild/defines
+++ b/app-shells/fish/autobuild/defines
@@ -1,11 +1,21 @@
 PKGNAME=fish
 PKGSEC=shells
-PKGDEP="bc gcc-runtime inetutils ncurses which"
-BUILDDEP="sphinx"
+PKGDEP="bc gcc-runtime ncurses gettext coreutils findutils gawk python-3 \
+        groff pcre2"
+BUILDDEP="sphinx rustc llvm which"
 PKGDES="A smart and user-friendly shell intended mostly for interactive use"
 
-CMAKE_AFTER="-DBUILD_DOCS=True \
-             -DCMAKE_INSTALL_SYSCONFDIR=/etc"
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=ON'
+    '-DFISH_USE_SYSTEM_PCRE2=ON'
+    '-DWITH_GETTEXT=ON'
+    '-DCMAKE_INSTALL_SYSCONFDIR=/etc'
+)
 
+USECLANG=1
 ABSHADOW=0
 RECONF=0
+
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol
+# 'DW.ref.rust_eh_personality'; recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/app-shells/fish/autobuild/patches/0001-Disable-SIGSTKFLT-on-mips.patch
+++ b/app-shells/fish/autobuild/patches/0001-Disable-SIGSTKFLT-on-mips.patch
@@ -1,0 +1,26 @@
+From f91e24cd2525e6eb9606a23f3b1741680c701067 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 23 Dec 2024 16:55:35 -0800
+Subject: [PATCH 1/2] Disable SIGSTKFLT on mips
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/signal.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/signal.rs b/src/signal.rs
+index 9b51e6dfe..699ff455c 100644
+--- a/src/signal.rs
++++ b/src/signal.rs
+@@ -401,7 +401,7 @@ const SIGNAL_TABLE : &[LookupEntry] = &[
+     #[cfg(any(bsd, target_os = "macos"))]
+     LookupEntry::new(libc::SIGINFO,   L!("SIGINFO"), L!("Information request")),
+ 
+-    #[cfg(target_os = "linux")]
++    #[cfg(all(target_os = "linux", not(target_arch = "mips64")))]
+     LookupEntry::new(libc::SIGSTKFLT, L!("SISTKFLT"), L!("Stack fault")),
+ 
+     #[cfg(target_os = "linux")]
+-- 
+2.48.1
+

--- a/app-shells/fish/autobuild/patches/0002-Fix-typo-in-hard-coded-name-of-SIGSTKFLT.patch
+++ b/app-shells/fish/autobuild/patches/0002-Fix-typo-in-hard-coded-name-of-SIGSTKFLT.patch
@@ -1,0 +1,25 @@
+From 63affa8969f858d59f5fc3efb9326172688625c0 Mon Sep 17 00:00:00 2001
+From: Mahmoud Al-Qudsi <mqudsi@neosmart.net>
+Date: Mon, 23 Dec 2024 14:29:00 -0600
+Subject: [PATCH 2/2] Fix typo in hard-coded name of SIGSTKFLT
+
+---
+ src/signal.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/signal.rs b/src/signal.rs
+index 699ff455c..26f4b19c2 100644
+--- a/src/signal.rs
++++ b/src/signal.rs
+@@ -402,7 +402,7 @@ const SIGNAL_TABLE : &[LookupEntry] = &[
+     LookupEntry::new(libc::SIGINFO,   L!("SIGINFO"), L!("Information request")),
+ 
+     #[cfg(all(target_os = "linux", not(target_arch = "mips64")))]
+-    LookupEntry::new(libc::SIGSTKFLT, L!("SISTKFLT"), L!("Stack fault")),
++    LookupEntry::new(libc::SIGSTKFLT, L!("SIGSTKFLT"), L!("Stack fault")),
+ 
+     #[cfg(target_os = "linux")]
+     LookupEntry::new(libc::SIGIOT,   L!("SIGIOT"), L!("Abort (Alias for SIGABRT)")),
+-- 
+2.48.1
+

--- a/app-shells/fish/spec
+++ b/app-shells/fish/spec
@@ -1,4 +1,4 @@
-VER=3.7.1
+VER=4.0.0
 SRCS="git::commit=tags/$VER::https://github.com/fish-shell/fish-shell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=815"


### PR DESCRIPTION
Topic Description
-----------------

- fish: update to 4.0b1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fish: 4.0b1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
