### PR TITLE
plymouth: drop unused gtk-3 dep

### DIFF
--- a/app-admin/plymouth/autobuild/defines
+++ b/app-admin/plymouth/autobuild/defines
@@ -1,15 +1,22 @@
 PKGNAME=plymouth
 PKGSEC=kernel
-PKGDEP="dracut libdrm pango systemd gtk-3 libevdev"
+PKGDEP="dracut libdrm pango systemd libevdev"
 PKGRECOM="plymouth-semaphore"
 BUILDDEP="docbook-xsl intltool"
 PKGDES="Graphical boot animation and logger"
 
-AUTOTOOLS_AFTER="--enable-tracing \
-                 --with-release-file=/etc/os-release \
-                 --enable-systemd-integration \
-                 --without-system-root-install \
-                 --without-rhgb-compat-link \
-                 --disable-gtk"
+# Note: GTK+ support is used for Plymouth's X11 preview program.
+MESON_AFTER=(
+    '-Drelease-file=/etc/os-release'
+    '-Dtracing=false'
+    '-Dupstart-monitoring=false'
+    '-Dsystemd-integration=true'
+    '-Dudev=enabled'
+    '-Dpango=enabled'
+    '-Dfreetype=enabled'
+    '-Dgtk=disabled'
+    '-Ddrm=true'
+    '-Ddocs=true'
+)
 
 PKGEPOCH=2

--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,5 +1,5 @@
 VER=24.004.60
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- plymouth: drop unused gtk\-3 dep
    \- Drop gtk\-3 dependency as we do not enable it.
    \- Switch to Meson build type.

Package(s) Affected
-------------------

- plymouth: 2:24.004.60-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
