### PR TITLE
containers-common: update to 0.61.1+image5.33.0+shortnames2023.02.20+skopeo1.17.0+storage1.56.0

### DIFF
--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.61.0
+UPSTREAM_VER=0.61.1
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.61.1+image5.33.0+shortnames2023.02.20+skopeo1.17.0+storage1.56.0
    Co-authored-by: xtex (@xtexChooser) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- containers-common: 0.61.1+image5.33.0+shortnames2023.02.20+skopeo1.17.0+storage1.56.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
