### PR TITLE
mihomo-party: update to 1.5.13

### DIFF
--- a/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
+++ b/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
@@ -1,4 +1,4 @@
-From 3b3150e66b1e813aac5d1f1051aeda302d1b4a56 Mon Sep 17 00:00:00 2001
+From 5fa6b2e5443e8421f38a7d176373ed95047ca230 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 24 Nov 2024 17:58:46 +0800
 Subject: [PATCH 1/6] Keep old productName on linux

--- a/app-network/mihomo-party/autobuild/patches/0002-Remove-check-update-UI.patch
+++ b/app-network/mihomo-party/autobuild/patches/0002-Remove-check-update-UI.patch
@@ -1,4 +1,4 @@
-From 14c8061df0c089241d9ecb0f71823d204f0d91f4 Mon Sep 17 00:00:00 2001
+From d4d253b782966181ab562268a292d240c3f72794 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 24 Nov 2024 17:50:25 +0800
 Subject: [PATCH 2/6] Remove check update UI
@@ -10,7 +10,7 @@ Subject: [PATCH 2/6] Remove check update UI
  3 files changed, 1 insertion(+), 37 deletions(-)
 
 diff --git a/src/main/utils/template.ts b/src/main/utils/template.ts
-index e2a0341..5e3f6c7 100644
+index 6bc3513..e9f04fd 100644
 --- a/src/main/utils/template.ts
 +++ b/src/main/utils/template.ts
 @@ -11,7 +11,7 @@ export const defaultConfig: IAppConfig = {

--- a/app-network/mihomo-party/autobuild/patches/0003-Drop-clash-meta-alpha-support.patch
+++ b/app-network/mihomo-party/autobuild/patches/0003-Drop-clash-meta-alpha-support.patch
@@ -1,4 +1,4 @@
-From 3d99502cbe440786627f104a76443adc73fe4d8b Mon Sep 17 00:00:00 2001
+From f0067e9c89fcaab91d961d8fd9a22dcc21a8a742 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:01:33 +0800
 Subject: [PATCH 3/6] Drop clash-meta-alpha support

--- a/app-network/mihomo-party/autobuild/patches/0004-Remove-upgrade-mihomo-UI.patch
+++ b/app-network/mihomo-party/autobuild/patches/0004-Remove-upgrade-mihomo-UI.patch
@@ -1,4 +1,4 @@
-From a358491aa6a6455c8d2a6cb9339dc7a1a6f4c62b Mon Sep 17 00:00:00 2001
+From ee4bf73c6bc2585ee741d1b8ce3cf7d826050775 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:04:04 +0800
 Subject: [PATCH 4/6] Remove upgrade mihomo UI

--- a/app-network/mihomo-party/autobuild/patches/0005-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
+++ b/app-network/mihomo-party/autobuild/patches/0005-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
@@ -1,4 +1,4 @@
-From fc1abf809fc2a50ea6262f567954dd9abd1a21d4 Mon Sep 17 00:00:00 2001
+From 3af6c341e51445392a2ea0207c8b0f61c697ec68 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:10:02 +0800
 Subject: [PATCH 5/6] Do not fetch Mihomo (Clash Meta) binaries We use a system

--- a/app-network/mihomo-party/autobuild/patches/0006-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
+++ b/app-network/mihomo-party/autobuild/patches/0006-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
@@ -1,4 +1,4 @@
-From 44875d2bc54dcb4225a22f4ff17a7482570e223c Mon Sep 17 00:00:00 2001
+From db51dbc9de05bbdecda838853842d456c0cab815 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:54:50 +0800
 Subject: [PATCH 6/6] Do not find Mihomo(Clash Meta) binary in sidecar dir

--- a/app-network/mihomo-party/spec
+++ b/app-network/mihomo-party/spec
@@ -1,5 +1,4 @@
-VER=1.5.12
-REL=1
+VER=1.5.13
 SRCS="git::commit=tags/v$VER::https://github.com/mihomo-party-org/mihomo-party.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375292"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo-party: update to 1.5.13

Package(s) Affected
-------------------

- mihomo-party: 1.5.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo-party
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
