### PR TITLE
kitty: update to 0.38.1

### DIFF
--- a/app-utils/kitty/autobuild/prepare
+++ b/app-utils/kitty/autobuild/prepare
@@ -1,0 +1,2 @@
+# FIXME: build system of this package doesn't use CPPFLAGS, instead merge it with CFLAGS
+export CFLAGS="${CFLAGS} ${CPPFLAGS}"

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.36.2
+VER=0.38.1
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::16db7fba5541f322ecc35f15755bc5dc0b4ab3d02156778317f541c44447fb62"
+CHKSUMS="sha256::81b81fb4640588dc630871d48243c0e704535412e66ec500ecec3e436673b643"
 CHKUPDATE="anitya::id=17405"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.38.1
    Co-authored-by: Lain Yang (@Fearyncess) <fsf@live.com>

Package(s) Affected
-------------------

- kitty: 0.38.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
