### PR TITLE
strawberry: rebuild for protobuf update

### DIFF
--- a/app-multimedia/strawberry/spec
+++ b/app-multimedia/strawberry/spec
@@ -1,5 +1,5 @@
 VER=1.0.23
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/strawberrymusicplayer/strawberry"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19048"


### PR DESCRIPTION
Topic Description
-----------------

- strawberry: rebuild for protobuf update
    Previously...
    strawberry: symbol lookup error: strawberry: undefined symbol: _ZN6google8protobuf8internal17AssignDescriptorsEPFPKNS1_15DescriptorTableEvEPN4absl12lts_202401169once_flagERKNS0_8MetadataE

Package(s) Affected
-------------------

- strawberry: 1.0.23-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit strawberry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
