### PR TITLE
dongguanti: fix version

### DIFF
--- a/desktop-fonts/dongguanti/autobuild/defines
+++ b/desktop-fonts/dongguanti/autobuild/defines
@@ -6,3 +6,5 @@ PKGDES="A font family inspired by the typeface used by Eastern Han classics stor
 ABHOST=noarch
 
 PKGPROV="stdongguanti fonts-dongguanti fonts-stdongguanti ttf-dongguanti ttf-stdongguanti"
+
+PKGEPOCH=1

--- a/desktop-fonts/dongguanti/spec
+++ b/desktop-fonts/dongguanti/spec
@@ -1,8 +1,5 @@
-# Note: According to official description:
-#
-#  2023年4月，上海图书馆联合汉仪字库定制的专属字体“上图东观体”完成制作，经过
-#  内部测试后，现正式向社会发布。
-VER=2023.04
+# Note: Version taken from TTF file.
+VER=1.100
 SRCS="tbl::https://www.library.sh.cn/special/dongguanti/static/download/%E4%B8%8A%E5%9B%BE%E4%B8%9C%E8%A7%82%E4%BD%93%EF%BC%883%E7%A7%8D%E8%A7%84%E6%A0%BC%EF%BC%89.zip"
 CHKSUMS="sha256::5ade456d6168306b9cb4fefd3fd41ddfb42a537fc10aa930345c9e7c9280940d"
 SUBDIR="上图东观体（3种规格）"


### PR DESCRIPTION
Topic Description
-----------------

- dongguanti: fix version
    Should be 1.100 as found in the TTF file metadata.

Package(s) Affected
-------------------

- dongguanti: 1:1.100

Security Update?
----------------

No

Build Order
-----------

```
#buildit dongguanti
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
