### PR TITLE
fcitx5-pinyin-moegirl: update to 20250209

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20241211
+VER=20250209
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::c89610ff31c51f67538e464c1f868cd54e910cd1a58e097c881dc4ab953063d4 \
-         sha256::9806b6b1e22a07312023032891f53797203f1b0c03541be35dac778b697eaa6f \
+CHKSUMS="sha256::f84217048bb7384e7d5699c059a96688da83e05b2fb92811afbf4e402aab80c0 \
+         sha256::f4d94e2fad4a29c43d4e7a3d68dbf34cf861a9027f5e39db64a48b797c350fd0 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250209

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250209
- rime-pinyin-moegirl: 20250209

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
