### PR TITLE
tzdata: update to 2025a

### DIFF
--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,4 +1,4 @@
-VER=2024a
+VER=2025a
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
-CHKSUMS="sha256::0d0434459acbd2059a7a8da1f3304a84a86591f6ed69c6248fffa502b6edffe3"
+CHKSUMS="sha256::4d5fcbc72c7c450ebfe0b659bd0f1c02fbf52fd7f517a9ea13fe71c21eb5f0d0"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: update to 2025a
    Signed\-off\-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- tzdata: 2025a

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
