### PR TITLE
buildah: update to 1.39.0

### DIFF
--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,4 +1,4 @@
-VER=1.38.1
+VER=1.39.0
 SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14974"


### PR DESCRIPTION
Topic Description
-----------------

- buildah: update to 1.39.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- buildah: 1.39.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit buildah
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
