### PR TITLE
appstream-qt,discover: fix dynamic linked library not found

### DIFF
--- a/app-admin/appstream/02-appstream-qt/defines
+++ b/app-admin/appstream/02-appstream-qt/defines
@@ -3,4 +3,4 @@ PKGSEC=admin
 PKGDEP="appstream qt-5 qt-6"
 PKGDES="Qt bindings for AppStream"
 
-PKGBREAK="plasma-workspace<=5.27.11-2"
+PKGBREAK="plasma-workspace<=5.27.11-2 discover<=5.27.11-2"

--- a/app-admin/appstream/spec
+++ b/app-admin/appstream/spec
@@ -1,5 +1,5 @@
 VER=1.0.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/ximion/appstream.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10385"

--- a/desktop-kde/discover/spec
+++ b/desktop-kde/discover/spec
@@ -1,5 +1,5 @@
 VER=5.27.11
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
 CHKSUMS="sha256::342b62522b6d81335a47be429fe513ad8f3958b385640760edd5bfe77ae9e92c"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

- discover: bump REL due to appstream-qt update to 1.0.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- appstream-qt: mark discover as PKGBREAK
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- discover: 5.27.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream-qt:-pkgbreak discover appstream-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
