### PR TITLE
q: new, 0.19.3

### DIFF
--- a/app-network/nexttrace/autobuild/build
+++ b/app-network/nexttrace/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building nexttrace ..."
+go build -ldflags "-s -w -buildid= -linkmode external \
+    -X 'github.com/nxtrace/NTrace-core/config.Version=$PKGVER' \
+    -X 'github.com/nxtrace/NTrace-core/config.CommitID=$commit' \
+    -X 'github.com/nxtrace/NTrace-core/config.BuildDate=$date'" \
+    -o "$PKGDIR"/usr/bin/nexttrace

--- a/app-network/nexttrace/autobuild/defines
+++ b/app-network/nexttrace/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="nexttrace"
+PKGSEC=net
+PKGDES="Command line tool for visual route tracking"
+PKGDEP="gcc-runtime"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
+ABSPLITDBG=0

--- a/app-network/nexttrace/autobuild/prepare
+++ b/app-network/nexttrace/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Setting build information ..."
+export commit=$(git rev-parse --short HEAD)
+export date=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")

--- a/app-network/nexttrace/spec
+++ b/app-network/nexttrace/spec
@@ -1,0 +1,4 @@
+VER=1.3.6
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/nxtrace/NTrace-core.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=356726"

--- a/app-network/q/autobuild/build
+++ b/app-network/q/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building q ..."
+go build -ldflags "-s -w -buildid= -linkmode external \
+    -X main.version=$PKGVER \
+    -X main.commit=$commit \
+    -X main.date=$date" \
+    -o "$PKGDIR"/usr/bin/q

--- a/app-network/q/autobuild/defines
+++ b/app-network/q/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME="q"
+PKGSEC=net
+PKGDES="Command line DNS client with support for multiple protocols"
+PKGDEP="gcc-runtime"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
+ABSPLITDBG=0

--- a/app-network/q/autobuild/prepare
+++ b/app-network/q/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Setting build information ..."
+export commit=$(git rev-parse --short HEAD)
+export date=$(git show -s --format=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' HEAD)

--- a/app-network/q/spec
+++ b/app-network/q/spec
@@ -1,0 +1,4 @@
+VER=0.19.2
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/natesales/q.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376437"


### PR DESCRIPTION
Topic Description
-----------------

- nexttrace: 1.3.6, new
- q: 0.19.2, new

Package(s) Affected
-------------------

- nexttrace: 1.3.6
- q: 0.19.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit q nexttrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
