### PR TITLE
extreme-tux-rider: new, 0.8.4

### DIFF
--- a/app-games/extreme-tux-rider/autobuild/defines
+++ b/app-games/extreme-tux-rider/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=extreme-tux-racer
+PKGDES="Downhill racing game starring Tux"
+PKGSEC=games
+PKGDEP="sfml glu freetype"

--- a/app-games/extreme-tux-rider/spec
+++ b/app-games/extreme-tux-rider/spec
@@ -1,0 +1,4 @@
+VER=0.8.4
+SRCS="tbl::https://downloads.sourceforge.net/extremetuxracer/etr-$VER.tar.xz"
+CHKSUMS="sha512::65d54bfef59cf83eec9ee761ac24c728d3118cf47105920f22057b59425eba65e03967196d4a93039f30b9420e67b10f296ec7deed7e506ad78c7bb5ce5ed0d2"
+CHKUPDATE="anitya::id=774"


### PR DESCRIPTION
Topic Description
-----------------
extreme-tux-rider: new, 0.8.4

Package(s) Affected
-------------------
extreme-tux-rider: new, 0.8.4


Security Update?
----------------
No

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`