### PR TITLE
gparted: update to 1.7.0

### DIFF
--- a/app-admin/gparted/autobuild/defines
+++ b/app-admin/gparted/autobuild/defines
@@ -10,6 +10,5 @@ PKGDES="A graphical partition manager"
 #                                 display [default=disabled]
 AUTOTOOLS_AFTER="--enable-nls \
                  --enable-doc \
-                 --enable-online-resize \
                  --enable-libparted-dmraid \
                  --disable-xhost-root"

--- a/app-admin/gparted/spec
+++ b/app-admin/gparted/spec
@@ -1,4 +1,4 @@
-VER=1.6.0
+VER=1.7.0
 SRCS="tbl::https://sourceforge.net/projects/gparted/files/gparted/gparted-$VER/gparted-$VER.tar.gz"
-CHKSUMS="sha256::9b9f51b3ce494ddcb59a55e1ae6679c09436604e331dbf5a536d60ded6c6ea5b"
+CHKSUMS="sha256::84ae3b9973e443a2175f07aa0dc2aceeadb1501e0f8953cec83b0ec3347b7d52"
 CHKUPDATE="anitya::id=1235"


### PR DESCRIPTION
Topic Description
-----------------

- gparted: update to 1.7.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gparted: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gparted
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
