### PR TITLE
containers-common: update to 0.61.1+image5.33.1+shortnames2023.02.20+skopeo1.17.0+storage1.56.1


### DIFF
--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=0.61.0
+UPSTREAM_VER=0.61.1
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-__IMAGE_VER=5.33.0
-__STORAGE_VER=1.56.0
+__IMAGE_VER=5.33.1
+__STORAGE_VER=1.56.1
 # FIXME: the following two dependencies are not in the go.sum file above.
 __SHORTNAMES_VER=2023.02.20
 __SKOPEO_VER=1.17.0


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.61.1+image5.33.1+shortnames2023.02.20+skopeo1.17.0+storage1.56.1

Package(s) Affected
-------------------

- containers-common: 0.61.1+image5.33.1+shortnames2023.02.20+skopeo1.17.0+storage1.56.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
