### PR TITLE
sunshine: fix outdated FAIL_ARCH

### DIFF
--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -5,9 +5,9 @@ PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg miniupnpc \
         libnotify libappindicator libvdpau mesa"
 PKGDEP__AMD64="${PKGDEP} intel-media-driver"
 PKGRECOM="avahi"
-BUILDDEP="nodejs ffnvcodec"
-BUILDDEP__AMD64="${BUILDDEP} cuda"
-BUILDDEP__ARM64="${BUILDDEP} cuda"
+BUILDDEP="nodejs"
+BUILDDEP__AMD64="${BUILDDEP} ffnvcodec cuda"
+BUILDDEP__ARM64="${BUILDDEP} ffnvcodec cuda"
 PKGSUG__AMD64="cuda"
 PKGSUG__ARM64="cuda"
 
@@ -15,21 +15,21 @@ ABTYPE=cmakeninja
 
 # SUNSHINE_ASSETS_DIR is set to make data files follow FHS, otherwise it will
 # come at /usr/assets
-CMAKE_AFTER="-DSUNSHINE_ENABLE_DRM=ON \
-             -DSUNSHINE_ENABLE_X11=ON \
-             -DSUNSHINE_ENABLE_WAYLAND=ON \
-             -DSUNSHINE_ASSETS_DIR=share/sunshine"
+CMAKE_AFTER=(
+    '-DSUNSHINE_ENABLE_DRM=ON'
+    '-DSUNSHINE_ENABLE_X11=ON'
+    '-DSUNSHINE_ENABLE_WAYLAND=ON'
+    '-DSUNSHINE_ASSETS_DIR=share/sunshine'
+    '-DSUNSHINE_ENABLE_CUDA=OFF'
+)
 
-CMAKE_AFTER__AMD64="${CMAKE_AFTER} \
-                -DSUNSHINE_ENABLE_CUDA=ON \
-                -DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc"
-
-CMAKE_AFTER__ARM64="${CMAKE_AFTER} \
-                -DSUNSHINE_ENABLE_CUDA=ON \
-                -DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc"
-
-CMAKE_AFTER__PPC64EL="${CMAKE_AFTER} \
-                -DSUNSHINE_ENABLE_CUDA=OFF"
-
-# FIXME: Links against bundled FFmpeg binaries.
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER[@]}"
+    '-DSUNSHINE_ENABLE_CUDA=ON'
+    '-DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc'
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    '-DSUNSHINE_ENABLE_CUDA=ON'
+    '-DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc'
+)

--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -22,14 +22,3 @@ CMAKE_AFTER=(
     '-DSUNSHINE_ASSETS_DIR=share/sunshine'
     '-DSUNSHINE_ENABLE_CUDA=OFF'
 )
-
-CMAKE_AFTER__AMD64=(
-    "${CMAKE_AFTER[@]}"
-    '-DSUNSHINE_ENABLE_CUDA=ON'
-    '-DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc'
-)
-CMAKE_AFTER__ARM64=(
-    "${CMAKE_AFTER[@]}"
-    '-DSUNSHINE_ENABLE_CUDA=ON'
-    '-DCMAKE_CUDA_COMPILER:PATH=/usr/lib/cuda/bin/nvcc'
-)

--- a/app-multimedia/sunshine/spec
+++ b/app-multimedia/sunshine/spec
@@ -1,5 +1,5 @@
 VER=0.23.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/LizardByte/Sunshine"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236300"


### PR DESCRIPTION
Topic Description
-----------------

- sunshine: fix outdated FAIL_ARCH
    - Sunshine actually links against system FFmpeg now.
    - Limit CUDA to amd64, arm64.

Package(s) Affected
-------------------

- sunshine: 0.23.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sunshine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
