### PR TITLE
ed: update to 1.21

### DIFF
--- a/app-editors/ed/spec
+++ b/app-editors/ed/spec
@@ -1,4 +1,4 @@
-VER=1.20.2
+VER=1.21
 SRCS="tbl::https://ftp.gnu.org/gnu/ed/ed-$VER.tar.lz"
-CHKSUMS="sha256::65fec7318f48c2ca17f334ac0f4703defe62037bb13cc23920de077b5fa24523"
+CHKSUMS="sha256::60e24998727d453a5cf02c54664b97536de46a2b34cd1f4f67c1c1a61bbbad75"
 CHKUPDATE="anitya::id=659"


### PR DESCRIPTION
Topic Description
-----------------

- ed: update to 1.21
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ed: 1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
