### PR TITLE
libheif: update to 1.19.5

### DIFF
--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,5 +1,4 @@
-VER=1.17.6
-REL=2
+VER=1.19.5
 SRCS="tbl::https://github.com/strukturag/libheif/releases/download/v${VER}/libheif-${VER}.tar.gz"
-CHKSUMS="sha256::8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee"
+CHKSUMS="sha256::d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf"
 CHKUPDATE="anitya::id=64439"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: update to 1.19.5
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- libheif: 1.19.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libheif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
