### PR TITLE
llvm-18, llvm-19: update and create versioned executable symlinks

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -7,7 +7,7 @@ printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/
     >> "$SRCDIR/autobuild/postinst"
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
     BIN="$(basename $i)"
-    [ "$BIN" == 'llvm-config' ] || \
+    [[ "$BIN" == 'llvm-config' || "$BIN" == "clang$LLVM_SUFFIX" ]] || \
         printf " --slave /usr/bin/$BIN $BIN /usr/lib/llvm%s/bin/$BIN" \
             "$LLVM_SUFFIX" \
             >> "$SRCDIR/autobuild/postinst"

--- a/app-devel/llvm-18/02-compiler/build
+++ b/app-devel/llvm-18/02-compiler/build
@@ -83,3 +83,12 @@ abinfo "Making Clang prefix symlinks ..."
 mkdir -pv "$PKGDIR"/usr/lib/clang
 ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
     "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}
+
+abinfo "Creating versioned executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cd "$PKGDIR"/usr/bin
+for i in ../lib/llvm-${PKGVER%%.*}/bin/*; do 
+    ln -sv $i $(basename $i)-${PKGVER%%.*}
+done
+# Note: Remove double-suffixed executables.
+rm -v "$PKGDIR"/usr/bin/*-${PKGVER%%.*}-${PKGVER%%.*}

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=6
+REL=7
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -7,7 +7,7 @@ printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/
     >> "$SRCDIR/autobuild/postinst"
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
     BIN="$(basename $i)"
-    [ "$BIN" == 'llvm-config' ] || \
+    [[ "$BIN" == 'llvm-config' || "$BIN" == "clang$LLVM_SUFFIX" ]] || \
         printf " --slave /usr/bin/$BIN $BIN /usr/lib/llvm%s/bin/$BIN" \
             "$LLVM_SUFFIX" \
             >> "$SRCDIR/autobuild/postinst"

--- a/app-devel/llvm-19/02-compiler/build
+++ b/app-devel/llvm-19/02-compiler/build
@@ -83,3 +83,12 @@ abinfo "Making Clang prefix symlinks ..."
 mkdir -pv "$PKGDIR"/usr/lib/clang
 ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
     "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}
+
+abinfo "Creating versioned executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cd "$PKGDIR"/usr/bin
+for i in ../lib/llvm-${PKGVER%%.*}/bin/*; do
+    ln -sv $i $(basename $i)-${PKGVER%%.*}
+done
+# Note: Remove double-suffixed executables.
+rm -v "$PKGDIR"/usr/bin/*-${PKGVER%%.*}-${PKGVER%%.*}

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,8 +1,7 @@
-VER=19.1.6
-REL=3
+VER=19.1.7
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
-CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"
+CHKSUMS="sha256::82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"
 CHKUPDATE="anitya::id=1830"
 # Note: Prefer larger RAM.
 ENVREQ__ARM64="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-18: create versioned executable symlinks in /usr/bin
- llvm-19: update to 19.1.7
    Create versioned executable symlinks in /usr/bin.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- llvm-18: 18.1.8-7
- llvm-19: 19.1.7
- llvm-runtime-18: 18.1.8-7
- llvm-runtime-19: 19.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
