### PR TITLE
davfs2: new, 1.7.1

### DIFF
--- a/app-admin/davfs2/autobuild/defines
+++ b/app-admin/davfs2/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=davfs2
+PKGSEC=admin
+PKGDEP="neon"
+BUILDDEP="po4a"
+PKGDES="Utilities to mount a WebDAV resource as a regular file system"
+
+AUTOTOOLS_AFTER=(
+    '--enable-nls'
+    '--disable-rpath'
+    '--enable-largefile'
+    '--enable-year2038'
+    '--with-neon=/usr'
+)

--- a/app-admin/davfs2/autobuild/patches/0001-AOSCOS-configure.ac-support-detecting-neon-0.33.x.patch
+++ b/app-admin/davfs2/autobuild/patches/0001-AOSCOS-configure.ac-support-detecting-neon-0.33.x.patch
@@ -1,0 +1,25 @@
+From ffa0a04a60870a361f82f3661bf0485d5e853563 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 27 Dec 2024 18:11:06 +0800
+Subject: [PATCH] AOSCOS: configure.ac: support detecting neon 0.33.x
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4f86cde..ede9b1e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -36,7 +36,7 @@ AC_PROG_LN_S
+ # Checks for libraries.
+ AM_GNU_GETTEXT_VERSION(0.19.8)
+ AM_GNU_GETTEXT([external])
+-NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32])
++NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33])
+ DAV_CHECK_NEON
+ 
+ # Checks for header files.
+-- 
+2.47.1
+

--- a/app-admin/davfs2/spec
+++ b/app-admin/davfs2/spec
@@ -1,0 +1,4 @@
+VER=1.7.0
+SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/davfs2/davfs2-$VER.tar.gz"
+CHKSUMS="sha256::251db75a27380cca1330b1b971700c5e5dcc0c90e5a47622285f0140edfe3a2f"
+CHKUPDATE="anitya::id=7487"


### PR DESCRIPTION
Topic Description
-----------------

- davfs2: new, 1.7.1

Package(s) Affected
-------------------

- davfs2: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit davfs2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
