### PR TITLE
font-manager: update to 0.9.2

### DIFF
--- a/app-utils/font-manager/autobuild/defines
+++ b/app-utils/font-manager/autobuild/defines
@@ -1,10 +1,25 @@
 PKGNAME=font-manager
 PKGSEC=utils
-PKGDEP="file-roller gucharmap libgee libxml2 sqlite"
-BUILDDEP="gobject-introspection gtk-update-icon-cache intltool vala yelp-tools nautilus nemo"
+PKGDEP="libxml2 sqlite glib freetype fontconfig cairo gtk-4 harfbuzz json-glib \
+        cairo libsoup-3 webkit2gtk libadwaita file-roller"
+BUILDDEP="gobject-introspection gtk-update-icon-cache gettext vala yelp-tools \
+          nautilus nemo thunar gtk-doc"
 PKGDES="Simple font management for GTK+ desktop environments"
 
-AUTOTOOLS_AFTER="--disable-schemas-compile \
-                 --with-nautilus \
-                 --with-nemo"
-ABSHADOW=0
+ABTYPE=meson
+MESON_AFTER=(
+    -Dmanager=true
+    -Dviewer=true
+    -Dsearch-provider=true
+    -Dadwaita=true
+    -Dwebkit=true
+    -Dyelp-doc=true
+    -Denable-nls=true
+    -Dunihan=true
+    -Dnautilus=true
+    -Dnemo=true
+    -Dthunar=true
+    -Dgtk-doc=true
+    -Dreproducible=true
+    -Dapp-armor=false
+)

--- a/app-utils/font-manager/spec
+++ b/app-utils/font-manager/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.9.2
 SRCS="tbl::https://github.com/FontManager/font-manager/releases/download/$VER/font-manager-$VER.tar.xz"
-CHKSUMS="sha256::1dd711ea8d8fd99a6801037465dda0b129ba66185bfbf272a8f9a906c4e28d6c"
+CHKSUMS="sha256::5a6ef285f6011b4661fec8561c72515b7b2dfeaebbc7e944f7f6385ce89497a6"
 CHKUPDATE="anitya::id=15389"


### PR DESCRIPTION
Topic Description
-----------------

- font-manager: update to 0.9.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- font-manager: 0.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit font-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
