### PR TITLE
json-c: update to 0.18

### DIFF
--- a/runtime-common/json-c/spec
+++ b/runtime-common/json-c/spec
@@ -1,5 +1,4 @@
-VER=0.16
-REL=1
+VER=0.18
 SRCS="tbl::https://github.com/json-c/json-c/archive/json-c-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::c169436bd63a30fce4f9560befccb6bad3d375c8c7e9905ceb4e1f28f2cb24f7"
+CHKSUMS="sha256::8069b5e6100bb8b9908dcfdd368f0e99bdeea2cb139cba558e536715c8c8ac8e"
 CHKUPDATE="anitya::id=1477"


### PR DESCRIPTION
Topic Description
-----------------

- json-c: update to 0.18
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- json-c: 0.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit json-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
