### PR TITLE
starship: update to 1.22.1

### DIFF
--- a/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
+++ b/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
@@ -1,4 +1,4 @@
-From b9e5c236f42ea3dcc93a096de0c4dcd3177637b4 Mon Sep 17 00:00:00 2001
+From b33929647dd5b9030056d6784a9194872ef34a9a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 17 Sep 2023 18:30:43 +0800
 Subject: [PATCH 1/2] feat(status): add `success_symbol_rootuser` option
@@ -12,10 +12,10 @@ This commit will allow user to set a different success symbol for root users tha
  4 files changed, 43 insertions(+)
 
 diff --git a/.github/config-schema.json b/.github/config-schema.json
-index 3dc390b6..989a53cf 100644
+index 6ec2c4b0..a0b73b02 100644
 --- a/.github/config-schema.json
 +++ b/.github/config-schema.json
-@@ -1722,6 +1722,7 @@
+@@ -1729,6 +1729,7 @@
          "signal_symbol": "⚡",
          "style": "bold red",
          "success_symbol": "",
@@ -23,7 +23,7 @@ index 3dc390b6..989a53cf 100644
          "symbol": "❌"
        },
        "allOf": [
-@@ -5969,6 +5970,10 @@
+@@ -5989,6 +5990,10 @@
            "default": "",
            "type": "string"
          },
@@ -35,18 +35,18 @@ index 3dc390b6..989a53cf 100644
            "default": "🚫",
            "type": "string"
 diff --git a/docs/config/README.md b/docs/config/README.md
-index 83ae1332..d00f4218 100644
+index d481f84d..7cda892e 100644
 --- a/docs/config/README.md
 +++ b/docs/config/README.md
-@@ -4277,6 +4277,7 @@ To enable it, set `disabled` to `false` in your configuration file.
- | `format`                    | `'[$symbol$status]($style) '`                                                 | The format of the module                                              |
- | `symbol`                    | `'❌'`                                                                        | The symbol displayed on program error                                 |
- | `success_symbol`            | `''`                                                                          | The symbol displayed on program success                               |
+@@ -4282,6 +4282,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+ | `format`                    | `'[$symbol$status]($style) '`                                                  | The format of the module                                              |
+ | `symbol`                    | `'❌'`                                                                         | The symbol displayed on program error                                 |
+ | `success_symbol`            | `''`                                                                           | The symbol displayed on program success                               |
 +| `success_symbol_rootuser`   | `''`                                                                          | The symbol displayed on program success (root user only)              |
- | `not_executable_symbol`     | `'🚫'`                                                                        | The symbol displayed when file isn't executable                       |
- | `not_found_symbol`          | `'🔍'`                                                                        | The symbol displayed when the command can't be found                  |
- | `sigint_symbol`             | `'🧱'`                                                                        | The symbol displayed on SIGINT (Ctrl + c)                             |
-@@ -4316,6 +4317,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+ | `not_executable_symbol`     | `'🚫'`                                                                         | The symbol displayed when file isn't executable                       |
+ | `not_found_symbol`          | `'🔍'`                                                                         | The symbol displayed when the command can't be found                  |
+ | `sigint_symbol`             | `'🧱'`                                                                         | The symbol displayed on SIGINT (Ctrl + c)                             |
+@@ -4323,6 +4324,7 @@ To enable it, set `disabled` to `false` in your configuration file.
  style = 'bg:blue'
  symbol = '🔴 '
  success_symbol = '🟢 SUCCESS'
@@ -55,7 +55,7 @@ index 83ae1332..d00f4218 100644
  map_symbol = true
  disabled = false
 diff --git a/src/configs/status.rs b/src/configs/status.rs
-index a27f2ed2..c21cb856 100644
+index c4e4ed8d..c795e2e7 100644
 --- a/src/configs/status.rs
 +++ b/src/configs/status.rs
 @@ -11,6 +11,7 @@ pub struct StatusConfig<'a> {
@@ -66,7 +66,7 @@ index a27f2ed2..c21cb856 100644
      pub not_executable_symbol: &'a str,
      pub not_found_symbol: &'a str,
      pub sigint_symbol: &'a str,
-@@ -32,6 +33,7 @@ impl<'a> Default for StatusConfig<'a> {
+@@ -36,6 +37,7 @@ impl Default for StatusConfig<'_> {
              format: "[$symbol$status]($style) ",
              symbol: "❌",
              success_symbol: "",
@@ -75,7 +75,7 @@ index a27f2ed2..c21cb856 100644
              not_found_symbol: "🔍",
              sigint_symbol: "🧱",
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index 6dfa168b..a6d56318 100644
+index d9276f2e..0f9e03d6 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
 @@ -46,6 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -94,7 +94,7 @@ index 6dfa168b..a6d56318 100644
                      0 => Some(config.success_symbol),
                      126 if config.map_symbol => Some(config.not_executable_symbol),
                      127 if config.map_symbol => Some(config.not_found_symbol),
-@@ -255,6 +257,38 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
+@@ -260,6 +262,38 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
      }
  }
  
@@ -134,5 +134,5 @@ index 6dfa168b..a6d56318 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 -- 
-2.47.0
+2.47.1
 

--- a/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
+++ b/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
@@ -1,4 +1,4 @@
-From 9d178520026f23023d7848b750e7643891171bf6 Mon Sep 17 00:00:00 2001
+From dd25fe463af9365096cdd259a43e560eacd84abd Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 21 Sep 2023 18:11:16 +0800
 Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
@@ -13,7 +13,7 @@ Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
  create mode 100644 src/modules/utils/is_root_user.rs
 
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index a6d56318..9f6b83c7 100644
+index 0f9e03d6..6821a483 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
 @@ -1,5 +1,6 @@
@@ -23,7 +23,7 @@ index a6d56318..9f6b83c7 100644
  use super::{Context, Module, ModuleConfig};
  
  use crate::configs::status::StatusConfig;
-@@ -257,38 +258,6 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
+@@ -262,38 +263,6 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
      }
  }
  
@@ -63,7 +63,7 @@ index a6d56318..9f6b83c7 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 diff --git a/src/modules/username.rs b/src/modules/username.rs
-index 8ba3509e..143e7113 100644
+index c25a5bd2..97ef9824 100644
 --- a/src/modules/username.rs
 +++ b/src/modules/username.rs
 @@ -1,3 +1,4 @@
@@ -97,12 +97,12 @@ index 8ba3509e..143e7113 100644
 -    )
 -}
 -
--#[cfg(all(target_os = "windows", test))]
+-#[cfg(test)]
 -fn is_root_user() -> bool {
 -    false
 -}
 -
--#[cfg(not(target_os = "windows"))]
+-#[cfg(all(not(target_os = "windows"), not(test)))]
 -fn is_root_user() -> bool {
 -    nix::unistd::geteuid() == nix::unistd::ROOT
 -}
@@ -112,7 +112,7 @@ index 8ba3509e..143e7113 100644
      ssh_env.iter().any(|env| context.get_env_os(env).is_some())
 diff --git a/src/modules/utils/is_root_user.rs b/src/modules/utils/is_root_user.rs
 new file mode 100644
-index 00000000..a5109790
+index 00000000..968a2d86
 --- /dev/null
 +++ b/src/modules/utils/is_root_user.rs
 @@ -0,0 +1,31 @@
@@ -138,12 +138,12 @@ index 00000000..a5109790
 +    )
 +}
 +
-+#[cfg(all(target_os = "windows", test))]
++#[cfg(test)]
 +pub fn is_root_user() -> bool {
 +    false
 +}
 +
-+#[cfg(not(target_os = "windows"))]
++#[cfg(all(not(target_os = "windows"), not(test)))]
 +pub fn is_root_user() -> bool {
 +    nix::unistd::geteuid() == nix::unistd::ROOT
 +}
@@ -158,5 +158,5 @@ index 209da8ed..445898b0 100644
 +
 +pub mod is_root_user;
 -- 
-2.47.0
+2.47.1
 

--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.21.1
+VER=1.22.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- starship: update to 1.22.1
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- starship: 1.22.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit starship
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
