### PR TITLE
libunistring: update to 1.3

### DIFF
--- a/app-admin/sssd/spec
+++ b/app-admin/sssd/spec
@@ -1,5 +1,5 @@
 VER=2.9.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/SSSD/sssd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12810"

--- a/app-devel/gettext/spec
+++ b/app-devel/gettext/spec
@@ -1,4 +1,5 @@
 VER=0.25
+REL=1
 SRCS="https://ftp.gnu.org/gnu/gettext/gettext-$VER.tar.xz"
 CHKSUMS="sha256::05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"
 CHKUPDATE="anitya::id=898"

--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,4 +1,5 @@
 VER=28.12
+REL=1
 SRCS="tbl::https://github.com/owntone/owntone-server/releases/download/$VER/owntone-$VER.tar.xz"
 CHKSUMS="sha256::731ce61f83b111e3c329fdf8182f3eb6310a212063e6025f307d3a10efbc6b1e"
 CHKUPDATE="anitya::id=230673"

--- a/desktop-gnome/rygel/spec
+++ b/desktop-gnome/rygel/spec
@@ -1,5 +1,5 @@
 VER=0.40.4
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/rygel/${VER%.*}/rygel-$VER.tar.xz"
 CHKSUMS="sha256::736d8adbe8615f6cbc8fcfff9845dc985fd10e16629da236b4b52dbedf0a348b"
 CHKUPDATE="anitya::id=4751"

--- a/lang-lisp/guile-2.2/spec
+++ b/lang-lisp/guile-2.2/spec
@@ -1,4 +1,4 @@
 VER=2.2.7
-REL=2
+REL=3
 SRCS="tbl::https://ftp.gnu.org/gnu/guile/guile-$VER.tar.xz"
 CHKSUMS="sha256::cdf776ea5f29430b1258209630555beea6d2be5481f9da4d64986b077ff37504"

--- a/lang-lisp/guile/spec
+++ b/lang-lisp/guile/spec
@@ -1,4 +1,5 @@
 VER=3.0.10
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/guile/guile-$VER.tar.xz"
 CHKSUMS="sha256::bd7168517fd526333446d4f7ab816527925634094fbd37322e17e2b8d8e76388"
 CHKUPDATE="anitya::id=1277"

--- a/runtime-common/libunistring/autobuild/defines
+++ b/runtime-common/libunistring/autobuild/defines
@@ -5,3 +5,8 @@ BUILDDEP="gperf"
 PKGDES="Library for manipulating Unicode strings and C strings"
 
 RECONF=0
+ABTYPE=autotools
+
+PKGBREAK="gettext<=1:0.25 gnutls<=3.8.7 guile<=3.0.10 guile-2.2<=2.2.7-2 \
+          libidn2<=2.3.8-1 libratbag<=0.18 owntone<=28.9-2 rygel<=0.40.4-1 \
+          sssd<=2.9.5-1"

--- a/runtime-common/libunistring/spec
+++ b/runtime-common/libunistring/spec
@@ -1,5 +1,4 @@
-VER=0.9.10
-REL=4
+VER=1.3
 SRCS="tbl::https://ftp.gnu.org/gnu/libunistring/libunistring-$VER.tar.xz"
-CHKSUMS="sha256::eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
+CHKSUMS="sha256::f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527"
 CHKUPDATE="anitya::id=1747"

--- a/runtime-cryptography/gnutls/spec
+++ b/runtime-cryptography/gnutls/spec
@@ -1,4 +1,5 @@
 VER=3.8.7
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
 CHKSUMS="sha256::fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477"
 CHKUPDATE="anitya::id=1221"

--- a/runtime-devices/libratbag/spec
+++ b/runtime-devices/libratbag/spec
@@ -1,4 +1,5 @@
 VER=0.18
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/libratbag/libratbag/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15171"

--- a/runtime-network/libidn2/spec
+++ b/runtime-network/libidn2/spec
@@ -1,5 +1,5 @@
 VER=2.3.8
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/pub/gnu/libidn/libidn2-$VER.tar.gz"
 CHKSUMS="sha256::f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
 CHKUPDATE="anitya::id=5597"


### PR DESCRIPTION
Topic Description
-----------------

- sssd: bump REL due to libunistring update to 1.3
- rygel: bump REL due to libunistring update to 1.3
- owntone: bump REL due to libunistring update to 1.3
- libratbag: bump REL due to libunistring update to 1.3
- libidn2: bump REL due to libunistring update to 1.3
- guile-2.2: bump REL due to libunistring update to 1.3
- guile: bump REL due to libunistring update to 1.3
- gnutls: bump REL due to libunistring update to 1.3
- gettext: bump REL due to libunistring update to 1.3
- libunistring: update to 1.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gettext: 1:0.25-1
- gnutls: 3.8.7-1
- guile: 3.0.10-1
- guile-2.2: 2.2.7-3
- libidn2: 2.3.8-2
- libratbag: 0.18-1
- libunistring: 1.3
- owntone: 28.12-1
- rygel: 0.40.4-2
- sssd: 2.9.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libunistring:-pkgbreak gettext libidn2 gnutls guile guile-2.2 libratbag owntone rygel sssd libunistring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
