### PR TITLE
gnu-efi: update to 3.0.18

### DIFF
--- a/app-devel/gnu-efi/autobuild/build
+++ b/app-devel/gnu-efi/autobuild/build
@@ -1,29 +1,5 @@
-abinfo "Setting architecture for build ..."
-[[ "${CROSS:-$ARCH}" = "amd64" ]] && export NEWARCH="x86_64"
-[[ "${CROSS:-$ARCH}" = "armv7hf" ]] && export NEWARCH="arm"
-[[ "${CROSS:-$ARCH}" = "arm64" ]] && export NEWARCH="aarch64"
-[[ "${CROSS:-$ARCH}" = "riscv64" ]] && export NEWARCH="riscv64"
-
-abinfo "Building gnu-efi ..."
+abinfo "Building..."
 make
 
-abinfo "Building gnu-efi libraries ..."
-make -C "$SRCDIR"/lib
-
-abinfo "Building gnu-efi components ..."
-make -C "$SRCDIR"/gnuefi
-
-abinfo "Building gnu-efi headers ..."
-make -C "$SRCDIR"/inc
-
-abinfo "Building gnu-efi applications ..."
-make -C "$SRCDIR"/apps
-
-abinfo "Installing gnu-efi ..."
-make install \
-    INSTALLROOT="$PKGDIR" \
-    PREFIX=/usr
-
-abinfo "Installing EFI binaries ..."
-install -Dvm644 "$SRCDIR"/apps/*.efi -t \
-    "$PKGDIR"/usr/share/gnu-efi/apps/"${NEWARCH}"
+abinfo "Installing..."
+make PREFIX=/usr DESTDIR="$PKGDIR" install

--- a/app-devel/gnu-efi/autobuild/defines
+++ b/app-devel/gnu-efi/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=gnu-efi
 PKGSEC=devel
-PKGDEP=""
 PKGDES="Libraries for building UEFI applications using the GNU toolchain"
 
 ABSTRIP=0
 NOPARALLEL=1
 NOSTATIC=0
 
-FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64)"
+FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64|loongarch64)"

--- a/app-devel/gnu-efi/spec
+++ b/app-devel/gnu-efi/spec
@@ -1,4 +1,4 @@
-VER=3.0.14
+VER=3.0.18
 SRCS="tbl::https://download.sourceforge.net/gnu-efi/gnu-efi-$VER.tar.bz2"
-CHKSUMS="sha256::b73b643a0d5697d1f396d7431448e886dd805668789578e3e1a28277c9528435"
+CHKSUMS="sha256::7f212c96ee66547eeefb531267b641e5473d7d8529f0bd8ccdefd33cf7413f5c"
 CHKUPDATE="anitya::id=1202"


### PR DESCRIPTION
Topic Description
-----------------

- gnu-efi: update to 3.0.18
    - Enable building for loongarch64, loongson3

Package(s) Affected
-------------------

- gnu-efi: 3.0.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnu-efi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
