### PR TITLE
guestfs-tools: new

### DIFF
--- a/runtime-virtualization/guestfs-tools/autobuild/defines
+++ b/runtime-virtualization/guestfs-tools/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=guestfs-tools
 PKGSEC=libs
 PKGDEP="libguestfs qemu glibc cpio fuse augeas xz zstd"
-BUILDDEP="ocaml gperf findlib ocaml-augeas"
+BUILDDEP="ocaml gperf findlib ocaml-augeas perl-module-build perl-string-shellquote"
 PKGDES="Tools for accessing and modifying guest disk images"
 
 AUTOTOOLS_AFTER="--disable-werror \

--- a/runtime-virtualization/guestfs-tools/autobuild/defines
+++ b/runtime-virtualization/guestfs-tools/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=guestfs-tools
+PKGSEC=libs
+PKGDEP="libguestfs qemu glibc cpio fuse augeas xz zstd"
+BUILDDEP="ocaml gperf findlib ocaml-augeas"
+PKGDES="Tools for accessing and modifying guest disk images"
+
+AUTOTOOLS_AFTER="--disable-werror \
+                 --enable-largefile \
+                 --enable-nls \
+                 --disable-rpath \
+                 --with-libvirt \
+                 PYTHON=/usr/bin/python3"
+
+ABSPLITDBG=0
+
+# FIXME: OCaml has LTO disabled, enabling LTO here results in linkage failure.
+NOLTO=1

--- a/runtime-virtualization/guestfs-tools/spec
+++ b/runtime-virtualization/guestfs-tools/spec
@@ -1,0 +1,4 @@
+VER=1.53.5
+SRCS="git::commit=tags/v${VER}::https://github.com/libguestfs/guestfs-tools.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376362"

--- a/runtime-virtualization/libguestfs/autobuild/defines
+++ b/runtime-virtualization/libguestfs/autobuild/defines
@@ -8,7 +8,6 @@ BUILDDEP="gperf libintl-perl pcre perl-module-build perl-string-shellquote \
 PKGDES="Access and modify virtual machine disk image"
 
 # FIXME: --disable-appliance, missing a lot of dependencies, to re-visit later.
-# FIXME: --disable-ocaml, OCaml bindings fails to build.
 # FIXME: --disable-rust, fails to build with Rust 1.71.1.
 AUTOTOOLS_AFTER="--disable-werror \
                  --enable-largefile \

--- a/runtime-virtualization/libguestfs/spec
+++ b/runtime-virtualization/libguestfs/spec
@@ -1,4 +1,5 @@
 VER=1.54.0
+REL=1
 SRCS="tbl::https://download.libguestfs.org/${VER%.*}-stable/libguestfs-$VER.tar.gz"
 CHKSUMS="sha256::b4afa0f8fd580205ea5548d468bc6e43c3becb995e2f60e63265527a63054246"
 CHKUPDATE="anitya::id=229572"


### PR DESCRIPTION
Topic Description
-----------------

- libguestfs: enable ocaml binding
- guestfs-tools: new, 1.53.5

Package(s) Affected
-------------------

- guestfs-tools: 1.53.5
- libguestfs: 1.54.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libguestfs guestfs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
