### PR TITLE
systemd: rename scheduler in SSD I/O scheduler rules, noop => none

### DIFF
--- a/app-admin/systemd/autobuild/overrides/usr/lib/udev/rules.d/60-ssd-scheduler.rules
+++ b/app-admin/systemd/autobuild/overrides/usr/lib/udev/rules.d/60-ssd-scheduler.rules
@@ -1,2 +1,2 @@
-# set noop scheduler for non-rotating disks
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="noop"
+# set none scheduler for non-rotating disks
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="none"

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=257.2
 
 # Use this for stable releases.
-#REL=1
+REL=1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 


### PR DESCRIPTION
Topic Description
-----------------

systemd: rename scheduler in SSD I/O scheduler rules, noop => none

As part of the multiqueue block I/O scheduler refactor in the Linux Kernel, the "noop" scheduler first aliased as "none" and then renamed to "none" (the exact sequence of events is unclear but one can refer to the changes in `block/elevator.c`).

This commit fixes the following error:

`(udev-worker)[8974]: sda: /usr/lib/udev/rules.d/60-ssd-scheduler.rules:2 Failed to write ATTR{/sys/devices/platform/bus@10000000/1a000000.pci/pci0000:00/0000:00:08.2/ata3/host2/target2:0:0/2:0:0:0/block/sda/queue/scheduler}="noop", ignoring: Invalid argument`

Package(s) Affected
-------------------

- systemd: 1:257.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
