### PR TITLE
curtail: new, 1.12.0

### DIFF
--- a/app-imaging/curtail/autobuild/defines
+++ b/app-imaging/curtail/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=curtail
+PKGSEC=graphics
+PKGDES="Image compressor that supports PNG, JPEG, WebP and SVG file"
+PKGDEP="dconf gdk-pixbuf glib gtk-4 hicolor-icon-theme jpegoptim libadwaita libwebp pngquant python-3 pygobject-3 scour oxipng"
+BUILDDEP="appstream gtk-update-icon-cache"
+
+ABHOST=noarch

--- a/app-imaging/curtail/spec
+++ b/app-imaging/curtail/spec
@@ -1,0 +1,4 @@
+VER=1.12.0
+SRCS="git::commit=tags/$VER::https://github.com/Huluti/Curtail.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=312431"


### PR DESCRIPTION
Topic Description
-----------------

- curtail: new, 1.12.0

Package(s) Affected
-------------------

- curtail: 1.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curtail
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
