### PR TITLE
gdb: update to 16.1

### DIFF
--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,4 @@
-VER=15.2
+VER=16.1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
-CHKSUMS="sha256::83350ccd35b5b5a0cba6b334c41294ea968158c573940904f00b92f76345314d"
+CHKSUMS="sha256::c2cc5ccca029b7a7c3879ce8a96528fdfd056b4d884f2b0511e8f7bc723355c6"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: update to 16.1
    Co-authored-by: Chen (@jiegec) <c@jia.je>

Package(s) Affected
-------------------

- gdb: 16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
