### PR TITLE
rustc: update to 1.84.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From ba28fdb727b883690a37ebc1b23e42dbbc88255c Mon Sep 17 00:00:00 2001
+From 0eb87214cd03a079a2e8b6f499a3996583b253fd Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 82e11a3afc..1c813d903b 100644
+index 321ab40403..9130d21170 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1622,6 +1622,7 @@ supported_targets! {
+@@ -1623,6 +1623,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,4 +1,4 @@
-From ac98d84d26ce1305335275bb75bf3d55beed4870 Mon Sep 17 00:00:00 2001
+From 4fb049c839649d6adeb67ee4b53093673b5e0fd1 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
 Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys

--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -99,6 +99,7 @@ cat >> "$SRCDIR"/config.toml << EOF
 prefix = "/usr"
 
 [rust]
+download-rustc = false
 EOF
 
 if ! ab_match_arch armv4 && \

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,17 +1,16 @@
-VER=1.83.0
-REL=1
+VER=1.84.0
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::7b11d4242dab0921a7d54758ad3fe805153c979c144625fecde11735760f97df"
+CHKSUMS="sha256::bc2c1639f26814c7b17a323992f1e08c3b01fe88cdff9a27d951987d886e00b3"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.
 #
 # Comment the following segment if this is not the case.
-#SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz \
+#SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.x \
 #      tbl::rename=rustc-bootstrap-${VER}-loongson3.tar.xz::https://repo.aosc.io/aosc-repacks/rust-loongson3/rustc-bootstrap-${VER}-loongson3.tar.xz"
-#CHKSUMS="sha256::7b11d4242dab0921a7d54758ad3fe805153c979c144625fecde11735760f97df \
+#CHKSUMS="sha256::bc2c1639f26814c7b17a323992f1e08c3b01fe88cdff9a27d951987d886e00b3 \
 #         sha256::c8bad5abe44f459fd7983a66337543952fea756fcfa73ddd10a869c4c753c336"
 
 CHKUPDATE="anitya::id=7635"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.84.0

Package(s) Affected
-------------------

- rustc: 1:1.84.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
