### PR TITLE
nodejs-20: backport corepack update to 0.31.0

### DIFF
--- a/lang-js/nodejs-20/autobuild/patches/0001-BACKPORT-deps-update-corepack-to-0.30.0.patch
+++ b/lang-js/nodejs-20/autobuild/patches/0001-BACKPORT-deps-update-corepack-to-0.30.0.patch
@@ -1,0 +1,215 @@
+From 9c5f17e334dd598d165d9b74c2a35520bddb56ba Mon Sep 17 00:00:00 2001
+From: "Node.js GitHub Bot" <github-bot@iojs.org>
+Date: Mon, 25 Nov 2024 20:02:35 -0500
+Subject: [PATCH 1/2] BACKPORT: deps: update corepack to 0.30.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+X-Developer-Signature: v=1; a=openpgp-sha256; l=8218; i=xtexchooser@duck.com;
+ h=from:subject; bh=2BpVeYfruzvIMsj7C/QBi6hCldFOFmFmYBO/WLyqIFE=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDOnLTdMT77ar7jFdPOsDn0W9xgcF36hFfe2rptr+WKPt6
+ LPphkNnRykLgxgXg6yYIkuRYYM3q046v+iyclmYOaxMIEMYuDgFYCLW6owMRx9mvrc7HSxU8qjm
+ l96J5HVSnQ4BZ2Ubz66y33NUpDjkCCPD9aU8M734/eYt3fxUdtG2a0+ui/y+WlrmfkJ36protKU
+ RjAA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+PR-URL: https://github.com/nodejs/node/pull/55977
+Reviewed-By: Michaël Zasso <targos@protonmail.com>
+Reviewed-By: Trivikram Kamat <trivikr.dev@gmail.com>
+Reviewed-By: Antoine du Hamel <duhamelantoine1995@gmail.com>
+---
+ deps/corepack/CHANGELOG.md          | 12 ++++++++++++
+ deps/corepack/dist/corepack.js      |  1 +
+ deps/corepack/dist/lib/corepack.cjs | 20 +++++++++++++-------
+ deps/corepack/dist/npm.js           |  1 +
+ deps/corepack/dist/npx.js           |  1 +
+ deps/corepack/dist/pnpm.js          |  1 +
+ deps/corepack/dist/pnpx.js          |  1 +
+ deps/corepack/dist/yarn.js          |  1 +
+ deps/corepack/dist/yarnpkg.js       |  1 +
+ deps/corepack/package.json          |  2 +-
+ 10 files changed, 33 insertions(+), 8 deletions(-)
+
+diff --git a/deps/corepack/CHANGELOG.md b/deps/corepack/CHANGELOG.md
+index 7de934c0d2c0..941d0b6b7e5e 100644
+--- a/deps/corepack/CHANGELOG.md
++++ b/deps/corepack/CHANGELOG.md
+@@ -1,5 +1,17 @@
+ # Changelog
+ 
++## [0.30.0](https://github.com/nodejs/corepack/compare/v0.29.4...v0.30.0) (2024-11-23)
++
++
++### Features
++
++* update package manager versions ([#578](https://github.com/nodejs/corepack/issues/578)) ([a286c8f](https://github.com/nodejs/corepack/commit/a286c8f5537ea9ecf9b6ff53c7bc3e8da4e3c8bb))
++
++
++### Performance Improvements
++
++* prefer `module.enableCompileCache` over `v8-compile-cache` ([#574](https://github.com/nodejs/corepack/issues/574)) ([cba6905](https://github.com/nodejs/corepack/commit/cba690575bd606faeee54bd512ccb8797d49055f))
++
+ ## [0.29.4](https://github.com/nodejs/corepack/compare/v0.29.3...v0.29.4) (2024-09-07)
+ 
+ 
+diff --git a/deps/corepack/dist/corepack.js b/deps/corepack/dist/corepack.js
+index b1b22662466f..6179b11c083c 100755
+--- a/deps/corepack/dist/corepack.js
++++ b/deps/corepack/dist/corepack.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='0';
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(process.argv.slice(2));
+\ No newline at end of file
+diff --git a/deps/corepack/dist/lib/corepack.cjs b/deps/corepack/dist/lib/corepack.cjs
+index 2978fc336232..e1919339dc38 100644
+--- a/deps/corepack/dist/lib/corepack.cjs
++++ b/deps/corepack/dist/lib/corepack.cjs
+@@ -21260,7 +21260,7 @@ function String2(descriptor, ...args) {
+ }
+ 
+ // package.json
+-var version = "0.29.4";
++var version = "0.30.0";
+ 
+ // sources/Engine.ts
+ var import_fs9 = __toESM(require("fs"));
+@@ -21274,7 +21274,7 @@ var import_valid3 = __toESM(require_valid2());
+ var config_default = {
+   definitions: {
+     npm: {
+-      default: "10.8.3+sha1.e6085b2864fcfd9b1aad7b602601b5a2fc116699",
++      default: "10.9.1+sha1.ab141c1229765c11c8c59060fc9cf450a2207bd6",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "npm"
+@@ -21311,7 +21311,7 @@ var config_default = {
+       }
+     },
+     pnpm: {
+-      default: "9.9.0+sha1.3edbe440f4e570aa8f049adbd06b9483d55cc2d2",
++      default: "9.14.2+sha1.5202b50ab92394b3c922d2e293f196e2df6d441b",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "pnpm"
+@@ -21375,7 +21375,7 @@ var config_default = {
+         package: "yarn"
+       },
+       transparent: {
+-        default: "4.4.1+sha224.fd21d9eb5fba020083811af1d4953acc21eeb9f6ff97efd1b3f9d4de",
++        default: "4.5.2+sha224.c2e2e9ed3cdadd6ec250589b3393f71ae56d5ec297af11cec1eba3b4",
+         commands: [
+           [
+             "yarn",
+@@ -21965,8 +21965,11 @@ async function runVersion(locator, installSpec, binName, args) {
+   }
+   if (!binPath)
+     throw new Error(`Assertion failed: Unable to locate path for bin '${binName}'`);
+-  if (locator.name !== `npm` || (0, import_lt.default)(locator.reference, `9.7.0`))
+-    await Promise.resolve().then(() => __toESM(require_v8_compile_cache()));
++  if (!import_module.default.enableCompileCache) {
++    if (locator.name !== `npm` || (0, import_lt.default)(locator.reference, `9.7.0`)) {
++      await Promise.resolve().then(() => __toESM(require_v8_compile_cache()));
++    }
++  }
+   process.env.COREPACK_ROOT = import_path7.default.dirname(require.resolve("corepack/package.json"));
+   process.argv = [
+     process.execPath,
+@@ -21976,6 +21979,9 @@ async function runVersion(locator, installSpec, binName, args) {
+   process.execArgv = [];
+   process.mainModule = void 0;
+   process.nextTick(import_module.default.runMain, binPath);
++  if (import_module.default.flushCompileCache) {
++    setImmediate(import_module.default.flushCompileCache);
++  }
+ }
+ function shouldSkipIntegrityCheck() {
+   return process.env.COREPACK_INTEGRITY_KEYS === `` || process.env.COREPACK_INTEGRITY_KEYS === `0`;
+@@ -22553,7 +22559,7 @@ var EnableCommand = class extends Command {
+     [`enable`]
+   ];
+   static usage = Command.Usage({
+-    description: `Add the Corepack shims to the install directories`,
++    description: `Add the Corepack shims to the install directory`,
+     details: `
+       When run, this command will check whether the shims for the specified package managers can be found with the correct values inside the install directory. If not, or if they don't exist, they will be created.
+ 
+diff --git a/deps/corepack/dist/npm.js b/deps/corepack/dist/npm.js
+index 7d10ba5bdf36..75f68b058f2d 100755
+--- a/deps/corepack/dist/npm.js
++++ b/deps/corepack/dist/npm.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['npm', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/dist/npx.js b/deps/corepack/dist/npx.js
+index a8bd3e690143..b1138bb48e1a 100755
+--- a/deps/corepack/dist/npx.js
++++ b/deps/corepack/dist/npx.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['npx', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/dist/pnpm.js b/deps/corepack/dist/pnpm.js
+index a0a872634355..56ba50940503 100755
+--- a/deps/corepack/dist/pnpm.js
++++ b/deps/corepack/dist/pnpm.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['pnpm', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/dist/pnpx.js b/deps/corepack/dist/pnpx.js
+index 57ad4842631c..ee36be2e99c6 100755
+--- a/deps/corepack/dist/pnpx.js
++++ b/deps/corepack/dist/pnpx.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['pnpx', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/dist/yarn.js b/deps/corepack/dist/yarn.js
+index eaed8596eaba..ce628c82b6a7 100755
+--- a/deps/corepack/dist/yarn.js
++++ b/deps/corepack/dist/yarn.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['yarn', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/dist/yarnpkg.js b/deps/corepack/dist/yarnpkg.js
+index aada6032fa67..9541ed726aaa 100755
+--- a/deps/corepack/dist/yarnpkg.js
++++ b/deps/corepack/dist/yarnpkg.js
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env node
+ process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
++require('module').enableCompileCache?.();
+ require('./lib/corepack.cjs').runMain(['yarnpkg', ...process.argv.slice(2)]);
+\ No newline at end of file
+diff --git a/deps/corepack/package.json b/deps/corepack/package.json
+index 571c359407e0..c9c6662e99e6 100644
+--- a/deps/corepack/package.json
++++ b/deps/corepack/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "corepack",
+-  "version": "0.29.4",
++  "version": "0.30.0",
+   "homepage": "https://github.com/nodejs/corepack#readme",
+   "bugs": {
+     "url": "https://github.com/nodejs/corepack/issues"
+
+base-commit: 53a57efd83a18efe7a84bf1b460acc789139939b
+-- 
+2.48.1
+

--- a/lang-js/nodejs-20/autobuild/patches/0002-BACKPORT-deps-update-corepack-to-0.31.0.patch
+++ b/lang-js/nodejs-20/autobuild/patches/0002-BACKPORT-deps-update-corepack-to-0.31.0.patch
@@ -1,0 +1,184 @@
+From 77d6797c41b867ccdbe661cbed1d7a10bc7717d5 Mon Sep 17 00:00:00 2001
+From: "Node.js GitHub Bot" <github-bot@iojs.org>
+Date: Tue, 28 Jan 2025 05:58:55 -0500
+Subject: [PATCH 2/2] BACKPORT: deps: update corepack to 0.31.0
+X-Developer-Signature: v=1; a=openpgp-sha256; l=6204; i=xtexchooser@duck.com;
+ h=from:subject; bh=dlv9SZyMJ9zCK2N7Lq3+yXiwXiLZzGxYT8Y+5Eq96BU=;
+ b=kA0DAAoWuRgIbtgEW5EByyZiAGenNWfIXUyVHQ9SpmTXEaMMLyPN8/QJO0IeoKfZvqhdAbZPS
+ Ih1BAAWCgAdFiEEcjGASwUsZw8VpncduRgIbtgEW5EFAmenNWcACgkQuRgIbtgEW5EKMAEAzoqW
+ mz1OESmrfvP7ehLMGrXI8giXnV7zk7DTytPS+NQBAPOcH4ZqfX/yAdsvE49u1lY6khAVHSdYFIe
+ JEuNPAmUD
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+PR-URL: https://github.com/nodejs/node/pull/56795
+Reviewed-By: Antoine du Hamel <duhamelantoine1995@gmail.com>
+Reviewed-By: Chengzhong Wu <legendecas@gmail.com>
+---
+ deps/corepack/CHANGELOG.md          | 22 +++++++++++++++++++
+ deps/corepack/README.md             |  2 ++
+ deps/corepack/dist/lib/corepack.cjs | 33 +++++++++++++++++++++--------
+ deps/corepack/package.json          |  6 +++---
+ 4 files changed, 51 insertions(+), 12 deletions(-)
+
+diff --git a/deps/corepack/CHANGELOG.md b/deps/corepack/CHANGELOG.md
+index 941d0b6b7e5e..88363683a9d5 100644
+--- a/deps/corepack/CHANGELOG.md
++++ b/deps/corepack/CHANGELOG.md
+@@ -1,5 +1,27 @@
+ # Changelog
+ 
++## [0.31.0](https://github.com/nodejs/corepack/compare/v0.30.0...v0.31.0) (2025-01-27)
++
++
++### ⚠ BREAKING CHANGES
++
++* drop support for Node.js 21.x ([#594](https://github.com/nodejs/corepack/issues/594))
++
++### Features
++
++* update package manager versions ([#595](https://github.com/nodejs/corepack/issues/595)) ([c7a9bde](https://github.com/nodejs/corepack/commit/c7a9bde16dcbbb7e6ef03fef740656cde7ade360))
++
++
++### Bug Fixes
++
++* only print message for `UsageError`s ([#602](https://github.com/nodejs/corepack/issues/602)) ([72a588c](https://github.com/nodejs/corepack/commit/72a588c2370c17e415b24fe389efdafb3c84e90b))
++* update npm registry keys ([#614](https://github.com/nodejs/corepack/issues/614)) ([8c90caa](https://github.com/nodejs/corepack/commit/8c90caab7f1c5c9b89f1de113bc1dfc441bf25d2))
++
++
++### Miscellaneous Chores
++
++* drop support for Node.js 21.x ([#594](https://github.com/nodejs/corepack/issues/594)) ([8bebc0c](https://github.com/nodejs/corepack/commit/8bebc0c0a5cbcdeec41673dcbaf581e6e1c1be11))
++
+ ## [0.30.0](https://github.com/nodejs/corepack/compare/v0.29.4...v0.30.0) (2024-11-23)
+ 
+ 
+diff --git a/deps/corepack/README.md b/deps/corepack/README.md
+index d94614affc53..66bfbc3fb6aa 100644
+--- a/deps/corepack/README.md
++++ b/deps/corepack/README.md
+@@ -302,6 +302,8 @@ same major line. Should you need to upgrade to a new major, use an explicit
+ 
+ ## Troubleshooting
+ 
++The environment variable `DEBUG` can be set to `corepack` to enable additional debug logging.
++
+ ### Networking
+ 
+ There are a wide variety of networking issues that can occur while running
+diff --git a/deps/corepack/dist/lib/corepack.cjs b/deps/corepack/dist/lib/corepack.cjs
+index e1919339dc38..7a92f3334f76 100644
+--- a/deps/corepack/dist/lib/corepack.cjs
++++ b/deps/corepack/dist/lib/corepack.cjs
+@@ -21260,7 +21260,7 @@ function String2(descriptor, ...args) {
+ }
+ 
+ // package.json
+-var version = "0.30.0";
++var version = "0.31.0";
+ 
+ // sources/Engine.ts
+ var import_fs9 = __toESM(require("fs"));
+@@ -21274,7 +21274,7 @@ var import_valid3 = __toESM(require_valid2());
+ var config_default = {
+   definitions: {
+     npm: {
+-      default: "10.9.1+sha1.ab141c1229765c11c8c59060fc9cf450a2207bd6",
++      default: "11.0.0+sha1.7bba7c80740ef1f5b2c5d4cecc55e94912faa5e6",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "npm"
+@@ -21311,7 +21311,7 @@ var config_default = {
+       }
+     },
+     pnpm: {
+-      default: "9.14.2+sha1.5202b50ab92394b3c922d2e293f196e2df6d441b",
++      default: "9.15.4+sha1.ffa0b5c573381e8035b354028ccff97c8e452047",
+       fetchLatestFrom: {
+         type: "npm",
+         package: "pnpm"
+@@ -21375,7 +21375,7 @@ var config_default = {
+         package: "yarn"
+       },
+       transparent: {
+-        default: "4.5.2+sha224.c2e2e9ed3cdadd6ec250589b3393f71ae56d5ec297af11cec1eba3b4",
++        default: "4.6.0+sha224.acd0786f07ffc6c933940eb65fc1d627131ddf5455bddcc295dc90fd",
+         commands: [
+           [
+             "yarn",
+@@ -21438,11 +21438,18 @@ var config_default = {
+   keys: {
+     npm: [
+       {
+-        expires: null,
++        expires: "2025-01-29T00:00:00.000Z",
+         keyid: "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+         keytype: "ecdsa-sha2-nistp256",
+         scheme: "ecdsa-sha2-nistp256",
+         key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="
++      },
++      {
++        expires: null,
++        keyid: "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U",
++        keytype: "ecdsa-sha2-nistp256",
++        scheme: "ecdsa-sha2-nistp256",
++        key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="
+       }
+     ]
+   }
+@@ -23099,10 +23106,18 @@ async function runMain(argv) {
+       process.exitCode ??= code2;
+     }
+   } else {
+-    await engine.executePackageManagerRequest(request, {
+-      cwd: process.cwd(),
+-      args: restArgs
+-    });
++    try {
++      await engine.executePackageManagerRequest(request, {
++        cwd: process.cwd(),
++        args: restArgs
++      });
++    } catch (error) {
++      if (error?.name === `UsageError`) {
++        console.error(error.message);
++        process.exit(1);
++      }
++      throw error;
++    }
+   }
+ }
+ // Annotate the CommonJS export names for ESM import in node:
+diff --git a/deps/corepack/package.json b/deps/corepack/package.json
+index c9c6662e99e6..91b95f31d77b 100644
+--- a/deps/corepack/package.json
++++ b/deps/corepack/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "corepack",
+-  "version": "0.30.0",
++  "version": "0.31.0",
+   "homepage": "https://github.com/nodejs/corepack#readme",
+   "bugs": {
+     "url": "https://github.com/nodejs/corepack/issues"
+@@ -10,7 +10,7 @@
+     "url": "https://github.com/nodejs/corepack.git"
+   },
+   "engines": {
+-    "node": "^18.17.1 || >=20.10.0"
++    "node": "^18.17.1 || ^20.10.0 || >=22.11.0"
+   },
+   "exports": {
+     "./package.json": "./package.json"
+@@ -26,7 +26,7 @@
+     "@yarnpkg/eslint-config": "^2.0.0",
+     "@yarnpkg/fslib": "^3.0.0-rc.48",
+     "@zkochan/cmd-shim": "^6.0.0",
+-    "better-sqlite3": "^10.0.0",
++    "better-sqlite3": "^11.7.2",
+     "clipanion": "patch:clipanion@npm%3A3.2.1#~/.yarn/patches/clipanion-npm-3.2.1-fc9187f56c.patch",
+     "debug": "^4.1.1",
+     "esbuild": "^0.21.0",
+-- 
+2.48.1
+

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,4 +1,5 @@
 VER=20.18.2
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::69bf81b70f3a95ae0763459f02860c282d7e3a47567c8afaf126cc778176a882"
 CHKUPDATE="anitya::id=369796"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-20: backport corepack update to 0.31.0
    This resolves the same error as in PR 9597 for nodejs 20.x, updating
    Corepack's pinned registry public keys.
    Patch 1 \(update corepack to 0.30.0\) is included in
    nodejs v20.18.3 proposal and should be removed in the next nodejs
    update.
    Patch 2 \(update to 0.31.0\) is not included in that proposal and should
    be removed after two new nodejs 20.x releases.
    Link: https://github.com/nodejs/node/pull/56699
    Link: https://github.com/nodejs/corepack/issues/627
    Link: https://github.com/nodejs/corepack/releases/tag/v0.31.0
    Link: https://github.com/nodejs/corepack/releases/tag/v0.30.0
    Link: https://github.com/nodejs/node/commit/f7131cf178231f578f1da2aa7ff52a427c953b98
    Link: https://github.com/nodejs/node/commit/63c1859e019465cbb0b6b46ba0d481fb41d94a22
    Link: https://github.com/nodejs/node/pull/55977
    Link: https://github.com/nodejs/node/pull/56795
    Link: https://github.com/AOSC-Dev/aosc-os-abbs/pull/9597
    Backport-of: f7131cf178231f578f1da2aa7ff52a427c953b98
    Backport-of: 64ee8a025815553af30d9d273e2f2d07a5eb83ea
    Reviewed-by: xtex <xtex@aosc.io>
    Signed-off-by: xtex <xtex@aosc.io>

Package(s) Affected
-------------------

- nodejs-20: 20.18.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
