### PR TITLE
linux-firmware: update to 20241220

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,10 +1,10 @@
 UPSTREAM_VER=20241128
-DEBIANVER=20240909-2
+DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 REL=2
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=e6c08272f15b6802bd9832a364074ec7e8a37166::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=9e1d9ae6ef3d3e00e8551266b9c96ea1ace814e4::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
@@ -15,6 +15,6 @@ CHKSUMS="SKIP \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::6e0aeaae6b726785c3a9dafb4372da09eaf351a8cfab85f86699349bc83b5aa6"
+         sha256::b37bfaff703166f41612420fa19a425c66c32cab32c144c737882e25163b9e69"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20241220
    - Update Linux Firmware to current (20241220) HEAD 9e1d9ae6ef3d3e00e8551266b9c96ea1ace814e4...
    - Changelog below...
    - AMD
    - Add firmwares for amdnpu (amdxdna).
    - Add and update lots of AMDGPU firmwares...
    - GC...
    - 11.0.0
    - 11.0.1
    - 11.0.2
    - 11.0.3
    - 11.0.4
    - 11.5.1
    - 11.5.2
    - 12.0.0
    - 12.0.1
    - PSP...
    - 13.0.6
    - 13.0.14
    - 14.0.0
    - 14.0.2
    - 14.0.3
    - 14.0.4
    - SDMA...
    - 7.0.0
    - 7.0.1
    - SMU...
    - 14.0.2
    - 14.0.3
    - VCN...
    - 3.1.2
    - 4.0.0
    - 4.0.2
    - 4.0.4
    - 4.0.5
    - 4.0.6
    - 5.0.0
    - VPE...
    - 6.1.3
    - Aldebaran / Beige Goby / Dimgrey Cavefish / Green Sardine / Navy Flounder / Picasso / Raven / Renoir / Sienna Cichlid / Vangogh / Yellow Carp
    - Navi10/Navi12/Navi14
    - DMCUB for DCN314, DCN35, DCN351 and DCN401, version 0.0.246.0.
    - Chips&Media
    - Update firmware for WAVE521C for K3 devices to 1.0.7.
    - Cirrus
    - Add and update firmwares for various Cirrus CS35L54 and CS35L56 laptops.
    - Intel
    - Update Bluetooth firmware for Intel BlazarU core (AX201/AX101), build BT_BlazarU_S_REL67159_23.90.24382.67159.
    - Qualcomm
    - Add QCA Bluetooth firmwares for WCN785x, version 2.0.0-00515-2.
    - Update venus firmware for SC7180 and QCS615, version VIDEO.VE.5.4-00059-PROD-1.
    - Realtek
    - Add rtl_nic firmware for RTL8125D Rev.B, version 0.0.4.
    - Add rtl_nic firmware for RTL8125BP Rev.B, version 0.0.4.
    - Update firmware-nonfree from Debian to 20241210-1, changelog below...
    > firmware-nonfree (20241210-1) unstable; urgency=medium
    >
    >   * New upstream version:
    >     - Add a link from TAS2XXX1EB3.bin -> ti/tas2781/TAS2XXX1EB30.bin
    >     - Add firmware for Cirrus CS35L41
    >     - amdgpu: add GC 11.5.2 microcode
    >     - amdgpu: add gc 12.0.0 firmware
    >     - amdgpu: add gc 12.0.1 firmware
    >     - amdgpu: add gc 9.4.4 firmware
    >     - amdgpu: add psp 13.0.14 firmware
    >     - amdgpu: add psp 14.0.2 firmware
    >     - amdgpu: add psp 14.0.3 firmware
    >     - amdgpu: add sdma 4.4.5 firmware
    >     - amdgpu: add SDMA 6.1.2 microcode
    >     - amdgpu: add sdma 7.0.0 firmware
    >     - amdgpu: add sdma 7.0.1 firmware
    >     - amdgpu: add smu 13.0.14 firmware
    >     - amdgpu: add smu 14.0.2 firmware
    >     - amdgpu: add smu 14.0.3 firmware
    >     - amdgpu: Add support for PSP 14.0.4
    >     - amdgpu: add vcn 5.0.0 firmware
    >     - amdgpu: Add VPE 6.1.3 microcode
    >     - amdgpu: DMCUB DCN35 update
    >     - amdgpu: DMCUB updates for various AMDGPU ASICs
    >     - amdgpu: DMCUB updates forvarious AMDGPU ASICs
    >     - amdgpu: update aldebaran firmware
    >     - amdgpu: update arcturus firmware
    >     - amdgpu: update beige goby firmware
    >     - amdgpu: update dimgrey cavefish firmware
    >     - amdgpu: update dmcub 0.0.246.0 firmware
    >     - amdgpu: update DMCUB to v0.0.233.0 DCN351
    >     - amdgpu: update DMCUB to v9.0.10.0 for DCN314
    >     - amdgpu: update DMCUB to v9.0.10.0 for DCN351
    >     - amdgpu: update GC 11.0.0 firmware
    >     - amdgpu: update GC 11.0.1 firmware
    >     - amdgpu: update GC 11.0.2 firmware
    >     - amdgpu: update GC 11.0.3 firmware
    >     - amdgpu: update gc 11.0.4 firmware
    >     - amdgpu: update GC 11.5.0 firmware
    >     - amdgpu: update GC 11.5.1 firmware
    >     - amdgpu: update GC 11.5.2 firmware
    >     - amdgpu: update GC 9.4.3 firmware
    >     - amdgpu: update green sardine firmware
    >     - amdgpu: update navi10 firmware
    >     - amdgpu: update navi12 firmware
    >     - amdgpu: update navi14 firmware
    >     - amdgpu: update navy flounder firmware
    >     - amdgpu: update picasso firmware
    >     - amdgpu: update PSP 13.0.0 firmware
    >     - amdgpu: update PSP 13.0.10 firmware
    >     - amdgpu: update psp 13.0.11 firmware
    >     - amdgpu: update psp 13.0.14 firmware
    >     - amdgpu: update PSP 13.0.4 firmware
    >     - amdgpu: update PSP 13.0.5 firmware
    >     - amdgpu: update PSP 13.0.6 firmware
    >     - amdgpu: update PSP 13.0.7 firmware
    >     - amdgpu: update PSP 13.0.8 firmware
    >     - amdgpu: update PSP 14.0.0 firmware
    >     - amdgpu: update PSP 14.0.1 firmware
    >     - amdgpu: update PSP 14.0.4 firmware
    >     - amdgpu: update raven firmware
    >     - amdgpu: update renoir firmware
    >     - amdgpu: update sdma 4.4.2 firmware
    >     - amdgpu: update SDMA 4.4.2 firmware
    >     - amdgpu: update sdma 6.0.3 firmware
    >     - amdgpu: update sienna cichlid firmware
    >     - amdgpu: update smu 13.0.0 firmware
    >     - amdgpu: update SMU 13.0.10 firmware
    >     - amdgpu: update SMU 13.0.6 firmware
    >     - amdgpu: update vangogh firmware
    >     - amdgpu: update VCN 3.1.2 firmware
    >     - amdgpu: update VCN 4.0.0 firmware
    >     - amdgpu: update VCN 4.0.2 firmware
    >     - amdgpu: update VCN 4.0.4 firmware
    >     - amdgpu: update VCN 4.0.5 firmware
    >     - amdgpu: update VCN 4.0.6 firmware
    >     - amdgpu: update vega10 firmware
    >     - amdgpu: update vega12 firmware
    >     - amdgpu: update vega20 firmware
    >     - amdgpu: update vpe 6.1.1 firmware
    >     - amdgpu: update vpe 6.1.3 firmware
    >     - amdgpu: update yellow carp firmware
    >     - ath11k: move WCN6750 firmware to the device-specific subdir
    >     - ath12k: WCN7850 hw2.0: update board-2.bin
    >     - brcm: Add BCM4354 NVRAM for Jetson TX1
    >     - brcm: Link FriendlyElec NanoPi M4 to AP6356S nvram
    >     - brcm: replace NVRAM for Jetson TX1
    >     - check_whence.py: ban link-to-a-link
    >     - cirrus: cs35l56: Add firmware for Cirrus Amps for some HP laptops
    >     - cirrus: cs35l56: Add firmware for Cirrus CS35L56 for a Lenovo Laptop
    >     - cirrus: cs35l56: Add firmware for Cirrus CS35L56 for some ASUS laptops
    >     - cirrus: cs35l56: Add firmware for Cirrus CS35L56 for various Dell laptops
    >     - cirrus: cs35l56: Update firmware for Cirrus Amps for some HP laptops
    >     - cnm: update chips&media wave521c firmware.
    >     - i915: Add Xe3LPD DMC
    >     - i915: Update GUC to v70.36.0 for ADL-P, DG1, DG2, MTL, TGL
    >     - i915: Update MTL/ARL GSC to v102.1.15.1926
    >     - i915: Update Xe2LPD DMC to v2.23
    >     - i915: Update Xe2LPD DMC to v2.24
    >     - ice: update ice DDP comms package to 1.3.52.0
    >     - ice: update ice DDP package to ice-1.3.41.0
    >     - ice: update ice DDP wireless_edge package to 1.3.20.0
    >     - iwlwifi: add Bz-gf FW for core89-91 release
    >     - iwlwifi: add Bz-gf FW for core91-69 release
    >     - iwlwifi: add gl/Bz FW for core91-69 release
    >     - iwlwifi: update cc/Qu/QuZ firmwares for core91-69 release
    >     - iwlwifi: update ty/So/Ma firmwares for core91-69 release
    >     - mediatek MT7921: update bluetooth firmware to 20241106151414
    >     - mediatek MT7922: update bluetooth firmware to 20241106163512
    >     - mediatek: Add sof-tolg for mt8195
    >     - mtk_wed: add firmware for mt7988 Wireless Ethernet Dispatcher
    >     - QCA: Add 22 bluetooth firmware nvm files for QCA2066
    >     - QCA: Add Bluetooth firmwares for WCN785x with UART transport
    >     - QCA: Add Bluetooth nvm files for WCN785x
    >     - QCA: Update Bluetooth WCN785x firmware to 2.0.0-00515-2
    >     - qcom: Add link for QCS6490 GPU firmware
    >     - qcom: Add QDU100 firmware image files.
    >     - qcom: Update aic100 firmware files
    >     - qcom: update gpu firmwares for qcm6490 chipset
    >     - qcom: update gpu firmwares for qcs615 chipset
    >     - qcom: update venus firmware file for SC7280
    >     - qcom: venus-5.4: add venus firmware file for qcs615
    >     - Remove execute bit from firmware files
    >     - Revert "ath12k: WCN7850 hw2.0: update board-2.bin"
    >     - rtl_bt: Update RTL8852B BT USB FW to 0x0447_9301
    >     - rtl_bt: Update RTL8852BT/RTL8852BE-VT BT USB FW to 0x04D7_63F7
    >     - rtl_nic: add firmware rtl8125d-1
    >     - rtlwifi: Add firmware v39.0 for RTL8192DU
    >     - rtlwifi: Update firmware for RTL8192FU to v7.3
    >     - rtw88: Add firmware v52.14.0 for RTL8812AU
    >     - rtw89: 8852a: update fw to v0.13.36.2
    >     - rtw89: 8922a: add fw format-2 v0.35.42.1
    >     - tas2781: Upload dsp firmware for ASUS laptop 1EB30 & 1EB31
    >     - Update firmware file for Intel BlazarI core
    >     - Update firmware file for Intel BlazarU core
    >     - Update firmware file for Intel Bluetooth Magnetor core
    >     - Update firmware file for Intel Bluetooth Solar core
    >     - update firmware for en8811h 2.5G ethernet phy
    >     - update firmware for mediatek bluetooth chip (MT7925)
    >     - update firmware for MT7921 WiFi device
    >     - update firmware for MT7922 WiFi device
    >     - update firmware for MT7925 WiFi device
    >     - xe: Update GUC to v70.36.0 for BMG, LNL
    >     - xe: Update LNL GSC to v104.0.0.1263
    >
    >   [ Ben Hutchings ]
    >   * d/copyright: Stop excluding wsm_22.bin, which is distributable
    >   * atheros: Remove some long-obsolete ath9k firmware files
    >   * qlogic: Remove qed firmware versions not used in any Debian release
    >   * intel-graphics: Remove firmware versions not used in any Debian release
    >   * iwlwifi: Remove firmware version not used in any Debian release
    >   * d/copyright: Exclude currently unreferenced amlogic/*
    >   * copy-firmware: Don't create links to excluded files
    >   * d/copyright: Exclude some newly added files to limit orig tarball size
    >   * Revert "copy-firmware.sh: remove no longer reachable test -f"
    >   * Revert "copy-firmware.sh: call ./check_whence.py before parsing the file"
    >   * d/rules: Run dedup-firmware.sh after copy-firmware.sh
    >   * Update to linux-support-6.12.5
    >
    >  -- Ben Hutchings <benh@debian.org>  Thu, 19 Dec 2024 22:13:29 +0100
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20241128+debian20241210+1-2
- firmware-nonfree: 20241128+debian20241210+1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
