### PR TITLE
webrtc-audio-processing: downgrade to 1.3 as both PulseAudio and PipeWire have not supported 2.x yet

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.2.7
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=17.0
 XRDP_VER=0.7
 VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
+REL=1
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/defines
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/defines
@@ -2,4 +2,5 @@ PKGNAME=webrtc-audio-processing
 PKGSEC=libs
 PKGDEP="glibc abseil-cpp"
 PKGDES="Audio Processing library based on Google implementation of WebRTC"
-PKGBREAK="pipewire<=1.2.7-2"
+PKGBREAK="pipewire<=1.2.7-3"
+PKGEPOCH=1

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0001-Bring-arch.h-in-line-with-upstream-webrtc.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0001-Bring-arch.h-in-line-with-upstream-webrtc.patch
@@ -1,0 +1,106 @@
+From f7c1439580e634a4c31d8e3f8088457f40975bc0 Mon Sep 17 00:00:00 2001
+From: Ben Brown <ben@demerara.io>
+Date: Tue, 21 Jun 2022 08:55:37 +0100
+Subject: [PATCH 1/6] Bring arch.h in line with upstream webrtc
+
+Largely to bring in preprocessor support for additional architectures as
+based on 6215ba804eb500f3e28b39088c73af3c4f4cd10a by
+Timothy Gu <timothygu99@gmail.com>:
+
+Add preprocessor support for additional architectures
+
+- _M_ARM is used by Microsoft [1]
+- __riscv and __riscv_xlen are defined by [2]
+- __sparc and __sparc__ are documented at [3]
+- __MIPSEB__, __PPC__, __PPC64__ are documented at [3] and used in
+  Chromium's build/build_config.h [4]
+  Note: Chromium assumes that all PowerPC architectures are 64-bit. This
+  is in fact not true.
+
+[1]: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160
+[2]: https://github.com/riscv/riscv-toolchain-conventions/tree/feca4793566811993f67e008a449d794cfc48953#cc-preprocessor-definitions
+[3]: https://sourceforge.net/p/predef/wiki/Architectures/
+[4]: https://source.chromium.org/chromium/chromium/src/+/master:build/build_config.h;drc=e12bf2e5ff1eacb9aca3e9a26bdeebdbdad5965a
+---
+ webrtc/rtc_base/system/arch.h | 44 ++++++++++++++++++++++++++---------
+ 1 file changed, 33 insertions(+), 11 deletions(-)
+
+diff --git a/webrtc/rtc_base/system/arch.h b/webrtc/rtc_base/system/arch.h
+index aee3756..be2367b 100644
+--- a/webrtc/rtc_base/system/arch.h
++++ b/webrtc/rtc_base/system/arch.h
+@@ -15,8 +15,9 @@
+ #define RTC_BASE_SYSTEM_ARCH_H_
+ 
+ // Processor architecture detection.  For more info on what's defined, see:
+-//   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
+-//   http://www.agner.org/optimize/calling_conventions.pdf
++//   https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
++//   https://www.agner.org/optimize/calling_conventions.pdf
++//   https://sourceforge.net/p/predef/wiki/Architectures/
+ //   or with gcc, run: "echo | gcc -E -dM -"
+ #if defined(_M_X64) || defined(__x86_64__)
+ #define WEBRTC_ARCH_X86_FAMILY
+@@ -27,29 +28,50 @@
+ #define WEBRTC_ARCH_ARM_FAMILY
+ #define WEBRTC_ARCH_64_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+-#elif defined(__riscv) || defined(__riscv__)
+-#define WEBRTC_ARCH_LITTLE_ENDIAN
+-#if __riscv_xlen == 64
+-#define WEBRTC_ARCH_64_BITS
+-#else
+-#define WEBRTC_ARCH_32_BITS
+-#endif
+ #elif defined(_M_IX86) || defined(__i386__)
+ #define WEBRTC_ARCH_X86_FAMILY
+ #define WEBRTC_ARCH_X86
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+-#elif defined(__ARMEL__)
++#elif defined(_M_ARM) || defined(__ARMEL__)
+ #define WEBRTC_ARCH_ARM_FAMILY
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+-#elif defined(__MIPSEL__)
++#elif defined(__MIPSEL__) || defined(__MIPSEB__)
+ #define WEBRTC_ARCH_MIPS_FAMILY
+ #if defined(__LP64__)
+ #define WEBRTC_ARCH_64_BITS
+ #else
+ #define WEBRTC_ARCH_32_BITS
+ #endif
++#if defined(__MIPSEL__)
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#else
++#define WEBRTC_ARCH_BIG_ENDIAN
++#endif
++#elif defined(__PPC__)
++#if defined(__PPC64__)
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
++#if defined(__LITTLE_ENDIAN__)
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#else
++#define WEBRTC_ARCH_BIG_ENDIAN
++#endif
++#elif defined(__sparc) || defined(__sparc__)
++#if __SIZEOF_LONG__ == 8
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
++#define WEBRTC_ARCH_BIG_ENDIAN
++#elif defined(__riscv) && __riscv_xlen == 64
++#define WEBRTC_ARCH_64_BITS
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__riscv) && __riscv_xlen == 32
++#define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+ #elif defined(__pnacl__)
+ #define WEBRTC_ARCH_32_BITS
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0002-Fix-MIPS-specific-source-path.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0002-Fix-MIPS-specific-source-path.patch
@@ -1,0 +1,26 @@
+From 9646fc3babbc3cea4a031f9dd102fcdd377e7930 Mon Sep 17 00:00:00 2001
+From: Jonas Smedegaard <dr@jones.dk>
+Date: Wed, 3 Aug 2022 16:22:45 +0200
+Subject: [PATCH 2/6] Fix MIPS-specific source path
+
+Link: https://sources.debian.org/patches/webrtc-audio-processing/1.0-0.2/fix-mips-source-path.patch
+---
+ webrtc/common_audio/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/webrtc/common_audio/meson.build b/webrtc/common_audio/meson.build
+index 30ff0f2..98d60fc 100644
+--- a/webrtc/common_audio/meson.build
++++ b/webrtc/common_audio/meson.build
+@@ -99,7 +99,7 @@ if have_mips
+     'signal_processing/min_max_operations_mips.c',
+     'signal_processing/resample_by_2_mips.c',
+     'signal_processing/vector_scaling_operations_mips.c',
+-    'third_party/ooura/fft_size_128/ooura_fft_mips.c',
++    'third_party/ooura/fft_size_128/ooura_fft_mips.cc',
+     'third_party/spl_sqrt_floor/spl_sqrt_floor_mips.c',
+   ]
+ endif
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0003-meson-Drop-malformed-WEBRTC_ARCH_MIPS_FAMILY-cflags-.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0003-meson-Drop-malformed-WEBRTC_ARCH_MIPS_FAMILY-cflags-.patch
@@ -1,0 +1,47 @@
+From 9d157a1b1ca9bc805f2b11e90d0b9678d6111b99 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Thu, 24 Oct 2024 22:51:15 +0300
+Subject: [PATCH 3/6] meson: Drop malformed WEBRTC_ARCH_MIPS_FAMILY cflags
+ argument
+
+The top-level meson.build file adds WEBRTC_ARCH_MIPS_FAMILY to
+arch_cflags for mips architectures, which causes the following error:
+
+  [1/306] Compiling C++ object webrtc/rtc_base/liblibbase.a.p/synchronization_yield.cc.o
+  FAILED: webrtc/rtc_base/liblibbase.a.p/synchronization_yield.cc.o
+  c++ [...] -DWEBRTC_THREAD_RR WEBRTC_ARCH_MIPS_FAMILY -MD [...] ../webrtc/rtc_base/synchronization/yield.cc
+  c++: warning: WEBRTC_ARCH_MIPS_FAMILY: linker input file unused because linking not done
+  c++: error: WEBRTC_ARCH_MIPS_FAMILY: linker input file not found: No such file or directory
+
+It is supposed to be "-DWEBRTC_ARCH_MIPS_FAMILY". But, that macro is
+already defined in arch.h when building for mips:
+
+  [30/306] Compiling C++ object webrtc/system_wrappers/libsystem_wrappers.a.p/source_cpu_features.cc.o
+  In file included from ../webrtc/system_wrappers/source/cpu_features.cc:13:
+  ../webrtc/rtc_base/system/arch.h:47:9: warning: "WEBRTC_ARCH_MIPS_FAMILY" redefined
+     47 | #define WEBRTC_ARCH_MIPS_FAMILY
+        |         ^~~~~~~~~~~~~~~~~~~~~~~
+  <command-line>: note: this is the location of the previous definition
+
+Drop the broken, unnecessary argument from cflags.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+---
+ meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 3843e92..f56c87b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -137,7 +137,6 @@ if cc.compiles('''#ifndef __aarch64__
+ endif
+ if ['mips', 'mips64'].contains(host_machine.cpu_family())
+   have_mips = true
+-  arch_cflags += ['WEBRTC_ARCH_MIPS_FAMILY']
+ endif
+ if host_machine.cpu_family() == 'mips64'
+   have_mips64 = true
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0004-meson-Avoid-default-AECM-implementation-on-MIPS.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0004-meson-Avoid-default-AECM-implementation-on-MIPS.patch
@@ -1,0 +1,52 @@
+From 31255a8e6ba6a733d17ab92a241afa0eda6f7fba Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Fri, 25 Oct 2024 01:38:42 +0300
+Subject: [PATCH 4/6] meson: Avoid default AECM implementation on MIPS
+
+Trying to link both aecm/aecm_core_mips.cc and aecm/aecm_core_c.cc into
+the same library results in an error because they both try to implement
+webrtc::WebRtcAecm_ProcessBlock():
+
+  [306/306] Linking target webrtc/modules/audio_processing/libwebrtc-audio-processing-1.so.3
+  FAILED: webrtc/modules/audio_processing/libwebrtc-audio-processing-1.so.3
+  c++ @webrtc/modules/audio_processing/libwebrtc-audio-processing-1.so.3.rsp
+  /usr/bin/ld: webrtc/modules/audio_processing/libwebrtc-audio-processing-1.so.3.p/aecm_aecm_core_mips.cc.o: in function `webrtc::WebRtcAecm_ProcessBlock(webrtc::AecmCore*, short const*, short const*, short const*, short*)':
+  [...]/webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:934: multiple definition of `webrtc::WebRtcAecm_ProcessBlock(webrtc::AecmCore*, short const*, short const*, short const*, short*)'; webrtc/modules/audio_processing/libwebrtc-audio-processing-1.so.3.p/aecm_aecm_core_c.cc.o:[...]/webrtc/modules/audio_processing/aecm/aecm_core_c.cc:377: first defined here
+  collect2: error: ld returned 1 exit status
+  ninja: build stopped: subcommand failed.
+
+The MIPS-specific file is a replacement for the other, unlike the NEON
+case. Don't add the default implementation unconditionally, add it only
+for non-MIPS builds.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+---
+ webrtc/modules/audio_processing/meson.build | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/webrtc/modules/audio_processing/meson.build b/webrtc/modules/audio_processing/meson.build
+index 1309bc5..ff303b7 100644
+--- a/webrtc/modules/audio_processing/meson.build
++++ b/webrtc/modules/audio_processing/meson.build
+@@ -58,7 +58,6 @@ webrtc_audio_processing_sources = [
+   'aec3/suppression_gain.cc',
+   'aec3/transparent_mode.cc',
+   'aecm/aecm_core.cc',
+-  'aecm/aecm_core_c.cc',
+   'aecm/echo_control_mobile.cc',
+   'agc/agc.cc',
+   'agc/agc_manager_direct.cc',
+@@ -181,6 +180,10 @@ if have_mips
+   webrtc_audio_processing_sources += [
+     'aecm/aecm_core_mips.cc',
+   ]
++else
++  webrtc_audio_processing_sources += [
++    'aecm/aecm_core_c.cc',
++  ]
+ endif
+ 
+ if have_neon
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0005-AECM-MIPS-Use-uintptr_t-for-pointer-arithmetic.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0005-AECM-MIPS-Use-uintptr_t-for-pointer-arithmetic.patch
@@ -1,0 +1,68 @@
+From 9467d7667e4510a005aa83e6b9c1dc9e9c2fd9f4 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Fri, 25 Oct 2024 00:40:59 +0300
+Subject: [PATCH 5/6] AECM: MIPS: Use uintptr_t for pointer arithmetic
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Trying to compile the MIPS-specific AECM audio processing file for
+mips64el on Debian results in the following errors:
+
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc: In function ‘int webrtc::WebRtcAecm_ProcessBlock(AecmCore*, const int16_t*, const int16_t*, const int16_t*, int16_t*)’:
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:955:30: error: cast from ‘int16_t*’ {aka ‘short int*’} to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
+    955 |   int16_t* fft = (int16_t*)(((uint32_t)fft_buf + 31) & ~31);
+        |                              ^~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:955:18: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+    955 |   int16_t* fft = (int16_t*)(((uint32_t)fft_buf + 31) & ~31);
+        |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:956:36: error: cast from ‘int32_t*’ {aka ‘int*’} to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
+    956 |   int32_t* echoEst32 = (int32_t*)(((uint32_t)echoEst32_buf + 31) & ~31);
+        |                                    ^~~~~~~~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:956:24: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+    956 |   int32_t* echoEst32 = (int32_t*)(((uint32_t)echoEst32_buf + 31) & ~31);
+        |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:957:40: error: cast from ‘int32_t*’ {aka ‘int*’} to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
+    957 |   ComplexInt16* dfw = (ComplexInt16*)(((uint32_t)dfw_buf + 31) & ~31);
+        |                                        ^~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:957:23: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+    957 |   ComplexInt16* dfw = (ComplexInt16*)(((uint32_t)dfw_buf + 31) & ~31);
+        |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:958:40: error: cast from ‘int32_t*’ {aka ‘int*’} to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
+    958 |   ComplexInt16* efw = (ComplexInt16*)(((uint32_t)efw_buf + 31) & ~31);
+        |                                        ^~~~~~~~~~~~~~~~~
+  ../webrtc/modules/audio_processing/aecm/aecm_core_mips.cc:958:23: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+    958 |   ComplexInt16* efw = (ComplexInt16*)(((uint32_t)efw_buf + 31) & ~31);
+        |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Presumably, this file was written for 32-bit MIPS so the author used
+uint32_t to do pointer arithmetic over these arrays. Fix the errors by
+using uintptr_t to work with pointers.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+---
+ webrtc/modules/audio_processing/aecm/aecm_core_mips.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/webrtc/modules/audio_processing/aecm/aecm_core_mips.cc b/webrtc/modules/audio_processing/aecm/aecm_core_mips.cc
+index f2f43e1..80a5fde 100644
+--- a/webrtc/modules/audio_processing/aecm/aecm_core_mips.cc
++++ b/webrtc/modules/audio_processing/aecm/aecm_core_mips.cc
+@@ -952,10 +952,10 @@ int WebRtcAecm_ProcessBlock(AecmCore* aecm,
+   int32_t dfw_buf[PART_LEN2 + 8];
+   int32_t efw_buf[PART_LEN2 + 8];
+ 
+-  int16_t* fft = (int16_t*)(((uint32_t)fft_buf + 31) & ~31);
+-  int32_t* echoEst32 = (int32_t*)(((uint32_t)echoEst32_buf + 31) & ~31);
+-  ComplexInt16* dfw = (ComplexInt16*)(((uint32_t)dfw_buf + 31) & ~31);
+-  ComplexInt16* efw = (ComplexInt16*)(((uint32_t)efw_buf + 31) & ~31);
++  int16_t* fft = (int16_t*)(((uintptr_t)fft_buf + 31) & ~31);
++  int32_t* echoEst32 = (int32_t*)(((uintptr_t)echoEst32_buf + 31) & ~31);
++  ComplexInt16* dfw = (ComplexInt16*)(((uintptr_t)dfw_buf + 31) & ~31);
++  ComplexInt16* efw = (ComplexInt16*)(((uintptr_t)efw_buf + 31) & ~31);
+ 
+   int16_t hnl[PART_LEN1];
+   int16_t numPosCoef = 0;
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0006-Add-loongarch-arch-definitions.patch
+++ b/runtime-multimedia/webrtc-audio-processing/autobuild/patches/0006-Add-loongarch-arch-definitions.patch
@@ -1,0 +1,34 @@
+From d02118e50e5c275b797249f6ee93145fc6c276e7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Wed, 22 Jan 2025 23:58:37 -0800
+Subject: [PATCH 6/6] Add loongarch arch definitions
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ webrtc/rtc_base/system/arch.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/webrtc/rtc_base/system/arch.h b/webrtc/rtc_base/system/arch.h
+index be2367b..9d945ef 100644
+--- a/webrtc/rtc_base/system/arch.h
++++ b/webrtc/rtc_base/system/arch.h
+@@ -73,6 +73,16 @@
+ #elif defined(__riscv) && __riscv_xlen == 32
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__loongarch32)
++#define WEBRTC_ARCH_LOONG_FAMILY
++#define WEBRTC_ARCH_LOONG32
++#define WEBRTC_ARCH_32_BITS
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__loongarch64)
++#define WEBRTC_ARCH_LOONG_FAMILY
++#define WEBRTC_ARCH_LOONG64
++#define WEBRTC_ARCH_64_BITS
++#define WEBRTC_ARCH_LITTLE_ENDIAN
+ #elif defined(__pnacl__)
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+-- 
+2.48.1
+

--- a/runtime-multimedia/webrtc-audio-processing/spec
+++ b/runtime-multimedia/webrtc-audio-processing/spec
@@ -1,4 +1,4 @@
-VER=2.0
+VER=1.3
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/webrtc-audio-processing-$VER.tar.xz"
-CHKSUMS="sha256::7ea5b079073a9e8bfb55d2dc59471d6507dec1cf2fc697f1fdc53e2da1a2f77b"
+CHKSUMS="sha256::2365e93e778d7b61b5d6e02d21c47d97222e9c7deff9e1d0838ad6ec2e86f1b9"
 CHKUPDATE="anitya::id=15929"


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: bump REL due to webrtc-audio-processing downgrading to 1.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- pipewire: bump REL due to webrtc-audio-processing downgrading to 1.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- webrtc-audio-processing: downgrade to 1.3 as both PulseAudio and PipeWire have not supported 2.x yet
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- pipewire: 1.2.7-4
- pulseaudio: 17.0+xrdp0.7-1
- webrtc-audio-processing: 1:1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit webrtc-audio-processing:-pkgbreak pipewire pulseaudio webrtc-audio-processing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
