### PR TITLE
libunwind: (arm64) disable LTO

### DIFF
--- a/runtime-common/libunwind/autobuild/defines
+++ b/runtime-common/libunwind/autobuild/defines
@@ -6,3 +6,10 @@ PKGDES="Portable and efficient C programming interface (API) to determine the ca
 AUTOTOOLS_AFTER=(
     '--disable-tests'
 )
+
+# FIXME: Works around undefiend symbol errors on AArch64:
+# 
+# symbol lookup error: /usr/lib/libunwind.so.8: undefined symbol: __aarch64_cas8_acq_rel
+# 
+# See: https://github.com/libunwind/libunwind/issues/693
+NOLTO__ARM64=1

--- a/runtime-common/libunwind/spec
+++ b/runtime-common/libunwind/spec
@@ -1,4 +1,5 @@
 VER=1.8.1
+REL=1
 SRCS="https://github.com/libunwind/libunwind/releases/download/v$VER/libunwind-$VER.tar.gz"
 CHKSUMS="sha256::ddf0e32dd5fafe5283198d37e4bf9decf7ba1770b6e7e006c33e6df79e6a6157"
 CHKUPDATE="anitya::id=1748"


### PR DESCRIPTION
Topic Description
-----------------

- libunwind: \(arm64\) disable LTO
    - Works around undefiend symbol errors on AArch64:
    - symbol lookup error: /usr/lib/libunwind.so.8: undefined symbol: __aarch64_cas8_acq_rel
    - See: https://github.com/libunwind/libunwind/issues/693

Package(s) Affected
-------------------

- libunwind: 1.8.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libunwind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
