### PR TITLE
gtk-4: move tracker back to PKGDEP

### DIFF
--- a/desktop-gnome/gtk-4/01-main/defines
+++ b/desktop-gnome/gtk-4/01-main/defines
@@ -3,9 +3,9 @@ PKGSEC=x11
 PKGDEP="cairo colord cups dconf desktop-file-utils fontconfig fribidi \
         gdk-pixbuf glib graphene gstreamer libpng libxkbcommon harfbuzz \
         iso-codes libcloudproviders libepoxy librsvg libtiff libjpeg-turbo \
-        pango shared-mime-info vulkan-loader wayland x11-lib"
+        pango shared-mime-info tracker vulkan-loader wayland x11-lib"
 BUILDDEP="docutils gi-docgen gobject-introspection gtk-doc sassc shaderc \
-          tracker wayland-protocols vulkan"
+          wayland-protocols vulkan"
 PKGDES="GIMP toolkit version 4"
 
 MESON_AFTER="-Dx11-backend=true \

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,5 +1,5 @@
 VER=4.16.5
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
 CHKSUMS="sha256::302d6813fbed95c419fb3ab67c5da5e214882b6a645c3eab9028dfb91ab418a4"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-4: move tracker back to PKGDEP
    \`libgtk-4.so.1\` links against \`libtracker-sparql-3.0.so.0\` which is
    provided by tracker, gtk-4 based applications cannot start without this
    library.
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gtk-4: 4.16.5-2
- gtk-update-icon-cache: 4.16.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
