### PR TITLE
debootstrap: update to 1.0.140

### DIFF
--- a/app-utils/debootstrap/spec
+++ b/app-utils/debootstrap/spec
@@ -1,4 +1,4 @@
-VER=1.0.137
+VER=1.0.140
 CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/installer-team/debootstrap"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- debootstrap: update to 1.0.140
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- debootstrap: 1.0.140

Security Update?
----------------

No

Build Order
-----------

```
#buildit debootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
