### PR TITLE
rustc: update to 1.84.1

### DIFF
--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,8 +1,8 @@
-VER=1.84.0
+VER=1.84.1
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::bc2c1639f26814c7b17a323992f1e08c3b01fe88cdff9a27d951987d886e00b3"
+CHKSUMS="sha256::e23ec747a06ffd3e94155046f40b6664ac152c9ee3c2adfd90353a7ccff24226"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.84.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rustc: 1:1.84.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
