### PR TITLE
nodejs-22: backport corepack update to 0.31.0

### DIFF
--- a/lang-js/nodejs-22/autobuild/patches/0001-deps-update-corepack-to-0.31.0.patch
+++ b/lang-js/nodejs-22/autobuild/patches/0001-deps-update-corepack-to-0.31.0.patch
@@ -1,0 +1,181 @@
+From 63c1859e019465cbb0b6b46ba0d481fb41d94a22 Mon Sep 17 00:00:00 2001
+From: "Node.js GitHub Bot" <github-bot@iojs.org>
+Date: Tue, 28 Jan 2025 05:58:55 -0500
+Subject: [PATCH] deps: update corepack to 0.31.0
+X-Developer-Signature: v=1; a=openpgp-sha256; l=6207; i=xtexchooser@duck.com;
+ h=from:subject; bh=KiQjLdRtHV6vkfj0L1VKKRwWQp66sGcgJtgHK8MpnL8=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDOnLVd0dOqxawoLZ15vne4cuWMPa+5nnarLVfw+FijVzQ
+ k5ZFv3qKGVhEONikBVTZCkybPBm1UnnF11WLgszh5UJZAgDF6cATGQhJyPDorZqo4LNmdfMjDt7
+ zrzeflJqvmFpzLveAj32wD1SkfOjGRm+pNxk0rZjva0w+838u6sqOvmyD01L+RTDlDzRc0aY9R5
+ uAA==
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+PR-URL: https://github.com/nodejs/node/pull/56795
+Reviewed-By: Antoine du Hamel <duhamelantoine1995@gmail.com>
+Reviewed-By: Chengzhong Wu <legendecas@gmail.com>
+---
+ deps/corepack/CHANGELOG.md          | 22 +++++++++++++++++++
+ deps/corepack/README.md             |  2 ++
+ deps/corepack/dist/lib/corepack.cjs | 33 +++++++++++++++++++++--------
+ deps/corepack/package.json          |  6 +++---
+ 4 files changed, 51 insertions(+), 12 deletions(-)
+
+diff --git a/deps/corepack/CHANGELOG.md b/deps/corepack/CHANGELOG.md
+index 941d0b6b7e5e25..88363683a9d5f6 100644
+--- a/deps/corepack/CHANGELOG.md
++++ b/deps/corepack/CHANGELOG.md
+@@ -1,5 +1,27 @@
+ # Changelog
+ 
++## [0.31.0](https://github.com/nodejs/corepack/compare/v0.30.0...v0.31.0) (2025-01-27)
++
++
++### ⚠ BREAKING CHANGES
++
++* drop support for Node.js 21.x ([#594](https://github.com/nodejs/corepack/issues/594))
++
++### Features
++
++* update package manager versions ([#595](https://github.com/nodejs/corepack/issues/595)) ([c7a9bde](https://github.com/nodejs/corepack/commit/c7a9bde16dcbbb7e6ef03fef740656cde7ade360))
++
++
++### Bug Fixes
++
++* only print message for `UsageError`s ([#602](https://github.com/nodejs/corepack/issues/602)) ([72a588c](https://github.com/nodejs/corepack/commit/72a588c2370c17e415b24fe389efdafb3c84e90b))
++* update npm registry keys ([#614](https://github.com/nodejs/corepack/issues/614)) ([8c90caa](https://github.com/nodejs/corepack/commit/8c90caab7f1c5c9b89f1de113bc1dfc441bf25d2))
++
++
++### Miscellaneous Chores
++
++* drop support for Node.js 21.x ([#594](https://github.com/nodejs/corepack/issues/594)) ([8bebc0c](https://github.com/nodejs/corepack/commit/8bebc0c0a5cbcdeec41673dcbaf581e6e1c1be11))
++
+ ## [0.30.0](https://github.com/nodejs/corepack/compare/v0.29.4...v0.30.0) (2024-11-23)
+ 
+ 
+diff --git a/deps/corepack/README.md b/deps/corepack/README.md
+index d94614affc5353..66bfbc3fb6aae3 100644
+--- a/deps/corepack/README.md
++++ b/deps/corepack/README.md
+@@ -302,6 +302,8 @@ same major line. Should you need to upgrade to a new major, use an explicit
+ 
+ ## Troubleshooting
+ 
++The environment variable `DEBUG` can be set to `corepack` to enable additional debug logging.
++
+ ### Networking
+ 
+ There are a wide variety of networking issues that can occur while running
+diff --git a/deps/corepack/dist/lib/corepack.cjs b/deps/corepack/dist/lib/corepack.cjs
+index e1919339dc38bd..7a92f3334f7687 100644
+--- a/deps/corepack/dist/lib/corepack.cjs
++++ b/deps/corepack/dist/lib/corepack.cjs
+@@ -21260,7 +21260,7 @@ function String2(descriptor, ...args) {
+ }
+ 
+ // package.json
+-var version = "0.30.0";
++var version = "0.31.0";
+ 
+ // sources/Engine.ts
+ var import_fs9 = __toESM(require("fs"));
+@@ -21274,7 +21274,7 @@ var import_valid3 = __toESM(require_valid2());
+ var config_default = {
+   definitions: {
+     npm: {
+-      default: "10.9.1+sha1.ab141c1229765c11c8c59060fc9cf450a2207bd6",
++      default: "11.0.0+sha1.7bba7c80740ef1f5b2c5d4cecc55e94912faa5e6",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "npm"
+@@ -21311,7 +21311,7 @@ var config_default = {
+       }
+     },
+     pnpm: {
+-      default: "9.14.2+sha1.5202b50ab92394b3c922d2e293f196e2df6d441b",
++      default: "9.15.4+sha1.ffa0b5c573381e8035b354028ccff97c8e452047",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "pnpm"
+@@ -21375,7 +21375,7 @@ var config_default = {
+         package: "yarn"
+       },
+       transparent: {
+-        default: "4.5.2+sha224.c2e2e9ed3cdadd6ec250589b3393f71ae56d5ec297af11cec1eba3b4",
++        default: "4.6.0+sha224.acd0786f07ffc6c933940eb65fc1d627131ddf5455bddcc295dc90fd",
+         commands: [
+           [
+             "yarn",
+@@ -21438,11 +21438,18 @@ var config_default = {
+   keys: {
+     npm: [
+       {
+-        expires: null,
++        expires: "2025-01-29T00:00:00.000Z",
+         keyid: "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+         keytype: "ecdsa-sha2-nistp256",
+         scheme: "ecdsa-sha2-nistp256",
+         key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="
++      },
++      {
++        expires: null,
++        keyid: "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U",
++        keytype: "ecdsa-sha2-nistp256",
++        scheme: "ecdsa-sha2-nistp256",
++        key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="
+       }
+     ]
+   }
+@@ -23099,10 +23106,18 @@ async function runMain(argv) {
+       process.exitCode ??= code2;
+     }
+   } else {
+-    await engine.executePackageManagerRequest(request, {
+-      cwd: process.cwd(),
+-      args: restArgs
+-    });
++    try {
++      await engine.executePackageManagerRequest(request, {
++        cwd: process.cwd(),
++        args: restArgs
++      });
++    } catch (error) {
++      if (error?.name === `UsageError`) {
++        console.error(error.message);
++        process.exit(1);
++      }
++      throw error;
++    }
+   }
+ }
+ // Annotate the CommonJS export names for ESM import in node:
+diff --git a/deps/corepack/package.json b/deps/corepack/package.json
+index c9c6662e99e6c9..91b95f31d77b54 100644
+--- a/deps/corepack/package.json
++++ b/deps/corepack/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "corepack",
+-  "version": "0.30.0",
++  "version": "0.31.0",
+   "homepage": "https://github.com/nodejs/corepack#readme",
+   "bugs": {
+     "url": "https://github.com/nodejs/corepack/issues"
+@@ -10,7 +10,7 @@
+     "url": "https://github.com/nodejs/corepack.git"
+   },
+   "engines": {
+-    "node": "^18.17.1 || >=20.10.0"
++    "node": "^18.17.1 || ^20.10.0 || >=22.11.0"
+   },
+   "exports": {
+     "./package.json": "./package.json"
+@@ -26,7 +26,7 @@
+     "@yarnpkg/eslint-config": "^2.0.0",
+     "@yarnpkg/fslib": "^3.0.0-rc.48",
+     "@zkochan/cmd-shim": "^6.0.0",
+-    "better-sqlite3": "^10.0.0",
++    "better-sqlite3": "^11.7.2",
+     "clipanion": "patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch",
+     "debug": "^4.1.1",
+     "esbuild": "^0.21.0",

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.13.1
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::cfce282119390f7e0c2220410924428e90dadcb2df1744c0c4a0e7baae387cc2"
 CHKUPDATE="anitya::id=374342"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: backport corepack update to 0.31.0
    This backports node update of corepack to 0.31.0, updating npmjs.org
    keys pinned by corepack.
    The patch should be removed after nodejs 22.14.0 proposal gets released.
    This should fix the following error:
    corepack install -g pnpm@10.2.1
    Installing pnpm@10.2.1...
    Internal Error: Cannot find matching keyid: {"signatures":\[{"sig":"MEYCIQDkZyZZmBzkRcQowEEFiEcGp4/xV8GBLXxTEzz9QstrsAIhAPx6tvZixjTub6GPqJa82vcWFhUU39JCtoJvcoRK/K39","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}\],"keys":\[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}\]}
    Link: https://github.com/nodejs/node/pull/56910
    Link: https://github.com/pnpm/pnpm/issues/9014
    Link: https://github.com/nodejs/corepack/issues/612
    Link: https://github.com/misskey-dev/misskey/issues/15386
    Link: https://github.com/nodejs/corepack/releases/tag/v0.31.0
    Link: https://github.com/nodejs/node/commit/63c1859e019465cbb0b6b46ba0d481fb41d94a22
    Link: https://github.com/nodejs/node/pull/56795
    Backport-of: 63c1859e019465cbb0b6b46ba0d481fb41d94a22
    Reviewed-by: xtex <xtex@aosc.io>
    Signed-off-by: xtex <xtex@aosc.io>

Package(s) Affected
-------------------

- nodejs-22: 22.13.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
