### PR TITLE
cmake: update to 3.31.4

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,4 +1,4 @@
-VER=3.31.3
+VER=3.31.4
 SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::fac45bc6d410b49b3113ab866074888d6c9e9dc81a141874446eb239ac38cb87"
+CHKSUMS="sha256::a6130bfe75f5ba5c73e672e34359f7c0a1931521957e8393a5c2922c8b0f7f25"
 CHKUPDATE="anitya::id=306"


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 3.31.4
    Co-authored-by: Kexy Biscuit a.k.a. 百合ヶ咲るる (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- cmake: 3.31.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
