### PR TITLE
bc: update to 1.08.1

### DIFF
--- a/app-utils/bc/spec
+++ b/app-utils/bc/spec
@@ -1,5 +1,4 @@
-VER=1.07.1
-REL=3
+VER=1.08.1
 SRCS="tbl::https://ftp.gnu.org/gnu/bc/bc-$VER.tar.gz"
-CHKSUMS="sha256::62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a"
+CHKSUMS="sha256::b71457ffeb210d7ea61825ff72b3e49dc8f2c1a04102bbe23591d783d1bfe996"
 CHKUPDATE="anitya::id=170"


### PR DESCRIPTION
Topic Description
-----------------

- bc: update to 1.08.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bc: 1.08.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
