### PR TITLE
loonggpu-kernel-dkms: add patch to fix building on 6.14

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/build
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/build
@@ -4,4 +4,4 @@ dpkg -x "$SRCDIR"/loonggpu-kernel-dkms_${__UPSTREAM_VER}_loong64.deb \
 
 abinfo "Patching module sources to fix build with newer kernel versions ..."
 cd "$PKGDIR"/usr/src/loonggpu-${__UPSTREAM_VER%%-*}/
-ab_apply_patches "$SRCDIR"/autobuild/patches/*.deferred
+ab_apply_patches "$SRCDIR"/autobuild/patches.deferred/*.patch

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
@@ -1,0 +1,28 @@
+From 2e20048c55fa5ec168f5a44f4f5733c7e2703346 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 21 Jan 2025 17:49:15 +0800
+Subject: [PATCH 1/8] chore: initialise a gitignore file
+
+Just to make my life easier.
+---
+ .gitignore | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..223542a
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,8 @@
++*.o
++*.ko
++*.mod
++*.mod.c
++*.cmd
++*.symvers
++*.order
++conftest
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
@@ -1,7 +1,7 @@
-From 405d190d84e400898d143420ea087fc988a72ec0 Mon Sep 17 00:00:00 2001
+From f50458a8b381bb6b5858ad27b8ab51982d7655db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:29:59 +0800
-Subject: [PATCH 1/3] loonggpu: include: use video aperture helpers for Linux
+Subject: [PATCH 2/8] loonggpu: include: use video aperture helpers for Linux
  >= 6.13.
 
 Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
@@ -1,7 +1,7 @@
-From 3b12cb887716602100bfe36091f3184729029908 Mon Sep 17 00:00:00 2001
+From c8c543febf29491562e32a6c21805ca2af963c2f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:34:47 +0800
-Subject: [PATCH 2/3] loonggpu: pass string literal parameter to
+Subject: [PATCH 3/8] loonggpu: pass string literal parameter to
  MODULE_IMPORT_NS for Linux >= 6.13
 
 With commit cdd30ebb1b9f ("module: Convert symbol namespace to string

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
@@ -1,7 +1,7 @@
-From 095e20e815ab87cdf6e09b0eba61403925a16b22 Mon Sep 17 00:00:00 2001
+From d78344d1e4534a20fbe9a9691fb20c86fa605701 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 11:51:25 +0800
-Subject: [PATCH 3/3] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes option
+Subject: [PATCH 4/8] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes option
 
 This option is marked deprecated and causes a warning during DKMS builds.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
@@ -1,0 +1,44 @@
+From 37c11b5b83ccc184e10bdea24dc4c8ed02474d1d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 21 Jan 2025 17:49:35 +0800
+Subject: [PATCH 5/8] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
+ unused variable i
+
+A variable `i' was defined under multiple functions, triggering
+`-Wunused-variable'.
+
+Drop unused variable to fix compiler warnings.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ gsgpu-bridge/bridge_phy.c  | 1 -
+ gsgpu/gsgpu_dc_connector.c | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/gsgpu-bridge/bridge_phy.c b/gsgpu-bridge/bridge_phy.c
+index f67d8f3..921583e 100644
+--- a/gsgpu-bridge/bridge_phy.c
++++ b/gsgpu-bridge/bridge_phy.c
+@@ -66,7 +66,6 @@ static struct drm_encoder *
+ bridge_phy_connector_best_encoder(struct drm_connector *connector)
+ {
+ 	struct drm_encoder *encoder;
+-	int i;
+ 
+ 	/* pick the first one */
+ 	lg_drm_connector_for_each_possible_encoder(connector, encoder, i)
+diff --git a/gsgpu/gsgpu_dc_connector.c b/gsgpu/gsgpu_dc_connector.c
+index 86daef6..b0a9185 100644
+--- a/gsgpu/gsgpu_dc_connector.c
++++ b/gsgpu/gsgpu_dc_connector.c
+@@ -14,7 +14,6 @@
+ 
+ static struct drm_encoder *best_encoder(struct drm_connector *connector)
+ {
+-	int i;
+ 	struct drm_encoder *encoder;
+ 
+ 	/* pick the first one */
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
@@ -1,0 +1,176 @@
+From fb033217bfa7ca1b3b900ba448bd96688910b164 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 21 Jan 2025 18:30:31 +0800
+Subject: [PATCH 6/8] loonggpu: gsgpu_vm: move struct definition to
+ include/gsgpu_vm.h
+
+Move struct definition to header so that non-static functions may access
+them as parameters.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ gsgpu/gsgpu_vm.c   | 68 ----------------------------------------------
+ include/gsgpu_vm.h | 68 ++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 68 insertions(+), 68 deletions(-)
+
+diff --git a/gsgpu/gsgpu_vm.c b/gsgpu/gsgpu_vm.c
+index 7859bf1..b369090 100644
+--- a/gsgpu/gsgpu_vm.c
++++ b/gsgpu/gsgpu_vm.c
+@@ -30,74 +30,6 @@
+  * SI supports 16.
+  */
+ 
+-/**
+- * struct gsgpu_pte_update_params - Local structure
+- *
+- * Encapsulate some VM table update parameters to reduce
+- * the number of function parameters
+- *
+- */
+-struct gsgpu_pte_update_params {
+-
+-	/**
+-	 * @ldev: gsgpu device we do this update for
+-	 */
+-	struct gsgpu_device *ldev;
+-
+-	/**
+-	 * @vm: optional gsgpu_vm we do this update for
+-	 */
+-	struct gsgpu_vm *vm;
+-
+-	/**
+-	 * @src: address where to copy page table entries from
+-	 */
+-	u64 src;
+-
+-	/**
+-	 * @ib: indirect buffer to fill with commands
+-	 */
+-	struct gsgpu_ib *ib;
+-
+-	/**
+-	 * @func: Function which actually does the update
+-	 */
+-	void (*func)(struct gsgpu_pte_update_params *params,
+-		     struct gsgpu_bo *bo, u64 pe,
+-		     u64 addr, unsigned count, u32 incr,
+-		     u64 flags);
+-	/**
+-	 * @pages_addr:
+-	 *
+-	 * DMA addresses to use for mapping, used during VM update by CPU
+-	 */
+-	dma_addr_t *pages_addr;
+-
+-	/**
+-	 * @kptr:
+-	 *
+-	 * Kernel pointer of PD/PT BO that needs to be updated,
+-	 * used during VM update by CPU
+-	 */
+-	void *kptr;
+-};
+-
+-/**
+- * struct gsgpu_prt_cb - Helper to disable partial resident texture feature from a fence callback
+- */
+-struct gsgpu_prt_cb {
+-
+-	/**
+-	 * @ldev: gsgpu device
+-	 */
+-	struct gsgpu_device *ldev;
+-
+-	/**
+-	 * @cb: callback
+-	 */
+-	struct dma_fence_cb cb;
+-};
+-
+ /**
+  * gsgpu_vm_bo_base_init - Adds bo to the list of bos associated with the vm
+  *
+diff --git a/include/gsgpu_vm.h b/include/gsgpu_vm.h
+index 4e7da19..e71570a 100644
+--- a/include/gsgpu_vm.h
++++ b/include/gsgpu_vm.h
+@@ -60,6 +60,74 @@ struct gsgpu_bo_list_entry;
+ #define GSGPU_VM_CONTEXT_GFX 0
+ #define GSGPU_VM_CONTEXT_COMPUTE 1
+ 
++/**
++ * struct gsgpu_pte_update_params - Local structure
++ *
++ * Encapsulate some VM table update parameters to reduce
++ * the number of function parameters
++ *
++ */
++struct gsgpu_pte_update_params {
++
++	/**
++	 * @ldev: gsgpu device we do this update for
++	 */
++	struct gsgpu_device *ldev;
++
++	/**
++	 * @vm: optional gsgpu_vm we do this update for
++	 */
++	struct gsgpu_vm *vm;
++
++	/**
++	 * @src: address where to copy page table entries from
++	 */
++	u64 src;
++
++	/**
++	 * @ib: indirect buffer to fill with commands
++	 */
++	struct gsgpu_ib *ib;
++
++	/**
++	 * @func: Function which actually does the update
++	 */
++	void (*func)(struct gsgpu_pte_update_params *params,
++		     struct gsgpu_bo *bo, u64 pe,
++		     u64 addr, unsigned count, u32 incr,
++		     u64 flags);
++	/**
++	 * @pages_addr:
++	 *
++	 * DMA addresses to use for mapping, used during VM update by CPU
++	 */
++	dma_addr_t *pages_addr;
++
++	/**
++	 * @kptr:
++	 *
++	 * Kernel pointer of PD/PT BO that needs to be updated,
++	 * used during VM update by CPU
++	 */
++	void *kptr;
++};
++
++/**
++ * struct gsgpu_prt_cb - Helper to disable partial resident texture feature from a fence callback
++ */
++struct gsgpu_prt_cb {
++
++	/**
++	 * @ldev: gsgpu device
++	 */
++	struct gsgpu_device *ldev;
++
++	/**
++	 * @cb: callback
++	 */
++	struct dma_fence_cb cb;
++};
++
+ /* VMPT level enumerate, and the hiberachy is:
+  * DIR0->DIR1->DIR2
+  */
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
@@ -1,0 +1,249 @@
+From 960d2e37e3a0b833b7f5ce34fb4d80a22e6b0c7b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 21 Jan 2025 18:33:02 +0800
+Subject: [PATCH 7/8] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
+
+Lots of functions in this driver were missing prototype definitions,
+triggering a large number of `-Wmissing-prototypes' warnings.
+
+Add them to their respective headers and for driver code that do not
+clearly correspond to a header, declare them as static.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ gsgpu-bridge/bridge_phy.h    |  9 +++++++++
+ gsgpu-bridge/lt8619_drv.c    |  2 +-
+ gsgpu-bridge/lt8718_drv.h    | 12 ++++++++++++
+ gsgpu-bridge/lt9721_drv.h    |  3 +++
+ gsgpu-bridge/ncs8805_drv.h   |  2 ++
+ gsgpu/gsgpu_dc_drv.c         |  4 ++--
+ gsgpu/gsgpu_pm.c             |  1 +
+ gsgpu/gsgpu_sched.c          |  1 +
+ include/gsgpu_dc_connector.h |  1 +
+ include/gsgpu_dc_crtc.h      |  1 +
+ include/gsgpu_dc_irq.h       |  1 +
+ include/gsgpu_dc_vbios.h     |  1 +
+ include/gsgpu_display.h      |  5 +++++
+ include/gsgpu_ttm.h          |  3 +++
+ include/gsgpu_vm.h           |  3 +++
+ 15 files changed, 46 insertions(+), 3 deletions(-)
+
+diff --git a/gsgpu-bridge/bridge_phy.h b/gsgpu-bridge/bridge_phy.h
+index 14e3d27..40818ef 100644
+--- a/gsgpu-bridge/bridge_phy.h
++++ b/gsgpu-bridge/bridge_phy.h
+@@ -286,13 +286,22 @@ int bridge_phy_register(struct gsgpu_bridge_phy *phy,
+ 			u32 feature, struct bridge_phy_helper *helper);
+ 
+ int bridge_phy_lt6711_init(struct gsgpu_dc_bridge *dc_bridge);
++int bridge_phy_lt6711_remove(struct gsgpu_dc_bridge *phy);
+ int bridge_phy_lt9721_init(struct gsgpu_dc_bridge *res);
+ int bridge_phy_lt8619_init(struct gsgpu_dc_bridge *dc_bridge);
+ int bridge_phy_ncs8805_init(struct gsgpu_dc_bridge *dc_bridge);
++int bridge_phy_ncs8805_remove(struct gsgpu_dc_bridge *phy);
+ int bridge_phy_lt8718_init(struct gsgpu_dc_bridge *dc_bridge);
+ void bridge_phy_mode_set(struct gsgpu_bridge_phy *phy,
+ 				struct drm_display_mode *mode,
+ 				struct drm_display_mode *adj_mode);
+ void gsgpu_bridge_suspend(struct gsgpu_device *adev);
+ void gsgpu_bridge_resume(struct gsgpu_device *adev);
++
++void bridge_phy_reg_mask_seq(struct gsgpu_bridge_phy *phy,
++			     const struct reg_mask_seq *seq, size_t seq_size);
++void bridge_phy_reg_update_bits(struct gsgpu_bridge_phy *phy, unsigned int reg,
++				unsigned int mask, unsigned int val);
++int bridge_phy_reg_dump(struct gsgpu_bridge_phy *phy, size_t start,
++			size_t count);
+ #endif /* __BRIDGE_PHY_H__ */
+diff --git a/gsgpu-bridge/lt8619_drv.c b/gsgpu-bridge/lt8619_drv.c
+index 341ea62..31225fa 100644
+--- a/gsgpu-bridge/lt8619_drv.c
++++ b/gsgpu-bridge/lt8619_drv.c
+@@ -604,7 +604,7 @@ static int lt8619_lvds_config(struct gsgpu_bridge_phy *phy)
+ 	return 0;
+ }
+ 
+-void lt8619_bridge_enable(struct gsgpu_bridge_phy *phy)
++static void lt8619_bridge_enable(struct gsgpu_bridge_phy *phy)
+ {
+ 	lt8619_hdmi_rx_reset(phy);
+ 	lt8619_vid_chk_soft_reset(phy);
+diff --git a/gsgpu-bridge/lt8718_drv.h b/gsgpu-bridge/lt8718_drv.h
+index 65286fa..ac8417c 100644
+--- a/gsgpu-bridge/lt8718_drv.h
++++ b/gsgpu-bridge/lt8718_drv.h
+@@ -170,4 +170,16 @@ static const struct reg_sequence lt8718_output_set_cfg[] = {
+ 		{ 0x884b, 0x92},
+ 		{ 0x8074, 0x28},
+ };
++
++void dpcd_write_funtion(struct gsgpu_bridge_phy *phy, unsigned int  address, unsigned char data);
++unsigned char dpcd_read_funtion(struct gsgpu_bridge_phy *phy, unsigned int address);
++void link_configuration(struct gsgpu_bridge_phy *phy);
++void drive_write_funtion(struct gsgpu_bridge_phy *phy, unsigned char data);
++int tps_status(struct gsgpu_bridge_phy *phy, unsigned char tps);
++unsigned char read_adjust_request(struct gsgpu_bridge_phy *phy, unsigned char tps);
++void vd_dp_tx_swing_init(struct gsgpu_bridge_phy *phy,unsigned char swing);
++void end_training(struct gsgpu_bridge_phy *phy);
++void write_funtion(struct gsgpu_bridge_phy *phy, unsigned char number, unsigned char *data);
++void lt8718_edid_read(struct gsgpu_bridge_phy *phy);
++void dp_out_video_open(struct gsgpu_bridge_phy *phy);
+ #endif
+diff --git a/gsgpu-bridge/lt9721_drv.h b/gsgpu-bridge/lt9721_drv.h
+index 743eda9..e4d29cf 100644
+--- a/gsgpu-bridge/lt9721_drv.h
++++ b/gsgpu-bridge/lt9721_drv.h
+@@ -102,4 +102,7 @@ static const struct reg_sequence lt9721_tx_phy_cfg[] = {
+ 	{ 0x8030, 0x0e },
+ };
+ 
++int lt9721_hdmi_rx_cdr(struct gsgpu_bridge_phy *phy);
++int lt9721_rx_pll(struct gsgpu_bridge_phy *phy);
++int lt9721_hdmi_format(struct gsgpu_bridge_phy *phy);
+ #endif
+diff --git a/gsgpu-bridge/ncs8805_drv.h b/gsgpu-bridge/ncs8805_drv.h
+index 1a03ace..5b5b6ec 100644
+--- a/gsgpu-bridge/ncs8805_drv.h
++++ b/gsgpu-bridge/ncs8805_drv.h
+@@ -80,4 +80,6 @@ struct display_mode {
+ 	struct drm_display_mode  mode;
+ };
+ 
++int ncs8805_suspend(struct gsgpu_bridge_phy *phy);
++int ncs8805_resume(struct gsgpu_bridge_phy *phy);
+ #endif
+diff --git a/gsgpu/gsgpu_dc_drv.c b/gsgpu/gsgpu_dc_drv.c
+index 17beb0a..732f8b0 100644
+--- a/gsgpu/gsgpu_dc_drv.c
++++ b/gsgpu/gsgpu_dc_drv.c
+@@ -694,7 +694,7 @@ static void gsgpu_dc_commit_planes(struct drm_atomic_state *state,
+ 	}
+ }
+ 
+-void gsgpu_dc_atomic_commit_tail(struct drm_atomic_state *state)
++static void gsgpu_dc_atomic_commit_tail(struct drm_atomic_state *state)
+ {
+ 	struct drm_device *dev = state->dev;
+ 	struct gsgpu_device *adev = dev->dev_private;
+@@ -1069,7 +1069,7 @@ static int dc_hw_fini(void *handle)
+ 	return 0;
+ }
+ 
+-void gsgpu_dc_crtc_suspend(struct gsgpu_dc *dc)
++static void gsgpu_dc_crtc_suspend(struct gsgpu_dc *dc)
+ {
+ 	struct gsgpu_dc_crtc *dc_crtc;
+ 
+diff --git a/gsgpu/gsgpu_pm.c b/gsgpu/gsgpu_pm.c
+index 5fa0cbb..31fe5c8 100644
+--- a/gsgpu/gsgpu_pm.c
++++ b/gsgpu/gsgpu_pm.c
+@@ -1,6 +1,7 @@
+ #include "gsgpu.h"
+ #include "gsgpu_dc_resource.h"
+ #include "gsgpu_dc_vbios.h"
++#include "gsgpu_pm.h"
+ 
+ #define FREQ_LEVEL0 0xf
+ #define FREQ_LEVEL1 0xd
+diff --git a/gsgpu/gsgpu_sched.c b/gsgpu/gsgpu_sched.c
+index a5c44c5..7309719 100644
+--- a/gsgpu/gsgpu_sched.c
++++ b/gsgpu/gsgpu_sched.c
+@@ -3,6 +3,7 @@
+ #include <linux/file.h>
+ #include "gsgpu_drm.h"
+ #include "gsgpu.h"
++#include "gsgpu_sched.h"
+ #include "gsgpu_scheduler_helper.h"
+ #include "gsgpu_vm.h"
+ 
+diff --git a/include/gsgpu_dc_connector.h b/include/gsgpu_dc_connector.h
+index f347d81..882e086 100644
+--- a/include/gsgpu_dc_connector.h
++++ b/include/gsgpu_dc_connector.h
+@@ -24,5 +24,6 @@ struct gsgpu_dc_connector {
+ 
+ struct gsgpu_dc_connector *dc_connector_construct(struct gsgpu_dc *dc, struct connector_resource *resource);
+ int gsgpu_dc_connector_init(struct gsgpu_device *adev, uint32_t link_index);
++struct drm_connector_state *gsgpu_dc_connector_atomic_duplicate_state(struct drm_connector *connector);
+ 
+ #endif /* __GSGPU_DC_CONNECTOR__ */
+diff --git a/include/gsgpu_dc_crtc.h b/include/gsgpu_dc_crtc.h
+index 7abd75f..0eaa919 100644
+--- a/include/gsgpu_dc_crtc.h
++++ b/include/gsgpu_dc_crtc.h
+@@ -45,4 +45,5 @@ bool dc_crtc_vblank_enable(struct gsgpu_dc_crtc *crtc, bool enable);
+ u32 dc_crtc_get_vblank_counter(struct gsgpu_dc_crtc *crtc);
+ bool dc_crtc_vblank_ack(struct gsgpu_dc_crtc *crtc);
+ 
++bool dc_set_pll(struct gsgpu_dc_crtc *crtc, u32 clock);
+ #endif /* __DC_CRTC_H__ */
+diff --git a/include/gsgpu_dc_irq.h b/include/gsgpu_dc_irq.h
+index 9af2e9e..7f9d064 100644
+--- a/include/gsgpu_dc_irq.h
++++ b/include/gsgpu_dc_irq.h
+@@ -89,5 +89,6 @@ void dc_set_irq_funcs(struct gsgpu_device *adev);
+ void gsgpu_dc_hpd_init(struct gsgpu_device *adev);
+ void gsgpu_dc_hpd_disable(struct gsgpu_device *adev);
+ bool dc_interrupt_enable(struct gsgpu_dc *dc, enum dc_irq_source src, bool enable);
++void gsgpu_dc_irq_unregister_interrupt(struct gsgpu_device *adev, enum dc_irq_source irq_source, void *ih);
+ 
+ #endif /* __GSGPU_DM_IRQ_H__ */
+diff --git a/include/gsgpu_dc_vbios.h b/include/gsgpu_dc_vbios.h
+index 1d40a7d..a509a57 100644
+--- a/include/gsgpu_dc_vbios.h
++++ b/include/gsgpu_dc_vbios.h
+@@ -213,5 +213,6 @@ void dc_vbios_exit(struct gsgpu_vbios *vbios);
+ u8 gsgpu_vbios_checksum(const u8 *data, int size);
+ u32 gsgpu_vbios_version(struct gsgpu_vbios *vbios);
+ bool check_vbios_info(void);
++void dc_vbios_show(struct gsgpu_vbios *vbios);
+ 
+ #endif
+diff --git a/include/gsgpu_display.h b/include/gsgpu_display.h
+index ea7530e..46523aa 100644
+--- a/include/gsgpu_display.h
++++ b/include/gsgpu_display.h
+@@ -6,5 +6,10 @@ struct drm_framebuffer *
+ gsgpu_display_user_framebuffer_create(struct drm_device *dev,
+ 				       struct drm_file *file_priv,
+ 				       const struct drm_mode_fb_cmd2 *mode_cmd);
++int gsgpu_display_crtc_page_flip_target(struct drm_crtc *crtc,
++                                struct drm_framebuffer *fb,
++                                struct drm_pending_vblank_event *event,
++                                uint32_t page_flip_flags, uint32_t target,
++                                struct drm_modeset_acquire_ctx *ctx);
+ 
+ #endif /* __GSGPU_DISPLAY_H__ */
+diff --git a/include/gsgpu_ttm.h b/include/gsgpu_ttm.h
+index 4ab73b1..bdbc722 100644
+--- a/include/gsgpu_ttm.h
++++ b/include/gsgpu_ttm.h
+@@ -102,6 +102,9 @@ int gsgpu_fill_buffer(struct gsgpu_bo *bo,
+ 
+ int gsgpu_mmap(struct file *filp, struct vm_area_struct *vma);
+ int gsgpu_ttm_alloc_gart(struct ttm_buffer_object *bo);
++int gsgpu_ttm_gart_bind(struct gsgpu_device *adev,
++			struct ttm_buffer_object *tbo,
++			uint64_t flags);
+ int gsgpu_ttm_recover_gart(struct ttm_buffer_object *tbo);
+ 
+ int gsgpu_ttm_tt_get_user_pages(struct ttm_tt *ttm, struct page **pages);
+diff --git a/include/gsgpu_vm.h b/include/gsgpu_vm.h
+index e71570a..36e533f 100644
+--- a/include/gsgpu_vm.h
++++ b/include/gsgpu_vm.h
+@@ -327,6 +327,9 @@ int gsgpu_vm_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+ bool gsgpu_vm_need_pipeline_sync(struct gsgpu_ring *ring,
+ 				  struct gsgpu_job *job);
+ 
++void gsgpu_vm_get_entry(struct gsgpu_pte_update_params *p, u64 addr,
++			struct gsgpu_vm_pt **entry,
++			struct gsgpu_vm_pt **parent);
+ void gsgpu_vm_get_task_info(struct gsgpu_device *adev, unsigned int pasid,
+ 			 struct gsgpu_task_info *task_info);
+ 
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,0 +1,46 @@
+From 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Thu, 6 Feb 2025 18:12:15 +0800
+Subject: [PATCH 8/8] AOSCOS: loonggpu: remove driver date
+
+Following upstream changes.
+
+Fixes: cb2e1c2136f7 ("drm: remove driver date from struct drm_driver and all drivers")
+Fixes: "chore: import 1.0.1-alpha-lnd25.5"
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ gsgpu/gsgpu_drv.c   | 2 ++
+ include/gsgpu_drv.h | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/gsgpu/gsgpu_drv.c b/gsgpu/gsgpu_drv.c
+index 94c0608..94d9f88 100644
+--- a/gsgpu/gsgpu_drv.c
++++ b/gsgpu/gsgpu_drv.c
+@@ -563,7 +563,9 @@ static struct drm_driver kms_driver = {
+ 
+ 	.name = DRIVER_NAME,
+ 	.desc = DRIVER_DESC,
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0))
+ 	.date = DRIVER_DATE,
++#endif
+ 	.major = KMS_DRIVER_MAJOR,
+ 	.minor = KMS_DRIVER_MINOR,
+ 	.patchlevel = KMS_DRIVER_PATCHLEVEL,
+diff --git a/include/gsgpu_drv.h b/include/gsgpu_drv.h
+index 8a34e3f..891c43b 100644
+--- a/include/gsgpu_drv.h
++++ b/include/gsgpu_drv.h
+@@ -10,7 +10,9 @@
+ 
+ #define DRIVER_NAME		"loonggpu"
+ #define DRIVER_DESC		"Loongson LGxx GPU Driver"
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0))
+ #define DRIVER_DATE		"20241219"
++#endif
+ 
+ long gsgpu_drm_ioctl(struct file *filp,
+ 		      unsigned int cmd, unsigned long arg);
+-- 
+2.48.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,6 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
+REL=1
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- loonggpu-kernel-dkms: add patch to fix building on 6.14
    - Track AOSC OS patches at https://github.com/AOSC-Tracking/loonggpu-kernel-dkms @ aosc/v1.0.1-alpha-lnd25.5, current HEAD is 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: 1.0.1~alpha~lnd25.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
