### PR TITLE
ddrescue: update to 1.29

### DIFF
--- a/app-utils/ddrescue/spec
+++ b/app-utils/ddrescue/spec
@@ -1,4 +1,4 @@
-VER=1.28
+VER=1.29
 SRCS="tbl::https://ftp.gnu.org/gnu/ddrescue/ddrescue-$VER.tar.lz"
-CHKSUMS="sha256::6626c07a7ca1cc1d03cad0958522c5279b156222d32c342e81117cfefaeb10c1"
+CHKSUMS="sha256::01a414327853b39fba2fd0ece30f7bee2e9d8c8e8eb314318524adf5a60039a3"
 CHKUPDATE="anitya::id=410"


### PR DESCRIPTION
Topic Description
-----------------

- ddrescue: update to 1.29
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ddrescue: 1.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddrescue
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
