### PR TITLE
tsukimi: new 0.18.0

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=tsukimi
+PKGSEC=video
+PKGDES="A desktop client implementation for Emby"
+BUILDDEP="meson llvm rustc libadwaita gtk-update-icon-cache gtk-4 gstreamer"
+PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv openssl pango"
+
+ABTYPE=meson
+
+# FIXME: ld.lld is not yet supported
+NOLTO__LOONGSON3=1

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,0 +1,4 @@
+VER=0.18.0
+SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376111"


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: new, 0.18.0

Package(s) Affected
-------------------

- tsukimi: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
