### PR TITLE
sass, sass-listen, rb-inotify: rebuild for Ruby 3.4

### DIFF
--- a/app-devel/sass/spec
+++ b/app-devel/sass/spec
@@ -1,5 +1,5 @@
 VER=3.7.4
-REL=5
+REL=6
 SRCS="tbl::https://rubygems.org/downloads/sass-$VER.gem"
 CHKSUMS="sha256::808b0d39053aa69068df939e24671fe84fd5a9d3314486e1a1457d0934a4255d"
 CHKUPDATE="anitya::id=4335"

--- a/lang-ruby/rb-inotify/autobuild/build
+++ b/lang-ruby/rb-inotify/autobuild/build
@@ -1,11 +1,12 @@
-# From Arch Linux.
+abinfo "Building rb-inotify ..."
+gem build "$SRCDIR"/rb-inotify.gemspec
 
-sed -r 's|~>|>=|g' -i rb-inotify.gemspec
-sed 's|git ls-files|find -type f|' -i rb-inotify.gemspec
+abinfo "Installing rb-inotify ..."
+gem install \
+    --ignore-dependencies \
+    --no-user-install \
+    -i "$PKGDIR"/$(gem env gemdir) \
+    -n "$PKGDIR"/usr/bin rb-inotify-$PKGVER.gem
 
-gem build rb-inotify.gemspec
-
-local _gemdir="$(gem env gemdir)"
-gem install --ignore-dependencies --no-user-install \
-    -i "$PKGDIR"/${_gemdir} -n "$PKGDIR"/usr/bin rb-inotify-$PKGVER.gem
-rm "$PKGDIR"/${_gemdir}/cache/rb-inotify-$PKGVER.gem
+abinfo "Removing cached gem ..."
+rm -v "$PKGDIR"/$(gem env gemdir)/cache/rb-inotify-$PKGVER.gem

--- a/lang-ruby/rb-inotify/autobuild/defines
+++ b/lang-ruby/rb-inotify/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=rb-inotify
 PKGSEC=ruby
 PKGDEP="ruby-ffi"
-PKGDES="Thorough inotify wrapper for Ruby using FFI"
+PKGDES="Inotify wrapper for Ruby using FFI"
 
 ABHOST=noarch

--- a/lang-ruby/rb-inotify/spec
+++ b/lang-ruby/rb-inotify/spec
@@ -1,5 +1,5 @@
 VER=0.10.1
-SRCS="tbl::https://github.com/guard/rb-inotify/archive/v$VER.tar.gz"
-CHKSUMS="sha256::0953e27e19d48be3e41a93419f2d7a2618b36c18fe398d87e5cb1abc5a3621ea"
+REL=2
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/guard/rb-inotify"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4702"
-REL=1

--- a/lang-ruby/sass-listen/autobuild/build
+++ b/lang-ruby/sass-listen/autobuild/build
@@ -1,13 +1,12 @@
-# From Arch Linux.
+abinfo "Building sass-listen ..."
+gem build "$SRCDIR"/sass-listen.gemspec
 
-sed -r 's|~>|>=|g' -i sass-listen.gemspec
-sed -r '/rb-fsevent/d' -i sass-listen.gemspec
-sed 's|git ls-files -z|find -type f -print0\|sed "s,\\\\./,,g"|' \
-    -i sass-listen.gemspec
+abinfo "Installing sass-listen ..."
+gem install \
+    --ignore-dependencies \
+    --no-user-install \
+    -i "$PKGDIR"/$(gem env gemdir) \
+    -n "$PKGDIR"/usr/bin sass-listen-$PKGVER.gem
 
-gem build sass-listen.gemspec
-
-local _gemdir="$(gem env gemdir)"
-gem install --ignore-dependencies --no-user-install \
-    -i "$PKGDIR"/${_gemdir} -n "$PKGDIR"/usr/bin sass-listen-$PKGVER.gem
-rm "$PKGDIR"/${_gemdir}/cache/sass-listen-$PKGVER.gem
+abinfo "Removing cached gem ..."
+rm -v "$PKGDIR"/$(gem env gemdir)/cache/sass-listen-$PKGVER.gem

--- a/lang-ruby/sass-listen/autobuild/defines
+++ b/lang-ruby/sass-listen/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=sass-listen
 PKGSEC=ruby
 PKGDEP="rb-inotify"
-PKGDES="Listens to file modifications and notifies you about the changes"
+PKGDES="API to provide a file modification notification API the Ruby Sass CLI"
 
 ABHOST=noarch

--- a/lang-ruby/sass-listen/autobuild/patches/0001-AOSCOS-chore-loosen-dependency-requirements.patch
+++ b/lang-ruby/sass-listen/autobuild/patches/0001-AOSCOS-chore-loosen-dependency-requirements.patch
@@ -1,0 +1,30 @@
+From 8f3507c2ebd02cf9f08995b35a8d78da0584450c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 10 Feb 2025 11:03:30 +0800
+Subject: [PATCH 1/2] AOSCOS: chore: loosen dependency requirements
+
+So that we can more easily update dependencies - and we will test it too.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ sass-listen.gemspec | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sass-listen.gemspec b/sass-listen.gemspec
+index 7844632..82cce42 100644
+--- a/sass-listen.gemspec
++++ b/sass-listen.gemspec
+@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
+ 
+   s.required_ruby_version = '>= 1.9.3'
+ 
+-  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.4'
+-  s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
++  s.add_dependency 'rb-fsevent', '>= 0.9', '>= 0.9.4'
++  s.add_dependency 'rb-inotify', '>= 0.9', '>= 0.9.7'
+ 
+   s.add_development_dependency 'bundler', '>= 1.3.5'
+ end
+-- 
+2.48.1
+

--- a/lang-ruby/sass-listen/autobuild/patches/0002-AOSCOS-fix-remove-rb-fsevent-dependency.patch
+++ b/lang-ruby/sass-listen/autobuild/patches/0002-AOSCOS-fix-remove-rb-fsevent-dependency.patch
@@ -1,0 +1,27 @@
+From 4113668997af81e1fc10bb3d1bbe0f68d19d7499 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 10 Feb 2025 11:04:51 +0800
+Subject: [PATCH 2/2] AOSCOS: fix: remove rb-fsevent dependency
+
+This is a macOS-specific dependency for hookup to their FSEvent API.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ sass-listen.gemspec | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/sass-listen.gemspec b/sass-listen.gemspec
+index 82cce42..80b1cf1 100644
+--- a/sass-listen.gemspec
++++ b/sass-listen.gemspec
+@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
+ 
+   s.required_ruby_version = '>= 1.9.3'
+ 
+-  s.add_dependency 'rb-fsevent', '>= 0.9', '>= 0.9.4'
+   s.add_dependency 'rb-inotify', '>= 0.9', '>= 0.9.7'
+ 
+   s.add_development_dependency 'bundler', '>= 1.3.5'
+-- 
+2.48.1
+

--- a/lang-ruby/sass-listen/spec
+++ b/lang-ruby/sass-listen/spec
@@ -1,5 +1,5 @@
 VER=4.0.0
-SRCS="tbl::https://github.com/sass/listen/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5b09daf811df4ae3d8657cf919976b9795d275a3792ab08bdf3b1cccaecd3f4b"
-REL=2
+REL=3
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/sass/listen"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4471"


### PR DESCRIPTION
Topic Description
-----------------

- rb-inotify: rebuild for Ruby 3.4
    - Revise all sed invocations to patches.
    - Track patches at AOSC-Tracking/rb-inotify @ aosc/v0.10.1
    \(HEAD: 9d9e6a85645518ea5542aee2f76332c907a228a6\).
- sass-listen: rebuild for Ruby 3.4
    - Revise all sed invocations to patches.
    - Track patches at AOSC-Tracking/listen @ aosc/v4.0.0
    \(HEAD: 4113668997af81e1fc10bb3d1bbe0f68d19d7499\).
- sass: rebuild for Ruby 3.4

Package(s) Affected
-------------------

- rb-inotify: 0.10.1-2
- sass: 3.7.4-6
- sass-listen: 4.0.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rb-inotify sass-listen sass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
