### PR TITLE
xrdp: update to 0.10.2

### DIFF
--- a/app-network/xorgxrdp/spec
+++ b/app-network/xorgxrdp/spec
@@ -1,4 +1,4 @@
-VER=0.10.1
+VER=0.10.3
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xorgxrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13478"

--- a/app-network/xrdp/autobuild/defines
+++ b/app-network/xrdp/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=xrdp
 PKGSEC=net
-PKGDEP="fuse libjpeg-turbo pulseaudio tigervnc lame linux-pam"
+PKGDEP="fuse libjpeg-turbo pulseaudio tigervnc lame linux-pam x264 fuse-3"
 PKGRECOM="xorgxrdp"
 BUILDDEP__AMD64="nasm"
 PKGDES="An open source remote desktop protocol (RDP) server"
@@ -21,7 +21,8 @@ AUTOTOOLS_AFTER="--with-socketdir=/var/run/xrdp \
                  --disable-neutrinordp \
                  --disable-xrdpvr \
                  --enable-ipv6 \
-                 --enable-static"
+                 --enable-static \
+                 --enable-x264"
 ABSHADOW=0
 # For subprojects that cannot understand many parameters
 AUTOTOOLS_STRICT=0

--- a/app-network/xrdp/spec
+++ b/app-network/xrdp/spec
@@ -1,4 +1,4 @@
-VER=0.10.1
+VER=0.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231006"


### PR DESCRIPTION
Topic Description
-----------------

- xrdp: update to 0.10.2
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- xrdp: 0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xrdp xorgxrdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
