### PR TITLE
usbmuxd Rework

### DIFF
--- a/runtime-common/libplist/spec
+++ b/runtime-common/libplist/spec
@@ -1,4 +1,5 @@
 VER=2.6.0
-SRCS="git::commit=tags/$UPSTREAM_VER;copy-repo=true::https://github.com/libimobiledevice/libplist.git"
+REL=1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/libimobiledevice/libplist.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11675"

--- a/runtime-devices/libimobiledevice-glue/spec
+++ b/runtime-devices/libimobiledevice-glue/spec
@@ -1,4 +1,5 @@
 VER=1.3.1
-SRCS="git::commit=tags/$UPSTREAM_VER;copy-repo=true::https://github.com/libimobiledevice/libimobiledevice-glue.git"
+REL=1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/libimobiledevice/libimobiledevice-glue.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=342550"


### PR DESCRIPTION
Topic Description
-----------------

- libimobiledevice-glue: fix $VER reference
- libplist: fix $VER reference
- usbmuxd: update to 1.1.1+git20240916
    - Upstream have not published tags since June 2020.
    - Code in master brings support for more devices.
    - Code in master also removed some redundant code.
    - These commits can not be individually picked.
    - Also add newly introduced dependency libimobiledevice-glue.
- libplist: update to 2.6.0
    - Clean up build scripts.
    - Disable build for Python 2.
- libimobiledevice-glue: new, 1.3.1
    This is a library shared across all projects within
    libimobiledevice.org.

Package(s) Affected
-------------------

- libimobiledevice-glue: 1.3.1-1
- libplist: 2.6.0-1
- usbmuxd: 1.1.1+git20240916

Security Update?
----------------

No

Build Order
-----------

```
#buildit libplist libimobiledevice-glue usbmuxd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
