### PR TITLE
kea: new, kea-2.6.1

### DIFF
--- a/app-network/kea/autobuild/conffiles
+++ b/app-network/kea/autobuild/conffiles
@@ -1,0 +1,5 @@
+/etc/kea/kea-ctrl-agent.conf
+/etc/kea/kea-dhcp-ddns.conf
+/etc/kea/kea-dhcp4.conf
+/etc/kea/kea-dhcp6.conf
+/etc/kea/keactrl.conf

--- a/app-network/kea/autobuild/defines
+++ b/app-network/kea/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=kea
+PKGSEC=net
+PKGDES="IPv4 and IPv6 DHCP server from ISC"
+PKGDEP="boost openssl log4cplus bison postgresql mariadb"
+
+AUTOTOOLS_AFTER="--with-pgsql --with-mysql --enable-shell --enable-perfdhcp"

--- a/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-ctrl-agent.service
+++ b/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-ctrl-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kea Control Agent
+Wants=network.target
+After=network.target
+
+[Service]
+Type=exec
+User=kea
+ExecStart=/usr/sbin/kea-ctrl-agent -c /etc/kea/kea-ctrl-agent.conf
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp-ddns.service
+++ b/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp-ddns.service
@@ -1,0 +1,13 @@
+[Unit]
+Wants=network.target
+After=network.target
+
+[Service]
+Type=exec
+User=kea
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/kea-dhcp-ddns -c /etc/kea/kea-dhcp-ddns.conf
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp4-server.service
+++ b/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp4-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kea IPv4 DHCP server
+After=network.target
+
+[Service]
+Type=exec
+User=kea
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
+ExecStart=/usr/bin/kea-dhcp4 -c /etc/kea/kea-dhcp4.conf
+KillSignal=SIGINT
+ExecReload=kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp6-server.service
+++ b/app-network/kea/autobuild/overrides/usr/lib/systemd/system/kea-dhcp6-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kea IPv6 DHCP server
+After=network.target
+
+[Service]
+Type=exec
+User=kea
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
+ExecStart=/usr/bin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
+KillSignal=SIGINT
+ExecReload=kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/kea/autobuild/overrides/usr/lib/sysusers.d/kea.conf
+++ b/app-network/kea/autobuild/overrides/usr/lib/sysusers.d/kea.conf
@@ -1,0 +1,2 @@
+g kea -
+u kea -:kea "Kea DHCP Server" /var/lib/kea

--- a/app-network/kea/autobuild/overrides/usr/lib/tmpfiles.d/kea.conf
+++ b/app-network/kea/autobuild/overrides/usr/lib/tmpfiles.d/kea.conf
@@ -1,0 +1,2 @@
+d /run/kea 0755 kea kea -
+d /var/lib/kea 0755 kea kea -

--- a/app-network/kea/autobuild/patches/0001-default-config-log-format-and-ctrl-socket.patch
+++ b/app-network/kea/autobuild/patches/0001-default-config-log-format-and-ctrl-socket.patch
@@ -1,0 +1,157 @@
+diff --git a/src/bin/keactrl/kea-ctrl-agent.conf.pre b/src/bin/keactrl/kea-ctrl-agent.conf.pre
+index d8e0429..b13b723 100644
+--- a/src/bin/keactrl/kea-ctrl-agent.conf.pre
++++ b/src/bin/keactrl/kea-ctrl-agent.conf.pre
+@@ -32,15 +32,15 @@
+     "control-sockets": {
+         "dhcp4": {
+             "socket-type": "unix",
+-            "socket-name": "/tmp/kea4-ctrl-socket"
++            "socket-name": "/run/kea/kea4-ctrl-socket"
+         },
+         "dhcp6": {
+             "socket-type": "unix",
+-            "socket-name": "/tmp/kea6-ctrl-socket"
++            "socket-name": "/run/kea/kea6-ctrl-socket"
+         },
+         "d2": {
+             "socket-type": "unix",
+-            "socket-name": "/tmp/kea-ddns-ctrl-socket"
++            "socket-name": "/run/kea/kea-ddns-ctrl-socket"
+         }
+     },
+ 
+@@ -73,11 +73,12 @@
+                 // - syslog (logs to syslog)
+                 // - syslog:name (logs to syslog using specified name)
+                 // Any other value is considered a name of the file
+-                "output": "@localstatedir@/log/kea-ctrl-agent.log"
++                // "output": "@localstatedir@/log/kea-ctrl-agent.log"
++                "output": "syslog",
+ 
+                 // Shorter log pattern suitable for use with systemd,
+                 // avoids redundant information
+-                // "pattern": "%-5p %m\n"
++                "pattern": "%-5p %m\n"
+ 
+                 // This governs whether the log output is flushed to disk after
+                 // every write.
+diff --git a/src/bin/keactrl/kea-dhcp-ddns.conf.pre b/src/bin/keactrl/kea-dhcp-ddns.conf.pre
+index b75b51f..a7c5a43 100644
+--- a/src/bin/keactrl/kea-dhcp-ddns.conf.pre
++++ b/src/bin/keactrl/kea-dhcp-ddns.conf.pre
+@@ -23,7 +23,7 @@
+   "port": 53001,
+   "control-socket": {
+       "socket-type": "unix",
+-      "socket-name": "/tmp/kea-ddns-ctrl-socket"
++      "socket-name": "/run/kea/kea-ddns-ctrl-socket"
+   },
+   "tsig-keys": [],
+   "forward-ddns" : {},
+@@ -44,11 +44,12 @@
+                 // - syslog (logs to syslog)
+                 // - syslog:name (logs to syslog using specified name)
+                 // Any other value is considered a name of the file
+-                "output": "@localstatedir@/log/kea-ddns.log"
++                // "output": "@localstatedir@/log/kea-ddns.log"
++                "output": "syslog",
+ 
+                 // Shorter log pattern suitable for use with systemd,
+                 // avoids redundant information
+-                // "pattern": "%-5p %m\n"
++                "pattern": "%-5p %m\n"
+ 
+                 // This governs whether the log output is flushed to disk after
+                 // every write.
+diff --git a/src/bin/keactrl/kea-dhcp4.conf.pre b/src/bin/keactrl/kea-dhcp4.conf.pre
+index 55af9db..96bcbb8 100644
+--- a/src/bin/keactrl/kea-dhcp4.conf.pre
++++ b/src/bin/keactrl/kea-dhcp4.conf.pre
+@@ -49,7 +49,7 @@
+     // more. For detailed description, see Sections 8.8, 16 and 15.
+     "control-socket": {
+         "socket-type": "unix",
+-        "socket-name": "/tmp/kea4-ctrl-socket"
++        "socket-name": "/run/kea/kea4-ctrl-socket"
+     },
+ 
+     // Use Memfile lease database backend to store leases in a CSV file.
+@@ -436,11 +436,12 @@
+                 // - syslog (logs to syslog)
+                 // - syslog:name (logs to syslog using specified name)
+                 // Any other value is considered a name of the file
+-                "output": "@localstatedir@/log/kea-dhcp4.log"
++                // "output": "@localstatedir@/log/kea-dhcp4.log"
++                "output": "syslog",
+ 
+                 // Shorter log pattern suitable for use with systemd,
+                 // avoids redundant information
+-                // "pattern": "%-5p %m\n",
++                "pattern": "%-5p %m\n"
+ 
+                 // This governs whether the log output is flushed to disk after
+                 // every write.
+diff --git a/src/bin/keactrl/kea-dhcp6.conf.pre b/src/bin/keactrl/kea-dhcp6.conf.pre
+index 271021b..3173ba4 100644
+--- a/src/bin/keactrl/kea-dhcp6.conf.pre
++++ b/src/bin/keactrl/kea-dhcp6.conf.pre
+@@ -43,7 +43,7 @@
+     // description, see Sections 9.12, 16 and 15.
+     "control-socket": {
+         "socket-type": "unix",
+-        "socket-name": "/tmp/kea6-ctrl-socket"
++        "socket-name": "/run/kea/kea6-ctrl-socket"
+     },
+ 
+     // Use Memfile lease database backend to store leases in a CSV file.
+@@ -395,11 +395,12 @@
+                 // - syslog (logs to syslog)
+                 // - syslog:name (logs to syslog using specified name)
+                 // Any other value is considered a name of the file
+-                "output": "@localstatedir@/log/kea-dhcp6.log"
++                // "output": "@localstatedir@/log/kea-dhcp6.log"
++                "output": "syslog",
+ 
+                 // Shorter log pattern suitable for use with systemd,
+                 // avoids redundant information
+-                // "pattern": "%-5p %m\n",
++                "pattern": "%-5p %m\n"
+ 
+                 // This governs whether the log output is flushed to disk after
+                 // every write.
+diff --git a/src/bin/keactrl/kea-netconf.conf.pre b/src/bin/keactrl/kea-netconf.conf.pre
+index c8a3878..5bce47c 100644
+--- a/src/bin/keactrl/kea-netconf.conf.pre
++++ b/src/bin/keactrl/kea-netconf.conf.pre
+@@ -30,13 +30,13 @@
+         "dhcp4": {
+             "control-socket": {
+                 "socket-type": "unix",
+-                "socket-name": "/tmp/kea4-ctrl-socket"
++                "socket-name": "/run/kea/kea4-ctrl-socket"
+             }
+         },
+         "dhcp6": {
+             "control-socket": {
+                 "socket-type": "unix",
+-                "socket-name": "/tmp/kea6-ctrl-socket"
++                "socket-name": "/run/kea/kea6-ctrl-socket"
+             }
+         }
+     },
+@@ -69,11 +69,12 @@
+                 // - syslog (logs to syslog)
+                 // - syslog:name (logs to syslog using specified name)
+                 // Any other value is considered a name of a time
+-                "output": "@localstatedir@/log/kea-netconf.log"
++                // "output": "@localstatedir@/log/kea-netconf.log"
++                "output": "syslog",
+ 
+                 // Shorter log pattern suitable for use with systemd,
+                 // avoids redundant information
+-                // "pattern": "%-5p %m\n"
++                "pattern": "%-5p %m\n"
+ 
+                 // This governs whether the log output is flushed to disk after
+                 // every write.

--- a/app-network/kea/autobuild/postinst
+++ b/app-network/kea/autobuild/postinst
@@ -1,0 +1,5 @@
+echo "Setting up kea group and user ..."
+systemd-sysusers kea.conf
+
+echo "Setting up kea runtime directory ..."
+systemd-tmpfiles --create kea.conf

--- a/app-network/kea/spec
+++ b/app-network/kea/spec
@@ -1,0 +1,4 @@
+VER=2.6.1
+SRCS="tbl::https://ftp.isc.org/isc/kea/${VER}/kea-${VER}.tar.gz"
+CHKSUMS="sha256::d2ce14a91c2e248ad2876e29152d647bcc5e433bc68dafad0ee96ec166fcfad1"
+CHKUPDATE="anitya::id=12915"

--- a/runtime-common/log4cplus/autobuild/defines
+++ b/runtime-common/log4cplus/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=log4cplus
+PKGSEC=libs
+PKGDES="C++ logging API modeled after the Java log4j API"
+BUILDDEP="doxygen"

--- a/runtime-common/log4cplus/spec
+++ b/runtime-common/log4cplus/spec
@@ -1,0 +1,4 @@
+VER=2.1.2
+SRCS="tbl::https://github.com/log4cplus/log4cplus/releases/download/REL_${VER//./_}/log4cplus-${VER}.tar.xz"
+CHKSUMS="sha512::d6285e4964e8eda072b61e0585d5fe08c1d942b688752baf75ba230d49691070156ab4da1803d82d0c09128bcb87e21910e38ee9441df13ff762d527fe431444"
+CHKUPDATE="anitya::id=1835"


### PR DESCRIPTION
Topic Description
-----------------

- kea: 2.6.1 new
    ISC DHCP Server Kea with dependency log4cplus
    Built with openssl instead of botan

Package(s) Affected
-------------------

- kea: 2.6.1
- log4cplus: 2.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit log4cplus kea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
