### PR TITLE
libcap-ng: update to 0.8.5, drop python 2 support

### DIFF
--- a/runtime-common/libcap-ng/autobuild/defines
+++ b/runtime-common/libcap-ng/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libcap-ng
 PKGSEC=libs
-PKGDEP="glibc python-2 python-3"
+PKGDEP="glibc python-3"
 BUILDDEP="swig"
 PKGDES="A library making programming with POSIX capabilities easier than traditional libcap"
 
-AUTOTOOLS_ATER="--enable-static=no --with-python --with-python3"
+AUTOTOOLS_ATER="--enable-static=no --with-python3"

--- a/runtime-common/libcap-ng/spec
+++ b/runtime-common/libcap-ng/spec
@@ -1,5 +1,4 @@
-VER=0.7.11
+VER=0.8.5
 SRCS="tbl::https://people.redhat.com/sgrubb/libcap-ng/libcap-ng-$VER.tar.gz"
-CHKSUMS="sha256::85815c711862d01a440db471f12fba462c9949e923966f5859607e652d9c0ae9"
+CHKSUMS="sha256::3ba5294d1cbdfa98afaacfbc00b6af9ed2b83e8a21817185dfd844cc8c7ac6ff"
 CHKUPDATE="anitya::id=1570"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libcap-ng: update to 0.8.5, drop python-2 support
    upstream dropped python-2 support since 0.8.4

Package(s) Affected
-------------------

- libcap-ng: 0.8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcap-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
