### PR TITLE
desktop-file-utils: update to 0.28

### DIFF
--- a/app-admin/desktop-file-utils/spec
+++ b/app-admin/desktop-file-utils/spec
@@ -1,4 +1,4 @@
-VER=0.27
+VER=0.28
 SRCS="tbl::https://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-$VER.tar.xz"
-CHKSUMS="sha256::a0817df39ce385b6621880407c56f1f298168c040c2032cedf88d5b76affe836"
+CHKSUMS="sha256::4401d4e231d842c2de8242395a74a395ca468cd96f5f610d822df33594898a70"
 CHKUPDATE="anitya::id=421"


### PR DESCRIPTION
Topic Description
-----------------

- desktop-file-utils: update to 0.28
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- desktop-file-utils: 0.28

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-file-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
