### PR TITLE
dracut-ng: introduce loongson3-specific quirks and size optimisation

### DIFF
--- a/app-admin/dracut-ng/autobuild/beyond
+++ b/app-admin/dracut-ng/autobuild/beyond
@@ -12,9 +12,5 @@ mkdir -pv "$PKGDIR"/usr/lib/modules
 mkdir -pv "$PKGDIR"/usr/lib/dracut.conf.d/
 touch "$PKGDIR"/var/log/dracut.log
 
-abinfo "Installing distribution configuration ..."
-install -vm0644 "$SRCDIR"/dracut.conf.d/fedora.conf.example \
-    "$PKGDIR"/usr/lib/dracut.conf.d/01-dist.conf
-
 abinfo "Dropping SUSE man pages ..."
 rm -fv "$PKGDIR"/usr/share/man?/*suse*

--- a/app-admin/dracut-ng/autobuild/loongson3/overrides/etc/dracut.conf
+++ b/app-admin/dracut-ng/autobuild/loongson3/overrides/etc/dracut.conf
@@ -1,0 +1,26 @@
+# PUT YOUR CONFIG IN separate files
+# in /etc/dracut.conf.d named "<name>.conf"
+# SEE man dracut.conf(5) for options
+
+# Note: Please use caution when configuring dracut.
+#
+# Some MIPS-based Loongson firmware (especially early Kunlun "LEFI"
+# firmware) may have trouble booting a vmlinuz + initramfs combo larger
+# than ~64MiB.
+
+# Use xz compression for more aggressive compression.
+compress="xz"
+
+# Defaults for dracut module omission.
+#
+# Exclude several functionalities to lighten the initramfs:
+#
+#   - Networking and netbooting support.
+#   - Extra kernel modules.
+#   - Terminfo settings.
+#   - Virtualisation and VFIO.
+#   - Bcache support.
+#   - Other non-critical miscellaneous features.
+omit_dracutmodules+=" bcache hwdb kernel-modules-extra kernel-network-modules \
+                      network-manager network nfs nvdimm ostree qemu qemu-net \
+                      systemd-networkd terminfo virtiofs "

--- a/app-admin/dracut-ng/autobuild/loongson3/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/loongson3/overrides/usr/bin/update-initramfs
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]; then
+	echo "This script should be run as root."
+	exit
+fi
+
+# $1 = single|parallel   - whether initrd generation is in parallel
+#      single   = print message at start
+#      parallel = print completion notice or error message
+# $2 = <ver>-local-ver e.g. 5.19.0-aosc-main
+generate_initrd_if_needed() {
+	local mode="$1"
+	local version="$2"
+
+	if [ -f "/usr/lib/modules/${version}/modules.dep" ] && [ -f "/usr/lib/modules/${version}/modules.order" ] && [ -f "/usr/lib/modules/${version}/modules.builtin" ]; then
+		[[ "$mode" == "single" ]] && echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for kernel version $version ..."
+		dracut -q --force "/boot/initramfs-$version.img" "$version"
+		local dracut_ret=$?
+		if [[ "$mode" == "parallel" ]]; then
+			if [[ $dracut_ret -eq 0 ]]; then
+				echo -e "Successfully generated initrd."
+			else
+				echo -e "\033[31mDracut returned non-zero exit code $dracut_ret.\033[0m"
+				echo -e "\033[31mSee messages for details.\033[0m"
+			fi
+		fi
+	else
+		if [[ "$mode" == "parallel" ]]; then
+			echo -e "\033[33mSkipping incomplete kernel modules tree ...\033[0m"
+		else
+			echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $version ..."
+		fi
+	fi
+
+}
+
+export -f generate_initrd_if_needed
+
+# Generate initrd using Dracut.
+if [ -x /usr/bin/dracut ]; then
+	if [ -x /usr/bin/parallel ]; then
+		task_list=$(ls /usr/lib/modules | grep -v 'extramodules')
+		if [[ "e$task_list" != "e" ]]; then
+			echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for $(echo ${task_list} | wc -w) kernel versions ..."
+			parallel --will-cite --tagstring '{=$_=$_ . " " x (20 - length($_))=}' generate_initrd_if_needed parallel ::: ${task_list}
+		else
+			echo -e "\033[36m**\033[0m\tNo kernel module tree found, skipping generation."
+		fi
+	else
+		echo -e "\033[33m**\033[0m\tGNU parallel is not available, generating initramfs one-by-one..."
+		for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+			generate_initrd_if_needed single "$i"
+		done
+	fi
+else
+	echo -e "\033[33m**\033[0m\tCommand \"dracut\" is not installed, skipping generation.\n\tYou may not be able to boot the new kernel on the next boot."
+fi
+
+# Notify bootloader
+if ! systemd-detect-virt -cq; then
+	if [[ -x /usr/bin/grub-mkconfig ]]; then
+		echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
+		update-grub
+	fi
+	if [[ -x /usr/bin/sbf && -r /etc/systemd-boot-friend.conf ]]; then
+		echo -e "\033[36m**\033[0m\tUpdating systemd-boot entries ..."
+		sbf update
+	fi
+fi
+
+# TODO: Support for multiple other initramfs/initrd manager.
+# TODO: Write in signal for PS1 to show "reboot" demand.

--- a/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-50drm-limit-DRM-module-installation.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-50drm-limit-DRM-module-installation.patch
@@ -1,0 +1,59 @@
+From 8ed9f8f36ca23a29db0849767d5f482ae07c1b1c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 23 Jan 2025 11:45:36 +0800
+Subject: [PATCH 1/5] AOSCOS: LOONGSON3: 50drm: limit DRM module installation
+ to amdgpu, loongson, and radeon
+
+If we are using mips64el (assumed to be MIPS-based Loongson), only install
+modules for loongson, radeon, and amdgpu as these are the only three DRM
+drivers supported by these platforms. We need to minimise the sizes of the
+initramfs so that it fits within the RAM allocated by the system firmware.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ modules.d/50drm/module-setup.sh | 23 ++++++++++++++++++-----
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/modules.d/50drm/module-setup.sh b/modules.d/50drm/module-setup.sh
+index 8e52f111..46e029eb 100755
+--- a/modules.d/50drm/module-setup.sh
++++ b/modules.d/50drm/module-setup.sh
+@@ -18,7 +18,11 @@ installkernel() {
+             "=drivers/video/backlight"
+     fi
+ 
+-    instmods amdkfd hyperv_fb "=drivers/pwm"
++    if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++        instmods amdkfd hyperv_fb "=drivers/pwm"
++    else
++        instmods "=drivers/pwm"
++    fi
+ 
+     # if the hardware is present, include module even if it is not currently loaded,
+     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
+@@ -50,9 +54,18 @@ installkernel() {
+             instmods "$modname"
+         done
+     else
+-        dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"
+-        # also include privacy screen providers (see above comment)
+-        # atm all providers live under drivers/platform/x86
+-        dracut_instmods -o -s "drm_privacy_screen_register" "=drivers/platform/x86"
++        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++            dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"
++            # also include privacy screen providers (see above comment)
++            # atm all providers live under drivers/platform/x86
++            dracut_instmods -o -s "drm_privacy_screen_register" "=drivers/platform/x86"
++        else
++            # If we are using mips64 (assumed to be MIPS-based
++            # Loongson), only install loongson, radeon, and amdgpu as
++            # these are the only three DRM drivers supported by these
++            # platforms. We need to minimise the sizes of the initramfs so
++            # that it fits within the RAM allocated by the system firmware.
++            dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm/amd/amdgpu" "=drivers/gpu/drm/amd/amdxcp" "=drivers/gpu/drm/loongson" "=drivers/gpu/drm/radeon"
++        fi
+     fi
+ }
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-01systemd-crypsetup-remove-TPM2-dep.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-01systemd-crypsetup-remove-TPM2-dep.patch
@@ -1,0 +1,36 @@
+From da6805b1a1cf30fe48b350858ebd9d82ee1adf45 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 27 Jan 2025 04:55:49 +0800
+Subject: [PATCH 2/5] AOSCOS: LOONGSON3: 01systemd-crypsetup: remove TPM2
+ dependency
+
+There is just no way that we will get TPM2 on MIPS-based Loongson 3
+systems - and it saves almost 10MiB post-XZ.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ modules.d/01systemd-cryptsetup/module-setup.sh | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/01systemd-cryptsetup/module-setup.sh b/modules.d/01systemd-cryptsetup/module-setup.sh
+index 034d4ecf..00a59ff5 100755
+--- a/modules.d/01systemd-cryptsetup/module-setup.sh
++++ b/modules.d/01systemd-cryptsetup/module-setup.sh
+@@ -31,7 +31,13 @@ depends() {
+             deps+=" tpm2-tss"
+         fi
+     elif [[ ! $hostonly ]]; then
+-        for module in fido2 pkcs11 tpm2-tss; do
++        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++            modules="fido pkcs11 tpm2-tss"
++        else
++            # MIPS64: No chance for TPM2 on these platforms.
++            modules="fido pkcs11 tpm2-tss"
++        fi
++        for module in "$modules"; do
+             module_check $module > /dev/null 2>&1
+             if [[ $? == 255 ]]; then
+                 deps+=" $module"
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-90kernel-modules-minimise-default-k.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-90kernel-modules-minimise-default-k.patch
@@ -1,0 +1,120 @@
+From 06f1dc4052d9a08bcf923d50c260b1bd2bbe94f1 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 27 Jan 2025 04:56:34 +0800
+Subject: [PATCH 3/5] AOSCOS: LOONGSON3: 90kernel-modules: minimise default
+ kernel drivers
+
+Make sure that only drivers that were likely needed at early-boot were
+included as part of the initramfs.
+
+Saves about 5MiB post-XZ.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ modules.d/90kernel-modules/module-setup.sh | 83 +++++++++++++++-------
+ 1 file changed, 56 insertions(+), 27 deletions(-)
+
+diff --git a/modules.d/90kernel-modules/module-setup.sh b/modules.d/90kernel-modules/module-setup.sh
+index f159f0be..4a04647b 100755
+--- a/modules.d/90kernel-modules/module-setup.sh
++++ b/modules.d/90kernel-modules/module-setup.sh
+@@ -25,12 +25,22 @@ installkernel() {
+     }
+ 
+     install_block_modules() {
+-        instmods \
+-            scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
+-            =drivers/usb/storage \
+-            =ide nvme vmd \
+-            virtio_blk virtio_scsi \
+-            =drivers/ufs
++        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++            instmods \
++                scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
++                =drivers/usb/storage \
++                =ide nvme vmd \
++                virtio_blk virtio_scsi \
++                =drivers/ufs
++        else
++            # MIPS64: Minimise kernel modules to save initramfs size,
++            # taking into account USB mass storage, IDE/ATA, NVMe, and
++            # virtualised storage (virtio).
++            instmods \
++                =drivers/usb/storage \
++                =ide nvme \
++                virtio_blk virtio_scsi
++        fi
+ 
+         dracut_instmods -o -s "${_blockfuncs}" "=drivers"
+     }
+@@ -39,27 +49,46 @@ installkernel() {
+         hostonly='' instmods \
+             hid_generic unix
+ 
+-        hostonly=$(optional_hostonly) instmods \
+-            ehci-hcd ehci-pci ehci-platform \
+-            ohci-hcd ohci-pci \
+-            uhci-hcd \
+-            usbhid \
+-            xhci-hcd xhci-pci xhci-plat-hcd \
+-            "=drivers/hid" \
+-            "=drivers/tty/serial" \
+-            "=drivers/input/serio" \
+-            "=drivers/input/keyboard" \
+-            "=drivers/pci/host" \
+-            "=drivers/pci/controller" \
+-            "=drivers/pinctrl" \
+-            "=drivers/usb/typec" \
+-            "=drivers/watchdog"
+-
+-        instmods \
+-            yenta_socket intel_lpss_pci spi_pxa2xx_platform \
+-            atkbd i8042 firewire-ohci hv-vmbus \
+-            virtio virtio_ring virtio_pci pci_hyperv \
+-            surface_aggregator_registry psmouse
++        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++            hostonly=$(optional_hostonly) instmods \
++                ehci-hcd ehci-pci ehci-platform \
++                ohci-hcd ohci-pci \
++                uhci-hcd \
++                usbhid \
++                xhci-hcd xhci-pci xhci-plat-hcd \
++                "=drivers/hid" \
++                "=drivers/tty/serial" \
++                "=drivers/input/serio" \
++                "=drivers/input/keyboard" \
++                "=drivers/pci/host" \
++                "=drivers/pci/controller" \
++                "=drivers/pinctrl" \
++                "=drivers/usb/typec" \
++                "=drivers/watchdog"
++        else
++            # MIPS64: Minimise kernel modules to save initramfs size,
++            # taking into account generic USB HID drivers and USB hosts.
++            hostonly=$(optional_hostonly) instmods \
++                ehci-hcd ehci-pci ehci-platform \
++                ohci-hcd ohci-pci \
++                uhci-hcd \
++                usbhid \
++                xhci-hcd xhci-pci xhci-plat-hcd
++        fi
++
++        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
++            instmods \
++                yenta_socket intel_lpss_pci spi_pxa2xx_platform \
++                atkbd i8042 firewire-ohci hv-vmbus \
++                virtio virtio_ring virtio_pci pci_hyperv \
++                surface_aggregator_registry psmouse
++        else
++            # MIPS64: Minimise kernel modules to save initramfs size,
++            # taking into account AT keyboards, i8042, and virtio devices.
++            instmods \
++                atkbd i8042 \
++                virtio virtio_ring virtio_pci
++        fi
+ 
+         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
+             # arm/aarch64 specific modules
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/autobuild/patches/0004-AOSCOS-dracut-init-decompress-kernel-modules-and-fir.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-AOSCOS-dracut-init-decompress-kernel-modules-and-fir.patch
@@ -1,0 +1,78 @@
+From e53e42a5cfee8ae17f75e3d7e4533ce98aabeab4 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 27 Jan 2025 04:58:49 +0800
+Subject: [PATCH 4/5] AOSCOS: dracut-init: decompress kernel modules and
+ firmware before final compression
+
+Decompress all kernel modules and firmware (if compressed), this allows
+for better compression ratio as we make the compressed initramfs.
+
+This may save over 10MiB post-XZ.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dracut-init.sh | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/dracut-init.sh b/dracut-init.sh
+index 1ce0d7ed..914ab3e2 100755
+--- a/dracut-init.sh
++++ b/dracut-init.sh
+@@ -1029,6 +1029,54 @@ for_each_module_dir() {
+ dracut_kernel_post() {
+     local dstdir="${dstdir:-"$initdir"}"
+ 
++    # Check for the necessary if(1) command for post-processing.
++    if ! find_binary find &> /dev/null; then
++        derror "Will not process kernel modules and firmware as find(1) is not available!"
++        return 1
++    fi
++
++    # Check for necessary compression utilities.
++    for cmd in gzip xz zstd; do
++        if ! find_binary "$cmd" &> /dev/null; then
++            derror "Will not process kernel modules and firmware compressed with '$cmd' as the command is not available!"
++            return 1
++        fi
++    done
++
++    # Decompress all firmware and module data for more optimal final
++    # compression ratio.
++    for kerndir in "${dstdir}/lib/firmware" \
++                   "${dstdir}/lib/modules/$kernel"; do
++        for kernfile in `find "$kerndir" -type f`; do
++            case "$kernfile" in
++                *.gz)
++                    ddebug "Decompressing gzipped kernel module/firmware: $kernfile ..."
++                    gzip -d "$kernfile"
++                    ;;
++                *.xz)
++                    ddebug "Decompressing xz-compressed kernel module/firmware: $kernfile ..."
++                    xz -d "$kernfile"
++                    ;;
++                *.zst)
++                    ddebug "Decompressing zstd-compressed kernel module/firmware: $kernfile ..."
++                    zstd -q --rm -d "$kernfile"
++                    ;;
++            esac
++        done
++    done
++
++    # Fixup symlinks to compressed firmware.
++    for fwlink in `find "${dstdir}/lib/firmware" \
++                       -name '*.gz' -o -name '*.xz' -o -name '*.zst' \
++                       -type l`; do
++        ddebug "Fixing up decompressed firmware: $fwlink ..."
++        fwtarget=$(readlink $fwlink)
++        rm $fwlink
++        for ext in gz xz zst; do
++            ln -s ${fwtarget%.*} ${fwlink%.*} && break
++        done
++    done
++
+     for _f in modules.builtin modules.builtin.alias modules.builtin.modinfo modules.order; do
+         [[ -e $srcmods/$_f ]] && inst_simple "$srcmods/$_f" "/lib/modules/$kernel/$_f"
+     done
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/autobuild/patches/0005-AOSCOS-dracut-init-strip-out-unused-unlikely-AMDGPU-.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-AOSCOS-dracut-init-strip-out-unused-unlikely-AMDGPU-.patch
@@ -1,0 +1,103 @@
+From cf5fd6cf8f393be74278cdeef9cb1c071d48278f Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 27 Jan 2025 05:00:38 +0800
+Subject: [PATCH 5/5] AOSCOS: dracut-init: strip out unused/unlikely AMDGPU
+ firmware
+
+Introduce logic to remove unlikely or impossible firmware on a platform-
+specific basis to save space - this is the largest set of firmware in the
+linux-firmware.git tree.
+
+To update the list of prefixes:
+
+  1. Look for (grep) MODULE_FIRMWARE in /drivers/gpu/drm/amd (please note
+     that AMD does not always use the file name to the firmware as
+     parameter to this macro.
+  2. Reference "Misc AMDGPU driver information"[^1], Wikipedia, and
+     TechPowerUp to determine which class certain set(s) of firmware
+     belong out of the list below.
+  3. Refer to manufacturers and/or OEM contacts for state of support
+     (some should be obvious - there is no non-x86 APUs - yet?).
+
+[^1]: https://docs.kernel.org/gpu/amdgpu/driver-misc.html
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dracut-init.sh | 61 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 61 insertions(+)
+
+diff --git a/dracut-init.sh b/dracut-init.sh
+index 914ab3e2..8258fa29 100755
+--- a/dracut-init.sh
++++ b/dracut-init.sh
+@@ -1065,6 +1065,67 @@ dracut_kernel_post() {
+         done
+     done
+ 
++    # AMDGPU firmware stripping: Remove unlikely or impossible firmware on a
++    # platform-specific basis to save space - this is the largest set of
++    # firmware in the linux-firmware.git tree.
++    #
++    # To update the list of prefixes below:
++    #
++    #   1. Look for (grep) MODULE_FIRMWARE in /drivers/gpu/drm/amd (please note
++    #      that AMD does not always use the file name to the firmware as
++    #      parameter to this macro.
++    #   2. Reference "Misc AMDGPU driver information"[^1], Wikipedia, and
++    #      TechPowerUp to determine which class certain set(s) of firmware
++    #      belong out of the list below.
++    #   3. Refer to manufacturers and/or OEM contacts for state of support
++    #      (some should be obvious - there is no non-x86 APUs - yet?).
++    #
++    # [^1]: https://docs.kernel.org/gpu/amdgpu/driver-misc.html
++
++    # APU-specific firmware.
++    _apu_prefix=" \
++        cyan_skillfish2 kabini kaveri mullins picasso raven renoir vangogh"
++    # AMD Instinct firmware.
++    _mi_prefix="aldebaran arcturus"
++    # Mobile firmware.
++    _mobile_prefix="hainan stoney topaz"
++    # Some firmware (non-x86/ARM platforms with no x86-64 GOP support/
++    # emulation) are unlikely to support post-GCN 4.0 cards. Firmware found on
++    # MIPS-based Loongson 3 boards with x86 GOP emulation support are known to
++    # crash with these cards installed.
++    _post_gcn4_prefix=" \
++        beige_goby dcn dimgrey_cavefish gc green_sardine navi navy_flounder \
++        psp sdma_4 sdma_5 sdma_6 sdma_7 sienna_cichlid vega vpe yellow_carp"
++
++    # To avoid the directory being removed if for some reason a prefix variable
++    # was not defined.
++    cd "${dstdir}"/lib/firmware/amdgpu/
++
++    # Using `rm -f' below as some distribution may not ship all firmware.
++
++    # Non-x86 APU is not a thing (yet).
++    if [[ ${DRACUT_ARCH:-$(uname -m)} != x86_64 ]]; then
++        ddebug "Removing AMDGPU firmware unused by non-x86-64 systems ..."
++        for _amdgpu_prefix in ${_apu_prefix}; do
++            rm -f ${_amdgpu_prefix}*
++        done
++    fi
++
++    if [[ ${DRACUT_ARCH:-$(uname -m)} = arm64 ]]; then
++        ddebug "Removing AMDGPU firmware unused by AArch64 systems ..."
++        for _amdgpu_prefix in ${_mobile_prefix}; do
++            rm -f ${_amdgpu_prefix}*
++        done
++    elif [[ ${DRACUT_ARCH:-$(uname -m)} = mips64 ]]; then
++        # No post-GCN 4.0 support - crashes firmware.
++        # Mobile AMD GPUs likely.
++        ddebug "Removing AMDGPU firmware unused by MIPS64 (Loongson 3) systems ..."
++        for _amdgpu_prefix in \
++            ${_mi_prefix} ${_post_gcn4_prefix}; do
++            rm -f ${_amdgpu_prefix}*
++        done
++    fi
++
+     # Fixup symlinks to compressed firmware.
+     for fwlink in `find "${dstdir}/lib/firmware" \
+                        -name '*.gz' -o -name '*.xz' -o -name '*.zst' \
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,4 +1,5 @@
 VER=105
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: introduce loongson3-specific quirks and size optimisation
    Introduce a few quirks to lighten the initramfs so that it works within
    the memory allocation confines found on many MIPS-based Loongson firmware.
    - dracut.conf: Use xz to enhance compression ratio and exclude a few
    modules, namely...
    - Networking and netbooting support.
    - Extra kernel modules.
    - Terminfo settings.
    - Virtualisation and VFIO.
    - Bcache support.
    - Other non-critical miscellaneous features.
    - 50drm: If we are using mips64el \(assumed to be MIPS-based Loongson\),
    only install modules for loongson, radeon, and amdgpu as these are the
    only three DRM drivers supported by these platforms. We need to minimise
    the sizes of the initramfs so that it fits within the RAM allocated by
    the system firmware.
    Other platform-specific changes:
    - Minimise the set of basic kernel modules to include.
    - Remove TPM2 dependency from systemd-cryptsetup as it is unlikely to be
    found on such platforms.
    Universal changes:
    - Decompress kernel modules and firmware before final compression - this
    allows for better compression ratio as we make the compressed initramfs
    \(saves over 10MiB post-XZ according to my testing\).
    - Strip out unused/unlikely AMDGPU firmware: Introduce logic to remove
    them on a platform-specific basis to save space. This is the largest set
    of firmware in the linux-firmware.git tree.

Package(s) Affected
-------------------

- dracut-ng: 105-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
