### PR TITLE
u-boot-menu: Enforce /boot/u-boot for U-Boot partition

### DIFF
--- a/app-admin/u-boot-menu/autobuild/patches/0001-replace-linux-version-script-with-plain-shell-comman.patch
+++ b/app-admin/u-boot-menu/autobuild/patches/0001-replace-linux-version-script-with-plain-shell-comman.patch
@@ -1,7 +1,7 @@
-From 5b7c58bf958b0f80a5cd04dc0770532d35938a8f Mon Sep 17 00:00:00 2001
+From ddd374eb63393a723d464c44e45abda82d1127d1 Mon Sep 17 00:00:00 2001
 From: Errant404 <erigidissimus@gmail.com>
 Date: Mon, 19 Aug 2024 22:10:09 +0800
-Subject: [PATCH] replace `linux-version` script with plain shell commands
+Subject: [PATCH 1/5] replace `linux-version` script with plain shell commands
 
 ---
  u-boot-update | 2 +-
@@ -21,5 +21,5 @@ index 6b20e7f..8e91b97 100755
  for _KERNEL in ${_KERNELS}
  do
 -- 
-2.46.0
+2.47.1
 

--- a/app-admin/u-boot-menu/autobuild/patches/0002-fix-dtbs-path.patch
+++ b/app-admin/u-boot-menu/autobuild/patches/0002-fix-dtbs-path.patch
@@ -1,7 +1,7 @@
-From 9b4b435775499a298faff7d4491cb4fe187965e2 Mon Sep 17 00:00:00 2001
+From 791b44a9b273a8c84c7583d6a1f3bd3bdc755d24 Mon Sep 17 00:00:00 2001
 From: Errant404 <erigidissimus@gmail.com>
 Date: Tue, 20 Aug 2024 00:38:36 +0800
-Subject: [PATCH] fix dtbs path
+Subject: [PATCH 2/5] fix dtbs path
 
 ---
  etc/default/u-boot                   | 2 +-
@@ -71,5 +71,5 @@ index 8e91b97..ab6eb68 100755
  		_FDT="fdt /${U_BOOT_FDT:-dtb-${_VERSION}}"
  	else
 -- 
-2.46.0
+2.47.1
 

--- a/app-admin/u-boot-menu/autobuild/patches/0003-customize-configuration-files.patch
+++ b/app-admin/u-boot-menu/autobuild/patches/0003-customize-configuration-files.patch
@@ -1,7 +1,7 @@
-From 3cdca7ecdf88a9464b1eb5434bb05a62e6b793ea Mon Sep 17 00:00:00 2001
+From 7a6b4f3873f4c0405f31fc4e5380fceebbc04ac5 Mon Sep 17 00:00:00 2001
 From: Errant404 <erigidissimus@gmail.com>
 Date: Wed, 21 Aug 2024 17:29:00 +0800
-Subject: [PATCH] customize configuration files
+Subject: [PATCH 3/5] customize configuration files
 
 ---
  etc/default/u-boot | 3 ++-
@@ -46,5 +46,5 @@ index f5c8421..0bd0a11 100644
  if [ -z "${U_BOOT_PARAMETERS}" ] && [ -f /etc/kernel/cmdline ]
  then
 -- 
-2.46.0
+2.47.1
 

--- a/app-admin/u-boot-menu/autobuild/patches/0004-make-the-initrd-matching-pattern-suitable-for-AOSC-s.patch
+++ b/app-admin/u-boot-menu/autobuild/patches/0004-make-the-initrd-matching-pattern-suitable-for-AOSC-s.patch
@@ -1,7 +1,7 @@
-From 4ae23eda57d5ffbecaead5fa4f01d784466d011c Mon Sep 17 00:00:00 2001
+From 719ea08b5ae04f98f480052aef4c9d5e8bad6f3a Mon Sep 17 00:00:00 2001
 From: Errant404 <erigidissimus@gmail.com>
 Date: Wed, 21 Aug 2024 20:09:15 +0800
-Subject: [PATCH] make the initrd matching pattern suitable for AOSC style.
+Subject: [PATCH 4/5] make the initrd matching pattern suitable for AOSC style.
 
 ---
  u-boot-update | 3 +++
@@ -22,5 +22,5 @@ index ab6eb68..b7778c4 100755
  	then
  		_INITRD="initrd ${_BOOT_DIRECTORY}/${U_BOOT_INITRD}"
 -- 
-2.46.0
+2.47.1
 

--- a/app-admin/u-boot-menu/autobuild/patches/0005-chore-use-boot-u-boot-as-the-boot-filesystem.patch
+++ b/app-admin/u-boot-menu/autobuild/patches/0005-chore-use-boot-u-boot-as-the-boot-filesystem.patch
@@ -1,0 +1,109 @@
+From e953e0e17a8a9d8da21164c67546ebf391839509 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Tue, 31 Dec 2024 17:29:01 +0800
+Subject: [PATCH 5/5] chore: use /boot/u-boot as the boot filesystem
+
+Using /boot with FAT32 causes problems for dpkg. We now require the
+u-boot filesystem to be mounted at /boot/u-boot.
+---
+ etc/kernel/postinst.d/zz-u-boot-menu |  2 +-
+ read-config                          | 28 ++++++++++++++++++++++++++--
+ u-boot-update                        | 10 +++++++++-
+ 3 files changed, 36 insertions(+), 4 deletions(-)
+
+diff --git a/etc/kernel/postinst.d/zz-u-boot-menu b/etc/kernel/postinst.d/zz-u-boot-menu
+index 7ef7b0e..db5348d 100755
+--- a/etc/kernel/postinst.d/zz-u-boot-menu
++++ b/etc/kernel/postinst.d/zz-u-boot-menu
+@@ -9,7 +9,7 @@ srcdir="/usr/lib/aosc-os-${ARCH}-boot/dtbs-kernel-${version}"
+ destdir="${_BOOT_PATH}${_BOOT_DIRECTORY}${U_BOOT_FDT_DIR}${version}"
+ 
+ # Sync DTBs if /boot is on a different partition than /
+-if has_separate_boot && [ "${U_BOOT_SYNC_DTBS}" = "true" ] && command -v rsync >/dev/null 2>&1
++if u_boot_mounted && [ "${U_BOOT_SYNC_DTBS}" = "true" ] && command -v rsync >/dev/null 2>&1
+ then
+ 	if [ -d "${srcdir}" ]
+ 	then
+diff --git a/read-config b/read-config
+index 0bd0a11..8a8b1d3 100644
+--- a/read-config
++++ b/read-config
+@@ -6,6 +6,10 @@ has_separate_boot() {
+     [ "$(stat --printf %d /)" != "$(stat --printf %d /boot)" ]
+ }
+ 
++u_boot_mounted() {
++	grep -q '[[:space:]]\+/boot/u-boot[[:space:]]\+' /proc/mounts
++}
++
+ # Reading the default file
+ if [ -e /etc/default/u-boot ]
+ then
+@@ -44,9 +48,29 @@ fi
+ # Find boot directory as seen in u-boot, and path prefix while in linux
+ if has_separate_boot
+ then
+-	# / and /boot are on different filesystems
++	echo "E: AOSC OS does not support /boot as the U-Boot filesystem."
++	echo "   Please mount the filesystem to /boot/u-boot, and try again."
++	echo "W: Remember to modify your /etc/fstab."
++	exit 1
++# In case of fstab is not generated yet.
++elif u_boot_mounted
++then
++	UBOOT_MOUNTED=1
++	_BOOT_DIRECTORY=""
++	_U_BOOT_DIRECTORY="/boot/u-boot/extlinux"
++	_BOOT_PATH="/boot/u-boot/"
++	if [ "${U_BOOT_SYNC_DTBS}" = "true" ]
++	then
++		_FDT_DIR="/dtb-"
++	fi
++elif grep -q /boot/u-boot /etc/fstab
++then
++	echo "W: /boot/u-boot is not mounted. Mounting ..."
++	mount /boot/u-boot || { echo "E: Failed to mount /boot/u-boot. Exiting." ; exit 1 ;}
++	UBOOT_MOUNTED=1
+ 	_BOOT_DIRECTORY=""
+-	_BOOT_PATH="/boot"
++	_U_BOOT_DIRECTORY="/boot/u-boot/extlinux"
++	_BOOT_PATH="/boot/u-boot"
+ 	if [ "${U_BOOT_SYNC_DTBS}" = "true" ]
+ 	then
+ 		_FDT_DIR="/dtb-"
+diff --git a/u-boot-update b/u-boot-update
+index b7778c4..22cc888 100755
+--- a/u-boot-update
++++ b/u-boot-update
+@@ -120,19 +120,27 @@ do
+ 	# Strip kernel prefix to derive version.
+ 	_VERSION=${_KERNEL#*-}
+ 	echo "P: Writing config for ${_KERNEL}..."
+-
++	(($UBOOT_MOUNTED)) && install /boot/${_KERNEL} \
++		/boot/u-boot/${_KERNEL}
+ 	_NUMBER="${_NUMBER:-0}"
+ 	_ENTRY="${_ENTRY:-1}"
+ 
+ 	if [ -e "/boot/${U_BOOT_INITRD}-${_VERSION}" ]
+ 	then
+ 		_INITRD="initrd ${_BOOT_DIRECTORY}/${U_BOOT_INITRD}-${_VERSION}"
++		(($UBOOT_MOUNTED)) && install "/boot/${U_BOOT_INITRD}-${_VERSION}" \
++			/boot/u-boot/"${U_BOOT_INITRD}-${_VERSION}"
++
+ 	elif [ -e "/boot/${U_BOOT_INITRD}-${_VERSION}.img" ]
+ 	then
+ 		_INITRD="initrd ${_BOOT_DIRECTORY}/${U_BOOT_INITRD}-${_VERSION}.img"
++		(($UBOOT_MOUNTED)) && install "/boot/${U_BOOT_INITRD}-${_VERSION}.img" \
++			/boot/u-boot/"${U_BOOT_INITRD}-${_VERSION}.img"
+ 	elif [ -e "/boot/${U_BOOT_INITRD}" ]
+ 	then
+ 		_INITRD="initrd ${_BOOT_DIRECTORY}/${U_BOOT_INITRD}"
++		(($UBOOT_MOUNTED)) && install "/boot/${U_BOOT_INITRD}" \
++			/boot/u-boot/"${U_BOOT_INITRD}"
+ 	else
+ 		_INITRD=""
+ 	fi
+-- 
+2.47.1
+

--- a/app-admin/u-boot-menu/spec
+++ b/app-admin/u-boot-menu/spec
@@ -1,5 +1,5 @@
 VER=4.2.3
-REL=1
+REL=2
 SRCS="git::commit=tags/debian/${VER}::https://salsa.debian.org/debian/u-boot-menu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374086"


### PR DESCRIPTION
Topic Description
-----------------

- u-boot-menu: Enforce /boot/u-boot as the boot filesystem
    Our device images mount the boot filesystem directly to /boot. While
    some of the devices may use ext4 for it, others use FAT32 which is a
    problem for dpkg.
    From now on we enforce the boot partition must mounted at /boot/u-boot.

Package(s) Affected
-------------------

- u-boot-menu: 4.2.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit u-boot-menu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
