### PR TITLE
diffutils: update to 3.11

### DIFF
--- a/app-utils/diffutils/autobuild/defines
+++ b/app-utils/diffutils/autobuild/defines
@@ -5,3 +5,9 @@ BUILDDEP="autoconf-archive gperf"
 PKGSEC=utils
 
 PKGESS=1
+
+# FIXME: reconf failed because it extracts threadlib.m4 "serial 10" from
+# /usr/share/gettext/archive.dir.tar.xz (because
+# AM_GNU_GETTEXT_VERSION([0.19.2]) in configure.ac), overwriting the
+# shipped threadlib.m4 "serial 42".
+RECONF=0

--- a/app-utils/diffutils/spec
+++ b/app-utils/diffutils/spec
@@ -1,5 +1,4 @@
-VER=3.10
+VER=3.11
 SRCS="tbl::https://ftp.gnu.org/gnu/diffutils/diffutils-$VER.tar.xz"
-CHKSUMS="sha256::90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e"
+CHKSUMS="sha256::a73ef05fe37dd585f7d87068e4a0639760419f810138bd75c61ddaa1f9e2131e"
 CHKUPDATE="anitya::id=436"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- diffutils: update to 3.11
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- diffutils: 3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit diffutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
