### PR TITLE
flatpak: update to 1.16.0

### DIFF
--- a/app-admin/flatpak/autobuild/defines
+++ b/app-admin/flatpak/autobuild/defines
@@ -1,43 +1,35 @@
 PKGNAME=flatpak
 PKGSEC=admin
-PKGDEP="appstream bubblewrap curl dbus elfutils fuse json-glib libarchive \
-        libcap ostree systemd x11-app xdg-dbus-proxy"
-BUILDDEP="docbook-dtd gobject-introspection gtk-doc intltool xmlto"
+PKGDEP="appstream bubblewrap curl dbus fuse-3 json-glib libarchive malcontent \
+        libcap ostree systemd x11-app xdg-dbus-proxy glib libxml2 gpgme zstd \
+        dconf polkit gdk-pixbuf libseccomp wayland"
+BUILDDEP="gobject-introspection gtk-doc intltool xmlto wayland-protocols \
+          libxslt"
 PKGDES="Application deployment framework for desktop applications"
 
-ABSHADOW=0
-AUTOTOOLS_AFTER="--enable-nls \
-                 --disable-rpath \
-                 --disable-valgrind \
-                 --enable-otmpfile \
-                 --disable-wrpseudo-compat \
-                 --disable-selinux-module \
-                 --enable-system-helper \
-                 --enable-auto-sideloading \
-                 --enable-xauth \
-                 --enable-gdm-env-file \
-                 --enable-sandboxed-triggers \
-                 --enable-seccomp \
-                 --enable-sudo \
-                 --disable-asan \
-                 --enable-documentation \
-                 --enable-introspection=yes \
-                 --enable-gtk-doc \
-                 --enable-gtk-doc-html \
-                 --disable-gtk-doc-pdf \
-                 --disable-gtk-doc-check \
-                 --enable-docbook-docs \
-                 --disable-coverage \
-                 --disable-internal-checks \
-                 --disable-installed-tests \
-                 --disable-always-build-tests \
-                 --with-privileged-group=wheel \
-                 --with-system-bubblewrap \
-                 --with-system-dbus-proxy \
-                 --with-systemd \
-                 --with-curl \
-                 --with-gpgme-prefix=/usr \
-                 --with-priv-mode=setuid"
+MESON_AFTER="-Dselinux_module=disabled \
+	     -Dsystem_helper=enabled \
+	     -Dauto_sideloading=true \
+	     -Ddconf=enabled \
+	     -Dgir=enabled \
+	     -Dhttp_backend=curl \
+	     -Dlibzstd=enabled \
+	     -Dmalcontent=enabled \
+	     -Dman=enabled \
+	     -Dgdm_env_file=true \
+	     -Dsandboxed_triggers=true \
+	     -Dseccomp=enabled \
+	     -Dgtkdoc=enabled \
+	     -Ddocbook_docs=enabled \
+	     -Dinternal_checks=false \
+	     -Dinstalled_tests=false \
+	     -Dprivileged_group=wheel \
+	     -Dsystem_bubblewrap=/usr/bin/bwrap \
+	     -Dsystem_dbus_proxy=/usr/bin/xdg-dbus-proxy \
+	     -Dsystem_fusermount=/usr/bin/fusermount3 \
+	     -Dsystemd=enabled \
+	     -Dxauth=enabled \
+	     -Dtests=false"
 
 PKGBREAK="xdg-app<=0.5.2 discover<=5.27.10 gnome-builder<=42.1-4 gnome-software<=42.4 \
           malcontent<=0.10.5 xdg-desktop-portal<=1.16.0 flatpak-builder<=1.0.14"

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,7 +1,6 @@
-VER=1.14.10
+VER=1.16.0
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \
          sha256::3371dd250e61d9e1633630073fefda153cd4426f72f4afa0c3373ae2e8fea03a"
 CHKUPDATE="anitya::id=6377"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- flatpak: update to 1.16.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- flatpak: 1.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
