### PR TITLE
nvidia: fix building on 6.14

### DIFF
--- a/runtime-display/nvidia/03-kernel/patches/0001-Fix-symbolic-links-for-Linux-kernel-6.13-rc1.patch
+++ b/runtime-display/nvidia/03-kernel/patches/0001-Fix-symbolic-links-for-Linux-kernel-6.13-rc1.patch
@@ -1,15 +1,7 @@
 From abc88d52ee5e86decd5e98b3223d3feec0dd66bc Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 7 Dec 2024 21:12:25 +0800
-Subject: [PATCH 1/3] Fix symbolic links for Linux kernel 6.13-rc1
-X-Developer-Signature: v=1; a=openpgp-sha256; l=2446; i=xtexchooser@duck.com;
- h=from:subject; bh=4orMdTlyFiafvwXo+YIZ8q0Emww7pH1RBNOMMhTxeIA=;
- b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDOkhRf8mHj1+2F2S4/++tk08GT2s/1V53Oae4X80O37Fm
- Z7LB/Tnd5SyMIhxMciKKbIUGTZ4s+qk84suK5eFmcPKBDKEgYtTACby15Lhf3xXOu/XpxkPLX0y
- PrS79T/1r0twMuGZtCmd8WMUF+fFtwx/pbrnVs2cIGt6WOZU9OU74Uq3f27f8yCoTNHmfW9mpaY
- hLwA=
-X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
- fpr=7231804B052C670F15A6771DB918086ED8045B91
+Subject: [PATCH 1/4] Fix symbolic links for Linux kernel 6.13-rc1
 
 Link: https://gist.github.com/joanbm/d1f89391a4b20f4b56ba931ef6ca62da
 Link: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/747
@@ -20,7 +12,7 @@ Author: Joan Bruguera <joanbrugueram@gmail.com>
  2 files changed, 10 insertions(+), 6 deletions(-)
 
 diff --git a/nvidia-modeset/nvidia-modeset.Kbuild b/nvidia-modeset/nvidia-modeset.Kbuild
-index 9698b59e24de..75e3563cde37 100644
+index 9698b59..75e3563 100644
 --- a/nvidia-modeset/nvidia-modeset.Kbuild
 +++ b/nvidia-modeset/nvidia-modeset.Kbuild
 @@ -40,13 +40,15 @@ NV_KERNEL_MODULE_TARGETS += $(NVIDIA_MODESET_KO)
@@ -43,7 +35,7 @@ index 9698b59e24de..75e3563cde37 100644
  nvidia-modeset-y += $(NVIDIA_MODESET_BINARY_OBJECT_O)
  
 diff --git a/nvidia/nvidia.Kbuild b/nvidia/nvidia.Kbuild
-index ea4ef5badea7..4262c6f35fb3 100644
+index ea4ef5b..4262c6f 100644
 --- a/nvidia/nvidia.Kbuild
 +++ b/nvidia/nvidia.Kbuild
 @@ -40,13 +40,15 @@ NVIDIA_KO = nvidia/nvidia.ko
@@ -65,8 +57,6 @@ index ea4ef5badea7..4262c6f35fb3 100644
  
  nvidia-y += $(NVIDIA_BINARY_OBJECT_O)
  
-
-base-commit: 6127483bad1f7ecf052c9aaba198452d4cf47ce9
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/nvidia/03-kernel/patches/0002-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch
+++ b/runtime-display/nvidia/03-kernel/patches/0002-FROM-AOSC-Use-linux-aperture.c-for-removing-conflict.patch
@@ -1,16 +1,8 @@
 From 8113cd50461f05da52b66934237415dd303ec55c Mon Sep 17 00:00:00 2001
 From: Bingwu Zhang <xtex@aosc.io>
 Date: Sat, 7 Dec 2024 23:01:26 +0800
-Subject: [PATCH 2/3] FROM AOSC: Use linux/aperture.c for removing conflicting
+Subject: [PATCH 2/4] FROM AOSC: Use linux/aperture.c for removing conflicting
  PCI devices on Linux 6.13.0-rc1+
-X-Developer-Signature: v=1; a=openpgp-sha256; l=6111; i=xtexchooser@duck.com;
- h=from:subject; bh=hS408kVBp8zz0JO5do1a5Ut1vawCN67uYWAOfNTDy/w=;
- b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDOkhRf8j7mS/f32ZLdl9b2TWxCs3m5lyr+aoKs8zKJFn7
- /OcNSmho5SFQYyLQVZMkaXIsMGbVSedX3RZuSzMHFYmkCEMXJwCMBHD1YwMhyfeyKryPeXAv2pm
- q5nasVPaO/YZnf4Q8X6PiPPvW3+PcDIy3HF1/3BpUxDXm5sWDPxPGJp/l2X9OHr21zPZv7ZrCmd
- M5AEA
-X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
- fpr=7231804B052C670F15A6771DB918086ED8045B91
 
 Link: https://github.com/torvalds/linux/commit/689274a56c0c088796d359f6c6267323931a2429
 Link: https://github.com/torvalds/linux/commit/7283f862bd991c8657e9bf1c02db772fcf018f13
@@ -24,7 +16,7 @@ Link: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/749
  5 files changed, 46 insertions(+)
 
 diff --git a/conftest.sh b/conftest.sh
-index fdceda72da33..5a0f39e0b2a7 100755
+index fdceda7..5a0f39e 100755
 --- a/conftest.sh
 +++ b/conftest.sh
 @@ -6615,6 +6615,8 @@ compile_test() {
@@ -61,7 +53,7 @@ index fdceda72da33..5a0f39e0b2a7 100755
              #
              # Determine whether drm_aperture_remove_conflicting_pci_framebuffers
 diff --git a/header-presence-tests.mk b/header-presence-tests.mk
-index 9d5217a9f8b9..b02685418629 100644
+index 9d5217a..b026854 100644
 --- a/header-presence-tests.mk
 +++ b/header-presence-tests.mk
 @@ -34,6 +34,7 @@ NV_HEADER_PRESENCE_TESTS = \
@@ -73,7 +65,7 @@ index 9d5217a9f8b9..b02685418629 100644
    linux/kconfig.h \
    linux/platform/tegra/mc_utils.h \
 diff --git a/nvidia-drm/nvidia-drm-drv.c b/nvidia-drm/nvidia-drm-drv.c
-index 8f905f821444..57a4ab82b3fc 100644
+index 8f905f8..57a4ab8 100644
 --- a/nvidia-drm/nvidia-drm-drv.c
 +++ b/nvidia-drm/nvidia-drm-drv.c
 @@ -65,7 +65,16 @@
@@ -111,7 +103,7 @@ index 8f905f821444..57a4ab82b3fc 100644
              nvKms->framebufferConsoleDisabled(nv_dev->pDevice);
          }
 diff --git a/nvidia-drm/nvidia-drm-os-interface.h b/nvidia-drm/nvidia-drm-os-interface.h
-index a6b0f947e0ab..71ca5f226ad7 100644
+index a6b0f94..71ca5f2 100644
 --- a/nvidia-drm/nvidia-drm-os-interface.h
 +++ b/nvidia-drm/nvidia-drm-os-interface.h
 @@ -63,11 +63,21 @@ typedef struct nv_timer nv_drm_timer;
@@ -137,7 +129,7 @@ index a6b0f947e0ab..71ca5f226ad7 100644
  
  /* Set to true when the atomic modeset feature is enabled. */
 diff --git a/nvidia-drm/nvidia-drm-sources.mk b/nvidia-drm/nvidia-drm-sources.mk
-index 9aaebd04ace2..a4dcad6de609 100644
+index 9aaebd0..a4dcad6 100644
 --- a/nvidia-drm/nvidia-drm-sources.mk
 +++ b/nvidia-drm/nvidia-drm-sources.mk
 @@ -66,6 +66,7 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += dma_fence_set_error
@@ -149,5 +141,5 @@ index 9aaebd04ace2..a4dcad6de609 100644
  NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_fbdev_ttm_setup
  NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_connector_attach_hdr_output_metadata_property
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/nvidia/03-kernel/patches/0003-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch
+++ b/runtime-display/nvidia/03-kernel/patches/0003-FROM-AOSC-TTM-fbdev-emulation-for-Linux-6.13.patch
@@ -1,15 +1,7 @@
 From 686f6869c0edfc725e1af2e1e72e30caa7589887 Mon Sep 17 00:00:00 2001
 From: Bingwu Zhang <xtex@aosc.io>
 Date: Sat, 7 Dec 2024 23:56:43 +0800
-Subject: [PATCH 3/3] FROM AOSC: TTM fbdev emulation for Linux 6.13+
-X-Developer-Signature: v=1; a=openpgp-sha256; l=5409; i=xtexchooser@duck.com;
- h=from:subject; bh=+rLvUfeSo5yL2QZg7/YHp54RjssmMnMdIH/tCswBBvY=;
- b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDOkhRf8L3Q/X+l1zYDhZoCS/Pnr5tvNPtq4Kaks5duFbP
- JPGFdXmjlIWBjEuBlkxRZYiwwZvVp10ftFl5bIwc1iZQIYwcHEKwEQElzD84d39be3dDUWTfzS3
- 922c9aYriyd4c4NR2tKSmik7agSOnGZk+KX57nBit8ax2gr92xo/5GZ/kd/96+uWzbWl6dYO0/X
- PcwAA
-X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
- fpr=7231804B052C670F15A6771DB918086ED8045B91
+Subject: [PATCH 3/4] FROM AOSC: TTM fbdev emulation for Linux 6.13+
 
 Link: https://github.com/torvalds/linux/commit/1000634477d8d178179b1ad45d92e925fabe3deb
 Link: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/749
@@ -21,7 +13,7 @@ Signed-off-by: xtex <xtexchooser@duck.com>
  3 files changed, 81 insertions(+)
 
 diff --git a/nvidia-drm/nvidia-drm-drv.c b/nvidia-drm/nvidia-drm-drv.c
-index 57a4ab82b3fc..2618d48a74af 100644
+index 57a4ab8..2618d48 100644
 --- a/nvidia-drm/nvidia-drm-drv.c
 +++ b/nvidia-drm/nvidia-drm-drv.c
 @@ -1951,7 +1951,60 @@ void nv_drm_update_drm_driver_features(void)
@@ -126,7 +118,7 @@ index 57a4ab82b3fc..2618d48a74af 100644
  
      nv_drm_dev_free(dev);
 diff --git a/nvidia-drm/nvidia-drm-linux.c b/nvidia-drm/nvidia-drm-linux.c
-index 78d4c343fc80..87715c0bf09e 100644
+index 78d4c34..87715c0 100644
 --- a/nvidia-drm/nvidia-drm-linux.c
 +++ b/nvidia-drm/nvidia-drm-linux.c
 @@ -39,8 +39,12 @@ MODULE_PARM_DESC(
@@ -143,7 +135,7 @@ index 78d4c343fc80..87715c0bf09e 100644
  
  /*************************************************************************
 diff --git a/nvidia-drm/nvidia-drm-os-interface.h b/nvidia-drm/nvidia-drm-os-interface.h
-index 71ca5f226ad7..8195af32c39e 100644
+index 71ca5f2..8195af3 100644
 --- a/nvidia-drm/nvidia-drm-os-interface.h
 +++ b/nvidia-drm/nvidia-drm-os-interface.h
 @@ -78,6 +78,11 @@ typedef struct nv_timer nv_drm_timer;
@@ -159,5 +151,5 @@ index 71ca5f226ad7..8195af32c39e 100644
  
  /* Set to true when the atomic modeset feature is enabled. */
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/nvidia/03-kernel/patches/0004-AOSCOS-nvidia-drm-remove-driver-date.patch
+++ b/runtime-display/nvidia/03-kernel/patches/0004-AOSCOS-nvidia-drm-remove-driver-date.patch
@@ -1,0 +1,39 @@
+From c722b12cb2b5f8be2e23a76e1206116a63cf95de Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Sun, 9 Feb 2025 18:22:16 +0800
+Subject: [PATCH 4/4] AOSCOS: nvidia-drm: remove driver date
+
+Following upstream changes.
+
+Fixes: cb2e1c2136f7 ("drm: remove driver date from struct drm_driver and all drivers")
+Fixes: "chore: import from 565.77"
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ nvidia-drm/nvidia-drm-drv.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/nvidia-drm/nvidia-drm-drv.c b/nvidia-drm/nvidia-drm-drv.c
+index 2618d48..add9abd 100644
+--- a/nvidia-drm/nvidia-drm-drv.c
++++ b/nvidia-drm/nvidia-drm-drv.c
+@@ -86,6 +86,7 @@
+ 
+ #include <linux/pci.h>
+ #include <linux/workqueue.h>
++#include <linux/version.h>
+ 
+ /*
+  * Commit fcd70cd36b9b ("drm: Split out drm_probe_helper.h")
+@@ -1913,7 +1914,9 @@ static struct drm_driver nv_drm_driver = {
+     .name                   = "nvidia-drm",
+ 
+     .desc                   = "NVIDIA DRM driver",
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0))
+     .date                   = "20160202",
++#endif
+ 
+ #if defined(NV_DRM_DRIVER_HAS_DEVICE_LIST)
+     .device_list            = LIST_HEAD_INIT(nv_drm_driver.device_list),
+-- 
+2.48.1
+

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,5 +1,5 @@
 VER=565.77
-REL=1
+REL=2
 
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
 CHKSUMS__AMD64="sha256::0a7aa742c46bcf34d766982402d17b3db1fdb3bc1b89344d70cd123c1cb3147c"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia: fix building on 6.14
    - Track AOSC OS patches at https://github.com/AOSC-Tracking/nvidia-driver @ aosc/565.77, current HEAD is 770e72583d7acb73b2603f282adc5dfde2c64abf.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- nvidia: 565.77-2
- nvidia-firmware: 565.77-2
- nvidia-utils: 565.77-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
