### PR TITLE
linux-firmware: update to 20250120

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250113
+UPSTREAM_VER=20250120
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=a28a9226ccb8bf393b8e7dd8970a4d967c1a1d92::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=e7a96ae916909f4620bc1999fe481a606eeb4adf::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux\-firmware: update to 20250120
    \- Update Linux Firmware to current \(20250120\) HEAD e7a96ae916909f4620bc1999fe481a606eeb4adf...
    \- Changelog below...
    \- AMD
    \- Update DMCUB for DCN35 and DCN401, version 0.0.250.0.
    \- Add and update lots of AMDGPU firmwares...
    \- GC...
    \- 9.4.3
    \- 11.0.0
    \- 11.0.2
    \- 11.0.3
    \- 12.0.0
    \- 12.0.1
    \- PSP...
    \- 13.0.0
    \- 13.0.5
    \- 13.0.7
    \- 13.0.8
    \- 13.0.10
    \- 14.0.2
    \- 14.0.3
    \- SMU...
    \- 14.0.2
    \- 14.0.3
    \- VCN...
    \- 4.0.0
    \- 4.0.4
    \- Beige Goby / Dimgrey Cavefish / Navy Flounder / Sienna Cichlid / Yellow Carp
    \- Navi10/Navi12/Navi14
    \- Intel
    \- Add iwlwifi firmware for Bz device, build Core\_manual\_signed\_core90\-93.
    \- MediaTek
    \- Update MT7988 firmware, version 10.
    \- Update MT7925 firmwares, WLAN PATCH\_MCU version 20250113153001a, WLAN RAM\_CODE version 20250113152854, Bluetooth firmware version 20250113153307.
    \- Microchip
    \- Add WLAN firmware for WILC3000.
    \- Qualcomm
    \- Add DSP firmware for Qualcomm SA8775P / QCS9100 platforms.
    \- Update the Sensors DSP firmware for the Qualcomm RB5 Robotics platform.
    Signed\-off\-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250120+debian20241210+1
- firmware-nonfree: 20250120+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
