### PR TITLE
flat-remix-icon-theme: 20240201 Rework

### DIFF
--- a/desktop-themes/flat-remix-icon-theme/spec
+++ b/desktop-themes/flat-remix-icon-theme/spec
@@ -1,4 +1,6 @@
 VER=20240201
-SRCS="git::commit=tags/$VER::https://github.com/daniruiz/flat-remix"
+# FIXME: Upstream uses a submodule from AUR pulled via SSH (inaccessible).
+SRCS="git::submodule=false;commit=tags/$VER::https://github.com/daniruiz/flat-remix"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231526"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- flat-remix-icon-theme: bump REL, no pull submodules in git source

Package(s) Affected
-------------------

- flat-remix-icon-theme: 20240201-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit flat-remix-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
