### PR TITLE
appstream: rework for plasma-workspace

### DIFF
--- a/app-admin/appstream/02-appstream-qt/defines
+++ b/app-admin/appstream/02-appstream-qt/defines
@@ -2,3 +2,5 @@ PKGNAME=appstream-qt
 PKGSEC=admin
 PKGDEP="appstream qt-5 qt-6"
 PKGDES="Qt bindings for AppStream"
+
+PKGBREAK="plasma-workspace<=5.27.11-2"

--- a/app-admin/appstream/spec
+++ b/app-admin/appstream/spec
@@ -1,4 +1,5 @@
 VER=1.0.3
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/ximion/appstream.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10385"

--- a/desktop-kde/plasma-workspace/spec
+++ b/desktop-kde/plasma-workspace/spec
@@ -1,5 +1,5 @@
 VER=5.27.11
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-workspace-$VER.tar.xz"
 CHKSUMS="sha256::07d69bc43660ec5335f250abb34c1059cef6cc64833838a7f0f749a4b4ee7add"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-workspace: rebuild for AppStream 1.0.3
- appstream(appstream-qt): add breakage for plasma-workspace<=5.27.11-2

Package(s) Affected
-------------------

- appstream: 1.0.3-1
- appstream-qt: 1.0.3-1
- plasma-workspace: 5.27.11-3
- plasma-workspace-wayland-session: 5.27.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream:-pkgbreak plasma-workspace appstream
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
