### PR TITLE
pyelftools: update to 0.31

### DIFF
--- a/lang-python/pyelftools/spec
+++ b/lang-python/pyelftools/spec
@@ -1,4 +1,4 @@
-VER=0.30
+VER=0.31
 SRCS="tbl::https://pypi.io/packages/source/p/pyelftools/pyelftools-$VER.tar.gz"
-CHKSUMS="sha256::2fc92b0d534f8b081f58c7c370967379123d8e00984deb53c209364efd575b40"
+CHKSUMS="sha256::c774416b10310156879443b81187d182d8d9ee499660380e645918b50bc88f99"
 CHKUPDATE="anitya::id=16219"


### PR DESCRIPTION
Topic Description
-----------------

- pyelftools: update to 0.31
    Co-authored-by: Xeonacid \(@Xeonacid\)

Package(s) Affected
-------------------

- pyelftools: 0.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyelftools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
