### PR TITLE
qt5ct: update to 1.9

### DIFF
--- a/app-utils/qt5ct/spec
+++ b/app-utils/qt5ct/spec
@@ -1,4 +1,4 @@
-VER=1.8
+VER=1.9
 SRCS="tbl::https://downloads.sourceforge.net/project/qt5ct/qt5ct-$VER.tar.bz2"
-CHKSUMS="sha256::23b74054415ea4124328772ef9a6f95083a9b86569e128034a3ff75dfad808e9"
+CHKSUMS="sha256::dc10e6939d423b925981ce67febb1a015b6f61c022a9cc7e6c8b5efea4588bff"
 CHKUPDATE="anitya::id=10638"


### PR DESCRIPTION
Topic Description
-----------------

- qt5ct: update to 1.9
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- qt5ct: 1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt5ct
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
