### PR TITLE
libdrm: update to 2.4.124

### DIFF
--- a/runtime-display/libdrm/spec
+++ b/runtime-display/libdrm/spec
@@ -1,4 +1,4 @@
-VER=2.4.123
+VER=2.4.124
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e"
+CHKSUMS="sha256::ac36293f61ca4aafaf4b16a2a7afff312aa4f5c37c9fbd797de9e3c0863ca379"
 CHKUPDATE="anitya::id=1596"


### PR DESCRIPTION
Topic Description
-----------------

- libdrm: update to 2.4.124
    Co-authored-by: Kexy Biscuit a.k.a. 百合ヶ咲るる \(@KexyBiscuit\) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- libdrm: 2.4.124

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdrm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
