### PR TITLE
dracut-ng: update to 106

### DIFF
--- a/app-admin/dracut-ng/autobuild/beyond
+++ b/app-admin/dracut-ng/autobuild/beyond
@@ -14,3 +14,6 @@ touch "$PKGDIR"/var/log/dracut.log
 
 abinfo "Dropping SUSE man pages ..."
 rm -fv "$PKGDIR"/usr/share/man?/*suse*
+
+abinfo "Creating a cache directory for initrd generation ..."
+mkdir -pv "$PKGDIR"/var/cache/dracut

--- a/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
@@ -5,6 +5,9 @@ if [ "$EUID" -ne 0 ]; then
 	exit
 fi
 
+# The return status of GNU parallel.
+parallel_status=0
+
 # $1 = single|parallel   - whether initrd generation is in parallel
 #      single   = print message at start
 #      parallel = print completion notice or error message
@@ -20,9 +23,11 @@ generate_initrd_if_needed() {
 		if [[ "$mode" == "parallel" ]]; then
 			if [[ $dracut_ret -eq 0 ]]; then
 				echo -e "Successfully generated initrd."
+				return 0
 			else
 				echo -e "\033[31mDracut returned non-zero exit code $dracut_ret.\033[0m"
 				echo -e "\033[31mSee messages for details.\033[0m"
+				return 1
 			fi
 		fi
 	else
@@ -31,8 +36,9 @@ generate_initrd_if_needed() {
 		else
 			echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $version ..."
 		fi
+		return 0
 	fi
-
+	return $dracut_ret
 }
 
 export -f generate_initrd_if_needed
@@ -45,9 +51,11 @@ if [ -x /usr/bin/dracut ]; then
 			echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for $(echo ${task_list} | wc -w) kernel versions ..."
 			parallel \
 				--tmpdir=/var/cache/dracut \
+				--halt-on-error soon,fail=1 \
 				--will-cite \
 				--tagstring '{=$_=$_ . " " x (20 - length($_))=}' \
 				generate_initrd_if_needed parallel ::: ${task_list}
+			parallel_status=$?
 		else
 			echo -e "\033[36m**\033[0m\tNo kernel module tree found, skipping generation."
 		fi
@@ -59,6 +67,11 @@ if [ -x /usr/bin/dracut ]; then
 	fi
 else
 	echo -e "\033[33m**\033[0m\tCommand \"dracut\" is not installed, skipping generation.\n\tYou may not be able to boot the new kernel on the next boot."
+fi
+
+if [ "x$parallel_status" != "x0" ] ; then
+	echo -e "\033[33m**\033[0m\tOne or more jobs have failed, aborting.\n\tSee the output above for details."
+	exit 1
 fi
 
 # Notify bootloader

--- a/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
@@ -43,7 +43,11 @@ if [ -x /usr/bin/dracut ]; then
 		task_list=$(ls /usr/lib/modules | grep -v 'extramodules')
 		if [[ "e$task_list" != "e" ]]; then
 			echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for $(echo ${task_list} | wc -w) kernel versions ..."
-			parallel --will-cite --tagstring '{=$_=$_ . " " x (20 - length($_))=}' generate_initrd_if_needed parallel ::: ${task_list}
+			parallel \
+				--tmpdir=/var/cache/dracut \
+				--will-cite \
+				--tagstring '{=$_=$_ . " " x (20 - length($_))=}' \
+				generate_initrd_if_needed parallel ::: ${task_list}
 		else
 			echo -e "\033[36m**\033[0m\tNo kernel module tree found, skipping generation."
 		fi

--- a/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
@@ -1,7 +1,7 @@
-From 8ed9f8f36ca23a29db0849767d5f482ae07c1b1c Mon Sep 17 00:00:00 2001
+From 8cd77cbba30818b6322fb2b811adac7c45f75574 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 23 Jan 2025 11:45:36 +0800
-Subject: [PATCH 1/5] AOSCOS: LOONGSON3: 50drm: limit DRM module installation
+Subject: [PATCH 1/7] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
  to amdgpu, loongson, and radeon
 
 If we are using mips64el (assumed to be MIPS-based Loongson), only install
@@ -11,13 +11,13 @@ initramfs so that it fits within the RAM allocated by the system firmware.
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- modules.d/50drm/module-setup.sh | 23 ++++++++++++++++++-----
+ modules.d/45drm/module-setup.sh | 23 ++++++++++++++++++-----
  1 file changed, 18 insertions(+), 5 deletions(-)
 
-diff --git a/modules.d/50drm/module-setup.sh b/modules.d/50drm/module-setup.sh
+diff --git a/modules.d/45drm/module-setup.sh b/modules.d/45drm/module-setup.sh
 index 8e52f111..46e029eb 100755
---- a/modules.d/50drm/module-setup.sh
-+++ b/modules.d/50drm/module-setup.sh
+--- a/modules.d/45drm/module-setup.sh
++++ b/modules.d/45drm/module-setup.sh
 @@ -18,7 +18,11 @@ installkernel() {
              "=drivers/video/backlight"
      fi

--- a/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-01systemd-crypsetup-remove-TPM2-dep.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-01systemd-crypsetup-remove-TPM2-dep.patch
@@ -1,7 +1,7 @@
-From da6805b1a1cf30fe48b350858ebd9d82ee1adf45 Mon Sep 17 00:00:00 2001
+From 8dc6c00c8a000350ec91afe8d72a919fa10169df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:55:49 +0800
-Subject: [PATCH 2/5] AOSCOS: LOONGSON3: 01systemd-crypsetup: remove TPM2
+Subject: [PATCH 2/7] AOSCOS: LOONGSON3: 01systemd-crypsetup: remove TPM2
  dependency
 
 There is just no way that we will get TPM2 on MIPS-based Loongson 3
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/modules.d/01systemd-cryptsetup/module-setup.sh b/modules.d/01systemd-cryptsetup/module-setup.sh
-index 034d4ecf..00a59ff5 100755
+index 023c65d1..5c983923 100755
 --- a/modules.d/01systemd-cryptsetup/module-setup.sh
 +++ b/modules.d/01systemd-cryptsetup/module-setup.sh
 @@ -31,7 +31,13 @@ depends() {

--- a/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-90kernel-modules-minimise-default-k.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-90kernel-modules-minimise-default-k.patch
@@ -1,7 +1,7 @@
-From 06f1dc4052d9a08bcf923d50c260b1bd2bbe94f1 Mon Sep 17 00:00:00 2001
+From cb1920b94bbd616363b91a12e078cface9e1f2a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:56:34 +0800
-Subject: [PATCH 3/5] AOSCOS: LOONGSON3: 90kernel-modules: minimise default
+Subject: [PATCH 3/7] AOSCOS: LOONGSON3: 90kernel-modules: minimise default
  kernel drivers
 
 Make sure that only drivers that were likely needed at early-boot were

--- a/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-strip-out-unused-unlikely-AMDGPU-firmw.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-strip-out-unused-unlikely-AMDGPU-firmw.patch
@@ -1,7 +1,7 @@
-From 239a81469f41f5b816126e70fef53b9b605fa413 Mon Sep 17 00:00:00 2001
+From e2e9215303ca41255de1b98f48f372f6ef7ec4c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 05:00:38 +0800
-Subject: [PATCH 4/5] FROMLIST: feat: strip out unused/unlikely AMDGPU firmware
+Subject: [PATCH 4/7] FROMLIST: feat: strip out unused/unlikely AMDGPU firmware
 
 Introduce logic to remove unlikely or impossible firmware on a platform-
 specific basis to save space - this is the largest set of firmware in the
@@ -27,10 +27,10 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 64 insertions(+)
 
 diff --git a/dracut-init.sh b/dracut-init.sh
-index 1ce0d7ed..84dbda24 100755
+index be8eb9fb..2733937e 100755
 --- a/dracut-init.sh
 +++ b/dracut-init.sh
-@@ -1029,6 +1029,70 @@ for_each_module_dir() {
+@@ -985,6 +985,70 @@ for_each_module_dir() {
  dracut_kernel_post() {
      local dstdir="${dstdir:-"$initdir"}"
  

--- a/app-admin/dracut-ng/autobuild/patches/0005-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
@@ -1,7 +1,7 @@
-From 80ded534c52b1e7dba6c78d8a0c716bf590fdd81 Mon Sep 17 00:00:00 2001
+From 5b0d40b3ba279ba59e877b40a639db0f9efa0b15 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:58:49 +0800
-Subject: [PATCH 5/5] FROMLIST: feat: decompress kernel modules and firmware
+Subject: [PATCH 5/7] FROMLIST: feat: decompress kernel modules and firmware
  before final compression
 
 Decompress all kernel modules and firmware (if compressed), this allows
@@ -16,10 +16,10 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 48 insertions(+)
 
 diff --git a/dracut-init.sh b/dracut-init.sh
-index 84dbda24..e1a9f8c5 100755
+index 2733937e..c9b1e051 100755
 --- a/dracut-init.sh
 +++ b/dracut-init.sh
-@@ -1093,6 +1093,54 @@ dracut_kernel_post() {
+@@ -1049,6 +1049,54 @@ dracut_kernel_post() {
          fi
      fi
  

--- a/app-admin/dracut-ng/autobuild/patches/0006-fix-90kernel-modules-Explicitly-include-xhci-pci-ren.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0006-fix-90kernel-modules-Explicitly-include-xhci-pci-ren.patch
@@ -1,0 +1,88 @@
+From 45e22439e742f5a3cef0f5e430c5db010c56ad9a Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sat, 1 Mar 2025 00:54:31 +0800
+Subject: [PATCH 6/7] fix(90kernel-modules): Explicitly include
+ xhci-pci-renesas
+
+Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends
+on xhci-pci-renesas, causing the Renesas driver to be omitted during
+initramfs generation (when built as a module).
+
+This makes platforms with such xHCI controllers unavailable during
+initrd, and unable to boot from a USB drive. There are SuperSpeed ports
+routed through such controller on some platforms, too, which also
+renders the USB keyboard and mouse unusable.
+
+Here's a snippet of the kernel log from such platform, showing a
+keyboard and a mouse being detected only after the initrd switched root:
+
+[    9.352608] systemd-journald[187]: Received SIGTERM from PID 1 (systemd).
+[    9.500146] systemd[1]: systemd 257.2 running in system mode (OMITTED)
+...
+[   11.187756] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
+[   11.187870] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 7
+[   11.193261] xhci-pci-renesas 0000:04:00.0: hcc params 0x014051cf hci version 0x100 quirks 0x0000000100000010
+[   11.194806] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
+[   11.196601] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 8
+[   11.196613] xhci-pci-renesas 0000:04:00.0: Host supports USB 3.0 SuperSpeed
+[   11.196927] usb usb7: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.13
+[   11.196931] usb usb7: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[   11.196935] usb usb7: Product: xHCI Host Controller
+[   11.196938] usb usb7: Manufacturer: Linux 6.13.3-aosc-main xhci-hcd
+[   11.196941] usb usb7: SerialNumber: 0000:04:00.0
+[   11.199598] hub 7-0:1.0: USB hub found
+[   11.199630] hub 7-0:1.0: 4 ports detected
+...
+[   11.439561] usb 7-2: new high-speed USB device number 2 using xhci-pci-renesas
+[   11.568361] usb 7-2: New USB device found, idVendor=1532, idProduct=0114, bcdDevice= 1.00
+[   11.568369] usb 7-2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[   11.568372] usb 7-2: Product: DeathStalker Ultimate
+[   11.568376] usb 7-2: Manufacturer: Razer
+[   11.600474] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.0/0003:1532:0114.0001/input/input12
+[   11.600686] hid-generic 0003:1532:0114.0001: input,hidraw0: USB HID v1.11 Mouse [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input0
+[   11.601137] input: Razer DeathStalker Ultimate Keyboard as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input13
+[   11.652148] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input14
+[   11.652409] hid-generic 0003:1532:0114.0002: input,hidraw1: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input1
+[   11.653054] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.2/0003:1532:0114.0003/input/input15
+[   11.703768] hid-generic 0003:1532:0114.0003: input,hidraw2: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input2
+---
+ modules.d/90kernel-modules/module-setup.sh | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/modules.d/90kernel-modules/module-setup.sh b/modules.d/90kernel-modules/module-setup.sh
+index 4a04647b..5adb191d 100755
+--- a/modules.d/90kernel-modules/module-setup.sh
++++ b/modules.d/90kernel-modules/module-setup.sh
+@@ -49,13 +49,19 @@ installkernel() {
+         hostonly='' instmods \
+             hid_generic unix
+ 
++        # Explicitly include xhci-pci-renesas module.
++        # Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer
++        # depends on xhci-pci-renesas, causing the Renesas driver to be
++        # omitted during initramfs generation (when built as a module).
++        # This makes platforms with such xHCI controllers unavailable
++        # during initrd, and unable to boot from a USB drive.
+         if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
+             hostonly=$(optional_hostonly) instmods \
+                 ehci-hcd ehci-pci ehci-platform \
+                 ohci-hcd ohci-pci \
+                 uhci-hcd \
+                 usbhid \
+-                xhci-hcd xhci-pci xhci-plat-hcd \
++                xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
+                 "=drivers/hid" \
+                 "=drivers/tty/serial" \
+                 "=drivers/input/serio" \
+@@ -73,7 +79,7 @@ installkernel() {
+                 ohci-hcd ohci-pci \
+                 uhci-hcd \
+                 usbhid \
+-                xhci-hcd xhci-pci xhci-plat-hcd
++                xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd
+         fi
+ 
+         if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/autobuild/patches/0007-fix-systemd-sysusers-silence-Creating-on-stderr.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0007-fix-systemd-sysusers-silence-Creating-on-stderr.patch
@@ -1,0 +1,58 @@
+From 79f36075ff108874a5e54800e038a6124478a9e1 Mon Sep 17 00:00:00 2001
+From: Benjamin Drung <benjamin.drung@canonical.com>
+Date: Fri, 21 Feb 2025 23:49:04 +0100
+Subject: [PATCH 7/7] fix(systemd-sysusers): silence "Creating " on stderr
+
+dracut prints 20 lines when creating users and groups even with
+`--quiet` option. Sample output:
+
+```
+Creating group 'nobody' with GID 65534.
+Creating group 'audio' with GID 997.
+Creating group 'disk' with GID 995.
+Creating group 'input' with GID 994.
+Creating group 'kmem' with GID 993.
+Creating group 'kvm' with GID 992.
+Creating group 'lp' with GID 991.
+Creating group 'optical' with GID 990.
+Creating group 'render' with GID 989.
+Creating group 'sgx' with GID 988.
+Creating group 'storage' with GID 987.
+Creating group 'tty' with GID 5.
+Creating group 'uucp' with GID 986.
+Creating group 'video' with GID 985.
+Creating group 'users' with GID 984.
+Creating group 'systemd-journal' with GID 983.
+Creating user 'root' (Super User) with UID 0 and GID 0.
+Creating user 'nobody' (Kernel Overflow User) with UID 65534 and GID 65534.
+Creating group 'nobody' with GID 65534.
+Creating group 'audio' with GID 997.
+```
+
+Filter "Creating " messages from stderr, but keep the other messages on
+stderr and all messages on stdout untouched.
+
+Fixes: https://github.com/dracut-ng/dracut-ng/issues/1195
+Fixes: f3dacc013d90 ("feat(systemd-sysusers): run systemd-sysusers as part of the build process")
+---
+ modules.d/60systemd-sysusers/module-setup.sh | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/60systemd-sysusers/module-setup.sh b/modules.d/60systemd-sysusers/module-setup.sh
+index 05680553..0461d613 100755
+--- a/modules.d/60systemd-sysusers/module-setup.sh
++++ b/modules.d/60systemd-sysusers/module-setup.sh
+@@ -15,5 +15,9 @@ check() {
+ install() {
+     inst_sysusers basic.conf
+ 
+-    systemd-sysusers --root="$initdir"
++    # redirect stdout temporarily to FD 2 to use filter stderr
++    {
++        set -o pipefail
++        systemd-sysusers --root="$initdir" 2>&1 >&3 | grep -v "^Creating " >&2
++    } 3>&1
+ }
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,4 @@
-VER=105
-REL=5
+VER=106
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: update to 106
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
    Co-authored-by: Harico Twilight (@ruaharico) <harico@yurier.net>

Package(s) Affected
-------------------

- dracut-ng: 106

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
