### PR TITLE
vscodium: add patch to fix pwsh detection

### DIFF
--- a/app-editors/vscodium/autobuild/patches/0001-AOSCOS-add-microsoft-vscode-240054.patch
+++ b/app-editors/vscodium/autobuild/patches/0001-AOSCOS-add-microsoft-vscode-240054.patch
@@ -1,0 +1,114 @@
+From f19881e8ccacb5b79b62bec13fa6f03849221033 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Tue, 11 Feb 2025 14:37:48 +0800
+Subject: [PATCH] AOSCOS: add microsoft/vscode#240054
+
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ patches/240054.patch | 94 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 94 insertions(+)
+ create mode 100644 patches/240054.patch
+
+diff --git a/patches/240054.patch b/patches/240054.patch
+new file mode 100644
+index 000000000000..427dae4f59a0
+--- /dev/null
++++ b/patches/240054.patch
+@@ -0,0 +1,94 @@
++From 6832e5ceda5a85042d2d9001266c3b7fde78105e Mon Sep 17 00:00:00 2001
++From: Kexy Biscuit <kexybiscuit@outlook.com>
++Date: Sat, 8 Feb 2025 13:36:43 +0800
++Subject: [PATCH 1/2] Fix PowerShell executable name detection.
++
++The executable name can be `pwsh`, `pwsh-preview`, or `powershell`. The
++new regular expression matches them all.
++
++Fixes #240053.
++
++Fixes: 9fc5861de216 ("Speculative fix when pwsh is 'powershell' on mac/linux")
++Co-authored-by: Garfield Lee <Garfield550@users.noreply.github.com>
++Signed-off-by: Kexy Biscuit <kexybiscuit@outlook.com>
++---
++ src/vs/platform/shell/node/shellEnv.ts | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/src/vs/platform/shell/node/shellEnv.ts b/src/vs/platform/shell/node/shellEnv.ts
++index 31a1ebe1ecf11..0fde4b76e6e29 100644
++--- a/src/vs/platform/shell/node/shellEnv.ts
+++++ b/src/vs/platform/shell/node/shellEnv.ts
++@@ -129,7 +129,7 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
++ 		const name = basename(systemShellUnix);
++ 		let command: string, shellArgs: Array<string>;
++ 		const extraArgs = '';
++-		if (/^(?:pwsh(?:-preview)|powershell)$/.test(name)) {
+++		if (/^(?:pwsh(?:-preview)?|powershell)$/.test(name)) {
++ 			// Older versions of PowerShell removes double quotes sometimes so we use "double single quotes" which is how
++ 			// you escape single quotes inside of a single quoted string.
++ 			command = `& '${process.execPath}' ${extraArgs} -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`;
++
++From d4478add5e0868b20ec9a741da52622e4cb5cbfa Mon Sep 17 00:00:00 2001
++From: Kexy Biscuit <kexybiscuit@outlook.com>
++Date: Sat, 8 Feb 2025 14:15:54 +0800
++Subject: [PATCH 2/2] Detect the powershell-preview snap.
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++The powershell-preview snap provides `powershell-preview` command, make
++the regular expression detects that too.
++
++```shell
++kexybiscuit@ProArtB550-CREATOR:~$ snap info powershell-preview
++name:      powershell-preview
++summary:   PowerShell for every system!
++publisher: Microsoft PowerShell✓
++store-url: https://snapcraft.io/powershell-preview
++contact:   https://github.com/powershell/powershell
++license:   unset
++description: |
++  PowerShell is an automation and configuration management platform.
++  It consists of a cross-platform (Windows, Linux, and macOS)
++  command-line shell and associated scripting language.
++
++  See https://docs.microsoft.com/powershell/scripting/powershell-support-lifecycle for support
++  details.
++commands:
++  - powershell-preview
++snap-id:      D0A7ph8R6LBXQ8rgs2ad06s8tjyeowsd
++tracking:     latest/stable
++refresh-date: today at 14:12 CST
++channels:
++  latest/stable:    7.6.0-preview.2 2025-01-27 (165) 77MB classic
++  latest/candidate: ↑
++  latest/beta:      ↑
++  latest/edge:      7.4.0-preview.3 2023-05-03 (142) 72MB classic
++installed:          7.6.0-preview.2            (165) 77MB classic
++kexybiscuit@ProArtB550-CREATOR:~$ sudo snap install powershell-preview --classic
++2025-02-08T14:12:33+08:00 INFO Waiting for automatic snapd restart...
++powershell-preview 7.6.0-preview.2 from Microsoft PowerShell✓ installed
++kexybiscuit@ProArtB550-CREATOR:~$ command -v powershell-preview
++/snap/bin/powershell-preview
++```
++
++Co-authored-by: Garfield Lee <Garfield550@users.noreply.github.com>
++Signed-off-by: Kexy Biscuit <kexybiscuit@outlook.com>
++---
++ src/vs/platform/shell/node/shellEnv.ts | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/src/vs/platform/shell/node/shellEnv.ts b/src/vs/platform/shell/node/shellEnv.ts
++index 0fde4b76e6e29..8f4fbf6c49502 100644
++--- a/src/vs/platform/shell/node/shellEnv.ts
+++++ b/src/vs/platform/shell/node/shellEnv.ts
++@@ -129,7 +129,7 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
++ 		const name = basename(systemShellUnix);
++ 		let command: string, shellArgs: Array<string>;
++ 		const extraArgs = '';
++-		if (/^(?:pwsh(?:-preview)?|powershell)$/.test(name)) {
+++		if (/^(?:pwsh|powershell)(?:-preview)?$/.test(name)) {
++ 			// Older versions of PowerShell removes double quotes sometimes so we use "double single quotes" which is how
++ 			// you escape single quotes inside of a single quoted string.
++ 			command = `& '${process.execPath}' ${extraArgs} -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`;
+-- 
+2.48.0.rc2.windows.1.472.g0c796d3013.20250123145154
+

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,5 @@
 VER=1.97.0.25037
+REL=1
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: add patch to fix pwsh detection
    - Track AOSC OS patches at https://github.com/AOSC-Tracking/vscodium aosc/1.97.0.25037, current HEAD is f19881e8ccacb5b79b62bec13fa6f03849221033.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- vscodium: 1.97.0.25037-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
