### PR TITLE
perl-tk: update to 804.036

### DIFF
--- a/lang-perl/perl-tk/autobuild/patches/0001-Avoid-using-incompatible-pointer-type-for-old_warn.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0001-Avoid-using-incompatible-pointer-type-for-old_warn.patch
@@ -1,0 +1,45 @@
+From 2e2e3bae687b296af86f25f23ce7b8c1bf7d70f9 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:32:51 +0800
+Subject: [PATCH 1/6] Avoid using incompatible pointer type for old_warn
+
+---
+ Event/Event.xs | 2 +-
+ tkGlue.c       | 7 +------
+ 2 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/Event/Event.xs b/Event/Event.xs
+index 82bbb244..f2c95234 100644
+--- a/Event/Event.xs
++++ b/Event/Event.xs
+@@ -1532,7 +1532,7 @@ PROTOTYPES: DISABLE
+ BOOT:
+  {
+ #ifdef pWARN_NONE
+-  SV *old_warn = PL_curcop->cop_warnings;
++  void *old_warn = PL_curcop->cop_warnings;
+   PL_curcop->cop_warnings = pWARN_NONE;
+ #endif
+   newXS("Tk::Event::INIT", XS_Tk__Event_INIT, file);
+diff --git a/tkGlue.c b/tkGlue.c
+index 68a7e0fa..ca4a13aa 100644
+--- a/tkGlue.c
++++ b/tkGlue.c
+@@ -5543,13 +5543,8 @@ _((pTHX))
+  char *XEventMethods = "abcdfhkmopstvwxyABDEKNRSTWXY#";
+  char buf[128];
+  CV *cv;
+-#if PERL_REVISION > 5 || (PERL_REVISION == 5 && PERL_VERSION >= 9)
+-#define COP_WARNINGS_TYPE STRLEN*
+-#else
+-#define COP_WARNINGS_TYPE SV*
+-#endif
+ #ifdef pWARN_NONE
+- COP_WARNINGS_TYPE old_warn = PL_curcop->cop_warnings;
++ void *old_warn = PL_curcop->cop_warnings;
+  PL_curcop->cop_warnings = pWARN_NONE;
+ #endif
+ 
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/autobuild/patches/0002-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0002-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch
@@ -1,0 +1,28 @@
+From bbbddf8b8808aa41ff8825f33432b7bae9d37c38 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:33:53 +0800
+Subject: [PATCH 2/6] Fix STRLEN vs int pointer confusion in Tcl_GetByteAr
+
+---
+ objGlue.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/objGlue.c b/objGlue.c
+index d4927eaf..dbd6a50e 100644
+--- a/objGlue.c
++++ b/objGlue.c
+@@ -627,7 +627,10 @@ Tcl_GetByteArrayFromObj(Tcl_Obj * objPtr, int * lengthPtr)
+  sv_utf8_downgrade(objPtr, 0);
+  if (lengthPtr)
+   {
+-   return (unsigned char *) SvPV(objPtr, *lengthPtr);
++   STRLEN len;
++   unsigned char *s = SvPV(objPtr, len);
++   *lengthPtr = len;
++   return s;
+   }
+  else
+   {
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/autobuild/patches/0003-Fix-build-with-clang-16.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0003-Fix-build-with-clang-16.patch
@@ -1,0 +1,25 @@
+From 3f7dfc09d6571ab395a37c733305576e46e19f04 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:36:55 +0800
+Subject: [PATCH 3/6] Fix build with clang-16
+
+---
+ pTk/Xlib.t | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pTk/Xlib.t b/pTk/Xlib.t
+index a193fc5e..c90964cb 100644
+--- a/pTk/Xlib.t
++++ b/pTk/Xlib.t
+@@ -331,7 +331,7 @@ VFUNC(int,XIntersectRegion,V_XIntersectRegion,_ANSI_ARGS_((Region, Region, Regio
+ #endif /* !DO_X_EXCLUDE */
+ 
+ #ifndef XKeycodeToKeysym
+-VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, unsigned int, int)))
++VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, KeyCode, int)))
+ #endif /* #ifndef XKeycodeToKeysym */
+ 
+ #ifndef XKeysymToString
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/autobuild/patches/0004-Fix-incompatible-pointer-type-in-function-GetTextInd.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0004-Fix-incompatible-pointer-type-in-function-GetTextInd.patch
@@ -1,0 +1,25 @@
+From f889ee4c764cb2f65c1babbb8bc6efd9cf8d958d Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:37:34 +0800
+Subject: [PATCH 4/6] Fix incompatible pointer type in function GetTextIndex
+
+---
+ pTk/mTk/generic/tkCanvText.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pTk/mTk/generic/tkCanvText.c b/pTk/mTk/generic/tkCanvText.c
+index 1a950a5a..de03da27 100644
+--- a/pTk/mTk/generic/tkCanvText.c
++++ b/pTk/mTk/generic/tkCanvText.c
+@@ -1234,7 +1234,7 @@ GetTextIndex(interp, canvas, itemPtr, obj, indexPtr)
+ 				 * index. */
+ {
+     TextItem *textPtr = (TextItem *) itemPtr;
+-    size_t length;
++    int length;
+     int c;
+     TkCanvas *canvasPtr = (TkCanvas *) canvas;
+     Tk_CanvasTextInfo *textInfoPtr = textPtr->textInfoPtr;
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/autobuild/patches/0005-pregcomp2.c-Avoid-using-incompatible-pointer-type.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0005-pregcomp2.c-Avoid-using-incompatible-pointer-type.patch
@@ -1,0 +1,23 @@
+From fb545116e8233bd51b4fbdbe86b30f5a4f91ba78 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:38:32 +0800
+Subject: [PATCH 5/6] pregcomp2.c: Avoid using incompatible pointer type
+
+---
+ config/pregcomp2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/pregcomp2.c b/config/pregcomp2.c
+index 98506999..bb0b4539 100644
+--- a/config/pregcomp2.c
++++ b/config/pregcomp2.c
+@@ -4,5 +4,5 @@
+ 
+ int main() {
+     SV* sv = newSViv(0);
+-    regexp* rx = pregcomp(sv, 0);
++    void* rx = pregcomp(sv, 0);
+ }
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/autobuild/patches/0006-Avoid-using-incompatible-pointer-type-for-c99.patch
+++ b/lang-perl/perl-tk/autobuild/patches/0006-Avoid-using-incompatible-pointer-type-for-c99.patch
@@ -1,0 +1,98 @@
+From 4bf2e1dcbef98f01837d8e85979a1af08dc17cb6 Mon Sep 17 00:00:00 2001
+From: salieri <maliya355@outlook.com>
+Date: Thu, 26 Dec 2024 10:39:37 +0800
+Subject: [PATCH 6/6] Avoid using incompatible pointer type for c99
+
+---
+ config/signedchar.c       | 2 +-
+ config/unsigned.c         | 5 +++--
+ pTk/config/Hstrdup.c      | 2 +-
+ pTk/config/Hstrtoul.c     | 1 +
+ pTk/mTk/generic/tkEvent.c | 1 +
+ pTk/mTk/generic/tkImage.c | 2 ++
+ 6 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/config/signedchar.c b/config/signedchar.c
+index bcf419dc..e96c1b1e 100644
+--- a/config/signedchar.c
++++ b/config/signedchar.c
+@@ -1,4 +1,4 @@
+-main()
++int main(void)
+ {
+  signed char x = 'a';
+  return (x - 'a');
+diff --git a/config/unsigned.c b/config/unsigned.c
+index 914506bb..fa9669ab 100644
+--- a/config/unsigned.c
++++ b/config/unsigned.c
+@@ -1,15 +1,16 @@
++#include <stdio.h>
+ int main()
+ {
+  char x[] = "\377";
+  if (x[0] > 0)
+   {
+    printf("char is unsigned type\n");
+-   exit(0);
++   return 0;
+   }
+  else
+   {
+    printf("char is signed type\n");
+-   exit(1);
++   return 1;
+   }
+ }
+ 
+diff --git a/pTk/config/Hstrdup.c b/pTk/config/Hstrdup.c
+index bbde6d2c..d3054134 100644
+--- a/pTk/config/Hstrdup.c
++++ b/pTk/config/Hstrdup.c
+@@ -6,7 +6,7 @@ int main()
+ {char *e;
+  char *p = strdup(STRING);
+  if (!p || strcmp(p,STRING))
+-  exit(1);
++  return 1;
+  return 0;
+ }
+ 
+diff --git a/pTk/config/Hstrtoul.c b/pTk/config/Hstrtoul.c
+index a5be7031..e29e4e4e 100644
+--- a/pTk/config/Hstrtoul.c
++++ b/pTk/config/Hstrtoul.c
+@@ -1,4 +1,5 @@
+ #include <stdlib.h>
++#include <string.h>
+ 
+ int main()
+ {char *e;
+diff --git a/pTk/mTk/generic/tkEvent.c b/pTk/mTk/generic/tkEvent.c
+index 3fc5821b..bdcb712f 100644
+--- a/pTk/mTk/generic/tkEvent.c
++++ b/pTk/mTk/generic/tkEvent.c
+@@ -1153,6 +1153,7 @@ TkEventDeadWindow(winPtr)
+ Time
+ TkCurrentTime(dispPtr, fallbackCurrent)
+     TkDisplay *dispPtr;		/* Display for which the time is desired. */
++    int fallbackCurrent;
+ {
+     register XEvent *eventPtr;
+     ThreadSpecificData *tsdPtr = (ThreadSpecificData *)
+diff --git a/pTk/mTk/generic/tkImage.c b/pTk/mTk/generic/tkImage.c
+index 7bfc3406..45b39573 100644
+--- a/pTk/mTk/generic/tkImage.c
++++ b/pTk/mTk/generic/tkImage.c
+@@ -1083,6 +1083,8 @@ int x;
+ int y;
+ int width;
+ int height;
++int imgWidth;
++int imgHeight;
+ {
+     Tk_Tile tile = (Tk_Tile) clientData;
+     Tk_TileChange *handler;
+-- 
+2.34.1
+

--- a/lang-perl/perl-tk/spec
+++ b/lang-perl/perl-tk/spec
@@ -1,5 +1,4 @@
-VER=804.034
+VER=804.036
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/S/SR/SREZIC/Tk-$VER.tar.gz"
-CHKSUMS="sha256::fea6b144c723528a2206c8cd9175844032ee9c14ee37791f0f151e5e5b293fe2"
-REL=3
+CHKSUMS="sha256::32aa7271a6bdfedc3330119b3825daddd0aa4b5c936f84ad74eabb932a200a5e"
 CHKUPDATE="anitya::id=3471"


### PR DESCRIPTION
Topic Description
-----------------

- perl-tk: (Fedora) fix incompatible pointer type
- perl-tk: udpate to 804.036

Package(s) Affected
-------------------

- perl-tk: 804.036

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-tk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
