### PR TITLE
ncurses: update to 6.5

### DIFF
--- a/runtime-common/ncurses/spec
+++ b/runtime-common/ncurses/spec
@@ -1,5 +1,4 @@
-VER=6.4
-REL=3
+VER=6.5
 SRCS="https://ftp.gnu.org/gnu/ncurses/ncurses-${VER}.tar.gz"
-CHKSUMS="sha256::6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
+CHKSUMS="sha256::136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
 CHKUPDATE="anitya::id=2057"


### PR DESCRIPTION
Topic Description
-----------------

- ncurses: update to 6.5
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ncurses: 1:6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncurses
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
