### PR TITLE
[FLIGHT] grub: add patch for Sophgo devices

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/46] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/47] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -11,7 +11,7 @@ This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
  2 files changed, 5 insertions(+), 8 deletions(-)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 32c480dae..7516a015b 100644
+index 32c480da..7516a015 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -140,9 +140,6 @@ GRUB_DEVICE_PARTUUID="`${grub_probe} --device ${GRUB_DEVICE} --target=partuuid 2
@@ -41,7 +41,7 @@ index 32c480dae..7516a015b 100644
    GRUB_SAVEDEFAULT \
    GRUB_ENABLE_CRYPTODISK \
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index 656301eaf..30f27f15b 100644
+index 656301ea..30f27f15 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -26,8 +26,8 @@ export TEXTDOMAINDIR="@localedir@"
@@ -71,5 +71,5 @@ index 656301eaf..30f27f15b 100644
  
  osx_entry() {
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/46] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/47] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -10,7 +10,7 @@ This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
  2 files changed, 9 insertions(+), 14 deletions(-)
 
 diff --git a/docs/grub.texi b/docs/grub.texi
-index a225f9a88..974bc0ddb 100644
+index a225f9a8..974bc0dd 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1552,13 +1552,10 @@ boot sequence.  If you have problems, set this option to @samp{text} and
@@ -46,7 +46,7 @@ index a225f9a88..974bc0ddb 100644
  First create a separate GRUB partition, big enough to hold GRUB. Some of the
  following entries show how to load OS installer images from this same partition,
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index 30f27f15b..f300e46fc 100644
+index 30f27f15..f300e46f 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -26,8 +26,7 @@ export TEXTDOMAINDIR="@localedir@"
@@ -69,5 +69,5 @@ index 30f27f15b..f300e46fc 100644
  
  osx_entry() {
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/46] Don't add '*' to highlighted row
+Subject: [PATCH 03/47] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -9,7 +9,7 @@ It is already highlighted.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index b1321eb26..b147e0657 100644
+index b1321eb2..b147e065 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -242,7 +242,7 @@ print_entry (int y, int highlight, grub_menu_entry_t entry,
@@ -22,5 +22,5 @@ index b1321eb26..b147e0657 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,14 +1,14 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/46] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/47] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index b147e0657..e5960fd65 100644
+index b147e065..e5960fd6 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -334,12 +334,12 @@ grub_menu_init_page (int nested, int edit,
@@ -28,5 +28,5 @@ index b147e0657..e5960fd65 100644
    geo->timeout_lines = 2;
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,14 +1,14 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/46] Indent menu entries
+Subject: [PATCH 05/47] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index e5960fd65..fd1de05e3 100644
+index e5960fd6..fd1de05e 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -242,7 +242,8 @@ print_entry (int y, int highlight, grub_menu_entry_t entry,
@@ -22,5 +22,5 @@ index e5960fd65..fd1de05e3 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,14 +1,14 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/46] Fix margins
+Subject: [PATCH 06/47] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
  1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index fd1de05e3..371524bf2 100644
+index fd1de05e..371524bf 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -336,17 +336,15 @@ grub_menu_init_page (int nested, int edit,
@@ -33,5 +33,5 @@ index fd1de05e3..371524bf2 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/46] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/47] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -10,7 +10,7 @@ Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index 371524bf2..f83f7ca54 100644
+index 371524bf..f83f7ca5 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -337,7 +337,7 @@ grub_menu_init_page (int nested, int edit,
@@ -23,5 +23,5 @@ index 371524bf2..f83f7ca54 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/46] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/47] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -9,7 +9,7 @@ Subject: [PATCH 08/46] Don't say "GNU/Linux" in generated menus.
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index cc393be7e..c9bde9182 100644
+index cc393be7..c9bde918 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -29,9 +29,9 @@ export TEXTDOMAINDIR="@localedir@"
@@ -25,7 +25,7 @@ index cc393be7e..c9bde9182 100644
  fi
  
 diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
-index 94dd8be13..98ee5bc58 100644
+index 94dd8be1..98ee5bc5 100644
 --- a/util/grub.d/20_linux_xen.in
 +++ b/util/grub.d/20_linux_xen.in
 @@ -29,9 +29,9 @@ export TEXTDOMAINDIR="@localedir@"
@@ -41,5 +41,5 @@ index 94dd8be13..98ee5bc58 100644
  fi
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/46] Don't draw a border around the menu
+Subject: [PATCH 09/47] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -9,7 +9,7 @@ It looks cleaner without it.
  1 file changed, 43 deletions(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index f83f7ca54..982ef9100 100644
+index f83f7ca5..982ef910 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -108,47 +108,6 @@ grub_print_message_indented (const char *msg, int margin_left, int margin_right,
@@ -70,5 +70,5 @@ index f83f7ca54..982ef9100 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/46] Use the standard margin for the timeout string
+Subject: [PATCH 10/47] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -9,7 +9,7 @@ So that it aligns with the other messages
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index 982ef9100..986877454 100644
+index 982ef910..98687745 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -375,7 +375,7 @@ grub_menu_init_page (int nested, int edit,
@@ -39,5 +39,5 @@ index 982ef9100..986877454 100644
      }
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/46] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/47] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -9,7 +9,7 @@ This allows GRUB rescue ISOs to boot on LoongArch firmware.
  1 file changed, 2 insertions(+)
 
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index abcc1c2f5..27696e034 100644
+index abcc1c2f..27696e03 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -514,6 +514,8 @@ main (int argc, char *argv[])
@@ -22,5 +22,5 @@ index abcc1c2f5..27696e034 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/46] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/47] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 12/46] 10_linux: do not count intel-ucode image as a valid
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index c9bde9182..e896c0c1a 100644
+index c9bde918..e896c0c1 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -263,7 +263,8 @@ for linux in ${reverse_sorted_list}; do
@@ -23,5 +23,5 @@ index c9bde9182..e896c0c1a 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/46] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/47] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -9,7 +9,7 @@ Subject: [PATCH 13/46] util: add GRUB_COLOR_* variables
  2 files changed, 10 insertions(+)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 7516a015b..73a973b25 100644
+index 7516a015..73a973b2 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -246,6 +246,8 @@ export GRUB_DEFAULT \
@@ -22,7 +22,7 @@ index 7516a015b..73a973b25 100644
    GRUB_INIT_TUNE \
    GRUB_SAVEDEFAULT \
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index 6a316a5ba..6816e09d4 100644
+index 6a316a5b..6816e09d 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -125,6 +125,14 @@ cat <<EOF
@@ -41,5 +41,5 @@ index 6a316a5ba..6816e09d4 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 59e7ba1bf0d63ddcd8e3d40888bcac0b7223e70e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/46] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/47] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -10,7 +10,7 @@ encourage reinstalling GRUB anyway.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
-index bd4431000..8b8565f24 100644
+index bd443100..8b8565f2 100644
 --- a/grub-core/normal/main.c
 +++ b/grub-core/normal/main.c
 @@ -209,7 +209,7 @@ grub_normal_init_page (struct grub_term_output *term,
@@ -23,5 +23,5 @@ index bd4431000..8b8565f24 100644
      return;
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From c23c121bde5381debb61889fb3cc94a6061628ab Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/46] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/47] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 15/46] grub-install: add /efi to the candidate of the ESP
  1 file changed, 9 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 7dc5657bb..c5eef8ac6 100644
+index 7dc5657b..c5eef8ac 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -1075,6 +1075,15 @@ main (int argc, char *argv[])
@@ -29,5 +29,5 @@ index 7dc5657bb..c5eef8ac6 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From 71cb4fcc6a76c5cdc3a629351097a73c664fb6f5 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/46] commands: add new command memsize
+Subject: [PATCH 16/47] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -41,7 +41,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  create mode 100644 grub-core/commands/memsize.c
 
 diff --git a/docs/grub.texi b/docs/grub.texi
-index 974bc0ddb..acf6f4428 100644
+index 974bc0dd..acf6f442 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -4379,6 +4379,7 @@ you forget a command, you can run the command @command{help}
@@ -122,7 +122,7 @@ index 974bc0ddb..acf6f4428 100644
  @subsection md5sum
  
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 1571421d7..b3b847766 100644
+index 1571421d..b3b84776 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -1033,6 +1033,11 @@ module = {
@@ -139,7 +139,7 @@ index 1571421d7..b3b847766 100644
    common = commands/minicmd.c;
 diff --git a/grub-core/commands/memsize.c b/grub-core/commands/memsize.c
 new file mode 100644
-index 000000000..b5ab52f4b
+index 00000000..b5ab52f4
 --- /dev/null
 +++ b/grub-core/commands/memsize.c
 @@ -0,0 +1,233 @@
@@ -377,5 +377,5 @@ index 000000000..b5ab52f4b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From b98c6eb9ba1e8f88e7d2df1c6700fef74a9b4fe2 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/46] commands: add new command 'pause'
+Subject: [PATCH 17/47] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -12,7 +12,7 @@ Subject: [PATCH 17/46] commands: add new command 'pause'
  create mode 100644 grub-core/commands/pause.c
 
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index b3b847766..542262731 100644
+index b3b84776..54226273 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -1058,6 +1058,11 @@ module = {
@@ -29,7 +29,7 @@ index b3b847766..542262731 100644
    x86 = commands/i386/pc/play.c;
 diff --git a/grub-core/commands/pause.c b/grub-core/commands/pause.c
 new file mode 100644
-index 000000000..7b7fc185b
+index 00000000..7b7fc185
 --- /dev/null
 +++ b/grub-core/commands/pause.c
 @@ -0,0 +1,54 @@
@@ -88,5 +88,5 @@ index 000000000..7b7fc185b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 5855f82d979f2db3e185e75c356686f5b23943ae Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/46] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/47] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -9,7 +9,7 @@ And add an extra blank line above it.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index 986877454..584620a52 100644
+index 98687745..584620a5 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -393,7 +393,8 @@ menu_text_print_timeout (int timeout, void *dataptr)
@@ -23,5 +23,5 @@ index 986877454..584620a52 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 0ec6cd51f5f49d1c2b82737279589431427f3838 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/46] po: add patch to disable parallel execution
+Subject: [PATCH 19/47] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -17,7 +17,7 @@ Subject: [PATCH 19/46] po: add patch to disable parallel execution
  create mode 100644 po/gettext-patches/0005-po-Makefile.in.in-disable-parallel-execution.patch
 
 diff --git a/bootstrap.conf b/bootstrap.conf
-index 7a7813d28..a7b3c657f 100644
+index 7a7813d2..a7b3c657 100644
 --- a/bootstrap.conf
 +++ b/bootstrap.conf
 @@ -90,7 +90,8 @@ bootstrap_post_import_hook () {
@@ -31,7 +31,7 @@ index 7a7813d28..a7b3c657f 100644
        < "po/gettext-patches/$patchname.patch"
    done
 diff --git a/conf/Makefile.extra-dist b/conf/Makefile.extra-dist
-index 5e7126f98..d21702f11 100644
+index 5e7126f9..d21702f1 100644
 --- a/conf/Makefile.extra-dist
 +++ b/conf/Makefile.extra-dist
 @@ -112,6 +112,7 @@ EXTRA_DIST += po/gettext-patches/0001-Support-POTFILES-shell.patch
@@ -44,7 +44,7 @@ index 5e7126f98..d21702f11 100644
  EXTRA_DIST += po/README
 diff --git a/po/gettext-patches/0005-po-Makefile.in.in-disable-parallel-execution.patch b/po/gettext-patches/0005-po-Makefile.in.in-disable-parallel-execution.patch
 new file mode 100644
-index 000000000..0cef9fafe
+index 00000000..0cef9faf
 --- /dev/null
 +++ b/po/gettext-patches/0005-po-Makefile.in.in-disable-parallel-execution.patch
 @@ -0,0 +1,27 @@
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From b69e36efa6f9745e73e9312d2db26875ce83a8fc Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/46] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/47] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is
@@ -47,7 +47,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  create mode 100644 util/bash-completion.d/grub-sparc64-setup.bash.in
 
 diff --git a/util/bash-completion.d/Makefile.am b/util/bash-completion.d/Makefile.am
-index 136287cf1..33fff9546 100644
+index 136287cf..33fff954 100644
 --- a/util/bash-completion.d/Makefile.am
 +++ b/util/bash-completion.d/Makefile.am
 @@ -1,13 +1,117 @@
@@ -175,7 +175,7 @@ index 136287cf1..33fff9546 100644
 +	$(top_builddir)/config.status --file=$@:$<
 diff --git a/util/bash-completion.d/grub-bios-setup.bash.in b/util/bash-completion.d/grub-bios-setup.bash.in
 new file mode 100644
-index 000000000..2d362b5e2
+index 00000000..2d362b5e
 --- /dev/null
 +++ b/util/bash-completion.d/grub-bios-setup.bash.in
 @@ -0,0 +1,30 @@
@@ -210,7 +210,7 @@ index 000000000..2d362b5e2
 +# End:
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-completion.bash.in b/util/bash-completion.d/grub-completion.bash.in
-index 213ce1e57..4c88ee901 100644
+index 213ce1e5..4c88ee90 100644
 --- a/util/bash-completion.d/grub-completion.bash.in
 +++ b/util/bash-completion.d/grub-completion.bash.in
 @@ -150,7 +150,7 @@ __grub_list_modules () {
@@ -425,7 +425,7 @@ index 213ce1e57..4c88ee901 100644
  # mode: shell-script
 diff --git a/util/bash-completion.d/grub-editenv.bash.in b/util/bash-completion.d/grub-editenv.bash.in
 new file mode 100644
-index 000000000..29b1333ea
+index 00000000..29b1333e
 --- /dev/null
 +++ b/util/bash-completion.d/grub-editenv.bash.in
 @@ -0,0 +1,30 @@
@@ -461,7 +461,7 @@ index 000000000..29b1333ea
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-install.bash.in b/util/bash-completion.d/grub-install.bash.in
 new file mode 100644
-index 000000000..a89fc614a
+index 00000000..a89fc614
 --- /dev/null
 +++ b/util/bash-completion.d/grub-install.bash.in
 @@ -0,0 +1,30 @@
@@ -497,7 +497,7 @@ index 000000000..a89fc614a
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-mkconfig.bash.in b/util/bash-completion.d/grub-mkconfig.bash.in
 new file mode 100644
-index 000000000..862e0c58f
+index 00000000..862e0c58
 --- /dev/null
 +++ b/util/bash-completion.d/grub-mkconfig.bash.in
 @@ -0,0 +1,30 @@
@@ -533,7 +533,7 @@ index 000000000..862e0c58f
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-mkfont.bash.in b/util/bash-completion.d/grub-mkfont.bash.in
 new file mode 100644
-index 000000000..17baccdf5
+index 00000000..17baccdf
 --- /dev/null
 +++ b/util/bash-completion.d/grub-mkfont.bash.in
 @@ -0,0 +1,30 @@
@@ -569,7 +569,7 @@ index 000000000..17baccdf5
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-mkimage.bash.in b/util/bash-completion.d/grub-mkimage.bash.in
 new file mode 100644
-index 000000000..a383ed3e9
+index 00000000..a383ed3e
 --- /dev/null
 +++ b/util/bash-completion.d/grub-mkimage.bash.in
 @@ -0,0 +1,30 @@
@@ -605,7 +605,7 @@ index 000000000..a383ed3e9
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in b/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in
 new file mode 100644
-index 000000000..32b8fd6eb
+index 00000000..32b8fd6e
 --- /dev/null
 +++ b/util/bash-completion.d/grub-mkpasswd-pbkdf2.bash.in
 @@ -0,0 +1,30 @@
@@ -641,7 +641,7 @@ index 000000000..32b8fd6eb
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-mkrescue.bash.in b/util/bash-completion.d/grub-mkrescue.bash.in
 new file mode 100644
-index 000000000..5968ba00e
+index 00000000..5968ba00
 --- /dev/null
 +++ b/util/bash-completion.d/grub-mkrescue.bash.in
 @@ -0,0 +1,30 @@
@@ -677,7 +677,7 @@ index 000000000..5968ba00e
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-probe.bash.in b/util/bash-completion.d/grub-probe.bash.in
 new file mode 100644
-index 000000000..08400f2f1
+index 00000000..08400f2f
 --- /dev/null
 +++ b/util/bash-completion.d/grub-probe.bash.in
 @@ -0,0 +1,30 @@
@@ -713,7 +713,7 @@ index 000000000..08400f2f1
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-reboot.bash.in b/util/bash-completion.d/grub-reboot.bash.in
 new file mode 100644
-index 000000000..154aecea9
+index 00000000..154aecea
 --- /dev/null
 +++ b/util/bash-completion.d/grub-reboot.bash.in
 @@ -0,0 +1,30 @@
@@ -749,7 +749,7 @@ index 000000000..154aecea9
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-script-check.bash.in b/util/bash-completion.d/grub-script-check.bash.in
 new file mode 100644
-index 000000000..22d376832
+index 00000000..22d37683
 --- /dev/null
 +++ b/util/bash-completion.d/grub-script-check.bash.in
 @@ -0,0 +1,30 @@
@@ -785,7 +785,7 @@ index 000000000..22d376832
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-set-default.bash.in b/util/bash-completion.d/grub-set-default.bash.in
 new file mode 100644
-index 000000000..14501b4fb
+index 00000000..14501b4f
 --- /dev/null
 +++ b/util/bash-completion.d/grub-set-default.bash.in
 @@ -0,0 +1,30 @@
@@ -821,7 +821,7 @@ index 000000000..14501b4fb
 +# ex: ts=4 sw=4 et filetype=sh
 diff --git a/util/bash-completion.d/grub-sparc64-setup.bash.in b/util/bash-completion.d/grub-sparc64-setup.bash.in
 new file mode 100644
-index 000000000..6123d7b7c
+index 00000000..6123d7b7
 --- /dev/null
 +++ b/util/bash-completion.d/grub-sparc64-setup.bash.in
 @@ -0,0 +1,30 @@
@@ -856,5 +856,5 @@ index 000000000..6123d7b7c
 +# End:
 +# ex: ts=4 sw=4 et filetype=sh
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 1632a45c5d4d78dea18e449b3592120cc8517bff Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/46] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/47] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion
@@ -19,7 +19,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 22 insertions(+), 39 deletions(-)
 
 diff --git a/util/bash-completion.d/grub-completion.bash.in b/util/bash-completion.d/grub-completion.bash.in
-index 4c88ee901..749a5d3cf 100644
+index 4c88ee90..749a5d3c 100644
 --- a/util/bash-completion.d/grub-completion.bash.in
 +++ b/util/bash-completion.d/grub-completion.bash.in
 @@ -151,13 +151,10 @@ __grub_list_modules () {
@@ -185,5 +185,5 @@ index 4c88ee901..749a5d3cf 100644
      if [[ "$cur" == -* ]]; then
          __grubcomp "$(__grub_get_options_from_help)"
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 2f40e35813a4677b7409d6d6b9459c0ed3e98bca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/46] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/47] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index 27696e034..cfb749967 100644
+index 27696e03..cfb74996 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -769,8 +769,8 @@ main (int argc, char *argv[])
@@ -93,5 +93,5 @@ index 27696e034..cfb749967 100644
        free (imgname);
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 624eb1c0887dba508ef03385e7f49f7d951b3ac4 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 23/46] loongarch64: able to start on legacy firmware
+Subject: [PATCH 23/47] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.
@@ -13,7 +13,7 @@ be dynamically decided by detecting if DMW is enabled.
  1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/include/grub/loongarch64/efi/memory.h b/include/grub/loongarch64/efi/memory.h
-index d460267be..534ba4b32 100644
+index d460267b..534ba4b3 100644
 --- a/include/grub/loongarch64/efi/memory.h
 +++ b/include/grub/loongarch64/efi/memory.h
 @@ -19,6 +19,25 @@
@@ -44,5 +44,5 @@ index d460267be..534ba4b32 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 977635494cb3f3418924842943088801ee241ee5 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 24/46] Add support for forcing EFI installation to the
+Subject: [PATCH 24/47] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI
@@ -15,7 +15,7 @@ with new boot paths.
  1 file changed, 109 insertions(+), 4 deletions(-)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index c5eef8ac6..efa5cc573 100644
+index c5eef8ac..efa5cc57 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -55,6 +55,7 @@
@@ -222,5 +222,5 @@ index c5eef8ac6..efa5cc573 100644
  
  	free (dst);
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From 6015952363f071aacf6f5d2de607fc168daa1746 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 25/46] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 25/47] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not
@@ -13,7 +13,7 @@ both old- and new-world firmware.
  1 file changed, 18 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index efa5cc573..6a5f86b09 100644
+index efa5cc57..6a5f86b0 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -938,6 +938,8 @@ main (int argc, char *argv[])
@@ -72,5 +72,5 @@ index efa5cc573..6a5f86b09 100644
  	grub_set_install_backup_ponr ();
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From 61a3db3ad1e300a531aaa7dcdd4bf496f1b5be65 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 26/46] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 26/47] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-
@@ -73,7 +73,7 @@ Subject: [PATCH 26/46] mips64: Add support for 64-bit MIPS.
  create mode 100644 include/grub/mips64/types.h
 
 diff --git a/configure.ac b/configure.ac
-index cd667a2eb..9a29936a7 100644
+index cd667a2e..9a29936a 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -109,7 +109,11 @@ case "$target_cpu" in
@@ -143,7 +143,7 @@ index cd667a2eb..9a29936a7 100644
    fi
    grub_CHECK_LINK_DIR
 diff --git a/gentpl.py b/gentpl.py
-index bfab2113a..3a1968705 100644
+index bfab2113..3a196870 100644
 --- a/gentpl.py
 +++ b/gentpl.py
 @@ -29,7 +29,7 @@ import re
@@ -173,7 +173,7 @@ index bfab2113a..3a1968705 100644
  GROUPS["ieee1275"]   = [ "i386_ieee1275", "sparc64_ieee1275", "powerpc_ieee1275" ]
  GROUPS["uboot"] = [ "arm_uboot" ]
 diff --git a/grub-core/Makefile.am b/grub-core/Makefile.am
-index f18550c1c..6b6089817 100644
+index f18550c1..6b608981 100644
 --- a/grub-core/Makefile.am
 +++ b/grub-core/Makefile.am
 @@ -239,6 +239,12 @@ KERNEL_HEADER_FILES += $(top_builddir)/include/grub/machine/memory.h
@@ -190,7 +190,7 @@ index f18550c1c..6b6089817 100644
  KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/ieee1275/ieee1275.h
  KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/ieee1275/alloc.h
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 542262731..a0152bb71 100644
+index 54226273..a0152bb7 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -113,6 +113,9 @@ kernel = {
@@ -267,7 +267,7 @@ index 542262731..a0152bb71 100644
  module = {
 diff --git a/grub-core/kern/mips64/cache.S b/grub-core/kern/mips64/cache.S
 new file mode 100644
-index 000000000..e88338a8a
+index 00000000..e88338a8
 --- /dev/null
 +++ b/grub-core/kern/mips64/cache.S
 @@ -0,0 +1,22 @@
@@ -295,7 +295,7 @@ index 000000000..e88338a8a
 +	jr.hb	$ra
 diff --git a/grub-core/kern/mips64/dl.c b/grub-core/kern/mips64/dl.c
 new file mode 100644
-index 000000000..049d3187c
+index 00000000..049d3187
 --- /dev/null
 +++ b/grub-core/kern/mips64/dl.c
 @@ -0,0 +1,149 @@
@@ -450,7 +450,7 @@ index 000000000..049d3187c
 +}
 diff --git a/grub-core/kern/mips64/efi/init.c b/grub-core/kern/mips64/efi/init.c
 new file mode 100644
-index 000000000..074736db9
+index 00000000..074736db
 --- /dev/null
 +++ b/grub-core/kern/mips64/efi/init.c
 @@ -0,0 +1,44 @@
@@ -500,7 +500,7 @@ index 000000000..074736db9
 +}
 diff --git a/grub-core/kern/mips64/efi/startup.S b/grub-core/kern/mips64/efi/startup.S
 new file mode 100644
-index 000000000..d49df16ce
+index 00000000..d49df16c
 --- /dev/null
 +++ b/grub-core/kern/mips64/efi/startup.S
 @@ -0,0 +1,46 @@
@@ -552,7 +552,7 @@ index 000000000..d49df16ce
 +	.set		pop
 diff --git a/grub-core/kern/mips64/init.c b/grub-core/kern/mips64/init.c
 new file mode 100644
-index 000000000..8fd0a88a5
+index 00000000..8fd0a88a
 --- /dev/null
 +++ b/grub-core/kern/mips64/init.c
 @@ -0,0 +1,47 @@
@@ -604,7 +604,7 @@ index 000000000..8fd0a88a5
 +  grub_install_get_time_ms (grub_rtc_get_time_ms);
 +}
 diff --git a/grub-core/lib/efi/halt.c b/grub-core/lib/efi/halt.c
-index a58a747e5..0dbf13682 100644
+index a58a747e..0dbf1368 100644
 --- a/grub-core/lib/efi/halt.c
 +++ b/grub-core/lib/efi/halt.c
 @@ -30,7 +30,7 @@ grub_halt (void)
@@ -618,7 +618,7 @@ index a58a747e5..0dbf13682 100644
  #endif
 diff --git a/grub-core/lib/mips64/relocator.c b/grub-core/lib/mips64/relocator.c
 new file mode 100644
-index 000000000..9712b6f73
+index 00000000..9712b6f7
 --- /dev/null
 +++ b/grub-core/lib/mips64/relocator.c
 @@ -0,0 +1,169 @@
@@ -793,7 +793,7 @@ index 000000000..9712b6f73
 +}
 diff --git a/grub-core/lib/mips64/relocator_asm.S b/grub-core/lib/mips64/relocator_asm.S
 new file mode 100644
-index 000000000..78d40ef9e
+index 00000000..78d40ef9
 --- /dev/null
 +++ b/grub-core/lib/mips64/relocator_asm.S
 @@ -0,0 +1,56 @@
@@ -855,7 +855,7 @@ index 000000000..78d40ef9e
 +	.set pop
 diff --git a/grub-core/lib/mips64/setjmp.S b/grub-core/lib/mips64/setjmp.S
 new file mode 100644
-index 000000000..a3d0a6320
+index 00000000..a3d0a632
 --- /dev/null
 +++ b/grub-core/lib/mips64/setjmp.S
 @@ -0,0 +1,69 @@
@@ -929,7 +929,7 @@ index 000000000..a3d0a6320
 +	jr $ra
 +	nop
 diff --git a/grub-core/lib/relocator.c b/grub-core/lib/relocator.c
-index e0478ae5b..8745fca7a 100644
+index e0478ae5..8745fca7 100644
 --- a/grub-core/lib/relocator.c
 +++ b/grub-core/lib/relocator.c
 @@ -1266,6 +1266,9 @@ grub_relocator_alloc_chunk_addr (struct grub_relocator *rel,
@@ -943,7 +943,7 @@ index e0478ae5b..8745fca7a 100644
        if (malloc_in_range (rel, target, max_addr, 1, size, chunk, 1, 0))
  	break;
 diff --git a/grub-core/lib/setjmp.S b/grub-core/lib/setjmp.S
-index ffb26df79..c213cc111 100644
+index ffb26df7..c213cc11 100644
 --- a/grub-core/lib/setjmp.S
 +++ b/grub-core/lib/setjmp.S
 @@ -9,7 +9,11 @@
@@ -960,7 +960,7 @@ index ffb26df79..c213cc111 100644
  #elif defined(__ia64__)
 diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
 new file mode 100644
-index 000000000..84f9f2f81
+index 00000000..84f9f2f8
 --- /dev/null
 +++ b/grub-core/loader/mips64/linux.c
 @@ -0,0 +1,335 @@
@@ -1300,7 +1300,7 @@ index 000000000..84f9f2f81
 +  grub_unregister_command (cmd_initrd);
 +}
 diff --git a/grub-core/term/serial.c b/grub-core/term/serial.c
-index 8260dcb7a..1e507a734 100644
+index 8260dcb7..1e507a73 100644
 --- a/grub-core/term/serial.c
 +++ b/grub-core/term/serial.c
 @@ -22,7 +22,7 @@
@@ -1340,7 +1340,7 @@ index 8260dcb7a..1e507a734 100644
  #endif
  #ifdef GRUB_MACHINE_IEEE1275
 diff --git a/include/grub/cache.h b/include/grub/cache.h
-index 7aa8d7933..a4fda155c 100644
+index 7aa8d793..a4fda155 100644
 --- a/include/grub/cache.h
 +++ b/include/grub/cache.h
 @@ -35,7 +35,7 @@ void EXPORT_FUNC(grub_arch_sync_caches) (void *address, grub_size_t len);
@@ -1353,7 +1353,7 @@ index 7aa8d7933..a4fda155c 100644
  #elif defined (__i386__) || defined (__x86_64__)
  static inline void
 diff --git a/include/grub/dl.h b/include/grub/dl.h
-index cd1f46c8b..8db1922e5 100644
+index cd1f46c8..8db1922e 100644
 --- a/include/grub/dl.h
 +++ b/include/grub/dl.h
 @@ -188,7 +188,7 @@ struct grub_dl
@@ -1391,7 +1391,7 @@ index cd1f46c8b..8db1922e5 100644
      (defined(__riscv) && (__riscv_xlen == 64))
  #define GRUB_ARCH_DL_TRAMP_ALIGN 8
 diff --git a/include/grub/efi/pe32.h b/include/grub/efi/pe32.h
-index 4e6e9d254..5609d9bc9 100644
+index 4e6e9d25..5609d9bc 100644
 --- a/include/grub/efi/pe32.h
 +++ b/include/grub/efi/pe32.h
 @@ -84,6 +84,7 @@ struct grub_pe32_coff_header
@@ -1415,7 +1415,7 @@ index 4e6e9d254..5609d9bc9 100644
  #define GRUB_PE32_REL_BASED_SECTION		6
 diff --git a/include/grub/mips64/asm.h b/include/grub/mips64/asm.h
 new file mode 100644
-index 000000000..062bdf5e9
+index 00000000..062bdf5e
 --- /dev/null
 +++ b/include/grub/mips64/asm.h
 @@ -0,0 +1,10 @@
@@ -1431,10 +1431,10 @@ index 000000000..062bdf5e9
 +#endif
 diff --git a/include/grub/mips64/efi/boot.h b/include/grub/mips64/efi/boot.h
 new file mode 100644
-index 000000000..e69de29bb
+index 00000000..e69de29b
 diff --git a/include/grub/mips64/efi/loader.h b/include/grub/mips64/efi/loader.h
 new file mode 100644
-index 000000000..71a015977
+index 00000000..71a01597
 --- /dev/null
 +++ b/include/grub/mips64/efi/loader.h
 @@ -0,0 +1,25 @@
@@ -1465,7 +1465,7 @@ index 000000000..71a015977
 +#endif /* ! GRUB_LOADER_MACHINE_HEADER */
 diff --git a/include/grub/mips64/efi/memory.h b/include/grub/mips64/efi/memory.h
 new file mode 100644
-index 000000000..52e6ae6eb
+index 00000000..52e6ae6e
 --- /dev/null
 +++ b/include/grub/mips64/efi/memory.h
 @@ -0,0 +1,6 @@
@@ -1477,10 +1477,10 @@ index 000000000..52e6ae6eb
 +#endif /* ! GRUB_MEMORY_CPU_HEADER */
 diff --git a/include/grub/mips64/efi/time.h b/include/grub/mips64/efi/time.h
 new file mode 100644
-index 000000000..e69de29bb
+index 00000000..e69de29b
 diff --git a/include/grub/mips64/io.h b/include/grub/mips64/io.h
 new file mode 100644
-index 000000000..5f341037a
+index 00000000..5f341037
 --- /dev/null
 +++ b/include/grub/mips64/io.h
 @@ -0,0 +1,62 @@
@@ -1548,7 +1548,7 @@ index 000000000..5f341037a
 +#endif /* _SYS_IO_H */
 diff --git a/include/grub/mips64/kernel.h b/include/grub/mips64/kernel.h
 new file mode 100644
-index 000000000..909d5397d
+index 00000000..909d5397
 --- /dev/null
 +++ b/include/grub/mips64/kernel.h
 @@ -0,0 +1,24 @@
@@ -1578,7 +1578,7 @@ index 000000000..909d5397d
 +#endif /* ! GRUB_KERNEL_MACHINE_HEADER */
 diff --git a/include/grub/mips64/memory.h b/include/grub/mips64/memory.h
 new file mode 100644
-index 000000000..573a70f79
+index 00000000..573a70f7
 --- /dev/null
 +++ b/include/grub/mips64/memory.h
 @@ -0,0 +1,56 @@
@@ -1640,7 +1640,7 @@ index 000000000..573a70f79
 +#endif
 diff --git a/include/grub/mips64/mips.h b/include/grub/mips64/mips.h
 new file mode 100644
-index 000000000..a13c709e0
+index 00000000..a13c709e
 --- /dev/null
 +++ b/include/grub/mips64/mips.h
 @@ -0,0 +1,30 @@
@@ -1676,7 +1676,7 @@ index 000000000..a13c709e0
 +#endif
 diff --git a/include/grub/mips64/relocator.h b/include/grub/mips64/relocator.h
 new file mode 100644
-index 000000000..88153142a
+index 00000000..88153142
 --- /dev/null
 +++ b/include/grub/mips64/relocator.h
 @@ -0,0 +1,38 @@
@@ -1720,7 +1720,7 @@ index 000000000..88153142a
 +#endif /* ! GRUB_RELOCATOR_CPU_HEADER */
 diff --git a/include/grub/mips64/setjmp.h b/include/grub/mips64/setjmp.h
 new file mode 100644
-index 000000000..d9a0776b6
+index 00000000..d9a0776b
 --- /dev/null
 +++ b/include/grub/mips64/setjmp.h
 @@ -0,0 +1,27 @@
@@ -1753,7 +1753,7 @@ index 000000000..d9a0776b6
 +#endif /* ! GRUB_SETJMP_CPU_HEADER */
 diff --git a/include/grub/mips64/time.h b/include/grub/mips64/time.h
 new file mode 100644
-index 000000000..c9a733488
+index 00000000..c9a73348
 --- /dev/null
 +++ b/include/grub/mips64/time.h
 @@ -0,0 +1,39 @@
@@ -1798,7 +1798,7 @@ index 000000000..c9a733488
 +#endif
 diff --git a/include/grub/mips64/types.h b/include/grub/mips64/types.h
 new file mode 100644
-index 000000000..fc896c83b
+index 00000000..fc896c83
 --- /dev/null
 +++ b/include/grub/mips64/types.h
 @@ -0,0 +1,38 @@
@@ -1841,7 +1841,7 @@ index 000000000..fc896c83b
 +
 +#endif /* ! GRUB_TYPES_CPU_HEADER */
 diff --git a/include/grub/misc.h b/include/grub/misc.h
-index 1b35a167f..237764d2f 100644
+index 1b35a167..237764d2 100644
 --- a/include/grub/misc.h
 +++ b/include/grub/misc.h
 @@ -460,7 +460,7 @@ void grub_reboot (void) __attribute__ ((noreturn));
@@ -1854,7 +1854,7 @@ index 1b35a167f..237764d2f 100644
  #else
  void grub_halt (void) __attribute__ ((noreturn));
 diff --git a/include/grub/serial.h b/include/grub/serial.h
-index d7e063578..c83d91781 100644
+index d7e06357..c83d9178 100644
 --- a/include/grub/serial.h
 +++ b/include/grub/serial.h
 @@ -21,7 +21,7 @@
@@ -1885,7 +1885,7 @@ index d7e063578..c83d91781 100644
  struct grub_serial_port *grub_ns8250_spcr_init (void);
  struct grub_serial_port *grub_serial_ns8250_add_port (grub_port_t port,
 diff --git a/include/grub/util/install.h b/include/grub/util/install.h
-index 35cf17a8d..03b176985 100644
+index 35cf17a8..03b17698 100644
 --- a/include/grub/util/install.h
 +++ b/include/grub/util/install.h
 @@ -110,6 +110,7 @@ enum grub_install_plat
@@ -1897,7 +1897,7 @@ index 35cf17a8d..03b176985 100644
    };
  
 diff --git a/util/grub-install-common.c b/util/grub-install-common.c
-index ce854d86f..3fc91148b 100644
+index ce854d86..3fc91148 100644
 --- a/util/grub-install-common.c
 +++ b/util/grub-install-common.c
 @@ -914,6 +914,7 @@ static struct
@@ -1909,7 +1909,7 @@ index ce854d86f..3fc91148b 100644
      [GRUB_INSTALL_PLATFORM_POWERPC_IEEE1275] = { "powerpc",     "ieee1275"  },
      [GRUB_INSTALL_PLATFORM_IA64_EFI] =         { "ia64",        "efi"       },
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 6a5f86b09..fabba39fc 100644
+index 6a5f86b0..fabba39f 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -322,7 +322,11 @@ get_default_platform (void)
@@ -2009,7 +2009,7 @@ index 6a5f86b09..fabba39fc 100644
        {
  	char *dst = grub_util_path_concat (2, efidir, efi_file);
 diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
-index e50b29533..1969f1f90 100644
+index e50b2953..1969f1f9 100644
 --- a/util/grub-mkimagexx.c
 +++ b/util/grub-mkimagexx.c
 @@ -842,7 +842,11 @@ SUFFIX (relocate_addrs) (Elf_Ehdr *e, struct section_metadata *smd,
@@ -2347,7 +2347,7 @@ index e50b29533..1969f1f90 100644
        }
  
 diff --git a/util/grub-mknetdir.c b/util/grub-mknetdir.c
-index 46f304c2b..e97518ae5 100644
+index 46f304c2..e97518ae 100644
 --- a/util/grub-mknetdir.c
 +++ b/util/grub-mknetdir.c
 @@ -111,6 +111,7 @@ static const struct
@@ -2359,7 +2359,7 @@ index 46f304c2b..e97518ae5 100644
  
  static void
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index cfb749967..25b861f1f 100644
+index cfb74996..25b861f1 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -566,6 +566,7 @@ main (int argc, char *argv[])
@@ -2390,7 +2390,7 @@ index cfb749967..25b861f1f 100644
  	{
  	  imgname = grub_util_path_concat (2, efidir_efi_boot, "boot.efi");
 diff --git a/util/grub-module-verifier.c b/util/grub-module-verifier.c
-index 91d9e8f88..6beca0802 100644
+index 91d9e8f8..6beca080 100644
 --- a/util/grub-module-verifier.c
 +++ b/util/grub-module-verifier.c
 @@ -209,6 +209,19 @@ struct grub_module_verifier_arch archs[] = {
@@ -2414,7 +2414,7 @@ index 91d9e8f88..6beca0802 100644
  
  struct platform_whitelist {
 diff --git a/util/grub-module-verifierXX.c b/util/grub-module-verifierXX.c
-index a42c20bd1..886c31983 100644
+index a42c20bd..886c3198 100644
 --- a/util/grub-module-verifierXX.c
 +++ b/util/grub-module-verifierXX.c
 @@ -378,7 +378,14 @@ section_check_relocations (const char * const modname,
@@ -2434,7 +2434,7 @@ index a42c20bd1..886c31983 100644
        if (arch->machine == EM_SPARCV9)
  	type &= 0xff;
 diff --git a/util/mkimage.c b/util/mkimage.c
-index 4237383ac..53a3fd107 100644
+index 4237383a..53a3fd10 100644
 --- a/util/mkimage.c
 +++ b/util/mkimage.c
 @@ -622,6 +622,22 @@ static const struct grub_install_image_target_desc image_targets[] =
@@ -2461,5 +2461,5 @@ index 4237383ac..53a3fd107 100644
        .dirname = "loongarch64-efi",
        .names = { "loongarch64-efi", NULL },
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From e4e7a42521c5b178a86caf1ac950dfc1f79e0a30 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 27/46] mips64: Add support for Loongson.
+Subject: [PATCH 27/47] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-
@@ -21,7 +21,7 @@ Subject: [PATCH 27/46] mips64: Add support for Loongson.
  create mode 100644 include/grub/mips64/efi/loongson.h
 
 diff --git a/configure.ac b/configure.ac
-index 9a29936a7..50154e2b6 100644
+index 9a29936a..50154e2b 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -110,15 +110,15 @@ case "$target_cpu" in
@@ -44,7 +44,7 @@ index 9a29936a7..50154e2b6 100644
  		;;
    arm*)		target_cpu=arm ;;
 diff --git a/grub-core/Makefile.am b/grub-core/Makefile.am
-index 6b6089817..2d8c1b982 100644
+index 6b608981..2d8c1b98 100644
 --- a/grub-core/Makefile.am
 +++ b/grub-core/Makefile.am
 @@ -243,6 +243,7 @@ if COND_mips64_efi
@@ -56,7 +56,7 @@ index 6b6089817..2d8c1b982 100644
  
  if COND_powerpc_ieee1275
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index a0152bb71..3ee912c45 100644
+index a0152bb7..3ee912c4 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -337,6 +337,9 @@ kernel = {
@@ -70,7 +70,7 @@ index a0152bb71..3ee912c45 100644
    powerpc_ieee1275 = kern/powerpc/cache.S;
    powerpc_ieee1275 = kern/powerpc/dl.c;
 diff --git a/grub-core/kern/mips64/efi/init.c b/grub-core/kern/mips64/efi/init.c
-index 074736db9..9a4e68727 100644
+index 074736db..9a4e6872 100644
 --- a/grub-core/kern/mips64/efi/init.c
 +++ b/grub-core/kern/mips64/efi/init.c
 @@ -24,21 +24,61 @@
@@ -139,7 +139,7 @@ index 074736db9..9a4e68727 100644
  }
 diff --git a/grub-core/kern/mips64/efi/loongson.c b/grub-core/kern/mips64/efi/loongson.c
 new file mode 100644
-index 000000000..542294a98
+index 00000000..542294a9
 --- /dev/null
 +++ b/grub-core/kern/mips64/efi/loongson.c
 @@ -0,0 +1,32 @@
@@ -177,7 +177,7 @@ index 000000000..542294a98
 +}
 diff --git a/grub-core/lib/mips64/efi/loongson.c b/grub-core/lib/mips64/efi/loongson.c
 new file mode 100644
-index 000000000..19eefeb4a
+index 00000000..19eefeb4
 --- /dev/null
 +++ b/grub-core/lib/mips64/efi/loongson.c
 @@ -0,0 +1,492 @@
@@ -675,7 +675,7 @@ index 000000000..19eefeb4a
 +}
 diff --git a/grub-core/lib/mips64/efi/loongson_asm.S b/grub-core/lib/mips64/efi/loongson_asm.S
 new file mode 100644
-index 000000000..c3d1c91dd
+index 00000000..c3d1c91d
 --- /dev/null
 +++ b/grub-core/lib/mips64/efi/loongson_asm.S
 @@ -0,0 +1,60 @@
@@ -740,7 +740,7 @@ index 000000000..c3d1c91dd
 +
 +	.set		pop
 diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
-index 84f9f2f81..afa508f81 100644
+index 84f9f2f8..afa508f8 100644
 --- a/grub-core/loader/mips64/linux.c
 +++ b/grub-core/loader/mips64/linux.c
 @@ -27,19 +27,24 @@
@@ -1080,7 +1080,7 @@ index 84f9f2f81..afa508f81 100644
        goto fail;
 diff --git a/include/grub/mips64/efi/loongson.h b/include/grub/mips64/efi/loongson.h
 new file mode 100644
-index 000000000..a5aaec263
+index 00000000..a5aaec26
 --- /dev/null
 +++ b/include/grub/mips64/efi/loongson.h
 @@ -0,0 +1,305 @@
@@ -1390,7 +1390,7 @@ index 000000000..a5aaec263
 +EXPORT_FUNC (grub_efi_loongson_memmap_sort) (struct memmap array[], grub_uint32_t length, mem_map * bpmem, grub_uint32_t index, grub_uint32_t memtype);
 +#endif /* ! GRUB_EFI_LOONGSON_HEADER */
 diff --git a/include/grub/mips64/efi/memory.h b/include/grub/mips64/efi/memory.h
-index 52e6ae6eb..e4063783f 100644
+index 52e6ae6e..e4063783 100644
 --- a/include/grub/mips64/efi/memory.h
 +++ b/include/grub/mips64/efi/memory.h
 @@ -1,6 +1,6 @@
@@ -1402,5 +1402,5 @@ index 52e6ae6eb..e4063783f 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From e5d36fc00b3467b49851f20effb4e9c3400e73ce Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 28/46] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 28/47] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 28/46] loader/mips64/linux: fix missing type args while
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
-index afa508f81..226207303 100644
+index afa508f8..22620730 100644
 --- a/grub-core/loader/mips64/linux.c
 +++ b/grub-core/loader/mips64/linux.c
 @@ -21,6 +21,7 @@
@@ -30,5 +30,5 @@ index afa508f81..226207303 100644
      return grub_errno;
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From fb3c7be5f6bd065554321f75d65132dfd53bb2d4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 29/46] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 29/47] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 29/46] util/grub-mkimagexx: fix uncorrect section var in
  1 file changed, 3 insertions(+)
 
 diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
-index 1969f1f90..36a30bbcd 100644
+index 1969f1f9..36a30bbc 100644
 --- a/util/grub-mkimagexx.c
 +++ b/util/grub-mkimagexx.c
 @@ -2329,6 +2329,9 @@ make_reloc_section (Elf_Ehdr *e, struct grub_mkimage_layout *layout,
@@ -23,5 +23,5 @@ index 1969f1f90..36a30bbcd 100644
  	grub_util_info ("translating the relocation section %s",
  			smd->strtab + grub_le_to_cpu32 (s->sh_name));
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 828d7983742c9336e8a512b1bd4ec74cb3e4ec33 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 30/46] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 30/47] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 30/46] loader/mips64/linux: drop argv[] args when calling
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
-index 226207303..514335e47 100644
+index 22620730..514335e4 100644
 --- a/grub-core/loader/mips64/linux.c
 +++ b/grub-core/loader/mips64/linux.c
 @@ -523,7 +523,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
@@ -22,5 +22,5 @@ index 226207303..514335e47 100644
  
    grub_snprintf ((char *) linux_args_addr + rd_addr_arg_off,
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From d4942f62fdf97f922516b3e7ea3d72e7c8dcf772 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 31/46] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 31/47] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----
@@ -9,7 +9,7 @@ Subject: [PATCH 31/46] lib/mips64: drop all efi_call wrappers
  2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/grub-core/kern/mips64/efi/init.c b/grub-core/kern/mips64/efi/init.c
-index 9a4e68727..7fd508c54 100644
+index 9a4e6872..7fd508c5 100644
 --- a/grub-core/kern/mips64/efi/init.c
 +++ b/grub-core/kern/mips64/efi/init.c
 @@ -52,9 +52,9 @@ grub_machine_init (void)
@@ -36,7 +36,7 @@ index 9a4e68727..7fd508c54 100644
    if (grub_efi_is_loongson ())
      grub_efi_loongson_fini ();
 diff --git a/grub-core/lib/mips64/efi/loongson.c b/grub-core/lib/mips64/efi/loongson.c
-index 19eefeb4a..f06f9ae4b 100644
+index 19eefeb4..f06f9ae4 100644
 --- a/grub-core/lib/mips64/efi/loongson.c
 +++ b/grub-core/lib/mips64/efi/loongson.c
 @@ -354,7 +354,7 @@ grub_efi_loongson_alloc_boot_params (void)
@@ -49,5 +49,5 @@ index 19eefeb4a..f06f9ae4b 100644
      grub_fatal ("cannot allocate Loongson boot parameters!");
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,14 +1,14 @@
 From 402da3bece331169230d07b83496885cd305529a Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 32/46] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 32/47] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/lib/mips64/efi/loongson.c b/grub-core/lib/mips64/efi/loongson.c
-index f06f9ae4b..e8acb6965 100644
+index f06f9ae4..e8acb696 100644
 --- a/grub-core/lib/mips64/efi/loongson.c
 +++ b/grub-core/lib/mips64/efi/loongson.c
 @@ -412,7 +412,7 @@ grub_efi_loongson_get_boot_params (void)
@@ -21,5 +21,5 @@ index f06f9ae4b..e8acb6965 100644
  
    if (boot_params)
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,14 +1,14 @@
 From 8ca095a942e8e19033c3e0dde9da7412c62f8698 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 33/46] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 33/47] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/kern/mips64/dl.c b/grub-core/kern/mips64/dl.c
-index 049d3187c..6d518b537 100644
+index 049d3187..6d518b53 100644
 --- a/grub-core/kern/mips64/dl.c
 +++ b/grub-core/kern/mips64/dl.c
 @@ -138,7 +138,7 @@ grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
@@ -21,5 +21,5 @@ index 049d3187c..6d518b537 100644
  	  }
  	  break;
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 8d9bff60ccfd4e9d67e83479df15b5c072fd7b14 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 34/46] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 34/47] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 34/46] kern/mips64: fix missing grub_install_get_time_ms
  1 file changed, 1 insertion(+)
 
 diff --git a/grub-core/kern/mips64/efi/init.c b/grub-core/kern/mips64/efi/init.c
-index 7fd508c54..ab225cb98 100644
+index 7fd508c5..ab225cb9 100644
 --- a/grub-core/kern/mips64/efi/init.c
 +++ b/grub-core/kern/mips64/efi/init.c
 @@ -21,6 +21,7 @@
@@ -21,5 +21,5 @@ index 7fd508c54..ab225cb98 100644
  #include <grub/efi/efi.h>
  #include <grub/loader.h>
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
@@ -1,14 +1,14 @@
 From 1c99dd698362042f2da9e9ac7283061984405c8c Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 35/46] lib/mips64: silence werror
+Subject: [PATCH 35/47] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/lib/mips64/efi/loongson.c b/grub-core/lib/mips64/efi/loongson.c
-index e8acb6965..a283b41b1 100644
+index e8acb696..a283b41b 100644
 --- a/grub-core/lib/mips64/efi/loongson.c
 +++ b/grub-core/lib/mips64/efi/loongson.c
 @@ -43,6 +43,9 @@ static struct
@@ -31,5 +31,5 @@ index e8acb6965..a283b41b1 100644
  		   bpmem->map[index].memtype,
  		   bpmem->map[index].memstart,
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
@@ -1,14 +1,14 @@
 From cb1215b5499cb16020d9cca639d95ca0ba31b642 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 36/46] loader/mips64: fix warnings and style
+Subject: [PATCH 36/47] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------
  1 file changed, 44 insertions(+), 38 deletions(-)
 
 diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
-index 514335e47..6b6cac273 100644
+index 514335e4..6b6cac27 100644
 --- a/grub-core/loader/mips64/linux.c
 +++ b/grub-core/loader/mips64/linux.c
 @@ -124,11 +124,11 @@ grub_linux_boot (void)
@@ -141,5 +141,5 @@ index 514335e47..6b6cac273 100644
    if (linux_size == 0)
      return grub_errno;
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0037-kern-efi-mm-mips64-allocate-more-memory-at-initializ.patch
+++ b/app-admin/grub/autobuild/patches/0037-kern-efi-mm-mips64-allocate-more-memory-at-initializ.patch
@@ -1,7 +1,7 @@
 From 80d7a2cf0cac578a840163fe53e989a261a6de28 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 8 Oct 2024 16:40:04 +0800
-Subject: [PATCH 37/46] kern/efi/mm: mips64: allocate more memory at
+Subject: [PATCH 37/47] kern/efi/mm: mips64: allocate more memory at
  initialization
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 37/46] kern/efi/mm: mips64: allocate more memory at
  1 file changed, 65 insertions(+)
 
 diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
-index 6a6fba891..9bd82c223 100644
+index 6a6fba89..9bd82c22 100644
 --- a/grub-core/kern/efi/mm.c
 +++ b/grub-core/kern/efi/mm.c
 @@ -39,7 +39,11 @@
@@ -93,5 +93,5 @@ index 6a6fba891..9bd82c223 100644
  grub_efi_mm_init (void)
  {
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0038-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0038-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From 72963d5d984e8874f55638941e92b2b34939a8bb Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 38/46] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 38/47] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI
@@ -10,7 +10,7 @@ as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index fabba39fc..3fc2a6007 100644
+index fabba39f..3fc2a600 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -1293,7 +1293,7 @@ main (int argc, char *argv[])
@@ -23,5 +23,5 @@ index fabba39fc..3fc2a6007 100644
  	    default:
  	      grub_util_error ("%s", _("You've found a bug"));
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0039-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0039-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From 44a244b939e79586ebda49b9ab74bc03ec930295 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 39/46] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 39/47] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.
@@ -10,7 +10,7 @@ Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index 25b861f1f..3759f522d 100644
+index 25b861f1..3759f522 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -830,7 +830,7 @@ main (int argc, char *argv[])
@@ -23,5 +23,5 @@ index 25b861f1f..3759f522d 100644
        free (imgname);
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0040-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0040-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 35d070776ebcc91654e454d5b4eee6141a5a72bb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 40/46] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 40/47] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index 6816e09d4..5e17a9db4 100644
+index 6816e09d..5e17a9db 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -234,6 +234,17 @@ EOF
@@ -35,5 +35,5 @@ index 6816e09d4..5e17a9db4 100644
      if [ "x$GRUB_THEME" != x ] && [ -f "$GRUB_THEME" ] \
  	&& is_path_readable_by_grub "$GRUB_THEME"; then
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0041-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0041-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From e4beb231ba77c3cd3a0afa182c707d8cce1197ff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 41/46] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 41/47] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 29 insertions(+), 4 deletions(-)
 
 diff --git a/docs/grub.texi b/docs/grub.texi
-index acf6f4428..7ae4f4886 100644
+index acf6f442..7ae4f488 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1593,6 +1593,10 @@ This option may be set to a list of GRUB module names separated by spaces.
@@ -38,7 +38,7 @@ index acf6f4428..7ae4f4886 100644
  
  The following options are still accepted for compatibility with existing
 diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
-index 6a90e091f..78566b264 100644
+index 6a90e091..78566b26 100644
 --- a/grub-core/normal/menu.c
 +++ b/grub-core/normal/menu.c
 @@ -32,6 +32,7 @@
@@ -88,7 +88,7 @@ index 6a90e091f..78566b264 100644
  	    case GRUB_TERM_ESC:
  	      if (nested)
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 73a973b25..b15bfc13a 100644
+index 73a973b2..b15bfc13 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -254,7 +254,8 @@ export GRUB_DEFAULT \
@@ -102,7 +102,7 @@ index 73a973b25..b15bfc13a 100644
  if test "x${grub_cfg}" != "x"; then
    rm -f "${grub_cfg}.new"
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index 5e17a9db4..0adf84019 100644
+index 5e17a9db..0adf8401 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -37,6 +37,7 @@ if [ "x${GRUB_DEFAULT}" = "x" ] ; then GRUB_DEFAULT=0 ; fi
@@ -123,5 +123,5 @@ index 5e17a9db4..0adf84019 100644
 +set right_to_select=${GRUB_RIGHT_TO_SELECT}
 +EOF
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0042-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0042-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From ab46b6a4e5ec936c635692e5cf662afa3f599149 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 42/46] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 42/47] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe
@@ -15,7 +15,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/util/grub.d/30_uefi-firmware.in b/util/grub.d/30_uefi-firmware.in
-index 1c2365ddb..9cbeac6cc 100644
+index 1c2365dd..9cbeac6c 100644
 --- a/util/grub.d/30_uefi-firmware.in
 +++ b/util/grub.d/30_uefi-firmware.in
 @@ -26,7 +26,7 @@ export TEXTDOMAINDIR="@localedir@"
@@ -28,5 +28,5 @@ index 1c2365ddb..9cbeac6cc 100644
  gettext_printf "Adding boot menu entry for UEFI Firmware Settings ...\n" >&2
  
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0043-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0043-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,14 +1,14 @@
 From c8aa509735011d988096e8166075244ee47d8650 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 43/46] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 43/47] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 3 ---
  1 file changed, 3 deletions(-)
 
 diff --git a/.gitignore b/.gitignore
-index 4d0dfb700..7523b9895 100644
+index 4d0dfb70..7523b989 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -245,8 +245,6 @@ widthspec.bin
@@ -29,5 +29,5 @@ index 4d0dfb700..7523b9895 100644
  /po/stamp-po
  /printf_test
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0045-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0045-po-update-zh_CN-translation.patch
@@ -1,14 +1,14 @@
 From 81bca2cb3dc87f594481e2f1359b0b22c062669d Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 45/46] po: update zh_CN translation
+Subject: [PATCH 45/47] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------
  1 file changed, 854 insertions(+), 460 deletions(-)
 
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index 468f6368f..64fe257e6 100644
+index 468f6368..64fe257e 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
 @@ -12,7 +12,7 @@ msgid ""
@@ -2689,5 +2689,5 @@ index 468f6368f..64fe257e6 100644
  
  #~ msgid "Predicted = %d, written = %llu\n"
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0046-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0046-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From 69a8ab9133a1d2369bfe60c00c8afbdda49df3ee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 46/46] po: update zh_TW translations
+Subject: [PATCH 46/47] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---
@@ -9,7 +9,7 @@ Add translation for UEFI Settings.
  1 file changed, 7639 insertions(+), 1421 deletions(-)
 
 diff --git a/po/zh_TW.po b/po/zh_TW.po
-index 8713a1ac1..6e863c161 100644
+index 8713a1ac..6e863c16 100644
 --- a/po/zh_TW.po
 +++ b/po/zh_TW.po
 @@ -6,2034 +6,8252 @@
@@ -9687,5 +9687,5 @@ index 8713a1ac1..6e863c161 100644
 +#~ msgid "cannot guess the root device. Specify the option `--root-device'"
 +#~ msgstr "無法猜測根裝置。請指定「--root-device」選項"
 -- 
-2.47.0
+2.48.0.rc2.windows.1
 

--- a/app-admin/grub/autobuild/patches/0047-SOPHGO-include-grub-riscv64-modify-efi_max_usable-ad.patch
+++ b/app-admin/grub/autobuild/patches/0047-SOPHGO-include-grub-riscv64-modify-efi_max_usable-ad.patch
@@ -1,0 +1,32 @@
+From ebbcb82e52d2882396c50eac2366b63e648b8ca4 Mon Sep 17 00:00:00 2001
+From: "jingyu.li01" <jingyu.li01@sophgo.com>
+Date: Tue, 2 Jan 2024 10:09:53 +0800
+Subject: [PATCH 47/47] SOPHGO: include/grub/riscv64: modify efi_max_usable
+ addr
+
+This is a temporary solution for relocation overflow on a segmented memory
+layout.
+
+Signed-off-by: jingyu.li01 <jingyu.li01@sophgo.com>
+
+Link: https://github.com/sophgo/grub/commit/7ab0dc548f8221a9c336a1682df9f729b975c7ff
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ include/grub/riscv64/efi/memory.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/grub/riscv64/efi/memory.h b/include/grub/riscv64/efi/memory.h
+index c6cb3241..eb6f1bb8 100644
+--- a/include/grub/riscv64/efi/memory.h
++++ b/include/grub/riscv64/efi/memory.h
+@@ -1,6 +1,6 @@
+ #ifndef GRUB_MEMORY_CPU_HEADER
+ #include <grub/efi/memory.h>
+ 
+-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffULL
++#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffULL
+ 
+ #endif /* ! GRUB_MEMORY_CPU_HEADER */
+-- 
+2.48.0.rc2.windows.1
+


### PR DESCRIPTION
Topic Description
-----------------

- grub: add patch for Sophgo devices
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- grub: 2:2.12+unifont16.0.01-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
