### PR TITLE
krb5: update to 1.21.3

### DIFF
--- a/app-network/krb5/autobuild/defines
+++ b/app-network/krb5/autobuild/defines
@@ -18,7 +18,6 @@ AUTOTOOLS_AFTER="--localstatedir=/var/lib \
                  --with-system-et \
                  --with-system-ss \
                  --disable-rpath \
-                 --without-tcl \
                  --enable-dns-for-realm \
                  --with-ldap \
                  --without-system-verto"

--- a/app-network/krb5/spec
+++ b/app-network/krb5/spec
@@ -1,6 +1,6 @@
-VER=1.17.1
-REL=9
+UPSTREAM_VER=1.21.3-final
+VER=${UPSTREAM_VER/-final/}
 SRCS="tbl::https://web.mit.edu/kerberos/dist/krb5/${VER%.*}/krb5-$VER.tar.gz"
-CHKSUMS="sha256::3706d7ec2eaa773e0e32d3a87bf742ebaecae7d064e190443a3acddfd8afb181"
+CHKSUMS="sha256::b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
 CHKUPDATE="anitya::id=13287"
 SUBDIR="krb5-$VER/src"


### PR DESCRIPTION
Topic Description
-----------------

- krb5: update to 1.21.3

Package(s) Affected
-------------------

- krb5: 1.21.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit krb5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
