### PR TITLE
libxkbcommon: rebuild to fix Spiral markers

### DIFF
--- a/runtime-display/libxkbcommon/spec
+++ b/runtime-display/libxkbcommon/spec
@@ -1,4 +1,5 @@
 VER=1.7.0
+REL=1
 SRCS="tbl::https://xkbcommon.org/download/libxkbcommon-$VER.tar.xz"
 CHKSUMS="sha256::65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247"
 CHKUPDATE="anitya::id=1780"


### PR DESCRIPTION
Topic Description
-----------------

- libxkbcommon: rebuild to fix Spiral markers
    Early Spiral marking implementation did not correctly handle Spiral alias
    with multiple dashes (-) in the package name, resulting in erroneous
    results such as `libxkbcommonx11-0`, where as it should have been
    `libxkbcommon-x11-0`.
    Rebuild this package to fix Spiral markers.

Package(s) Affected
-------------------

- libxkbcommon: 1.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxkbcommon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
