### PR TITLE
luabitop, lua-expat, lua-socket, lgi: rebuild to rework dependencies

### DIFF
--- a/desktop-gnome/gtk-4/01-main/defines
+++ b/desktop-gnome/gtk-4/01-main/defines
@@ -3,9 +3,9 @@ PKGSEC=x11
 PKGDEP="cairo colord cups dconf desktop-file-utils fontconfig fribidi \
         gdk-pixbuf glib graphene gstreamer libpng libxkbcommon harfbuzz \
         iso-codes libcloudproviders libepoxy librsvg libtiff libjpeg-turbo \
-        pango shared-mime-info tracker vulkan-loader wayland x11-lib"
+        pango shared-mime-info vulkan-loader wayland x11-lib"
 BUILDDEP="docutils gi-docgen gobject-introspection gtk-doc sassc shaderc \
-          wayland-protocols vulkan"
+          tracker wayland-protocols vulkan"
 PKGDES="GIMP toolkit version 4"
 
 MESON_AFTER="-Dx11-backend=true \

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,5 @@
 VER=4.16.5
+REL=1
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
 CHKSUMS="sha256::302d6813fbed95c419fb3ab67c5da5e214882b6a645c3eab9028dfb91ab418a4"
 CHKUPDATE="anitya::id=13942"

--- a/lang-lua/lgi/autobuild/build
+++ b/lang-lua/lgi/autobuild/build
@@ -1,17 +1,16 @@
+abinfo "Building lgi ..."
 make 
-make install LUA_LIBDIR=/usr/lib/lua/5.1 \
-             LUA_SHAREDIR=/usr/share/lua/5.1 \
-             DESTDIR="$PKGDIR"
 
-install -Dm755 tools/dump-typelib.lua \
+abinfo "Installing lgi ..."
+make install \
+    LUA_LIBDIR=/usr/lib/lua/5.1 \
+    LUA_SHAREDIR=/usr/share/lua/5.1 \
+    DESTDIR="$PKGDIR"
+
+abinfo "Installing dump-typelib ..."
+install -Dvm755 "$SRCDIR"/tools/dump-typelib.lua \
     "$PKGDIR"/usr/bin/dump-typelib
 
-install -d "$PKGDIR"/usr/share/doc/lgi
-install -Dm644 docs/* \
-    "$PKGDIR"/usr/share/doc/lgi
-
-install -d "$PKGDIR"/usr/share/lgi/samples/gtk-demo
-install -Dm644 samples/*.lua \
-    "$PKGDIR"/usr/share/lgi/samples
-install -Dm644 samples/gtk-demo/* \
-    "$PKGDIR"/usr/share/lgi/samples/gtk-demo
+abinfo "Installing documentation ..."
+install -Dvm644 docs/* \
+    -t "$PKGDIR"/usr/share/doc/lgi/

--- a/lang-lua/lgi/spec
+++ b/lang-lua/lgi/spec
@@ -1,6 +1,5 @@
 VER=0.9.2
-SRCS="tbl::https://github.com/pavouk/lgi/archive/$VER.tar.gz"
-CHKSUMS="sha256::cfc4105482b4730b3a40097c9d9e7e35c46df2fb255370bdeb2f45a886548c4f"
-SUBDIR="lgi-$VER"
-REL=2
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/pavouk/lgi"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1851"

--- a/lang-lua/lua-5.1/autobuild/defines
+++ b/lang-lua/lua-5.1/autobuild/defines
@@ -4,4 +4,3 @@ PKGDEP="readline"
 PKGDES="Powerful lightweight programming language designed for extending applications"
 
 PKGREP="lua<=1:5.1.5-5"
-PKGBREAK="lua<=1:5.1.5-5"

--- a/lang-lua/lua-5.1/spec
+++ b/lang-lua/lua-5.1/spec
@@ -1,5 +1,5 @@
 VER=5.1.5
-REL=5
+REL=6
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
 CHKSUMS="sha256::2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
 CHKUPDATE="anitya::id=230578"

--- a/lang-lua/lua-expat/spec
+++ b/lang-lua/lua-expat/spec
@@ -1,5 +1,5 @@
 VER=1.5.2
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/lunarmodules/luaexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11782"

--- a/lang-lua/lua-socket/spec
+++ b/lang-lua/lua-socket/spec
@@ -1,4 +1,5 @@
 VER=3.1.0
+REL=1
 SRCS="tbl::https://github.com/diegonehab/luasocket/archive/v${VER/+/-}.tar.gz"
 CHKSUMS="sha256::bf033aeb9e62bcaa8d007df68c119c966418e8c9ef7e4f2d7e96bddeca9cca6e"
 CHKUPDATE="anitya::id=6302"

--- a/lang-lua/lua/autobuild/build
+++ b/lang-lua/lua/autobuild/build
@@ -1,1 +1,3 @@
-mkdir -v "$PKGDIR"
+abinfo "Creating a dummy file ..."
+mkdir -pv "$PKGDIR"/usr/share/doc/lua
+touch "$PKGDIR"/usr/share/doc/lua/TRANSITIONAL

--- a/lang-lua/lua/autobuild/build.stage2
+++ b/lang-lua/lua/autobuild/build.stage2
@@ -1,1 +1,0 @@
-mkdir -v "$PKGDIR"

--- a/lang-lua/lua/spec
+++ b/lang-lua/lua/spec
@@ -1,2 +1,3 @@
 VER=0
+REL=1
 DUMMYSRC=1

--- a/lang-lua/luabitop/spec
+++ b/lang-lua/luabitop/spec
@@ -1,5 +1,5 @@
 VER=1.0.2
-REL=3
+REL=4
 SRCS="tbl::https://bitop.luajit.org/download/LuaBitOp-$VER.tar.gz"
 CHKSUMS="sha256::1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99"
 CHKUPDATE="anitya::id=230581"


### PR DESCRIPTION
Topic Description
-----------------

- lua-5.1: use only PKGREP to note file migration
    Lest an empty package would be noted for removal.
- lgi: rework packaging and refresh lua dependency
    - Lint scripts in accordance with the Styling Manual.
    - Do not install demo and samples.
- gtk-4: move tracker to BUILDDEP
    This saves a lot of dependency burden for most other desktop environments
    \(and gets rid of a massive dependency loop\).
- luabitop: rebuild to rework dependencies
- lua-expat: rebuild to rework dependencies
- lua-socket: rebuild to rework dependencies

Package(s) Affected
-------------------

- gtk-4: 4.16.5-1
- gtk-update-icon-cache: 4.16.5-1
- lgi: 0.9.2-3
- lua-5.1: 5.1.5-6
- lua-expat: 1.5.2-2
- lua-socket: 3.1.0-1
- luabitop: 1.0.2-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit luabitop lua-expat lua-socket gtk-4 lgi lua-5.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
