### PR TITLE
buildah, skopeo: rebuild due to shadow update

### DIFF
--- a/app-containers/buildah/autobuild/defines
+++ b/app-containers/buildah/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=buildah
 PKGSEC=devel
-PKGDEP="gpgme containers-common"
+PKGDEP="gpgme containers-common shadow"
 PKGDES="Utility for building OCI images"
 BUILDDEP="go"
 

--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,4 +1,5 @@
 VER=1.38.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14974"

--- a/app-containers/skopeo/autobuild/defines
+++ b/app-containers/skopeo/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=skopeo
 PKGSEC=admin
-PKGDEP="gpgme containers-common"
+PKGDEP="gpgme containers-common skopeo"
 PKGDES="Utility for operating on container images and repositories"
 BUILDDEP="go go-md2man"
 

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,4 +1,5 @@
 VER=1.17.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"


### PR DESCRIPTION
Topic Description
-----------------

- skopeo: add shadow as a dependency
- buildah: add shadow as a dependency

Package(s) Affected
-------------------

- buildah: 1.38.0-1
- skopeo: 1.17.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit buildah skopeo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
