### PR TITLE
llvm-18, llvm-19: fix OpenMP library

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -13,6 +13,13 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
             >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
+    OMP_LIB="$(basename $i)"
+    printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
     update-alternatives --remove-all llvm || true

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=5
+REL=6
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -13,6 +13,13 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
             >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
+    OMP_LIB="$(basename $i)"
+    printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
     update-alternatives --remove-all llvm || true

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,5 +1,5 @@
 VER=19.1.6
-REL=2
+REL=3
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-18: fix OpenMP library
- llvm-19: fix OpenMP library

Package(s) Affected
-------------------

- llvm-18: 18.1.8-6
- llvm-19: 19.1.6-3
- llvm-runtime-18: 18.1.8-6
- llvm-runtime-19: 19.1.6-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
