### PR TITLE
gdbm: update to 1.24

### DIFF
--- a/app-database/gdbm/spec
+++ b/app-database/gdbm/spec
@@ -1,5 +1,4 @@
-VER=1.23
-REL=1
+VER=1.24
 SRCS="https://ftp.gnu.org/gnu/gdbm/gdbm-$VER.tar.gz"
-CHKSUMS="sha256::74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd"
+CHKSUMS="sha256::695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf"
 CHKUPDATE="anitya::id=882"


### PR DESCRIPTION
Topic Description
-----------------

- gdbm: update to 1.24
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gdbm: 1.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdbm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
