### PR TITLE
libxnvctrl: update to 565.57.01

### DIFF
--- a/runtime-display/libxnvctrl/spec
+++ b/runtime-display/libxnvctrl/spec
@@ -1,5 +1,5 @@
-VER=545.23.06
-SRCS="tbl::https://github.com/NVIDIA/nvidia-settings/archive/${VER}.tar.gz"
-CHKSUMS="sha256::a4e0045c77406678c0d6c52433398b74d51f58cf19d350682b6408e154d7b6e8"
+VER=565.57.01
+SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"
-SUBDIR="nvidia-settings-${VER}/src/libXNVCtrl"
+SUBDIR="libxnvctrl/src/libXNVCtrl"


### PR DESCRIPTION
Topic Description
-----------------

- libxnvctrl: update to 565.57.01
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libxnvctrl: 565.57.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxnvctrl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
