### PR TITLE
foot: update to 1.20.1

### DIFF
--- a/app-utils/foot/spec
+++ b/app-utils/foot/spec
@@ -1,4 +1,4 @@
-VER=1.20.0
+VER=1.20.1
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/foot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141611"


### PR DESCRIPTION
Topic Description
-----------------

- foot: update to 1.20.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- foot: 1.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit foot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
