### PR TITLE
virtiofsd: new, 1.13.0

### DIFF
--- a/app-virtualization/qemu/01-shared/defines
+++ b/app-virtualization/qemu/01-shared/defines
@@ -6,7 +6,7 @@ PKGDEP="pixman libcacard libjpeg-turbo libpng sdl alsa-lib nss \
         usbredir curl spice libssh libnfs brltty dtc jemalloc \
         capstone liburing virglrenderer vte-gtk3 sdl2 glu snappy \
         multipath-tools sndio ndctl lzfse rdma-core libu2f-emu \
-        canokey-qemu fuse-3 libblkio"
+        canokey-qemu fuse-3 libblkio virtiofsd"
 BUILDDEP="spice-protocol xmlto doxygen dtc sphinx jack glib-static \
           libgcrypt-static libgpg-error-static libnfs-static pcre-static \
           zlib-static zstd-static acpica-unix linux+api"

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=9.2.0
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::f859f0bc65e1f533d040bbe8c92bcfecee5af2c921a6687c652fb44d089bd894"
 CHKUPDATE="anitya::id=13607"

--- a/app-virtualization/virtiofsd/autobuild/beyond
+++ b/app-virtualization/virtiofsd/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Moving /usr/bin to /usr/libexec ..."
+mv -v "$PKGDIR"/usr/bin "$PKGDIR"/usr/libexec
+
+abinfo "Installing vhost-user JSON ..."
+install -Dvm 644 50-virtiofsd.json \
+    "$PKGDIR"/usr/share/qemu/vhost-user/50-virtiofsd.json
+
+abinfo "Installing documentations ..."
+install -Dvm 644 "$SRCDIR"/doc/*.md \
+    -t "$PKGDIR"/usr/share/doc/virtiofsd/

--- a/app-virtualization/virtiofsd/autobuild/beyond
+++ b/app-virtualization/virtiofsd/autobuild/beyond
@@ -1,5 +1,8 @@
-abinfo "Moving /usr/bin to /usr/libexec ..."
-mv -v "$PKGDIR"/usr/bin "$PKGDIR"/usr/libexec
+abinfo "Making symbolic links in /usr/libexec ..."
+# The path in libexec is used by many programs and the vhost-user json
+mkdir -vp "$PKGDIR"/usr/libexec
+ln -sv /usr/bin/virtiofsd \
+    "$PKGDIR"/usr/libexec/virtiofsd
 
 abinfo "Installing vhost-user JSON ..."
 install -Dvm 644 50-virtiofsd.json \

--- a/app-virtualization/virtiofsd/autobuild/defines
+++ b/app-virtualization/virtiofsd/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=virtiofsd
+PKGSEC=utils
+PKGDEP="qemu libcap-ng libseccomp"
+BUILDDEP="rustc llvm"
+PKGDES="Virtio-fs device backend for vhost-user"
+
+USECLANG=1

--- a/app-virtualization/virtiofsd/autobuild/defines
+++ b/app-virtualization/virtiofsd/autobuild/defines
@@ -5,3 +5,7 @@ BUILDDEP="rustc llvm"
 PKGDES="Virtio-fs device backend for vhost-user"
 
 USECLANG=1
+
+# FIXME: linker errors on loongson3
+# "ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; recompile with -fPIC"
+NOLTO__LOONGSON3=1

--- a/app-virtualization/virtiofsd/spec
+++ b/app-virtualization/virtiofsd/spec
@@ -1,0 +1,4 @@
+VER=1.13.0
+SRCS="git::commit=tags/v${VER}::https://gitlab.com/virtio-fs/virtiofsd.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=347345"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: depend on virtiofsd
- virtiofsd: new, 1.13.0

Package(s) Affected
-------------------

- qemu: 9.2.0-1
- qemu-aarch64-static: 9.2.0-1
- qemu-alpha-static: 9.2.0-1
- qemu-arm-static: 9.2.0-1
- qemu-armeb-static: 9.2.0-1
- qemu-guest-agent: 9.2.0-1
- qemu-i386-static: 9.2.0-1
- qemu-loongarch64-static: 9.2.0-1
- qemu-m68k-static: 9.2.0-1
- qemu-microblaze-static: 9.2.0-1
- qemu-microblazeel-static: 9.2.0-1
- qemu-mips-static: 9.2.0-1
- qemu-mips64-static: 9.2.0-1
- qemu-mips64el-static: 9.2.0-1
- qemu-mipsel-static: 9.2.0-1
- qemu-mipsn32-static: 9.2.0-1
- qemu-mipsn32el-static: 9.2.0-1
- qemu-or32-static: 9.2.0-1
- qemu-ppc-static: 9.2.0-1
- qemu-ppc64-static: 9.2.0-1
- qemu-ppc64le-static: 9.2.0-1
- qemu-riscv32-static: 9.2.0-1
- qemu-riscv64-static: 9.2.0-1
- qemu-s390x-static: 9.2.0-1
- qemu-sh4-static: 9.2.0-1
- qemu-sh4eb-static: 9.2.0-1
- qemu-sparc-static: 9.2.0-1
- qemu-sparc32plus-static: 9.2.0-1
- qemu-sparc64-static: 9.2.0-1
- qemu-user-static: 9.2.0-1
- qemu-x86-64-static: 9.2.0-1
- virtiofsd: 1.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtiofsd qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
