### PR TITLE
zed: update to 0.171.6

### DIFF
--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.170.2
+VER=0.171.6
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.171.6
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- zed: 0.171.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
