### PR TITLE
openldap: update to 2.6.9

### DIFF
--- a/app-admin/openldap/spec
+++ b/app-admin/openldap/spec
@@ -1,4 +1,5 @@
-VER=2.6.7
+UPSTREAM_VER=2_6_9
+VER=${UPSTREAM_VER//_/.}
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::cd775f625c944ed78a3da18a03b03b08eea73c8aabc97b41bb336e9a10954930"
+CHKSUMS="sha256::2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff"
 CHKUPDATE="anitya::id=2551"


### PR DESCRIPTION
Topic Description
-----------------

- openldap: update to 2.6.9

Package(s) Affected
-------------------

- openldap: 2.6.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
