### PR TITLE
OpenJDK GA Updates Survey (Jan. 2025)

### DIFF
--- a/lang-java/openjdk-17/autobuild/build
+++ b/lang-java/openjdk-17/autobuild/build
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-17"
 
@@ -18,14 +17,9 @@ OPENJDK_SUFFIX="-17"
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -49,14 +43,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs

--- a/lang-java/openjdk-17/autobuild/build.stage2
+++ b/lang-java/openjdk-17/autobuild/build.stage2
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 BOOTSTRAP_ADOPTIUM=17.0.9+9
 BOOTSTRAP_ALPINE="v3.20"
@@ -24,14 +23,9 @@ JDKBOOTDIR=""
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -179,14 +173,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=17.0.13-ga
+UPSTREAM_VER=17.0.14-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-21/autobuild/build
+++ b/lang-java/openjdk-21/autobuild/build
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-21"
 
@@ -18,14 +17,9 @@ OPENJDK_SUFFIX="-21"
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -39,6 +33,7 @@ abinfo "Configuring OpenJDK ${PKGVER} ..."
 install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -49,14 +44,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -65,7 +62,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-21/autobuild/build.stage2
+++ b/lang-java/openjdk-21/autobuild/build.stage2
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 BOOTSTRAP_ADOPTIUM=21.0.4+7
 BOOTSTRAP_ALPINE="v3.20"
@@ -24,14 +23,9 @@ JDKBOOTDIR=""
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -169,6 +163,7 @@ install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --with-boot-jdk="$JDKBOOTDIR" \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -179,14 +174,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -195,7 +192,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=21.0.5-ga
+UPSTREAM_VER=21.0.6-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-22/autobuild/build
+++ b/lang-java/openjdk-22/autobuild/build
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-22"
 
@@ -18,14 +17,9 @@ OPENJDK_SUFFIX="-22"
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -39,6 +33,7 @@ abinfo "Configuring OpenJDK ${PKGVER} ..."
 install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -49,14 +44,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -65,7 +62,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-22/autobuild/build.stage2
+++ b/lang-java/openjdk-22/autobuild/build.stage2
@@ -1,5 +1,4 @@
 ##### Control part variables
-SJAVAC=0
 EXTRA_FEATURES="jfr"
 BOOTSTRAP_ADOPTIUM=21.0.4+7
 BOOTSTRAP_ALPINE="v3.20"
@@ -25,14 +24,9 @@ JDKBOOTDIR="/usr/lib/java-21"
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
-    SJAVAC=0
 else
     config_zero=" "
     EXTRA_FEATURES+=",shenandoahgc,zgc"
-fi
-
-if [[ "${SJAVAC}" == "1" ]]; then
-    use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
 if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
@@ -170,6 +164,7 @@ install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --with-boot-jdk="$JDKBOOTDIR" \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -180,14 +175,16 @@ sh "$SRCDIR"/configure \
     --with-libpng=system \
     --with-libjpeg=system \
     --with-giflib=system \
-    ${config_zero} ${use_sjavac} \
+    ${config_zero} \
     ${config_bits} \
     --with-jvm-features="${EXTRA_FEATURES}" \
     --enable-precompiled-headers \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -196,7 +193,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-22/spec
+++ b/lang-java/openjdk-22/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=22.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
+REL=2
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373785"

--- a/lang-java/openjdk-23/autobuild/build
+++ b/lang-java/openjdk-23/autobuild/build
@@ -33,6 +33,7 @@ abinfo "Configuring OpenJDK ${PKGVER} ..."
 install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -50,7 +51,9 @@ sh "$SRCDIR"/configure \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -59,7 +62,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-23/autobuild/build.stage2
+++ b/lang-java/openjdk-23/autobuild/build.stage2
@@ -163,6 +163,7 @@ install -dv -m 755 "$SRCDIR"/image
 sh "$SRCDIR"/configure \
     --with-boot-jdk="$JDKBOOTDIR" \
     --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
     --with-version-pre='' \
     --with-version-opt="AOSC" \
     --with-stdc++lib=dynamic \
@@ -180,7 +181,9 @@ sh "$SRCDIR"/configure \
     --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
     --with-extra-cflags="${EXTRA_CFLAGS}" \
     --with-extra-ldflags="${LDFLAGS}" \
-    JOBS=$(nproc)
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
 
 abinfo "Building OpenJDK ..."
 make product-images docs
@@ -189,7 +192,7 @@ mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
 install -dv -m 755 "$PKGDIR"/usr/share/doc
 
-IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
+IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,7 +1,6 @@
 MAJOR_VER=23
-UPSTREAM_VER=23.0.1-ga
+UPSTREAM_VER=23.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374464"

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=8u432-ga
+UPSTREAM_VER=8u442-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk\-23: update to 23.0.2+ga
- openjdk\-22: update to 22.0.2+ga
- openjdk\-21: update to 21.0.6+ga
- openjdk\-17: update to 17.0.14+ga
- openjdk\-8: update to 8u442+ga

Package(s) Affected
-------------------

- openjdk-17: 3:17.0.14+ga
- openjdk-21: 3:21.0.6+ga
- openjdk-22: 3:22.0.2+ga-2
- openjdk-23: 3:23.0.2+ga
- openjdk-8: 3:8u442+ga

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/9411

Build Order
-----------

```
#buildit openjdk-8 openjdk-17 openjdk-21 openjdk-22 openjdk-23
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
