### PR TITLE
mtools: update to 4.0.47

### DIFF
--- a/app-admin/mtools/spec
+++ b/app-admin/mtools/spec
@@ -1,4 +1,4 @@
-VER=4.0.46
+VER=4.0.47
 SRCS="https://ftp.gnu.org/gnu/mtools/mtools-$VER.tar.gz"
-CHKSUMS="sha256::4243e79af24133525755f37fc85e9c09fd904c89561ee19cd669454fc5b28ded"
+CHKSUMS="sha256::e0111d863f9ef55715582f4b69a7ffd261645e0c89417cefeb308cd080002e04"
 CHKUPDATE="anitya::id=2028"


### PR DESCRIPTION
Topic Description
-----------------

- mtools: update to 4.0.47
    Co\-authored\-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mtools: 4.0.47

Security Update?
----------------

No

Build Order
-----------

```
#buildit mtools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
