### PR TITLE
ab-download-manager: new, 1.5.1

### DIFF
--- a/app-web/abdownloadmanager/autobuild/build
+++ b/app-web/abdownloadmanager/autobuild/build
@@ -1,0 +1,20 @@
+abinfo "Building ab-download-manager..."
+chmod -v +x "$SRCDIR"/gradlew
+"$SRCDIR"/gradlew createReleaseDistributable
+
+abinfo "Installing ab-download-manager..."
+install -dvm755 "$PKGDIR/usr/lib/ab-download-manager"
+cp -rv "$SRCDIR"/desktop/app/build/compose/binaries/main-release/app/ABDownloadManager/* \
+    "$PKGDIR"/usr/lib/ab-download-manager/
+
+abinfo "Creating symbolic link to Java runtime ..."
+rm -rv  "$PKGDIR"/usr/lib/ab-download-manager/lib/runtime/
+ln -sv ../../java \
+    "$PKGDIR"/usr/lib/ab-download-manager/lib/runtime
+install -dvm755 "$PKGDIR"/usr/bin
+ln -sv ../lib/ab-download-manager/bin/ABDownloadManager \
+    "$PKGDIR"/usr/bin/ABDownloadManager
+
+abinfo "Extracting desktop icon..."
+install -Dvm644 "$SRCDIR"/desktop/app/build/compose/binaries/main-release/app/ABDownloadManager/lib/ABDownloadManager.png \
+    "$PKGDIR"/usr/share/pixmaps/ABDownloadManager.png

--- a/app-web/abdownloadmanager/autobuild/defines
+++ b/app-web/abdownloadmanager/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=ab-download-manager
+PKGSEC=web
+PKGDES="A multifunctional file downloader"
+BUILDDEP="openjdk"
+PKGDEP="openjdk gcc-runtime"
+
+PKGPROV=abdownloadmanager
+
+# FIXME: kotlinMultiplatform only supported on amd64, arm64.
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-web/abdownloadmanager/autobuild/overrides/usr/share/applications/abdownloadmanager.desktop
+++ b/app-web/abdownloadmanager/autobuild/overrides/usr/share/applications/abdownloadmanager.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=AB Download Manager
+Comment=Multifunctional file downloader
+Comment[zh_CN]=多功能下载器
+Comment[zh_TW]=多功能下載器
+Exec=/usr/bin/ABDownloadManager
+Icon=ABDownloadManager
+Terminal=false
+Categories=Utility;Network;
+StartupWMClass=com-abdownloadmanager-desktop-AppKt

--- a/app-web/abdownloadmanager/spec
+++ b/app-web/abdownloadmanager/spec
@@ -1,0 +1,4 @@
+VER=1.5.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/amir1376/ab-download-manager"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376269"


### PR DESCRIPTION
Topic Description
-----------------

- ab-download-manager: new, 1.5.1

Package(s) Affected
-------------------

- ab-download-manager: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit abdownloadmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
