### PR TITLE
sof-firmware: update to 2025.01

### DIFF
--- a/runtime-kernel/sof-firmware/spec
+++ b/runtime-kernel/sof-firmware/spec
@@ -1,4 +1,4 @@
-VER=2024.09.1
+VER=2025.01
 SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-${VER}.tar.gz"
-CHKSUMS="sha256::a9b94d96648ab139d8270c728522d0ad7470276bc6a30efaf3752650d21e84e6"
+CHKSUMS="sha256::34d565db757a32450106317cc51f38bf67962e0fc8b7f7c72e6e39fd89e99263"
 CHKUPDATE="anitya::id=246473"


### PR DESCRIPTION
Topic Description
-----------------

- sof-firmware: update to 2025.01
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sof-firmware: 2025.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
