### PR TITLE
gcompris: new, 4.3

### DIFF
--- a/app-games/gcompris/autobuild/defines
+++ b/app-games/gcompris/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME="gcompris"
+PKGSEC="games"
+PKGDES="An educational software suite"
+PKGDEP="qt-5 gstreamer hicolor-icon-theme"
+BUILDDEP="extra-cmake-modules"
+
+CMAKE_AFTER=(
+        '-DCMAKE_INSTALL_PREFIX=/usr'
+        '-DCOMPILE_DOC=ON'
+)

--- a/app-games/gcompris/spec
+++ b/app-games/gcompris/spec
@@ -1,0 +1,4 @@
+VER=4.3
+SRCS="git::commit=tags/V$VER::https://invent.kde.org/education/gcompris.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=879"


### PR DESCRIPTION
Topic Description
-----------------

- gcompris: new, 4.3

Package(s) Affected
-------------------

- gcompris: 4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcompris
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
