### PR TITLE
ocrad: update to 0.29

### DIFF
--- a/app-doc/ocrad/spec
+++ b/app-doc/ocrad/spec
@@ -1,5 +1,4 @@
-VER=0.27
-REL=3
+VER=0.29
 SRCS="tbl::https://ftp.gnu.org/gnu/ocrad/ocrad-$VER.tar.lz"
-CHKSUMS="sha256::a9bfe67e9a040907aff5640dca56392476b6a89e48e37dc94ba846c5b6733b36"
+CHKSUMS="sha256::11200cc6b0b7ba16884a72dccb58ef694f7aa26cd2b2041e555580f064d2d9e9"
 CHKUPDATE="anitya::id=2526"


### PR DESCRIPTION
Topic Description
-----------------

- ocrad: update to 0.29
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ocrad: 0.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocrad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
