### PR TITLE
sunshine: update to 2025.118.151840

### DIFF
--- a/app-multimedia/sunshine/spec
+++ b/app-multimedia/sunshine/spec
@@ -1,5 +1,4 @@
-VER=0.23.1
-REL=1
+VER=2025.118.151840
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/LizardByte/Sunshine"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236300"


### PR DESCRIPTION
Topic Description
-----------------

- sunshine: update to 2025.118.151840
    Co\-authored\-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- sunshine: 2025.118.151840

Security Update?
----------------

No

Build Order
-----------

```
#buildit sunshine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
