### PR TITLE
libcamera: update to 0.4.0

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.2.7
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -5,4 +5,6 @@ BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
           libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
           texlive yaml graphviz"
 
+PKGBREAK="pipewire<=1.2.7-1"
+
 MESON_AFTER="-Dv4l2=true"

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.3.2
+VER=0.4.0
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.4.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- libcamera: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera:-pkgbreak pipewire libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
