### PR TITLE
ronn-ng: rebuild for Ruby 3.4.1

### DIFF
--- a/lang-ruby/ronn-ng/spec
+++ b/lang-ruby/ronn-ng/spec
@@ -1,5 +1,5 @@
 VER=0.10.1
-REL=2
-SRCS="tbl::https://github.com/apjanke/ronn-ng/archive/v$VER.tar.gz"
-CHKSUMS="sha256::180f18015ce01be1d10c24e13414134363d56f9efb741fda460358bb67d96684"
+REL=3
+SRCS="git::commit=tags/v$VER::https://github.com/apjanke/ronn-ng"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=90983"


### PR DESCRIPTION
Topic Description
-----------------

- ronn-ng: rebuild for Ruby 3.4.1

Package(s) Affected
-------------------

- ronn-ng: 0.10.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ronn-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
