### PR TITLE
wayvnc: new, 0.9.1

### DIFF
--- a/runtime-network/neatvnc/spec
+++ b/runtime-network/neatvnc/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
-REL=1
+VER=0.9.2
 SRCS="git::commit=tags/v$VER::https://github.com/any1/neatvnc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370162"

--- a/runtime-network/wayvnc/autobuild/defines
+++ b/runtime-network/wayvnc/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=wayvnc
+PKGSEC=net
+PKGDEP="aml mesa libdrm libxkbcommon neatvnc linux-pam pixman jansson"
+BUILDDEP="meson ninja scdoc"
+PKGDES="A VNC server for wlroots-based Wayland compositors"
+
+MESON_AFTER=(
+    -Dman-pages=enabled
+    -Dtests=false
+)

--- a/runtime-network/wayvnc/spec
+++ b/runtime-network/wayvnc/spec
@@ -1,0 +1,4 @@
+VER=0.9.1
+SRCS="git::commit=tags/v$VER::https://github.com/any1/wayvnc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=137711"


### PR DESCRIPTION
Topic Description
-----------------

- wayvnc: new, 0.9.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- neatvnc: update to 0.9.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- neatvnc: 0.9.2
- wayvnc: 0.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit neatvnc wayvnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
