### PR TITLE
loupe: new, 47.4

### DIFF
--- a/desktop-gnome/loupe/autobuild/beyond
+++ b/desktop-gnome/loupe/autobuild/beyond
@@ -1,0 +1,8 @@
+# FIXME: Loupe's SVG icon does not render properly under KDE, use a PNG to replace it.
+abinfo "Generating bitmap icon..."
+mkdir -pv "$PKGDIR"/usr/share/pixmaps/
+inkscape -o "$PKGDIR"/usr/share/pixmaps/org.gnome.Loupe.png \
+         -w 512 -h 512 "$SRCDIR"/data/icons/hicolor/scalable/apps/org.gnome.Loupe.svg
+
+abinfo "Deleting SVG icon..."
+rm -v "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/org.gnome.Loupe.svg

--- a/desktop-gnome/loupe/autobuild/defines
+++ b/desktop-gnome/loupe/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=loupe
+PKGSEC=gnome
+PKGDEP="cairo dconf fontconfig gcc-runtime glib glibc glycin graphene gtk-4 hicolor-icon-theme \
+        lcms2 libadwaita libgweather libseccomp pango gdk-pixbuf"
+BUILDDEP="itstool rustc gtk-update-icon-cache llvm inkscape"
+PKGDES="Image Viewer for GNOME"
+
+USECLANG=1
+# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/desktop-gnome/loupe/spec
+++ b/desktop-gnome/loupe/spec
@@ -1,0 +1,4 @@
+VER=47.4
+SRCS="https://download.gnome.org/sources/loupe/${VER%.*}/loupe-$VER.tar.xz"
+CHKSUMS="sha256::8dc926829a9c338800c8f432b5a347246e6dcbd9ad2dd1a24c498eafdd3e89ab"
+CHKUPDATE="antiya::id=368849"


### PR DESCRIPTION
Topic Description
-----------------

- loupe: new, 47.4

Package(s) Affected
-------------------

- loupe: 47.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit loupe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
