### PR TITLE
aosc-os-repository-data: update to v20250109

### DIFF
--- a/runtime-data/aosc-os-repository-data/spec
+++ b/runtime-data/aosc-os-repository-data/spec
@@ -1,4 +1,4 @@
-VER=20231211
+VER=20250109
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-os-repository-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230634"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-repository-data: update to v20250109

Package(s) Affected
-------------------

- aosc-os-repository-data: 20250109

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-repository-data
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
