### PR TITLE
sequoia-sq: update to 1.1.0

### DIFF
--- a/app-cryptography/sequoia-sq/autobuild/defines
+++ b/app-cryptography/sequoia-sq/autobuild/defines
@@ -9,6 +9,3 @@ USECLANG=1
 
 # FIXME: Segfaults during linkage.
 NOLTO__LOONGSON3=1
-
-# FIXME: ld.lld is not yet available for loongarch64.
-NOLTO__LOONGARCH64=1

--- a/app-cryptography/sequoia-sq/autobuild/patches/0001-inject-lto.patch
+++ b/app-cryptography/sequoia-sq/autobuild/patches/0001-inject-lto.patch
@@ -1,7 +1,0 @@
---- a/Cargo.toml	2022-08-10 03:27:37.152222052 +0000
-+++ b/Cargo.toml	2022-08-10 03:31:49.115242729 +0000
-@@ -11,3 +11,4 @@
- 
- [profile.release]
- debug = true
-+lto = true

--- a/app-cryptography/sequoia-sq/spec
+++ b/app-cryptography/sequoia-sq/spec
@@ -1,4 +1,4 @@
-VER=0.36.0
-SRCS="git::commit=tags/v$VER::https://gitlab.com/sequoia-pgp/sequoia-sq"
+VER=1.1.0
+SRCS="git::commit=tags/v$VER::https://gitlab.com/sequoia-pgp/sequoia-sq.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=191617"


### PR DESCRIPTION
Topic Description
-----------------

- sequoia-sq: update to 1.1.0
    Co-authored-by: xtex \(@xtexChooser\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- sequoia-sq: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sequoia-sq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
