### PR TITLE
zed: update to 0.172.8

### DIFF
--- a/app-editors/zed/autobuild/defines
+++ b/app-editors/zed/autobuild/defines
@@ -15,5 +15,5 @@ FAIL_ARCH="!(amd64|arm64)"
 
 USECLANG=1
 
-CARGO_AFTER="--bin zed \
-             --bin cli"
+CARGO_AFTER="--package zed \
+             --package cli"

--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.170.2
+VER=0.172.8
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.172.8
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- zed: 0.172.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
