### PR TITLE
autobuild4: update to 4.7.0

### DIFF
--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=devel
 PKGDES="Multi-backend and extensible packaging toolkit"
 PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
         spdx-licenses gcc-runtime glibc tomli python-build python-installer
-        wheel"
+        wheel elfutils"
 BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
 

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.6.6
+VER=4.7.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.7.0

Package(s) Affected
-------------------

- autobuild4: 4.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
