### PR TITLE
weechat: update to 4.5.1

### DIFF
--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.5.0
+VER=4.5.1
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::b85e800af0f7c9f2d60d72c0f7e56abbaa60274a4d47be17407907292da30398"
+CHKSUMS="sha256::67c143c7bc70e689b9ea86df674c9a9ff3cf44ccc9cdff21be6a561d5eafc528"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.5.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- weechat: 4.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
