### PR TITLE
xorgxrdp: update to 0.10.3

### DIFF
--- a/app-network/xorgxrdp/spec
+++ b/app-network/xorgxrdp/spec
@@ -1,4 +1,4 @@
-VER=0.10.1
+VER=0.10.3
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xorgxrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13478"


### PR DESCRIPTION
Topic Description
-----------------

- xorgxrdp: update to 0.10.3
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- xorgxrdp: 0.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorgxrdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
