### PR TITLE
libtasn1: update to 4.20.0

### DIFF
--- a/runtime-cryptography/libtasn1/spec
+++ b/runtime-cryptography/libtasn1/spec
@@ -1,5 +1,4 @@
-VER=4.15.0
-REL=4
+VER=4.20.0
 SRCS="tbl::https://ftp.gnu.org/gnu/libtasn1/libtasn1-$VER.tar.gz"
-CHKSUMS="sha256::dd77509fe8f5304deafbca654dc7f0ea57f5841f41ba530cff9a5bf71382739e"
+CHKSUMS="sha256::92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c"
 CHKUPDATE="anitya::id=1734"


### PR DESCRIPTION
Topic Description
-----------------

- libtasn1: update to 4.20.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libtasn1: 4.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtasn1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
