### PR TITLE
lutris: correct 0.5.18

### DIFF
--- a/app-games/lutris/autobuild/defines
+++ b/app-games/lutris/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=lutris
 PKGSEC=contrib/games
 PKGDEP="pygobject-3 pyyaml python-evdev gtk-3 glib psmisc cabextract unrar \
-        unzip p7zip curl x11-app gnome-desktop requests pillow webkit2gtk"
+        unzip p7zip curl x11-app gnome-desktop requests pillow webkit2gtk \
+	gtk-update-icon-cache lxml winetricks"
 BUILDDEP="python-build python-installer wheel"
 PKGDES="Game emulation and compatibility runtime manager and launcher"
 

--- a/app-games/lutris/spec
+++ b/app-games/lutris/spec
@@ -2,3 +2,4 @@ VER=0.5.18
 SRCS="tbl::https://lutris.net/releases/lutris_$VER.tar.xz"
 CHKSUMS="sha256::fe93437cc0e68b8117e1b28147807c0c6c6db9bb19c2320fc8d3a963719770a5"
 CHKUPDATE="anitya::id=12270"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

lutris: correct 0.5.18

Package(s) Affected
-------------------

lutris: correct 0.5.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit lutris
```


Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

