### PR TITLE
nettle: update to 3.10.1

### DIFF
--- a/runtime-cryptography/nettle/spec
+++ b/runtime-cryptography/nettle/spec
@@ -1,4 +1,4 @@
-VER=3.10
+VER=3.10.1
 SRCS="tbl::https://ftp.gnu.org/gnu/nettle/nettle-$VER.tar.gz"
-CHKSUMS="sha256::b4c518adb174e484cb4acea54118f02380c7133771e7e9beb98a0787194ee47c"
+CHKSUMS="sha256::b0fcdd7fc0cdea6e80dcf1dd85ba794af0d5b4a57e26397eee3bc193272d9132"
 CHKUPDATE="anitya::id=2073"


### PR DESCRIPTION
Topic Description
-----------------

- nettle: update to 3.10.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nettle: 3.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nettle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
