### PR TITLE
memtest86plus: Add translations for GRUB menu entry and grub-mkconfig output

### DIFF
--- a/app-benchmarks/memtest86plus/autobuild/beyond
+++ b/app-benchmarks/memtest86plus/autobuild/beyond
@@ -1,0 +1,57 @@
+# Sorry, I have to put it like this...
+cat > /dev/null << EOF
+=========================
+          NOTES
+=========================
+
+Creating/updating the POT file
+------------------------------
+
+Since the GRUB menu uses a special wrapper to get the localized string, the
+following command can be used to update the PO template file:
+
+xgettext -o po/memtest-grub.pot \
+	--keyword="gettext_printf" \
+	--language=Shell \
+	--copyright-holder="AOSC OS Maintainers <maintainers@aosc.io>" \
+	--package-name="memtest-grub" \
+	--package-version="0.1.0" \
+	overrides/etc/grub.d/26_memtest86plus
+
+Updating translation files according to the new PO Template
+-----------------------------------------------------------
+
+Once you updated the PO Template, run the following command to update the
+translations:
+
+msgmerge -U po/$LOCALE.po po/memtest-grub.pot
+
+Please check if there's any fuzzy translations.
+
+Initializing a new translation
+------------------------------
+
+To initialize a PO file for a new language, run:
+
+msginit -i po/memtest-grub.pot -l $LANG -o po/$LANG.po
+
+While you should know that, don't put encoding part into the file name.
+And then edit it using your favorite editor. Don't forget to git add and
+commit your translation file!
+EOF
+
+TEXTDOMAIN=memtest-grub
+
+abinfo "Building translations ..."
+
+files=("$SRCDIR"/autobuild/po/*.po)
+if [ "${#files[@]}" -lt 1 ] ; then
+	abdie "Translation files not found in autobuild/po."
+fi
+for po in "${files[@]}" ; do
+	locale="$(basename $po)"
+	locale="${locale%%.po}"
+	install -dv "$PKGDIR"/usr/share/locale/"$locale"/LC_MESSAGES
+	echo -n "$locale: "
+	msgfmt -v -o "$PKGDIR"/usr/share/locale/"$locale"/LC_MESSAGES/"$TEXTDOMAIN".mo "$po"
+done

--- a/app-benchmarks/memtest86plus/autobuild/overrides/etc/grub.d/26_memtest86plus
+++ b/app-benchmarks/memtest86plus/autobuild/overrides/etc/grub.d/26_memtest86plus
@@ -13,6 +13,10 @@ exec_prefix="${prefix}"
 datarootdir="/usr/share"
 datadir="${datarootdir}"
 
+export OLD_TEXTDOMAIN="$TEXTDOMAIN"
+
+export TEXTDOMAIN=memtest-grub
+
 . "${datadir}/grub/grub-mkconfig_lib"
 
 MEMTEST86_IMAGE_EFI64="/boot/memtest86plus/memtest64.efi"
@@ -20,11 +24,13 @@ MEMTEST86_IMAGE_EFI32="/boot/memtest86plus/memtest32.efi"
 MEMTEST86_IMAGE_PCBIOS="/boot/memtest86plus/memtest32.bin"
 CLASS="--class memtest86 --class gnu --class tool"
 
+MEMTEST_TITLE="$(gettext_printf "Memory Test")"
+
 if [ -d /sys/firmware/efi ] && \
    [ -e "${MEMTEST86_IMAGE_EFI64}" ] && \
    is_path_readable_by_grub "${MEMTEST86_IMAGE_EFI64}" ; then
     ## image exists, create menu entry
-    echo "Found memtest86+ image: ${MEMTEST86_IMAGE_EFI64}" >&2
+    echo "$(gettext_printf "Found Memtest86+ image: %s" "${MEMTEST86_IMAGE_EFI64}")" >&2
     _GRUB_MEMTEST_HINTS_STRING="$(${grub_probe} --target=hints_string ${MEMTEST86_IMAGE_EFI64})"
     _GRUB_MEMTEST_FS_UUID="$(${grub_probe} --target=fs_uuid ${MEMTEST86_IMAGE_EFI64})"
     _GRUB_MEMTEST_REL_PATH="$(make_system_path_relative_to_its_root ${MEMTEST86_IMAGE_EFI64})"
@@ -32,7 +38,7 @@ if [ -d /sys/firmware/efi ] && \
     cat << EOF
 if [ "\${grub_platform}" == "efi" -a \
    "\${grub_cpu}" == "x86_64" -o "\${grub_cpu}" == "loongarch64" ]; then
-    menuentry "Memory Test" ${CLASS} {
+    menuentry '$MEMTEST_TITLE' ${CLASS} {
         if loadfont unicode ; then
             set gfxmode=1024x768,800x600,auto
             set gfxpayload=800x600,1024x768
@@ -43,19 +49,18 @@ if [ "\${grub_platform}" == "efi" -a \
     }
 fi
 EOF
-fi
 
-if [ -d /sys/firmware/efi ] && \
+elif [ -d /sys/firmware/efi ] && \
    [ -e "${MEMTEST86_IMAGE_EFI32}" ] && \
    is_path_readable_by_grub "${MEMTEST86_IMAGE_EFI32}" ; then
     ## image exists, create menu entry
-    echo "Found memtest86+ image: ${MEMTEST86_IMAGE_EFI32}" >&2
+    echo "$(gettext_printf "Found Memtest86+ image: %s" "${MEMTEST86_IMAGE_EFI32}")" >&2
     _GRUB_MEMTEST_HINTS_STRING="$(${grub_probe} --target=hints_string ${MEMTEST86_IMAGE_EFI32})"
     _GRUB_MEMTEST_FS_UUID="$(${grub_probe} --target=fs_uuid ${MEMTEST86_IMAGE_EFI32})"
     _GRUB_MEMTEST_REL_PATH="$(make_system_path_relative_to_its_root ${MEMTEST86_IMAGE_EFI32})"
     cat << EOF
 if [ "\${grub_platform}" == "efi" -a "\${grub_cpu}" = "i386" ]; then
-    menuentry "Memory Test" ${CLASS} {
+    menuentry '$MEMTEST_TITLE' ${CLASS} {
         if loadfont unicode ; then
             set gfxmode=1024x768,800x600,auto
             set gfxpayload=800x600,1024x768
@@ -66,22 +71,22 @@ if [ "\${grub_platform}" == "efi" -a "\${grub_cpu}" = "i386" ]; then
     }
 fi
 EOF
-fi
-
-if [ ! -d /sys/firmware/efi ] && \
+elif [ ! -d /sys/firmware/efi ] && \
    [ -e "${MEMTEST86_IMAGE_PCBIOS}" ] && \
    is_path_readable_by_grub "${MEMTEST86_IMAGE_PCBIOS}" ; then
     ## image exists, create menu entry
-    echo "Found memtest86plus image: ${MEMTEST86_IMAGE_PCBIOS}" >&2
+    echo "$(gettext_printf "Found Memtest86+ image: %s" "${MEMTEST86_IMAGE_PCBIOS}")" >&2
     _GRUB_MEMTEST_HINTS_STRING="$(${grub_probe} --target=hints_string ${MEMTEST86_IMAGE_PCBIOS})"
     _GRUB_MEMTEST_FS_UUID="$(${grub_probe} --target=fs_uuid ${MEMTEST86_IMAGE_PCBIOS})"
     _GRUB_MEMTEST_REL_PATH="$(make_system_path_relative_to_its_root ${MEMTEST86_IMAGE_PCBIOS})"
     cat << EOF
 if [ "\${grub_platform}" == "pc" ]; then
-    menuentry "Memory Test" ${CLASS} {
+    menuentry '$MEMTEST_TITLE' ${CLASS} {
         search --fs-uuid --no-floppy --set=root ${_GRUB_MEMTEST_HINTS_STRING} ${_GRUB_MEMTEST_FS_UUID}
         linux16 ${_GRUB_MEMTEST_REL_PATH} ${GRUB_CMDLINE_MEMTEST86}
     }
 fi
 EOF
 fi
+
+export TEXTDOMAIN="$OLD_TEXTDOMAIN"

--- a/app-benchmarks/memtest86plus/autobuild/patches/0001-temperature-Add-support-for-AMD-Excavator-440.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0001-temperature-Add-support-for-AMD-Excavator-440.patch
@@ -1,0 +1,48 @@
+From 32c45739ce6e16534063070ba53113a5c0427976 Mon Sep 17 00:00:00 2001
+From: Jonathan Teh <30538043+jonathan-teh@users.noreply.github.com>
+Date: Mon, 11 Nov 2024 22:49:31 +0000
+Subject: [PATCH 01/12] temperature: Add support for AMD Excavator (#440)
+
+Read current temperature from SMU via root complex.
+---
+ system/temperature.c | 8 ++++++++
+ system/temperature.h | 4 ++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/system/temperature.c b/system/temperature.c
+index 6907511..7b9ec08 100644
+--- a/system/temperature.c
++++ b/system/temperature.c
+@@ -103,6 +103,14 @@ int get_cpu_temperature(void)
+ 
+             return cpu_temp_offset + 0.125f * (float)((regl >> 21) & 0x7FF);
+ 
++        } else if (cpuid_info.version.extendedFamily == 6 && (cpuid_info.version.extendedModel == 6 || cpuid_info.version.extendedModel == 7)) { // Target family 15h (Excavator)
++
++            pci_config_write32(0, 0, 0, AMD_SMU_INDEX_ADDR_REG, AMD_F15_M60H_TEMP_CTRL_OFFSET);
++            regl = pci_config_read32(0, 0, 0, AMD_SMU_INDEX_DATA_REG);
++            int raw_temp = ((regl >> 21) & 0x7FF) / 8;
++
++            return (raw_temp > 0) ? raw_temp : 0;
++
+         } else if (cpuid_info.version.extendedFamily > 0) { // Target K10 to K15 (Bulldozer)
+ 
+             regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K10);
+diff --git a/system/temperature.h b/system/temperature.h
+index 0677fa8..65cc798 100644
+--- a/system/temperature.h
++++ b/system/temperature.h
+@@ -14,6 +14,10 @@
+ #define AMD_TEMP_REG_K8     0xE4
+ #define AMD_TEMP_REG_K10    0xA4
+ 
++#define AMD_SMU_INDEX_ADDR_REG 0xB8
++#define AMD_SMU_INDEX_DATA_REG 0xBC
++#define AMD_F15_M60H_TEMP_CTRL_OFFSET 0xD8200CA4
++
+ // Temp Registers on AMD ZEN System Management Network
+ #define SMN_SMUIO_THM               0x00059800
+ #define SMN_THM_TCON_CUR_TMP        (SMN_SMUIO_THM + 0x00)
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0002-Add-PCI-ID-for-the-SMBus-controller-behind-the-VT823.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0002-Add-PCI-ID-for-the-SMBus-controller-behind-the-VT823.patch
@@ -1,0 +1,27 @@
+From 26a19147a99993afb6e85491415e4298725f9e96 Mon Sep 17 00:00:00 2001
+From: Lionel Debroux <lionel_debroux@yahoo.fr>
+Date: Mon, 11 Nov 2024 23:57:36 +0100
+Subject: [PATCH 02/12] Add PCI ID for the SMBus controller behind the VT8237S
+ bridge. (#448)
+
+00:11.0 ISA bridge [0601]: VIA Technologies, Inc. VT8237S PCI to ISA Bridge [1106:3372]
+---
+ system/i2c_x86.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/system/i2c_x86.c b/system/i2c_x86.c
+index 4ef4a0b..166aa12 100644
+--- a/system/i2c_x86.c
++++ b/system/i2c_x86.c
+@@ -297,7 +297,7 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
+                 case 0x3177: // 8235
+                 case 0x3227: // 8237
+                 // case 0x3337: // 8237A
+-                // case 0x3372: // 8237S
++                case 0x3372: // 8237S
+                 // case 0x3287: // 8251
+                 // case 0x8324: // CX700
+                 // case 0x8353: // VX800
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0003-hwquirks-Detect-cache-on-VIA-VP3-MVP3-356.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0003-hwquirks-Detect-cache-on-VIA-VP3-MVP3-356.patch
@@ -1,0 +1,91 @@
+From 0d7b0324b647a698bb36e98dca613c3dbf7bfeec Mon Sep 17 00:00:00 2001
+From: Jonathan Teh <30538043+jonathan-teh@users.noreply.github.com>
+Date: Mon, 11 Nov 2024 23:10:40 +0000
+Subject: [PATCH 03/12] hwquirks: Detect cache on VIA VP3/MVP3 (#356)
+
+Add quirk to detect motherboard cache on VIA VP3/MVP3.
+
+Co-authored-by: Sam Demeulemeester <38105886+x86fr@users.noreply.github.com>
+---
+ system/hwquirks.c | 38 ++++++++++++++++++++++++++++++++++++++
+ system/hwquirks.h |  1 +
+ 2 files changed, 39 insertions(+)
+
+diff --git a/system/hwquirks.c b/system/hwquirks.c
+index 9cc66c7..f3781ec 100644
+--- a/system/hwquirks.c
++++ b/system/hwquirks.c
+@@ -50,6 +50,16 @@ static void asus_tusl2_configure_mux(void)
+     outb(0xAA, 0x2E);
+ }
+ 
++static int *get_motherboard_cache(void)
++{
++    if (l2_cache == 0) {
++        return &l2_cache;
++    } else if (l3_cache == 0) {
++        return &l3_cache;
++    }
++    return NULL;
++}
++
+ static void get_m1541_l2_cache_size(void)
+ {
+     if (l2_cache != 0) {
+@@ -69,6 +79,24 @@ static void get_m1541_l2_cache_size(void)
+     if (reg == 0b10) { l2_cache = 1024; }
+ }
+ 
++static void get_vt82c597_mb_cache_size(void)
++{
++    int *const mb_cache = get_motherboard_cache();
++    if (!mb_cache) {
++        return;
++    }
++
++    // Check if cache is enabled with CC1 Register[7:6]
++    if ((pci_config_read8(0, 0, 0, 0x50) & 0xc0) != 0x80) {
++        return;
++    }
++
++    // Get cache size with CC2 Register[1:0]
++    const uint8_t reg = pci_config_read8(0, 0, 0, 0x51) & 0x03;
++
++    *mb_cache = 256 << reg;
++}
++
+ static void disable_temp_reporting(void)
+ {
+     enable_temperature = false;
+@@ -140,6 +168,16 @@ void quirks_init(void)
+         quirk.process = get_m1541_l2_cache_size;
+     }
+ 
++    //  -----------------------------------------------
++    //  -- VIA VP3 (VT82C597), MVP3 (VT82C598) Quirk --
++    //  -----------------------------------------------
++    // Motherboard cache detection
++    else if (quirk.root_vid == PCI_VID_VIA && (quirk.root_did == 0x0597 || quirk.root_did == 0x0598)) { // VIA VT82C597/8
++        quirk.id    = QUIRK_VIA_VP3;
++        quirk.type |= QUIRK_TYPE_MEM_SIZE;
++        quirk.process = get_vt82c597_mb_cache_size;
++    }
++
+     //  ------------------------
+     //  -- ASUS TUSL2-C Quirk --
+     //  ------------------------
+diff --git a/system/hwquirks.h b/system/hwquirks.h
+index bc3365d..9e715cd 100644
+--- a/system/hwquirks.h
++++ b/system/hwquirks.h
+@@ -29,6 +29,7 @@ typedef enum {
+     QUIRK_K8_BSTEP_NOTEMP,
+     QUIRK_K8_REVFG_TEMP,
+     QUIRK_AMD_ERRATA_319,
++    QUIRK_VIA_VP3,
+     QUIRK_LOONGSON7A00_EHCI_WORKARD
+ } quirk_id_t;
+ 
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0004-Add-a-few-RAM-manufacturers-in-JEDEC-DB.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0004-Add-a-few-RAM-manufacturers-in-JEDEC-DB.patch
@@ -1,0 +1,33 @@
+From f41ef9bc479baa4982d602b611faee0755465579 Mon Sep 17 00:00:00 2001
+From: Sam Demeulemeester <github@x86-secret.com>
+Date: Tue, 12 Nov 2024 00:25:38 +0100
+Subject: [PATCH 04/12] Add a few RAM manufacturers in JEDEC DB
+
+---
+ system/jedec_id.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/system/jedec_id.h b/system/jedec_id.h
+index 5a35971..37f5b1c 100644
+--- a/system/jedec_id.h
++++ b/system/jedec_id.h
+@@ -1005,7 +1005,7 @@ static const struct __attribute__((packed)) spd_jedec_manufacturer jep106[] = {
+ //  { 0x076C, "Hon-Hai Precision" },
+ //  { 0x076D, "Smart Storage Systems" },
+ //  { 0x076E, "Toumaz Group" },
+-//  { 0x076F, "Zentel Electronics Corporation" },
++    { 0x076F, "Zentel" },
+ //  { 0x0770, "Panram International Corporation" },
+ //  { 0x0771, "Silicon Space Technology" },
+     { 0x0772, "LITE-ON" },
+@@ -1678,5 +1678,7 @@ static const struct __attribute__((packed)) spd_jedec_manufacturer jep106[] = {
+ //  { 0x0D1E, "Creative World International Limited" },
+ //  { 0x0D1F, "Base Creation International Limited" },
+     { 0x0E51, "Xiaoli AI" },
++    { 0x0E58, "Trium Elek." },
++    { 0x0F33, "Xllbyte" },
+     { 0xFFFF, "Unknown"}
+ };
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0005-Fix-LD-error-while-linking-LoongArch-EFI-binary-457.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0005-Fix-LD-error-while-linking-LoongArch-EFI-binary-457.patch
@@ -1,0 +1,38 @@
+From fe2314bc4d504b2a42cbaf2f3b6b3554e544d685 Mon Sep 17 00:00:00 2001
+From: Sam Demeulemeester <38105886+x86fr@users.noreply.github.com>
+Date: Mon, 25 Nov 2024 17:39:00 +0100
+Subject: [PATCH 05/12] Fix LD error while linking LoongArch EFI binary (#457)
+
+---
+ build64/la64/Makefile                  | 4 +++-
+ build64/la64/ldscripts/memtest_efi.lds | 2 +-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/build64/la64/Makefile b/build64/la64/Makefile
+index e1a9235..39a9a0f 100644
+--- a/build64/la64/Makefile
++++ b/build64/la64/Makefile
+@@ -183,7 +183,9 @@ memtest.debug: memtest_shared
+ 
+ memtest.efi: memtest_shared.bin boot/loongarch/header.o ldscripts/memtest_efi.lds
+ 	$(eval SIZES=$(shell size -B -d memtest_shared | grep memtest_shared))
+-	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_shared.bin -o memtest.efi
++	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_shared.bin -o memtest.elf
++	$(OBJCOPY) -O binary memtest.elf memtest.efi
++	rm -f memtest.elf
+ 
+ esp.img: memtest.efi
+ 	@mkdir -p iso/EFI/BOOT
+diff --git a/build64/la64/ldscripts/memtest_efi.lds b/build64/la64/ldscripts/memtest_efi.lds
+index b2b760c..6482b23 100644
+--- a/build64/la64/ldscripts/memtest_efi.lds
++++ b/build64/la64/ldscripts/memtest_efi.lds
+@@ -1,4 +1,4 @@
+-OUTPUT_FORMAT("binary")
++OUTPUT_FORMAT("elf64-loongarch")
+ OUTPUT_ARCH(loongarch)
+ 
+ ENTRY(head);
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0006-system-hwquirks-Optimization-Loongson-7A2000-EHCI-qu.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0006-system-hwquirks-Optimization-Loongson-7A2000-EHCI-qu.patch
@@ -1,0 +1,37 @@
+From baeea57c40b41ee7b7c4fee924c9de402df2f0ab Mon Sep 17 00:00:00 2001
+From: Chao Li <lichao@loongson.cn>
+Date: Sat, 7 Dec 2024 05:51:18 +0800
+Subject: [PATCH 06/12] system/hwquirks: Optimization Loongson 7A2000 EHCI
+ quirk (#473)
+
+Currentilly, it only compares the root bus DID is 0x7A00 which sometimes
+fails, a new logic was added to compare the 7A2000 EHCI DID to fix it.
+
+Signed-off-by: Chao Li <lichao@loongson.cn>
+---
+ system/hwquirks.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/system/hwquirks.c b/system/hwquirks.c
+index f3781ec..48545ee 100644
+--- a/system/hwquirks.c
++++ b/system/hwquirks.c
+@@ -259,9 +259,11 @@ void quirks_init(void)
+     //  -----------------------------------------------------------
+     //  -- Loongson 7A1000 and 7A2000 chipset USB 2.0 workaround --
+     //  -----------------------------------------------------------
+-    if (quirk.root_vid == PCI_VID_LOONGSON && quirk.root_did == 0x7a00) {
+-        quirk.id    = QUIRK_LOONGSON7A00_EHCI_WORKARD;
+-        quirk.type |= QUIRK_TYPE_USB;
+-        quirk.process = loongson_7a00_ehci_workaround;
++    if (quirk.root_vid == PCI_VID_LOONGSON) {
++        if (pci_config_read16(0, 4, 1, PCI_DID_REG) == 0x7a14) {
++            quirk.id    = QUIRK_LOONGSON7A00_EHCI_WORKARD;
++            quirk.type |= QUIRK_TYPE_USB;
++            quirk.process = loongson_7a00_ehci_workaround;
++        }
+     }
+ }
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0007-Add-Thermaltake-and-SSTC-Jedec-IDs.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0007-Add-Thermaltake-and-SSTC-Jedec-IDs.patch
@@ -1,0 +1,32 @@
+From 5acc767e5ee6e217a04e7982593f614cf6aaf00e Mon Sep 17 00:00:00 2001
+From: Sam Demeulemeester <github@x86-secret.com>
+Date: Mon, 27 Jan 2025 19:41:36 +0100
+Subject: [PATCH 07/12] Add Thermaltake and SSTC Jedec IDs
+
+---
+ system/jedec_id.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/system/jedec_id.h b/system/jedec_id.h
+index 37f5b1c..20d78af 100644
+--- a/system/jedec_id.h
++++ b/system/jedec_id.h
+@@ -1333,7 +1333,7 @@ static const struct __attribute__((packed)) spd_jedec_manufacturer jep106[] = {
+ //  { 0x0A3F, "Shanghai Han Rong Microelectronics Co" },
+ //  { 0x0A40, "Shenzhen Zhongguang Yunhe Trading" },
+ //  { 0x0A41, "Smart Shine(QingDao) Microelectronics" },
+-//  { 0x0A42, "Thermaltake Technology Co Ltd" },
++    { 0x0A42, "Thermaltake" },
+ //  { 0x0A43, "Shenzhen O?Yang Maile Technology Ltd" },
+ //  { 0x0A44, "UPMEM" },
+     { 0x0A45, "Chun Well" },
+@@ -1680,5 +1680,6 @@ static const struct __attribute__((packed)) spd_jedec_manufacturer jep106[] = {
+     { 0x0E51, "Xiaoli AI" },
+     { 0x0E58, "Trium Elek." },
+     { 0x0F33, "Xllbyte" },
++    { 0x0F37, "SSTC" },
+     { 0xFFFF, "Unknown"}
+ };
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0008-Ignore-PS-2-mouse-events-issue-456-484.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0008-Ignore-PS-2-mouse-events-issue-456-484.patch
@@ -1,0 +1,45 @@
+From e4dc0f251c9d71768caa53627c9c177ef8c106f5 Mon Sep 17 00:00:00 2001
+From: martinwhitaker <memtest@martin-whitaker.me.uk>
+Date: Mon, 27 Jan 2025 20:54:54 +0000
+Subject: [PATCH 08/12] Ignore PS/2 mouse events (issue #456) (#484)
+
+If a legacy BIOS has enabled PS/2 mouse input, the bytes received on
+port 0x60 may come from either the keyboard or the mouse. Currently
+we treat all bytes as keyboard input, which means mouse input will be
+translated into arbitrary key codes. This may cause a memory test to
+be interrupted or aborted. We should instead disable or ignore any
+mouse input.
+
+Although it should be possible to reconfigure the PS/2 controller to
+disable mouse input, it's quite likely that there's some quirky H/W
+out there that makes this more complicated than it seems. The simple
+solution is to detect mouse input by checking whether bit 5 of the
+received byte is set and discarding it if so.
+---
+ system/keyboard.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/system/keyboard.c b/system/keyboard.c
+index 71a37af..2ad896b 100644
+--- a/system/keyboard.c
++++ b/system/keyboard.c
+@@ -248,9 +248,13 @@ char get_key(void)
+ 
+     static bool escaped = false;
+     if (keyboard_types & KT_LEGACY) {
+-        uint8_t c = inb(0x64);
+-        if (c & 0x01) {
+-            c = inb(0x60);
++        uint8_t status = inb(0x64);
++        if (status & 0x01) {
++            uint8_t c = inb(0x60);
++            if (status & 0x20) {
++                // Ignore mouse events.
++                return '\0';
++            }
+             if (escaped) {
+                 escaped = false;
+                 switch (c) {
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0009-Fix-DDR5-SPD-parsing-issue-for-XMP-3.0-frequency.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0009-Fix-DDR5-SPD-parsing-issue-for-XMP-3.0-frequency.patch
@@ -1,0 +1,38 @@
+From 411f94755f32f8cb3e266870ee7b033bd5847cba Mon Sep 17 00:00:00 2001
+From: Sam Demeulemeester <github@x86-secret.com>
+Date: Sun, 20 Apr 2025 19:16:51 +0200
+Subject: [PATCH 09/12] Fix DDR5 SPD parsing issue for XMP 3.0 frequency On
+ DDR5, limit XMP profile parsing to 2 to avoid conflict between XMP and EXPO
+ Add a check to skip very low tCK values
+
+---
+ system/spd.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/system/spd.c b/system/spd.c
+index f0f7630..f53c4dd 100644
+--- a/system/spd.c
++++ b/system/spd.c
+@@ -202,14 +202,14 @@ static void parse_spd_ddr5(spd_info *spdi, uint8_t slot_idx)
+     if (spdi->XMP == 3) {
+         // XMP 3.0 (enumerate all profiles to find the fastest)
+         tCK = 0;
+-        for (int offset = 0; offset < 3*64; offset += 64) {
++        for (int offset = 0; offset < 2*64; offset += 64) {
+             tCKtmp = get_spd(slot_idx, 710 + offset) << 8 |
+                      get_spd(slot_idx, 709 + offset);
+ 
+-            if (tCKtmp != 0 && (tCK == 0 || tCKtmp < tCK)) {
+-                xmp_offset = offset;
+-                tCK = tCKtmp;
+-            }
++            if (tCKtmp == 0 || tCKtmp < 100 || (tCK != 0 && tCKtmp >= tCK)) continue;
++
++            xmp_offset = offset;
++            tCK = tCKtmp;
+         }
+     } else {
+         // JEDEC
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0010-loongarch-Supports-2K2000-3B6000M-512.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0010-loongarch-Supports-2K2000-3B6000M-512.patch
@@ -1,0 +1,104 @@
+From 77020c4e7dfb6af976e26cb1eb7ac4d96e8b3680 Mon Sep 17 00:00:00 2001
+From: Dongyan Qian <qiandongyan@loongson.cn>
+Date: Mon, 12 May 2025 19:56:30 +0800
+Subject: [PATCH 10/12] loongarch: Supports 2K2000/3B6000M (#512)
+
+* loongarch: adjust 2K/3B6000M DDR rate factor
+* loongarch: Supports fewer cache layers than L3
+
+For example: 2K2000 chip does not have L3, but has L2.
+If L2Cache is not flushed to memory, it will cause read and write data errors after cache_off.
+---
+ system/cache.h                    | 32 +++++++++++++++++++++++++------
+ system/imc/loongson/loongson_la.c |  6 ++++--
+ 2 files changed, 30 insertions(+), 8 deletions(-)
+
+diff --git a/system/cache.h b/system/cache.h
+index 81074af..148e31f 100644
+--- a/system/cache.h
++++ b/system/cache.h
+@@ -94,12 +94,22 @@ static inline void cache_flush(void)
+         : "memory"
+     );
+ #elif defined (__loongarch_lp64)
+-    if (!(__cpucfg(0x10) & (1 << 10))) {
+-        return; // No L3
++    uint64_t cache_present, cache_info_reg;
++    /*detect_max_cache_level*/
++    if (__cpucfg(0x10) & (1 << 10)) {
++	cache_present = 3; //L3 unified cache
++    } else if (__cpucfg(0x10) & (1 << 3)) {
++	cache_present = 2; //L2 unified cache
++    } else if (__cpucfg(0x10) & (1 << 0)) {
++	cache_present = 1; //L1 data cache
++    } else {
++	return; //No Cache present
+     }
+-    uint64_t ways = (__cpucfg(0x14) & 0xFFFF) + 1;
+-    uint64_t sets = 1 << ((__cpucfg(0x14) >> 16) & 0xFF);
+-    uint64_t line_size = 1 << ((__cpucfg(0x14) >> 24) & 0x7F);
++    cache_info_reg = 0x11 + cache_present; //cache last leaf
++
++    uint64_t ways = (__cpucfg(cache_info_reg) & 0xFFFF) + 1;
++    uint64_t sets = 1 << ((__cpucfg(cache_info_reg) >> 16) & 0xFF);
++    uint64_t line_size = 1 << ((__cpucfg(cache_info_reg) >> 24) & 0x7F);
+     uint64_t va, i, j;
+     uint64_t cpu_module[1];
+     va = 0;
+@@ -119,7 +129,17 @@ static inline void cache_flush(void)
+     } else {
+         for (i = 0; i < sets; i++) {
+             for (j = 0; j < ways; j++) {
+-                cache_op(0xB, va);
++		switch (cache_present) {
++		    case 1:
++		        cache_op(0x9,va); //Flush L1
++			break;
++		    case 2:
++		        cache_op(0xA,va); //Flush L2
++			break;
++		    case 3:
++		        cache_op(0xB,va); //Flush L3
++			break;
++		}
+                 va++;
+             }
+             va -= ways;
+diff --git a/system/imc/loongson/loongson_la.c b/system/imc/loongson/loongson_la.c
+index e6deb1a..ba0a4cc 100644
+--- a/system/imc/loongson/loongson_la.c
++++ b/system/imc/loongson/loongson_la.c
+@@ -123,11 +123,12 @@ void get_imc_config_loongson_ddr4(void)
+ {
+     uint32_t val;
+     uint16_t refc, loopc, div, div_mode, ref_clk;
+-    uint8_t  max_mc, node_num;
++    uint8_t  max_mc, node_num, ddr_rate_factor;
+     bool route_flag;
+ 
+     imc.type  = "DDR4";
+     node_num  = 1;
++    ddr_rate_factor = 4;
+ 
+     if (strstr(cpuid_info.brand_id.str, "3C") ||
+         (strstr(cpuid_info.brand_id.str, "3B6000") &&
+@@ -150,6 +151,7 @@ void get_imc_config_loongson_ddr4(void)
+                 strstr(cpuid_info.brand_id.str, "3B6000M")) {
+         route_flag = false;
+         max_mc     = 1;
++        ddr_rate_factor = 2;
+     } else {
+         route_flag = false;
+         max_mc     = 0;
+@@ -164,7 +166,7 @@ void get_imc_config_loongson_ddr4(void)
+         div_mode = 0x1 << ((val >> 4) & 0x3);
+         refc     = (val >> 8) & 0x1f;
+         ref_clk  = (uint16_t)(((__cpucfg(0x4) * (__cpucfg(0x5) & 0xFFFF)) / ((__cpucfg(0x5) >> 16) & 0xFFFF)) / 1000000);
+-        imc.freq = (ref_clk * loopc / refc / div / div_mode) * 4;
++        imc.freq = (ref_clk * loopc / refc / div / div_mode) * ddr_rate_factor;
+     } else {
+         imc.freq = 0;
+     }
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0011-Add-support-for-AMD-Hawk-Point-FP7-Phoenix.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0011-Add-support-for-AMD-Hawk-Point-FP7-Phoenix.patch
@@ -1,0 +1,38 @@
+From f9b73e2ccbe6dc686141dd5bc01d94a56f571dc5 Mon Sep 17 00:00:00 2001
+From: Sam Demeulemeester <github@x86-secret.com>
+Date: Tue, 27 May 2025 22:02:41 +0200
+Subject: [PATCH 11/12] Add support for AMD Hawk Point FP7 (Phoenix)
+
+---
+ system/i2c_x86.c | 2 +-
+ system/memctrl.c | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/system/i2c_x86.c b/system/i2c_x86.c
+index 166aa12..d892150 100644
+--- a/system/i2c_x86.c
++++ b/system/i2c_x86.c
+@@ -446,7 +446,7 @@ static bool fch_zen_get_smb(void)
+     pm_reg |= __inb(AMD_DATA_IO_PORT);
+ 
+     // Special case for AMD Family 19h & Extended Model > 4 (get smb address in memory)
+-    if ((imc.family == IMC_K19_CZN || imc.family == IMC_K19_RPL || imc.family >= IMC_K1A_STP) && pm_reg == 0xFFFF) {
++    if ((imc.family == IMC_K19_CZN || imc.family == IMC_K19_PHX || imc.family == IMC_K19_RPL || imc.family >= IMC_K1A_STP) && pm_reg == 0xFFFF) {
+         smbusbase = ((*(const uint32_t *)(0xFED80000 + 0x300) >> 8) & 0xFF) << 8;
+         return true;
+     }
+diff --git a/system/memctrl.c b/system/memctrl.c
+index b9e6964..efbef80 100644
+--- a/system/memctrl.c
++++ b/system/memctrl.c
+@@ -37,6 +37,7 @@ void memctrl_init(void)
+       case IMC_K19_VRM:
+       case IMC_K19_RPL:
+       case IMC_K19_RBT:
++      case IMC_K19_PHX:
+       case IMC_K1A_GRG:
+         get_imc_config_amd_zen();
+         break;
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/patches/0012-imc-Enable-support-for-AMD-Cezanne-Zen-3-APU-525.patch
+++ b/app-benchmarks/memtest86plus/autobuild/patches/0012-imc-Enable-support-for-AMD-Cezanne-Zen-3-APU-525.patch
@@ -1,0 +1,38 @@
+From e58a707bbcd767d73965c257b490edb842306947 Mon Sep 17 00:00:00 2001
+From: Jonathan Teh <30538043+jonathan-teh@users.noreply.github.com>
+Date: Sun, 6 Jul 2025 12:06:38 +0100
+Subject: [PATCH 12/12] imc: Enable support for AMD Cezanne (Zen 3 APU) (#525)
+
+---
+ system/cpuinfo.c | 2 +-
+ system/memctrl.c | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/system/cpuinfo.c b/system/cpuinfo.c
+index d06001b..c4d3bf7 100644
+--- a/system/cpuinfo.c
++++ b/system/cpuinfo.c
+@@ -350,7 +350,7 @@ static void determine_imc(void)
+                 imc.family = IMC_K19_RBT; // Zen3+ (Family 19h - Rembrandt FP7 & AM5 FTV)
+                 break;
+               case 5:
+-                imc.family = IMC_K19_CZN; // Zen3 APU (Family 19h - Cezanne FP6)
++                imc.family = IMC_K19_CZN; // Zen3 APU (Family 19h - Cezanne FP6/AM4)
+                 break;
+               case 6:
+                 imc.family = IMC_K19_RPL; // Zen4 (Family 19h - Raphael AM5)
+diff --git a/system/memctrl.c b/system/memctrl.c
+index efbef80..26a18b0 100644
+--- a/system/memctrl.c
++++ b/system/memctrl.c
+@@ -35,6 +35,7 @@ void memctrl_init(void)
+     switch(imc.family) {
+       case IMC_K17:
+       case IMC_K19_VRM:
++      case IMC_K19_CZN:
+       case IMC_K19_RPL:
+       case IMC_K19_RBT:
+       case IMC_K19_PHX:
+-- 
+2.50.1
+

--- a/app-benchmarks/memtest86plus/autobuild/po/en_US.po
+++ b/app-benchmarks/memtest86plus/autobuild/po/en_US.po
@@ -1,0 +1,28 @@
+# Translation file for AOSC OS Memtest86+ package maintenance script.
+# Copyright (C) 2025 AOSC OS Maintainers <maintainers@aosc.io>
+# This file is distributed under the same license as the memtest-grub package.
+# Xinhui Yang <cyanoxygen@aosc.io>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: memtest-grub 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-23 11:24+0800\n"
+"PO-Revision-Date: 2025-01-22 00:16+0800\n"
+"Last-Translator: Xinhui Yang <cyanoxygen@aosc.io>\n"
+"Language-Team: English\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: overrides/etc/grub.d/26_memtest86plus:27
+msgid "Memory Test"
+msgstr "Memory Test"
+
+#: overrides/etc/grub.d/26_memtest86plus:33
+#: overrides/etc/grub.d/26_memtest86plus:57
+#: overrides/etc/grub.d/26_memtest86plus:78
+msgid "Found Memtest86+ image: %s"
+msgstr "Found Memtest86+ image: %s"

--- a/app-benchmarks/memtest86plus/autobuild/po/memtest-grub.pot
+++ b/app-benchmarks/memtest86plus/autobuild/po/memtest-grub.pot
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR AOSC OS Maintainers <maintainers@aosc.io>
+# This file is distributed under the same license as the memtest-grub package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: memtest-grub 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-23 11:24+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: overrides/etc/grub.d/26_memtest86plus:27
+msgid "Memory Test"
+msgstr ""
+
+#: overrides/etc/grub.d/26_memtest86plus:33
+#: overrides/etc/grub.d/26_memtest86plus:57
+#: overrides/etc/grub.d/26_memtest86plus:78
+msgid "Found Memtest86+ image: %s"
+msgstr ""

--- a/app-benchmarks/memtest86plus/autobuild/po/zh_CN.po
+++ b/app-benchmarks/memtest86plus/autobuild/po/zh_CN.po
@@ -1,0 +1,27 @@
+# Translation file for AOSC OS Memtest86+ package maintenance script.
+# Copyright (C) 2025 AOSC OS Maintainers <maintainers@aosc.io>
+# This file is distributed under the same license as the memtest-grub package.
+# Xinhui Yang <cyanoxygen@aosc.io>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: memtest-grub 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-23 11:24+0800\n"
+"PO-Revision-Date: 2025-01-22 00:14+0800\n"
+"Last-Translator: Xinhui Yang <cyanoxygen@aosc.io>\n"
+"Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: overrides/etc/grub.d/26_memtest86plus:27
+msgid "Memory Test"
+msgstr "内存测试"
+
+#: overrides/etc/grub.d/26_memtest86plus:33
+#: overrides/etc/grub.d/26_memtest86plus:57
+#: overrides/etc/grub.d/26_memtest86plus:78
+msgid "Found Memtest86+ image: %s"
+msgstr "找到 Memtest86+ 程序：%s"

--- a/app-benchmarks/memtest86plus/autobuild/po/zh_TW.po
+++ b/app-benchmarks/memtest86plus/autobuild/po/zh_TW.po
@@ -1,0 +1,28 @@
+# Chinese translations for memtest-grub package
+# memtest-grub 套件的正體中文翻譯.
+# Copyright (C) 2025 AOSC OS Maintainers <maintainers@aosc.io>
+# This file is distributed under the same license as the memtest-grub package.
+# Kaiyang Wu <self@origincode.me>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: memtest-grub 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-23 11:24+0800\n"
+"PO-Revision-Date: 2025-01-23 11:31+0800\n"
+"Last-Translator: Kaiyang Wu <self@origincode.me>\n"
+"Language-Team: Chinese (traditional) <zh-l10n@lists.slat.org>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: overrides/etc/grub.d/26_memtest86plus:27
+msgid "Memory Test"
+msgstr "記憶體測試"
+
+#: overrides/etc/grub.d/26_memtest86plus:33
+#: overrides/etc/grub.d/26_memtest86plus:57
+#: overrides/etc/grub.d/26_memtest86plus:78
+msgid "Found Memtest86+ image: %s"
+msgstr "找到 Memtest86+ 程式：%s"

--- a/app-benchmarks/memtest86plus/spec
+++ b/app-benchmarks/memtest86plus/spec
@@ -1,4 +1,5 @@
 VER=7.20
+REL=1
 SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/memtest86plus/memtest86plus.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1966"


### PR DESCRIPTION
Topic Description
-----------------

- memtest86plus: add translations for the GRUB helper script
    Co-authored-by: Kaiyang Wu <self@origincode.me>
    Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
- topics: add busybox-1.37.0-1.toml
- busybox: update to 1.37.0-1
- llvm-19: add loongarch64_nosimd build option
    Signed-off-by: Ilikara <3435193369@qq.com>
- qtcreator: add loongarch64_nosimd build config
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- memtest86plus: 7.20-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit memtest86plus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
