### PR TITLE
MATE Desktop Survey (January, 2025)

### DIFF
--- a/desktop-mate/atril/spec
+++ b/desktop-mate/atril/spec
@@ -1,4 +1,4 @@
-VER=1.28.0
+VER=1.28.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/atril-$VER.tar.xz"
-CHKSUMS="sha256::ced4725f6e9b71c4ea63676bfc3cc3be09d29dba08aa7a7ab97964e0b4355162"
+CHKSUMS="sha256::74c4f42979f3ead52def23767448d06ad7f715421e03c9b509404b096de8193e"
 CHKUPDATE="anitya::id=198706"

--- a/desktop-mate/mate-applets/spec
+++ b/desktop-mate/mate-applets/spec
@@ -1,4 +1,4 @@
-VER=1.28.0
+VER=1.28.1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-applets-$VER.tar.xz"
-CHKSUMS="sha256::1b6bef6bd5d326fb9dc828ff910e4b1b9294b4660c311dc1c90310fd9c356686"
+CHKSUMS="sha256::a5967141527dc5b172d322a6003c23aeec253160f650bb36430a06ddaefa7e2e"
 CHKUPDATE="anitya::id=230607"

--- a/desktop-mate/mate-notification-daemon/spec
+++ b/desktop-mate/mate-notification-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.28.1
+VER=1.28.3
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-notification-daemon-$VER.tar.xz"
-CHKSUMS="sha256::fffef553bea15becff5ed40d64e18c23d3b649c4599cc1eb1e82f70533853b34"
+CHKSUMS="sha256::e00cecb1ff9f75b9ccc2644558e44343b80941edb40377dd8100ed3922adf413"
 CHKUPDATE="anitya::id=230618"


### PR DESCRIPTION
Topic Description
-----------------

- mate-notification-daemon: update to 1.28.3
- mate-applets: update to 1.28.1
- atril: update to 1.28.1

Package(s) Affected
-------------------

- atril: 1.28.1
- mate-applets: 1:1.28.1
- mate-notification-daemon: 1:1.28.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit mate-notification-daemon mate-applets atril
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
