### PR TITLE
rsync: update to 3.4.1

### DIFF
--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.4.1
 SRCS="tbl::https://download.samba.org/pub/rsync/rsync-$VER.tar.gz"
-CHKSUMS="sha256::8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4"
+CHKSUMS="sha256::2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52"
 CHKUPDATE="anitya::id=4217"


### PR DESCRIPTION
Topic Description
-----------------

- rsync: update to 3.4.1
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rsync: 3.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
