### PR TITLE
papirus-icon-theme: update to 20250201

### DIFF
--- a/desktop-themes/papirus-icon-theme/spec
+++ b/desktop-themes/papirus-icon-theme/spec
@@ -1,4 +1,4 @@
-VER=20240501
+VER=20250201
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/PapirusDevelopmentTeam/papirus-icon-theme.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18645"


### PR DESCRIPTION
Topic Description
-----------------

- papirus-icon-theme: update to 20250201
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- papirus-icon-theme: 20250201

Security Update?
----------------

No

Build Order
-----------

```
#buildit papirus-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
