### PR TITLE
ast-grep: update to 0.33.0

### DIFF
--- a/app-devel/ast-grep/autobuild/defines
+++ b/app-devel/ast-grep/autobuild/defines
@@ -3,6 +3,7 @@ PKGDES="A command-line tool for code structure search, lint, and rewriting"
 PKGDEP="glibc gcc-runtime"
 BUILDDEP="rustc llvm"
 PKGSEC="utils"
+ABTYPE="rust"
 
 USECLANG=1
 ABSPLITDBG=0

--- a/app-devel/ast-grep/spec
+++ b/app-devel/ast-grep/spec
@@ -1,4 +1,4 @@
-VER=0.30.0
+VER=0.33.0
 SRCS="git::commit=tags/$VER::https://github.com/ast-grep/ast-grep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=361439"


### PR DESCRIPTION
Topic Description
-----------------

- ast-grep: update to 0.33.0
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- ast-grep: 0.33.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ast-grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
