### PR TITLE
LoongGPU preinstallation

### DIFF
--- a/meta-bases/kernel-base/autobuild/defines
+++ b/meta-bases/kernel-base/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=kernel-base
 PKGSEC=Bases
 PKGRECOM="dracut-ng firmware-free firmware-nonfree linux+kernel kmod openfwwf \
-        wireless-regdb"
+          wireless-regdb"
+PKGRECOM__LOONGARCH64="${PKGRECOM} loonggpu-kernel-dkms"
 PKGRECOM__RETRO="kmod linux+kernel+retro"
 PKGRECOM__I486="${PKGRECOM__RETRO}"
 PKGRECOM__LOONGSON2F="${PKGRECOM__RETRO}"

--- a/meta-bases/kernel-base/spec
+++ b/meta-bases/kernel-base/spec
@@ -1,2 +1,2 @@
-VER=5
+VER=6
 DUMMYSRC=1

--- a/meta-bases/x11-base/autobuild/defines
+++ b/meta-bases/x11-base/autobuild/defines
@@ -4,16 +4,18 @@ PKGDEP="xf86-video-fbdev xorg-server"
 PKGRECOM="xf86-input-wacom xf86-video-amdgpu xf86-video-ati \
           xf86-video-nouveau xf86-input-libinput"
 PKGRECOM__AMD64=" \
-        ${PKGRECOM} xf86-input-vmmouse xf86-video-vesa"
+          ${PKGRECOM} xf86-input-vmmouse xf86-video-vesa"
+PKGRECOM__LOONGARCH64=" \
+          ${PKGRECOM} loonggpu-driver"
 
 PKGDEP__ARMV4="${PKGDEP} xf86-input-evdev"
 PKGDEP__ARMV6HF="${PKGDEP} xf86-input-evdev"
 PKGDEP__ARMV7HF="${PKGDEP} xf86-input-evdev"
 PKGDEP__I486="${PKGDEP} xf86-input-evdev"
 PKGRECOM__I486="xf86-input-synaptics xf86-video-ati \
-               xf86-video-chips xf86-video-fbdev xf86-video-intel \
-               xf86-video-mach64 xf86-video-neomagic \
-               xf86-video-nouveau xf86-video-siliconmotion xf86-video-vesa"
+                xf86-video-chips xf86-video-fbdev xf86-video-intel \
+                xf86-video-mach64 xf86-video-neomagic \
+                xf86-video-nouveau xf86-video-siliconmotion xf86-video-vesa"
 PKGDEP__LOONGSON2F="${PKGDEP} xf86-input-evdev"
 PKGRECOM__LOONGSON2F="xf86-input-synaptics xf86-video-siliconmotion xf86-video-sis"
 PKGDEP__POWERPC="${PKGDEP} xf86-input-evdev"

--- a/meta-bases/x11-base/spec
+++ b/meta-bases/x11-base/spec
@@ -1,2 +1,2 @@
-VER=3
+VER=4
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- x11-base: \(loongarch64\) recommend loonggpu-driver
- kernel-base: \(loongarch64\) recommend loonggpu-kernel-dkms

Package(s) Affected
-------------------

- kernel-base: 6
- x11-base: 4

Security Update?
----------------

No

Build Order
-----------

```
#buildit kernel-base x11-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
