### PR TITLE
libde265: update to 1.0.15

### DIFF
--- a/runtime-multimedia/libde265/autobuild/defines
+++ b/runtime-multimedia/libde265/autobuild/defines
@@ -5,3 +5,5 @@ BUILDDEP="gdk-pixbuf qt-5"
 PKGSEC=libs
 
 ABSHADOW=0
+# encoder is disabled by default from 1.0.10. Enabling it here.
+AUTOTOOLS_AFTER='--enable-encoder'

--- a/runtime-multimedia/libde265/spec
+++ b/runtime-multimedia/libde265/spec
@@ -1,5 +1,4 @@
-VER=1.0.8
-REL=4
+VER=1.0.15
 SRCS="tbl::https://github.com/strukturag/libde265/releases/download/v${VER}/libde265-${VER}.tar.gz"
-CHKSUMS="sha256::24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905"
+CHKSUMS="sha256::00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d"
 CHKUPDATE="anitya::id=11239"


### PR DESCRIPTION
Topic Description
-----------------

- libde265: update to 1.0.15
    Co-authored-by: billchenchina (@billchenchina) <billchenchina2001@gmail.com>

Package(s) Affected
-------------------

- libde265: 1.0.15

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libde265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
