### PR TITLE
oxipng: new, 9.1.3

### DIFF
--- a/app-utils/oxipng/autobuild/defines
+++ b/app-utils/oxipng/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=oxipng
+PKGSEC=utils
+PKGDEP="gcc-runtime"
+BUILDDEP="rustc llvm"
+PKGDES="A multithreaded lossless PNG/APNG compression optimizer"
+
+USECLANG=1
+
+# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/app-utils/oxipng/spec
+++ b/app-utils/oxipng/spec
@@ -1,0 +1,4 @@
+VER=9.1.3
+SRCS="git::commit=tags/v$VER::https://github.com/shssoichiro/oxipng.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=209796"


### PR DESCRIPTION
Topic Description
-----------------

- oxipng: new, 9.1.3

Package(s) Affected
-------------------

- oxipng: 9.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit oxipng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
