### PR TITLE
Autobuild Defines Survey (Dec. 2024)

### DIFF
--- a/app-database/ldb/autobuild/defines
+++ b/app-database/ldb/autobuild/defines
@@ -15,7 +15,5 @@ PKGDES="Schema-less ldap-like API and database"
 
 NOPARALLEL=1
 
-alias BUILD_FINAL='doxygen Doxyfile'
-
 PKGEPOCH=2
 PKGBREAK="sssd<=2.4.0 samba<=4.10.17-1"

--- a/app-database/ldb/autobuild/prepare
+++ b/app-database/ldb/autobuild/prepare
@@ -9,3 +9,7 @@ fi
 
 # Workaround for hardcoded PATH to waf - Fedora rpm/libtdb.
 sed -e 's:\.\./\.\./buildtools:./buildtools:' -i Makefile
+
+BUILD_FINAL() {
+    doxygen Doxyfile
+}

--- a/app-database/ldb/spec
+++ b/app-database/ldb/spec
@@ -1,5 +1,5 @@
 VER=2.6.1
-REL=2
-SRCS="tbl::https://www.samba.org/ftp/pub/ldb/ldb-$VER.tar.gz"
+REL=3
+SRCS="tbl::https://www.samba.org/ftp/ldb/ldb-$VER.tar.gz"
 CHKSUMS="sha256::467403f77df86782c3965bb175440baa2ed751a9feb9560194bd8c06bf1736c9"
 CHKUPDATE="anitya::id=1652"

--- a/app-multimedia/espeak-ng/autobuild/defines
+++ b/app-multimedia/espeak-ng/autobuild/defines
@@ -4,8 +4,3 @@ PKGDEP="pcaudiolib"
 PKGDES="A multi-lingual open source synthesizer"
 
 ABSHADOW=0
-
-BUILD_READY() {
-    abinfo "Building extra components ..."
-    make src/espeak-ng src/speak-ng
-}

--- a/app-multimedia/espeak-ng/autobuild/prepare
+++ b/app-multimedia/espeak-ng/autobuild/prepare
@@ -1,0 +1,4 @@
+BUILD_READY() {
+    abinfo "Building extra components ..."
+    make src/espeak-ng src/speak-ng
+}

--- a/app-multimedia/espeak-ng/spec
+++ b/app-multimedia/espeak-ng/spec
@@ -1,4 +1,5 @@
 VER=1.51.1
+REL=1
 SRCS="tbl::https://github.com/espeak-ng/espeak-ng/archive/refs/tags/$VER.tar.gz"
 CHKSUMS="sha256::0823df5648659dcb67915baaf99118dcc8853639f47cadaa029c174bdd768d20"
 CHKUPDATE="anitya::id=12958"

--- a/app-scientific/maxima/autobuild/defines
+++ b/app-scientific/maxima/autobuild/defines
@@ -17,6 +17,4 @@ NOLTO=1
 
 ABSPLITDBG=0
 
-BUILD_FINAL() {
-    export MAKE_AFTER="emacsdir=/usr/share/emacs/site-lisp/maxima"
-}
+MAKE_AFTER="emacsdir=/usr/share/emacs/site-lisp/maxima"

--- a/app-scientific/maxima/spec
+++ b/app-scientific/maxima/spec
@@ -1,4 +1,5 @@
 VER=5.46.0
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/maxima/maxima-$VER.tar.gz"
 CHKSUMS="sha256::7390f06b48da65c9033e8b2f629b978b90056454a54022db7de70e2225aa8b07"
 CHKUPDATE="anitya::id=6365"

--- a/app-utils/pinentry/autobuild/defines
+++ b/app-utils/pinentry/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=pinentry
 PKGSEC=utils
 PKGDEP="libassuan libcap ncurses libsecret pcre2 gtk-2"
-BUILDDEP="gcr"
-PKGSUG="gcr"
+BUILDDEP="gcr qt-5"
+BUILDDEP__RISCV64="${BUILDDEP/qt-5/}"
+PKGSUG="gcr qt-5"
+PKGSUG__RISCV64="${PKGSUG/qt-5/}"
 PKGDES="A collection of simple PIN or passphrase entry dialogs"
 
 AUTOTOOLS_AFTER="--enable-pinentry-curses \
@@ -10,12 +12,8 @@ AUTOTOOLS_AFTER="--enable-pinentry-curses \
                  --enable-pinentry-tty \
                  --enable-pinentry-emacs \
                  --enable-pinentry-gtk2 \
-                 --enable-pinentry-gnome3"
-
-if [[ "${CROSS:-$ARCH}" != "riscv64" ]]; then
-	BUILDDEP+=" qt-5"
-	PKGSUG+=" qt-5"
-	AUTOTOOLS_AFTER+=" --enable-pinentry-qt"
-fi
+                 --enable-pinentry-gnome3 \
+                 --enable-pinentry-qt"
+AUTOTOOLS_AFTER__RISCV64="${AUTOTOOLS_AFTER/--enable-pinentry-qt/}"
 
 ABRPMAUTOPROVONLY=1

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,5 @@
 VER=1.1.0
-REL=8
+REL=9
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570"
 CHKUPDATE="anitya::id=3643"

--- a/runtime-multimedia/stk/autobuild/defines
+++ b/runtime-multimedia/stk/autobuild/defines
@@ -10,4 +10,3 @@ AUTOTOOLS_AFTER="--prefix=/usr \
                  --enable-debug"
 RECONF=1
 ABSHADOW=0
-export RAWWAVE_PATH="/usr/share/stk/rawwaves/"

--- a/runtime-multimedia/stk/autobuild/prepare
+++ b/runtime-multimedia/stk/autobuild/prepare
@@ -1,1 +1,4 @@
-cp /usr/share/automake-1.16/config.* "$SRCDIR"/config/
+export RAWWAVE_PATH="/usr/share/stk/rawwaves/"
+
+abinfo "Copying automake configs ..."
+cp -v /usr/bin/config.* "$SRCDIR"/config/

--- a/runtime-multimedia/stk/spec
+++ b/runtime-multimedia/stk/spec
@@ -1,4 +1,5 @@
 VER=5.0.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/thestk/stk.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4895"


### PR DESCRIPTION
Topic Description
-----------------

- stk: move RAWWAVE_PATH to prepare
- pinentry: replace if-else with conditional variable
- maxima: remove unused BUILD_FINAL
- espeak-ng: move BUILD_READY to prepare
- ldb: move BUILD_FINAL to prepare

Package(s) Affected
-------------------

- espeak-ng: 1.51.1-1
- ldb: 2:2.6.1-3
- maxima: 5.46.0-1
- pinentry: 1.1.0-9
- stk: 5.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ldb espeak-ng maxima pinentry stk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
