### PR TITLE
linux-firmware: update to 20250107

### DIFF
--- a/runtime-kernel/linux-firmware/01-nonfree/defines
+++ b/runtime-kernel/linux-firmware/01-nonfree/defines
@@ -1,7 +1,7 @@
 PKGNAME=firmware-nonfree
 PKGSEC=non-free/kernel
 PKGDEP=""
-BUILDDEP="rdfind rsync"
+BUILDDEP="rdfind rsync parallel"
 PKGDES="Firmwares for Linux Kernel (The non-free part)"
 
 PKGPROV="linux-firmware"

--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=20241128
+UPSTREAM_VER=20250107
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
-REL=2
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=9e1d9ae6ef3d3e00e8551266b9c96ea1ace814e4::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=c0f414a6f71154fdbb0e88f29f64e401241ca33d::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250107
    - Update Linux Firmware to current (20250107) HEAD c0f414a6f71154fdbb0e88f29f64e401241ca33d...
    - Changelog below...
    - AMD
    - Revert some AMDGPU firmwares resulting timeouts after extended periods of encoding....
    - VCN...
    - 3.1.2
    - Dimgrey Cavefish / Navy Flounder / Sienna Cichlid / Yellow Carp
    - Realtek
    - Update Realtek RTL8852B BT USB controller firmware, version 0x04BE_1F5E.
    - Add separate config for RLT8723CS Bluetooth part.
    - Miscellaneous
    - Link the Raspberry Pi CM5 and 500 to the 4B in WHENCE.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250107+debian20241210+1
- firmware-nonfree: 20250107+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
