### PR TITLE
pam-u2f: update to 1.3.2

### DIFF
--- a/runtime-admin/pam-u2f/spec
+++ b/runtime-admin/pam-u2f/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.3.2
 SRCS="git::commit=tags/pam_u2f-$VER::https://github.com/Yubico/pam-u2f.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8511"


### PR DESCRIPTION
Topic Description
-----------------

- pam-u2f: update to 1.3.2
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- pam-u2f: 1.3.2

Security Update?
----------------

https://nvd.nist.gov/vuln/detail/CVE-2025-23013

Build Order
-----------

```
#buildit pam-u2f
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
