### PR TITLE
lua: touch a transitional file to prevent erroneous replacement

### DIFF
--- a/lang-lua/lua/autobuild/build
+++ b/lang-lua/lua/autobuild/build
@@ -1,1 +1,11 @@
-mkdir -v "$PKGDIR"
+# FIXME:
+#
+# Touch a transitional file to prevent accidental removal by dpkg, as it
+# would otherwise consider the package fully replaced (does not provide any
+# file), causing lua to be removed as a dependency whilst its reverse
+# dependencies continued to be configured - resulting in dpkg errors.
+#  
+# Is this a dpkg bug? Not sure.
+abinfo "Creating a dummy file ..."
+mkdir -pv "$PKGDIR"/usr/share/doc/lua
+touch "$PKGDIR"/usr/share/doc/lua/TRANSITIONAL

--- a/lang-lua/lua/autobuild/build.stage2
+++ b/lang-lua/lua/autobuild/build.stage2
@@ -1,1 +1,0 @@
-mkdir -v "$PKGDIR"

--- a/lang-lua/lua/spec
+++ b/lang-lua/lua/spec
@@ -1,2 +1,3 @@
 VER=0
+REL=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- lua: touch a TRANSITIONAL file
    Touch a transitional file to prevent accidental removal by dpkg, as it
    would otherwise consider the package fully replaced \(does not provide any
    file\), causing lua to be removed as a dependency whilst its reverse
    dependencies continued to be configured - resulting in dpkg errors.
    Is this a dpkg bug? Not sure.
- ecl: fix path in prepare
- maxima: change autotools after
- maxima, ecl: change per request
- ecl, sbcl: set pkgbreak for ecl and sbcl
- maxima: use sbcl to build on amd64, arm64 and ppc64el

Package(s) Affected
-------------------

- lua: 2:0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lua
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
