### PR TITLE
vscode: update to 1.97.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.96.4
+VER=1.97.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::67f8a32eb1e24e3ba3c8e586f0871ae20a5522dc8d76323e187cd9b5f9bce0e9"
-CHKSUMS__ARM64="sha256::1d8a7ea71fc5c90863bf29f64c1a4cd5ba9a4004b673a7b7553e4db769f9ffd3"
+CHKSUMS__AMD64="sha256::0f67a00c7cc406f0424d0d19e69be67eb9a2577694f300a4e44d6316af5ae16b"
+CHKSUMS__ARM64="sha256::674f9f276a5670c8a636d3a1d10adcb3963be279554cf029aa9d0ad5f66e6ce5"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.97.0
    Co-authored-by: Kexy Biscuit a.k.a. 百合ヶ咲るる \(@KexyBiscuit\) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.97.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
