### PR TITLE
libtool: update to 2.5.4

### DIFF
--- a/app-devel/libtool/spec
+++ b/app-devel/libtool/spec
@@ -1,4 +1,4 @@
-VER=2.4.7
+VER=2.5.4
 SRCS="tbl::https://ftp.gnu.org/gnu/libtool/libtool-$VER.tar.xz"
-CHKSUMS="sha256::4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
+CHKSUMS="sha256::f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675"
 CHKUPDATE="anitya::id=1741"


### PR DESCRIPTION
Topic Description
-----------------

- libtool: update to 2.5.4
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libtool: 2.5.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
