### PR TITLE
Telegram Desktop: update to 5.10.0

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -29,5 +29,8 @@ ABTYPE=cmakeninja
 # lto1: fatal error: LTO_symtab_tags out of range: Range is 0 to 5, value is 237
 NOLTO__RISCV64=1
 
+# FIXME: LTO requires enormous amount of RAM
+NOLTO__LOONGSON3=1
+
 # FIXME: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
 AB_FLAGS_OS__LOONGSON3=1

--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From fa41306dac4996967acb70d9c8a13ee9033459ad Mon Sep 17 00:00:00 2001
+From 4dd553d011935fbe8bb034611ad60e346482aab6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 1/8] fix(window.style): set default window width to 360px
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index 32e233a0..308eadf9 100644
+index 30026da2..7f7de659 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From 7c7325681794e28dd284ee1ee7bb0280d92f822a Mon Sep 17 00:00:00 2001
+From 6ef0b150cd0f47f2ca5bf5f73cf0643f9099475f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 2/8] fix(core_settings.h): use system window decoration by

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 7dd11a98d5b86d26e12cc59669aa6ac74c8db1dc Mon Sep 17 00:00:00 2001
+From b953f5c56ab128bde8e8eee4cbf01a4fb69657d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 3/8] fix(ui): fix build with Qt 5

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From da878a531aa9e605fe122930d26d9e708996a16f Mon Sep 17 00:00:00 2001
+From 7078e410339a70e35591df47a6aa1ea5515285fd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 4/8] fix(core/launcher.cpp): revert to old HiDPI handling

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From ad4f8d71884d33857354c5b295a89070684aa4d0 Mon Sep 17 00:00:00 2001
+From f094a07013e9952810f6abeb32560bd4dcbb039c Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 5/8] fix(settings): use system fonts by default

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 69dd9b486c0fff460cd61a35cd4a85a01b5457af Mon Sep 17 00:00:00 2001
+From 94ced89f2f2f822beafdfd803c45a4662bf67259 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 6/8] Remove the confusing "Default" option from selectable

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From 3321522548969ae3b045e06a2fdc9172783a9bb4 Mon Sep 17 00:00:00 2001
+From 5f6c8ca90f8b19cb9077ffdab6651d800baaf5c3 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 7/8] fix(lib_tl): add missing cstring include

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From bfa3a22e9afc84303d163cda2dd0f9f2b99188dc Mon Sep 17 00:00:00 2001
+From 0175035d9eafe6f776a0de291ef8272a6e0ad5ff Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 8/8] fix(lib_webview): add missing cstdint include

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,13 @@
-VER=5.9.0
+VER=5.10.0
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=be39b8c8d0db1f377118f813f0c4bd331d341d5e
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::c9e74a9b49284c0d4197f0be7e02415e14c4f8bf46403d0663d39f44d7ac2fbc \
+CHKSUMS="sha256::ce21d0e71e5b5b318edf56778d47756a4db2e175bfa41314832f03a50a9be420 \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem_per_core=4"
+ENVREQ__LOONGSON3="total_mem_per_core=4"
+ENVREQ__PPC64EL="total_mem_per_core=4"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.10.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- telegram-desktop: 5.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
