### PR TITLE
shadow: update to 4.17.1

### DIFF
--- a/app-admin/shadow/autobuild/patches/0001-login.defs-Adapt-to-AOSC-configuration.patch
+++ b/app-admin/shadow/autobuild/patches/0001-login.defs-Adapt-to-AOSC-configuration.patch
@@ -1,4 +1,4 @@
-From 88041e40396103c98590d357b0cf9f0da4ff8b23 Mon Sep 17 00:00:00 2001
+From 964a317ef6fc3eb92ac6d2b99604c2b6e89c5047 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 30 Dec 2024 22:12:24 +0800
 Subject: [PATCH] login.defs: Adapt to AOSC configuration
@@ -13,7 +13,7 @@ Subject: [PATCH] login.defs: Adapt to AOSC configuration
  1 file changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/etc/login.defs b/etc/login.defs
-index 33622c29..d6622d8f 100644
+index 33622c29..48073d7e 100644
 --- a/etc/login.defs
 +++ b/etc/login.defs
 @@ -86,8 +86,7 @@ CONSOLE		/etc/securetty
@@ -32,8 +32,8 @@ index 33622c29..d6622d8f 100644
  # (they are minimal, add the rest in the shell startup files)
 -ENV_SUPATH	PATH=/sbin:/bin:/usr/sbin:/usr/bin
 -ENV_PATH	PATH=/bin:/usr/bin
-+ENV_SUPATH	PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
-+ENV_PATH	PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
++ENV_SUPATH	PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
++ENV_PATH	PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
  
  #
  # Terminal permissions

--- a/app-admin/shadow/spec
+++ b/app-admin/shadow/spec
@@ -1,4 +1,4 @@
-VER=4.17.0
+VER=4.17.1
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/$VER/shadow-$VER.tar.xz"
-CHKSUMS="sha256::df0d29d09ed1db609234aaec670f55ebf724bc7bd0b377c8a299913669b7878e"
+CHKSUMS="sha256::4115a57f9404a038085e160920fb395827fe34363287f709bb9d8c1ed8cbce02"
 CHKUPDATE="anitya::id=4802"


### PR DESCRIPTION
Topic Description
-----------------

- shadow: update to 4.17.1
    - Proritise PATHs in /usr before /.
    - This release fixes a regresion where `su -` and `su -l` may fail to
    launch a new shell.
    - Track patches at AOSC-Tracking/shadow @ aosc/4.17.1
    (HEAD: 964a317ef6fc3eb92ac6d2b99604c2b6e89c5047).

Package(s) Affected
-------------------

- shadow: 4.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
