### PR TITLE
kstars: update to 3.7.5

### DIFF
--- a/app-scientific/astrometry.net/autobuild/beyond
+++ b/app-scientific/astrometry.net/autobuild/beyond
@@ -1,5 +1,4 @@
-sed -e "s|$PKGDIR/usr/data|/usr/share/astrometry/data|" \
+sed -e "s|$PKGDIR/usr/data||" \
     -i "$PKGDIR"/etc/astrometry.cfg
-rm "$PKGDIR"/usr/share/doc/astrometry/report.txt
-rm "$PKGDIR"/usr/bin/fitscopy
-rm "$PKGDIR"/usr/bin/imcopy
+abinfo "Removing report.txt ..."
+rm -v "$PKGDIR"/usr/share/doc/astrometry/report.txt

--- a/app-scientific/astrometry.net/autobuild/patches/0001-AOSCOS-Pin-data-directory.patch
+++ b/app-scientific/astrometry.net/autobuild/patches/0001-AOSCOS-Pin-data-directory.patch
@@ -1,0 +1,27 @@
+From c1814fa841b5095f549b34d1ddfc8a56dd841195 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Thu, 30 Jan 2025 09:34:18 +0800
+Subject: [PATCH 1/2] AOSCOS: Pin data directory
+
+---
+ etc/astrometry.cfg-dist | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/astrometry.cfg-dist b/etc/astrometry.cfg-dist
+index 4e5c3c22f6b3..2777a450819b 100644
+--- a/etc/astrometry.cfg-dist
++++ b/etc/astrometry.cfg-dist
+@@ -26,7 +26,7 @@
+ cpulimit 300
+ 
+ # In which directories should we search for indices?
+-add_path DATA_INSTALL_DIR
++add_path /usr/share/astrometry/data
+ 
+ # Load any indices found in the directories listed above.
+ autoindex
+
+base-commit: 3f5bd4fa3226a63faf06b1f8ec5ac4c7b59b1576
+-- 
+2.48.1
+

--- a/app-scientific/astrometry.net/autobuild/patches/0002-AOSCOS-Use-Autobuild-flags.patch
+++ b/app-scientific/astrometry.net/autobuild/patches/0002-AOSCOS-Use-Autobuild-flags.patch
@@ -1,7 +1,17 @@
-diff -Naur astrometry.net-0.73/util/makefile.common astrometry.net-0.73.nonative/util/makefile.common
---- astrometry.net-0.73/util/makefile.common	2017-11-17 20:03:49.000000000 +0000
-+++ astrometry.net-0.73.nonative/util/makefile.common	2017-11-19 23:54:44.424713814 +0000
-@@ -162,58 +162,6 @@
+From 620baf49d96c061e3df22486fae8456956b502f9 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Thu, 30 Jan 2025 09:34:54 +0800
+Subject: [PATCH 2/2] AOSCOS: Use Autobuild flags
+
+---
+ util/makefile.common | 52 --------------------------------------------
+ 1 file changed, 52 deletions(-)
+
+diff --git a/util/makefile.common b/util/makefile.common
+index 9bd3bc99d231..d877cd6fa35f 100644
+--- a/util/makefile.common
++++ b/util/makefile.common
+@@ -163,58 +163,6 @@ FLAGS_DEF += $(shell $(CCTEST))
  #ARG := -std=c99
  #FLAGS_DEF += $(shell $(CCTEST))
  
@@ -60,4 +70,6 @@ diff -Naur astrometry.net-0.73/util/makefile.common astrometry.net-0.73.nonative
  STR := __APPLE__
  X := $(shell $(DEFTEST) && echo "-DNOBOOL")
  
+-- 
+2.48.1
 

--- a/app-scientific/astrometry.net/spec
+++ b/app-scientific/astrometry.net/spec
@@ -1,4 +1,4 @@
-VER=0.94
+VER=0.97
 SRCS="git::commit=tags/$VER::https://github.com/dstndstn/astrometry.net"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16047"

--- a/desktop-kde/kstars/autobuild/defines
+++ b/desktop-kde/kstars/autobuild/defines
@@ -16,5 +16,3 @@ PKGEPOCH=1
 CMAKE_AFTER=(
         -DBUILD_TESTING=OFF
 )
-
-FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,4 +1,4 @@
-VER=3.7.4
+VER=3.7.5
 SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
-CHKSUMS="sha256::59d56c3c2c034165bf34845e86eaa4e5ff2b82db9c01b18b49b9b064b30b8873"
+CHKSUMS="sha256::2fd87255f76016515f33a3328d1e1b51af3a1473db560ef10563d8f18487517c"
 CHKUPDATE="anitya::id=229035"

--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,4 +1,4 @@
-VER=3.7.3
+VER=3.7.4
 SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
-CHKSUMS="sha256::d3a469ad8068ceaa47fb145f90bc0818a8162a0545e15e424c00ddf0ac3f588d"
+CHKSUMS="sha256::59d56c3c2c034165bf34845e86eaa4e5ff2b82db9c01b18b49b9b064b30b8873"
 CHKUPDATE="anitya::id=229035"

--- a/runtime-scientific/libindi/spec
+++ b/runtime-scientific/libindi/spec
@@ -1,4 +1,4 @@
-VER=2.0.5
+VER=2.1.1
 SRCS="https://github.com/indilib/indi/archive/v$VER.tar.gz"
-CHKSUMS="sha256::50f95a3f90ff3f262095e8d8aa02eefce2f509c432f3cf1554dd5e8c675c5958"
+CHKSUMS="sha256::919862d5ccb4ea91ecb0e94f8f89a88c76bd1716e0098be07870c4408b233a20"
 CHKUPDATE="anitya::id=6838"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.7.5
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>
- libindi: update to 2.1.1
- astrometry.net: update to 0.97
- kstars: update to 3.7.4
    Co-authored-by: xtex \(@xtexChooser\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- astrometry.net: 0.97
- kstars: 1:3.7.5
- libindi: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit astrometry.net libindi kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
