### PR TITLE
tsukimi: enable LTO and use clang

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -7,3 +7,7 @@ PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv open
 ABTYPE=meson
 
 USECLANG=1
+
+# FIXME: ld.lld does not support loongson3
+NOLTO__LOONGSON3=1
+USECLANG__LOONGSON3=0

--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -6,5 +6,4 @@ PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv open
 
 ABTYPE=meson
 
-# FIXME: undefined symbol: ring_core
-NOLTO=1
+USECLANG=1

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,5 @@
 VER=0.18.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376111"


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: enable LTO and use clang

Package(s) Affected
-------------------

- tsukimi: 0.18.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
