### PR TITLE
polyphone: update to 2.5.1

### DIFF
--- a/app-multimedia/polyphone/autobuild/build
+++ b/app-multimedia/polyphone/autobuild/build
@@ -1,16 +1,23 @@
-abinfo "Building polyphone..." 
+abinfo "Building polyphone ..." 
 qmake-qt5 CONFIG+=release CONFIG+=force_debug_info "$SRCDIR"/sources/polyphone.pro
 make
 
-abinfo "Installing polyphone..."
-install -vDm 755 "$SRCDIR"/bin/polyphone -t "$PKGDIR"/usr/bin/
-install -vDm 644 "$SRCDIR"/sources/resources/logo.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/polyphone.svg
-install -vDm 644 "$SRCDIR"/sources/resources/polyphone.png -t "$PKGDIR"/usr/share/icons/hicolor/512x512/apps
-install -vDm 644 "$SRCDIR"/sources/contrib/man/fr/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/fr/man1/
-install -vDm 644 "$SRCDIR"/sources/contrib/man/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/man1/
-install -vDm 644 "$SRCDIR"/sources/contrib/man/ru/man1/polyphone.*1 -t "$PKGDIR"/usr/share/man/ru/man1/
-install -vDm 644 "$SRCDIR"/sources/contrib/*.desktop -t "$PKGDIR"/usr/share/applications/
-install -vDm 644 "$SRCDIR"/sources/contrib/audio-x-soundfont.svg -t "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/
-install -vDm 644 "$SRCDIR"/sources/contrib/*.xml -t "$PKGDIR"/usr/share/metainfo/
-install -vDm 644 "$SRCDIR"/sources/contrib/polyphone.xml -t "$PKGDIR"/usr/share/mime/packages/
-install -vDm 644 "$SRCDIR"/{README.md,sources/changelog} -t "$PKGDIR"/usr/share/doc/polyphone/
+abinfo "Installing polyphone ..."
+install -vDm 755 "$SRCDIR"/bin/polyphone \
+    -t "$PKGDIR"/usr/bin/
+install -vDm 644 "$SRCDIR"/sources/resources/polyphone.png \
+    -t "$PKGDIR"/usr/share/icons/hicolor/512x512/apps
+install -vDm 644 "$SRCDIR"/sources/contrib/man/fr/man1/polyphone.*1 \
+    -t "$PKGDIR"/usr/share/man/fr/man1/
+install -vDm 644 "$SRCDIR"/sources/contrib/man/man1/polyphone.*1 \
+    -t "$PKGDIR"/usr/share/man/man1/
+install -vDm 644 "$SRCDIR"/sources/contrib/io.polyphone.polyphone.desktop \
+    -t "$PKGDIR"/usr/share/applications/
+install -vDm 644 "$SRCDIR"/sources/resources/polyphone.png \
+    -t "$PKGDIR"/usr/share/icons/hicolor/512x512/mimetypes/audio-x-soundfont.png
+install -vDm 644 "$SRCDIR"/sources/contrib/polyphone.xml \
+    -t "$PKGDIR"/usr/share/metainfo/
+install -vDm 644 "$SRCDIR"/sources/contrib/polyphone.xml \
+    -t "$PKGDIR"/usr/share/mime/packages/
+install -vDm 644 "$SRCDIR"/{README.md,sources/changelog} \
+    -t "$PKGDIR"/usr/share/doc/polyphone/

--- a/app-multimedia/polyphone/autobuild/defines
+++ b/app-multimedia/polyphone/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=polyphone
 PKGSEC=sound
-PKGDEP="qt-5 zlib openssl"
-BUILDDEP="flac jack libogg libvorbis portaudio qcustomplot rtmidi stk"
+PKGDEP="gcc-runtime qt-5 zlib openssl rtmidi alsa-lib stk libvorbis \
+    libsndfile libogg jack"
+BUILDDEP="flac portaudio qcustomplot"
 PKGDES="A soundfont editor for quickly designing musical instruments"

--- a/app-multimedia/polyphone/spec
+++ b/app-multimedia/polyphone/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=2.5.1
 SRCS="git::commit=tags/$VER::https://github.com/davy7125/polyphone.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372486"

--- a/runtime-desktop/qcustomplot/autobuild/build
+++ b/runtime-desktop/qcustomplot/autobuild/build
@@ -9,5 +9,5 @@ install -vdm 755 "$PKGDIR"/usr/lib/
 cp -av "$SRCDIR"/libqcustomplot.so* "$PKGDIR"/usr/lib/
 install -vDm 644 "$SRCDIR"/changelog.txt -t "$PKGDIR"/usr/share/doc/qcustomplot/
 install -vDm 644 "$SRCDIR"/documentation/*.qch -t "$PKGDIR"/usr/share/doc/qt/
-find "$SRCDIR"/examples -type f -exec install -vDm 644 {} "$PKGDIR"/usr/share/doc/qcustomplot/{} \; 
-find "$SRCDIR"/documentation/html -type f -exec install -vDm 644 {} "$PKGDIR"/usr/share/doc/qcustomplot/{} \;
+cp -vR "$SRCDIR"/documentation/html "$PKGDIR"/usr/share/doc/qcustomplot
+cp -vR "$SRCDIR"/examples/* -t "$PKGDIR"/usr/share/doc/qcustomplot

--- a/runtime-desktop/qcustomplot/spec
+++ b/runtime-desktop/qcustomplot/spec
@@ -1,4 +1,5 @@
 VER=2.1.1
+REL=1
 SRCS="tbl::https://www.qcustomplot.com/release/$VER/QCustomPlot.tar.gz \
      file::rename=sharedlib.tar.gz::https://www.qcustomplot.com/release/$VER/QCustomPlot-sharedlib.tar.gz"
 CHKSUMS="sha256::9afc16e70e8bd8c8d5b13020387716f5e063e115b6599f0421a3846dc6ec312a \


### PR DESCRIPTION
Topic Description
-----------------

- qcustomplot: rework to fix documentation path
- polyphone: update to 2.5.1

Package(s) Affected
-------------------

- polyphone: 2.5.1
- qcustomplot: 2.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qcustomplot polyphone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
