### PR TITLE
rsync: security update to 3.4.0

### DIFF
--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -1,5 +1,4 @@
-VER=3.2.7
-SRCS="tbl::https://download.samba.org/pub/rsync/src/rsync-$VER.tar.gz"
-CHKSUMS="sha256::4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
+VER=3.4.0
+SRCS="tbl::https://download.samba.org/pub/rsync/rsync-$VER.tar.gz"
+CHKSUMS="sha256::8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4"
 CHKUPDATE="anitya::id=4217"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- rsync: security update to 3.4.0
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- rsync: 3.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
