### PR TITLE
texinfo: update to 7.2

### DIFF
--- a/app-utils/texinfo/spec
+++ b/app-utils/texinfo/spec
@@ -1,4 +1,4 @@
-VER=7.1
+VER=7.2
 SRCS="tbl::https://ftp.gnu.org/gnu/texinfo/texinfo-$VER.tar.xz"
-CHKSUMS="sha256::deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953"
+CHKSUMS="sha256::0329d7788fbef113fa82cb80889ca197a344ce0df7646fe000974c5d714363a6"
 CHKUPDATE="anitya::id=4958"


### PR DESCRIPTION
Topic Description
-----------------

- texinfo: update to 7.2
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- texinfo: 7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit texinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
