### PR TITLE
chromium: update to 131.0.6778.264

### DIFF
--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=131.0.6778.204
+VER=131.0.6778.264
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::c03b6d9c10a2b2db4b1d2cef0657e85ad2e2d836f029655106cebd9a140692e6 \
+CHKSUMS="sha256::7e02c65865a3095180d60838d2d7a912873d8d4f582c27c2afb9ef876152f2a5 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::06352f7ea6c2c5147824fe880e36173e9be6a541368cb9bb48c57f55a7e58b14"
+         sha256::110206c410a3063795f6db958a107145824fa862b9968759852558155a5ef7e4"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 131.0.6778.264
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- chromium: 131.0.6778.264

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
