### PR TITLE
vscodium: update to 1.96.3.25013

### DIFF
--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.96.2.24355
+VER=1.96.3.25013
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.96.3.25013
    Co-authored-by: Kexy Biscuit a.k.a. 百合ヶ咲るる (@KexyBiscuit) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- vscodium: 1.96.3.25013

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
