### PR TITLE
nali: new, 0.8.1

### DIFF
--- a/app-network/nali/autobuild/beyond
+++ b/app-network/nali/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing completion files ..."
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
+"$PKGDIR"/usr/bin/nali completion bash > "$PKGDIR"/usr/share/bash-completion/completions/nali
+mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
+"$PKGDIR"/usr/bin/nali completion zsh > "$PKGDIR"/usr/share/zsh/site-functions/_nali
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d
+"$PKGDIR"/usr/bin/nali completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/nali.fish

--- a/app-network/nali/autobuild/defines
+++ b/app-network/nali/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="nali"
+PKGSEC=net
+PKGDES="An offline tool for querying IP geographic information and CDN provider"
+PKGDEP="gcc-runtime"
+BUILDDEP="go"
+# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
+ABSPLITDBG=0
+
+GO_LDFLAGS+=("-X github.com/zu1k/nali/internal/constant.Version=$PKGVER")

--- a/app-network/nali/spec
+++ b/app-network/nali/spec
@@ -1,0 +1,4 @@
+VER=0.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/zu1k/nali.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376443"

--- a/app-utils/qdiskinfo/autobuild/defines
+++ b/app-utils/qdiskinfo/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="qdiskinfo"
+PKGSEC=utils
+PKGDES="A frontend for smartctl"
+PKGDEP="gcc-runtime qt-5 hicolor-icon-theme"
+BUILDDEP="extra-cmake-modules"
+
+CMAKE_AFTER=('-DQT_VERSION_MAJOR=5')

--- a/app-utils/qdiskinfo/spec
+++ b/app-utils/qdiskinfo/spec
@@ -1,0 +1,4 @@
+VER=0.3
+SRCS="git::commit=tags/$VER::https://github.com/edisionnano/QDiskInfo.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376447"


### PR DESCRIPTION
Topic Description
-----------------

- qdiskinfo: new, 0.3
- nali: new, 0.8.1

Package(s) Affected
-------------------

- nali: 0.8.1
- qdiskinfo: 0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nali qdiskinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
