### PR TITLE
lmms: update to 1.2.2+git20250101

### DIFF
--- a/app-creativity/lmms/autobuild/defines
+++ b/app-creativity/lmms/autobuild/defines
@@ -16,6 +16,7 @@ ABTYPE=cmakeninja
 CMAKE_AFTER="-DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt5 \
              -DWANT_QT5=yes \
              -DCMAKE_SKIP_RPATH=OFF \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF \
              -DWANT_WEAKJACK=OFF \
              -DWANT_VST=OFF"
 CMAKE_AFTER__AMD64=" \

--- a/app-creativity/lmms/autobuild/postinst
+++ b/app-creativity/lmms/autobuild/postinst
@@ -1,1 +1,0 @@
-ldconfig

--- a/app-creativity/lmms/autobuild/prepare
+++ b/app-creativity/lmms/autobuild/prepare
@@ -1,6 +1,0 @@
-# Due to issue described in https://bugzilla.mozilla.org/show_bug.cgi?id=1444251 ...
-# When using IBM long double, constexpr for float-point operations is unavailable in GCC.
-if [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
-    abinfo "Working around build failure with IBM long double ABI ..."
-    sed -i 's|constexpr|const|g' include/lmms_constants.h
-fi

--- a/app-creativity/lmms/spec
+++ b/app-creativity/lmms/spec
@@ -1,5 +1,4 @@
-VER=1.2.2+git20240508
-SRCS="git::commit=acefd06f9baca67ef4cc68c6dc0d2072e96f15e6::https://github.com/LMMS/lmms"
+VER=1.2.2+git20250101
+SRCS="git::commit=303215f8b1c6d6a684a47a618565dbf83141b916::https://github.com/LMMS/lmms"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1832"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- lmms: update to 1.2.2+git20250101
    - set CMAKE_SKIP_INSTALL_RPATH to off

Package(s) Affected
-------------------

- lmms: 2:1.2.2+git20250101

Security Update?
----------------

No

Build Order
-----------

```
#buildit lmms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
