### PR TITLE
mixxx: update to 2.5.0

### DIFF
--- a/app-creativity/mixxx/autobuild/defines
+++ b/app-creativity/mixxx/autobuild/defines
@@ -7,8 +7,11 @@ PKGDEP="lilv libebur128 mp4v2 libsndfile faad2 fftw libshout libmad qt-5 \
         upower qtkeychain ffmpeg wavpack"
 BUILDDEP="gtest mesa glu microsoft-gsl benchmark"
 
-CMAKE_AFTER="-DDOWNLOAD_MANUAL=ON \
-             -DINSTALL_USER_UDEV_RULES=OFF"
+CMAKE_AFTER=(
+    '-DDOWNLOAD_MANUAL=ON'
+    '-DINSTALL_USER_UDEV_RULES=OFF'
+    '-DQT6=OFF'
+)
 
 AB_FLAGS_O3=1
 

--- a/app-creativity/mixxx/spec
+++ b/app-creativity/mixxx/spec
@@ -1,5 +1,4 @@
-VER=2.4.1
-REL=4
+VER=2.5.0
 SRCS="git::commit=tags/$VER::https://github.com/mixxxdj/mixxx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8389"


### PR DESCRIPTION
Topic Description
-----------------

- mixxx: update to 2.5.0
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mixxx: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mixxx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
