### PR TITLE
gtk-4: move tracker to BUILDDEP

### DIFF
--- a/desktop-gnome/gtk-4/01-main/defines
+++ b/desktop-gnome/gtk-4/01-main/defines
@@ -3,9 +3,9 @@ PKGSEC=x11
 PKGDEP="cairo colord cups dconf desktop-file-utils fontconfig fribidi \
         gdk-pixbuf glib graphene gstreamer libpng libxkbcommon harfbuzz \
         iso-codes libcloudproviders libepoxy librsvg libtiff libjpeg-turbo \
-        pango shared-mime-info tracker vulkan-loader wayland x11-lib"
+        pango shared-mime-info vulkan-loader wayland x11-lib"
 BUILDDEP="docutils gi-docgen gobject-introspection gtk-doc sassc shaderc \
-          wayland-protocols vulkan"
+          tracker wayland-protocols vulkan"
 PKGDES="GIMP toolkit version 4"
 
 MESON_AFTER="-Dx11-backend=true \

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,5 @@
 VER=4.16.5
+REL=1
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
 CHKSUMS="sha256::302d6813fbed95c419fb3ab67c5da5e214882b6a645c3eab9028dfb91ab418a4"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-4: move tracker to BUILDDEP
    This saves a lot of dependency burden for most other desktop environments
    \(and gets rid of a massive dependency loop\).
    Tracker would be installed when needed anyway and should not be something
    a user sought before an environment with gtk-4 was already available.
- ecl: fix path in prepare
- maxima: change autotools after
- maxima, ecl: change per request
- ecl, sbcl: set pkgbreak for ecl and sbcl
- maxima: use sbcl to build on amd64, arm64 and ppc64el

Package(s) Affected
-------------------

- gtk-4: 4.16.5-1
- gtk-update-icon-cache: 4.16.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
