### PR TITLE
xz: enable sandboxing via landlock

### DIFF
--- a/app-utils/xz/autobuild/defines
+++ b/app-utils/xz/autobuild/defines
@@ -18,9 +18,6 @@ PKGSEC=utils
 # x86_64, big endian PowerPC, and some ARM systems."
 #
 # FIXME: --enable-external-sha256 is not supported on Linux/Glibc.
-#
-# FIXME: xz only supports "capsicum" and "pledge" sandboxes, neither of which
-# supported by Linux.
 MAKE_AFTER="pkgconfigdir=/usr/lib/pkgconfig"
 AUTOTOOLS_AFTER="--disable-debug \
                  --disable-external-sha256 \
@@ -37,7 +34,7 @@ AUTOTOOLS_AFTER="--disable-debug \
                  --enable-lzma-links \
                  --enable-scripts \
                  --enable-doc \
-                 --disable-sandbox \
+                 --enable-sandbox=landlock \
                  --enable-symbol-versions \
                  --enable-nls \
                  --disable-rpath \

--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,4 +1,5 @@
 VER=5.6.3
+REL=1
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
 CHKSUMS="sha256::db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a"
 CHKUPDATE="anitya::id=5277"


### PR DESCRIPTION
Topic Description
-----------------

- xz: enable sandboxing via landlock

Package(s) Affected
-------------------

- xz: 5.6.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
