### PR TITLE
libspice: fix USB ACL operation not permitted issue

### DIFF
--- a/runtime-virtualization/libspice-gtk/autobuild/postinst
+++ b/runtime-virtualization/libspice-gtk/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Setting capabilities for USB ACL helper ..."
+setcap CAP_FOWNER=+ep /usr/libexec/spice-client-glib-usb-acl-helper

--- a/runtime-virtualization/libspice-gtk/spec
+++ b/runtime-virtualization/libspice-gtk/spec
@@ -1,5 +1,5 @@
 VER=0.42
-REL=2
+REL=3
 SRCS="tbl::https://www.spice-space.org/download/gtk/spice-gtk-$VER.tar.xz"
 CHKSUMS="sha256::9380117f1811ad1faa1812cb6602479b6290d4a0d8cc442d44427f7f6c0e7a58"
 CHKUPDATE="anitya::id=11576"


### PR DESCRIPTION
Topic Description
-----------------

- libspice-gtk: set capabilities for USB ACL helper
    Link: https://bugs.archlinux.org/task/69428
    Link: https://gitlab.archlinux.org/archlinux/packaging/packages/spice-gtk/-/blob/c57c20c3ce7637b21a248e0d4f6aa7f15c39c0d1/spice-gtk.install
    For the record, Gentoo uses chmod 4755 on this file, but setcap seems a
    more reasonable solution.
    Link: https://bugs.gentoo.org/775554

Package(s) Affected
-------------------

- libspice-gtk: 0.42-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libspice-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
