### PR TITLE
GRUB: Disable firmware setup entry for mips64el

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/46] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/47] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -71,5 +71,5 @@ index 656301eaf..30f27f15b 100644
  
  osx_entry() {
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/46] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/47] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -69,5 +69,5 @@ index 30f27f15b..f300e46fc 100644
  
  osx_entry() {
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/46] Don't add '*' to highlighted row
+Subject: [PATCH 03/47] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -22,5 +22,5 @@ index b1321eb26..b147e0657 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/46] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/47] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
@@ -28,5 +28,5 @@ index b147e0657..e5960fd65 100644
    geo->timeout_lines = 2;
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/46] Indent menu entries
+Subject: [PATCH 05/47] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
@@ -22,5 +22,5 @@ index e5960fd65..fd1de05e3 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/46] Fix margins
+Subject: [PATCH 06/47] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
@@ -33,5 +33,5 @@ index fd1de05e3..371524bf2 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/46] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/47] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -23,5 +23,5 @@ index 371524bf2..f83f7ca54 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/46] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/47] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -41,5 +41,5 @@ index 94dd8be13..98ee5bc58 100644
  fi
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/46] Don't draw a border around the menu
+Subject: [PATCH 09/47] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -70,5 +70,5 @@ index f83f7ca54..982ef9100 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/46] Use the standard margin for the timeout string
+Subject: [PATCH 10/47] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -39,5 +39,5 @@ index 982ef9100..986877454 100644
      }
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/46] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/47] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -22,5 +22,5 @@ index abcc1c2f5..27696e034 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/46] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/47] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -23,5 +23,5 @@ index c9bde9182..e896c0c1a 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/46] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/47] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -41,5 +41,5 @@ index 6a316a5ba..6816e09d4 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 59e7ba1bf0d63ddcd8e3d40888bcac0b7223e70e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/46] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/47] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -23,5 +23,5 @@ index bd4431000..8b8565f24 100644
      return;
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From c23c121bde5381debb61889fb3cc94a6061628ab Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/46] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/47] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -29,5 +29,5 @@ index 7dc5657bb..c5eef8ac6 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From 71cb4fcc6a76c5cdc3a629351097a73c664fb6f5 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/46] commands: add new command memsize
+Subject: [PATCH 16/47] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -377,5 +377,5 @@ index 000000000..b5ab52f4b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From b98c6eb9ba1e8f88e7d2df1c6700fef74a9b4fe2 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/46] commands: add new command 'pause'
+Subject: [PATCH 17/47] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -88,5 +88,5 @@ index 000000000..7b7fc185b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 5855f82d979f2db3e185e75c356686f5b23943ae Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/46] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/47] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -23,5 +23,5 @@ index 986877454..584620a52 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 0ec6cd51f5f49d1c2b82737279589431427f3838 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/46] po: add patch to disable parallel execution
+Subject: [PATCH 19/47] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From b69e36efa6f9745e73e9312d2db26875ce83a8fc Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/46] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/47] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is
@@ -856,5 +856,5 @@ index 000000000..6123d7b7c
 +# End:
 +# ex: ts=4 sw=4 et filetype=sh
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 1632a45c5d4d78dea18e449b3592120cc8517bff Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/46] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/47] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion
@@ -185,5 +185,5 @@ index 4c88ee901..749a5d3cf 100644
      if [[ "$cur" == -* ]]; then
          __grubcomp "$(__grub_get_options_from_help)"
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 2f40e35813a4677b7409d6d6b9459c0ed3e98bca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/46] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/47] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:
@@ -93,5 +93,5 @@ index 27696e034..cfb749967 100644
        free (imgname);
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 624eb1c0887dba508ef03385e7f49f7d951b3ac4 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 23/46] loongarch64: able to start on legacy firmware
+Subject: [PATCH 23/47] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.
@@ -44,5 +44,5 @@ index d460267be..534ba4b32 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 977635494cb3f3418924842943088801ee241ee5 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 24/46] Add support for forcing EFI installation to the
+Subject: [PATCH 24/47] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI
@@ -222,5 +222,5 @@ index c5eef8ac6..efa5cc573 100644
  
  	free (dst);
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From 6015952363f071aacf6f5d2de607fc168daa1746 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 25/46] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 25/47] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not
@@ -72,5 +72,5 @@ index efa5cc573..6a5f86b09 100644
  	grub_set_install_backup_ponr ();
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From 61a3db3ad1e300a531aaa7dcdd4bf496f1b5be65 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 26/46] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 26/47] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-
@@ -2461,5 +2461,5 @@ index 4237383ac..53a3fd107 100644
        .dirname = "loongarch64-efi",
        .names = { "loongarch64-efi", NULL },
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From e4e7a42521c5b178a86caf1ac950dfc1f79e0a30 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 27/46] mips64: Add support for Loongson.
+Subject: [PATCH 27/47] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-
@@ -1402,5 +1402,5 @@ index 52e6ae6eb..e4063783f 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From e5d36fc00b3467b49851f20effb4e9c3400e73ce Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 28/46] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 28/47] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---
@@ -30,5 +30,5 @@ index afa508f81..226207303 100644
      return grub_errno;
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From fb3c7be5f6bd065554321f75d65132dfd53bb2d4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 29/46] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 29/47] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---
@@ -23,5 +23,5 @@ index 1969f1f90..36a30bbcd 100644
  	grub_util_info ("translating the relocation section %s",
  			smd->strtab + grub_le_to_cpu32 (s->sh_name));
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 828d7983742c9336e8a512b1bd4ec74cb3e4ec33 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 30/46] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 30/47] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---
@@ -22,5 +22,5 @@ index 226207303..514335e47 100644
  
    grub_snprintf ((char *) linux_args_addr + rd_addr_arg_off,
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From d4942f62fdf97f922516b3e7ea3d72e7c8dcf772 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 31/46] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 31/47] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----
@@ -49,5 +49,5 @@ index 19eefeb4a..f06f9ae4b 100644
      grub_fatal ("cannot allocate Loongson boot parameters!");
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,7 +1,7 @@
 From 402da3bece331169230d07b83496885cd305529a Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 32/46] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 32/47] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-
@@ -21,5 +21,5 @@ index f06f9ae4b..e8acb6965 100644
  
    if (boot_params)
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,7 +1,7 @@
 From 8ca095a942e8e19033c3e0dde9da7412c62f8698 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 33/46] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 33/47] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-
@@ -21,5 +21,5 @@ index 049d3187c..6d518b537 100644
  	  }
  	  break;
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 8d9bff60ccfd4e9d67e83479df15b5c072fd7b14 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 34/46] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 34/47] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---
@@ -21,5 +21,5 @@ index 7fd508c54..ab225cb98 100644
  #include <grub/efi/efi.h>
  #include <grub/loader.h>
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
@@ -1,7 +1,7 @@
 From 1c99dd698362042f2da9e9ac7283061984405c8c Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 35/46] lib/mips64: silence werror
+Subject: [PATCH 35/47] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-
@@ -31,5 +31,5 @@ index e8acb6965..a283b41b1 100644
  		   bpmem->map[index].memtype,
  		   bpmem->map[index].memstart,
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
@@ -1,7 +1,7 @@
 From cb1215b5499cb16020d9cca639d95ca0ba31b642 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 36/46] loader/mips64: fix warnings and style
+Subject: [PATCH 36/47] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------
@@ -141,5 +141,5 @@ index 514335e47..6b6cac273 100644
    if (linux_size == 0)
      return grub_errno;
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0037-kern-efi-mm-mips64-allocate-more-memory-at-initializ.patch
+++ b/app-admin/grub/autobuild/patches/0037-kern-efi-mm-mips64-allocate-more-memory-at-initializ.patch
@@ -1,7 +1,7 @@
 From 80d7a2cf0cac578a840163fe53e989a261a6de28 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 8 Oct 2024 16:40:04 +0800
-Subject: [PATCH 37/46] kern/efi/mm: mips64: allocate more memory at
+Subject: [PATCH 37/47] kern/efi/mm: mips64: allocate more memory at
  initialization
 
 ---
@@ -93,5 +93,5 @@ index 6a6fba891..9bd82c223 100644
  grub_efi_mm_init (void)
  {
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0038-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0038-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From 72963d5d984e8874f55638941e92b2b34939a8bb Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 38/46] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 38/47] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI
@@ -23,5 +23,5 @@ index fabba39fc..3fc2a6007 100644
  	    default:
  	      grub_util_error ("%s", _("You've found a bug"));
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0039-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0039-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From 44a244b939e79586ebda49b9ab74bc03ec930295 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 39/46] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 39/47] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.
@@ -23,5 +23,5 @@ index 25b861f1f..3759f522d 100644
        free (imgname);
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0040-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0040-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 35d070776ebcc91654e454d5b4eee6141a5a72bb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 40/46] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 40/47] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken
@@ -35,5 +35,5 @@ index 6816e09d4..5e17a9db4 100644
      if [ "x$GRUB_THEME" != x ] && [ -f "$GRUB_THEME" ] \
  	&& is_path_readable_by_grub "$GRUB_THEME"; then
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0041-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0041-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From e4beb231ba77c3cd3a0afa182c707d8cce1197ff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 41/46] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 41/47] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and
@@ -123,5 +123,5 @@ index 5e17a9db4..0adf84019 100644
 +set right_to_select=${GRUB_RIGHT_TO_SELECT}
 +EOF
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0042-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0042-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From ab46b6a4e5ec936c635692e5cf662afa3f599149 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 42/46] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 42/47] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe
@@ -28,5 +28,5 @@ index 1c2365ddb..9cbeac6cc 100644
  gettext_printf "Adding boot menu entry for UEFI Firmware Settings ...\n" >&2
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0043-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0043-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,7 +1,7 @@
 From c8aa509735011d988096e8166075244ee47d8650 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 43/46] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 43/47] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 3 ---
@@ -29,5 +29,5 @@ index 4d0dfb700..7523b9895 100644
  /po/stamp-po
  /printf_test
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0045-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0045-po-update-zh_CN-translation.patch
@@ -1,7 +1,7 @@
 From 81bca2cb3dc87f594481e2f1359b0b22c062669d Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 45/46] po: update zh_CN translation
+Subject: [PATCH 45/47] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------
@@ -2689,5 +2689,5 @@ index 468f6368f..64fe257e6 100644
  
  #~ msgid "Predicted = %d, written = %llu\n"
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0046-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0046-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From 69a8ab9133a1d2369bfe60c00c8afbdda49df3ee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 46/46] po: update zh_TW translations
+Subject: [PATCH 46/47] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---
@@ -9687,5 +9687,5 @@ index 8713a1ac1..6e863c161 100644
 +#~ msgid "cannot guess the root device. Specify the option `--root-device'"
 +#~ msgstr "無法猜測根裝置。請指定「--root-device」選項"
 -- 
-2.47.0
+2.48.1
 

--- a/app-admin/grub/autobuild/patches/0047-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
+++ b/app-admin/grub/autobuild/patches/0047-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
@@ -1,0 +1,26 @@
+From 1a952dbf057f8791004854bf9a17f3f5b7d5785b Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sun, 19 Jan 2025 23:18:56 +0800
+Subject: [PATCH 47/47] grub.d/30_uefi-firmware: disable fwsetup menu for
+ mips64el-efi
+
+---
+ util/grub.d/30_uefi-firmware.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/grub.d/30_uefi-firmware.in b/util/grub.d/30_uefi-firmware.in
+index 9cbeac6cc..4ff256a20 100644
+--- a/util/grub.d/30_uefi-firmware.in
++++ b/util/grub.d/30_uefi-firmware.in
+@@ -31,7 +31,7 @@ LABEL=$(gettext_printf "UEFI Firmware Settings")
+ gettext_printf "Adding boot menu entry for UEFI Firmware Settings ...\n" >&2
+ 
+ cat << EOF
+-if [ "\$grub_platform" = "efi" ]; then
++if [ "\$grub_platform" = "efi" -a "\$grub_cpu" != "mips64el" ]; then
+ 	fwsetup --is-supported
+ 	if [ "\$?" = 0 ]; then
+ 		menuentry '$LABEL' \$menuentry_id_option 'uefi-firmware' {
+-- 
+2.48.1
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=16.0.01
 RETROFONTVER=20200402
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=2
+REL=3
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftp.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: add patch to apply the fwsetup quirk for mips64el
    Some EFI firmware on Loongson 3 on mips64el has a broken OsIndicator
    implementation \- running \`fwsetup' command on such platform freezes the
    machine. Disabling the fwsetup entry for mips64el to work around this
    issue.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont16.0.01-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
