### PR TITLE
Fcitx 5 Survey (Jan. 2025)

### DIFF
--- a/app-i18n/fcitx5-anthy/spec
+++ b/app-i18n/fcitx5-anthy/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
+VER=5.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-anthy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174357"

--- a/app-i18n/fcitx5-chewing/spec
+++ b/app-i18n/fcitx5-chewing/spec
@@ -1,4 +1,4 @@
-VER=5.1.6
+VER=5.1.7
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chewing"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138243"

--- a/app-i18n/fcitx5-chinese-addons/spec
+++ b/app-i18n/fcitx5-chinese-addons/spec
@@ -1,7 +1,7 @@
-VER=5.1.7
+VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chinese-addons \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \
-         sha256::920ec6fb6abc93f80514eff3f7e64fce822dbd820a98afd816fe5039459520b3"
+         sha256::8306a2854be6a6d981271a9a1559517bb084e5ee018629571af4786038379a1a"
 CHKUPDATE="anitya::id=138238"
 SUBDIR="fcitx5-chinese-addons-$VER"

--- a/app-i18n/fcitx5-configtool/spec
+++ b/app-i18n/fcitx5-configtool/spec
@@ -1,4 +1,4 @@
-VER=5.1.7
+VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-configtool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138233"

--- a/app-i18n/fcitx5-hangul/spec
+++ b/app-i18n/fcitx5-hangul/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
+VER=5.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-hangul"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174360"

--- a/app-i18n/fcitx5-kkc/spec
+++ b/app-i18n/fcitx5-kkc/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
+VER=5.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-kkc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138241"

--- a/app-i18n/fcitx5-libthai/spec
+++ b/app-i18n/fcitx5-libthai/spec
@@ -1,4 +1,4 @@
-VER=5.1.4
+VER=5.1.5
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-libthai"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174358"

--- a/app-i18n/fcitx5-lua/spec
+++ b/app-i18n/fcitx5-lua/spec
@@ -1,4 +1,4 @@
-VER=5.0.13
-SRCS="tbl::https://github.com/fcitx/fcitx5-lua/archive/$VER.tar.gz"
-CHKSUMS="sha256::f39932c7425cf0e33e9fa75cc63775ad5095d719ea9bd2a84d37bfb9d14e9309"
+VER=5.0.14
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-lua"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138242"

--- a/app-i18n/fcitx5-m17n/spec
+++ b/app-i18n/fcitx5-m17n/spec
@@ -1,4 +1,4 @@
-VER=5.1.2
+VER=5.1.3
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-m17n"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174359"

--- a/app-i18n/fcitx5-qt/spec
+++ b/app-i18n/fcitx5-qt/spec
@@ -1,5 +1,4 @@
-VER=5.1.8
+VER=5.1.9
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-qt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138234"
-REL=1

--- a/app-i18n/fcitx5-rime/spec
+++ b/app-i18n/fcitx5-rime/spec
@@ -1,4 +1,4 @@
-VER=5.1.9
+VER=5.1.10
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-rime"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138239"

--- a/app-i18n/fcitx5-sayura/spec
+++ b/app-i18n/fcitx5-sayura/spec
@@ -1,4 +1,4 @@
-VER=5.1.2
-SRCS="tbl::https://github.com/fcitx/fcitx5-sayura/archive/$VER.tar.gz"
-CHKSUMS="sha256::04f1015d52e85986c52976e1c79cecbd95fcb5d9f5313bae76ae0b3e698a8767"
+VER=5.1.3
+SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-sayura"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174361"

--- a/app-i18n/fcitx5-skk/spec
+++ b/app-i18n/fcitx5-skk/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
+VER=5.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-skk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138240"

--- a/app-i18n/fcitx5-unikey/spec
+++ b/app-i18n/fcitx5-unikey/spec
@@ -1,4 +1,4 @@
-VER=5.1.5
+VER=5.1.6
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-unikey"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180082"

--- a/app-i18n/fcitx5/spec
+++ b/app-i18n/fcitx5/spec
@@ -1,7 +1,7 @@
-VER=5.1.11
+VER=5.1.12
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5 \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \
-         sha256::6d16ce1eea7a86eacbb8e738329b924469c93fee954e8851ec58aed906577d89"
+         sha256::19da94d26e66d7b1028ab6bd1b13dddde937a23c280798f3ba53747259c455ff"
 CHKUPDATE="anitya::id=138232"
 SUBDIR="fcitx5-$VER"

--- a/runtime-i18n/libime/spec
+++ b/runtime-i18n/libime/spec
@@ -1,7 +1,7 @@
-VER=1.1.9
+VER=1.1.10
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/libime/ \
       tbl::https://download.fcitx-im.org/fcitx5/libime/libime-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \
-         sha256::d128cdf13393722ee5c2ae9a5f74530d43dbfb19539fc32522be7dd239c78389"
+         sha256::a4746bc855516968114cdfab32d0b48afdbd4185c0c3e7b8acdbac85e4eaad9e"
 CHKUPDATE="anitya::id=138236"
 SUBDIR="libime-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-unikey: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-skk: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-sayura: update to 5.1.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-rime: update to 5.1.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-m17n: update to 5.1.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-libthai: update to 5.1.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-kkc: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-hangul: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-chewing: update to 5.1.7
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- fcitx5-anthy: update to 5.1.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

... and 6 more commits

Package(s) Affected
-------------------

- fcitx5: 1:5.1.12
- fcitx5-anthy: 1:5.1.6
- fcitx5-chewing: 5.1.7
- fcitx5-chinese-addons: 1:5.1.8
- fcitx5-configtool: 1:5.1.8
- fcitx5-hangul: 5.1.6
- fcitx5-kkc: 1:5.1.6
- fcitx5-libthai: 5.1.5
- fcitx5-lua: 1:5.0.14
- fcitx5-m17n: 5.1.3
- fcitx5-migrator: 1:5.1.8
- fcitx5-qt: 1:5.1.9
- fcitx5-rime: 1:5.1.10
- fcitx5-sayura: 5.1.3
- fcitx5-skk: 5.1.6
- fcitx5-unikey: 5.1.6
- libime: 1:1.1.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5 libime fcitx5-qt fcitx5-lua fcitx5-chinese-addons fcitx5-configtool fcitx5-anthy fcitx5-chewing fcitx5-hangul fcitx5-kkc fcitx5-libthai fcitx5-m17n fcitx5-rime fcitx5-sayura fcitx5-skk fcitx5-unikey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
