### PR TITLE
wireplumber: update to 0.5.8

### DIFF
--- a/app-multimedia/wireplumber/spec
+++ b/app-multimedia/wireplumber/spec
@@ -1,4 +1,4 @@
-VER=0.5.7
+VER=0.5.8
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/wireplumber"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235056"


### PR DESCRIPTION
Topic Description
-----------------

- wireplumber: update to 0.5.8
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wireplumber: 0.5.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireplumber
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
