### PR TITLE
podman: add shadow as a dependency


### DIFF
--- a/app-containers/podman/autobuild/defines
+++ b/app-containers/podman/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=podman
 PKGSEC=admin
 PKGDES="A tool for managing OCI containers and pods"
-PKGDEP="ostree gpgme conmon containers-common passt catatonit"
+PKGDEP="ostree gpgme conmon containers-common passt catatonit shadow"
 PKGRECOM="btrfs-progs"
 BUILDDEP="go btrfs-progs go-md2man"
 

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -3,6 +3,7 @@ UPSTREAM_VER=5.3.1
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
 GVISOR_TAP_VSOCK_VER=0.7.5
+REL=1
 
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
 SRCS="git::commit=v${UPSTREAM_VER};rename=podman-${UPSTREAM_VER}::https://github.com/containers/podman \


### PR DESCRIPTION
Topic Description
-----------------

- podman: add shadow as a dependency

Package(s) Affected
-------------------

- podman: 5.3.1+vsock0.7.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
