### PR TITLE
[PREVIEW] oma: update to 1.13.0~rc.3

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -15,7 +15,7 @@ cp -v "$SRCDIR"/data/command-not-found/command-not-found.fish \
 
 abinfo "Installing man to /usr/share/man/man1 ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
-cp -v "$SRCDIR"/man/*.1 \
+cp -v "$SRCDIR"/data/man/*.1 \
 	"$PKGDIR"/usr/share/man/man1
 
 abinfo "Installing Policykit config file ..."

--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp gnutls libcap \
         libgcrypt libgpg-error lz4 nettle openssl systemd xxhash xz zlib \
         zstd ripgrep aosc-os-repository-data"
 PKGRECOM="apt-gen-list"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm-19"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"
 PKGREP="mirrormgr<=0.11.1"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.12.9
+VER=1.13.0~rc.3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.13.0~rc.3

Package(s) Affected
-------------------

- oma: 1.13.0~rc.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`



