### PR TITLE
uv: new, 0.5.18

### DIFF
--- a/lang-python/uv/autobuild/beyond
+++ b/lang-python/uv/autobuild/beyond
@@ -1,0 +1,12 @@
+abinfo "Installing shell completions ..."
+
+for command in uv uvx
+do
+    "$SRCDIR"/target/release/"$command" --generate-shell-completion bash > "$SRCDIR"/"$command".bash
+    "$SRCDIR"/target/release/"$command" --generate-shell-completion fish > "$SRCDIR"/"$command".fish
+    "$SRCDIR"/target/release/"$command" --generate-shell-completion zsh > "$SRCDIR"/_"$command"
+
+    install -Dm0644 "$command".bash -t "$PKGDIR"/usr/share/bash-completion/completions/
+    install -Dm0644 "$command".fish -t "$PKGDIR"/usr/share/fish/vendor_completions.d/
+    install -Dm0644 _"$command" -t "$PKGDIR"/usr/share/zsh/site-functions/
+done

--- a/lang-python/uv/autobuild/defines
+++ b/lang-python/uv/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=uv
+PKGSEC=utils
+BUILDDEP="llvm rustc maturin"
+PKGDEP="glibc gcc-runtime zlib bzip2"
+PKGDES="A Python package and project manager"
+
+# FIXME: ld.lld doesn't work properly on loongson3
+NOLTO__LOONGSON3=1

--- a/lang-python/uv/autobuild/prepare
+++ b/lang-python/uv/autobuild/prepare
@@ -1,0 +1,4 @@
+# This resolves the LTO issue when compiling a static library from C code in a Cargo crate
+# Ref: https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/issues/20
+abinfo "Appending -ffat-lto-objects to workaround linkage failure ..."
+CFLAGS+=' -ffat-lto-objects'

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,0 +1,4 @@
+VER=0.5.18
+SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: new, 0.5.18

Package(s) Affected
-------------------

- uv: 0.5.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
