### PR TITLE
[LEGACY RUNTIME] openldap-2.4: new, 2.4.59

### DIFF
--- a/app-admin/openldap-2.4/autobuild/beyond
+++ b/app-admin/openldap-2.4/autobuild/beyond
@@ -1,0 +1,8 @@
+abinfo "Removing non-runtime files ..."
+rm -rv "$PKGDIR"/{etc,usr/{bin,include,libexec,share},var}
+
+abinfo "Removing non-versioned libraries ..."
+rm -v "$PKGDIR"/usr/lib/legacy/openldap-2.4/*.so
+
+abinfo "Setting executable bits for shared libraries ..."
+chmod -v +x "$PKGDIR"/usr/lib/legacy/openldap-2.4/*.so*

--- a/app-admin/openldap-2.4/autobuild/defines
+++ b/app-admin/openldap-2.4/autobuild/defines
@@ -1,0 +1,26 @@
+PKGNAME=openldap-2.4
+PKGSEC=net
+PKGDEP="e2fsprogs cyrus-sasl"
+BUILDDEP="groff"
+PKGDES="Lightweight Directory Access Protocol (LDAP) client/server (legacy 2.4 runtime)"
+
+RECONF=0
+ABSHADOW=0
+AUTOTOOLS_AFTER="--libdir=/usr/lib/legacy/openldap-2.4 \
+                 --libexecdir=/usr/libexec \
+                 --localstatedir=/var/lib/openldap \
+                 --enable-ipv6 \
+                 --enable-syslog \
+                 --enable-local \
+                 --enable-crypt \
+                 --enable-dynamic \
+                 --with-threads \
+                 --disable-wrappers \
+                 --without-fetch \
+                 --enable-spasswd \
+                 --with-cyrus-sasl \
+                 --enable-overlays=mod \
+                 --enable-modules=yes \
+                 --enable-static \
+                 --enable-slapd \
+                 --enable-slapi"

--- a/app-admin/openldap-2.4/autobuild/overrides/etc/ld.so.conf.d/openldap-2.4.conf
+++ b/app-admin/openldap-2.4/autobuild/overrides/etc/ld.so.conf.d/openldap-2.4.conf
@@ -1,0 +1,1 @@
+/usr/lib/legacy/openldap-2.4

--- a/app-admin/openldap-2.4/autobuild/patches/0001-GENTOO-fix-build-errors-due-to-implicit-function-dec.patch
+++ b/app-admin/openldap-2.4/autobuild/patches/0001-GENTOO-fix-build-errors-due-to-implicit-function-dec.patch
@@ -1,0 +1,70 @@
+From d83ee3425fc0580863378b2c637ea278fae17969 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 6 Feb 2025 18:16:38 +0800
+Subject: [PATCH 1/4] GENTOO: fix build errors due to implicit function
+ declaration with GCC >= 14
+
+Closes: https://bugs.gentoo.org/show_bug.cgi?id=920380
+Closes: https://bugs.gentoo.org/show_bug.cgi?id=882183
+Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
+
+Link: https://gitweb.gentoo.org/repo/gentoo.git/commit/net-nds/openldap/files/openldap-2.4.59-implicit-function.patch?id=783532d33df25206c20ecc175a6910ab6b0a29fb
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ servers/slapd/back-ldap/bind.c | 1 +
+ servers/slapd/back-meta/conn.c | 1 +
+ servers/slapd/config.c         | 1 +
+ servers/slapd/proto-slap.h     | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/servers/slapd/back-ldap/bind.c b/servers/slapd/back-ldap/bind.c
+index 91c62cdc8d..c5ce52ce89 100644
+--- a/servers/slapd/back-ldap/bind.c
++++ b/servers/slapd/back-ldap/bind.c
+@@ -31,6 +31,7 @@
+ 
+ #define AVL_INTERNAL
+ #include "slap.h"
++#include "proto-slap.h"
+ #include "back-ldap.h"
+ #include "lutil.h"
+ #include "lutil_ldap.h"
+diff --git a/servers/slapd/back-meta/conn.c b/servers/slapd/back-meta/conn.c
+index ba87d01a53..c49c204d7e 100644
+--- a/servers/slapd/back-meta/conn.c
++++ b/servers/slapd/back-meta/conn.c
+@@ -31,6 +31,7 @@
+ 
+ #define AVL_INTERNAL
+ #include "slap.h"
++#include "proto-slap.h"
+ #include "../back-ldap/back-ldap.h"
+ #include "back-meta.h"
+ 
+diff --git a/servers/slapd/config.c b/servers/slapd/config.c
+index bd68a24218..8821bd1bd0 100644
+--- a/servers/slapd/config.c
++++ b/servers/slapd/config.c
+@@ -43,6 +43,7 @@
+ #endif
+ 
+ #include "slap.h"
++#include "proto-slap.h"
+ #ifdef LDAP_SLAPI
+ #include "slapi/slapi.h"
+ #endif
+diff --git a/servers/slapd/proto-slap.h b/servers/slapd/proto-slap.h
+index 7f8e604fa7..e86b1e98ea 100644
+--- a/servers/slapd/proto-slap.h
++++ b/servers/slapd/proto-slap.h
+@@ -739,6 +739,7 @@ LDAP_SLAPD_F (int) bindconf_unparse LDAP_P((
+ LDAP_SLAPD_F (int) bindconf_tls_set LDAP_P((
+ 	slap_bindconf *bc, LDAP *ld ));
+ LDAP_SLAPD_F (void) bindconf_free LDAP_P(( slap_bindconf *bc ));
++LDAP_SLAPD_F (void) slap_client_keepalive LDAP_P(( LDAP *ld, slap_keepalive *sk ));
+ LDAP_SLAPD_F (int) slap_client_connect LDAP_P(( LDAP **ldp, slap_bindconf *sb ));
+ LDAP_SLAPD_F (int) config_generic_wrapper LDAP_P(( Backend *be,
+ 	const char *fname, int lineno, int argc, char **argv ));
+-- 
+2.48.1
+

--- a/app-admin/openldap-2.4/autobuild/patches/0002-GENTOO-fix-crash-at-atexit.patch
+++ b/app-admin/openldap-2.4/autobuild/patches/0002-GENTOO-fix-crash-at-atexit.patch
@@ -1,0 +1,78 @@
+From 38c77b50d163b276ebc9bc67b247b5ca9c30e81b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 6 Feb 2025 18:20:31 +0800
+Subject: [PATCH 2/4] GENTOO: fix crash at atexit()
+
+Port upstream commit 337455eb3a66176cc3f66d2c663a72cc7b4178bd to 2.4.59.
+
+With 2.4.x, gentoo-infra saw crashes in nsscache during exit.
+This patch was later reverted upstream because it was not portable to AIX And
+was fixed in a different way in 2.5 & 2.6 releases.
+
+original https://github.com/openldap/openldap/commit/337455eb3a66176cc3f66d2c663a72cc7b4178bd
+revert: https://github.com/openldap/openldap/commit/5e13ef87a94491f9339dbca709db29e76741f1a9
+AIX discussion: https://bugs.openldap.org/show_bug.cgi?id=10176
+
+Link: https://gitweb.gentoo.org/repo/gentoo.git/commit/net-nds/openldap/files/openldap-2.4.59-atexit-fix.patch?id=783532d33df25206c20ecc175a6910ab6b0a29fb
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libraries/libldap/init.c |  3 ---
+ libraries/libldap/tls2.c | 14 +++++++++++++-
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/libraries/libldap/init.c b/libraries/libldap/init.c
+index 182ef7d7ea..46e52f7f7c 100644
+--- a/libraries/libldap/init.c
++++ b/libraries/libldap/init.c
+@@ -508,9 +508,6 @@ ldap_int_destroy_global_options(void)
+ 		gopts->ldo_def_sasl_authcid = NULL;
+ 	}
+ #endif
+-#ifdef HAVE_TLS
+-	ldap_int_tls_destroy( gopts );
+-#endif
+ }
+ 
+ /* 
+diff --git a/libraries/libldap/tls2.c b/libraries/libldap/tls2.c
+index 82ca5272cc..e100f1191e 100644
+--- a/libraries/libldap/tls2.c
++++ b/libraries/libldap/tls2.c
+@@ -153,6 +153,14 @@ ldap_pvt_tls_destroy( void )
+ 	tls_imp->ti_tls_destroy();
+ }
+ 
++static void
++ldap_exit_tls_destroy( void )
++{
++	struct ldapoptions *lo = LDAP_INT_GLOBAL_OPT();
++
++	ldap_int_tls_destroy( lo );
++}
++
+ /*
+  * Initialize a particular TLS implementation.
+  * Called once per implementation.
+@@ -161,6 +169,7 @@ static int
+ tls_init(tls_impl *impl )
+ {
+ 	static int tls_initialized = 0;
++	int rc;
+ 
+ 	if ( !tls_initialized++ ) {
+ #ifdef LDAP_R_COMPILE
+@@ -173,7 +182,10 @@ tls_init(tls_impl *impl )
+ #ifdef LDAP_R_COMPILE
+ 	impl->ti_thr_init();
+ #endif
+-	return impl->ti_tls_init();
++	rc = impl->ti_tls_init();
++
++	atexit( ldap_exit_tls_destroy );
++	return rc;
+ }
+ 
+ /*
+-- 
+2.48.1
+

--- a/app-admin/openldap-2.4/autobuild/patches/0003-BACKPORT-Make-prototypes-available-where-needed.patch
+++ b/app-admin/openldap-2.4/autobuild/patches/0003-BACKPORT-Make-prototypes-available-where-needed.patch
@@ -1,0 +1,60 @@
+From 06544b5f4f806efca3f96b6219653c2eda2ac757 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Kuzn=C3=ADk?= <ondra@openldap.org>
+Date: Tue, 19 Feb 2019 10:26:39 +0000
+Subject: [PATCH 3/4] BACKPORT: Make prototypes available where needed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Ondřej Kuzník <ondra@openldap.org>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libraries/libldap/tls2.c   | 3 +++
+ servers/slapd/config.c     | 1 +
+ servers/slapd/proto-slap.h | 3 +++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/libraries/libldap/tls2.c b/libraries/libldap/tls2.c
+index e100f1191e..253cf062c8 100644
+--- a/libraries/libldap/tls2.c
++++ b/libraries/libldap/tls2.c
+@@ -76,6 +76,9 @@ static oid_name oids[] = {
+ 
+ #ifdef HAVE_TLS
+ 
++LDAP_F(int) ldap_pvt_tls_check_hostname LDAP_P(( LDAP *ld, void *s, const char *name_in ));
++LDAP_F(int) ldap_pvt_tls_get_peercert LDAP_P(( void *s, struct berval *der ));
++
+ void
+ ldap_pvt_tls_ctx_free ( void *c )
+ {
+diff --git a/servers/slapd/config.c b/servers/slapd/config.c
+index 8821bd1bd0..b25b4c3ba0 100644
+--- a/servers/slapd/config.c
++++ b/servers/slapd/config.c
+@@ -49,6 +49,7 @@
+ #endif
+ #include "lutil.h"
+ #include "lutil_ldap.h"
++#include "ldif.h"
+ #include "config.h"
+ 
+ #ifdef _WIN32
+diff --git a/servers/slapd/proto-slap.h b/servers/slapd/proto-slap.h
+index e86b1e98ea..de1cabf32b 100644
+--- a/servers/slapd/proto-slap.h
++++ b/servers/slapd/proto-slap.h
+@@ -1657,6 +1657,9 @@ LDAP_SLAPD_F (int) slap_sasl_external( Connection *c,
+ 	slap_ssf_t ssf,	/* relative strength of external security */
+ 	struct berval *authid );	/* asserted authenication id */
+ 
++LDAP_SLAPD_F (int) slap_sasl_cbinding( Connection *c,
++	struct berval *cbv );
++
+ LDAP_SLAPD_F (int) slap_sasl_reset( Connection *c );
+ LDAP_SLAPD_F (int) slap_sasl_close( Connection *c );
+ 
+-- 
+2.48.1
+

--- a/app-admin/openldap-2.4/autobuild/patches/0004-GENTOO-fix-implicit-function-declarations-for-pthrea.patch
+++ b/app-admin/openldap-2.4/autobuild/patches/0004-GENTOO-fix-implicit-function-declarations-for-pthrea.patch
@@ -1,0 +1,60 @@
+From 4b4334f76f4a3da5bca6741e3d229412d3d07892 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 7 Feb 2025 17:29:07 +0800
+Subject: [PATCH 4/4] GENTOO: fix implicit function declarations for pthread
+ functions
+
+Signed-off-by: Patrick McLean <chutzpah@gentoo.org>
+
+Link: https://gitweb.gentoo.org/repo/gentoo.git/commit/net-nds/openldap/files/openldap-2.4.47-warnings.patch?id=2d676affba9a313563bee463daba47235862724b
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ include/ldap.h            | 4 ++++
+ include/ldap_int_thread.h | 2 +-
+ libraries/libldap/tls2.c  | 2 ++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/include/ldap.h b/include/ldap.h
+index 389441031f..127135bab0 100644
+--- a/include/ldap.h
++++ b/include/ldap.h
+@@ -2040,6 +2040,10 @@ LDAP_F( int )
+ ldap_is_ldap_url LDAP_P((
+ 	LDAP_CONST char *url ));
+ 
++LDAP_F( int )
++ldap_is_ldapc_url LDAP_P((
++	LDAP_CONST char *url ));
++
+ LDAP_F( int )
+ ldap_is_ldaps_url LDAP_P((
+ 	LDAP_CONST char *url ));
+diff --git a/include/ldap_int_thread.h b/include/ldap_int_thread.h
+index ee85e6f44f..8abf731b46 100644
+--- a/include/ldap_int_thread.h
++++ b/include/ldap_int_thread.h
+@@ -33,7 +33,7 @@ LDAP_END_DECL
+  * definitions for POSIX Threads  *
+  *                                *
+  **********************************/
+-
++#define __USE_UNIX98
+ #include <pthread.h>
+ #ifdef HAVE_SCHED_H
+ #include <sched.h>
+diff --git a/libraries/libldap/tls2.c b/libraries/libldap/tls2.c
+index 253cf062c8..84d4a3247c 100644
+--- a/libraries/libldap/tls2.c
++++ b/libraries/libldap/tls2.c
+@@ -79,6 +79,8 @@ static oid_name oids[] = {
+ LDAP_F(int) ldap_pvt_tls_check_hostname LDAP_P(( LDAP *ld, void *s, const char *name_in ));
+ LDAP_F(int) ldap_pvt_tls_get_peercert LDAP_P(( void *s, struct berval *der ));
+ 
++int ldap_pvt_tls_check_hostname( LDAP *ld, void *s, const char *name_in );
++
+ void
+ ldap_pvt_tls_ctx_free ( void *c )
+ {
+-- 
+2.48.1
+

--- a/app-admin/openldap-2.4/autobuild/postinst
+++ b/app-admin/openldap-2.4/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Refreshing dynamic library cache ..."
+ldconfig

--- a/app-admin/openldap-2.4/autobuild/prepare
+++ b/app-admin/openldap-2.4/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Appending flags to fix configure ..."
+export CFLAGS="${CFLAGS} -Wno-error=implicit-int -Wno-error=int-conversion -Wno-error=incompatible-pointer-types"

--- a/app-admin/openldap-2.4/spec
+++ b/app-admin/openldap-2.4/spec
@@ -1,0 +1,5 @@
+UPSTREAM_VER=2_4_59
+VER=${UPSTREAM_VER//_/.}
+SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
+CHKSUMS="sha256::99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34"
+# Note: No more branch update, no need for CHKUPDATE.


### PR DESCRIPTION
Topic Description
-----------------

- openldap-2.4: new, 2.4.59
    Track patches at AOSC-Tracking/openldap @ aosc/OPENLDAP_REL_ENG_2_4_59
    \(HEAD: 4b4334f76f4a3da5bca6741e3d229412d3d07892\).

Package(s) Affected
-------------------

- openldap-2.4: 2.4.59

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap-2.4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
