### PR TITLE
systemd-detect-virt survey 20250209

### DIFF
--- a/app-admin/dracut-ng/autobuild/loongson3/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/loongson3/overrides/usr/bin/update-initramfs
@@ -58,7 +58,8 @@ else
 fi
 
 # Notify bootloader
-if ! systemd-detect-virt -cq; then
+# Note: Both "systemd-detect-virt -q --container" and "systemd-detect-virt -q --chroot" return 0 in arch-chroot.
+if ! systemd-detect-virt -q --container || ( systemd-detect-virt -q --container && systemd-detect-virt -q --chroot ) ; then
 	if [[ -x /usr/bin/grub-mkconfig ]]; then
 		echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
 		update-grub

--- a/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
@@ -58,7 +58,8 @@ else
 fi
 
 # Notify bootloader
-if ! systemd-detect-virt -cq; then
+# Note: Both "systemd-detect-virt -q --container" and "systemd-detect-virt -q --chroot" return 0 in arch-chroot.
+if ! systemd-detect-virt -q --container || ( systemd-detect-virt -q --container && systemd-detect-virt -q --chroot ) ; then
 	if [[ -x /usr/bin/grub-mkconfig ]]; then
 		echo -e "\033[36m**\033[0m\tUpdating GRUB for the new kernel..."
 		update-grub

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,5 @@
 VER=105
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"

--- a/runtime-cryptography/opencryptoki/autobuild/postinst
+++ b/runtime-cryptography/opencryptoki/autobuild/postinst
@@ -2,8 +2,10 @@ getent group pkcs11 > /dev/null || groupadd -r pkcs11
 
 systemd-tmpfiles --create opencryptoki.conf
 
+systemctl enable pkcsslotd.service
+
 # FIXME: This should be run when nspawn is launched in boot mode, but there is
 # currently no way to distinguish between different container implementations.
 if ! systemd-detect-virt --container; then
-    systemctl enable pkcsslotd.service --now
+    systemctl start pkcsslotd.service
 fi

--- a/runtime-cryptography/opencryptoki/spec
+++ b/runtime-cryptography/opencryptoki/spec
@@ -1,5 +1,5 @@
 VER=3.21.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/opencryptoki/opencryptoki"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112179"

--- a/runtime-kernel/linux-kernel-rpi64-lts/autobuild/postinst.in
+++ b/runtime-kernel/linux-kernel-rpi64-lts/autobuild/postinst.in
@@ -21,8 +21,10 @@ if [ -x /etc/kernel/postinst.d/apt-auto-removal ]; then
 	/etc/kernel/postinst.d/apt-auto-removal
 fi
 
-if systemd-detect-virt -q -c ; then
-	echo "Running in build environment, skipping kernel update."
+if systemd-detect-virt -q --container ; then
+	if ! systemd-detect-virt -q --chroot ; then
+		echo "Running in a container, skipping kernel update."
+	fi
 elif grep -q /boot/rpi /proc/mounts; then
 	echo "Updating kernel..."
 	cp -r /usr/lib/rpi64/kernel/"$VER"/* /boot/rpi/

--- a/runtime-kernel/linux-kernel-rpi64-lts/spec
+++ b/runtime-kernel/linux-kernel-rpi64-lts/spec
@@ -2,7 +2,7 @@ VER=6.6.69
 # Downstream kernels often rebases upon upstream releases.
 COMMIT=eec7048c4e3aec1aadc21fcffcf6be9f5385f72a
 # Use this for stable releases.
-#REL=1
+REL=1
 
 SRCS="git::commit=${COMMIT}::https://github.com/raspberrypi/linux.git"
 CHKSUMS="SKIP"

--- a/runtime-kernel/rpi-firmware-boot/autobuild/postinst
+++ b/runtime-kernel/rpi-firmware-boot/autobuild/postinst
@@ -3,9 +3,11 @@
 # In case of building a raw image, the post installation must handle this
 # manually.
 # Check if the system is running in a container.
-if systemd-detect-virt -q -c ; then
-	echo "Running in build environment, skipping firmware update."
-	exit 0
+if systemd-detect-virt -q --container ; then
+	if ! systemd-detect-virt -q --chroot ; then
+		echo "Running in a container, skipping firmware update."
+		exit 0
+	fi
 fi
 
 if ! grep -q "/boot/rpi" /proc/mounts; then

--- a/runtime-kernel/rpi-firmware-boot/spec
+++ b/runtime-kernel/rpi-firmware-boot/spec
@@ -1,5 +1,6 @@
 UPSTREAM_VER=1.20250127
 VER="${UPSTREAM_VER}"
+REL=1
 SRCS="tbl::https://github.com/raspberrypi/firmware/releases/download/$VER/raspi-firmware_$VER.orig.tar.xz"
 CHKSUMS="sha256::0b8e290c829f5deee53b01037e4307d9f9242ea262949043e702e033d088eeb4"
 CHKUPDATE="anitya::id=21744"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: fix postinst logic
    - update grub for non-container and arch-chroot
- opencryptoki: fix postinst logic
    - separate enable service and start service
- rpi-firmware-boot: fix postinst logic
    - double check systemd-detect-virt
- linux-kernel-rpi64-lts: fix postinst logic
    - double check systemd-detect-virt

Package(s) Affected
-------------------

- dracut-ng: 105-1
- linux-kernel-rpi64-lts-6.6.69: 6.6.69
- opencryptoki: 3.21.0-2
- rpi-firmware-boot: 1.20250127

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-rpi64-lts rpi-firmware-boot opencryptoki dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
