### PR TITLE
v2ray-rules-dat: update to 202412282210

### DIFF
--- a/runtime-data/v2ray-rules-dat/spec
+++ b/runtime-data/v2ray-rules-dat/spec
@@ -1,6 +1,6 @@
-VER=202412012212
+VER=202412282210
 SRCS="file::rename=geoip.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geoip.dat \
       file::rename=geosite.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geosite.dat"
-CHKSUMS="sha256::5134a75b7ff17c1ec97c91a15a21363b15de6f91c554b2cd8425a55aeabdc9a5 \
-         sha256::3b669e7301596e59ce739433f4bfee94e3fd19060df4605f30e20f2eeb58cee4"
+CHKSUMS="sha256::de48de9a387944451ee94ac223eac6eee58c6c25e8866870cff5aee307c49832 \
+         sha256::5f2b188e170f6e53d87614c2538ec48a22c988e87e04ea9bdc8d2ae24febcb06"
 CHKUPDATE="anitya::id=375331"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray-rules-dat: update to 202412282210
    Co-authored-by: yidaduizuoye (@CAB233)

Package(s) Affected
-------------------

- v2ray-rules-dat: 202412282210

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray-rules-dat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
