### PR TITLE
libvpl: update to 2.14.0

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/build
+++ b/app-multimedia/ffmpeg/autobuild/build
@@ -24,7 +24,7 @@ if ab_match_arch armv6hf; then
 fi
 
 if ab_match_arch amd64; then
-    MFX="--enable-libmfx"
+    VPL="--enable-libvpl"
     NVENC="--enable-nvenc"
     CUDA="--enable-cuda-llvm"
 fi
@@ -109,7 +109,7 @@ fi
 abinfo "Configuring FFmpeg ..."
 "$SRCDIR"/configure \
     ${CONFIGURE_OPTIONS} \
-    ${MIPSCONF} ${PPCCONF} ${ARMCONF} ${MFX} ${NVENC} ${CUDA}
+    ${MIPSCONF} ${PPCCONF} ${ARMCONF} ${VPL} ${NVENC} ${CUDA}
 
 abinfo "Building FFmpeg ..."
 make

--- a/app-multimedia/ffmpeg/autobuild/defines
+++ b/app-multimedia/ffmpeg/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass \
         libvpx libxcb x264 x265 opencore-amr opus schroedinger sdl speex \
         v4l-utils xvidcore zlib soxr libva sdl2 numactl ladspa-sdk xz aom \
         samba dav1d avisynthplus svt-av1 libwebp"
-PKGDEP__AMD64="${PKGDEP} intel-media-sdk"
+PKGDEP__AMD64="${PKGDEP} libvpl"
 BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec llvm"
 BUILDDEP_ARM64="${BUILDDEP} yasm"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \

--- a/app-multimedia/ffmpeg/autobuild/patches/0001-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0001-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,19 +1,19 @@
-From 1d0c743eb8eaf62ba35d5ac4120b741b3465f523 Mon Sep 17 00:00:00 2001
+From 1ace584bbc51082635887013d5da6d09d8c73f7d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 1/2] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 1/4] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
- libavutil/mips/asmdefs.h | 48 ----------------------------------------
+ libavutil/mips/asmdefs.h | 42 -----------------------------------
  libavutil/mips/cpu.c     | 48 +---------------------------------------
- 2 files changed, 1 insertion(+), 95 deletions(-)
+ 2 files changed, 1 insertion(+), 89 deletions(-)
 
 diff --git a/libavutil/mips/asmdefs.h b/libavutil/mips/asmdefs.h
-index 659342bab9..1815e83dad 100644
+index 659342bab9..4d3bf1f09a 100644
 --- a/libavutil/mips/asmdefs.h
 +++ b/libavutil/mips/asmdefs.h
-@@ -57,52 +57,4 @@
+@@ -57,48 +57,6 @@
  # define PTR_SLL        "sll "
  #endif
  
@@ -59,13 +59,9 @@ index 659342bab9..1815e83dad 100644
 -        ".endif\n\t"
 -        ".endm");
 -
--/* General union structure for clang adaption */
--union mmi_intfloat64 {
--    int64_t i;
--    double  f;
--};
--
- #endif /* AVCODEC_MIPS_ASMDEFS_H */
+ /* General union structure for clang adaption */
+ union mmi_intfloat64 {
+     int64_t i;
 diff --git a/libavutil/mips/cpu.c b/libavutil/mips/cpu.c
 index 2009c70f71..5002261b25 100644
 --- a/libavutil/mips/cpu.c
@@ -133,5 +129,5 @@ index 2009c70f71..5002261b25 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.46.2
+2.47.1
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0002-Add-av_stream_get_first_dts-for-Chromium.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0002-Add-av_stream_get_first_dts-for-Chromium.patch
@@ -1,7 +1,7 @@
-From 826412bf00285dbcaccca03a3c28b6676fbab404 Mon Sep 17 00:00:00 2001
+From fe4537f7a8fbce54efae9a6734c45e84b0fcdb35 Mon Sep 17 00:00:00 2001
 From: Frank Liberato <liberato@chromium.org>
 Date: Wed, 7 Jul 2021 19:01:22 -0700
-Subject: [PATCH 2/2] Add av_stream_get_first_dts for Chromium
+Subject: [PATCH 2/4] Add av_stream_get_first_dts for Chromium
 
 ---
  libavformat/avformat.h | 4 ++++
@@ -42,5 +42,5 @@ index e9ded627ad..399c777f2a 100644
  #define SANE_CHUNK_SIZE (50000000)
  
 -- 
-2.46.2
+2.47.1
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0003-fix-libavcodec-mips-constify-src-for-mmi.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0003-fix-libavcodec-mips-constify-src-for-mmi.patch
@@ -1,0 +1,340 @@
+From 6eb863465aa2ec0d88c890ddd51fdd5c0b34c071 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Mon, 30 Dec 2024 11:36:37 +0800
+Subject: [PATCH 3/4] fix(libavcodec/mips): constify src for mmi
+
+---
+ libavcodec/mips/vp8dsp_mmi.c | 72 ++++++++++++++++++------------------
+ 1 file changed, 36 insertions(+), 36 deletions(-)
+
+diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
+index bc774aa365..55599e58f9 100644
+--- a/libavcodec/mips/vp8dsp_mmi.c
++++ b/libavcodec/mips/vp8dsp_mmi.c
+@@ -1439,7 +1439,7 @@ void ff_vp8_h_loop_filter_simple_mmi(uint8_t *dst, ptrdiff_t stride, int flim)
+             vp8_filter_common_is4tap(dst + i * stride, 1);
+ }
+ 
+-void ff_put_vp8_pixels16_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_pixels16_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int x, int y)
+ {
+ #if 1
+@@ -1486,7 +1486,7 @@ void ff_put_vp8_pixels16_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_pixels8_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_pixels8_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int x, int y)
+ {
+ #if 1
+@@ -1526,7 +1526,7 @@ void ff_put_vp8_pixels8_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_pixels4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_pixels4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int x, int y)
+ {
+ #if 1
+@@ -1566,7 +1566,7 @@ void ff_put_vp8_pixels4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -1651,7 +1651,7 @@ void ff_put_vp8_epel16_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -1721,7 +1721,7 @@ void ff_put_vp8_epel8_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -1784,7 +1784,7 @@ void ff_put_vp8_epel4_h4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -1874,7 +1874,7 @@ void ff_put_vp8_epel16_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -1948,7 +1948,7 @@ void ff_put_vp8_epel8_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2016,7 +2016,7 @@ void ff_put_vp8_epel4_h6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2102,7 +2102,7 @@ void ff_put_vp8_epel16_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2173,7 +2173,7 @@ void ff_put_vp8_epel8_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2238,7 +2238,7 @@ void ff_put_vp8_epel4_v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2329,7 +2329,7 @@ void ff_put_vp8_epel16_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2405,7 +2405,7 @@ void ff_put_vp8_epel8_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2475,7 +2475,7 @@ void ff_put_vp8_epel4_v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2514,7 +2514,7 @@ void ff_put_vp8_epel16_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2553,7 +2553,7 @@ void ff_put_vp8_epel8_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2591,7 +2591,7 @@ void ff_put_vp8_epel4_h4v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2630,7 +2630,7 @@ void ff_put_vp8_epel16_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2669,7 +2669,7 @@ void ff_put_vp8_epel8_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2708,7 +2708,7 @@ void ff_put_vp8_epel4_h4v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2747,7 +2747,7 @@ void ff_put_vp8_epel16_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2786,7 +2786,7 @@ void ff_put_vp8_epel8_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2825,7 +2825,7 @@ void ff_put_vp8_epel4_h6v4_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel16_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel16_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2864,7 +2864,7 @@ void ff_put_vp8_epel16_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel8_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel8_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2903,7 +2903,7 @@ void ff_put_vp8_epel8_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_epel4_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
++void ff_put_vp8_epel4_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *src,
+         ptrdiff_t srcstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -2942,7 +2942,7 @@ void ff_put_vp8_epel4_h6v6_mmi(uint8_t *dst, ptrdiff_t dststride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear16_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear16_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3020,7 +3020,7 @@ void ff_put_vp8_bilinear16_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear16_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear16_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3090,7 +3090,7 @@ void ff_put_vp8_bilinear16_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear16_hv_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear16_hv_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3124,7 +3124,7 @@ void ff_put_vp8_bilinear16_hv_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear8_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear8_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3186,7 +3186,7 @@ void ff_put_vp8_bilinear8_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear8_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear8_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3250,7 +3250,7 @@ void ff_put_vp8_bilinear8_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear8_hv_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear8_hv_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3284,7 +3284,7 @@ void ff_put_vp8_bilinear8_hv_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear4_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear4_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3343,7 +3343,7 @@ void ff_put_vp8_bilinear4_h_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear4_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear4_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+@@ -3404,7 +3404,7 @@ void ff_put_vp8_bilinear4_v_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
+ #endif
+ }
+ 
+-void ff_put_vp8_bilinear4_hv_mmi(uint8_t *dst, ptrdiff_t dstride, uint8_t *src,
++void ff_put_vp8_bilinear4_hv_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *src,
+         ptrdiff_t sstride, int h, int mx, int my)
+ {
+ #if 1
+-- 
+2.47.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0004-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0004-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
@@ -1,0 +1,2493 @@
+From 3747eb2374a4c4d489ca5080e5bd6d199b14b436 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Mon, 30 Dec 2024 16:08:58 +0800
+Subject: [PATCH 4/4] fix(libavcodec/mips): use mmi mnemonics supported by
+ binutils 2.43.1
+
+Apparently Loongson's staff's proposal has never been upstreamed.
+
+see also: https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2021-July/282542.html
+---
+ libavcodec/mips/blockdsp_mmi.c     |   8 +-
+ libavcodec/mips/h264chroma_mmi.c   |  20 +-
+ libavcodec/mips/h264dsp_mmi.c      | 288 ++++++++++++++---------------
+ libavcodec/mips/h264pred_mmi.c     |  18 +-
+ libavcodec/mips/h264qpel_mmi.c     |  26 +--
+ libavcodec/mips/hevcdsp_mmi.c      |  32 ++--
+ libavcodec/mips/hpeldsp_mmi.c      |  26 +--
+ libavcodec/mips/idctdsp_mmi.c      |   2 +-
+ libavcodec/mips/mpegvideo_mmi.c    |  80 ++++----
+ libavcodec/mips/mpegvideoenc_mmi.c |  14 +-
+ libavcodec/mips/pixblockdsp_mmi.c  |   8 +-
+ libavcodec/mips/simple_idct_mmi.c  |  14 +-
+ libavcodec/mips/vc1dsp_mmi.c       |  34 ++--
+ libavcodec/mips/vp3dsp_idct_mmi.c  | 132 ++++++-------
+ libavcodec/mips/vp8dsp_mmi.c       |  80 ++++----
+ libavcodec/mips/vp9_mc_mmi.c       |  10 +-
+ libavcodec/mips/wmv2dsp_mmi.c      |   2 +-
+ 17 files changed, 397 insertions(+), 397 deletions(-)
+
+diff --git a/libavcodec/mips/blockdsp_mmi.c b/libavcodec/mips/blockdsp_mmi.c
+index 8b5c7e955c..68641e2544 100644
+--- a/libavcodec/mips/blockdsp_mmi.c
++++ b/libavcodec/mips/blockdsp_mmi.c
+@@ -76,8 +76,8 @@ void ff_clear_block_mmi(int16_t *block)
+     double ftmp[2];
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp1]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp1]                \n\t"
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x00)
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x10)
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x20)
+@@ -97,8 +97,8 @@ void ff_clear_blocks_mmi(int16_t *block)
+     double ftmp[2];
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp1]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp1]                \n\t"
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x00)
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x10)
+         MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x20)
+diff --git a/libavcodec/mips/h264chroma_mmi.c b/libavcodec/mips/h264chroma_mmi.c
+index fe05ccd671..1a08a524cd 100644
+--- a/libavcodec/mips/h264chroma_mmi.c
++++ b/libavcodec/mips/h264chroma_mmi.c
+@@ -75,7 +75,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         A.i = 64 - D.i - B.i - C.i;
+ 
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]           \n\t"
+             "pshufh     %[B],       %[B],           %[ftmp0]           \n\t"
+             "mtc1       %[tmp0],    %[ftmp9]                           \n\t"
+@@ -175,7 +175,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         A.i = 64 - E.i;
+ 
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]           \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]           \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                           \n\t"
+@@ -223,7 +223,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         A.i = 64 - E.i;
+ 
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]           \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]           \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]           \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                           \n\t"
+@@ -333,7 +333,7 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         C.i = (y << 3) - D.i;
+         A.i = 64 - D.i - B.i - C.i;
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]       \n\t"
+             "pshufh     %[B],       %[B],           %[ftmp0]       \n\t"
+             "mtc1       %[tmp0],    %[ftmp9]                       \n\t"
+@@ -401,7 +401,7 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         E.i = x << 3;
+         A.i = 64 - E.i;
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]       \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]       \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                       \n\t"
+@@ -450,7 +450,7 @@ void ff_avg_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+         E.i = y << 3;
+         A.i = 64 - E.i;
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]       \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]       \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]       \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                       \n\t"
+@@ -512,7 +512,7 @@ void ff_put_h264_chroma_mc4_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+ 
+     if (D.i) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]            \n\t"
+             "pshufh     %[B],       %[B],           %[ftmp0]            \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                            \n\t"
+@@ -561,7 +561,7 @@ void ff_put_h264_chroma_mc4_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+     } else if (E.i) {
+         const int step = C.i ? stride : 1;
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]            \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]            \n\t"
+             "mtc1       %[tmp0],    %[ftmp5]                            \n\t"
+@@ -633,7 +633,7 @@ void ff_avg_h264_chroma_mc4_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+ 
+     if (D.i) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]            \n\t"
+             "pshufh     %[B],       %[B],           %[ftmp0]            \n\t"
+             "mtc1       %[tmp0],    %[ftmp7]                            \n\t"
+@@ -684,7 +684,7 @@ void ff_avg_h264_chroma_mc4_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
+     } else if (E.i) {
+         const int step = C.i ? stride : 1;
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             "pshufh     %[A],       %[A],           %[ftmp0]            \n\t"
+             "pshufh     %[E],       %[E],           %[ftmp0]            \n\t"
+             "mtc1       %[tmp0],    %[ftmp5]                            \n\t"
+diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
+index bae1052dcf..09cfbecaee 100644
+--- a/libavcodec/mips/h264dsp_mmi.c
++++ b/libavcodec/mips/h264dsp_mmi.c
+@@ -34,7 +34,7 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
+     DECLARE_VAR_LOW32;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_LDC1(%[ftmp1], %[src], 0x00)
+         MMI_LDC1(%[ftmp2], %[src], 0x08)
+         MMI_LDC1(%[ftmp3], %[src], 0x10)
+@@ -89,7 +89,7 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         MMI_LDC1(%[ftmp2], %[block], 0x10)
+         MMI_LDC1(%[ftmp3], %[block], 0x18)
+         /* memset(block, 0, 32) */
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         MMI_SQC1(%[ftmp4], %[ftmp4], %[block], 0x00)
+         MMI_SQC1(%[ftmp4], %[ftmp4], %[block], 0x10)
+         "dli        %[tmp0],    0x01                                    \n\t"
+@@ -127,7 +127,7 @@ void ff_h264_idct_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "psubh      %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
+         MMI_ULWC1(%[ftmp2], %[dst], 0x00)
+         MMI_LWXC1(%[ftmp0], %[dst], %[stride], 0x00)
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "psrah      %[ftmp3],   %[ftmp10],      %[ftmp9]                \n\t"
+         "psrah      %[ftmp4],   %[ftmp11],      %[ftmp9]                \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp7]                \n\t"
+@@ -419,7 +419,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "psubh      %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+         MMI_SDC1(%[ftmp0], $sp, 0x10)
+         "dmfc1      %[tmp1],    %[ftmp2]                                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
+         MMI_SDC1(%[ftmp2], %[block], 0x00)
+         MMI_SDC1(%[ftmp2], %[block], 0x08)
+         MMI_SDC1(%[ftmp2], %[block], 0x10)
+@@ -555,7 +555,7 @@ void ff_h264_idct8_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         MMI_SDC1(%[ftmp7], $sp, 0x18)
+         "dmfc1      %[tmp2],    %[ftmp0]                                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_ULWC1(%[ftmp6], %[addr0], 0x00)
+         MMI_LWXC1(%[ftmp7], %[addr0], %[stride], 0x00)
+         "psrah      %[ftmp2],   %[ftmp2],       %[ftmp10]               \n\t"
+@@ -646,7 +646,7 @@ void ff_h264_idct_dc_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+ 
+     __asm__ volatile (
+         "mtc1       %[dc],      %[ftmp5]                                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[ftmp5],   %[ftmp5],       %[ftmp0]                \n\t"
+         MMI_ULWC1(%[ftmp1], %[dst0], 0x00)
+         MMI_ULWC1(%[ftmp2], %[dst1], 0x00)
+@@ -690,7 +690,7 @@ void ff_h264_idct8_dc_add_8_mmi(uint8_t *dst, int16_t *block, int stride)
+ 
+     __asm__ volatile (
+         "mtc1       %[dc],      %[ftmp5]                                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[ftmp5],   %[ftmp5],       %[ftmp0]                \n\t"
+         MMI_LDC1(%[ftmp1], %[dst0], 0x00)
+         MMI_LDC1(%[ftmp2], %[dst1], 0x00)
+@@ -930,7 +930,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "packsswh   %[ftmp0],   %[ftmp0],       %[ftmp1]                \n\t"
+         "packsswh   %[ftmp2],   %[ftmp2],       %[ftmp5]                \n\t"
+         "dmfc1      %[tmp1],    %[ftmp0]                                \n\t"
+-        "ssrld      %[ftmp0],   %[ftmp0],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp0],   %[ftmp0],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp0]                                \n\t"
+         "sh         %[tmp1],    0x00(%[output])                         \n\t"
+         "sh         %[input],   0x80(%[output])                         \n\t"
+@@ -939,7 +939,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "sh         %[tmp1],    0x20(%[output])                         \n\t"
+         "sh         %[input],   0xa0(%[output])                         \n\t"
+         "dmfc1      %[tmp1],    %[ftmp2]                                \n\t"
+-        "ssrld      %[ftmp2],   %[ftmp2],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp2],   %[ftmp2],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp2]                                \n\t"
+         "sh         %[tmp1],    0x40(%[output])                         \n\t"
+         "sh         %[input],   0xc0(%[output])                         \n\t"
+@@ -964,7 +964,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "packsswh   %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
+         "packsswh   %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+         "dmfc1      %[tmp1],    %[ftmp3]                                \n\t"
+-        "ssrld      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp3]                                \n\t"
+         "sh         %[tmp1],    0x100(%[output])                        \n\t"
+         "sh         %[input],   0x180(%[output])                        \n\t"
+@@ -973,7 +973,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "sh         %[tmp1],    0x120(%[output])                        \n\t"
+         "sh         %[input],   0x1a0(%[output])                        \n\t"
+         "dmfc1      %[tmp1],    %[ftmp4]                                \n\t"
+-        "ssrld      %[ftmp4],   %[ftmp4],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp4],   %[ftmp4],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp4]                                \n\t"
+         "sh         %[tmp1],    0x140(%[output])                        \n\t"
+         "sh         %[input],   0x1c0(%[output])                        \n\t"
+@@ -1017,7 +1017,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "packsswh   %[ftmp0],   %[ftmp0],       %[ftmp1]                \n\t"
+         "packsswh   %[ftmp2],   %[ftmp2],       %[ftmp5]                \n\t"
+         "dmfc1      %[tmp1],    %[ftmp0]                                \n\t"
+-        "ssrld      %[ftmp0],   %[ftmp0],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp0],   %[ftmp0],       %[ftmp9]                \n\t"
+         "sh         %[tmp1],    0x00(%[output])                         \n\t"
+         "mfc1       %[input],   %[ftmp0]                                \n\t"
+         "dsrl       %[tmp1],    %[tmp1],        0x10                    \n\t"
+@@ -1026,7 +1026,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         PTR_SRL    "%[input],   %[input],       0x10                    \n\t"
+         "dmfc1      %[tmp1],    %[ftmp2]                                \n\t"
+         "sh         %[input],   0xa0(%[output])                         \n\t"
+-        "ssrld      %[ftmp2],   %[ftmp2],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp2],   %[ftmp2],       %[ftmp9]                \n\t"
+         "sh         %[tmp1],    0x40(%[output])                         \n\t"
+         "mfc1       %[input],   %[ftmp2]                                \n\t"
+         "dsrl       %[tmp1],    %[tmp1],        0x10                    \n\t"
+@@ -1051,7 +1051,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "packsswh   %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
+         "packsswh   %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+         "dmfc1      %[tmp1],    %[ftmp3]                                \n\t"
+-        "ssrld      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp3]                                \n\t"
+         "sh         %[tmp1],    0x100(%[output])                        \n\t"
+         "sh         %[input],   0x180(%[output])                        \n\t"
+@@ -1060,7 +1060,7 @@ void ff_h264_luma_dc_dequant_idct_8_mmi(int16_t *output, int16_t *input,
+         "sh         %[tmp1],    0x120(%[output])                        \n\t"
+         "sh         %[input],   0x1a0(%[output])                        \n\t"
+         "dmfc1      %[tmp1],    %[ftmp4]                                \n\t"
+-        "ssrld      %[ftmp4],   %[ftmp4],       %[ftmp9]                \n\t"
++        "dsrl       %[ftmp4],   %[ftmp4],       %[ftmp9]                \n\t"
+         "mfc1       %[input],   %[ftmp4]                                \n\t"
+         "sh         %[tmp1],    0x140(%[output])                        \n\t"
+         "sh         %[input],   0x1c0(%[output])                        \n\t"
+@@ -1098,7 +1098,7 @@ void ff_h264_weight_pixels16_8_mmi(uint8_t *block, ptrdiff_t stride, int height,
+ 
+     for (y=0; y<height; y++, block+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_LDC1(%[ftmp1], %[block0], 0x00)
+             MMI_LDC1(%[ftmp2], %[block1], 0x00)
+             "mtc1       %[weight],  %[ftmp3]                            \n\t"
+@@ -1152,7 +1152,7 @@ void ff_h264_biweight_pixels16_8_mmi(uint8_t *dst, uint8_t *src,
+ 
+     for (y=0; y<height; y++, dst+=stride, src+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_LDC1(%[ftmp1], %[src0], 0x00)
+             MMI_LDC1(%[ftmp2], %[dst0], 0x00)
+             "mtc1       %[weights], %[ftmp3]                            \n\t"
+@@ -1225,7 +1225,7 @@ void ff_h264_weight_pixels8_8_mmi(uint8_t *block, ptrdiff_t stride, int height,
+ 
+     for (y=0; y<height; y++, block+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_LDC1(%[ftmp1], %[block], 0x00)
+             "mtc1       %[weight],  %[ftmp2]                            \n\t"
+             "mtc1       %[offset],  %[ftmp3]                            \n\t"
+@@ -1266,7 +1266,7 @@ void ff_h264_biweight_pixels8_8_mmi(uint8_t *dst, uint8_t *src,
+ 
+     for (y=0; y<height; y++, dst+=stride, src+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_LDC1(%[ftmp1], %[src], 0x00)
+             MMI_LDC1(%[ftmp2], %[dst], 0x00)
+             "mtc1       %[weights], %[ftmp3]                            \n\t"
+@@ -1320,7 +1320,7 @@ void ff_h264_weight_pixels4_8_mmi(uint8_t *block, ptrdiff_t stride, int height,
+ 
+     for (y=0; y<height; y++, block+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_ULWC1(%[ftmp1], %[block], 0x00)
+             "mtc1       %[weight],  %[ftmp2]                            \n\t"
+             "mtc1       %[offset],  %[ftmp3]                            \n\t"
+@@ -1356,7 +1356,7 @@ void ff_h264_biweight_pixels4_8_mmi(uint8_t *dst, uint8_t *src,
+ 
+     for (y=0; y<height; y++, dst+=stride, src+=stride) {
+         __asm__ volatile (
+-            "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++            "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+             MMI_ULWC1(%[ftmp1], %[src], 0x00)
+             MMI_ULWC1(%[ftmp2], %[dst], 0x00)
+             "mtc1       %[weight],  %[ftmp3]                            \n\t"
+@@ -1399,7 +1399,7 @@ void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int bet
+ 
+     __asm__ volatile (
+         PTR_ADDU   "%[addr0],   %[stride],      %[stride]               \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         PTR_ADDU   "%[addr1],   %[stride],      %[addr0]                \n\t"
+         "addi       %[alpha],   %[alpha],       -0x01                   \n\t"
+         PTR_SUBU   "%[addr1],   $0,             %[addr1]                \n\t"
+@@ -1417,18 +1417,18 @@ void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int bet
+         "packushb   %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp2]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp2],       %[ftmp3]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp4],       %[ftmp3]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "pcmpeqb    %[ftmp8],   %[ftmp8],       %[ftmp0]                \n\t"
+         "pcmpeqb    %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         MMI_ULWC1(%[ftmp5], %[tc0], 0x00)
+@@ -1436,21 +1436,21 @@ void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int bet
+         "punpcklbh  %[ftmp9],   %[ftmp5],       %[ftmp5]                \n\t"
+         "pcmpgtb    %[ftmp5],   %[ftmp9],       %[ftmp4]                \n\t"
+         MMI_LDC1(%[ftmp4], %[addr1], 0x00)
+-        "pand       %[ftmp10],  %[ftmp5],       %[ftmp8]                \n\t"
++        "and        %[ftmp10],  %[ftmp5],       %[ftmp8]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp4],       %[ftmp2]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp2],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp7],   %[ftmp7],       %[ftmp8]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+-        "pand       %[ftmp5],   %[ftmp10],      %[ftmp9]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "and        %[ftmp5],   %[ftmp10],      %[ftmp9]                \n\t"
+         "psubb      %[ftmp8],   %[ftmp5],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+         "pavgb      %[ftmp5],   %[ftmp2],       %[ftmp3]                \n\t"
+         MMI_LDC1(%[ftmp11], %[addr1], 0x00)
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp11]               \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp11]               \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp1],       %[ftmp7]                \n\t"
+         "paddusb    %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+@@ -1463,26 +1463,26 @@ void ff_deblock_v8_luma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int bet
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp6],   %[ftmp9],       %[ftmp7]                \n\t"
++        "and        %[ftmp6],   %[ftmp9],       %[ftmp7]                \n\t"
+         MMI_LDXC1(%[ftmp4], %[pix], %[stride], 0x00)
+         "pavgb      %[ftmp7],   %[ftmp2],       %[ftmp3]                \n\t"
+         MMI_LDXC1(%[ftmp11], %[pix], %[addr0], 0x00)
+         "pavgb      %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp11]               \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp11]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ff_pb_1]              \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp4],       %[ftmp6]                \n\t"
+         "paddusb    %[ftmp6],   %[ftmp6],       %[ftmp4]                \n\t"
+         "pmaxub     %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "pminub     %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+         MMI_SDXC1(%[ftmp5], %[pix], %[stride], 0x00)
+-        "pxor       %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
++        "xor        %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
+         "pcmpeqb    %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ff_pb_1]              \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp2]                \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp2]                \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ftmp1]                \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ff_pb_3]              \n\t"
+         "pavgb      %[ftmp5],   %[ftmp5],       %[ftmp3]                \n\t"
+@@ -1528,12 +1528,12 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+ 
+     __asm__ volatile (
+         "ori        %[tmp0],    $0,             0x01                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "mtc1       %[tmp0],    %[ftmp9]                                \n\t"
+         PTR_SLL    "%[addr0],   %[stride],      0x02                    \n\t"
+         PTR_ADDU   "%[addr2],   %[stride],      %[stride]               \n\t"
+         PTR_ADDIU  "%[alpha],   %[alpha],       -0x01                   \n\t"
+-        "sslld      %[ftmp11],  %[ftmp9],       %[ftmp9]                \n\t"
++        "dsll       %[ftmp11],  %[ftmp9],       %[ftmp9]                \n\t"
+         "bltz       %[alpha],   1f                                      \n\t"
+         PTR_ADDU   "%[addr1],   %[addr2],       %[stride]               \n\t"
+         PTR_ADDIU  "%[beta],    %[beta],        -0x01                   \n\t"
+@@ -1552,20 +1552,20 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp2]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp2],       %[ftmp3]                \n\t"
+         "packushb   %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         MMI_SDC1(%[ftmp5], %[stack], 0x10)
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp4],       %[ftmp3]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         MMI_LDC1(%[ftmp5], %[stack], 0x10)
+         "pcmpeqb    %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "ldc1       %[ftmp10],  %[ff_pb_1]                              \n\t"
+@@ -1578,14 +1578,14 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         "psubusb    %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+         MMI_LDC1(%[ftmp15], %[stack], 0x20)
+         "pcmpeqb    %[ftmp7],   %[ftmp7],       %[ftmp8]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp15]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp15]               \n\t"
+         MMI_LDXC1(%[ftmp15], %[addr0], %[stride], 0x00)
+         "psubusb    %[ftmp8],   %[ftmp15],      %[ftmp2]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp2],       %[ftmp15]               \n\t"
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp5],   %[ftmp5],       %[ftmp8]                \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         MMI_LDXC1(%[ftmp14], %[pix], %[addr2], 0x00)
+         MMI_SDC1(%[ftmp5], %[stack], 0x30)
+         "psubusb    %[ftmp8],   %[ftmp14],      %[ftmp3]                \n\t"
+@@ -1593,7 +1593,7 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp5],   %[ftmp5],       %[ftmp8]                \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         MMI_SDC1(%[ftmp5], %[stack], 0x40)
+         "pavgb      %[ftmp5],   %[ftmp15],      %[ftmp1]                \n\t"
+         "pavgb      %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
+@@ -1606,36 +1606,36 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         MMI_SDC1(%[ftmp7], %[stack], 0x00)
+         "psrlh      %[ftmp7],   %[ftmp7],       %[ftmp9]                \n\t"
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "pavgb      %[ftmp6],   %[ftmp15],      %[ftmp4]                \n\t"
+         "psubb      %[ftmp7],   %[ftmp15],      %[ftmp4]                \n\t"
+         "paddb      %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+         "psubb      %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+         MMI_LDC1(%[ftmp13], %[stack], 0x10)
+         "pavgb      %[ftmp6],   %[ftmp6],       %[ftmp1]                \n\t"
+         "psrlh      %[ftmp8],   %[ftmp8],       %[ftmp11]               \n\t"
+         "pavgb      %[ftmp6],   %[ftmp6],       %[ftmp13]               \n\t"
+         "pavgb      %[ftmp8],   %[ftmp8],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
++        "and        %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp8],   %[ftmp2],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp7],   %[ftmp2],       %[ftmp4]                \n\t"
+-        "pand       %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
++        "and        %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp7],   %[ftmp7],       %[ftmp8]                \n\t"
+         MMI_LDC1(%[ftmp13], %[stack], 0x30)
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+         MMI_LDC1(%[ftmp12], %[stack], 0x20)
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp2]                \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ftmp13]               \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp12]               \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp2]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp2]                \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ftmp13]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp12]               \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp2]                \n\t"
+         MMI_SDXC1(%[ftmp6], %[addr0], %[addr1], 0x00)
+         MMI_LDC1(%[ftmp6], %[addr0], 0x00)
+         "paddb      %[ftmp7],   %[ftmp15],      %[ftmp6]                \n\t"
+@@ -1646,16 +1646,16 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         "paddb      %[ftmp7],   %[ftmp7],       %[ftmp12]               \n\t"
+         "psrlh      %[ftmp7],   %[ftmp7],       %[ftmp11]               \n\t"
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         MMI_LDC1(%[ftmp12], %[stack], 0x30)
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp15]               \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ftmp12]               \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp15]               \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp15]               \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ftmp12]               \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp15]               \n\t"
+         MMI_SDXC1(%[ftmp5], %[addr0], %[addr2], 0x00)
+         MMI_SDXC1(%[ftmp6], %[addr0], %[stride], 0x00)
+         "pavgb      %[ftmp5],   %[ftmp14],      %[ftmp4]                \n\t"
+@@ -1669,36 +1669,36 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         MMI_SDC1(%[ftmp7], %[stack], 0x00)
+         "psrlh      %[ftmp7],   %[ftmp7],       %[ftmp9]                \n\t"
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "pavgb      %[ftmp6],   %[ftmp14],      %[ftmp1]                \n\t"
+         "paddb      %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+         "psubb      %[ftmp7],   %[ftmp14],      %[ftmp1]                \n\t"
+         "psubb      %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+         MMI_LDC1(%[ftmp12], %[stack], 0x10)
+         "pavgb      %[ftmp6],   %[ftmp6],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
+         "psrlh      %[ftmp8],   %[ftmp8],       %[ftmp11]               \n\t"
+         "pavgb      %[ftmp8],   %[ftmp8],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp6]                \n\t"
++        "and        %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp3],       %[ftmp1]                \n\t"
++        "xor        %[ftmp8],   %[ftmp3],       %[ftmp1]                \n\t"
+         "pavgb      %[ftmp7],   %[ftmp3],       %[ftmp1]                \n\t"
+-        "pand       %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
++        "and        %[ftmp8],   %[ftmp8],       %[ftmp10]               \n\t"
+         MMI_LDC1(%[ftmp12], %[stack], 0x40)
+         "psubb      %[ftmp7],   %[ftmp7],       %[ftmp8]                \n\t"
+         MMI_LDC1(%[ftmp13], %[stack], 0x20)
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp3]                \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp13]               \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp3]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp3]                \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp13]               \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp3]                \n\t"
+         MMI_SDC1(%[ftmp6], %[pix], 0x00)
+         MMI_LDXC1(%[ftmp6], %[pix], %[addr1], 0x00)
+         "paddb      %[ftmp7],   %[ftmp14],      %[ftmp6]                \n\t"
+@@ -1709,16 +1709,16 @@ static void deblock_v8_luma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alph
+         "paddb      %[ftmp7],   %[ftmp7],       %[ftmp12]               \n\t"
+         "psrlh      %[ftmp7],   %[ftmp7],       %[ftmp11]               \n\t"
+         "pavgb      %[ftmp7],   %[ftmp7],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp10]               \n\t"
+         MMI_LDC1(%[ftmp12], %[stack], 0x40)
+         "psubb      %[ftmp6],   %[ftmp6],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp14]               \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ftmp12]               \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp14]               \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp14]               \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ftmp12]               \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ftmp12]               \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp4]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp14]               \n\t"
+         MMI_SDXC1(%[ftmp5], %[pix], %[stride], 0x00)
+         MMI_SDXC1(%[ftmp6], %[pix], %[addr2], 0x00)
+         "1:                                                             \n\t"
+@@ -1762,7 +1762,7 @@ void ff_deblock_v_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         MMI_LDC1(%[ftmp3], %[pix], 0x00)
+         MMI_LDXC1(%[ftmp4], %[pix], %[stride], 0x00)
+ 
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "mtc1       %[alpha],   %[ftmp5]                                \n\t"
+         "mtc1       %[beta],    %[ftmp6]                                \n\t"
+         "pshufh     %[ftmp5],   %[ftmp5],       %[ftmp0]                \n\t"
+@@ -1771,29 +1771,29 @@ void ff_deblock_v_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         "packushb   %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp2]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp2],       %[ftmp3]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp4],       %[ftmp3]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "pcmpeqb    %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         MMI_ULWC1(%[ftmp7], %[tc0], 0x00)
+         "punpcklbh  %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
++        "and        %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "pcmpeqb    %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "pand       %[ftmp6],   %[ftmp6],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
++        "and        %[ftmp6],   %[ftmp6],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp2]                \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp2]                \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ff_pb_3]              \n\t"
+         "pavgb      %[ftmp5],   %[ftmp5],       %[ftmp3]                \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+@@ -1845,7 +1845,7 @@ void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         MMI_LDC1(%[ftmp3], %[pix], 0x00)
+         MMI_LDXC1(%[ftmp4], %[pix], %[stride], 0x00)
+ 
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "mtc1       %[alpha],   %[ftmp5]                                \n\t"
+         "mtc1       %[beta],    %[ftmp6]                                \n\t"
+         "pshufh     %[ftmp5],   %[ftmp5],       %[ftmp0]                \n\t"
+@@ -1854,36 +1854,36 @@ void ff_deblock_v_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         "packushb   %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp2]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp2],       %[ftmp3]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp4],       %[ftmp3]                \n\t"
+-        "por        %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
++        "or         %[ftmp5],   %[ftmp5],       %[ftmp7]                \n\t"
+         "psubusb    %[ftmp5],   %[ftmp5],       %[ftmp6]                \n\t"
+-        "por        %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "or         %[ftmp8],   %[ftmp8],       %[ftmp5]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "pcmpeqb    %[ftmp8],   %[ftmp8],       %[ftmp7]                \n\t"
+         "mov.d      %[ftmp6],   %[ftmp2]                                \n\t"
+         "mov.d      %[ftmp7],   %[ftmp3]                                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp2],       %[ftmp4]                \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp5],   %[ftmp2],       %[ftmp4]                \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp2],   %[ftmp2],       %[ftmp5]                \n\t"
+         "pavgb      %[ftmp2],   %[ftmp2],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp3],       %[ftmp1]                \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp5],   %[ftmp3],       %[ftmp1]                \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp3],   %[ftmp3],       %[ftmp5]                \n\t"
+         "pavgb      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+         "psubb      %[ftmp3],   %[ftmp3],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+-        "pand       %[ftmp3],   %[ftmp3],       %[ftmp8]                \n\t"
++        "and        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "and        %[ftmp3],   %[ftmp3],       %[ftmp8]                \n\t"
+         "paddb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+         "paddb      %[ftmp3],   %[ftmp3],       %[ftmp7]                \n\t"
+ 
+@@ -1950,7 +1950,7 @@ void ff_deblock_h_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int be
+         "mov.d      %[ftmp9],   %[ftmp0]                                \n\t"
+         "mov.d      %[ftmp10],  %[ftmp3]                                \n\t"
+ 
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+         "mtc1       %[alpha],   %[ftmp4]                                \n\t"
+         "mtc1       %[beta],    %[ftmp5]                                \n\t"
+         "pshufh     %[ftmp4],   %[ftmp4],       %[ftmp8]                \n\t"
+@@ -1959,29 +1959,29 @@ void ff_deblock_h_chroma_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha, int be
+         "packushb   %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp1],       %[ftmp0]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp0],       %[ftmp1]                \n\t"
+-        "por        %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
++        "or         %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp3],       %[ftmp2]                \n\t"
+-        "por        %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
++        "or         %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         MMI_ULWC1(%[ftmp6], %[tc0], 0x00)
+         "punpcklbh  %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
++        "and        %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+-        "pand       %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp5],   %[ftmp1],       %[ftmp2]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
++        "and        %[ftmp5],   %[ftmp5],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp1]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp1]                \n\t"
+         "pavgb      %[ftmp3],   %[ftmp3],       %[ff_pb_3]              \n\t"
+         "pavgb      %[ftmp4],   %[ftmp4],       %[ftmp2]                \n\t"
+         "pavgb      %[ftmp3],   %[ftmp3],       %[ftmp5]                \n\t"
+@@ -2088,7 +2088,7 @@ void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         "punpcklwd  %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+         "punpcklwd  %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+ 
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+         "mtc1       %[alpha],   %[ftmp4]                                \n\t"
+         "mtc1       %[beta],    %[ftmp5]                                \n\t"
+         "pshufh     %[ftmp4],   %[ftmp4],       %[ftmp8]                \n\t"
+@@ -2097,36 +2097,36 @@ void ff_deblock_h_chroma_intra_8_mmi(uint8_t *pix, ptrdiff_t stride, int alpha,
+         "packushb   %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp2],       %[ftmp1]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp1],       %[ftmp0]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp0],       %[ftmp1]                \n\t"
+-        "por        %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
++        "or         %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+         "psubusb    %[ftmp6],   %[ftmp2],       %[ftmp3]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp3],       %[ftmp2]                \n\t"
+-        "por        %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
++        "or         %[ftmp4],   %[ftmp4],       %[ftmp6]                \n\t"
+         "psubusb    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "por        %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
++        "or         %[ftmp7],   %[ftmp7],       %[ftmp4]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "pcmpeqb    %[ftmp7],   %[ftmp7],       %[ftmp6]                \n\t"
+         "mov.d      %[ftmp5],   %[ftmp1]                                \n\t"
+         "mov.d      %[ftmp6],   %[ftmp2]                                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp1],       %[ftmp3]                \n\t"
+-        "pand       %[ftmp4],   %[ftmp4],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp4],   %[ftmp1],       %[ftmp3]                \n\t"
++        "and        %[ftmp4],   %[ftmp4],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+         "psubusb    %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp2],       %[ftmp0]                \n\t"
+-        "pand       %[ftmp4],   %[ftmp4],       %[ff_pb_1]              \n\t"
++        "xor        %[ftmp4],   %[ftmp2],       %[ftmp0]                \n\t"
++        "and        %[ftmp4],   %[ftmp4],       %[ff_pb_1]              \n\t"
+         "pavgb      %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+         "psubusb    %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp2],   %[ftmp2],       %[ftmp3]                \n\t"
+         "psubb      %[ftmp1],   %[ftmp1],       %[ftmp5]                \n\t"
+         "psubb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+-        "pand       %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+-        "pand       %[ftmp2],   %[ftmp2],       %[ftmp7]                \n\t"
++        "and        %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
++        "and        %[ftmp2],   %[ftmp2],       %[ftmp7]                \n\t"
+         "paddb      %[ftmp1],   %[ftmp1],       %[ftmp5]                \n\t"
+         "paddb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+ 
+diff --git a/libavcodec/mips/h264pred_mmi.c b/libavcodec/mips/h264pred_mmi.c
+index 480411f5b5..3542d575be 100644
+--- a/libavcodec/mips/h264pred_mmi.c
++++ b/libavcodec/mips/h264pred_mmi.c
+@@ -162,7 +162,7 @@ void ff_pred8x8l_top_dc_8_mmi(uint8_t *src, int has_topleft,
+     DECLARE_VAR_ADDRT;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_ULDC1(%[ftmp10], %[srcA], 0x00)
+         MMI_ULDC1(%[ftmp9], %[src0], 0x00)
+         MMI_ULDC1(%[ftmp8], %[src1], 0x00)
+@@ -267,7 +267,7 @@ void ff_pred8x8l_dc_8_mmi(uint8_t *src, int has_topleft, int has_topright,
+         MMI_ULDC1(%[ftmp4], %[srcA], 0x00)
+         MMI_ULDC1(%[ftmp5], %[src0], 0x00)
+         MMI_ULDC1(%[ftmp6], %[src1], 0x00)
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x03                                    \n\t"
+         "punpcklbh  %[ftmp7],   %[ftmp4],       %[ftmp0]                \n\t"
+         "punpckhbh  %[ftmp8],   %[ftmp4],       %[ftmp0]                \n\t"
+@@ -358,7 +358,7 @@ void ff_pred8x8l_vertical_8_mmi(uint8_t *src, int has_topleft,
+     DECLARE_VAR_ALL64;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_LDC1(%[ftmp3], %[srcA], 0x00)
+         MMI_LDC1(%[ftmp4], %[src0], 0x00)
+         MMI_LDC1(%[ftmp5], %[src1], 0x00)
+@@ -531,7 +531,7 @@ void ff_pred8x8_top_dc_8_mmi(uint8_t *src, ptrdiff_t stride)
+ 
+     __asm__ volatile (
+         "dli        %[tmp0],    0x02                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         PTR_SUBU   "%[addr0],   %[src],         %[stride]               \n\t"
+         MMI_LDC1(%[ftmp1], %[addr0], 0x00)
+         "punpcklbh  %[ftmp2],   %[ftmp1],       %[ftmp0]                \n\t"
+@@ -641,7 +641,7 @@ void ff_pred8x8_dc_8_mmi(uint8_t *src, ptrdiff_t stride)
+         PTR_SRL    "%[addr4],   0x02                                    \n\t"
+         PTR_SRL    "%[addr1],   0x02                                    \n\t"
+         PTR_SRL    "%[addr2],   0x03                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dmtc1      %[addr3],   %[ftmp1]                                \n\t"
+         "pshufh     %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+         "dmtc1      %[addr4],   %[ftmp2]                                \n\t"
+@@ -758,9 +758,9 @@ static inline void pred16x16_plane_compat_mmi(uint8_t *src, int stride,
+         "dmtc1      %[tmp0],    %[ftmp4]                                \n\t"
+         MMI_ULDC1(%[ftmp0], %[addr0], -0x01)
+         MMI_ULDC1(%[ftmp2], %[addr0],  0x08)
+-        "ssrld      %[ftmp1],   %[ftmp0],       %[ftmp4]                \n\t"
+-        "ssrld      %[ftmp3],   %[ftmp2],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "dsrl       %[ftmp1],   %[ftmp0],       %[ftmp4]                \n\t"
++        "dsrl       %[ftmp3],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         "punpcklbh  %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+         "punpcklbh  %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+@@ -916,7 +916,7 @@ static inline void pred16x16_plane_compat_mmi(uint8_t *src, int stride,
+         "dmul       %[tmp3],    %[tmp3],        %[tmp2]                 \n\t"
+         "dsubu      %[tmp5],    %[tmp5],        %[tmp3]                 \n\t"
+ 
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         "dmtc1      %[tmp0],    %[ftmp0]                                \n\t"
+         "pshufh     %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+         "dmtc1      %[tmp1],    %[ftmp5]                                \n\t"
+diff --git a/libavcodec/mips/h264qpel_mmi.c b/libavcodec/mips/h264qpel_mmi.c
+index 3482956e13..99903a2258 100644
+--- a/libavcodec/mips/h264qpel_mmi.c
++++ b/libavcodec/mips/h264qpel_mmi.c
+@@ -114,7 +114,7 @@ static void put_h264_qpel4_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     DECLARE_VAR_LOW32;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x04                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULWC1(%[ftmp1], %[src], -0x02)
+@@ -169,7 +169,7 @@ static void put_h264_qpel8_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     DECLARE_VAR_ALL64;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x08                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULDC1(%[ftmp1], %[src], -0x02)
+@@ -250,7 +250,7 @@ static void avg_h264_qpel4_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     DECLARE_VAR_LOW32;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x04                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULWC1(%[ftmp1], %[src], -0x02)
+@@ -307,7 +307,7 @@ static void avg_h264_qpel8_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     DECLARE_VAR_ALL64;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x08                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULDC1(%[ftmp1], %[src], -0x02)
+@@ -394,7 +394,7 @@ static void put_h264_qpel4_v_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     __asm__ volatile (
+         ".set       push                                                \n\t"
+         ".set       noreorder                                           \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x02                                    \n\t"
+         MMI_LWC1(%[ftmp1], %[src], 0x00)
+         "mtc1       %[tmp0],    %[ftmp10]                               \n\t"
+@@ -516,7 +516,7 @@ static void put_h264_qpel8_v_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+             PTR_ADDU   "%[src],     %[src],         %[srcStride]        \n\t"
+             MMI_LWC1(%[ftmp2], %[src], 0x00)
+             PTR_ADDU   "%[src],     %[src],         %[srcStride]        \n\t"
+-            "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
++            "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
+             MMI_LWC1(%[ftmp3], %[src], 0x00)
+             PTR_ADDU   "%[src],     %[src],         %[srcStride]        \n\t"
+             MMI_LWC1(%[ftmp4], %[src], 0x00)
+@@ -812,7 +812,7 @@ static void avg_h264_qpel4_v_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+         ".set       push                                                \n\t"
+         ".set       noreorder                                           \n\t"
+         "dli        %[tmp0],    0x02                                    \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "mtc1       %[tmp0],    %[ftmp9]                                \n\t"
+         "dli        %[tmp0],    0x05                                    \n\t"
+         MMI_LWC1(%[ftmp0], %[src], 0x00)
+@@ -930,7 +930,7 @@ static void avg_h264_qpel8_v_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+             ".set       push                                            \n\t"
+             ".set       noreorder                                       \n\t"
+             "dli        %[tmp0],    0x02                                \n\t"
+-            "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
++            "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
+             "mtc1       %[tmp0],    %[ftmp9]                            \n\t"
+             "dli        %[tmp0],    0x05                                \n\t"
+             MMI_LWC1(%[ftmp0], %[src], 0x00)
+@@ -1269,7 +1269,7 @@ static void put_h264_qpel4_hv_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     src -= 2*srcStride;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x09                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULWC1(%[ftmp1], %[src], -0x02)
+@@ -1347,7 +1347,7 @@ static void put_h264_qpel8or16_hv1_lowpass_mmi(int16_t *tmp,
+             MMI_ULWC1(%[ftmp0], %[src], 0x00)
+             "mtc1       %[tmp0],    %[ftmp10]                           \n\t"
+             PTR_ADDU   "%[src],     %[src],         %[srcStride]        \n\t"
+-            "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
++            "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"
+             MMI_ULWC1(%[ftmp1], %[src], 0x00)
+             PTR_ADDU   "%[src],     %[src],         %[srcStride]        \n\t"
+             MMI_ULWC1(%[ftmp2], %[src], 0x00)
+@@ -1684,7 +1684,7 @@ static void put_h264_qpel8_h_lowpass_l2_mmi(uint8_t *dst, const uint8_t *src,
+         "dli        %[tmp0],    0x02                                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp7]                                \n\t"
+         "dli        %[tmp0],    0x05                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "mtc1       %[tmp0],    %[ftmp8]                                \n\t"
+         "1:                                                             \n\t"
+         MMI_ULDC1(%[ftmp1], %[src], 0x00)
+@@ -1833,7 +1833,7 @@ static void avg_h264_qpel4_hv_lowpass_mmi(uint8_t *dst, const uint8_t *src,
+     src -= 2*srcStride;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "dli        %[tmp0],    0x09                                    \n\t"
+         "1:                                                             \n\t"
+         MMI_ULWC1(%[ftmp1], %[src], -0x02)
+@@ -2005,7 +2005,7 @@ static void avg_h264_qpel8_h_lowpass_l2_mmi(uint8_t *dst, const uint8_t *src,
+         "ori        %[tmp0],    $0,             0x8                     \n\t"
+         "mtc1       %[tmp1],    %[ftmp7]                                \n\t"
+         "dli        %[tmp1],    0x05                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "mtc1       %[tmp1],    %[ftmp8]                                \n\t"
+         "1:                                                             \n\t"
+         MMI_ULDC1(%[ftmp1], %[src], 0x00)
+diff --git a/libavcodec/mips/hevcdsp_mmi.c b/libavcodec/mips/hevcdsp_mmi.c
+index 6ff52187e5..9a412aed76 100644
+--- a/libavcodec/mips/hevcdsp_mmi.c
++++ b/libavcodec/mips/hevcdsp_mmi.c
+@@ -47,7 +47,7 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, const uint8_t *_src, \
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"    \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"    \
+         "psrah        %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"    \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"    \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"    \
+                                                                          \
+         "1:                                                     \n\t"    \
+         "2:                                                     \n\t"    \
+@@ -145,7 +145,7 @@ void ff_hevc_put_hevc_qpel_hv##w##_8_mmi(int16_t *dst, const uint8_t *_src,\
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"    \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"    \
+         "psrah        %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"    \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"    \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"    \
+                                                                          \
+         "1:                                                     \n\t"    \
+         "2:                                                     \n\t"    \
+@@ -334,7 +334,7 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"   \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"   \
+         "psrah        %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"   \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
+         "punpcklhw    %[offset],     %[offset],     %[offset]   \n\t"   \
+         "punpcklwd    %[offset],     %[offset],     %[offset]   \n\t"   \
+                                                                         \
+@@ -388,7 +388,7 @@ void ff_hevc_put_hevc_qpel_bi_h##w##_8_mmi(uint8_t *_dst,               \
+         "psraw        %[ftmp6],      %[ftmp6],      %[shift]    \n\t"   \
+         "packsswh     %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp0]    \n\t"   \
+-        "pand         %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
++        "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+         MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+@@ -469,7 +469,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"   \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"   \
+         "psrah        %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"   \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+@@ -588,7 +588,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "psraw        %[ftmp5],      %[ftmp5],      %[ftmp0]    \n\t"   \
+         "packsswh     %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+         MMI_ULDC1(%[ftmp4], %[src2], 0x00)                              \
+-        "pxor         %[ftmp7],      %[ftmp7],      %[ftmp7]    \n\t"   \
++        "xor          %[ftmp7],      %[ftmp7],      %[ftmp7]    \n\t"   \
+         "li           %[rtmp0],      0x10                       \n\t"   \
+         "dmtc1        %[rtmp0],      %[ftmp8]                   \n\t"   \
+         "punpcklhw    %[ftmp5],      %[ftmp7],      %[ftmp3]    \n\t"   \
+@@ -607,7 +607,7 @@ void ff_hevc_put_hevc_qpel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "psraw        %[ftmp6],      %[ftmp6],      %[shift]    \n\t"   \
+         "packsswh     %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp7]    \n\t"   \
+-        "pand         %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
++        "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+         MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+@@ -686,7 +686,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "dmtc1        %[rtmp0],      %[ftmp0]                   \n\t"   \
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"   \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"   \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+@@ -747,7 +747,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "li           %[rtmp0],      0x06                       \n\t"   \
+         "dmtc1        %[rtmp0],      %[ftmp0]                   \n\t"   \
+         "punpcklwd    %[offset],     %[offset],     %[offset]   \n\t"   \
+-        "pxor         %[ftmp2],      %[ftmp2],      %[ftmp2]    \n\t"   \
++        "xor          %[ftmp2],      %[ftmp2],      %[ftmp2]    \n\t"   \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "li           %[x],        " #x_step "                  \n\t"   \
+@@ -792,7 +792,7 @@ void ff_hevc_put_hevc_epel_bi_hv##w##_8_mmi(uint8_t *_dst,              \
+         "psraw        %[ftmp6],      %[ftmp6],      %[shift]    \n\t"   \
+         "packsswh     %[ftmp5],      %[ftmp5],      %[ftmp6]    \n\t"   \
+         "pcmpgth      %[ftmp7],      %[ftmp5],      %[ftmp2]    \n\t"   \
+-        "pand         %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
++        "and          %[ftmp3],      %[ftmp5],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+         MMI_USWC1(%[ftmp3], %[dst], 0x0)                                \
+                                                                         \
+@@ -855,7 +855,7 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+     y = height;                                                           \
+     x = width >> 3;                                                       \
+     __asm__ volatile(                                                     \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"     \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"     \
+         "li           %[rtmp0],      0x06                       \n\t"     \
+         "dmtc1        %[rtmp0],      %[ftmp1]                   \n\t"     \
+         "li           %[rtmp0],      0x10                       \n\t"     \
+@@ -900,8 +900,8 @@ void ff_hevc_put_hevc_pel_bi_pixels##w##_8_mmi(uint8_t *_dst,             \
+         "packsswh     %[ftmp4],      %[ftmp4],      %[ftmp5]    \n\t"     \
+         "pcmpgth      %[ftmp3],      %[ftmp2],      %[ftmp0]    \n\t"     \
+         "pcmpgth      %[ftmp5],      %[ftmp4],      %[ftmp0]    \n\t"     \
+-        "pand         %[ftmp2],      %[ftmp2],      %[ftmp3]    \n\t"     \
+-        "pand         %[ftmp4],      %[ftmp4],      %[ftmp5]    \n\t"     \
++        "and          %[ftmp2],      %[ftmp2],      %[ftmp3]    \n\t"     \
++        "and          %[ftmp4],      %[ftmp4],      %[ftmp5]    \n\t"     \
+         "packushb     %[ftmp2],      %[ftmp2],      %[ftmp4]    \n\t"     \
+         MMI_USDC1(%[ftmp2], %[dst], 0x0)                                  \
+                                                                           \
+@@ -980,7 +980,7 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         "punpcklbh    %[ftmp1],      %[ftmp0],      %[ftmp1]    \n\t"   \
+         "psrah        %[ftmp1],      %[ftmp1],      %[ftmp0]    \n\t"   \
+         "psrah        %[ftmp2],      %[ftmp2],      %[ftmp0]    \n\t"   \
+-        "pxor         %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
++        "xor          %[ftmp0],      %[ftmp0],      %[ftmp0]    \n\t"   \
+                                                                         \
+         "1:                                                     \n\t"   \
+         "2:                                                     \n\t"   \
+@@ -1101,9 +1101,9 @@ void ff_hevc_put_hevc_qpel_uni_hv##w##_8_mmi(uint8_t *_dst,             \
+         "packsswh     %[ftmp3],      %[ftmp3],      %[ftmp5]    \n\t"   \
+         "paddh        %[ftmp3],      %[ftmp3],      %[offset]   \n\t"   \
+         "psrah        %[ftmp3],      %[ftmp3],      %[shift]    \n\t"   \
+-        "pxor         %[ftmp7],      %[ftmp7],      %[ftmp7]    \n\t"   \
++        "xor          %[ftmp7],      %[ftmp7],      %[ftmp7]    \n\t"   \
+         "pcmpgth      %[ftmp7],      %[ftmp3],      %[ftmp7]    \n\t"   \
+-        "pand         %[ftmp3],      %[ftmp3],      %[ftmp7]    \n\t"   \
++        "and          %[ftmp3],      %[ftmp3],      %[ftmp7]    \n\t"   \
+         "packushb     %[ftmp3],      %[ftmp3],      %[ftmp3]    \n\t"   \
+         MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
+                                                                         \
+diff --git a/libavcodec/mips/hpeldsp_mmi.c b/libavcodec/mips/hpeldsp_mmi.c
+index 8e9c0fa821..ce51815ff4 100644
+--- a/libavcodec/mips/hpeldsp_mmi.c
++++ b/libavcodec/mips/hpeldsp_mmi.c
+@@ -677,14 +677,14 @@ inline void ff_put_no_rnd_pixels8_l2_8_mmi(uint8_t *dst, const uint8_t *src1,
+         PTR_ADDU   "%[addr1],   %[src2],        %[src_stride2]          \n\t"
+         MMI_ULDC1(%[ftmp3], %[addr1], 0x00)
+         PTR_ADDU   "%[src1],    %[src1],        %[addr2]                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp0],   %[ftmp0],       %[ftmp2]                \n\t"
+         "pavgb      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+         MMI_SDC1(%[ftmp0], %[dst], 0x00)
+         MMI_SDXC1(%[ftmp1], %[dst], %[dst_stride], 0x00)
+         PTR_ADDU   "%[src2],    %[src2],        %[addr3]                \n\t"
+@@ -697,14 +697,14 @@ inline void ff_put_no_rnd_pixels8_l2_8_mmi(uint8_t *dst, const uint8_t *src1,
+         PTR_ADDU   "%[addr1],   %[src2],        %[src_stride2]          \n\t"
+         MMI_ULDC1(%[ftmp3], %[addr1], 0x00)
+         PTR_ADDU   "%[src1],    %[src1],        %[addr2]                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "pavgb      %[ftmp0],   %[ftmp0],       %[ftmp2]                \n\t"
+         "pavgb      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+         MMI_SDC1(%[ftmp0], %[dst], 0x00)
+         MMI_SDXC1(%[ftmp1], %[dst], %[dst_stride], 0x00)
+         PTR_ADDU   "%[src2],    %[src2],        %[addr3]                \n\t"
+@@ -847,7 +847,7 @@ void ff_put_pixels8_xy2_8_mmi(uint8_t *block, const uint8_t *pixels,
+     DECLARE_VAR_ADDRT;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "dli        %[addr0],   0x0f                                    \n\t"
+         "pcmpeqw    %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "dmtc1      %[addr0],   %[ftmp8]                                \n\t"
+diff --git a/libavcodec/mips/idctdsp_mmi.c b/libavcodec/mips/idctdsp_mmi.c
+index d96b3b1ac6..0065fdbb33 100644
+--- a/libavcodec/mips/idctdsp_mmi.c
++++ b/libavcodec/mips/idctdsp_mmi.c
+@@ -154,7 +154,7 @@ void ff_add_pixels_clamped_mmi(const int16_t *block,
+     uint64_t tmp[1];
+     __asm__ volatile (
+         "li         %[tmp0],    0x04                           \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]           \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]           \n\t"
+         "1:                                                    \n\t"
+         MMI_LDC1(%[ftmp5], %[pixels], 0x00)
+         PTR_ADDU   "%[pixels],  %[pixels],  %[line_size]       \n\t"
+diff --git a/libavcodec/mips/mpegvideo_mmi.c b/libavcodec/mips/mpegvideo_mmi.c
+index 7af421db6b..f4b27fe83e 100644
+--- a/libavcodec/mips/mpegvideo_mmi.c
++++ b/libavcodec/mips/mpegvideo_mmi.c
+@@ -54,13 +54,13 @@ void ff_dct_unquantize_h263_intra_mmi(MpegEncContext *s, int16_t *block,
+         nCoeffs = s->inter_scantable.raster_end[s->block_last_index[n]];
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "packsswh   %[qmul],    %[qmul],        %[qmul]                 \n\t"
+         "packsswh   %[qmul],    %[qmul],        %[qmul]                 \n\t"
+         "packsswh   %[qadd],    %[qadd],        %[qadd]                 \n\t"
+         "packsswh   %[qadd],    %[qadd],        %[qadd]                 \n\t"
+         "psubh      %[ftmp0],   %[ftmp0],       %[qadd]                 \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+         ".p2align   4                                                   \n\t"
+ 
+         "1:                                                             \n\t"
+@@ -73,12 +73,12 @@ void ff_dct_unquantize_h263_intra_mmi(MpegEncContext *s, int16_t *block,
+         "pmullh     %[ftmp2],   %[ftmp2],       %[qmul]                 \n\t"
+         "pcmpgth    %[ftmp3],   %[ftmp3],       %[ftmp5]                \n\t"
+         "pcmpgth    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+         "paddh      %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+         "paddh      %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp2]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp2]                \n\t"
+         "pcmpeqh    %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+         "pcmpeqh    %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+         "pandn      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+@@ -118,11 +118,11 @@ void ff_dct_unquantize_h263_inter_mmi(MpegEncContext *s, int16_t *block,
+     __asm__ volatile (
+         "packsswh   %[qmul],    %[qmul],        %[qmul]                 \n\t"
+         "packsswh   %[qmul],    %[qmul],        %[qmul]                 \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "packsswh   %[qadd],    %[qadd],        %[qadd]                 \n\t"
+         "packsswh   %[qadd],    %[qadd],        %[qadd]                 \n\t"
+         "psubh      %[ftmp0],   %[ftmp0],       %[qadd]                 \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+         ".p2align   4                                                   \n\t"
+         "1:                                                             \n\t"
+         PTR_ADDU   "%[addr0],   %[block],       %[nCoeffs]              \n\t"
+@@ -134,12 +134,12 @@ void ff_dct_unquantize_h263_inter_mmi(MpegEncContext *s, int16_t *block,
+         "pmullh     %[ftmp2],   %[ftmp2],       %[qmul]                 \n\t"
+         "pcmpgth    %[ftmp3],   %[ftmp3],       %[ftmp5]                \n\t"
+         "pcmpgth    %[ftmp4],   %[ftmp4],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+         "paddh      %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+         "paddh      %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp2]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp1]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp2]                \n\t"
+         "pcmpeqh    %[ftmp1],   %[ftmp1],       %[ftmp0]                \n\t"
+         "pcmpeqh    %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+         "pandn      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+@@ -203,18 +203,18 @@ void ff_dct_unquantize_mpeg1_intra_mmi(MpegEncContext *s, int16_t *block,
+         MMI_LDXC1(%[ftmp7], %[addr0], %[quant], 0x08)
+         "pmullh     %[ftmp6],   %[ftmp6],       %[ftmp1]                \n\t"
+         "pmullh     %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp9],   %[ftmp9],       %[ftmp9]                \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
++        "xor        %[ftmp9],   %[ftmp9],       %[ftmp9]                \n\t"
+         "pcmpgth    %[ftmp8],   %[ftmp8],       %[ftmp2]                \n\t"
+         "pcmpgth    %[ftmp9],   %[ftmp9],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "pmullh     %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+         "pmullh     %[ftmp3],   %[ftmp3],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "pcmpeqh    %[ftmp6],   %[ftmp6],       %[ftmp4]                \n\t"
+         "dli        %[tmp0],    0x03                                    \n\t"
+         "pcmpeqh    %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+@@ -223,10 +223,10 @@ void ff_dct_unquantize_mpeg1_intra_mmi(MpegEncContext *s, int16_t *block,
+         "psrah      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+-        "por        %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+-        "por        %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "or         %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
++        "or         %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "pandn      %[ftmp6],   %[ftmp6],       %[ftmp2]                \n\t"
+@@ -289,12 +289,12 @@ void ff_dct_unquantize_mpeg1_inter_mmi(MpegEncContext *s, int16_t *block,
+         MMI_LDXC1(%[ftmp7], %[addr0], %[quant], 0x08)
+         "pmullh     %[ftmp6],   %[ftmp6],       %[ftmp1]                \n\t"
+         "pmullh     %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp9],   %[ftmp9],       %[ftmp9]                \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
++        "xor        %[ftmp9],   %[ftmp9],       %[ftmp9]                \n\t"
+         "pcmpgth    %[ftmp8],   %[ftmp8],       %[ftmp2]                \n\t"
+         "pcmpgth    %[ftmp9],   %[ftmp9],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "paddh      %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
+@@ -303,8 +303,8 @@ void ff_dct_unquantize_mpeg1_inter_mmi(MpegEncContext *s, int16_t *block,
+         "paddh      %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+         "pmullh     %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+         "pmullh     %[ftmp3],   %[ftmp3],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+         "pcmpeqh    %[ftmp6],   %[ftmp6],       %[ftmp4]                \n\t"
+         "dli        %[tmp0],    0x04                                    \n\t"
+         "pcmpeqh    %[ftmp7],   %[ftmp7],       %[ftmp5]                \n\t"
+@@ -313,10 +313,10 @@ void ff_dct_unquantize_mpeg1_inter_mmi(MpegEncContext *s, int16_t *block,
+         "psrah      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+-        "por        %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
+-        "por        %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
++        "or         %[ftmp2],   %[ftmp2],       %[ftmp0]                \n\t"
++        "or         %[ftmp3],   %[ftmp3],       %[ftmp0]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp9]                \n\t"
+         "pandn      %[ftmp6],   %[ftmp6],       %[ftmp2]                \n\t"
+@@ -388,26 +388,26 @@ void ff_dct_unquantize_mpeg2_intra_mmi(MpegEncContext *s, int16_t *block,
+         MMI_LDXC1(%[ftmp6], %[addr0], %[quant], 0x08)
+         "pmullh     %[ftmp5],   %[ftmp5],       %[ftmp9]                \n\t"
+         "pmullh     %[ftmp6],   %[ftmp6],       %[ftmp9]                \n\t"
+-        "pxor       %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
++        "xor        %[ftmp7],   %[ftmp7],       %[ftmp7]                \n\t"
++        "xor        %[ftmp8],   %[ftmp8],       %[ftmp8]                \n\t"
+         "pcmpgth    %[ftmp7],   %[ftmp7],       %[ftmp1]                \n\t"
+         "pcmpgth    %[ftmp8],   %[ftmp8],       %[ftmp2]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "pmullh     %[ftmp1],   %[ftmp1],       %[ftmp5]                \n\t"
+         "pmullh     %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
+-        "pxor       %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
+-        "pxor       %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
++        "xor        %[ftmp5],   %[ftmp5],       %[ftmp5]                \n\t"
++        "xor        %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
+         "pcmpeqh    %[ftmp5],   %[ftmp5],       %[ftmp3]                \n\t"
+         "dli        %[tmp0],    0x03                                    \n\t"
+         "pcmpeqh    %[ftmp6] ,  %[ftmp6],       %[ftmp4]                \n\t"
+         "mtc1       %[tmp0],    %[ftmp3]                                \n\t"
+         "psrah      %[ftmp1],   %[ftmp1],       %[ftmp3]                \n\t"
+         "psrah      %[ftmp2],   %[ftmp2],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "psubh      %[ftmp1],   %[ftmp1],       %[ftmp7]                \n\t"
+         "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
+         "pandn      %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
+diff --git a/libavcodec/mips/mpegvideoenc_mmi.c b/libavcodec/mips/mpegvideoenc_mmi.c
+index 65da155e9f..be4a89506d 100644
+--- a/libavcodec/mips/mpegvideoenc_mmi.c
++++ b/libavcodec/mips/mpegvideoenc_mmi.c
+@@ -37,16 +37,16 @@ void ff_denoise_dct_mmi(MpegEncContext *s, int16_t *block)
+     s->dct_count[intra]++;
+ 
+     __asm__ volatile(
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "1:                                                             \n\t"
+         MMI_LDC1(%[ftmp1], %[block], 0x00)
+-        "pxor       %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
++        "xor        %[ftmp2],   %[ftmp2],       %[ftmp2]                \n\t"
+         MMI_LDC1(%[ftmp3], %[block], 0x08)
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         "pcmpgth    %[ftmp2],   %[ftmp2],       %[ftmp1]                \n\t"
+         "pcmpgth    %[ftmp4],   %[ftmp4],       %[ftmp3]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubh      %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         MMI_LDC1(%[ftmp6], %[offset], 0x00)
+@@ -55,8 +55,8 @@ void ff_denoise_dct_mmi(MpegEncContext *s, int16_t *block)
+         MMI_LDC1(%[ftmp6], %[offset], 0x08)
+         "mov.d      %[ftmp7],   %[ftmp3]                                \n\t"
+         "psubush    %[ftmp3],   %[ftmp3],       %[ftmp6]                \n\t"
+-        "pxor       %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
+-        "pxor       %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
++        "xor        %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
++        "xor        %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         "psubh      %[ftmp1],   %[ftmp1],       %[ftmp2]                \n\t"
+         "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
+         MMI_SDC1(%[ftmp1], %[block], 0x00)
+diff --git a/libavcodec/mips/pixblockdsp_mmi.c b/libavcodec/mips/pixblockdsp_mmi.c
+index dea85bf3fa..d4a0657d44 100644
+--- a/libavcodec/mips/pixblockdsp_mmi.c
++++ b/libavcodec/mips/pixblockdsp_mmi.c
+@@ -33,7 +33,7 @@ void ff_get_pixels_8_mmi(int16_t *restrict block, const uint8_t *pixels,
+     DECLARE_VAR_ADDRT;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+ 
+         MMI_LDC1(%[ftmp1], %[pixels], 0x00)
+         MMI_LDXC1(%[ftmp2], %[pixels], %[stride], 0x00)
+@@ -103,12 +103,12 @@ void ff_diff_pixels_mmi(int16_t *restrict block, const uint8_t *src1,
+ 
+     __asm__ volatile (
+         "li         %[tmp0],    0x08                                    \n\t"
+-        "pxor       %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
++        "xor        %[ftmp4],   %[ftmp4],       %[ftmp4]                \n\t"
+         "1:                                                             \n\t"
+         MMI_LDC1(%[ftmp0], %[src1], 0x00)
+-        "por        %[ftmp1],   %[ftmp0],       %[ftmp0]                \n\t"
++        "or         %[ftmp1],   %[ftmp0],       %[ftmp0]                \n\t"
+         MMI_LDC1(%[ftmp2], %[src2], 0x00)
+-        "por        %[ftmp3],   %[ftmp2],       %[ftmp2]                \n\t"
++        "or         %[ftmp3],   %[ftmp2],       %[ftmp2]                \n\t"
+         "punpcklbh  %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
+         "punpckhbh  %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
+diff --git a/libavcodec/mips/simple_idct_mmi.c b/libavcodec/mips/simple_idct_mmi.c
+index 4680520edc..7d5e271a39 100644
+--- a/libavcodec/mips/simple_idct_mmi.c
++++ b/libavcodec/mips/simple_idct_mmi.c
+@@ -135,7 +135,7 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         "psllh        $f28,     "#src1",    $f30                \n\t" \
+         "dmtc1        $9,        $f31                           \n\t" \
+         "punpcklhw    $f29,      $f28,      $f28                \n\t" \
+-        "pand         $f29,      $f29,      $f31                \n\t" \
++        "and          $f29,      $f29,      $f31                \n\t" \
+         "paddw        $f28,      $f28,      $f29                \n\t" \
+         "punpcklwd   "#src1",    $f28,      $f28                \n\t" \
+         "punpcklwd   "#src2",    $f28,      $f28                \n\t" \
+@@ -269,9 +269,9 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         "punpcklwd    $f8,       $f27,      $f29                \n\t"
+         "punpckhwd    $f12,      $f27,      $f29                \n\t"
+ 
+-        "por          $f26,      $f2,       $f6                 \n\t"
+-        "por          $f26,      $f26,      $f10                \n\t"
+-        "por          $f26,      $f26,      $f14                \n\t"
++        "or           $f26,      $f2,       $f6                 \n\t"
++        "or           $f26,      $f26,      $f10                \n\t"
++        "or           $f26,      $f26,      $f14                \n\t"
+         "dmfc1        $10,       $f26                           \n\t"
+         "bnez         $10,       1f                             \n\t"
+         /* case1: In this case, row[1,3,5,7] are all zero */
+@@ -339,9 +339,9 @@ void ff_simple_idct_8_mmi(int16_t *block)
+         "punpcklwd    $f9,       $f27,      $f29                \n\t"
+         "punpckhwd    $f13,      $f27,      $f29                \n\t"
+ 
+-        "por          $f26,      $f3,       $f7                 \n\t"
+-        "por          $f26,      $f26,      $f11                \n\t"
+-        "por          $f26,      $f26,      $f15                \n\t"
++        "or           $f26,      $f3,       $f7                 \n\t"
++        "or           $f26,      $f26,      $f11                \n\t"
++        "or           $f26,      $f26,      $f15                \n\t"
+         "dmfc1        $10,       $f26                           \n\t"
+         "bnez         $10,       1f                             \n\t"
+         /* case1: In this case, row[1,3,5,7] are all zero */
+diff --git a/libavcodec/mips/vc1dsp_mmi.c b/libavcodec/mips/vc1dsp_mmi.c
+index 290b47d697..6dd3f1d494 100644
+--- a/libavcodec/mips/vc1dsp_mmi.c
++++ b/libavcodec/mips/vc1dsp_mmi.c
+@@ -136,7 +136,7 @@ void ff_vc1_inv_trans_8x8_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
+     dc_u.i = dc;
+ 
+     __asm__ volatile(
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[dc],      %[dc],          %[ftmp0]                \n\t"
+         "li         %[count],   0x02                                    \n\t"
+ 
+@@ -426,7 +426,7 @@ void ff_vc1_inv_trans_8x4_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
+     dc_u.i = dc;
+ 
+     __asm__ volatile(
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[dc],      %[dc],          %[ftmp0]                \n\t"
+ 
+         MMI_LDC1(%[ftmp1], %[dest0], 0x00)
+@@ -704,7 +704,7 @@ void ff_vc1_inv_trans_8x4_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
+         MMI_LWC1(%[ftmp3], %[tmp0], 0x00)
+         PTR_ADDU    "%[tmp0],   %[tmp0],    %[linesize]                 \n\t"
+         MMI_LWC1(%[ftmp4], %[tmp0], 0x00)
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp1],   %[ftmp1],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp3],   %[ftmp3],   %[ftmp0]                    \n\t"
+@@ -828,7 +828,7 @@ void ff_vc1_inv_trans_8x4_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
+         MMI_LWC1(%[ftmp3], %[tmp0], 0x04)
+         PTR_ADDU    "%[tmp0],   %[tmp0],    %[linesize]                 \n\t"
+         MMI_LWC1(%[ftmp4], %[tmp0], 0x04)
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp1],   %[ftmp1],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp3],   %[ftmp3],   %[ftmp0]                    \n\t"
+@@ -878,7 +878,7 @@ void ff_vc1_inv_trans_4x8_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
+     dc_u.i = dc;
+ 
+     __asm__ volatile(
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[dc],      %[dc],          %[ftmp0]                \n\t"
+ 
+         MMI_LWC1(%[ftmp1], %[dest0], 0x00)
+@@ -1056,7 +1056,7 @@ void ff_vc1_inv_trans_4x8_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
+         MMI_LWC1(%[ftmp7], %[tmp0], 0x00)
+         PTR_ADDU  "%[tmp0],   %[tmp0],    %[linesize]                 \n\t"
+         MMI_LWC1(%[ftmp8], %[tmp0], 0x00)
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp1],   %[ftmp1],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp3],   %[ftmp3],   %[ftmp0]                    \n\t"
+@@ -1133,7 +1133,7 @@ void ff_vc1_inv_trans_4x4_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
+     dc_u.i = dc;
+ 
+     __asm__ volatile(
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]                \n\t"
+         "pshufh     %[dc],      %[dc],          %[ftmp0]                \n\t"
+ 
+         MMI_LWC1(%[ftmp1], %[dest0], 0x00)
+@@ -1337,7 +1337,7 @@ void ff_vc1_inv_trans_4x4_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *block)
+         MMI_LWC1(%[ftmp3], %[tmp0], 0x00)
+         PTR_ADDU    "%[tmp0],   %[tmp0],    %[linesize]                 \n\t"
+         MMI_LWC1(%[ftmp4], %[tmp0], 0x00)
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp1],   %[ftmp1],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp2],   %[ftmp2],   %[ftmp0]                    \n\t"
+         "punpcklbh  %[ftmp3],   %[ftmp3],   %[ftmp0]                    \n\t"
+@@ -1664,7 +1664,7 @@ static void vc1_put_ver_16b_shift2_mmi(int16_t *dst,
+     shift_u.i = shift;
+ 
+     __asm__ volatile(
+-        "pxor       $f0,    $f0,    $f0             \n\t"
++        "xor        $f0,    $f0,    $f0             \n\t"
+         "li         $8,     0x03                    \n\t"
+         LOAD_ROUNDER_MMI("%[rnd]")
+         "1:                                         \n\t"
+@@ -1768,7 +1768,7 @@ static void OPNAME ## vc1_shift2_mmi(uint8_t *dst, const uint8_t *src,      \
+     rnd = 8 - rnd;                                                          \
+                                                                             \
+     __asm__ volatile(                                                       \
+-        "pxor       $f0,    $f0,    $f0             \n\t"                   \
++        "xor        $f0,    $f0,    $f0             \n\t"                   \
+         "li         $10,    0x08                    \n\t"                   \
+         LOAD_ROUNDER_MMI("%[rnd]")                                          \
+         "1:                                         \n\t"                   \
+@@ -1896,7 +1896,7 @@ vc1_put_ver_16b_ ## NAME ## _mmi(int16_t *dst, const uint8_t *src,          \
+     src -= src_stride;                                                      \
+                                                                             \
+     __asm__ volatile(                                                       \
+-        "pxor       $f0,    $f0,    $f0             \n\t"                   \
++        "xor        $f0,    $f0,    $f0             \n\t"                   \
+         LOAD_ROUNDER_MMI("%[rnd]")                                          \
+         ".p2align 3                                 \n\t"                   \
+         "1:                                         \n\t"                   \
+@@ -1969,7 +1969,7 @@ OPNAME ## vc1_hor_16b_ ## NAME ## _mmi(uint8_t *dst, mips_reg stride,       \
+     rnd -= (-4+58+13-3)*256; /* Add -256 bias */                            \
+                                                                             \
+     __asm__ volatile(                                                       \
+-        "pxor       $f0,    $f0,    $f0             \n\t"                   \
++        "xor        $f0,    $f0,    $f0             \n\t"                   \
+         LOAD_ROUNDER_MMI("%[rnd]")                                          \
+         ".p2align 3                                 \n\t"                   \
+         "1:                                         \n\t"                   \
+@@ -2017,7 +2017,7 @@ OPNAME ## vc1_## NAME ## _mmi(uint8_t *dst, const uint8_t *src,             \
+     rnd = 32-rnd;                                                           \
+                                                                             \
+     __asm__ volatile (                                                      \
+-        "pxor       $f0,    $f0,    $f0             \n\t"                   \
++        "xor        $f0,    $f0,    $f0             \n\t"                   \
+         LOAD_ROUNDER_MMI("%[rnd]")                                          \
+         ".p2align 3                                 \n\t"                   \
+         "1:                                         \n\t"                   \
+@@ -2252,7 +2252,7 @@ void ff_put_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+ 
+     __asm__ volatile(
+         "li         %[tmp0],    0x06                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp9]                                \n\t"
+         "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
+         "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
+@@ -2308,7 +2308,7 @@ void ff_put_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+ 
+     __asm__ volatile(
+         "li         %[tmp0],    0x06                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp5]                                \n\t"
+         "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
+         "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
+@@ -2362,7 +2362,7 @@ void ff_avg_no_rnd_vc1_chroma_mc8_mmi(uint8_t *dst /* align 8 */,
+ 
+     __asm__ volatile(
+         "li         %[tmp0],    0x06                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp9]                                \n\t"
+         "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
+         "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
+@@ -2421,7 +2421,7 @@ void ff_avg_no_rnd_vc1_chroma_mc4_mmi(uint8_t *dst /* align 8 */,
+ 
+     __asm__ volatile(
+         "li         %[tmp0],    0x06                                    \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+         "mtc1       %[tmp0],    %[ftmp5]                                \n\t"
+         "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
+         "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
+diff --git a/libavcodec/mips/vp3dsp_idct_mmi.c b/libavcodec/mips/vp3dsp_idct_mmi.c
+index d505fcb765..2959c4314f 100644
+--- a/libavcodec/mips/vp3dsp_idct_mmi.c
++++ b/libavcodec/mips/vp3dsp_idct_mmi.c
+@@ -34,7 +34,7 @@ static void idct_row_mmi(int16_t *input)
+     double ftmp[23];
+     uint64_t tmp[2];
+     __asm__ volatile (
+-        "pxor       %[ftmp10],      %[ftmp10],        %[ftmp10] \n\t"
++        "xor        %[ftmp10],      %[ftmp10],        %[ftmp10] \n\t"
+         LOAD_CONST(%[csth_1], 1)
+         "li         %[tmp0],        0x02                        \n\t"
+         "1:                                                     \n\t"
+@@ -51,14 +51,14 @@ static void idct_row_mmi(int16_t *input)
+         LOAD_CONST(%[ftmp9], 12785)
+         "pmulhh     %[A],           %[ftmp9],         %[ftmp7]  \n\t"
+         "pcmpgth    %[C],           %[ftmp10],        %[ftmp1]  \n\t"
+-        "por        %[mask],        %[C],             %[csth_1] \n\t"
++        "or         %[mask],        %[C],             %[csth_1] \n\t"
+         "pmullh     %[B],           %[ftmp1],         %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],         %[B]      \n\t"
+         "pmullh     %[B],           %[B],             %[mask]   \n\t"
+         "paddh      %[A],           %[A],             %[B]      \n\t"
+         "paddh      %[A],           %[A],             %[C]      \n\t"
+         "pcmpgth    %[D],           %[ftmp10],        %[ftmp7]  \n\t"
+-        "por        %[mask],        %[D],             %[csth_1] \n\t"
++        "or         %[mask],        %[D],             %[csth_1] \n\t"
+         "pmullh     %[ftmp7],       %[ftmp7],         %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],         %[ftmp7]  \n\t"
+         "pmullh     %[B],           %[B],             %[mask]   \n\t"
+@@ -69,12 +69,12 @@ static void idct_row_mmi(int16_t *input)
+         LOAD_CONST(%[ftmp8], 54491)
+         LOAD_CONST(%[ftmp9], 36410)
+         "pcmpgth    %[Ad],          %[ftmp10],        %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ad],            %[csth_1] \n\t"
++        "or         %[mask],        %[Ad],            %[csth_1] \n\t"
+         "pmullh     %[ftmp1],       %[ftmp5],         %[mask]   \n\t"
+         "pmulhuh    %[C],           %[ftmp9],         %[ftmp1]  \n\t"
+         "pmullh     %[C],           %[C],             %[mask]   \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],        %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],            %[csth_1] \n\t"
++        "or         %[mask],        %[Bd],            %[csth_1] \n\t"
+         "pmullh     %[D],           %[ftmp3],         %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp8],         %[D]      \n\t"
+         "pmullh     %[D],           %[D],             %[mask]   \n\t"
+@@ -82,12 +82,12 @@ static void idct_row_mmi(int16_t *input)
+         "paddh      %[C],           %[C],             %[Ad]     \n\t"
+         "paddh      %[C],           %[C],             %[Bd]     \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],        %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],            %[csth_1] \n\t"
++        "or         %[mask],        %[Bd],            %[csth_1] \n\t"
+         "pmullh     %[ftmp1],       %[ftmp3],         %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp9],         %[ftmp1]  \n\t"
+         "pmullh     %[D],           %[D],             %[mask]   \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],        %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ed],            %[csth_1] \n\t"
++        "or         %[mask],        %[Ed],            %[csth_1] \n\t"
+         "pmullh     %[Ad],          %[ftmp5],         %[mask]   \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],         %[Ad]     \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]   \n\t"
+@@ -98,14 +98,14 @@ static void idct_row_mmi(int16_t *input)
+         LOAD_CONST(%[ftmp8], 46341)
+         "psubh      %[Ad],          %[A],             %[C]      \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],        %[Ad]     \n\t"
+-        "por        %[mask],        %[Bd],            %[csth_1] \n\t"
++        "or         %[mask],        %[Bd],            %[csth_1] \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]   \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],         %[Ad]     \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]   \n\t"
+         "paddh      %[Ad],          %[Ad],            %[Bd]     \n\t"
+         "psubh      %[Bd],          %[B],             %[D]      \n\t"
+         "pcmpgth    %[Cd],          %[ftmp10],        %[Bd]     \n\t"
+-        "por        %[mask],        %[Cd],            %[csth_1] \n\t"
++        "or         %[mask],        %[Cd],            %[csth_1] \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]   \n\t"
+         "pmulhuh    %[Bd],          %[ftmp8],         %[Bd]     \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]   \n\t"
+@@ -114,14 +114,14 @@ static void idct_row_mmi(int16_t *input)
+         "paddh      %[Dd],          %[B],             %[D]      \n\t"
+         "paddh      %[A],           %[ftmp0],         %[ftmp4]  \n\t"
+         "pcmpgth    %[B],           %[ftmp10],        %[A]      \n\t"
+-        "por        %[mask],        %[B],             %[csth_1] \n\t"
++        "or         %[mask],        %[B],             %[csth_1] \n\t"
+         "pmullh     %[A],           %[A],             %[mask]   \n\t"
+         "pmulhuh    %[A],           %[ftmp8],         %[A]      \n\t"
+         "pmullh     %[A],           %[A],             %[mask]   \n\t"
+         "paddh      %[A],           %[A],             %[B]      \n\t"
+         "psubh      %[B],           %[ftmp0],         %[ftmp4]  \n\t"
+         "pcmpgth    %[C],           %[ftmp10],        %[B]      \n\t"
+-        "por        %[mask],        %[C],             %[csth_1] \n\t"
++        "or         %[mask],        %[C],             %[csth_1] \n\t"
+         "pmullh     %[B],           %[B],             %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],         %[B]      \n\t"
+         "pmullh     %[B],           %[B],             %[mask]   \n\t"
+@@ -131,14 +131,14 @@ static void idct_row_mmi(int16_t *input)
+         LOAD_CONST(%[ftmp9], 25080)
+         "pmulhh     %[C],           %[ftmp9],         %[ftmp6]  \n\t"
+         "pcmpgth    %[D],           %[ftmp10],        %[ftmp2]  \n\t"
+-        "por        %[mask],        %[D],             %[csth_1] \n\t"
++        "or         %[mask],        %[D],             %[csth_1] \n\t"
+         "pmullh     %[Ed],          %[ftmp2],         %[mask]   \n\t"
+         "pmulhuh    %[Ed],          %[ftmp8],         %[Ed]     \n\t"
+         "pmullh     %[Ed],          %[Ed],            %[mask]   \n\t"
+         "paddh      %[C],           %[C],             %[Ed]     \n\t"
+         "paddh      %[C],           %[C],             %[D]      \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],        %[ftmp6]  \n\t"
+-        "por        %[mask],        %[Ed],            %[csth_1] \n\t"
++        "or         %[mask],        %[Ed],            %[csth_1] \n\t"
+         "pmullh     %[ftmp6],       %[ftmp6],         %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp8],         %[ftmp6]  \n\t"
+         "pmullh     %[D],           %[D],             %[mask]   \n\t"
+@@ -193,7 +193,7 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+     for (int i = 0; i < 8; ++i)
+         temp_value[i] = av_clip_uint8(128 + ((46341 * input[i << 3] + (8 << 16)) >> 20));
+     __asm__ volatile (
+-        "pxor       %[ftmp10],      %[ftmp10],          %[ftmp10] \n\t"
++        "xor        %[ftmp10],      %[ftmp10],          %[ftmp10] \n\t"
+         "li         %[tmp0],        0x02                          \n\t"
+         "1:                                                       \n\t"
+         "ldc1       %[ftmp0],       0x00(%[input])                \n\t"
+@@ -213,14 +213,14 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[Gd], 1)
+         "pmulhh     %[A],           %[ftmp9],           %[ftmp7]  \n\t"
+         "pcmpgth    %[C],           %[ftmp10],          %[ftmp1]  \n\t"
+-        "por        %[mask],        %[C],               %[Gd]     \n\t"
++        "or         %[mask],        %[C],               %[Gd]     \n\t"
+         "pmullh     %[B],           %[ftmp1],           %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],           %[B]      \n\t"
+         "pmullh     %[B],           %[B],               %[mask]   \n\t"
+         "paddh      %[A],           %[A],               %[B]      \n\t"
+         "paddh      %[A],           %[A],               %[C]      \n\t"
+         "pcmpgth    %[D],           %[ftmp10],          %[ftmp7]  \n\t"
+-        "por        %[mask],        %[D],               %[Gd]     \n\t"
++        "or         %[mask],        %[D],               %[Gd]     \n\t"
+         "pmullh     %[Ad],          %[ftmp7],           %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],           %[Ad]     \n\t"
+         "pmullh     %[B],           %[B],               %[mask]   \n\t"
+@@ -231,12 +231,12 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp8], 54491)
+         LOAD_CONST(%[ftmp9], 36410)
+         "pcmpgth    %[Ad],          %[ftmp10],          %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ad],              %[Gd]     \n\t"
++        "or         %[mask],        %[Ad],              %[Gd]     \n\t"
+         "pmullh     %[Cd],          %[ftmp5],           %[mask]   \n\t"
+         "pmulhuh    %[C],           %[ftmp9],           %[Cd]     \n\t"
+         "pmullh     %[C],           %[C],               %[mask]   \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],          %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],              %[Gd]     \n\t"
++        "or         %[mask],        %[Bd],              %[Gd]     \n\t"
+         "pmullh     %[D],           %[ftmp3],           %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp8],           %[D]      \n\t"
+         "pmullh     %[D],           %[D],               %[mask]   \n\t"
+@@ -244,12 +244,12 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         "paddh      %[C],           %[C],               %[Ad]     \n\t"
+         "paddh      %[C],           %[C],               %[Bd]     \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],          %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],              %[Gd]     \n\t"
++        "or         %[mask],        %[Bd],              %[Gd]     \n\t"
+         "pmullh     %[Cd],          %[ftmp3],           %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp9],           %[Cd]     \n\t"
+         "pmullh     %[D],           %[D],               %[mask]   \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],          %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ed],              %[Gd]     \n\t"
++        "or         %[mask],        %[Ed],              %[Gd]     \n\t"
+         "pmullh     %[Ad],          %[ftmp5],           %[mask]   \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],           %[Ad]     \n\t"
+         "pmullh     %[Ad],          %[Ad],              %[mask]   \n\t"
+@@ -260,14 +260,14 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp8], 46341)
+         "psubh      %[Ad],          %[A],             %[C]        \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],        %[Ad]       \n\t"
+-        "por        %[mask],        %[Bd],            %[Gd]       \n\t"
++        "or         %[mask],        %[Bd],            %[Gd]       \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]     \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],         %[Ad]       \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]     \n\t"
+         "paddh      %[Ad],          %[Ad],            %[Bd]       \n\t"
+         "psubh      %[Bd],          %[B],             %[D]        \n\t"
+         "pcmpgth    %[Cd],          %[ftmp10],        %[Bd]       \n\t"
+-        "por        %[mask],        %[Cd],            %[Gd]       \n\t"
++        "or         %[mask],        %[Cd],            %[Gd]       \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]     \n\t"
+         "pmulhuh    %[Bd],          %[ftmp8],         %[Bd]       \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]     \n\t"
+@@ -278,7 +278,7 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[Ed], 2056)
+         "paddh      %[A],           %[ftmp0],         %[ftmp4]    \n\t"
+         "pcmpgth    %[B],           %[ftmp10],        %[A]        \n\t"
+-        "por        %[mask],        %[B],             %[Gd]       \n\t"
++        "or         %[mask],        %[B],             %[Gd]       \n\t"
+         "pmullh     %[A],           %[A],             %[mask]     \n\t"
+         "pmulhuh    %[A],           %[ftmp8],         %[A]        \n\t"
+         "pmullh     %[A],           %[A],             %[mask]     \n\t"
+@@ -286,7 +286,7 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         "paddh      %[A],           %[A],             %[Ed]       \n\t"
+         "psubh      %[B],           %[ftmp0],         %[ftmp4]    \n\t"
+         "pcmpgth    %[C],           %[ftmp10],        %[B]        \n\t"
+-        "por        %[mask],        %[C],             %[Gd]       \n\t"
++        "or         %[mask],        %[C],             %[Gd]       \n\t"
+         "pmullh     %[B],           %[B],             %[mask]     \n\t"
+         "pmulhuh    %[B],           %[ftmp8],         %[B]        \n\t"
+         "pmullh     %[B],           %[B],             %[mask]     \n\t"
+@@ -297,14 +297,14 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp9], 25080)
+         "pmulhh     %[C],           %[ftmp9],         %[ftmp6]    \n\t"
+         "pcmpgth    %[D],           %[ftmp10],        %[ftmp2]    \n\t"
+-        "por        %[mask],        %[D],             %[Gd]       \n\t"
++        "or         %[mask],        %[D],             %[Gd]       \n\t"
+         "pmullh     %[Ed],          %[ftmp2],         %[mask]     \n\t"
+         "pmulhuh    %[Ed],          %[ftmp8],         %[Ed]       \n\t"
+         "pmullh     %[Ed],          %[Ed],            %[mask]     \n\t"
+         "paddh      %[C],           %[C],             %[Ed]       \n\t"
+         "paddh      %[C],           %[C],             %[D]        \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],        %[ftmp6]    \n\t"
+-        "por        %[mask],        %[Ed],            %[Gd]       \n\t"
++        "or         %[mask],        %[Ed],            %[Gd]       \n\t"
+         "pmullh     %[D],           %[ftmp6],         %[mask]     \n\t"
+         "pmulhuh    %[D],           %[ftmp8],         %[D]        \n\t"
+         "pmullh     %[D],           %[D],             %[mask]     \n\t"
+@@ -317,12 +317,12 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         "psubh      %[C],           %[B],             %[Ad]       \n\t"
+         "psubh      %[B],           %[Bd],            %[D]        \n\t"
+         "paddh      %[D],           %[Bd],            %[D]        \n\t"
+-        "por        %[mask],        %[ftmp1],         %[ftmp2]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp3]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp4]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp5]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp6]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp7]    \n\t"
++        "or         %[mask],        %[ftmp1],         %[ftmp2]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp3]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp4]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp5]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp6]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp7]    \n\t"
+         "pcmpeqh    %[mask],        %[mask],          %[ftmp10]   \n\t"
+         "packushb   %[mask],        %[mask],          %[ftmp10]   \n\t"
+         "li         %[tmp1],        0x04                          \n\t"
+@@ -361,7 +361,7 @@ static void idct_column_true_mmi(uint8_t *dst, int stride, int16_t *input)
+         "packushb   %[ftmp7],       %[ftmp7],         %[ftmp10]   \n\t"
+ 
+         "lwc1       %[Ed],          0x00(%[temp_value])           \n\t"
+-        "pand       %[Ed],          %[Ed],            %[mask]     \n\t"
++        "and        %[Ed],          %[Ed],            %[mask]     \n\t"
+         "paddb      %[ftmp0],       %[ftmp0],         %[Ed]       \n\t"
+         "paddb      %[ftmp1],       %[ftmp1],         %[Ed]       \n\t"
+         "paddb      %[ftmp2],       %[ftmp2],         %[Ed]       \n\t"
+@@ -412,7 +412,7 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+     for (int i = 0; i < 8; ++i)
+         temp_value[i] = (46341 * input[i << 3] + (8 << 16)) >> 20;
+     __asm__ volatile (
+-        "pxor       %[ftmp10],      %[ftmp10],          %[ftmp10] \n\t"
++        "xor        %[ftmp10],      %[ftmp10],          %[ftmp10] \n\t"
+         "li         %[tmp0],        0x02                          \n\t"
+         "1:                                                       \n\t"
+         "ldc1       %[ftmp0],       0x00(%[input])                \n\t"
+@@ -432,14 +432,14 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[Gd], 1)
+         "pmulhh     %[A],           %[ftmp9],           %[ftmp7]  \n\t"
+         "pcmpgth    %[C],           %[ftmp10],          %[ftmp1]  \n\t"
+-        "por        %[mask],        %[C],               %[Gd]     \n\t"
++        "or         %[mask],        %[C],               %[Gd]     \n\t"
+         "pmullh     %[B],           %[ftmp1],           %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],           %[B]      \n\t"
+         "pmullh     %[B],           %[B],               %[mask]   \n\t"
+         "paddh      %[A],           %[A],               %[B]      \n\t"
+         "paddh      %[A],           %[A],               %[C]      \n\t"
+         "pcmpgth    %[D],           %[ftmp10],          %[ftmp7]  \n\t"
+-        "por        %[mask],        %[D],               %[Gd]     \n\t"
++        "or         %[mask],        %[D],               %[Gd]     \n\t"
+         "pmullh     %[Ad],          %[ftmp7],           %[mask]   \n\t"
+         "pmulhuh    %[B],           %[ftmp8],           %[Ad]     \n\t"
+         "pmullh     %[B],           %[B],               %[mask]   \n\t"
+@@ -450,12 +450,12 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp8], 54491)
+         LOAD_CONST(%[ftmp9], 36410)
+         "pcmpgth    %[Ad],          %[ftmp10],          %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ad],              %[Gd]     \n\t"
++        "or         %[mask],        %[Ad],              %[Gd]     \n\t"
+         "pmullh     %[Cd],          %[ftmp5],           %[mask]   \n\t"
+         "pmulhuh    %[C],           %[ftmp9],           %[Cd]     \n\t"
+         "pmullh     %[C],           %[C],               %[mask]   \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],          %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],              %[Gd]     \n\t"
++        "or         %[mask],        %[Bd],              %[Gd]     \n\t"
+         "pmullh     %[D],           %[ftmp3],           %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp8],           %[D]      \n\t"
+         "pmullh     %[D],           %[D],               %[mask]   \n\t"
+@@ -463,12 +463,12 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         "paddh      %[C],           %[C],               %[Ad]     \n\t"
+         "paddh      %[C],           %[C],               %[Bd]     \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],          %[ftmp3]  \n\t"
+-        "por        %[mask],        %[Bd],              %[Gd]     \n\t"
++        "or         %[mask],        %[Bd],              %[Gd]     \n\t"
+         "pmullh     %[Cd],          %[ftmp3],           %[mask]   \n\t"
+         "pmulhuh    %[D],           %[ftmp9],           %[Cd]     \n\t"
+         "pmullh     %[D],           %[D],               %[mask]   \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],          %[ftmp5]  \n\t"
+-        "por        %[mask],        %[Ed],              %[Gd]     \n\t"
++        "or         %[mask],        %[Ed],              %[Gd]     \n\t"
+         "pmullh     %[Ad],          %[ftmp5],           %[mask]   \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],           %[Ad]     \n\t"
+         "pmullh     %[Ad],          %[Ad],              %[mask]   \n\t"
+@@ -479,14 +479,14 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp8], 46341)
+         "psubh      %[Ad],          %[A],             %[C]        \n\t"
+         "pcmpgth    %[Bd],          %[ftmp10],        %[Ad]       \n\t"
+-        "por        %[mask],        %[Bd],            %[Gd]       \n\t"
++        "or         %[mask],        %[Bd],            %[Gd]       \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]     \n\t"
+         "pmulhuh    %[Ad],          %[ftmp8],         %[Ad]       \n\t"
+         "pmullh     %[Ad],          %[Ad],            %[mask]     \n\t"
+         "paddh      %[Ad],          %[Ad],            %[Bd]       \n\t"
+         "psubh      %[Bd],          %[B],             %[D]        \n\t"
+         "pcmpgth    %[Cd],          %[ftmp10],        %[Bd]       \n\t"
+-        "por        %[mask],        %[Cd],            %[Gd]       \n\t"
++        "or         %[mask],        %[Cd],            %[Gd]       \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]     \n\t"
+         "pmulhuh    %[Bd],          %[ftmp8],         %[Bd]       \n\t"
+         "pmullh     %[Bd],          %[Bd],            %[mask]     \n\t"
+@@ -497,7 +497,7 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[Ed], 8)
+         "paddh      %[A],           %[ftmp0],         %[ftmp4]    \n\t"
+         "pcmpgth    %[B],           %[ftmp10],        %[A]        \n\t"
+-        "por        %[mask],        %[B],             %[Gd]       \n\t"
++        "or         %[mask],        %[B],             %[Gd]       \n\t"
+         "pmullh     %[A],           %[A],             %[mask]     \n\t"
+         "pmulhuh    %[A],           %[ftmp8],         %[A]        \n\t"
+         "pmullh     %[A],           %[A],             %[mask]     \n\t"
+@@ -505,7 +505,7 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         "paddh      %[A],           %[A],             %[Ed]       \n\t"
+         "psubh      %[B],           %[ftmp0],         %[ftmp4]    \n\t"
+         "pcmpgth    %[C],           %[ftmp10],        %[B]        \n\t"
+-        "por        %[mask],        %[C],             %[Gd]       \n\t"
++        "or         %[mask],        %[C],             %[Gd]       \n\t"
+         "pmullh     %[B],           %[B],             %[mask]     \n\t"
+         "pmulhuh    %[B],           %[ftmp8],         %[B]        \n\t"
+         "pmullh     %[B],           %[B],             %[mask]     \n\t"
+@@ -516,14 +516,14 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         LOAD_CONST(%[ftmp9], 25080)
+         "pmulhh     %[C],           %[ftmp9],         %[ftmp6]    \n\t"
+         "pcmpgth    %[D],           %[ftmp10],        %[ftmp2]    \n\t"
+-        "por        %[mask],        %[D],             %[Gd]       \n\t"
++        "or         %[mask],        %[D],             %[Gd]       \n\t"
+         "pmullh     %[Ed],          %[ftmp2],         %[mask]     \n\t"
+         "pmulhuh    %[Ed],          %[ftmp8],         %[Ed]       \n\t"
+         "pmullh     %[Ed],          %[Ed],            %[mask]     \n\t"
+         "paddh      %[C],           %[C],             %[Ed]       \n\t"
+         "paddh      %[C],           %[C],             %[D]        \n\t"
+         "pcmpgth    %[Ed],          %[ftmp10],        %[ftmp6]    \n\t"
+-        "por        %[mask],        %[Ed],            %[Gd]       \n\t"
++        "or         %[mask],        %[Ed],            %[Gd]       \n\t"
+         "pmullh     %[D],           %[ftmp6],         %[mask]     \n\t"
+         "pmulhuh    %[D],           %[ftmp8],         %[D]        \n\t"
+         "pmullh     %[D],           %[D],             %[mask]     \n\t"
+@@ -536,12 +536,12 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         "psubh      %[C],           %[B],             %[Ad]       \n\t"
+         "psubh      %[B],           %[Bd],            %[D]        \n\t"
+         "paddh      %[D],           %[Bd],            %[D]        \n\t"
+-        "por        %[mask],        %[ftmp1],         %[ftmp2]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp3]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp4]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp5]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp6]    \n\t"
+-        "por        %[mask],        %[mask],          %[ftmp7]    \n\t"
++        "or         %[mask],        %[ftmp1],         %[ftmp2]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp3]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp4]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp5]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp6]    \n\t"
++        "or         %[mask],        %[mask],          %[ftmp7]    \n\t"
+         "pcmpeqh    %[mask],        %[mask],          %[ftmp10]   \n\t"
+         "li         %[tmp1],        0x04                          \n\t"
+         "dmtc1      %[tmp1],        %[ftmp8]                      \n\t"
+@@ -587,16 +587,16 @@ static void idct_column_false_mmi(uint8_t *dst, int stride, int16_t *input)
+         "punpcklbh  %[Cd],          %[Cd],            %[ftmp10]   \n\t"
+         "punpcklbh  %[Dd],          %[Dd],            %[ftmp10]   \n\t"
+         "ldc1       %[Ed],          0x00(%[temp_value])           \n\t"
+-        "pand       %[Ed],          %[Ed],            %[mask]     \n\t"
+-        "pnor       %[mask],        %[mask],          %[mask]     \n\t"
+-        "pand       %[ftmp0],       %[ftmp0],         %[mask]     \n\t"
+-        "pand       %[ftmp1],       %[ftmp1],         %[mask]     \n\t"
+-        "pand       %[ftmp2],       %[ftmp2],         %[mask]     \n\t"
+-        "pand       %[ftmp3],       %[ftmp3],         %[mask]     \n\t"
+-        "pand       %[ftmp4],       %[ftmp4],         %[mask]     \n\t"
+-        "pand       %[ftmp5],       %[ftmp5],         %[mask]     \n\t"
+-        "pand       %[ftmp6],       %[ftmp6],         %[mask]     \n\t"
+-        "pand       %[ftmp7],       %[ftmp7],         %[mask]     \n\t"
++        "and        %[Ed],          %[Ed],            %[mask]     \n\t"
++        "nor        %[mask],        %[mask],          %[mask]     \n\t"
++        "and        %[ftmp0],       %[ftmp0],         %[mask]     \n\t"
++        "and        %[ftmp1],       %[ftmp1],         %[mask]     \n\t"
++        "and        %[ftmp2],       %[ftmp2],         %[mask]     \n\t"
++        "and        %[ftmp3],       %[ftmp3],         %[mask]     \n\t"
++        "and        %[ftmp4],       %[ftmp4],         %[mask]     \n\t"
++        "and        %[ftmp5],       %[ftmp5],         %[mask]     \n\t"
++        "and        %[ftmp6],       %[ftmp6],         %[mask]     \n\t"
++        "and        %[ftmp7],       %[ftmp7],         %[mask]     \n\t"
+         "paddh      %[ftmp0],       %[ftmp0],         %[A]        \n\t"
+         "paddh      %[ftmp1],       %[ftmp1],         %[B]        \n\t"
+         "paddh      %[ftmp2],       %[ftmp2],         %[C]        \n\t"
+@@ -689,7 +689,7 @@ void ff_vp3_idct_dc_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+     double ftmp[7];
+     uint64_t tmp;
+     __asm__ volatile (
+-        "pxor       %[ftmp0],     %[ftmp0],           %[ftmp0]      \n\t"
++        "xor        %[ftmp0],     %[ftmp0],           %[ftmp0]      \n\t"
+         "mtc1       %[dc],        %[ftmp5]                          \n\t"
+         "pshufh     %[ftmp5],     %[ftmp5],           %[ftmp0]      \n\t"
+         "li         %[tmp0],      0x08                              \n\t"
+@@ -734,10 +734,10 @@ void ff_put_no_rnd_pixels_l2_mmi(uint8_t *dst, const uint8_t *src1,
+             "1:                                                          \n\t"
+             MMI_ULDC1(%[ftmp1], %[src1], 0x0)
+             MMI_ULDC1(%[ftmp2], %[src2], 0x0)
+-            "pxor        %[ftmp3],       %[ftmp1],             %[ftmp2]  \n\t"
+-            "pand        %[ftmp3],       %[ftmp3],             %[ftmp4]  \n\t"
++            "xor         %[ftmp3],       %[ftmp1],             %[ftmp2]  \n\t"
++            "and         %[ftmp3],       %[ftmp3],             %[ftmp4]  \n\t"
+             "psrlw       %[ftmp3],       %[ftmp3],             %[ftmp5]  \n\t"
+-            "pand        %[ftmp6],       %[ftmp1],             %[ftmp2]  \n\t"
++            "and         %[ftmp6],       %[ftmp1],             %[ftmp2]  \n\t"
+             "paddw       %[ftmp3],       %[ftmp3],             %[ftmp6]  \n\t"
+             "sdc1        %[ftmp3],       0x00(%[dst])                    \n\t"
+             PTR_ADDU    "%[src1],        %[src1],              %[stride] \n\t"
+diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
+index 55599e58f9..7d0eba3491 100644
+--- a/libavcodec/mips/vp8dsp_mmi.c
++++ b/libavcodec/mips/vp8dsp_mmi.c
+@@ -38,10 +38,10 @@
+         "pcmpeqb    %[db_1],    "#src1",        "#src2"             \n\t"   \
+         "pmaxub     %[db_2],    "#src1",        "#src2"             \n\t"   \
+         "pcmpeqb    %[db_2],    %[db_2],        "#src1"             \n\t"   \
+-        "pxor       "#dst",     %[db_2],        %[db_1]             \n\t"
++        "xor        "#dst",     %[db_2],        %[db_1]             \n\t"
+ 
+ #define MMI_BTOH(dst_l, dst_r, src)                                         \
+-        "pxor       %[db_1],    %[db_1],        %[db_1]             \n\t"   \
++        "xor        %[db_1],    %[db_1],        %[db_1]             \n\t"   \
+         "pcmpgtb    %[db_2],    %[db_1],        "#src"              \n\t"   \
+         "punpcklbh  "#dst_r",   "#src",         %[db_2]             \n\t"   \
+         "punpckhbh  "#dst_l",   "#src",         %[db_2]             \n\t"
+@@ -84,17 +84,17 @@
+         "punpcklwd  %[ftmp3],   %[ftmp3],       %[ftmp3]            \n\t"   \
+         MMI_PCMPGTUB(%[mask], %[mask], %[ftmp3])                            \
+         "pcmpeqw    %[ftmp3],   %[ftmp3],       %[ftmp3]            \n\t"   \
+-        "pxor       %[mask],    %[mask],        %[ftmp3]            \n\t"   \
++        "xor        %[mask],    %[mask],        %[ftmp3]            \n\t"   \
+         /* VP8_MBFILTER */                                                  \
+         "li         %[tmp0],    0x80808080                          \n\t"   \
+         "dmtc1      %[tmp0],    %[ftmp7]                            \n\t"   \
+         "punpcklwd  %[ftmp7],   %[ftmp7],       %[ftmp7]            \n\t"   \
+-        "pxor       %[p2],      %[p2],          %[ftmp7]            \n\t"   \
+-        "pxor       %[p1],      %[p1],          %[ftmp7]            \n\t"   \
+-        "pxor       %[p0],      %[p0],          %[ftmp7]            \n\t"   \
+-        "pxor       %[q0],      %[q0],          %[ftmp7]            \n\t"   \
+-        "pxor       %[q1],      %[q1],          %[ftmp7]            \n\t"   \
+-        "pxor       %[q2],      %[q2],          %[ftmp7]            \n\t"   \
++        "xor        %[p2],      %[p2],          %[ftmp7]            \n\t"   \
++        "xor        %[p1],      %[p1],          %[ftmp7]            \n\t"   \
++        "xor        %[p0],      %[p0],          %[ftmp7]            \n\t"   \
++        "xor        %[q0],      %[q0],          %[ftmp7]            \n\t"   \
++        "xor        %[q1],      %[q1],          %[ftmp7]            \n\t"   \
++        "xor        %[q2],      %[q2],          %[ftmp7]            \n\t"   \
+         "psubsb     %[ftmp4],   %[p1],          %[q1]               \n\t"   \
+         "psubb      %[ftmp5],   %[q0],          %[p0]               \n\t"   \
+         MMI_BTOH(%[ftmp1],  %[ftmp0],  %[ftmp5])                            \
+@@ -109,8 +109,8 @@
+         "paddh      %[ftmp1],   %[ftmp3],       %[ftmp1]            \n\t"   \
+         /* Combine left and right part */                                   \
+         "packsshb   %[ftmp1],   %[ftmp0],       %[ftmp1]            \n\t"   \
+-        "pand       %[ftmp1],   %[ftmp1],       %[mask]             \n\t"   \
+-        "pand       %[ftmp2],   %[ftmp1],       %[hev]              \n\t"   \
++        "and        %[ftmp1],   %[ftmp1],       %[mask]             \n\t"   \
++        "and        %[ftmp2],   %[ftmp1],       %[hev]              \n\t"   \
+         "li         %[tmp0],    0x04040404                          \n\t"   \
+         "dmtc1      %[tmp0],    %[ftmp0]                            \n\t"   \
+         "punpcklwd  %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"   \
+@@ -129,8 +129,8 @@
+         "paddsb     %[p0],      %[p0],          %[ftmp4]            \n\t"   \
+         /* filt_val &= ~hev */                                              \
+         "pcmpeqw    %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"   \
+-        "pxor       %[hev],     %[hev],         %[ftmp0]            \n\t"   \
+-        "pand       %[ftmp1],   %[ftmp1],       %[hev]              \n\t"   \
++        "xor        %[hev],     %[hev],         %[ftmp0]            \n\t"   \
++        "and        %[ftmp1],   %[ftmp1],       %[hev]              \n\t"   \
+         MMI_BTOH(%[ftmp5],  %[ftmp6],  %[ftmp1])                            \
+         "li         %[tmp0],    0x07                                \n\t"   \
+         "dmtc1      %[tmp0],    %[ftmp2]                            \n\t"   \
+@@ -151,9 +151,9 @@
+         /* Combine left and right part */                                   \
+         "packsshb   %[ftmp4],   %[ftmp3],       %[ftmp4]            \n\t"   \
+         "psubsb     %[q0],      %[q0],          %[ftmp4]            \n\t"   \
+-        "pxor       %[q0],      %[q0],          %[ftmp7]            \n\t"   \
++        "xor        %[q0],      %[q0],          %[ftmp7]            \n\t"   \
+         "paddsb     %[p0],      %[p0],          %[ftmp4]            \n\t"   \
+-        "pxor       %[p0],      %[p0],          %[ftmp7]            \n\t"   \
++        "xor        %[p0],      %[p0],          %[ftmp7]            \n\t"   \
+         "li         %[tmp0],    0x00120012                          \n\t"   \
+         "dmtc1      %[tmp0],    %[ftmp1]                            \n\t"   \
+         "punpcklwd  %[ftmp1],   %[ftmp1],       %[ftmp1]            \n\t"   \
+@@ -168,9 +168,9 @@
+         /* Combine left and right part */                                   \
+         "packsshb   %[ftmp4],   %[ftmp3],       %[ftmp4]            \n\t"   \
+         "psubsb     %[q1],      %[q1],          %[ftmp4]            \n\t"   \
+-        "pxor       %[q1],      %[q1],          %[ftmp7]            \n\t"   \
++        "xor        %[q1],      %[q1],          %[ftmp7]            \n\t"   \
+         "paddsb     %[p1],      %[p1],          %[ftmp4]            \n\t"   \
+-        "pxor       %[p1],      %[p1],          %[ftmp7]            \n\t"   \
++        "xor        %[p1],      %[p1],          %[ftmp7]            \n\t"   \
+         "li         %[tmp0],    0x03                                \n\t"   \
+         "dmtc1      %[tmp0],    %[ftmp1]                            \n\t"   \
+         /* Right part */                                                    \
+@@ -186,9 +186,9 @@
+         /* Combine left and right part */                                   \
+         "packsshb   %[ftmp4],   %[ftmp3],       %[ftmp4]            \n\t"   \
+         "psubsb     %[q2],      %[q2],          %[ftmp4]            \n\t"   \
+-        "pxor       %[q2],      %[q2],          %[ftmp7]            \n\t"   \
++        "xor        %[q2],      %[q2],          %[ftmp7]            \n\t"   \
+         "paddsb     %[p2],      %[p2],          %[ftmp4]            \n\t"   \
+-        "pxor       %[p2],      %[p2],          %[ftmp7]            \n\t"
++        "xor        %[p2],      %[p2],          %[ftmp7]            \n\t"
+ 
+ #define PUT_VP8_EPEL4_H6_MMI(src, dst)                                      \
+         MMI_ULWC1(%[ftmp1], src, 0x00)                                      \
+@@ -997,7 +997,7 @@ void ff_vp8_luma_dc_wht_mmi(int16_t block[4][4][16], int16_t dc[16])
+     block[3][3][0] = (dc[12] - dc[15] + 3 - dc[13] + dc[14]) >> 3;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         MMI_SDC1(%[ftmp0], %[dc], 0x00)
+         MMI_SDC1(%[ftmp0], %[dc], 0x08)
+         MMI_SDC1(%[ftmp0], %[dc], 0x10)
+@@ -1114,7 +1114,7 @@ void ff_vp8_idct_add_mmi(uint8_t *dst, int16_t block[16], ptrdiff_t stride)
+     ff_ph_22a3_u.i = 0x22a322a322a322a3ULL;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         MMI_LDC1(%[ftmp1], %[block], 0x00)
+         MMI_LDC1(%[ftmp2], %[block], 0x08)
+         MMI_LDC1(%[ftmp3], %[block], 0x10)
+@@ -1280,7 +1280,7 @@ void ff_vp8_idct_dc_add_mmi(uint8_t *dst, int16_t block[16], ptrdiff_t stride)
+     block[0] = 0;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "mtc1       %[dc],      %[ftmp5]                            \n\t"
+         MMI_LWC1(%[ftmp1], %[dst0], 0x00)
+         MMI_LWC1(%[ftmp2], %[dst1], 0x00)
+@@ -1604,7 +1604,7 @@ void ff_put_vp8_epel16_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *
+     dst[15] = cm[(filter[2] * src[15] - filter[1] * src[14] + filter[3] * src[16] - filter[4] * src[17] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -1680,7 +1680,7 @@ void ff_put_vp8_epel8_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[7] = cm[(filter[2] * src[7] - filter[1] * src[ 6] + filter[3] * src[8] - filter[4] * src[9] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -1745,7 +1745,7 @@ void ff_put_vp8_epel4_h4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[3] = cm[(filter[2] * src[3] - filter[1] * src[ 2] + filter[3] * src[4] - filter[4] * src[5] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -1826,7 +1826,7 @@ void ff_put_vp8_epel16_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *
+     dst[15] = cm[(filter[2]*src[15] - filter[1]*src[14] + filter[0]*src[13] + filter[3]*src[16] - filter[4]*src[17] + filter[5]*src[18] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -1906,7 +1906,7 @@ void ff_put_vp8_epel8_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[7] = cm[(filter[2]*src[7] - filter[1]*src[ 6] + filter[0]*src[ 5] + filter[3]*src[8] - filter[4]*src[9] + filter[5]*src[10] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -1976,7 +1976,7 @@ void ff_put_vp8_epel4_h6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[3] = cm[(filter[2]*src[3] - filter[1]*src[ 2] + filter[0]*src[ 1] + filter[3]*src[4] - filter[4]*src[5] + filter[5]*src[ 6] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2054,7 +2054,7 @@ void ff_put_vp8_epel16_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *
+     dst[15] = cm[(filter[2] * src[15] - filter[1] * src[15-srcstride] + filter[3] * src[15+srcstride] - filter[4] * src[15+2*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2131,7 +2131,7 @@ void ff_put_vp8_epel8_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[7] = cm[(filter[2] * src[7] - filter[1] * src[7-srcstride] + filter[3] * src[7+srcstride] - filter[4] * src[7+2*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2198,7 +2198,7 @@ void ff_put_vp8_epel4_v4_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[3] = cm[(filter[2] * src[3] - filter[1] * src[3-srcstride] + filter[3] * src[3+srcstride] - filter[4] * src[3+2*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2280,7 +2280,7 @@ void ff_put_vp8_epel16_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *
+     dst[15] = cm[(filter[2]*src[15] - filter[1]*src[15-srcstride] + filter[0]*src[15-2*srcstride] + filter[3]*src[15+srcstride] - filter[4]*src[15+2*srcstride] + filter[5]*src[15+3*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2362,7 +2362,7 @@ void ff_put_vp8_epel8_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[7] = cm[(filter[2]*src[7] - filter[1]*src[7-srcstride] + filter[0]*src[7-2*srcstride] + filter[3]*src[7+srcstride] - filter[4]*src[7+2*srcstride] + filter[5]*src[7+3*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2434,7 +2434,7 @@ void ff_put_vp8_epel4_v6_mmi(uint8_t *dst, ptrdiff_t dststride, const uint8_t *s
+     dst[3] = cm[(filter[2]*src[3] - filter[1]*src[3-srcstride] + filter[0]*src[3-2*srcstride] + filter[3]*src[3+srcstride] - filter[4]*src[3+2*srcstride] + filter[5]*src[3+3*srcstride] + 64) >> 7];
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x07                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+ 
+@@ -2974,7 +2974,7 @@ void ff_put_vp8_bilinear16_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t
+     dst[15] = (a * src[15] + b * src[16] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[a],       %[a],           %[ftmp0]            \n\t"
+@@ -3043,7 +3043,7 @@ void ff_put_vp8_bilinear16_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t
+     dst[7] = (c * src[7] + d * src[7 + sstride] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[c],       %[c],           %[ftmp0]            \n\t"
+@@ -3146,7 +3146,7 @@ void ff_put_vp8_bilinear8_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *
+     dst[7] = (a * src[7] + b * src[8] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[a],       %[a],           %[ftmp0]            \n\t"
+@@ -3209,7 +3209,7 @@ void ff_put_vp8_bilinear8_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *
+     dst[7] = (c * src[7] + d * src[7 + sstride] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[c],       %[c],           %[ftmp0]            \n\t"
+@@ -3303,7 +3303,7 @@ void ff_put_vp8_bilinear4_h_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *
+     dst[3] = (a * src[3] + b * src[4] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[a],       %[a],           %[ftmp0]            \n\t"
+@@ -3363,7 +3363,7 @@ void ff_put_vp8_bilinear4_v_mmi(uint8_t *dst, ptrdiff_t dstride, const uint8_t *
+     dst[3] = (c * src[3] + d * src[3 + sstride] + 4) >> 3;
+     */
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
++        "xor        %[ftmp0],   %[ftmp0],       %[ftmp0]            \n\t"
+         "li         %[tmp0],    0x03                                \n\t"
+         "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
+         "pshufh     %[c],       %[c],           %[ftmp0]            \n\t"
+diff --git a/libavcodec/mips/vp9_mc_mmi.c b/libavcodec/mips/vp9_mc_mmi.c
+index 495cac3d0b..06ccf2d744 100644
+--- a/libavcodec/mips/vp9_mc_mmi.c
++++ b/libavcodec/mips/vp9_mc_mmi.c
+@@ -83,7 +83,7 @@ static void convolve_horiz_mmi(const uint8_t *src, int32_t src_stride,
+     dst_stride -= w;
+     __asm__ volatile (
+         "move       %[tmp1],    %[width]                   \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
++        "xor        %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
+         MMI_ULDC1(%[filter1], %[filter], 0x00)
+         MMI_ULDC1(%[filter2], %[filter], 0x08)
+         "li         %[tmp0],    0x07                       \n\t"
+@@ -154,7 +154,7 @@ static void convolve_vert_mmi(const uint8_t *src, int32_t src_stride,
+     dst_stride -= w;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
++        "xor        %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
+         MMI_ULDC1(%[ftmp4], %[filter], 0x00)
+         MMI_ULDC1(%[ftmp5], %[filter], 0x08)
+         "punpcklwd  %[filter10], %[ftmp4],   %[ftmp4]      \n\t"
+@@ -242,7 +242,7 @@ static void convolve_avg_horiz_mmi(const uint8_t *src, int32_t src_stride,
+ 
+     __asm__ volatile (
+         "move       %[tmp1],    %[width]                   \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
++        "xor        %[ftmp0],   %[ftmp0],    %[ftmp0]      \n\t"
+         MMI_ULDC1(%[filter1], %[filter], 0x00)
+         MMI_ULDC1(%[filter2], %[filter], 0x08)
+         "li         %[tmp0],    0x07                       \n\t"
+@@ -323,7 +323,7 @@ static void convolve_avg_vert_mmi(const uint8_t *src, int32_t src_stride,
+     dst_stride -= w;
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
++        "xor        %[ftmp0],    %[ftmp0],   %[ftmp0]      \n\t"
+         MMI_ULDC1(%[ftmp4], %[filter], 0x00)
+         MMI_ULDC1(%[ftmp5], %[filter], 0x08)
+         "punpcklwd  %[filter10], %[ftmp4],   %[ftmp4]      \n\t"
+@@ -419,7 +419,7 @@ static void convolve_avg_mmi(const uint8_t *src, int32_t src_stride,
+ 
+     __asm__ volatile (
+         "move       %[tmp1],    %[width]                  \n\t"
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]      \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]      \n\t"
+         "li         %[tmp0],    0x10001                   \n\t"
+         "dmtc1      %[tmp0],    %[ftmp3]                  \n\t"
+         "punpcklhw  %[ftmp3],   %[ftmp3],   %[ftmp3]      \n\t"
+diff --git a/libavcodec/mips/wmv2dsp_mmi.c b/libavcodec/mips/wmv2dsp_mmi.c
+index 1a6781ae77..82e16f929b 100644
+--- a/libavcodec/mips/wmv2dsp_mmi.c
++++ b/libavcodec/mips/wmv2dsp_mmi.c
+@@ -106,7 +106,7 @@ void ff_wmv2_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
+         wmv2_idct_col_mmi(block + i);
+ 
+     __asm__ volatile (
+-        "pxor       %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
++        "xor        %[ftmp0],   %[ftmp0],   %[ftmp0]                    \n\t"
+ 
+         // low 4 loop
+         MMI_LDC1(%[ftmp1], %[block], 0x00)
+-- 
+2.47.1
+

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=3
+REL=4
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"

--- a/app-multimedia/libvpl-tools/autobuild/defines
+++ b/app-multimedia/libvpl-tools/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=libvpl-tools
+PKGSEC=utils
+PKGDEP="libvpl intel-media-sdk vpl-gpu-rt libva libdrm x11-lib wayland"
+BUILDDEP="cmake wayland-protocols"
+PKGDES="Intel Video Processing Library tools"
+
+ABTYPE=cmake
+
+# libvpl only supports amd64
+FAIL_ARCH="!(amd64)"

--- a/app-multimedia/libvpl-tools/spec
+++ b/app-multimedia/libvpl-tools/spec
@@ -1,0 +1,4 @@
+VER=1.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl-tools"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376143"

--- a/runtime-multimedia/libvpl/autobuild/defines
+++ b/runtime-multimedia/libvpl/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=libvpl
 PKGSEC=libs
+PKGDEP="intel-media-sdk vpl-gpu-rt"
 BUILDDEP="cmake"
 PKGDES="Intel Video Processing Library"
 

--- a/runtime-multimedia/libvpl/spec
+++ b/runtime-multimedia/libvpl/spec
@@ -1,4 +1,4 @@
-VER=2.13.0
+VER=2.14.0
 SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242664"

--- a/runtime-multimedia/vpl-gpu-rt/autobuild/defines
+++ b/runtime-multimedia/vpl-gpu-rt/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=vpl-gpu-rt
+PKGSEC=libs
+PKGDEP="libva intel-media-driver"
+BUILDDEP="cmake"
+PKGDES="Intel Video Processing Library GPU runtime"
+
+ABTYPE=cmake
+
+# vpl-gpu-rt only supports amd64
+FAIL_ARCH="!(amd64)"

--- a/runtime-multimedia/vpl-gpu-rt/spec
+++ b/runtime-multimedia/vpl-gpu-rt/spec
@@ -1,0 +1,4 @@
+VER=24.4.4
+SRCS="git::commit=tags/intel-onevpl-$VER::https://github.com/intel/vpl-gpu-rt"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372126"


### PR DESCRIPTION
Topic Description
-----------------

- vpl-gpu-rt: new, 24.4.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libvpl: update to 2.14.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>
- libvpl-tools: new, 1.3.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- ffmpeg: switch from Intel Media SDK to libVPL as recommended by Intel
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- vpl-gpu-rt: 24.4.4
- libvpl: 2.14.0
- libvpl-tools: 1.3.0
- ffmpeg: 7.1-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit vpl-gpu-rt libvpl libvpl-tools ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
