### PR TITLE
tauri-cli: new, 2.2.4


### DIFF
--- a/lang-rust/tauri-cli/autobuild/build
+++ b/lang-rust/tauri-cli/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Building ..."
+cargo build --release \
+	-p tauri-cli \
+	--config 'profile.release.lto = true' \
+	--config 'profile.release.incremental = false' \
+	--config 'profile.release.codegen-units = 1' \
+	--config 'profile.release.strip = false'
+
+abinfo "Installing ..."
+install -Dvm755 "$SRCDIR"/target/release/cargo-tauri -t "$PKGDIR"/usr/bin/

--- a/lang-rust/tauri-cli/autobuild/build
+++ b/lang-rust/tauri-cli/autobuild/build
@@ -1,10 +1,5 @@
 abinfo "Building ..."
-cargo build --release \
-	-p tauri-cli \
-	--config 'profile.release.lto = true' \
-	--config 'profile.release.incremental = false' \
-	--config 'profile.release.codegen-units = 1' \
-	--config 'profile.release.strip = false'
+cargo build --release -p tauri-cli
 
 abinfo "Installing ..."
 install -Dvm755 "$SRCDIR"/target/release/cargo-tauri -t "$PKGDIR"/usr/bin/

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME="tauri-cli"
-PKGDES="Command line interface for building Tauri apps"
+PKGDES="Command line interface for building Tauri applications"
 PKGSEC=devel
 PKGDEP="bzip2 gcc-runtime glibc xz"
 BUILDDEP="rustc llvm"

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="tauri-cli"
+PKGDES="Command line interface for building Tauri apps"
+PKGSEC=devel
+PKGDEP="bzip2 gcc-runtime glibc xz"
+BUILDDEP="rustc llvm"
+
+CARGO_AFTER="-p tauri-cli"

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -3,5 +3,3 @@ PKGDES="Command line interface for building Tauri apps"
 PKGSEC=devel
 PKGDEP="bzip2 gcc-runtime glibc xz"
 BUILDDEP="rustc llvm"
-
-CARGO_AFTER="-p tauri-cli"

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -3,3 +3,6 @@ PKGDES="Command line interface for building Tauri apps"
 PKGSEC=devel
 PKGDEP="bzip2 gcc-runtime glibc xz"
 BUILDDEP="rustc llvm"
+
+# FIXME: ld.lld: error: undefined hidden symbol: ring_core_0_17_8_OPENSSL_ia32cap_P
+NOLTO=1

--- a/lang-rust/tauri-cli/spec
+++ b/lang-rust/tauri-cli/spec
@@ -1,0 +1,4 @@
+VER=2.2.4
+SRCS="git::commit=tags/tauri-cli-v$VER::https://github.com/tauri-apps/tauri"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371844"


### PR DESCRIPTION
Topic Description
-----------------

- tauri-cli: new, 2.2.4

Package(s) Affected
-------------------

- tauri-cli: 2.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit tauri-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
