### PR TITLE
vscodium: update to 1.97.0.25037

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -43,7 +43,7 @@ popd
 tar -czf "$SRCDIR"/vscode.tar.gz -T /dev/null
 
 abinfo "Packaging ..."
-"$SRCDIR"/package_linux_bin.sh
+"$SRCDIR"/dev/build.sh
 
 abinfo "Switching to SRCDIR ..."
 cd "$SRCDIR"

--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -43,7 +43,7 @@ popd
 tar -czf "$SRCDIR"/vscode.tar.gz -T /dev/null
 
 abinfo "Packaging ..."
-"$SRCDIR"/dev/build.sh
+"$SRCDIR"/build/linux/package_bin.sh
 
 abinfo "Switching to SRCDIR ..."
 cd "$SRCDIR"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.96.4.25017
+VER=1.97.0.25037
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.97.0.25037
    Co-authored-by: Kexy Biscuit a.k.a. 百合ヶ咲るる \(@KexyBiscuit\) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- vscodium: 1.97.0.25037

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
