### PR TITLE
podman: build for riscv64 and loongarch64


### DIFF
--- a/app-containers/podman/autobuild/defines
+++ b/app-containers/podman/autobuild/defines
@@ -6,4 +6,4 @@ PKGRECOM="btrfs-progs"
 BUILDDEP="go btrfs-progs go-md2man"
 
 ABSPLITDBG=0
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64|loongarch64)"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -4,6 +4,7 @@ UPSTREAM_VER=5.3.2
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
 GVISOR_TAP_VSOCK_VER=0.7.5
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
+REL=1
 SRCS="git::commit=v${UPSTREAM_VER};rename=podman-${UPSTREAM_VER}::https://github.com/containers/podman \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- podman: build for riscv64 and loongarch64

Package(s) Affected
-------------------

- podman: 5.3.2+vsock0.7.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
