### PR TITLE
ciel: update to 3.8.7


### DIFF
--- a/app-devel/ciel/autobuild/beyond
+++ b/app-devel/ciel/autobuild/beyond
@@ -1,2 +1,2 @@
-mv -v "$PKGDIR/usr/bin/ciel-rs" "$PKGDIR/usr/bin/ciel"
+abinfo "Installing extra assets ..."
 PREFIX="$PKGDIR/usr/" ./install-assets.sh

--- a/app-devel/ciel/autobuild/defines
+++ b/app-devel/ciel/autobuild/defines
@@ -8,13 +8,5 @@ USECLANG=1
 # FIXME: clang: error: clang frontend command failed with exit code 139
 USECLANG__MIPS64R6EL=0
 
-# FIXME
-# error: linking with `clang` failed: exit status: 1
-#   |
-#   = note: (command-line)
-#   = note: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol 'DW.ref.rust_eh_personality'; recompile with -fPIC
-#           >>> defined in /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib(std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o)
-#           >>> referenced by std.b38466d5fa66b5e1-cgu.0
-#           >>>               std-bccd059e17955a73.std.b38466d5fa66b5e1-cgu.0.rcgu.o:(.eh_frame+0x378F) in archive /usr/lib64/rustlib/mipsisa64r6el-unknown-linux-gnuabi64/lib/libstd-bccd059e17955a73.rlib
+# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
 NOLTO__LOONGSON3=1
-NOLTO__MIPS64R6EL=1

--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.5.2
+VER=3.8.7
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: update to 3.8.7

Package(s) Affected
-------------------

- ciel: 3.8.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
