### PR TITLE
v2ray-rules-dat: use relative path when linked

### DIFF
--- a/app-network/dae/autobuild/build
+++ b/app-network/dae/autobuild/build
@@ -11,7 +11,7 @@ install -Dvm644 "$SRCDIR"/example.dae "$PKGDIR"/etc/dae/config.dae.example
 
 abinfo "Linking to geofile directory ..."
 install -dv "$PKGDIR"/usr/share/dae
-ln -sv /usr/share/v2ray-rules-dat/{geoip.dat,geosite.dat} \
+ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
     "$PKGDIR"/usr/share/dae
 
 abinfo "Installing completion files ..."

--- a/app-network/dae/autobuild/defines
+++ b/app-network/dae/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="gcc-runtime v2ray-rules-dat"
 PKGCONFL="daed"
 BUILDDEP="go llvm"
 
+USECLANG=1
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0
 # FIXME: Missing vmlinux.h file for loongson3

--- a/app-network/dae/spec
+++ b/app-network/dae/spec
@@ -1,5 +1,5 @@
 VER=0.9.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/daeuniverse/dae/releases/download/v$VER/dae-full-src.zip"
 CHKSUMS="sha256::b631e2cc729f28410f5ccf584de18cf6a839c4a313d694df5e326377f6435ab1"
 CHKUPDATE="anitya::id=369479"

--- a/app-network/daed/autobuild/build
+++ b/app-network/daed/autobuild/build
@@ -13,5 +13,5 @@ install -dv "$PKGDIR"/etc/daed
 
 abinfo "Linking to geofile directory ..."
 install -dv "$PKGDIR"/usr/share/daed
-ln -sv /usr/share/v2ray-rules-dat/{geoip.dat,geosite.dat} \
+ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
     "$PKGDIR"/usr/share/daed

--- a/app-network/daed/autobuild/defines
+++ b/app-network/daed/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="gcc-runtime v2ray-rules-dat"
 PKGCONFL="dae"
 BUILDDEP="go llvm nodejs"
 
+USECLANG=1
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0
 # FIXME: Missing vmlinux.h file for loongson3 and SWC only supports amd64 and arm64.

--- a/app-network/daed/autobuild/defines
+++ b/app-network/daed/autobuild/defines
@@ -7,7 +7,5 @@ BUILDDEP="go llvm nodejs"
 
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0
-# Go module "github.com/sirupsen/logrus" does not support loongson3 and loongarch64
-# and build error on ppc64el and riscv64.
-# See: https://github.com/daeuniverse/dae/issues/696
+# FIXME: Missing vmlinux.h file for loongson3 and SWC only supports amd64 and arm64.
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-network/daed/spec
+++ b/app-network/daed/spec
@@ -1,4 +1,5 @@
 VER=0.8.0
+REL=1
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/daeuniverse/daed.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375373"

--- a/app-network/daed/spec
+++ b/app-network/daed/spec
@@ -1,5 +1,5 @@
-VER=0.8.0
-REL=1
-SRCS="git::commit=v$VER;copy-repo=true::https://github.com/daeuniverse/daed.git"
-CHKSUMS="SKIP"
+VER=0.9.0
+SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v0.9.0/daed-full-src.zip"
+CHKSUMS="sha256::4ad31c5b3640906a6ef301ee06f94162cb2f5e577b1bd579f47476cae4b2dbf8"
 CHKUPDATE="anitya::id=375373"
+SUBDIR=.

--- a/app-network/v2ray/autobuild/build
+++ b/app-network/v2ray/autobuild/build
@@ -3,7 +3,7 @@ abinfo "Arch Linux: Building V2Ray - Core ..."
 if ! ab_match_arch loongarch64 && \
    ! ab_match_arch loongson3; then
     go build -buildmode=pie -o v2ray ./main
-else 
+else
     go build -o v2ray ./main
 fi
 
@@ -23,5 +23,5 @@ install -Dvm755 "$SRCDIR"/v2ray \
 
 abinfo "Linking to geofile directory ..."
 install -dv "$PKGDIR"/usr/share/v2ray
-ln -sv /usr/share/v2ray-rules-dat/{geoip.dat,geosite.dat} \
+ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
     "$PKGDIR"/usr/share/v2ray/

--- a/app-network/v2ray/autobuild/build
+++ b/app-network/v2ray/autobuild/build
@@ -1,7 +1,6 @@
 abinfo "Arch Linux: Building V2Ray - Core ..."
-# FIXME: PIE not support on loongarch64 and loongson3.
-if ! ab_match_arch loongarch64 && \
-   ! ab_match_arch loongson3; then
+# FIXME: PIE not support on loongson3.
+if ! ab_match_arch loongson3; then
     go build -buildmode=pie -o v2ray ./main
 else
     go build -o v2ray ./main

--- a/app-network/v2ray/autobuild/defines
+++ b/app-network/v2ray/autobuild/defines
@@ -3,5 +3,5 @@ PKGSEC=non-free/net
 PKGDES="A platform for building proxies to bypass network restrictions"
 PKGDEP="glibc v2ray-rules-dat"
 BUILDDEP="go"
-
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0

--- a/app-network/v2ray/spec
+++ b/app-network/v2ray/spec
@@ -1,4 +1,5 @@
 VER=5.23.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/v2fly/v2ray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=134851"

--- a/app-network/xray/autobuild/build
+++ b/app-network/xray/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Building xray ..."
-go build -o xray -ldflags "-s -w -buildid=" "$SRCDIR"/main 
+go build -o xray -ldflags "-s -w -buildid=" "$SRCDIR"/main
 
 abinfo "Installing xray ..."
 install -Dvm755 "$SRCDIR"/xray -t "$PKGDIR"/usr/bin/
@@ -7,5 +7,5 @@ install -dv "$PKGDIR"/etc/xray
 install -dv "$PKGDIR"/usr/share/xray
 
 abinfo "Linking to geofile directory ..."
-ln -sv /usr/share/v2ray-rules-dat/{geoip.dat,geosite.dat} \
+ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
     "$PKGDIR"/usr/share/xray

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,5 @@
 VER=24.12.31
+REL=1
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/XTLS/Xray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- daed: use clang to build
- dae: use clang to build
- v2ray: PIE support on loongarch64
- daed: update to 0.9.0
- v2ray-rules-dat: Reverse dependencies use relative path

Package(s) Affected
-------------------

- dae: 0.9.0-2
- daed: 0.9.0
- v2ray: 5.23.0-1
- xray: 24.12.31-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dae daed v2ray xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
