### PR TITLE
libportal: update to 0.9.0

### DIFF
--- a/runtime-desktop/libportal/spec
+++ b/runtime-desktop/libportal/spec
@@ -1,4 +1,4 @@
-VER=0.8.1
+VER=0.9.0
 SRCS="tbl::https://github.com/flatpak/libportal/releases/download/$VER/libportal-$VER.tar.xz"
-CHKSUMS="sha256::281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac"
+CHKSUMS="sha256::113910f06f39387328805397053d20c7acafb7388d8e6cd5e06e05efb9690735"
 CHKUPDATE="anitya::id=230124"


### PR DESCRIPTION
Topic Description
-----------------

- libportal: update to 0.9.0
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- libportal: 0.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libportal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
