### PR TITLE
gradle: update to 8.12.0

### DIFF
--- a/lang-java/gradle/spec
+++ b/lang-java/gradle/spec
@@ -1,4 +1,4 @@
-VER=8.10.1
+VER=8.12.0
 SRCS="tbl::https://services.gradle.org/distributions/gradle-${VER%.0}-all.zip"
-CHKSUMS="sha256::fdfca5dbc2834f0ece5020465737538e5ba679deeff5ab6c09621d67f8bb1a15"
+CHKSUMS="sha256::7ebdac923867a3cec0098302416d1e3c6c0c729fc4e2e05c10637a8af33a76c5"
 CHKUPDATE="anitya::id=6088"


### PR DESCRIPTION
Topic Description
-----------------

- gradle: update to 8.12.0
    Co-authored-by: Alan Lin (@miwu04) <mail@alanlin.icu>

Package(s) Affected
-------------------

- gradle: 8.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gradle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
