### PR TITLE
gtk-3: update to 3.24.43

### DIFF
--- a/desktop-gnome/gtk-3/spec
+++ b/desktop-gnome/gtk-3/spec
@@ -1,5 +1,4 @@
-VER=3.24.38
-REL=5
+VER=3.24.43
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
-CHKSUMS="sha256::ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7"
+CHKSUMS="sha256::7e04f0648515034b806b74ae5d774d87cffb1a2a96c468cb5be476d51bf2f3c7"
 CHKUPDATE="anitya::id=10018"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-3: update to 3.24.43
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gtk-3: 3.24.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
