### PR TITLE
tigervnc: fix systemd service, use Arch Linux patches

### DIFF
--- a/app-network/tigervnc/autobuild/patches/0001-Arch-Linux-more-xsessions.patch
+++ b/app-network/tigervnc/autobuild/patches/0001-Arch-Linux-more-xsessions.patch
@@ -1,0 +1,19 @@
+diff --git a/unix/vncserver/vncserver.in b/unix/vncserver/vncserver.in
+index ebdd3a97..089177a9 100755
+--- a/unix/vncserver/vncserver.in
++++ b/unix/vncserver/vncserver.in
+@@ -447,7 +447,13 @@ sub SanityCheck
+ 	die "$prog: couldn't find \"$cmd\" on your PATH.\n";
+     }
+ 
+-    foreach $cmd ("/etc/X11/xinit/Xsession", "/etc/X11/Xsession") {
++    foreach $cmd ("/etc/X11/xinit/Xsession", "/etc/X11/Xsession",
++        "/etc/X11/xdm/Xsession",
++        "/usr/share/sddm/scripts/Xsession",
++        "/etc/gdm/Xsession",
++        "/etc/lightdm/Xsession",
++        "/etc/lxdm/Xsession",
++        "/etc/X11/tigervnc/Xsession") {
+         if (-x "$cmd") {
+             $Xsession = $cmd;
+             last;

--- a/app-network/tigervnc/autobuild/patches/0002-Arch-Linux-remove-selinux.patch
+++ b/app-network/tigervnc/autobuild/patches/0002-Arch-Linux-remove-selinux.patch
@@ -1,0 +1,27 @@
+diff --git a/unix/vncserver/tigervnc.pam b/unix/vncserver/tigervnc.pam
+index dda76c49..b372c821 100644
+--- a/unix/vncserver/tigervnc.pam
++++ b/unix/vncserver/tigervnc.pam
+@@ -3,10 +3,7 @@
+ # THIS IS AN EXAMPLE CONFIGURATION
+ # MODIFY AS NEEDED FOR YOUR DISTRIBUTION
+ 
+-# pam_selinux.so close should be the first session rule
+--session   required     pam_selinux.so close
+ session    required     pam_loginuid.so
+--session   required     pam_selinux.so open
+ session    required     pam_namespace.so
+ session    optional     pam_keyinit.so force revoke
+ session    required     pam_limits.so
+diff --git a/unix/vncserver/vncserver@.service.in b/unix/vncserver/vncserver@.service.in
+index 592ddb67..1ff14012 100644
+--- a/unix/vncserver/vncserver@.service.in
++++ b/unix/vncserver/vncserver@.service.in
+@@ -37,7 +37,6 @@ After=syslog.target network.target systemd-user-sessions.service
+ Type=forking
+ ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/vncsession-start %i
+ PIDFile=/run/vncsession-%i.pid
+-SELinuxContext=system_u:system_r:vnc_session_t:s0
+ 
+ [Install]
+ WantedBy=multi-user.target

--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=1.14.0
 XORG_VER=21.1.13
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
+REL=1
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: fix systemd service, use Arch Linux patches
    - Try to detect more Xsession files
    - Remove SELinux in PAM configuration

Package(s) Affected
-------------------

- tigervnc: 1.14.0+xserver21.1.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
