### PR TITLE
astyle: update to 3.6.6

### DIFF
--- a/app-devel/astyle/spec
+++ b/app-devel/astyle/spec
@@ -1,4 +1,4 @@
-VER=3.5.2
+VER=3.6.6
 SRCS="git::commit=tags/$VER::https://gitlab.com/saalen/astyle"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=123"


### PR DESCRIPTION
Topic Description
-----------------

- astyle: update to 3.6.6
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- astyle: 3.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit astyle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
