### PR TITLE
listenbrainz-mpd: new, 2.3.8

### DIFF
--- a/app-multimedia/listenbrainz-mpd/autobuild/beyond
+++ b/app-multimedia/listenbrainz-mpd/autobuild/beyond
@@ -1,0 +1,15 @@
+abinfo "Generating and installing documentation ..."
+asciidoctor -v -b manpage "$SRCDIR"/listenbrainz-mpd.adoc \
+    -o "$PKGDIR"/usr/share/man/man1/listenbrainz-mpd.1
+
+abinfo "Installing systemd user service ..."
+install -Dvm644 "$SRCDIR"/listenbrainz-mpd.service \
+    -t "$PKGDIR"/usr/lib/systemd/user/
+
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR"/generated_completions/_listenbrainz-mpd \
+    -t "$PKGDIR"/usr/share/zsh/functions/Completion/Linux/
+install -Dvm644 "$SRCDIR"/generated_completions/listenbrainz-mpd.fish \
+    -t "$PKGDIR"/usr/share/fish/vendor_completions.d/
+install -Dvm644 "$SRCDIR"/generated_completions/listenbrainz-mpd.bash \
+    -t "$PKGDIR"/usr/share/bash-completion/completions/

--- a/app-multimedia/listenbrainz-mpd/autobuild/defines
+++ b/app-multimedia/listenbrainz-mpd/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=listenbrainz-mpd
+PKGSEC=sound
+PKGDEP="mpd"
+BUILDDEP="rustc llvm asciidoctor"
+PKGDES="A ListenBrainz submission client for Music Player Daemon"
+
+ABTYPE=rust
+USECLANG=1
+
+CARGO_AFTER="--features systemd,shell_completion"
+
+# FIXME: ld.lld is not yet available on loongson3
+NOLTO__LOONGSON3=1

--- a/app-multimedia/listenbrainz-mpd/spec
+++ b/app-multimedia/listenbrainz-mpd/spec
@@ -1,0 +1,4 @@
+VER=2.3.8
+SRCS="git::commit=tags/v$VER::https://codeberg.org/elomatreb/listenbrainz-mpd.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376364"


### PR DESCRIPTION
Topic Description
-----------------

- listenbrainz-mpd: new, 2.3.8
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- listenbrainz-mpd: 2.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit listenbrainz-mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
