### PR TITLE
llvm-18, llvm-19: create a compatible Clang prefix symlink

### DIFF
--- a/app-devel/llvm-18/02-compiler/build
+++ b/app-devel/llvm-18/02-compiler/build
@@ -70,3 +70,16 @@ strip \
 abinfo "Making compatible version symlinks ..."
 ln -sv "${PKGVER%%.*}" \
     "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+# FIXME: Chromium would fail to detect Clang prefix unless a full absolute
+# path to the compilers were set. Debian creates a symlink:
+#
+#   /usr/lib/clang/${PKGVER%%.*}
+#       => /usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}
+#
+# to counteract this - not sure if needed anywhere else but create this
+# symlink just to be safe.
+abinfo "Making Clang prefix symlinks ..."
+mkdir -pv "$PKGDIR"/usr/lib/clang
+ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
+    "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=4
+REL=5
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/build
+++ b/app-devel/llvm-19/02-compiler/build
@@ -70,3 +70,16 @@ strip \
 abinfo "Making compatible version symlinks ..."
 ln -sv "${PKGVER%%.*}" \
     "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+# FIXME: Chromium would fail to detect Clang prefix unless a full absolute
+# path to the compilers were set. Debian creates a symlink:
+#
+#   /usr/lib/clang/${PKGVER%%.*}
+#       => /usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}
+#
+# to counteract this - not sure if needed anywhere else but create this
+# symlink just to be safe.
+abinfo "Making Clang prefix symlinks ..."
+mkdir -pv "$PKGDIR"/usr/lib/clang
+ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
+    "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,5 +1,5 @@
 VER=19.1.6
-REL=1
+REL=2
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-19: create a compatible Clang prefix symlink
    Chromium would fail to detect Clang prefix unless a full absolute path to
    the compilers were set. Debian creates a symlink:
    `/usr/lib/clang/${PKGVER%%.*}`
    => `/usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}`
    to counteract this - not sure if needed anywhere else but create this
    symlink just to be safe.
- llvm-18: create a compatible Clang prefix symlink
    Chromium would fail to detect Clang prefix unless a full absolute path to
    the compilers were set. Debian creates a symlink:
    `/usr/lib/clang/${PKGVER%%.*}`
    => `/usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}`
    to counteract this - not sure if needed anywhere else but create this
    symlink just to be safe.

Package(s) Affected
-------------------

- llvm-18: 18.1.8-5
- llvm-19: 19.1.6-2
- llvm-runtime-18: 18.1.8-5
- llvm-runtime-19: 19.1.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
