### PR TITLE
libidn2: update to 2.3.7

### DIFF
--- a/runtime-network/libidn2/spec
+++ b/runtime-network/libidn2/spec
@@ -1,5 +1,4 @@
-VER=2.3.0
-REL=3
-SRCS="tbl::https://ftp.gnu.org/pub/gnu/libidn/libidn2-$VER.tar.lz"
-CHKSUMS="sha256::6b222435016e2d9fce34af0b21057ebc85704c27e41a781466d9287f0627dc93"
+VER=2.3.7
+SRCS="tbl::https://ftp.gnu.org/pub/gnu/libidn/libidn2-$VER.tar.gz"
+CHKSUMS="sha256::4c21a791b610b9519b9d0e12b8097bf2f359b12f8dd92647611a929e6bfd7d64"
 CHKUPDATE="anitya::id=5597"


### PR DESCRIPTION
Topic Description
-----------------

- libidn2: update to 2.3.7

Package(s) Affected
-------------------

- libidn2: 2.3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libidn2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
