### PR TITLE
ntlm-auth: new, 1.5.0

### DIFF
--- a/lang-python/ntlm-auth/autobuild/defines
+++ b/lang-python/ntlm-auth/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=ntlm-auth
+PKGSEC=python
+PKGDEP="python-3 cryptography"
+BUILDDEP="python-build python-installer"
+PKGDES="A Python library for NTLM authentication"
+
+ABTYPE=python
+NOPYTHON2=1
+ABSPLITDBG=0

--- a/lang-python/ntlm-auth/spec
+++ b/lang-python/ntlm-auth/spec
@@ -1,0 +1,4 @@
+VER=1.5.0
+SRCS="git::commit=v$VER::https://github.com/jborean93/ntlm-auth.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17136"


### PR DESCRIPTION
Topic Description
-----------------

ntlm-auth: new, 1.5.0

Package(s) Affected
-------------------

ntlm-auth: new, 1.5.0

Security Update?
----------------
No

Build Order
-----------

```
#buildit ntlm-auth
```


Test Build(s) Done
------------------

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
