### PR TITLE
polyphone: update to 2.5.0

### DIFF
--- a/app-multimedia/polyphone/spec
+++ b/app-multimedia/polyphone/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=2.5.0
 SRCS="git::commit=tags/$VER::https://github.com/davy7125/polyphone.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372486"


### PR DESCRIPTION
Topic Description
-----------------

- polyphone: update to 2.5.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- polyphone: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit polyphone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
