### PR TITLE
linux+kernel+rc: fix typo in description

### DIFF
--- a/runtime-kernel/linux+kernel+rc/autobuild/defines
+++ b/runtime-kernel/linux+kernel+rc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=linux+kernel+rc
 PKGSEC=kernel
 PKGDEP="linux-kernel-rc-6.14.0"
-PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
+PKGDES="Generic Linux Kernel for AOSC OS (Prepatch)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"
 PKGPROV="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel+rc/spec
+++ b/runtime-kernel/linux+kernel+rc/spec
@@ -1,3 +1,4 @@
 VER=6.14.0
+REL=1
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"


### PR DESCRIPTION
Topic Description
-----------------

- linux+kernel+rc: fix typo in description
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- linux+kernel+rc: 2:6.14.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux+kernel+rc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
