### PR TITLE
mihomo: update systemd unit file, following upstream changes

### DIFF
--- a/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/clash-meta@.service
+++ b/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/clash-meta@.service
@@ -4,9 +4,12 @@ After=network.target
 
 [Service]
 Type=exec
+LimitNPROC=500
+LimitNOFILE=1000000
 User=%i
 Restart=on-abort
 ExecStart=/usr/bin/mihomo
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/mihomo.service
+++ b/app-network/mihomo/autobuild/overrides/usr/lib/systemd/system/mihomo.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Starting Mihomo (Clash Meta)
+After=network.target
+
+[Service]
+Type=exec
+LimitNPROC=500
+LimitNOFILE=1000000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+Restart=on-abort
+ExecStart=/usr/bin/mihomo -d /etc/mihomo
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/mihomo/autobuild/overrides/usr/lib/systemd/user/clash-meta.service
+++ b/app-network/mihomo/autobuild/overrides/usr/lib/systemd/user/clash-meta.service
@@ -4,8 +4,11 @@ After=network.target
 
 [Service]
 Type=exec
+LimitNPROC=500
+LimitNOFILE=1000000
 Restart=on-abort
 ExecStart=/usr/bin/mihomo
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=default.target

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,4 +1,5 @@
 VER=1.19.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: update systemd unit file, following upstream changes

Package(s) Affected
-------------------

- mihomo: 1.19.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
