### PR TITLE
p11-kit: update to 0.25.5

### DIFF
--- a/runtime-cryptography/p11-kit/spec
+++ b/runtime-cryptography/p11-kit/spec
@@ -1,4 +1,4 @@
-VER=0.25.3
+VER=0.25.5
 SRCS="tbl::https://github.com/p11-glue/p11-kit/releases/download/$VER/p11-kit-$VER.tar.xz"
-CHKSUMS="sha256::d8ddce1bb7e898986f9d250ccae7c09ce14d82f1009046d202a0eb1b428b2adc"
+CHKSUMS="sha256::04d0a86450cdb1be018f26af6699857171a188ac6d5b8c90786a60854e1198e5"
 CHKUPDATE="anitya::id=2582"


### PR DESCRIPTION
Topic Description
-----------------

- p11-kit: update to 0.25.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- p11-kit: 0.25.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit p11-kit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
