### PR TITLE
pycryptodome: update to 3.21.0

### DIFF
--- a/lang-python/pycryptodome/autobuild/defines
+++ b/lang-python/pycryptodome/autobuild/defines
@@ -1,8 +1,11 @@
 PKGNAME=pycryptodome
 PKGSEC=python
-PKGDEP="gmp python-2 python-3"
+PKGDEP="gmp python-3"
 BUILDDEP="setuptools"
 PKGDES="Collection of cryptographic algorithms and protocols"
 
 PKGBREAK="pycrypto<=2.6.1-4"
 PKGREP="pycrypto<=2.6.1-4"
+
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/pycryptodome/spec
+++ b/lang-python/pycryptodome/spec
@@ -1,5 +1,4 @@
-VER=3.7.3
-REL=4
+VER=3.21.0
 SRCS="tbl::https://github.com/Legrandin/pycryptodome/archive/v$VER.tar.gz"
-CHKSUMS="sha256::cc09c289b527d4cdeb171423ca85ab90dbe0125ae9f3804fa2f9ff65be300036"
+CHKSUMS="sha256::195e5cdfbb550b03f83f2af2aa4652c14b64783574d835fe61bb06c8fc06ba21"
 CHKUPDATE="anitya::id=36849"


### PR DESCRIPTION
Topic Description
-----------------

- pycryptodome: update to 3.21.0

Package(s) Affected
-------------------

- pycryptodome: 3.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycryptodome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
