### PR TITLE
abootimg: new, 0.6+git20120912

### DIFF
--- a/app-devices/abootimg/autobuild/build
+++ b/app-devices/abootimg/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building abootimg ..."
+cd "$SRCDIR"
+make all
+
+abinfo "Installing abootimg ..."
+install -Dvm755 abootimg "$PKGDIR/usr/bin/abootimg"

--- a/app-devices/abootimg/autobuild/defines
+++ b/app-devices/abootimg/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=abootimg
+PKGSEC=utils
+PKGDES="Android boot image manipulation tool"
+PKGDEP="cpio util-linux"
+
+ABTYPE=self

--- a/app-devices/abootimg/spec
+++ b/app-devices/abootimg/spec
@@ -1,0 +1,5 @@
+VER=0.6+git20120912
+_COMMIT="7e127fee6a3981f6b0a50ce9910267cd501e09d4"
+SRCS="git::commit=${_COMMIT}::https://github.com/ggrandou/abootimg"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376275"


### PR DESCRIPTION
Topic Description
-----------------

- abootimg: new, 0.6+git20120912

Package(s) Affected
-------------------

- abootimg: 0.6+git20120912

Security Update?
----------------

No

Build Order
-----------

```
#buildit abootimg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
