### PR TITLE
systemd: Fix booting problem with QEMU user emulation

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
 From 679d56b7d1bbff4141cf30d7cab9d97d619d897f Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 1/3] sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 1/4] sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/sleep/sleep.conf b/src/sleep/sleep.conf
-index 98430348a7bf..41534e6c15d3 100644
+index 98430348a7..41534e6c15 100644
 --- a/src/sleep/sleep.conf
 +++ b/src/sleep/sleep.conf
 @@ -18,7 +18,7 @@
@@ -22,5 +22,5 @@ index 98430348a7bf..41534e6c15d3 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.47.0
+2.47.1
 

--- a/app-admin/systemd/autobuild/patches/0002-main.c-revert-part-of-systemd-systemd-31442.patch
+++ b/app-admin/systemd/autobuild/patches/0002-main.c-revert-part-of-systemd-systemd-31442.patch
@@ -1,7 +1,7 @@
 From 0df968c5b5b0e0fc82aec9d37da9ca667fcac4c5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 27 Jul 2024 14:43:07 +0800
-Subject: [PATCH 2/3] main.c: revert part of systemd/systemd#31442
+Subject: [PATCH 2/4] main.c: revert part of systemd/systemd#31442
 
 To make the user happy.
 ---
@@ -9,7 +9,7 @@ To make the user happy.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/core/main.c b/src/core/main.c
-index 4b8a315d8609..830cd4a80138 100644
+index 4b8a315d86..830cd4a801 100644
 --- a/src/core/main.c
 +++ b/src/core/main.c
 @@ -3110,8 +3110,8 @@ int main(int argc, char *argv[]) {
@@ -24,5 +24,5 @@ index 4b8a315d8609..830cd4a80138 100644
                  }
  
 -- 
-2.47.0
+2.47.1
 

--- a/app-admin/systemd/autobuild/patches/0003-fix-do-not-tint-terminal-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0003-fix-do-not-tint-terminal-by-default.patch
@@ -1,7 +1,7 @@
 From 24c6faa5aaaec6d5408c0505c258ae8ace9d0828 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 12 Aug 2024 22:19:25 +0800
-Subject: [PATCH 3/3] fix: do not tint terminal by default
+Subject: [PATCH 3/4] fix: do not tint terminal by default
 
 Let's face it, it's weird and we have much better ways to notify the user
 about a system running in a container. Change the default behavior (tint by
@@ -11,7 +11,7 @@ default) to only tint when the user specifies a --background= parameter.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shared/pretty-print.c b/src/shared/pretty-print.c
-index 4692a6aedc80..695c986c9e12 100644
+index 4692a6aedc..695c986c9e 100644
 --- a/src/shared/pretty-print.c
 +++ b/src/shared/pretty-print.c
 @@ -453,7 +453,7 @@ bool shall_tint_background(void) {
@@ -24,5 +24,5 @@ index 4692a6aedc80..695c986c9e12 100644
                  log_debug_errno(cache, "Failed to parse $SYSTEMD_TINT_BACKGROUND, leaving background tinting enabled: %m");
  
 -- 
-2.47.0
+2.47.1
 

--- a/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
+++ b/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
@@ -1,0 +1,33 @@
+From 12aeedaeea35223fb3c9684ae84576ed476f7979 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sat, 28 Dec 2024 16:06:22 +0800
+Subject: [PATCH 4/4] exec-credential: try forking again without CLONE_NEWNS
+
+QEMU user emulation currently does not support CLONE_NEWS, fork()ing
+with it will result in an EINVAL, rendering the system unbootable with
+systemd-nspawn.
+---
+ src/core/exec-credential.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/core/exec-credential.c b/src/core/exec-credential.c
+index 6157ac4255..636092e9dc 100644
+--- a/src/core/exec-credential.c
++++ b/src/core/exec-credential.c
+@@ -976,6 +976,13 @@ int exec_setup_credentials(
+                 return r;
+ 
+         r = safe_fork("(sd-mkdcreds)", FORK_DEATHSIG_SIGTERM|FORK_WAIT|FORK_NEW_MOUNTNS, NULL);
++        if (r == -EINVAL) {
++                /* Well, try again without CLONE_NEWNS.
++                 * There's a chance that we might be running with QEMU user emulation.
++                 * QEMU user emulation does not support CLONE_NEWNS:
++                 * https://gitlab.com/qemu-project/qemu/-/issues/1962 */
++                r = safe_fork("(sd-mkdcreds)", FORK_DEATHSIG_SIGTERM|FORK_WAIT, NULL);
++        }
+         if (r < 0) {
+                 _cleanup_(rmdir_and_freep) char *u = NULL; /* remove the temporary workspace if we can */
+                 _cleanup_free_ char *t = NULL;
+-- 
+2.47.1
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,4 +1,5 @@
 VER=256.7
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205088"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: fix credential setup issue with QEMU user emulation
    Systemd tries to fork() with CLONE_NEWNS, which is not supported by QEMU
    user emulation, to set up credentials. Previously few systemd units use
    ImportCredential=, so the container can still boot with QEMU user
    emulation. Now almost all units use it, rendering the container
    unbootable.
    This fix tries to fork() again without CLONE_NEWNS if the returned value
    is -EINVAL, similar as [1].
    [1]: https://github.com/systemd/systemd/pull/28954

Package(s) Affected
-------------------

- systemd: 1:256.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
