### PR TITLE
lm-sensors: update to 3-6-0

### DIFF
--- a/app-utils/lm-sensors/spec
+++ b/app-utils/lm-sensors/spec
@@ -1,5 +1,4 @@
-VER=3.6.0
+VER=3-6-0
 SRCS="tbl::https://github.com/lm-sensors/lm-sensors/archive/V${VER//./-}.tar.gz"
 CHKSUMS="sha256::0591f9fa0339f0d15e75326d0365871c2d4e2ed8aa1ff759b3a55d3734b7d197"
 CHKUPDATE="anitya::id=1831"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- lm-sensors: update to 3-6-0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lm-sensors: 3-6-0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lm-sensors
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
