### PR TITLE
xxhash: update to 0.8.3

### DIFF
--- a/runtime-common/xxhash/spec
+++ b/runtime-common/xxhash/spec
@@ -1,4 +1,4 @@
-VER=0.8.2
+VER=0.8.3
 SRCS="git::commit=tags/v$VER::https://github.com/Cyan4973/xxHash"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17583"


### PR DESCRIPTION
Topic Description
-----------------

- xxhash: update to 0.8.3
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xxhash: 0.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xxhash
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
