### PR TITLE
fricas: new package, 1.3.11

### DIFF
--- a/app-scientific/fricas/autobuild/beyond
+++ b/app-scientific/fricas/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Checking fricas build..."
+cd "$BLDDIR"
+make check

--- a/app-scientific/fricas/autobuild/defines
+++ b/app-scientific/fricas/autobuild/defines
@@ -1,0 +1,53 @@
+PKGNAME=fricas
+PKGSEC=math
+
+# Note: x11-lib is used in the HyperDoc.
+PKGDEP__SBCL="gawk x11-lib sbcl"
+PKGDEP__ECL="gawk x11-lib ecl"
+PKGDEP__AMD64="$PKGDEP__SBCL"
+
+# FIXME: Continue out of heap while build with sbcl on PPC64EL and ARM64
+#PKGDEP__PPC64EL="$PKGDEP__SBCL"
+#PKGDEP__ARM64="$PKGDEP__SBCL"
+PKGDEP="$PKGDEP__ECL"
+
+# Note: Ref. https://fricas.github.io/install.html#latex-optional
+PKGSUG="texlive emacs"
+
+# Note: In order to build the graphical examples, xvfb
+# must be used, it is in this package. From FriCAS document
+# 
+#     If you compile FriCAS from the FriCAS git repository, 
+#     and configure does not detect the xvfb-run program, 
+#     then graphic examples will not be built. This results 
+#     in broken HyperDoc pages – all graphic examples will 
+#     be missing (and trying to access them will crash hypertex).
+#
+# Ref. https://fricas.github.io/install.html#hyperdoc-and-graphics
+#
+# FIXME: Disable now, since fricas2d have bug related to
+# "double free or corruption (!prev)", and I can't fix it:P
+#
+#BUILDDEP="xorg-server"
+
+PKGDES="General purpose computer algebra system"
+
+AUTOTOOLS_AFTER__ECL=(
+    --with-lisp=ecl
+)
+AUTOTOOLS_AFTER__SBCL=(
+    --with-lisp='sbcl --dynamic-space-size 4096'
+    --enable-gmp
+)
+AUTOTOOLS_AFTER__AMD64=("${AUTOTOOLS_AFTER__SBCL[@]}")
+
+# FIXME: Continue out of heap while build with sbcl on PPC64EL and ARM64
+#AUTOTOOLS_AFTER__ARM64="$AUTOTOOLS_AFTER__SBCL"
+#AUTOTOOLS_AFTER__PPC64EL="$AUTOTOOLS_AFTER__SBCL"
+AUTOTOOLS_AFTER=("${AUTOTOOLS_AFTER__ECL[@]}")
+
+# Note: Else sbcl version of the software will not run,
+# it seems FRICASsys got a lot of things inside.
+ABSTRIP__AMD64=0
+ABSTRIP__PPC64EL=0
+ABSTRIP__ARM64=0

--- a/app-scientific/fricas/autobuild/overrides/usr/share/applications/fricas.desktop
+++ b/app-scientific/fricas/autobuild/overrides/usr/share/applications/fricas.desktop
@@ -1,0 +1,12 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=FriCAS
+Keywords=computer algebra system;CAS;
+Keywords[zh_CN]=计算机代数系统;CAS;
+Comment=Fricas Computer Algebra System
+Comment[zh_CN]=FriCAS 计算机代数系统
+Exec=fricas
+Icon=fricas
+Terminal=true
+Type=Application
+Categories=Education;Math;

--- a/app-scientific/fricas/spec
+++ b/app-scientific/fricas/spec
@@ -1,0 +1,4 @@
+VER=1.3.11
+SRCS="git::commit=tags/$VER::https://github.com/fricas/fricas"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376467"


### PR DESCRIPTION
Topic Description
-----------------

- fricas: new, 1.3.11

Package(s) Affected
-------------------

None

Security Update?
----------------

No

Build Order
-----------

```
#buildit  fricas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
