### PR TITLE
ccls: update to 0.20241108

### DIFF
--- a/app-devel/ccls/spec
+++ b/app-devel/ccls/spec
@@ -1,5 +1,4 @@
-VER=0.20240202
-REL=1
+VER=0.20241108
 SRCS="git::commit=tags/$VER::https://github.com/MaskRay/ccls"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19536"


### PR DESCRIPTION
Topic Description
-----------------

- ccls: update to 0.20241108
    Co\-authored\-by: xtex \(@xtexChooser\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- ccls: 0.20241108

Security Update?
----------------

No

Build Order
-----------

```
#buildit ccls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
