### PR TITLE
ignition: new, 2.20.0


### DIFF
--- a/app-admin/ignition/autobuild/build
+++ b/app-admin/ignition/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Exporting package version and GLDFLAGS ..."
+export VERSION="$PKGVER"
+export GLDFLAGS=" -X github.com/coreos/ignition/v2/internal/distro.selinuxRelabel=false "
+
+abinfo "Building ignition ..."
+make all
+
+abinfo "Installing ignition ..."
+make install DESTDIR="$PKGDIR"

--- a/app-admin/ignition/autobuild/defines
+++ b/app-admin/ignition/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=ignition
+PKGSEC=utils
+PKGDEP="glibc util-linux-runtime"
+BUILDDEP="go"
+PKGDES="First-boot installer and configuration tool"
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
+ABSPLITDBG=0
+
+# FIXME: -buildmode=pie not supported on linux/mips64le
+FAIL_ARCH="loongson3"

--- a/app-admin/ignition/autobuild/overrides/usr/lib/dracut/modules.d/30ignition/ignition-kargs-helper.sh
+++ b/app-admin/ignition/autobuild/overrides/usr/lib/dracut/modules.d/30ignition/ignition-kargs-helper.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Requires sed to be present
+
+set -euxo pipefail
+
+# Mount /boot. Note that we mount /boot but we don't unmount it because we
+# are run in a systemd unit with MountFlags=slave so it is unmounted for us.
+bootmnt=/mnt/boot_partition
+mkdir -p ${bootmnt}
+bootdev=/dev/disk/by-label/boot
+mount -o rw ${bootdev} ${bootmnt}
+grubcfg="${bootmnt}/grub/grub.cfg"
+
+orig_kernelopts="$(grep kernelopts= $grubcfg | sed s,^kernelopts=,,)"
+# add leading and trailing whitespace to allow for easy sed replacements
+kernelopts=" $orig_kernelopts "
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+    --should-exist)
+        arg="$2"
+        # don't repeat the arg
+        if [[ ! "${kernelopts[*]}" =~ " ${arg} " ]]; then
+            kernelopts="$kernelopts$arg "
+        fi
+        shift 2
+        ;;
+    --should-not-exist)
+        kernelopts="$(echo "$kernelopts" | sed "s| $2 | |g")"
+        shift 2
+        ;;
+    *)
+        echo "Unknown option"
+        exit 1
+        ;;
+    esac
+done
+
+# trim the leading and trailing whitespace
+kernelopts="$(echo "$kernelopts" | sed -e 's,^[[:space:]]*,,' -e 's,[[:space:]]*$,,')"
+
+# only apply the changes & reboot if changes have been made
+if [[ "$kernelopts" != "$orig_kernelopts" ]]; then
+    sed -i "s|^\(kernelopts=\).*|\1$kernelopts|" $grubcfg
+
+    systemctl reboot --force
+fi

--- a/app-admin/ignition/spec
+++ b/app-admin/ignition/spec
@@ -1,0 +1,4 @@
+VER=2.20.0
+SRCS="git::commit=tags/v${VER}::https://github.com/coreos/ignition.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328236"


### PR DESCRIPTION
Topic Description
-----------------

- ignition: new, 2.20.0

Package(s) Affected
-------------------

- ignition: 2.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ignition
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
