### PR TITLE
cuda: update to 12.6.3+560.35.05, nvidia-open: provide nvidia

### DIFF
--- a/app-devel/cuda/autobuild/defines
+++ b/app-devel/cuda/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=cuda
 PKGSEC=non-free/devel
-PKGDEP="gcc-runtime gdb nvidia gcc glu pulseaudio qt-5"
+PKGDEP="gcc-runtime gdb gcc glu pulseaudio qt-5"
+# FIXME: cuda depends on `nvidia` or `nvidia-open`, ACBS currently lacks the
+# ability to specify "or" relationship, so we default to recommend `nvidia` here
+# as it is still what we preinstall
+PKGRECOM="nvidia"
 PKGDES="NVIDIA parallel computing platform and programming model"
 
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=12.5.0
-MIN_DRIVER_VER=555.42.02
+UPSTREAM_VER=12.6.3
+MIN_DRIVER_VER=560.35.05
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::90fcc7df48226434065ff12a4372136b40b9a4cbf0c8602bb763b745f22b7a99"
+CHKSUMS__AMD64="sha256::81d60e48044796d7883aa8a049afe6501b843f2c45639b3703b2378de30d55d3"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::e7b864c9ae27cef77cafc78614ec33cbb0a27606af9375deffa09c4269a07f04"
+CHKSUMS__ARM64="sha256::213ea63a6357020978a8b0a79a8c9d12a2a5941afa1cdc69d5a3f933fa8bed04"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 12.6.3+560.35.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 12.6.3+560.35.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
