### PR TITLE
ppsspp: update to 1.18.1

### DIFF
--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,5 +1,5 @@
-VER=1.17.1
+VER=1.18.1
 REL=1
-SRCS="git::commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Tracking/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- ppsspp: update to 1.18.1

Package(s) Affected
-------------------

- ppsspp: 1.18.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
