### PR TITLE
poppler: update to 25.02.0

### DIFF
--- a/app-creativity/inkscape/autobuild/patches/0001-Fix-building-with-poppler-24.12.0.patch
+++ b/app-creativity/inkscape/autobuild/patches/0001-Fix-building-with-poppler-24.12.0.patch
@@ -1,7 +1,7 @@
 From 77cfb71e1590ab83d99bf5132daf98d3744007d7 Mon Sep 17 00:00:00 2001
 From: KrIr17 <elendil.krir17@gmail.com>
 Date: Fri, 6 Dec 2024 12:11:19 +0000
-Subject: [PATCH 1/3] Fix building with poppler 24.12.0
+Subject: [PATCH 1/4] Fix building with poppler 24.12.0
 
 Fixes https://gitlab.com/inkscape/inkscape/-/issues/5415
 

--- a/app-creativity/inkscape/autobuild/patches/0002-Future-proof-against-poppler-24.10-changes.patch
+++ b/app-creativity/inkscape/autobuild/patches/0002-Future-proof-against-poppler-24.10-changes.patch
@@ -1,7 +1,7 @@
 From 91c8c1bc53111837164dcbb73926309321ddcce4 Mon Sep 17 00:00:00 2001
 From: PBS <pbs3141@gmail.com>
 Date: Tue, 22 Oct 2024 14:48:31 +0100
-Subject: [PATCH 2/3] Future-proof against poppler 24.10 changes
+Subject: [PATCH 2/4] Future-proof against poppler 24.10 changes
 
 ---
  .../internal/pdfinput/pdf-parser.cpp          | 120 ++++++++----------

--- a/app-creativity/inkscape/autobuild/patches/0003-Fix-building-with-Poppler-24.11.patch
+++ b/app-creativity/inkscape/autobuild/patches/0003-Fix-building-with-Poppler-24.11.patch
@@ -1,7 +1,7 @@
 From 499c87f86ccbd0bfb93c95d8e8f1bda11ae9044b Mon Sep 17 00:00:00 2001
 From: KrIr17 <elendil.krir17@gmail.com>
 Date: Tue, 5 Nov 2024 00:40:15 +0100
-Subject: [PATCH 3/3] Fix building with Poppler 24.11
+Subject: [PATCH 3/4] Fix building with Poppler 24.11
 
 Poppler 24.11 no longer sets the default value for faceIndex to 0 in
 `FoFiTrueType::make()` and `FoFiTrueType::load()` [1], so we do it

--- a/app-creativity/inkscape/autobuild/patches/0004-Fix-building-with-poppler-25.02.0.patch
+++ b/app-creativity/inkscape/autobuild/patches/0004-Fix-building-with-poppler-25.02.0.patch
@@ -1,0 +1,179 @@
+From ab3f27ed3dcd2a1a219e1edc5eeec77aadfb89fd Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Sun, 9 Feb 2025 18:35:50 +0530
+Subject: [PATCH 4/4] Fix building with poppler 25.02.0
+
+1. `getCodeToGIDMap`, `getCIDToGID`, `getCIDToGIDMap` are now `std::vector`
+
+2. `pdfDocEncodingToUTF16` returns an `std::string`
+---
+ .../pdfinput/poppler-cairo-font-engine.cpp    | 49 ++++++++++++++++---
+ .../pdfinput/poppler-transition-api.h         | 22 ++++++---
+ 2 files changed, 57 insertions(+), 14 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+index 02c55fda58..245c39bfbf 100644
+--- a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
++++ b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+@@ -407,13 +407,21 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             break;
+         case fontCIDType2:
+         case fontCIDType2OT:
++#if POPPLER_CHECK_VERSION(25,2,0)
++            if (!gfxcid->getCIDToGID().empty()) {
++#else
+             if (gfxcid->getCIDToGID()) {
+                 n = gfxcid->getCIDToGIDLen();
+                 if (n) {
+-                    const int *src = gfxcid->getCIDToGID();
++#endif
++                    const auto src = gfxcid->getCIDToGID();
++#if POPPLER_CHECK_VERSION(25,2,0)
++                    codeToGID = std::move(src);
++#else
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                 }
++#endif
+             } else {
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+                 std::unique_ptr<FoFiTrueType> ff;
+@@ -429,13 +437,18 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     goto err2;
+                 }
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+-                int *src = gfxcid->getCodeToGIDMap(ff.get(), &n);
++                auto src = gfxcid->_POPPLER_GET_CODE_TO_GID_MAP(ff.get(), &n);
+ #else
+-                int *src = gfxcid->getCodeToGIDMap(ff, &n);
++                auto src = gfxcid->_POPPLER_GET_CODE_TO_GID_MAP(ff, &n);
+ #endif
++
++#if POPPLER_CHECK_VERSION(25,2,0)
++                codeToGID = std::move(src);
++#else
+                 codeToGID.reserve(n);
+                 codeToGID.insert(codeToGID.begin(), src, src + n);
+                 gfree(src);
++#endif
+             }
+             /* Fall through */
+         case fontTrueType:
+@@ -457,13 +470,17 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             /* This might be set already for the CIDType2 case */
+             if (fontType == fontTrueType || fontType == fontTrueTypeOT) {
+ #if POPPLER_CHECK_VERSION(22, 1, 0)
+-                int *src = gfx8bit->getCodeToGIDMap(ff.get());
++                auto src = gfx8bit->getCodeToGIDMap(ff.get());
+ #else
+-                int *src = gfx8bit->getCodeToGIDMap(ff);
++                auto src = gfx8bit->getCodeToGIDMap(ff);
+ #endif
++#if POPPLER_CHECK_VERSION(25,2,0)
++                codeToGID = std::move(src);
++#else
+                 codeToGID.reserve(256);
+                 codeToGID.insert(codeToGID.begin(), src, src + 256);
+                 gfree(src);
++#endif
+             }
+             font_face = getFreeTypeFontFace(fontEngine, lib, fileName, std::move(font_data));
+             if (!font_face) {
+@@ -481,10 +498,14 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     ff1c = FoFiType1C::load(fileName.c_str());
+                 }
+                 if (ff1c) {
+-                    int *src = ff1c->getCIDToGIDMap(&n);
++                    auto src = ff1c->_POPPLER_GET_CID_TO_GID_MAP(&n);
++#if POPPLER_CHECK_VERSION(25,2,0)
++                    codeToGID = std::move(src);
++#else
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                     gfree(src);
++#endif
+                     delete ff1c;
+                 }
+             }
+@@ -497,13 +518,21 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+             break;
+ 
+         case fontCIDType0COT:
++#if POPPLER_CHECK_VERSION(25,2,0)
++            if (!gfxcid->getCIDToGID().empty()) {
++#else
+             if (gfxcid->getCIDToGID()) {
+                 n = gfxcid->getCIDToGIDLen();
+                 if (n) {
+-                    const int *src = gfxcid->getCIDToGID();
++#endif
++                    const auto src = gfxcid->getCIDToGID();
++#if POPPLER_CHECK_VERSION(25,2,0)
++                    codeToGID = std::move(src);
++#else
+                     codeToGID.reserve(n);
+                     codeToGID.insert(codeToGID.begin(), src, src + n);
+                 }
++#endif
+             }
+ 
+             if (codeToGID.empty()) {
+@@ -520,10 +549,14 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                     }
+                     if (ff) {
+                         if (ff->isOpenTypeCFF()) {
+-                            int *src = ff->getCIDToGIDMap(&n);
++                            auto src = ff1c->_POPPLER_GET_CID_TO_GID_MAP(&n);
++#if POPPLER_CHECK_VERSION(25,2,0)
++                            codeToGID = std::move(src);
++#else
+                             codeToGID.reserve(n);
+                             codeToGID.insert(codeToGID.begin(), src, src + n);
+                             gfree(src);
++#endif
+                         }
+                     }
+                 }
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index b7a54828e7..6f8c8e246f 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,22 @@
+ #include <glib/poppler-features.h>
+ #include <poppler/UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(25,2,0)
++#define _POPPLER_GET_CODE_TO_GID_MAP(ff, len) getCodeToGIDMap(ff)
++#define _POPPLER_GET_CID_TO_GID_MAP(len) getCIDToGIDMap()
++#define _POPPLER_PDF_DOC_ENCODING_TO_UTF16(str, strlen) pdfDocEncodingToUTF16(str).c_str()
++#else
++#define _POPPLER_GET_CODE_TO_GID_MAP(ff, len) getCodeToGIDMap(ff, len)
++#define _POPPLER_GET_CID_TO_GID_MAP(len) getCIDToGIDMap(len)
++#define _POPPLER_PDF_DOC_ENCODING_TO_UTF16(str, strlen) pdfDocEncodingToUTF16(str, strlen)
++#endif
++
++#if POPPLER_CHECK_VERSION(24,12,0)
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode, hasAlpha)
++#else
++#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode)
++#endif
++
+ #if POPPLER_CHECK_VERSION(24, 10, 0)
+ #define _POPPLER_CONSUME_UNIQPTR_ARG(value) std::move(value)
+ #else
+@@ -39,12 +55,6 @@
+ #define _POPPLER_FUNCTION_TYPE_STITCHING 3
+ #endif
+ 
+-#if POPPLER_CHECK_VERSION(24,12,0)
+-#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode, hasAlpha)
+-#else
+-#define _POPPLER_GET_IMAGE_PARAMS(bits, csMode, hasAlpha) getImageParams(bits, csMode)
+-#endif
+-
+ #if POPPLER_CHECK_VERSION(22, 4, 0)
+ #define _POPPLER_FONTPTR_TO_GFX8(font_ptr) ((Gfx8BitFont *)font_ptr.get())
+ #else
+-- 
+2.48.1
+

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,5 +1,5 @@
 VER=1.4
-REL=1
+REL=2
 SRCS="git::commit=tags/INKSCAPE_${VER//./_}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,5 @@
 VER=25.2.0.3
+REL=1
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-productivity/scribus/autobuild/patches/0001-scribus-poppler-25.02.0.patch
+++ b/app-productivity/scribus/autobuild/patches/0001-scribus-poppler-25.02.0.patch
@@ -1,0 +1,169 @@
+diff '--color=auto' -ruN scribus-1.6.3/scribus/plugins/import/pdf/importpdfconfig.h scribus-1.6.3-fixed/scribus/plugins/import/pdf/importpdfconfig.h
+--- scribus-1.6.3/scribus/plugins/import/pdf/importpdfconfig.h	2025-01-07 15:06:55.000000000 -0800
++++ scribus-1.6.3-fixed/scribus/plugins/import/pdf/importpdfconfig.h	2025-02-11 10:04:45.057629209 -0800
+@@ -15,6 +15,12 @@
+ 	+ ((micro) *     1))
+ #define POPPLER_ENCODED_VERSION POPPLER_VERSION_ENCODE(POPPLER_VERSION_MAJOR, POPPLER_VERSION_MINOR, POPPLER_VERSION_MICRO)
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++#define POPPLER_CONST_252 const
++#else
++#define POPPLER_CONST_252
++#endif
++
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(0, 82, 0)
+ #define POPPLER_CONST_082 const
+ #else
+diff '--color=auto' -ruN scribus-1.6.3/scribus/plugins/import/pdf/importpdf.cpp scribus-1.6.3-fixed/scribus/plugins/import/pdf/importpdf.cpp
+--- scribus-1.6.3/scribus/plugins/import/pdf/importpdf.cpp	2025-01-07 15:06:55.000000000 -0800
++++ scribus-1.6.3-fixed/scribus/plugins/import/pdf/importpdf.cpp	2025-02-11 10:09:26.868412744 -0800
+@@ -462,11 +462,11 @@
+ 
+ 			if (dev->isOk())
+ 			{
+-				OCGs* ocg = pdfDoc->getOptContentConfig();
++				POPPLER_CONST_252 OCGs* ocg = pdfDoc->getOptContentConfig();
+ 				if (ocg && ocg->hasOCGs())
+ 				{
+ 					QStringList ocgNames;
+-					Array *order = ocg->getOrderArray();
++					POPPLER_CONST_252 Array *order = ocg->getOrderArray();
+ 					if (order)
+ 					{
+ 						for (int i = 0; i < order->getLength (); ++i)
+diff '--color=auto' -ruN scribus-1.6.3/scribus/plugins/import/pdf/slaoutput.cpp scribus-1.6.3-fixed/scribus/plugins/import/pdf/slaoutput.cpp
+--- scribus-1.6.3/scribus/plugins/import/pdf/slaoutput.cpp	2025-01-07 15:06:55.000000000 -0800
++++ scribus-1.6.3-fixed/scribus/plugins/import/pdf/slaoutput.cpp	2025-02-11 10:12:01.229658576 -0800
+@@ -2932,7 +2932,7 @@
+ 	{
+ 		if (dictRef->isNull())
+ 			return;
+-		OCGs *contentConfig = m_catalog->getOptContentConfig();
++		POPPLER_CONST_252 OCGs *contentConfig = m_catalog->getOptContentConfig();
+ 		OptionalContentGroup *oc;
+ 		if (dictRef->isRef())
+ 		{
+@@ -3084,7 +3084,11 @@
+ #if POPPLER_ENCODED_VERSION < POPPLER_VERSION_ENCODE(22, 4, 0)
+ 	int tmpBufLen = 0;
+ #endif
++#if POPPLER_ENCODED_VERSION < POPPLER_VERSION_ENCODE(25, 2, 0)
+ 	int *codeToGID = nullptr;
++#else
++	std::vector<int> codeToGID;
++#endif
+ 	const double *textMat = nullptr;
+ 	double m11, m12, m21, m22, fontSize;
+ 	SplashCoord mat[4] = { 1.0, 0.0, 0.0, 1.0 };
+@@ -3244,10 +3248,20 @@
+ 			}
+ 			else
+ 			{
++#if POPPLER_ENCODED_VERSION < POPPLER_VERSION_ENCODE(25, 2, 0)
+ 				codeToGID = nullptr;
++#else
++				codeToGID.clear();
++#endif
+ 				n = 0;
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
+@@ -3278,6 +3292,18 @@
+ #endif
+ 			break;
+ 		case fontCIDType0COT:
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (((GfxCIDFont *) gfxFont)->getCIDToGIDLen() > 0)
++			{
++				n = ((GfxCIDFont *) gfxFont)->getCIDToGIDLen();
++				codeToGID = ((GfxCIDFont *) gfxFont)->getCIDToGID();
++			}
++			else
++			{
++				codeToGID.clear();
++				n = 0;
++			}
++#else
+ 			if (((GfxCIDFont *) gfxFont)->getCIDToGID())
+ 			{
+ 				n = ((GfxCIDFont *) gfxFont)->getCIDToGIDLen();
+@@ -3289,7 +3315,15 @@
+ 				codeToGID = nullptr;
+ 				n = 0;
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#endif
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadOpenTypeCFFFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'",
++					gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadOpenTypeCFFFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'",
+@@ -3307,6 +3341,18 @@
+ 			break;
+ 		case fontCIDType2:
+ 		case fontCIDType2OT:
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			codeToGID.clear();
++			n = 0;
++			if (((GfxCIDFont *) gfxFont)->getCIDToGIDLen() > 0)
++			{
++				n = ((GfxCIDFont *) gfxFont)->getCIDToGIDLen();
++				if (n)
++				{
++					codeToGID = ((GfxCIDFont *)gfxFont)->getCIDToGID();
++				}
++			}
++#else
+ 			codeToGID = nullptr;
+ 			n = 0;
+ 			if (((GfxCIDFont *) gfxFont)->getCIDToGID())
+@@ -3318,6 +3364,7 @@
+ 					memcpy(codeToGID, ((GfxCIDFont *)gfxFont)->getCIDToGID(), n * sizeof(*codeToGID));
+ 				}
+ 			}
++#endif
+ 			else
+ 			{
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+@@ -3338,7 +3385,10 @@
+ #endif
+ 				if (! ff)
+ 					goto err2;
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 2, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++				codeToGID = ((GfxCIDFont*) gfxFont)->getCodeToGIDMap(ff.get());
++				ff.reset();
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 2, 0)
+ 				codeToGID = ((GfxCIDFont*) gfxFont)->getCodeToGIDMap(ff.get(), &n);
+ 				ff.reset();
+ #else
+@@ -3346,7 +3396,13 @@
+ 				delete ff;
+ #endif
+ 			}
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 2, 0)
++			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, std::move(codeToGID), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 11, 0)
+ 			if (!(fontFile = m_fontEngine->loadTrueTypeFont(std::move(id), fontsrc, codeToGID, n, fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,4 +1,5 @@
 VER=1.6.3
+REL=1
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::0ae58ced410101e82655e3b4c20a070cf1767145ada233dcef7c20b8ba6bd487"
 CHKUPDATE="anitya::id=4773"

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=3
+REL=4
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/koffice-trinity/spec
+++ b/desktop-trinity/koffice-trinity/spec
@@ -5,4 +5,4 @@ CHKSUMS="sha256::06aa9488747a3c92a68d6a057b9bd238251465b21afc74c3c0d3faad85f58fe
          sha256::0e3d99fee00cdf3c257166dacc5c8679ad7418c8e8f22d6d71f4a5e67014387e"
 CHKUPDATE="anitya::id=16065"
 SUBDIR="koffice-trinity-$VER"
-REL=2
+REL=3

--- a/desktop-trinity/tdegraphics/spec
+++ b/desktop-trinity/tdegraphics/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=1
+REL=2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdegraphics-trinity-$VER.tar.xz"
 CHKSUMS="sha256::8771c5c80156dd2a3747f2138d98c6a2d63fe11dc008d52022293946dd4ebe2f"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-doc/poppler/autobuild/defines
+++ b/runtime-doc/poppler/autobuild/defines
@@ -21,13 +21,13 @@ CMAKE_AFTER__RETRO=" \
              -DENABLE_GTK_DOC=OFF"
 
 PKGBREAK="atril<=1.28.1 cantor<=23.08.5 evince<=42.3-1 \
-          gdal<=3.8.4-3 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
-          graphviz<=12.2.1 inkscape<=1.4 kfilemetadata<=5.115.0-1 \
-          kitinerary<=23.08.5-2 koffice-trinity<=14.1.2-1 krita<=5.2.2-1 \
-          libcupsfilters<=2.0.0-1 libreoffice<=24.8.4.2 okular<=23.08.5-2 \
+          gdal<=3.10.1 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
+          graphviz<=12.2.1 inkscape<=1.4-1 kfilemetadata<=5.115.0-1 \
+          kitinerary<=23.08.5-3 koffice-trinity<=14.1.2-2 krita<=5.2.2-1 \
+          libcupsfilters<=2.0.0-1 libreoffice<=25.2.0.3 okular<=23.08.5-2 \
           openscenegraph<=3:3.6.5-4 pdfgrep<=2.1.2-4 \
           python-poppler-qt5<=21.1.0+git20210304-3 rnote<=0.11.0 \
-          sane-backends<=1.0.32-2 scribus<=1.6.1-2 tdegraphics<=14.1.2 \
+          sane-backends<=1.0.32-2 scribus<=1.6.3 tdegraphics<=14.1.2-1 \
           texstudio<=4.0.2-4 texworks<=0.6.6-4 tracker-miners<=3.3.1-3 \
           tumbler<=4.20.0 xournalpp<=1.2.5 xreader<=4.2.2 \
           zathura-pdf-poppler<=0.3.3"

--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -1,4 +1,4 @@
-VER=25.01.0
+VER=25.02.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
-CHKSUMS="sha256::7eefc122207bbbd72a303c5e0743f4941e8ae861e24dcf0501e18ce1d1414112"
+CHKSUMS="sha256::21234cb2a9647d73c752ce4031e65a79d11a511a835f2798284c2497b8701dee"
 CHKUPDATE="anitya::id=3686"

--- a/runtime-gis/gdal/autobuild/patches/0001-Build-fix-build-against-Poppler-25.02.00.patch
+++ b/runtime-gis/gdal/autobuild/patches/0001-Build-fix-build-against-Poppler-25.02.00.patch
@@ -1,0 +1,256 @@
+From 0cd9e2defad907f08f2eb71ff9d57dfbdc8a4849 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 10 Feb 2025 21:07:30 -0800
+Subject: [PATCH] Build: fix build against Poppler 25.02.00
+
+Upstream commit: f6d4e0608dabfd4f2712172bdb604996178eb744
+
+Kaiyang Wu: Resolved merge conflicts with tarball release by removing changes to
+`autotest/gdrivers/pdf.py` which does not exist in the tarball release
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ frmts/pdf/pdfdataset.cpp           | 41 ++++++++++++++++++++++++++----
+ frmts/pdf/pdfio.cpp                | 17 +++++++++++++
+ frmts/pdf/pdfio.h                  | 12 +++++++++
+ frmts/pdf/pdfobject.cpp            |  6 ++---
+ frmts/pdf/pdfobject.h              |  2 +-
+ frmts/pdf/pdfsdk_headers_poppler.h |  9 +++++--
+ 6 files changed, 76 insertions(+), 11 deletions(-)
+
+diff --git a/frmts/pdf/pdfdataset.cpp b/frmts/pdf/pdfdataset.cpp
+index cb57e2a967..d6d0af9181 100644
+--- a/frmts/pdf/pdfdataset.cpp
++++ b/frmts/pdf/pdfdataset.cpp
+@@ -1964,6 +1964,14 @@ CPLErr PDFDataset::ReadPixels(int nReqXOff, int nReqYOff, int nReqXSize,
+         PDFDoc *poDoc = m_poDocPoppler;
+         poSplashOut->startDoc(poDoc);
+ 
++        // Note: Poppler 25.2 is certainly not the lowest version where we can
++        // avoid the hack.
++#if !(POPPLER_MAJOR_VERSION > 25 ||                                            \
++      (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2))
++#define USE_OPTCONTENT_HACK
++#endif
++
++#ifdef USE_OPTCONTENT_HACK
+         /* EVIL: we modify a private member... */
+         /* poppler (at least 0.12 and 0.14 versions) don't render correctly */
+         /* some PDFs and display an error message 'Could not find a OCG with
+@@ -1978,6 +1986,7 @@ CPLErr PDFDataset::ReadPixels(int nReqXOff, int nReqYOff, int nReqXSize,
+         OCGs *poOldOCGs = poCatalog->optContent;
+         if (!m_bUseOCG)
+             poCatalog->optContent = nullptr;
++#endif
+         try
+         {
+             poDoc->displayPageSlice(poSplashOut, m_iPage, m_dfDPI, m_dfDPI, 0,
+@@ -1988,14 +1997,19 @@ CPLErr PDFDataset::ReadPixels(int nReqXOff, int nReqYOff, int nReqXSize,
+         {
+             CPLError(CE_Failure, CPLE_AppDefined,
+                      "PDFDoc::displayPageSlice() failed with %s", e.what());
++
++#ifdef USE_OPTCONTENT_HACK
+             /* Restore back */
+             poCatalog->optContent = poOldOCGs;
++#endif
+             delete poSplashOut;
+             return CE_Failure;
+         }
+ 
++#ifdef USE_OPTCONTENT_HACK
+         /* Restore back */
+         poCatalog->optContent = poOldOCGs;
++#endif
+ 
+         SplashBitmap *poBitmap = poSplashOut->getBitmap();
+         if (poBitmap->getWidth() != nReqXSize ||
+@@ -3734,9 +3748,14 @@ void PDFDataset::ExploreLayersPoppler(GDALPDFArray *poArray,
+                 }
+                 else
+                     osCurLayer = std::move(osName);
+-                // CPLDebug("PDF", "Layer %s", osCurLayer.c_str());
++                    // CPLDebug("PDF", "Layer %s", osCurLayer.c_str());
+ 
+-                OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++                const
++#endif
++                    OCGs *optContentConfig =
++                        m_poDocPoppler->getOptContentConfig();
+                 struct Ref r;
+                 r.num = poObj->GetRefNum().toInt();
+                 r.gen = poObj->GetRefGen();
+@@ -3772,11 +3791,19 @@ void PDFDataset::FindLayersPoppler(int iPageOfInterest)
+     if (poPages)
+         nPageCount = poPages->GetLength();
+ 
+-    OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++    const
++#endif
++        OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
+     if (optContentConfig == nullptr || !optContentConfig->isOk())
+         return;
+ 
+-    Array *array = optContentConfig->getOrderArray();
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++    const
++#endif
++        Array *array = optContentConfig->getOrderArray();
+     if (array)
+     {
+         GDALPDFArray *poArray = GDALPDFCreateArray(array);
+@@ -3812,7 +3839,11 @@ void PDFDataset::FindLayersPoppler(int iPageOfInterest)
+ 
+ void PDFDataset::TurnLayersOnOffPoppler()
+ {
+-    OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++    const
++#endif
++        OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
+     if (optContentConfig == nullptr || !optContentConfig->isOk())
+         return;
+ 
+diff --git a/frmts/pdf/pdfio.cpp b/frmts/pdf/pdfio.cpp
+index bb5a5da2c8..40de797c8d 100644
+--- a/frmts/pdf/pdfio.cpp
++++ b/frmts/pdf/pdfio.cpp
+@@ -237,23 +237,40 @@ int VSIPDFFileStream::lookChar()
+ /*                                reset()                               */
+ /************************************************************************/
+ 
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++bool VSIPDFFileStream::reset()
++#else
+ void VSIPDFFileStream::reset()
++#endif
+ {
+     nSavedPos = VSIFTellL(f);
+     bHasSavedPos = TRUE;
+     VSIFSeekL(f, nCurrentPos = nStart, SEEK_SET);
+     nPosInBuffer = -1;
+     nBufferLength = -1;
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++    return true;
++#endif
+ }
+ 
+ /************************************************************************/
+ /*                         unfilteredReset()                            */
+ /************************************************************************/
+ 
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION > 2)
++bool VSIPDFFileStream::unfilteredReset()
++{
++    return reset();
++}
++#else
+ void VSIPDFFileStream::unfilteredReset()
+ {
+     reset();
+ }
++#endif
+ 
+ /************************************************************************/
+ /*                                close()                               */
+diff --git a/frmts/pdf/pdfio.h b/frmts/pdf/pdfio.h
+index d942b41626..5f7234dc08 100644
+--- a/frmts/pdf/pdfio.h
++++ b/frmts/pdf/pdfio.h
+@@ -48,8 +48,20 @@ class VSIPDFFileStream final : public BaseStream
+     virtual int getUnfilteredChar() override;
+     virtual int lookChar() override;
+ 
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++    virtual bool reset() override;
++#else
+     virtual void reset() override;
++#endif
++
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION > 2)
++    virtual bool unfilteredReset() override;
++#else
+     virtual void unfilteredReset() override;
++#endif
++
+     virtual void close() override;
+ 
+     bool FoundLinearizedHint() const
+diff --git a/frmts/pdf/pdfobject.cpp b/frmts/pdf/pdfobject.cpp
+index 9b04668946..38690b7c90 100644
+--- a/frmts/pdf/pdfobject.cpp
++++ b/frmts/pdf/pdfobject.cpp
+@@ -979,13 +979,13 @@ class GDALPDFDictionaryPoppler : public GDALPDFDictionary
+ class GDALPDFArrayPoppler : public GDALPDFArray
+ {
+   private:
+-    Array *m_poArray;
++    const Array *m_poArray;
+     std::vector<std::unique_ptr<GDALPDFObject>> m_v{};
+ 
+     CPL_DISALLOW_COPY_ASSIGN(GDALPDFArrayPoppler)
+ 
+   public:
+-    GDALPDFArrayPoppler(Array *poArray) : m_poArray(poArray)
++    GDALPDFArrayPoppler(const Array *poArray) : m_poArray(poArray)
+     {
+     }
+ 
+@@ -1334,7 +1334,7 @@ std::map<CPLString, GDALPDFObject *> &GDALPDFDictionaryPoppler::GetValues()
+ /*                           GDALPDFCreateArray()                       */
+ /************************************************************************/
+ 
+-GDALPDFArray *GDALPDFCreateArray(Array *array)
++GDALPDFArray *GDALPDFCreateArray(const Array *array)
+ {
+     return new GDALPDFArrayPoppler(array);
+ }
+diff --git a/frmts/pdf/pdfobject.h b/frmts/pdf/pdfobject.h
+index 73c3a27740..6f0ecf532b 100644
+--- a/frmts/pdf/pdfobject.h
++++ b/frmts/pdf/pdfobject.h
+@@ -405,7 +405,7 @@ class GDALPDFObjectPoppler : public GDALPDFObject
+     virtual int GetRefGen() override;
+ };
+ 
+-GDALPDFArray *GDALPDFCreateArray(Array *array);
++GDALPDFArray *GDALPDFCreateArray(const Array *array);
+ 
+ #endif  // HAVE_POPPLER
+ 
+diff --git a/frmts/pdf/pdfsdk_headers_poppler.h b/frmts/pdf/pdfsdk_headers_poppler.h
+index d2a3a449d1..fcb56e3343 100644
+--- a/frmts/pdf/pdfsdk_headers_poppler.h
++++ b/frmts/pdf/pdfsdk_headers_poppler.h
+@@ -51,10 +51,15 @@
+ 
+ #include <Dict.h>
+ 
+-#define private                                                                \
+-    public /* Ugly! Catalog::optContent is private but we need it... */
++#if POPPLER_MAJOR_VERSION > 25 ||                                              \
++    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 2)
++#include <Catalog.h>
++#else
++/* Ugly! Catalog::optContent is private but we need it for ancient Poppler versions. */
++#define private public
+ #include <Catalog.h>
+ #undef private
++#endif
+ 
+ #define private public /* Ugly! PDFDoc::str is private but we need it... */
+ #include <PDFDoc.h>
+-- 
+2.48.1
+

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,4 +1,5 @@
 VER=3.10.1
+REL=1
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::9211eac72b53f5f85d23cf6d83ee20245c6d818733405024e71f2af41e5c5f91"
 CHKUPDATE="anitya::id=881"


### PR DESCRIPTION
Topic Description
-----------------

- poppler: update to 25.02.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- poppler: 1:25.02.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit poppler:-pkgbreak gdal inkscape kitinerary tdegraphics koffice-trinity libreoffice scribus poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
