### PR TITLE
WeeChat: rebuild for PHP, fix BUILDDEP

### DIFF
--- a/app-web/weechat/autobuild/defines
+++ b/app-web/weechat/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=weechat
 PKGSEC=net
 PKGDEP="gnutls curl libgcrypt cjson"
-BUILDDEP="asciidoctor source-highlight cmake pkg-config perl python-3 lua tcl \
-          aspell guile php7 zstd"
+BUILDDEP="asciidoctor source-highlight cmake pkg-config zstd gettext ca-certs \
+          perl python-3 lua tcl aspell guile php argon2 libxml2 libsodium"
 PKGDES="A fast, light and extensible chat client"
 
 ABTYPE=cmakeninja
@@ -18,7 +18,3 @@ CMAKE_AFTER="-DENABLE_PYTHON=ON \
              -DENABLE_RUBY=OFF \
              -DENABLE_DOC_INCOMPLETE=ON \
              -DCA_FILE=/etc/ssl/ca-bundle.crt"
-# FIXME: Similar to the above issue, asciidoctor causes FTBFS with illegal
-# instruction on riscv64
-CMAKE_AFTER__RISCV64="${CMAKE_AFTER} \
-                      -DENABLE_DOC=OFF"

--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,5 @@
 VER=4.5.1
+REL=1
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
 CHKSUMS="sha256::67c143c7bc70e689b9ea86df674c9a9ff3cf44ccc9cdff21be6a561d5eafc528"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: mark optional plugin support dependencies as mandatory
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- weechat: 4.5.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
