### PR TITLE
mtools: update to 4.0.46

### DIFF
--- a/app-admin/mtools/spec
+++ b/app-admin/mtools/spec
@@ -1,4 +1,4 @@
-VER=4.0.45
+VER=4.0.46
 SRCS="https://ftp.gnu.org/gnu/mtools/mtools-$VER.tar.gz"
-CHKSUMS="sha256::eea170403f48f0cd19b3d940e4bd12630a82601e25f944f47654b13d9d7eb5d4"
+CHKSUMS="sha256::4243e79af24133525755f37fc85e9c09fd904c89561ee19cd669454fc5b28ded"
 CHKUPDATE="anitya::id=2028"


### PR DESCRIPTION
Topic Description
-----------------

- mtools: update to 4.0.46
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mtools: 4.0.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit mtools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
