### PR TITLE
osu-lazer: update to 2025.118.0

### DIFF
--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-VER=2025.114.0
+VER=2025.118.0
 SRCS="git::commit=tags/$VER::https://github.com/ppy/osu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2025.118.0
    Co-authored-by: Kaiyang Wu (@OriginCode) <self@origincode.me>

Package(s) Affected
-------------------

- osu-lazer: 2025.118.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
