### PR TITLE
zed: update to 0.169.2

### DIFF
--- a/app-editors/zed/autobuild/defines
+++ b/app-editors/zed/autobuild/defines
@@ -9,7 +9,9 @@ BUILDDEP="rustc llvm"
 # FIXME: Limited by wasmtime support.
 #
 # See https://wasmtime.dev/install.sh for architecture support.
-FAIL_ARCH="!(amd64|arm64|riscv64)"
+#
+# riscv64: zed Livekit only support amd64 and arm64
+FAIL_ARCH="!(amd64|arm64)"
 
 USECLANG=1
 

--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.168.3
+VER=0.169.2
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.169.2
    Co-authored-by: Mag Mell (@eatradish)

Package(s) Affected
-------------------

- zed: 0.169.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`