### PR TITLE
intel-media-driver: update to 24.4.4

### DIFF
--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=24.3.4
+VER=24.4.4
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: update to 24.4.4
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- intel-media-driver: 24.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
