### PR TITLE
ciel: update to 3.8.8

### DIFF
--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.8.7
+VER=3.8.8
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: update to 3.8.8
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- ciel: 3.8.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
