### PR TITLE
httpd: update to 2.4.63

### DIFF
--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,4 +1,4 @@
-VER=2.4.62
+VER=2.4.63
 SRCS="tbl::https://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::674188e7bf44ced82da8db522da946849e22080d73d16c93f7f4df89e25729ec"
+CHKSUMS="sha256::88fc236ab99b2864b248de7d49a008ec2afd7551e64dce8b95f58f32f94c46ab"
 CHKUPDATE="anitya::id=1335"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: update to 2.4.63
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- httpd: 2.4.63

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
