### PR TITLE
lgi: rework packaging

### DIFF
--- a/lang-lua/lgi/autobuild/build
+++ b/lang-lua/lgi/autobuild/build
@@ -1,17 +1,16 @@
+abinfo "Building lgi ..."
 make 
-make install LUA_LIBDIR=/usr/lib/lua/5.1 \
-             LUA_SHAREDIR=/usr/share/lua/5.1 \
-             DESTDIR="$PKGDIR"
 
-install -Dm755 tools/dump-typelib.lua \
+abinfo "Installing lgi ..."
+make install \
+    LUA_LIBDIR=/usr/lib/lua/5.1 \
+    LUA_SHAREDIR=/usr/share/lua/5.1 \
+    DESTDIR="$PKGDIR"
+
+abinfo "Installing dump-typelib ..."
+install -Dvm755 "$SRCDIR"/tools/dump-typelib.lua \
     "$PKGDIR"/usr/bin/dump-typelib
 
-install -d "$PKGDIR"/usr/share/doc/lgi
-install -Dm644 docs/* \
-    "$PKGDIR"/usr/share/doc/lgi
-
-install -d "$PKGDIR"/usr/share/lgi/samples/gtk-demo
-install -Dm644 samples/*.lua \
-    "$PKGDIR"/usr/share/lgi/samples
-install -Dm644 samples/gtk-demo/* \
-    "$PKGDIR"/usr/share/lgi/samples/gtk-demo
+abinfo "Installing documentation ..."
+install -Dvm644 docs/* \
+    -t "$PKGDIR"/usr/share/doc/lgi/

--- a/lang-lua/lgi/spec
+++ b/lang-lua/lgi/spec
@@ -1,6 +1,5 @@
 VER=0.9.2
-SRCS="tbl::https://github.com/pavouk/lgi/archive/$VER.tar.gz"
-CHKSUMS="sha256::cfc4105482b4730b3a40097c9d9e7e35c46df2fb255370bdeb2f45a886548c4f"
-SUBDIR="lgi-$VER"
-REL=2
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/pavouk/lgi"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1851"


### PR DESCRIPTION
Topic Description
-----------------

- lgi: rework packaging
    - Lint scripts in accordance with the Styling Manual.
    - Do not install demo and samples.
- ecl: fix path in prepare
- maxima: change autotools after
- maxima, ecl: change per request
- ecl, sbcl: set pkgbreak for ecl and sbcl
- maxima: use sbcl to build on amd64, arm64 and ppc64el

Package(s) Affected
-------------------

- lgi: 0.9.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lgi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
