### PR TITLE
fscan: update to 2.0.0

### DIFF
--- a/app-utils/fscan/spec
+++ b/app-utils/fscan/spec
@@ -1,4 +1,4 @@
-VER=1.8.4
+VER=2.0.0
 SRCS="git::commit=tags/$VER::https://github.com/shadow1ng/fscan.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375841"


### PR DESCRIPTION
Topic Description
-----------------

fscan: update to 2.0.0

Package(s) Affected
-------------------

fscan: update to 2.0.0

Security Update?
----------------


No

Build Order
-----------

```
#buildit fscan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`