### PR TITLE
sarasa-gothic-fonts: update to 1.0.28

### DIFF
--- a/desktop-fonts/sarasa-gothic-fonts/spec
+++ b/desktop-fonts/sarasa-gothic-fonts/spec
@@ -1,7 +1,7 @@
-VER=1.0.27
+VER=1.0.28
 SRCS="tbl::https://github.com/be5invis/Sarasa-Gothic/releases/download/v$VER/Sarasa-TTC-$VER.7z \
       git::commit=tags/v$VER::https://github.com/be5invis/Sarasa-Gothic"
-CHKSUMS="sha256::9eecd0122fa546d9a5f8d4b9b7fc6f9ddc41ca107b6f2990ae68456da80d61a6 \
+CHKSUMS="sha256::4569f7b58731c910da6cab08669c8a6557abc54c0279cbb8232549261b634d55 \
          SKIP"
 CHKUPDATE="anitya::id=227599"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- sarasa-gothic-fonts: update to 1.0.28
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- sarasa-gothic-fonts: 1.0.28

Security Update?
----------------

No

Build Order
-----------

```
#buildit sarasa-gothic-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
