### PR TITLE
forgejo: update to 10.0.1


### DIFF
--- a/app-web/forgejo/autobuild/defines
+++ b/app-web/forgejo/autobuild/defines
@@ -9,5 +9,7 @@ BUILDDEP="go nodejs"
 # FIXME: Autobuild does not yet support splitting out debug symbol from Go executables.
 ABSPLITDBG=0
 
-# FIXME: runtime.cgo_yield: relocation target _cgo_yield not defined
-FAIL_ARCH="riscv64"
+# FIXME: riscv: runtime.cgo_yield: relocation target _cgo_yield not defined
+# FIXME: loongson3: nodejs broken
+#        https://github.com/nodejs/node/issues/56973
+FAIL_ARCH="@(riscv64|loongson3)"

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,4 +1,4 @@
-VER=9.0.0
+VER=10.0.1
 # Note: copy-repo required by auto version detection
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- forgejo: update to 10.0.1

Package(s) Affected
-------------------

- forgejo: 10.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
