### PR TITLE
e2fsprogs: update to 1.47.2

### DIFF
--- a/app-admin/e2fsprogs/spec
+++ b/app-admin/e2fsprogs/spec
@@ -1,4 +1,4 @@
-VER=1.47.1
-SRCS="tbl::https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v$VER/e2fsprogs-$VER.tar.gz"
-CHKSUMS="sha256::9afcd201f39429d2db2492aeb13dba5e75d6cc50682b732dca35643bd5f092e3"
+VER=1.47.2
+SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=646"


### PR DESCRIPTION
Topic Description
-----------------

- e2fsprogs: update to 1.47.2
    \- Use git.kernel.org upstream.
    Signed\-off\-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- e2fsprogs: 1.47.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit e2fsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
