### PR TITLE
forgejo: fix FAIL_ARCH


### DIFF
--- a/app-web/forgejo/autobuild/defines
+++ b/app-web/forgejo/autobuild/defines
@@ -12,4 +12,4 @@ ABSPLITDBG=0
 # FIXME: riscv: runtime.cgo_yield: relocation target _cgo_yield not defined
 # FIXME: loongson3: nodejs broken
 #        https://github.com/nodejs/node/issues/56973
-FAIL_ARCH="@(riscv64|loongson3)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,4 +1,5 @@
 VER=10.0.1
+REL=1
 # Note: copy-repo required by auto version detection
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- forgejo: fix FAIL_ARCH

Package(s) Affected
-------------------

- forgejo: 10.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
