### PR TITLE
hmcl: backport a patch to fix Zink + amdgpu DDX

### DIFF
--- a/app-games/hmcl/autobuild/patches/0001-fix-DefaultLauncher-also-set-LIBGL_KOPPER_DRI2-1-for.patch
+++ b/app-games/hmcl/autobuild/patches/0001-fix-DefaultLauncher-also-set-LIBGL_KOPPER_DRI2-1-for.patch
@@ -1,0 +1,38 @@
+From 8e693ead433f5a15f79f409698871e8d8437330c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2=20=28Mingcong=20Bai=29?=
+ <jeffbai@aosc.io>
+Date: Wed, 25 Dec 2024 03:55:42 -0800
+Subject: [PATCH] fix(DefaultLauncher): also set LIBGL_KOPPER_DRI2=1 for Zink
+ mode (#3503)
+
+The amdgpu DDX is missing support for modifiers, causing Zink to fail.
+Disable DRI3 to workaround this issue.
+
+Link: https://gitlab.freedesktop.org/mesa/mesa/-/issues/10093
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ .../java/org/jackhuang/hmcl/launch/DefaultLauncher.java    | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+index 6bb049473..1f4c13043 100644
+--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
++++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+@@ -496,6 +496,13 @@ public class DefaultLauncher extends Launcher {
+                         break;
+                     case ZINK:
+                         env.put("MESA_LOADER_DRIVER_OVERRIDE", "zink");
++                        /**
++                         * The amdgpu DDX is missing support for modifiers, causing Zink to fail.
++                         * Disable DRI3 to workaround this issue.
++                         *
++                         * Link: https://gitlab.freedesktop.org/mesa/mesa/-/issues/10093
++                         */
++                        env.put("LIBGL_KOPPER_DRI2", "1");
+                         break;
+                 }
+             }
+-- 
+2.47.1
+

--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,5 @@
 VER=3.6.11
+REL=1
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKUPDATE="anitya::id=371893"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- hcml: backport a patch to fix Zink + amdgpu DDX
    The amdgpu DDX is missing support for modifiers, causing Zink to fail.
    Disable DRI3 to workaround this issue.
    Link: https://gitlab.freedesktop.org/mesa/mesa/-/issues/10093
    Link: https://github.com/HMCL-dev/HMCL/pull/3503

Package(s) Affected
-------------------

- hmcl: 3.6.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
