### PR TITLE
coreutils: update to 9.6

### DIFF
--- a/app-utils/coreutils/autobuild/defines
+++ b/app-utils/coreutils/autobuild/defines
@@ -25,3 +25,18 @@ AUTOTOOLS_AFTER="--enable-largefile \
                  --without-tty-group"
 
 PKGESS=1
+
+# FIXME: reconf failed because it extracts threadlib.m4 "serial 10" from
+# /usr/share/gettext/archive.dir.tar.xz (because
+# AM_GNU_GETTEXT_VERSION([0.19.2]) in configure.ac), overwriting the
+# shipped threadlib.m4 "serial 42".  Fedora uses a workaround:
+#
+#    sed -i 's/0.19.2/0.22.5/' bootstrap.conf configure.ac
+#
+# and LFS uses a different workaround (avoiding -i for autoreconf):
+#
+#    autoreconf -fv && automake -af
+#
+# But as we don't apply the Fedora i18n patch like them, we can simply
+# skip reconf here.
+RECONF=0

--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,5 +1,4 @@
-VER=9.5
+VER=9.6
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
-CHKSUMS="sha256::cd328edeac92f6a665de9f323c93b712af1858bc2e0d88f3f7100469470a1b8a"
+CHKSUMS="sha256::7a0124327b398fd9eb1a6abde583389821422c744ffa10734b24f557610d3283"
 CHKUPDATE="anitya::id=343"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- coreutils: update to 9.6
    Co-authored-by: 白铭骢 (Mingcong Bai) (@MingcongBai) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreutils: 9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
