### PR TITLE
linux-firmware: update to 20250113

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250107
+UPSTREAM_VER=20250113
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=c0f414a6f71154fdbb0e88f29f64e401241ca33d::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=a28a9226ccb8bf393b8e7dd8970a4d967c1a1d92::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250113
    - Update Linux Firmware to current (20250113) HEAD a28a9226ccb8bf393b8e7dd8970a4d967c1a1d92...
    - Changelog below...
    - AMD
    - Add and update lots of AMDGPU firmwares...
    - GC...
    - 9.4.3
    - 9.4.4
    - 11.0.0
    - 11.0.1
    - 11.0.2
    - 11.0.3
    - 11.0.4
    - 11.5.0
    - 12.0.0
    - 12.0.1
    - PSP...
    - 13.0.0
    - 13.0.4
    - 13.0.5
    - 13.0.6
    - 13.0.7
    - 13.0.10
    - 13.0.11
    - 13.0.14
    - 14.0.1
    - 14.0.2
    - 14.0.3
    - SDMA...
    - 4.4.2
    - 4.4.5
    - 6.0.3
    - SMU...
    - 14.0.2
    - 14.0.3
    - VCN...
    - 4.0.0
    - 4.0.2
    - 4.0.3
    - 4.0.4
    - 4.0.5
    - 4.0.6
    - 5.0.0
    - Aldebaran / Arcturus / Beige Goby / Dimgrey Cavefish / Navy Flounder / Picasso / Renoir / Sienna Cichlid / Vangogh / Yellow Carp
    - Navi10/Navi12/Navi14
    - Vega10/Vega12/Vega20
    - DMCUB updates for DCN314, DCN320, DCN321, DCN351 and DCN401, version 0.0.249.0.
    - Cirrus
    - Add cs35l41 firmware for Ayaneo system 1f660105.
    - Correct some links to address the correct amp instance.
    - Intel
    - Update Bluetooth firmware for Intel BlazarU core (AX201/AX101), Magnetar core (AX211/AX203/AX101), and Solar core (AX210/AX211/AX203).
    - Realtek
    - Update rtw89 firmwares for RTL8852B/BT/C, RTL8922A
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250113+debian20241210+1
- firmware-nonfree: 20250113+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
