### PR TITLE
binwalk: update to 3.1.0

### DIFF
--- a/app-devel/binwalk/autobuild/defines
+++ b/app-devel/binwalk/autobuild/defines
@@ -1,8 +1,6 @@
 PKGNAME=binwalk
 PKGSEC=devel
-PKGDEP="python-3"
-PKGSUG="bzip2 cabextract capstone cpio gzip p7zip squashfs-tools tar unrar xz"
+PKGDEP="bzip2 gcc-runtime freetype fontconfig xz python-3"
+PKGSUG="cabextract capstone cpio gzip p7zip squashfs-tools tar unrar"
 PKGDES="A tool for searching a given binary image for embedded files"
-
-NOPYTHON2=1
-ABHOST=noarch
+BUILDDEP="rustc llvm"

--- a/app-devel/binwalk/spec
+++ b/app-devel/binwalk/spec
@@ -1,4 +1,4 @@
-VER=2.3.4
+VER=3.1.0
 REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/devttys0/binwalk"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

binwalk: update to 3.1.0

Package(s) Affected
-------------------

binwalk: update to 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit binwalk
```


Test Build(s) Done
------------------

**Primary Architectures**



- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`


**Secondary Architectures**


Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
