### PR TITLE
virtualbox: update to 7.1.6a

### DIFF
--- a/app-virtualization/virtualbox/01-host/build
+++ b/app-virtualization/virtualbox/01-host/build
@@ -190,3 +190,17 @@ install -Dvm644 "$SRCDIR"/temp/usr/share/doc/virtualbox-${PKGVER%.*}/User* \
 abinfo "Installing Guest Additions ISO ..."
 install -Dvm644 "$SRCDIR"/../VBoxGuestAdditions.iso \
     "$PKGDIR"/usr/lib/virtualbox/additions/VBoxGuestAdditions.iso
+
+# FIXME: Wine processes may not exit cleanly post-build.
+processes=(
+    "wineserver"
+    "services.exe"
+    "explorer.exe"
+    "winedevice.exe"
+    "svchost.exe"
+    "plugplay.exe"
+)
+for process in "${processes[@]}"; do
+    abinfo "Killing unhandled Wine process: $i ..."
+    pgrep "$process" | xargs -r kill -9 || true
+done

--- a/app-virtualization/virtualbox/01-host/patches/0001-FROM-ARCHLINUX-fix-Frontends-VirtualBox-disable-upda.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0001-FROM-ARCHLINUX-fix-Frontends-VirtualBox-disable-upda.patch
@@ -1,4 +1,4 @@
-From 2f1a5a5e789cd06874b1f40f0a5c7fb220023d9d Mon Sep 17 00:00:00 2001
+From f83359a8ea3ec385467e71af0a9b361b999e03f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:26:00 +0800
 Subject: [PATCH 01/10] FROM ARCHLINUX: fix(Frontends/VirtualBox): disable
@@ -22,5 +22,5 @@ index cf81c1b50..44dd62c00 100644
  
  QString UIExtraDataManager::applicationUpdateData()
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0002-FROM-ARCHLINUX-properly-handle-i3wm.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0002-FROM-ARCHLINUX-properly-handle-i3wm.patch
@@ -1,4 +1,4 @@
-From 89fc798d9234a8a71e38e3b7912d3df5afdd631c Mon Sep 17 00:00:00 2001
+From 50cbf17b0b46940b3163fbe8296d660fc93fa242 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Tue, 17 Jan 2023 22:04:08 +0100
 Subject: [PATCH 02/10] FROM ARCHLINUX: properly handle i3wm
@@ -77,5 +77,5 @@ index e77a25ef5..9359d3d0b 100644
  
      /* Make sure we have no focus: */
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0003-FROM-ARCHLINUX-support-building-from-dkms.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0003-FROM-ARCHLINUX-support-building-from-dkms.patch
@@ -1,4 +1,4 @@
-From a6092c70f6c90ef2c2f9cb1b3ef026f149a2f4b6 Mon Sep 17 00:00:00 2001
+From 5ea21621575e848fdce6ae2585df8492aa547600 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:30:32 +0200
 Subject: [PATCH 03/10] FROM ARCHLINUX: support building from dkms
@@ -53,5 +53,5 @@ index 295fc49eb..f33fb3633 100644
 +endif # ! KBUILD_EXTMOD
  
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0004-FROM-ARCHLINUX-upate-xclient-script.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0004-FROM-ARCHLINUX-upate-xclient-script.patch
@@ -1,4 +1,4 @@
-From d0d564a6b82ed1f0663fed56154087778f846928 Mon Sep 17 00:00:00 2001
+From 9e58b57a886693ccc9bb443cf5a010ba9db300ab Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:40:29 +0200
 Subject: [PATCH 04/10] FROM ARCHLINUX: upate xclient script
@@ -34,5 +34,5 @@ index 1e38d05c7..699dbdbb5 100755
 -    /usr/bin/VBoxClient --vmsvga-session # In case VMSVGA emulation is enabled
  fi
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0005-FROM-AOSC-fix-libs-dxvk-fix-build-with-GCC-13.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0005-FROM-AOSC-fix-libs-dxvk-fix-build-with-GCC-13.patch
@@ -1,4 +1,4 @@
-From 1f17095784c62fa3c661ecfe7e31ce0c9bfcbca4 Mon Sep 17 00:00:00 2001
+From 3420ccce741252679890ecc77e3cd5ae6b99fe6f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:38:50 +0800
 Subject: [PATCH 05/10] FROM AOSC: fix(libs/dxvk): fix build with GCC >= 13
@@ -20,5 +20,5 @@ index 08fea02f2..2f431be5c 100644
  #include "util_bit.h"
  #include "util_math.h"
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0006-FROM-AOSC-chore-use-the-wheel-group-for-hardware-acc.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0006-FROM-AOSC-chore-use-the-wheel-group-for-hardware-acc.patch
@@ -1,4 +1,4 @@
-From 6153f59ef0c65eeef55d36f2273c92db1c9f00a9 Mon Sep 17 00:00:00 2001
+From 965e62fc71290d2b1fe5cbea424726f4e4457080 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:37:48 +0800
 Subject: [PATCH 06/10] FROM AOSC: chore: use the wheel group for hardware
@@ -928,10 +928,10 @@ index 9e20622ab..7e1431cf6 100644
      </message>
      <message>
 diff --git a/src/VBox/Frontends/VirtualBox/src/globals/UIMessageCenter.cpp b/src/VBox/Frontends/VirtualBox/src/globals/UIMessageCenter.cpp
-index 7486b0dc4..78c4757d0 100644
+index da79afcb4..2fea410cd 100644
 --- a/src/VBox/Frontends/VirtualBox/src/globals/UIMessageCenter.cpp
 +++ b/src/VBox/Frontends/VirtualBox/src/globals/UIMessageCenter.cpp
-@@ -2167,7 +2167,7 @@ void UIMessageCenter::prepare()
+@@ -2169,7 +2169,7 @@ void UIMessageCenter::prepare()
      /* Translations for Main.
       * Please make sure they corresponds to the strings coming from Main one-by-one symbol! */
      tr("Could not load the Host USB Proxy Service (VERR_FILE_NOT_FOUND). The service might not be installed on the host computer");
@@ -1059,7 +1059,7 @@ index a9dbcda58..fd0adce9d 100755
      # Remove any kernel modules left over from previously installed kernels.
      cleanup only_old
 diff --git a/src/VBox/Installer/solaris/vbox-ips.mog b/src/VBox/Installer/solaris/vbox-ips.mog
-index 03547eda0..f65086b51 100644
+index 6799a050f..2f7ef6e8e 100644
 --- a/src/VBox/Installer/solaris/vbox-ips.mog
 +++ b/src/VBox/Installer/solaris/vbox-ips.mog
 @@ -7,7 +7,7 @@ set name=variant.arch value=@UNAME_P@
@@ -1071,7 +1071,7 @@ index 03547eda0..f65086b51 100644
  # The data-xkb was renamed to xkeyboard-config in S11.4, so adjust this when
  # we have moved our builds away from S11.3.
  depend fmri=pkg:/x11/keyboard/data-xkb type=require
-@@ -62,7 +62,7 @@ $(HARDENED_ONLY)<transform file path=opt/VirtualBox/amd64/(VirtualBoxVM|VBoxHead
+@@ -66,7 +66,7 @@ $(HARDENED_ONLY)<transform file path=opt/VirtualBox/amd64/(VirtualBoxVM|VBoxHead
  <transform file path=platform/i86pc/kernel/drv/amd64/vboxdrv$ -> emit driver name=vboxdrv perms="* 0600 root sys" perms="vboxdrvu 0666 root sys" devlink=type=ddi_pseudo;name=vboxdrv;minor=vboxdrv\t\D devlink=type=ddi_pseudo;name=vboxdrv;minor=vboxdrvu\t\M0>
  <transform file path=platform/i86pc/kernel/drv/amd64/vboxnet$ -> emit driver name=vboxnet>
  <transform file path=platform/i86pc/kernel/drv/amd64/vboxbow$ -> emit driver name=vboxbow>
@@ -1124,10 +1124,10 @@ index b8352e5f0..a66e58d94 100644
      </message>
      <message>
 diff --git a/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp b/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
-index f0b2ee0f0..b56d8fe7d 100644
+index 5baff1cfb..6cfc55936 100644
 --- a/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
 +++ b/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
-@@ -2619,7 +2619,7 @@ int Console::i_configNetwork(const char *pszDevice,
+@@ -2624,7 +2624,7 @@ int Console::i_configNetwork(const char *pszDevice,
                                                               "Failed to open '/dev/%s' for read/write access.  Please check the "
                                                               "permissions of that node, and that the net.link.tap.user_open "
                                                               "sysctl is set.  Either run 'chmod 0666 /dev/%s' or change the "
@@ -1150,5 +1150,5 @@ index 0440ae781..515e73fa5 100644
                  return setWarning(E_FAIL,
                                    tr("VirtualBox is not currently allowed to access USB devices.  You can change this by allowing your user to access the 'usbfs' folder and files.  Please see the user manual for a more detailed explanation"));
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0007-FROM-ARCHLINUX-fix-python-3.12-compatibility.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0007-FROM-ARCHLINUX-fix-python-3.12-compatibility.patch
@@ -1,4 +1,4 @@
-From 4ed1ee6c19920a774208506b7091ddf5fece4b87 Mon Sep 17 00:00:00 2001
+From eb7bcdc5479f4f7ffa00b1de094422d3a0e9d847 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sun, 15 Sep 2024 21:24:25 +0800
 Subject: [PATCH 07/10] FROM ARCHLINUX: fix: python 3.12 compatibility
@@ -21,5 +21,5 @@ index 693e01e08..35a7c9528 100755
  if encoding:
      reload(sys)
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0008-FROM-AOSC-Link-against-vorbisenc.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0008-FROM-AOSC-Link-against-vorbisenc.patch
@@ -1,4 +1,4 @@
-From d8d69316378e220d08fecc603a087fef6e8d561b Mon Sep 17 00:00:00 2001
+From eecaacb52949eeebb9a2ba34702a5f00fc7ed03c Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 16 Sep 2024 20:28:29 +0800
 Subject: [PATCH 08/10] FROM AOSC: Link against vorbisenc
@@ -25,5 +25,5 @@ index 65791d554..6c7669005 100755
      cat > $ODIR.tmp_src.cc << EOF
  #include <cstdio>
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0009-FROM-AOSC-Add-gitignore.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0009-FROM-AOSC-Add-gitignore.patch
@@ -1,4 +1,4 @@
-From a8308b80fd7b34082279846d502ebcaf2cc4c82d Mon Sep 17 00:00:00 2001
+From 72632f408c3f8bda337bc11f57267f9ee813b659 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 30 Sep 2024 21:48:02 +0800
 Subject: [PATCH 09/10] FROM AOSC: Add gitignore
@@ -20,5 +20,5 @@ index 000000000..8610ed868
 +/env.sh
 +/out
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/01-host/patches/0010-FROM-AOSC-Add-localinst.sh.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0010-FROM-AOSC-Add-localinst.sh.patch
@@ -1,4 +1,4 @@
-From d09c47d1b6dfe42d74f9dd71e1f3ff7a9e26ebc3 Mon Sep 17 00:00:00 2001
+From c4601380b0aa4cbc16b5b75370837e72ab787ee1 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 30 Sep 2024 21:48:13 +0800
 Subject: [PATCH 10/10] FROM AOSC: Add localinst.sh
@@ -64,5 +64,5 @@ index 000000000..2073fcb25
 +install -vdm755 "$PKGDIR"/usr/lib/virtualbox/components
 +install -vm755 "$OUTPUTDIR"/components/* -t "$PKGDIR"/usr/lib/virtualbox/components
 -- 
-2.47.0
+2.48.1
 

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,11 +1,10 @@
-VER=7.1.4
+VER=7.1.6a
 # Note: Sometimes Oracle seems to release fix-up tarballs.
-UBUNTU_VBOX_VER="165100~Ubuntu~noble"
-SRCS="tbl::https://download.virtualbox.org/virtualbox/$VER/VirtualBox-${VER}.tar.bz2 \
-      file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/$VER/virtualbox-${VER%.*}_${VER}-${UBUNTU_VBOX_VER}_amd64.deb \
-      file::rename=VBoxGuestAdditions.iso::https://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso"
-CHKSUMS="sha256::872e7a42b41f8558abbf887f1bdc7aac932bb88b2764d07cbce270cab57e3b5e \
-         sha256::54c25c941678198b0baf78f5e4cf468b990fd625ec4e7b231cf1e8a6bace3d1a \
-         sha256::80c91d35742f68217cf47b13e5b50d53f54c22c485bacce41ad7fdc321649e61"
+UBUNTU_VBOX_VER="167084~Ubuntu~noble"
+SRCS="tbl::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/VirtualBox-${VER}.tar.bz2 \
+      file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/virtualbox-${VER%.*}_${VER%%[a-z]*}-${UBUNTU_VBOX_VER}_amd64.deb \
+      file::rename=VBoxGuestAdditions.iso::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/VBoxGuestAdditions_${VER%%[a-z]*}.iso"
+CHKSUMS="sha256::5a7b13066ec71990af0cc00a5eea9c7ec3c71ca5ed99bb549c85494ce2ea395d \
+         sha256::b1e8406c141ff40221cebe5a99224ec74f1960d1491986d3bb1300a99c4790a1 \
+         sha256::dbbda1645bc05c9260adfe9efc4949cb590ec5ec02680aff936375670cffcafc"
 CHKUPDATE="anitya::id=14449"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- virtualbox: update to 7.1.6a
    Track patches at AOSC-Tracking/virtualbox @ aosc/v7.1.6a.

Package(s) Affected
-------------------

- virtualbox: 7.1.6a
- virtualbox-guest: 7.1.6a

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtualbox virtualbox-guest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
