### PR TITLE
lfortran: update to 0.43.0

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -1,12 +1,13 @@
 PKGNAME=lfortran
 PKGSEC=devel
-PKGDEP="gcc-runtime glibc llvm ncurses python-3"
-BUILDDEP="fmt llvm python-3 re2c zlib-static zstd-static"
+PKGDEP="gcc-runtime glibc libunwind llvm ncurses python-3"
+BUILDDEP="fmt libunwind llvm python-3 re2c zlib-static zstd-static"
 PKGDES="Interactive LLVM-based Fortran compiler"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
     -DBUILD_SHARED_LIBS=ON \
+    -DLLVM_DIR=$(llvm-config --cmakedir) \
     -DWITH_FMT=ON \
     -DWITH_LLVM=ON \
     -DWITH_RUNTIME_LIBRARY=ON \

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.42.0
+VER=0.43.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::3144abce88da2bcfd39e2c5c655b1bc977c429f3e7dae58afbe45c0237f07298"
+CHKSUMS="sha256::c834622466eee4ffc13731cda89bd4578731625de96f8e1e09531c950e318580"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.43.0

Package(s) Affected
-------------------

- lfortran: 0.43.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
