### PR TITLE
arcanist: ship symbol cache

### DIFF
--- a/app-devel/arcanist/autobuild/build
+++ b/app-devel/arcanist/autobuild/build
@@ -4,6 +4,10 @@ rm -v "$SRCDIR"/support/xhpast/*.o
 rm -v "$SRCDIR"/support/xhpast/*.a
 rm -v "$SRCDIR"/support/xhpast/xhpast
 
+abinfo "Liberating arcanist ..."
+php -d extension=curl \
+    "$SRCDIR"/bin/arc liberate
+
 abinfo "Installing arcanist ..."
 install -dvm755 "$PKGDIR"/usr/lib/arcanist
 cp -vR "$SRCDIR"/{bin,externals,resources,scripts,src,support,LICENSE} "$PKGDIR"/usr/lib/arcanist/

--- a/app-devel/arcanist/autobuild/patches/0012-Skip-writing-symbol-cache-to-non-writable-directorie.patch
+++ b/app-devel/arcanist/autobuild/patches/0012-Skip-writing-symbol-cache-to-non-writable-directorie.patch
@@ -1,7 +1,7 @@
-From d8b413e4f8e73996d34c685c4f4e75966657c16c Mon Sep 17 00:00:00 2001
+From cd9d8a7a6a8cf4e7d949c878e30a4afa4c5b1e4e Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Tue, 11 Feb 2025 10:52:45 +0800
-Subject: [PATCH 13/14] Skip writing symbol cache to non-writable directories
+Subject: [PATCH 12/14] Skip writing symbol cache to non-writable directories
 
 ---
  src/moduleutils/PhutilLibraryMapBuilder.php | 5 +++++

--- a/app-devel/arcanist/autobuild/patches/0013-xhpast-Skip-minline-all-stringops-on-non-x86-archite.patch
+++ b/app-devel/arcanist/autobuild/patches/0013-xhpast-Skip-minline-all-stringops-on-non-x86-archite.patch
@@ -1,10 +1,20 @@
-From 05166cf3e0d8a8effeaa6313d6530a9176f1dcf8 Mon Sep 17 00:00:00 2001
+From f828289cd561b944496fa779acdfe4169f53ab9b Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Tue, 11 Feb 2025 11:31:10 +0800
-Subject: [PATCH 14/14] xhpast: Skip -minline-all-stringops on non-x86
+Subject: [PATCH 13/14] xhpast: Skip -minline-all-stringops on non-x86
  architectures
 
-It is a x86 only option.
+Summary:
+-minline-all-stringops is a x86 only option, and will not work on other architectures.
+Thus remove it for other architectures.
+
+Test Plan: Build on other architectures. I cherry-picked this to AOSC OS packaging and it has built successfully on amd64, arm64, riscv64, ppc64el, loongson3, loongarch64.
+
+Reviewers: O1 Blessed Committers!
+
+Subscribers: tobiaswiese, valerio.bozzolan, Matthew, Cigaryno
+
+Differential Revision: https://we.phorge.it/D25871
 ---
  support/xhpast/Makefile                           |  2 +-
  .../bin/xhpast-generate-release-cppflags.php      | 15 +++++++++++++++
@@ -26,21 +36,21 @@ index 3686de3e2e5e..64a211745909 100644
  ifdef PROFILE
 diff --git a/support/xhpast/bin/xhpast-generate-release-cppflags.php b/support/xhpast/bin/xhpast-generate-release-cppflags.php
 new file mode 100755
-index 000000000000..0f94fafb27b3
+index 000000000000..be38b249d2cc
 --- /dev/null
 +++ b/support/xhpast/bin/xhpast-generate-release-cppflags.php
 @@ -0,0 +1,15 @@
 +#!/usr/bin/env php
 +<?php
 +
-+$arcanist_root = dirname(dirname(dirname(dirname(__FILE__))));
-+require_once $arcanist_root.'/support/init/init-script.php';
++// $arcanist_root = dirname(dirname(dirname(dirname(__FILE__))));
++// require_once $arcanist_root.'/support/init/init-script.php';
 +
 +$cppflags = '';
-+$arch =php_uname('m');
++$arch = php_uname('m');
 +
 +if ($arch == 'i386' || $arch == 'x86_64') {
-+  $cppflags += ' -minline-all-stringops ';
++  $cppflags .= ' -minline-all-stringops ';
 +}
 +
 +echo $cppflags;

--- a/app-devel/arcanist/autobuild/patches/0014-AOSCOS-Remove-deprecated-E_STRICT.patch
+++ b/app-devel/arcanist/autobuild/patches/0014-AOSCOS-Remove-deprecated-E_STRICT.patch
@@ -1,7 +1,7 @@
-From 2440ff3905dd00d78437db927aceed2c45e5d46b Mon Sep 17 00:00:00 2001
+From 3a0b3b94a1d57a4820cda1597ae0ce79388731ad Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Tue, 11 Feb 2025 10:23:46 +0800
-Subject: [PATCH 12/14] AOSCOS: Remove deprecated E_STRICT
+Subject: [PATCH 14/14] AOSCOS: Remove deprecated E_STRICT
 
 This should be dropped once T15989 is resolved.
 ---

--- a/app-devel/arcanist/spec
+++ b/app-devel/arcanist/spec
@@ -1,4 +1,5 @@
 VER=2024.35
+REL=1
 SRCS="git::commit=tags/$VER::https://we.phorge.it/source/arcanist.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376712"


### PR DESCRIPTION
Topic Description
-----------------

- arcanist: ship symbol cache
    - Run liberation to generate the symbol cache.
    This avoids Arcanist's generating the cache for itself when being used
    for the first time, and improves performance \(as the cache is not
    written to file previously\).
    - Backport changes to pre-upstream patches.

Package(s) Affected
-------------------

- arcanist: 2024.35-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit arcanist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
