### PR TITLE
rz-ghidra: new, 0.7.0

### DIFF
--- a/app-devel/rz-ghidra/autobuild/defines
+++ b/app-devel/rz-ghidra/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=rz-ghidra
+PKGSEC=devel
+PKGDEP="cutter qt-5"
+PKGDES="Ghidra decompiler for rizin reverse engineering framework"
+
+CMAKE_AFTER="-DBUILD_CUTTER_PLUGIN=ON \
+	     -DCUTTER_INSTALL_PLUGDIR=/usr/share/rizin/cutter/plugins/native \
+	     -DCMAKE_SKIP_INSTALL_RPATH=OFF"
+
+# Ref: /rizin/librz/debug/p/native/linux/linux_debug.c
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/app-devel/rz-ghidra/spec
+++ b/app-devel/rz-ghidra/spec
@@ -1,0 +1,4 @@
+VER=0.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/rizinorg/rz-ghidra"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376621"


### PR DESCRIPTION
Topic Description
-----------------

rz-ghidra: new, 0.7.0

Package(s) Affected
-------------------

rz-ghidra: 0.7.0

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`