### PR TITLE
libipt: new, 2.1.1

### DIFF
--- a/app-devel/gdb/autobuild/defines
+++ b/app-devel/gdb/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gdb
 PKGSEC=devel
-PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline xz xxhash source-highlight ncurses"
+PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline xz xxhash source-highlight ncurses libipt"
 PKGDEP__RETRO="expat glibc-dbg isl readline"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -17,6 +17,7 @@ AUTOTOOLS_DEF="--prefix=/usr"
 AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
                  --with-python=/usr/bin/python3 \
                  --with-system-gdbinit=/etc/gdb/gdbinit \
+                 --with-intel-pt \
                  --enable-guile --enable-tui --enable-sim \
                  --enable-source-highlight --enable-threading \
                  --enable-64-bit-bfd --disable-install-libbfd \

--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,5 @@
 VER=16.1
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
 CHKSUMS="sha256::c2cc5ccca029b7a7c3879ce8a96528fdfd056b4d884f2b0511e8f7bc723355c6"
 CHKUPDATE="anitya::id=11798"

--- a/runtime-devices/libipt/autobuild/defines
+++ b/runtime-devices/libipt/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME="libipt"
+PKGDES="Intel(R) Processor Trace decoder library"
+PKGDEP="glibc"
+PKGSEC=libs

--- a/runtime-devices/libipt/spec
+++ b/runtime-devices/libipt/spec
@@ -1,0 +1,4 @@
+VER=2.1.1
+SRCS="git::commit=tags/v$VER::https://github.com/intel/libipt"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=7382"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: enable intel pt support
- libipt: new, 2.1.1

Package(s) Affected
-------------------

- gdb: 16.1-1
- libipt: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libipt gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
