### PR TITLE
wxmaxima: update to 24.11.0

### DIFF
--- a/app-scientific/wxmaxima/spec
+++ b/app-scientific/wxmaxima/spec
@@ -1,5 +1,4 @@
-VER=22.05.0
-REL=1
+VER=24.11.0
 SRCS="tbl::https://github.com/wxMaxima-developers/wxmaxima/archive/Version-$VER.tar.gz"
-CHKSUMS="sha256::a0140b9f6171540556bd40c6b5617eb9ea224debe592014cbfabd0c095594b93"
+CHKSUMS="sha256::e01fd8ca9bb8054e38f6d973f619e2549ab6ab9d0aaebae70c4ed73580258055"
 CHKUPDATE="anitya::id=6366"


### PR DESCRIPTION
Topic Description
-----------------

- wxmaxima: update to 24.11.0
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- wxmaxima: 24.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wxmaxima
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
