### PR TITLE
linux-firmware: update to 20250122

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250120
+UPSTREAM_VER=20250122
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=e7a96ae916909f4620bc1999fe481a606eeb4adf::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=40afb77bae42739556088af6a7399f2dad5939ce::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250122
    - Update Linux Firmware to current \(20250122\) HEAD 40afb77bae42739556088af6a7399f2dad5939ce...
    - Changelog below...
    - AMD
    - Revert DMCUB firmware for DCN35, DCN351, DCN314 and DCN401 from version 0.0.249.0 to 0.0.246.0.
    - This should fix #9425.
    - Amlogic
    - Update firmware for W265S2 to version 51.06.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250122+debian20241210+1
- firmware-nonfree: 20250122+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
