### PR TITLE
remmina: update to 1.4.39

### DIFF
--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,4 +1,4 @@
-VER=1.4.36
+VER=1.4.39
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::631248f047a1006c57c1f178c560b26cbd8f6caa6c0e251019abd8d54d1c63f3"
+CHKSUMS="sha256::885d41b3e91192c08d89599485a1b0054ca036cf2b8291ccbbcd99269ca86106"
 CHKUPDATE="anitya::id=4188"


### PR DESCRIPTION
Topic Description
-----------------

- remmina: update to 1.4.39

Package(s) Affected
-------------------

- remmina: 1.4.39

Security Update?
----------------

No

Build Order
-----------

```
#buildit remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
