### PR TITLE
libmicrohttpd: update to 1.0.1

### DIFF
--- a/runtime-web/libmicrohttpd/autobuild/beyond
+++ b/runtime-web/libmicrohttpd/autobuild/beyond
@@ -1,4 +1,0 @@
-install -Dm644 src/include/platform.h \
-               "$PKGDIR"/usr/include/libmicrohttpd/platform.h
-sed -i 's#Cflags: -I${includedir}#Cflags: -I${includedir} -I${includedir}/libmicrohttpd#' \
-       "$PKGDIR"/usr/lib/pkgconfig/libmicrohttpd.pc

--- a/runtime-web/libmicrohttpd/autobuild/defines
+++ b/runtime-web/libmicrohttpd/autobuild/defines
@@ -1,7 +1,13 @@
 PKGNAME=libmicrohttpd
 PKGDES="Embedding HTTP server functionality"
 PKGSEC=libs
-PKGDEP="gnutls libgcrypt file curl"
+PKGDEP="glibc gnutls"
 
-AUTOTOOLS_AFTER="--enable-largefile --enable-curl \
-                 --enable-messages --with-pic --disable-examples"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--disable-static"
+    "--enable-doc"
+    "--enable-examples"
+    "--enable-largefile"
+    "--enable-messages"
+)

--- a/runtime-web/libmicrohttpd/autobuild/prepare
+++ b/runtime-web/libmicrohttpd/autobuild/prepare
@@ -1,5 +1,0 @@
-export CPPFLAGS+=" -D_REENTRANT=1"
-export CFLAGS+=" -D_REENTRANT=1"
-export CXXFLAGS+=" -D_REENTRANT=1"
-export LDFLAGS+=" -D_REENTRANT=1"
-

--- a/runtime-web/libmicrohttpd/spec
+++ b/runtime-web/libmicrohttpd/spec
@@ -1,4 +1,4 @@
-VER=0.9.71
+VER=1.0.1
 SRCS="tbl::https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-$VER.tar.gz"
-CHKSUMS="sha256::e8f445e85faf727b89e9f9590daea4473ae00ead38b237cf1eda55172b89b182"
+CHKSUMS="sha256::a89e09fc9b4de34dde19f4fcb4faaa1ce10299b9908db1132bbfa1de47882b94"
 CHKUPDATE="anitya::id=1658"


### PR DESCRIPTION
Topic Description
-----------------

- libmicrohttpd: update to 1.0.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libmicrohttpd: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmicrohttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
