### PR TITLE
abdownloadmanager: update to 1.5.2

### DIFF
--- a/app-web/abdownloadmanager/spec
+++ b/app-web/abdownloadmanager/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.5.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/amir1376/ab-download-manager"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376269"


### PR DESCRIPTION
Topic Description
-----------------

- abdownloadmanager: update to 1.5.2
    Co\-authored\-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- ab-download-manager: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit abdownloadmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
