### PR TITLE
bash-pinyin-completion-rs: new, 0.2.3

### DIFF
--- a/app-shells/bash-pinyin-completion-rs/autobuild/beyond
+++ b/app-shells/bash-pinyin-completion-rs/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing bash-pinyin-completion script"
+install -Dvm644 "$SRCDIR"/scripts/bash_pinyin_completion \
+    "$PKGDIR"/etc/bash_completion.d/bash_pinyin_completion

--- a/app-shells/bash-pinyin-completion-rs/autobuild/defines
+++ b/app-shells/bash-pinyin-completion-rs/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=bash-pinyin-completion-rs
+PKGDES="Pinyin-based shell completion helper"
+PKGDEP="bash-completion"
+PKGSEC="shells"
+
+BUILDDEP="rustc llvm"
+ABTYPE=rust
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1
+NOLTO__MIPS64R6EL=1

--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,0 +1,4 @@
+VER=0.2.3
+SRCS="tbl::https://github.com/AOSC-Dev/bash-pinyin-completion-rs/archive/v$VER.tar.gz"
+CHKSUMS="sha256::53cb5dc97fe13fefe0d3c8d165e4167e60639a0cd1f7dae81cf70b075b1e9829"
+CHKUPDATE="anitya::id=376526"

--- a/runtime-data/bash-startup/autobuild/defines
+++ b/runtime-data/bash-startup/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=bash-startup
 PKGSEC=misc
 PKGDEP="bash sed bash-git-status"
+PKGRECOM="bash-pinyin-completion-rs"
 PKGDES="Generic Bash Startup Files for AOSC OS"
 
 PKGEPOCH=2

--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,5 @@
 VER=0.7.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-pinyin-completion-rs: update to v0.2.3
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-startup: set bash-pinyin-completion-rs as recomdep
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs: update to v0.2.2-beta
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs: add conffiles
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs: update to 0.2.1
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs: update to 0.15.1
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs:  update to 0.1.2
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>
- bash-pinyin-completion-rs: new, 0.1.0
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>

Package(s) Affected
-------------------

- bash-pinyin-completion-rs: 0.2.3
- bash-startup: 2:0.7.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-pinyin-completion-rs bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
