### PR TITLE
aosc-os-presets-desktop: (loongarch64) enable loonggl-sw.service

### DIFF
--- a/runtime-data/aosc-os-presets-desktop/autobuild/build
+++ b/runtime-data/aosc-os-presets-desktop/autobuild/build
@@ -21,7 +21,15 @@ enable avahi-daemon.service
 enable avahi-dnsconfd.service
 EOF
 
-if [[ "${CROSS:-$ARCH}" = "i486" ]]; then
+if ab_match_arch loongarch64; then
+    cat >> "$PKGDIR"/usr/lib/systemd/system-preset/75-aosc-os-desktop.preset << EOF
+
+# LoongGPU OpenGL runtime switching service
+enable loonggl-sw.service
+EOF
+fi
+
+if ab_match_archgroup retro; then
     cat >> "$PKGDIR"/usr/lib/systemd/system-preset/75-aosc-os-desktop.preset << EOF
 
 # XDM

--- a/runtime-data/aosc-os-presets-desktop/autobuild/defines
+++ b/runtime-data/aosc-os-presets-desktop/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=misc
 PKGDEP=""
 PKGDES="Systemd presets for AOSC OS Desktop distributions"
 
+# Note: Architecture-agnostic.
 ABSPLITDBG=0

--- a/runtime-data/aosc-os-presets-desktop/spec
+++ b/runtime-data/aosc-os-presets-desktop/spec
@@ -1,2 +1,2 @@
-VER=4
+VER=5
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-presets-desktop: \(loongarch64\) enable loonggl-sw service

Package(s) Affected
-------------------

- aosc-os-presets-desktop: 5

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-presets-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
