### PR TITLE
LoongGPU Driver Package

### DIFF
--- a/runtime-common/libedit/autobuild/beyond
+++ b/runtime-common/libedit/autobuild/beyond
@@ -1,2 +1,10 @@
-rm "$PKGDIR"/usr/share/man/man3/history.3
-cp "$PKGDIR"/usr/share/man/man3/editline.3 "$PKGDIR"/usr/share/man/man3/el.3
+abinfo "Adjusting man pages ..."
+rm -v "$PKGDIR"/usr/share/man/man3/history.3
+ln -sv editline.3 \
+    "$PKGDIR"/usr/share/man/man3/el.3
+
+# Note: Debian introduced a SONAME change in 2016 without specific
+# mentioning of an ABI breakage.
+abinfo "Creating a compatibility symlink to Debian-specific libedit.so.2 ..."
+ln -sv libedit.so.0 \
+    "$PKGDIR"/usr/lib/libedit.so.2

--- a/runtime-common/libedit/spec
+++ b/runtime-common/libedit/spec
@@ -1,5 +1,5 @@
 VER=20191231+3.1
-REL=1
+REL=2
 SRCS="tbl::https://thrysoee.dk/editline/libedit-${VER/+/-}.tar.gz"
 CHKSUMS="sha256::dbb82cb7e116a5f8025d35ef5b4f7d4a3cdd0a3909a146a39112095a2d229071"
 CHKUPDATE="anitya::id=1599"

--- a/runtime-display/ldrm/autobuild/build
+++ b/runtime-display/ldrm/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Unpacking ldrm ..."
+dpkg -x "$SRCDIR"/libldrm_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Moving libraries to the correct location ..."
+mv -v "$PKGDIR"/usr/lib/loongarch64-linux-gnu/* \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/usr/lib/loongarch64-linux-gnu
+
+abinfo "Setting executable bits for shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/*.so*

--- a/runtime-display/ldrm/autobuild/defines
+++ b/runtime-display/ldrm/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ldrm
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="DRM (Direct Rendering Manager) interface library for LoongGPU"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: Loongnix compatibility.
+PKGPROV="libldrm"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-display/ldrm/spec
+++ b/runtime-display/ldrm/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/ldrm/libldrm_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::bf4cbb3e43ff8fc184fae757b98f7005236cd107a351396bf1bfc0a27b81c6de"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-display/loonggl/autobuild/build
+++ b/runtime-display/loonggl/autobuild/build
@@ -1,0 +1,26 @@
+abinfo "Unpacking loonggl ..."
+dpkg -x "$SRCDIR"/loonggl_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Moving libraries to the correct location ..."
+mv -v "$PKGDIR"/usr/lib/loongarch64-linux-gnu/* \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/usr/lib/loongarch64-linux-gnu
+
+abinfo "Setting executable bits for shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/{,loonggpu/}*.so*
+
+abinfo "Moving systemd unit(s) to the correct location ..."
+mv -v "$PKGDIR"/etc/systemd \
+    "$PKGDIR"/usr/lib/
+
+# FIXME: X.Org Server does not earch for DRI in /usr/lib/dri.
+# Whereas LoongGPU expects DRI modules to be stored in this path.
+abinfo "Moving X11 DRI module to the correct location ..."
+mkdir -pv "$PKGDIR"/usr/lib/xorg/modules/dri
+ln -sv ../../../loonggpu/dri/gsgpu_dri.so \
+    "$PKGDIR"/usr/lib/xorg/modules/dri/gsgpu_dri.so
+
+abinfo "Creating a symlink to libglapidispatch ..."
+ln -sv loonggpu/libglapidispatch.so.0 \
+    "$PKGDIR"/usr/lib/libglapidispatch.so.0

--- a/runtime-display/loonggl/autobuild/defines
+++ b/runtime-display/loonggl/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=loonggl
+PKGSEC=libs
+PKGDEP="elfutils expat gcc-runtime glibc ldrm libdrm lm-sensors x11-lib zlib"
+PKGDES="OpenGL runtime components for LoongGPU"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-display/loonggl/autobuild/postinst
+++ b/runtime-display/loonggl/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Enabling LoongGPU switching utility service ..."
+systemctl enable loonggl-sw --now

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggl/loonggl_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::b5815a6cc0aef84d742cfd052cb506e148da45d6046c046d4daef9aa96c6fbc9"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-display/loonggpu-driver/autobuild/defines
+++ b/runtime-display/loonggpu-driver/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=loonggpu-driver
+PKGSEC=libs
+# Note: loonggpu-settings is not yet implemented, add it to dependencies
+# when it happens.
+PKGDEP="firmware-loongson-graphics ldrm loonggl loong-gpucomp \
+        loonggpu-kernel-dkms xserver-xorg-video-loonggpu"
+PKGDES="Meta package for LoongGPU drivers and runtimes"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"
+ABSPLITDBG=0
+
+ABTYPE=dummy

--- a/runtime-display/loonggpu-driver/spec
+++ b/runtime-display/loonggpu-driver/spec
@@ -1,0 +1,6 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+DUMMYSRC=1
+CHKUPDATE="anitya::id=376483"

--- a/runtime-display/xserver-xorg-video-loonggpu/autobuild/build
+++ b/runtime-display/xserver-xorg-video-loonggpu/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Unpacking xserver-xorg-video-loonggpu ..."
+dpkg -x "$SRCDIR"/xserver-xorg-video-loonggpu_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/

--- a/runtime-display/xserver-xorg-video-loonggpu/autobuild/defines
+++ b/runtime-display/xserver-xorg-video-loonggpu/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=xserver-xorg-video-loonggpu
+PKGSEC=libs
+PKGDEP="glibc ldrm libdrm systemd xorg-server"
+PKGDES="X.Org DDX (Device Dependent X) driver for LoongGPU"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: AOSC OS conventions.
+PKGPROV="xf86-video-loonggpu"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-display/xserver-xorg-video-loonggpu/spec
+++ b/runtime-display/xserver-xorg-video-loonggpu/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/x/xserver-xorg-video-loonggpu/xserver-xorg-video-loonggpu_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::c470fd65c61429ca3f80c6cf5d97f2ab6c0b95b015031a3900c4b22f2f5b0591"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-kernel/firmware-loongson-graphics/autobuild/build
+++ b/runtime-kernel/firmware-loongson-graphics/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Unpacking firmware-loongson-graphics ..."
+dpkg -x "$SRCDIR"/firmware-loongson-graphics_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Moving firmware to the correct location ..."
+mkdir -pv "$PKGDIR"/usr/lib
+mv -v "$PKGDIR"/lib/firmware \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/lib

--- a/runtime-kernel/firmware-loongson-graphics/autobuild/defines
+++ b/runtime-kernel/firmware-loongson-graphics/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=firmware-loongson-graphics
+PKGSEC=libs
+PKGDEP=""
+PKGDES="Device-specific firmware for LoongGPU"
+
+# Note: LoongArch-specific.
+ABSPLITDBG=0
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-kernel/firmware-loongson-graphics/spec
+++ b/runtime-kernel/firmware-loongson-graphics/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/f/firmware-loongson-graphics/firmware-loongson-graphics_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::9fd7550b34b105eb0b6bbdf8750b242a542c75893ee67872738692c519074d0d"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/build
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Unpacking loonggpu-kernel-dkms ..."
+dpkg -x "$SRCDIR"/loonggpu-kernel-dkms_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Patching module sources to fix build with newer kernel versions ..."
+cd "$PKGDIR"/usr/src/loonggpu-${__UPSTREAM_VER%%-*}/
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.deferred

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/defines
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=loonggpu-kernel-dkms
+PKGSEC=libs
+PKGDEP="dracut dkms"
+PKGDES="Kernel module sources (DKMS) for LoongGPU kernel-mode drivers"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"
+ABSPLITDBG=0

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0001-loonggpu-include-use-video-aperture-helpers-for-Linu.patch.deferred
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0001-loonggpu-include-use-video-aperture-helpers-for-Linu.patch.deferred
@@ -1,0 +1,58 @@
+From 405d190d84e400898d143420ea087fc988a72ec0 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 20 Jan 2025 18:29:59 +0800
+Subject: [PATCH 1/3] loonggpu: include: use video aperture helpers for Linux
+ >= 6.13.
+
+Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM
+aperture helpers were dropped in favour of video aperture helpers.
+
+Per other drivers in the mainline tree, for instance, commit 902014e20f7c
+("drm/loongson: Use video aperture helpers"), the
+call to `drm_aperture_remove_conflicting_framebuffers()' was rewritten
+as `aperture_remove_conflicting_devices()'.
+
+Follow upstream changes with condition:
+
+  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+
+To fix build for Linux >= 6.13.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ include/gsgpu_helper.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index c4f9727..fa26309 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -21,6 +21,10 @@
+ #include "gsgpu.h"
+ #include <linux/vgaarb.h>
+ #include <linux/console.h>
++#include <linux/version.h>
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++#include <linux/aperture.h>
++#endif
+ #if defined(LG_DRM_DRM_APERTURE_H_PRESENT)
+ #include <drm/drm_aperture.h>
+ #endif
+@@ -838,9 +842,14 @@ static int lg_kick_out_firmware_fb(struct pci_dev *pdev, struct drm_driver *drv)
+ 	kfree(ap);
+ 
+ 	return 0;
++#else
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++	aperture_remove_conflicting_devices(pci_resource_start(pdev, 2),
++					     pci_resource_len(pdev, 2), drv->name);
+ #else
+ 	drm_aperture_remove_conflicting_framebuffers(pci_resource_start(pdev, 2),
+ 						pci_resource_len(pdev, 2), drv);
++#endif
+ 	return 0;
+ #endif
+ }
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0002-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch.deferred
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0002-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch.deferred
@@ -1,0 +1,39 @@
+From 3b12cb887716602100bfe36091f3184729029908 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 20 Jan 2025 18:34:47 +0800
+Subject: [PATCH 2/3] loonggpu: pass string literal parameter to
+ MODULE_IMPORT_NS for Linux >= 6.13
+
+With commit cdd30ebb1b9f ("module: Convert symbol namespace to string
+literal"), introduced since Linux 6.13-rc2, the macro `MODULE_IMPORT_NS'
+uses string literal as parameter.
+
+Convert parameter `DMA_BUF' to string literal for Linux >= 6.13.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ gsgpu/gsgpu_display.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gsgpu/gsgpu_display.c b/gsgpu/gsgpu_display.c
+index 90bc2c4..8bcc5a2 100644
+--- a/gsgpu/gsgpu_display.c
++++ b/gsgpu/gsgpu_display.c
+@@ -14,9 +14,14 @@
+ #include <linux/dma-buf.h>
+ #include "gsgpu_helper.h"
+ #include "gsgpu_display.h"
++#include <linux/module.h>
+ #if defined (MODULE_IMPORT_NS)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++MODULE_IMPORT_NS("DMA_BUF");
++#else
+ MODULE_IMPORT_NS(DMA_BUF);
+ #endif
++#endif
+ 
+ static void gsgpu_display_flip_callback(struct dma_fence *f,
+ 					 struct dma_fence_cb *cb)
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0003-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch.deferred
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches/0003-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch.deferred
@@ -1,0 +1,27 @@
+From 095e20e815ab87cdf6e09b0eba61403925a16b22 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 21 Jan 2025 11:51:25 +0800
+Subject: [PATCH 3/3] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes option
+
+This option is marked deprecated and causes a warning during DKMS builds.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index d31fb96..044472a 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -8,7 +8,6 @@ BUILT_MODULE_NAME[0]="loonggpu"
+ DEST_MODULE_NAME[0]="$PACKAGE_NAME"
+ DEST_MODULE_LOCATION[0]="/updates/dkms"
+ AUTOINSTALL=yes
+-REMAKE_INITRD=yes
+ 
+ MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
+     make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/postinst.in
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/postinst.in
@@ -1,0 +1,16 @@
+VER=%PKGVER%
+unset ARCH
+
+echo "Installing LoongGPU kernel modules..."
+for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+	if [ -f "/usr/lib/modules/${i}/modules.dep" -a \
+	     -f "/usr/lib/modules/${i}/modules.order" -a \
+	     -f "/usr/lib/modules/${i}/modules.builtin" ]; then
+		echo -e "\033[36m**\033[0m\tBuilding LoongGPU kernel modules for $i ..."
+		dkms install loonggpu/${VER} -k $i > /dev/null
+	else
+		echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+	fi
+done
+
+update-initramfs

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/prepare
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/prepare
@@ -1,0 +1,7 @@
+for i in postinst prerm; do
+    abinfo "Generating $i ..."
+    sed -e \
+        "s/%PKGVER%/${PKGVER%%~*}/g" \
+        "${SRCDIR}/autobuild/${i}.in" > \
+        "${SRCDIR}/autobuild/${i}"
+done

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/prerm.in
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/prerm.in
@@ -1,0 +1,4 @@
+VER=%PKGVER%
+unset ARCH
+
+dkms remove loonggpu/${VER} --all || true > /dev/null

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-scientific/loong-gpucomp/autobuild/build
+++ b/runtime-scientific/loong-gpucomp/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Unpacking loong-gpucomp ..."
+dpkg -x "$SRCDIR"/libloong-gpucomp_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Moving libraries to the correct location ..."
+mv -v "$PKGDIR"/usr/lib/loongarch64-linux-gnu/* \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/usr/lib/loongarch64-linux-gnu
+
+abinfo "Setting executable bits for shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/*.so*

--- a/runtime-scientific/loong-gpucomp/autobuild/defines
+++ b/runtime-scientific/loong-gpucomp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=loong-gpucomp
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc libedit ncurses zlib"
+PKGDES="GPU compute runtime for LoongGPU"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: Loongnix compatibility.
+PKGPROV="libloong-gpucomp"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-scientific/loong-gpucomp/spec
+++ b/runtime-scientific/loong-gpucomp/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.1-alpha-lnd25.5
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/\~}
+SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loong-gpucomp/libloong-gpucomp_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::aadead1040efc076d8b6d71d88f8b7c11888a01b2446d46ee0c662c681075bc3"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"


### PR DESCRIPTION
Topic Description
-----------------

- libedit: add Debian\-compatible libedit.so.2 symlink
    Debian introduced a SONAME change in 2016 without specific mentioning of
    an ABI breakage.
    Also clean up man page adjustments.
- loonggpu\-driver: new, 1.0.1\~alpha\~lnd25.5
- firmware\-loongson\-graphics: new, 1.0.1\~alpha\~lnd25.5
- xserver\-xorg\-video\-loonggpu: new, 1.0.1\~alpha\~lnd25.5
- loonggpu\-kernel\-dkms: new, 1.0.1\~alpha\~lnd25.5
- loonggl: new, 1.0.1\~alpha\~lnd25.5
- loong\-gpucomp: new, 1.0.1\~alpha\~lnd25.5
- ldrm: new, 1.0.1\~alpha\~lnd25.5

Package(s) Affected
-------------------

- firmware-loongson-graphics: 1.0.1~alpha~lnd25.5
- ldrm: 1.0.1~alpha~lnd25.5
- libedit: 20191231+3.1-2
- loong-gpucomp: 1.0.1~alpha~lnd25.5
- loonggl: 1.0.1~alpha~lnd25.5
- loonggpu-driver: 1.0.1~alpha~lnd25.5
- loonggpu-kernel-dkms: 1.0.1~alpha~lnd25.5
- xserver-xorg-video-loonggpu: 1.0.1~alpha~lnd25.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ldrm loong-gpucomp loonggl loonggpu-kernel-dkms xserver-xorg-video-loonggpu firmware-loongson-graphics loonggpu-driver libedit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
