### PR TITLE
mesa: update to 24.3.4+dxheaders1.614.1

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,12 +1,11 @@
-UPSTREAM_VER=24.3.3
+UPSTREAM_VER=24.3.4
 DXHEADERS_VER=1.614.1
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::105afc00a4496fa4d29da74e227085544919ec7c86bd92b0b6e7fcc32c7125f4 \
+CHKSUMS="sha256::e641ae27191d387599219694560d221b7feaa91c900bcec46bf444218ed66025 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"
 
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 24.3.4+dxheaders1.614.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mesa: 1:24.3.4+dxheaders1.614.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
