### PR TITLE
pandoc: update to 3.6.1

### DIFF
--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,4 @@
-VER=3.6
+VER=3.6.1
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"


### PR DESCRIPTION
Topic Description
-----------------

- pandoc: update to 3.6.1
    Co-authored-by: Kexy Biscuit (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- pandoc: 3.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
