### PR TITLE
vim: update to 9.1.1002

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.1.0998
+VER=9.1.1002
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.1.1002
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- gvim: 9.1.1002
- vim: 9.1.1002

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
