### PR TITLE
ppsspp: update to 1.18.1

### DIFF
--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,5 +1,4 @@
-VER=1.17.1
-REL=1
-SRCS="git::commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
+VER=1.18.1+git20250206
+SRCS="git::commit=b24516544ff7d7d61fb33719f8ee930fdc7deacd::https://github.com/hrydgard/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- ppsspp: update to 1.18.1

Package(s) Affected
-------------------

- ppsspp: 1.18.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
