### PR TITLE
mold: update to 2.35.1

### DIFF
--- a/app-devel/mold/spec
+++ b/app-devel/mold/spec
@@ -1,4 +1,4 @@
-VER=2.35.0
+VER=2.35.1
 SRCS="git::commit=tags/v$VER::https://github.com/rui314/mold"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241732"


### PR DESCRIPTION
Topic Description
-----------------

- mold: update to 2.35.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- mold: 2.35.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mold
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
