### PR TITLE
binutils: backport loongarch64 patches to fix building issues

### DIFF
--- a/app-devel/binutils/01-main/patches/0001-Debian-Fix-gold-on-mips64-targets-loongson3-loongson2f-only.patch
+++ b/app-devel/binutils/01-main/patches/0001-Debian-Fix-gold-on-mips64-targets-loongson3-loongson2f-only.patch
@@ -1,8 +1,7 @@
-From 2b8122025d3f436a45907f5bd9eb8f13a9cdc2ae Mon Sep 17 00:00:00 2001
+From e9c89527c6e796e475c79971cb3747944d9aa0db Mon Sep 17 00:00:00 2001
 From: root <c@jia.je>
 Date: Fri, 2 Feb 2024 06:06:46 -0800
-Subject: [PATCH] [Debian] Fix gold on mips64 targets (loongson3/loongson2f
- only)
+Subject: [PATCH 1/5] Fix gold on mips64 targets (loongson3/loongson2f only)
 
 gold/
 
@@ -46,5 +45,5 @@ index a80ec6a3201..ccc17f735bc 100644
   targ_obj=mips
   targ_machine=EM_MIPS
 -- 
-2.45.2
+2.48.1
 

--- a/app-devel/binutils/01-main/patches/0002-LoongArch-Add-support-for-OUTPUT_FORMAT-binary.patch
+++ b/app-devel/binutils/01-main/patches/0002-LoongArch-Add-support-for-OUTPUT_FORMAT-binary.patch
@@ -1,7 +1,7 @@
-From 3a83f0342e545a638aba06f27bba76938ef251ab Mon Sep 17 00:00:00 2001
+From 8575cfa9cb29a2a59676dee611747a7ad3944371 Mon Sep 17 00:00:00 2001
 From: mengqinggang <mengqinggang@loongson.cn>
 Date: Fri, 28 Jun 2024 14:24:19 +0800
-Subject: [PATCH] LoongArch: Add support for OUTPUT_FORMAT("binary")
+Subject: [PATCH 2/5] LoongArch: Add support for OUTPUT_FORMAT("binary")
 
 In binary output format, loongarch_elf_hash_table return NULL and result
 in segment fault.
@@ -37,10 +37,10 @@ The tests of binutils, glibc and gcc is ok.
  create mode 100644 ld/testsuite/ld-loongarch-elf/binary.s
 
 diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
-index db6d419a052e..71fa8fa6f015 100644
+index 731af6a79a6..e8180fc2071 100644
 --- a/bfd/elfnn-loongarch.c
 +++ b/bfd/elfnn-loongarch.c
-@@ -157,9 +157,7 @@ loongarch_elf_new_section_hook (bfd *abfd, asection *sec)
+@@ -163,9 +163,7 @@ loongarch_elf_new_section_hook (bfd *abfd, asection *sec)
  
  /* Get the LoongArch ELF linker hash table from a link_info structure.  */
  #define loongarch_elf_hash_table(p)					\
@@ -52,7 +52,7 @@ index db6d419a052e..71fa8fa6f015 100644
  #define MINUS_ONE ((bfd_vma) 0 - 1)
  
 diff --git a/ld/emultempl/loongarchelf.em b/ld/emultempl/loongarchelf.em
-index 2da405820087..8a1a898f9e75 100644
+index 2da40582008..8a1a898f9e7 100644
 --- a/ld/emultempl/loongarchelf.em
 +++ b/ld/emultempl/loongarchelf.em
 @@ -102,23 +102,7 @@ gld${EMULATION_NAME}_after_allocation (void)
@@ -81,14 +81,14 @@ index 2da405820087..8a1a898f9e75 100644
 -LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS=larch_create_output_section_statements
 diff --git a/ld/testsuite/ld-loongarch-elf/binary.ld b/ld/testsuite/ld-loongarch-elf/binary.ld
 new file mode 100644
-index 000000000000..73cd4f2c1fc4
+index 00000000000..73cd4f2c1fc
 --- /dev/null
 +++ b/ld/testsuite/ld-loongarch-elf/binary.ld
 @@ -0,0 +1 @@
 +OUTPUT_FORMAT(binary);
 diff --git a/ld/testsuite/ld-loongarch-elf/binary.s b/ld/testsuite/ld-loongarch-elf/binary.s
 new file mode 100644
-index 000000000000..b0aeb62af1cf
+index 00000000000..b0aeb62af1c
 --- /dev/null
 +++ b/ld/testsuite/ld-loongarch-elf/binary.s
 @@ -0,0 +1,4 @@
@@ -97,7 +97,7 @@ index 000000000000..b0aeb62af1cf
 +.data
 +  .4byte 0x12345678
 diff --git a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
-index fb34eeb80cbb..16d89cd5a432 100644
+index 09c4c9fd5b2..d80014d9563 100644
 --- a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
 +++ b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
 @@ -118,6 +118,18 @@ if [istarget "loongarch64-*-*"] {
@@ -119,3 +119,6 @@ index fb34eeb80cbb..16d89cd5a432 100644
  }
  
  if [istarget "loongarch64-*-*"] {
+-- 
+2.48.1
+

--- a/app-devel/binutils/01-main/patches/0003-FROMLIST-LoongArch-Fix-broken-DESC-IE-transition-for.patch
+++ b/app-devel/binutils/01-main/patches/0003-FROMLIST-LoongArch-Fix-broken-DESC-IE-transition-for.patch
@@ -1,7 +1,7 @@
 From 08460fc56c7db0f7a341005bc33340c95df64b14 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 19 Dec 2024 13:23:02 +0800
-Subject: [PATCH 3/4] FROMLIST: LoongArch: Fix broken DESC => IE transition for
+Subject: [PATCH 3/5] FROMLIST: LoongArch: Fix broken DESC => IE transition for
  2.43 branch
 
 If code compiled with -fPIC -mtls-dialect=desc is linked into a PDE or
@@ -98,5 +98,5 @@ index e8180fc2071..3b149fe62e5 100644
  	{
  	case R_LARCH_ALIGN:
 -- 
-2.47.1
+2.48.1
 

--- a/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Add-elfNN_loongarch_mkobject-to-i.patch
+++ b/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Add-elfNN_loongarch_mkobject-to-i.patch
@@ -1,7 +1,7 @@
 From d3d8bd394bfdd8be15ced1f406a5231444801df1 Mon Sep 17 00:00:00 2001
 From: Xin Wang <yw987194828@gmail.com>
 Date: Fri, 6 Sep 2024 09:00:12 +0800
-Subject: [PATCH 4/4] BACKPORT: LoongArch: Add elfNN_loongarch_mkobject to
+Subject: [PATCH 4/5] BACKPORT: LoongArch: Add elfNN_loongarch_mkobject to
  initialize LoongArch tdata
 
 LoongArch: Add elfNN_loongarch_mkobject to initialize LoongArch tdata.
@@ -40,5 +40,5 @@ index 3b149fe62e5..ea480d74695 100644
    elfNN_loongarch_merge_private_bfd_data
  
 -- 
-2.47.1
+2.48.1
 

--- a/app-devel/binutils/01-main/patches/0005-LoongArch-Add-relaxation-support-for-call36-that-jum.patch
+++ b/app-devel/binutils/01-main/patches/0005-LoongArch-Add-relaxation-support-for-call36-that-jum.patch
@@ -1,0 +1,45 @@
+From 1417382a9ffb9c8141ded377d3a4d5d94b4873b8 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 26 Dec 2024 14:14:12 +0800
+Subject: [PATCH 5/5] LoongArch: Add relaxation support for call36 that jump to
+ PLT entry
+
+Part of commit a104f0a3e620 ("LoongArch: Add more relaxation support for
+call36") in master.  This part is needed for 2.43 branch to fix a link
+failure of QtWebEngine-6.8.1, which can be demonstrated with a reduced
+test case (with -shared):
+
+    .text
+    .zero 1 << 27   # pretending we have a lot of code in .text
+    .globl f        # preemptible, thus must be called via PLT
+    f:
+      move $a0, $r0
+      ret
+    g:
+      pcaddu18i $t0, %call36(f)
+      jr $t0
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ bfd/elfnn-loongarch.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index ea480d74695..1703f807db4 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -5408,6 +5408,11 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 		    && GOT_TLS_GD_BOTH_P (tls_type))
+ 		symval += 2 * GOT_ENTRY_SIZE;
+ 	    }
++	  else if (h->plt.offset != MINUS_ONE)
++	    {
++	      sym_sec = htab->elf.splt ? htab->elf.splt : htab->elf.iplt;
++	      symval = h->plt.offset;
++	    }
+ 	  else if ((h->root.type == bfd_link_hash_defined
+ 		  || h->root.type == bfd_link_hash_defweak)
+ 		&& h->root.u.def.section != NULL
+-- 
+2.48.1
+

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,5 @@
 VER=2.43.1
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: backport loongarch64 patches to fix building issues
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- binutils: 2.43.1-2
- binutils+cross-amd64: 2.43.1-2
- binutils+cross-arm64: 2.43.1-2
- binutils+cross-loongarch64: 2.43.1-2
- binutils+cross-loongson3: 2.43.1-2
- binutils+cross-mips64r6el: 2.43.1-2
- binutils+cross-ppc64el: 2.43.1-2
- binutils+cross-riscv64: 2.43.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
