### PR TITLE
sof-tools: update to 2.12

### DIFF
--- a/app-multimedia/sof-tools/spec
+++ b/app-multimedia/sof-tools/spec
@@ -1,4 +1,4 @@
-VER=2.11.2
+VER=2.12
 SRCS="git::commit=tags/v$VER::https://github.com/thesofproject/sof"
 CHKSUMS="SKIP"
 SUBDIR="sof-tools/tools"


### PR DESCRIPTION
Topic Description
-----------------

- sof-tools: update to 2.12

Package(s) Affected
-------------------

- sof-tools: 2.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
