### PR TITLE
xournalpp: update to 1.2.5

### DIFF
--- a/runtime-productivity/xournalpp/autobuild/defines
+++ b/runtime-productivity/xournalpp/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=xournalpp
 PKGDES="Handwriting notetaking software"
-PKGDEP="gtk-3 gtksourceview-4 poppler libxml2 libzip portaudio libsndfile librsvg lua"
+PKGDEP="gtk-3 gtksourceview-4 poppler libxml2 libzip portaudio libsndfile librsvg lua-5.4"
 PKGSEC=utils
 
 ABTYPE=cmakeninja
+CMAKE_AFTER=" \
+          -DLUA_INCLUDE_DIR=/usr/include/lua5.4 \
+          -DLUA_LIBRARY=/usr/lib/liblua-5.4.so \
+"

--- a/runtime-productivity/xournalpp/spec
+++ b/runtime-productivity/xournalpp/spec
@@ -1,4 +1,4 @@
-VER=1.1.3
+VER=1.2.5
 SRCS="git::commit=tags/v$VER::https://github.com/xournalpp/xournalpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57279"


### PR DESCRIPTION
Topic Description
-----------------

- xournalpp: update to 1.2.5

Package(s) Affected
-------------------

- xournalpp: 1.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit xournalpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
