### PR TITLE
dracut-ng: rework firmware symlink fix-up routine

### DIFF
--- a/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-strip-out-unused-unlikely-AMDGPU-firmw.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-strip-out-unused-unlikely-AMDGPU-firmw.patch
@@ -1,4 +1,4 @@
-From ed8d35a171f5331c5be5a594a9ba1c959f8b1e4f Mon Sep 17 00:00:00 2001
+From 239a81469f41f5b816126e70fef53b9b605fa413 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 05:00:38 +0800
 Subject: [PATCH 4/5] FROMLIST: feat: strip out unused/unlikely AMDGPU firmware

--- a/app-admin/dracut-ng/autobuild/patches/0005-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
@@ -1,4 +1,4 @@
-From 9e746abf44a5905d75b834dfbb14cc93bd436fc9 Mon Sep 17 00:00:00 2001
+From 80ded534c52b1e7dba6c78d8a0c716bf590fdd81 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:58:49 +0800
 Subject: [PATCH 5/5] FROMLIST: feat: decompress kernel modules and firmware
@@ -16,14 +16,14 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 48 insertions(+)
 
 diff --git a/dracut-init.sh b/dracut-init.sh
-index 84dbda24..cd620377 100755
+index 84dbda24..e1a9f8c5 100755
 --- a/dracut-init.sh
 +++ b/dracut-init.sh
 @@ -1093,6 +1093,54 @@ dracut_kernel_post() {
          fi
      fi
  
-+    # Check for the necessary if(1) command for post-processing.
++    # Check for the necessary find(1) command for post-processing.
 +    if ! find_binary find &> /dev/null; then
 +        derror "Will not process kernel modules and firmware as find(1) is not available!"
 +        return 1
@@ -68,7 +68,7 @@ index 84dbda24..cd620377 100755
 +            ddebug "Fixing up decompressed firmware: $fwlink ..."
 +            fwtarget=$(readlink "$fwlink")
 +            rm "$fwlink"
-+            ln -s "${fwtarget%.*}" "${fwlink%.*}" && break
++            ln -s "${fwtarget%.*}" "${fwlink%.*}"
 +        done
 +
      for _f in modules.builtin modules.builtin.alias modules.builtin.modinfo modules.order; do

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,5 @@
 VER=105
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: rework firmware symlink fix-up routine
    Track patches at AOSC-Tracking/dracut-ng @ aosc/105
    \(HEAD: 80ded534c52b1e7dba6c78d8a0c716bf590fdd81\).

Package(s) Affected
-------------------

- dracut-ng: 105-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
