### PR TITLE
openscad: update to 2021.01

### DIFF
--- a/app-creativity/openscad/spec
+++ b/app-creativity/openscad/spec
@@ -1,4 +1,4 @@
-VER=2021.01+git20230825
+VER=2021.01
 SRCS="git::commit=05b962168cce9bc30b967a19514c490b495bd732::https://github.com/openscad/openscad"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2560"


### PR DESCRIPTION
Topic Description
-----------------

- openscad: update to 2021.01
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openscad: 2021.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit openscad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
