### PR TITLE
linux-firmware: update to 20250129

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250122
+UPSTREAM_VER=20250129
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 # SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=40afb77bae42739556088af6a7399f2dad5939ce::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=97cf368b19e641f25f35d0603869305cf17497dd::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250129
    - Update Linux Firmware to current \(20250129\) HEAD 97cf368b19e641f25f35d0603869305cf17497dd...
    - Changelog below...
    - AMD
    - Update ISP FW for isp v4.1.1.
    - Intel
    - Update Xe2LPD DMC to v2.27.
    - NXP
    - Update FW files for Marvel SD8997 \(88W8997\) chips.
    - Qualcomm
    - Add Bluetooth firmware for QCA6698, version 2.1.2-00035.
    - Update Bluetooth WCN6856 firmware 2.1.0-00642 to 2.1.0-00650.
    - Realtek
    - Update RTL8852B BT USB FW to 0x049B_5037.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250129+debian20241210+1
- firmware-nonfree: 20250129+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
