### PR TITLE
gdb: update to 16.2

### DIFF
--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,5 +1,4 @@
-VER=16.1
-REL=1
+VER=16.2
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
-CHKSUMS="sha256::c2cc5ccca029b7a7c3879ce8a96528fdfd056b4d884f2b0511e8f7bc723355c6"
+CHKSUMS="sha256::4002cb7f23f45c37c790536a13a720942ce4be0402d929c9085e92f10d480119"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: update to 16.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gdb: 16.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
