### PR TITLE
ispc: update to 1.25.3

### DIFF
--- a/app-devel/ispc/spec
+++ b/app-devel/ispc/spec
@@ -1,4 +1,4 @@
-VER=1.25.1
+VER=1.25.3
 SRCS="git::commit=tags/v$VER::https://github.com/ispc/ispc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11544"


### PR DESCRIPTION
Topic Description
-----------------

- ispc: update to 1.25.3
    Co-authored-by: Anjia Wang (@ouankou) <anjia@ouankou.com>

Package(s) Affected
-------------------

- ispc: 1.25.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ispc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
