### PR TITLE
[PREVIEW] oma: update to 1.13.0~rc.1

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -15,7 +15,7 @@ cp -v "$SRCDIR"/data/command-not-found/command-not-found.fish \
 
 abinfo "Installing man to /usr/share/man/man1 ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
-cp -v "$SRCDIR"/man/*.1 \
+cp -v "$SRCDIR"/data/man/*.1 \
 	"$PKGDIR"/usr/share/man/man1
 
 abinfo "Installing Policykit config file ..."

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.12.9
+VER=1.13.0~rc.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.13.0~rc.1

Package(s) Affected
-------------------

- oma: 1.13.0~rc.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



