### PR TITLE
rpi-firmware-boot: update to 1.20250127

### DIFF
--- a/runtime-kernel/rpi-firmware-boot/spec
+++ b/runtime-kernel/rpi-firmware-boot/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER="1.20241126"
+UPSTREAM_VER=1.20250127
 VER="${UPSTREAM_VER}"
-REL=1
 SRCS="tbl::https://github.com/raspberrypi/firmware/releases/download/$VER/raspi-firmware_$VER.orig.tar.xz"
-CHKSUMS="sha256::020dbcdbb30af5942a62fc3eb355449aba45276b67e864dee2522ff53fd936e6"
+CHKSUMS="sha256::0b8e290c829f5deee53b01037e4307d9f9242ea262949043e702e033d088eeb4"
 CHKUPDATE="anitya::id=21744"


### PR DESCRIPTION
Topic Description
-----------------

- rpi-firmware-boot: update to 1.20250127
    Co-authored-by: multimode_Liu / 自大的刘某人 \(@Dustymind\)

Package(s) Affected
-------------------

- rpi-firmware-boot: 1.20250127

Security Update?
----------------

No

Build Order
-----------

```
#buildit rpi-firmware-boot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
