### PR TITLE
maturin: update to 1.8.1

### DIFF
--- a/lang-python/maturin/autobuild/build
+++ b/lang-python/maturin/autobuild/build
@@ -1,0 +1,30 @@
+# FIXME: ld.lld: error: undefined hidden symbol: ring_core_0_17_8_OPENSSL_ia32cap_P
+CFLAGS+=" -ffat-lto-objects"
+
+abinfo "Building maturin ..."
+cargo run -- \
+    build \
+    --release \
+    --bindings bin \
+    --sdist \
+    --out dist \
+    --features password-storage \
+    --compatibility linux
+
+abinfo "Installing maturin ..."
+python3 \
+    -m installer \
+    --destdir="$PKGDIR" \
+    "$SRCDIR"/dist/*.whl
+
+abinfo "Installing bash completions ..."
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions/
+"$PKGDIR"/usr/bin/maturin completions bash > "$PKGDIR"/usr/share/bash-completion/completions/maturin
+
+abinfo "Installing fish completions ..."
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d/
+"$PKGDIR"/usr/bin/maturin completions fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/maturin
+
+abinfo "Installing zsh completions ..."
+mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions/
+"$PKGDIR"/usr/bin/maturin completions zsh > "$PKGDIR"/usr/share/zsh/site-functions/_zsh

--- a/lang-python/maturin/autobuild/defines
+++ b/lang-python/maturin/autobuild/defines
@@ -1,14 +1,8 @@
 PKGNAME=maturin
 PKGSEC=python
-PKGDES="A tool building rust binaries as python packages"
-PKGDEP="python-3 typing-extensions"
-BUILDDEP="wheel python-build python-installer setuptools setuptools-rust llvm rustc"
+PKGDES="A tool for building Rust binaries as Python packages"
+PKGDEP="python-3 typing-extensions patchelf bzip2 xz"
+BUILDDEP="rustc llvm"
 
-ABTYPE=pep517
-NOPYTHON2=1
-
-# lld not available in LOONGARCH64 yet
-NOLTO__LOONGARCH64=1
-
-# rustc lto not available in LOONGSON3 yet
+# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
 NOLTO__LOONGSON3=1

--- a/lang-python/maturin/spec
+++ b/lang-python/maturin/spec
@@ -1,4 +1,4 @@
-VER=1.7.4
-SRCS="git::commit=v${VER}::https://github.com/PyO3/maturin"
+VER=1.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/PyO3/maturin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=42653"


### PR DESCRIPTION
Topic Description
-----------------

- maturin: update to 1.8.1
    Co-authored-by: (@stdmnpkg)

Package(s) Affected
-------------------

- maturin: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit maturin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
