### PR TITLE
helix: update to 25.01.1

### DIFF
--- a/app-editors/helix/autobuild/beyond
+++ b/app-editors/helix/autobuild/beyond
@@ -13,7 +13,7 @@ mv -v "$PKGDIR"/usr/bin/hx "$PKGDIR"/usr/lib/helix
 mv -v "$SRCDIR"/runtime "$PKGDIR"/usr/lib/helix
 
 abinfo "Dropping extraneous executables ..."
-rm -v "$PKGDIR"/usr/bin/*
+rm -fv "$PKGDIR"/usr/bin/*
 
 abinfo "Creating soft link for binaries to /usr/bin ..."
 ln -sv ../lib/helix/hx "$PKGDIR"/usr/bin/hx    # original name

--- a/app-editors/helix/autobuild/beyond
+++ b/app-editors/helix/autobuild/beyond
@@ -12,9 +12,6 @@ mkdir -pv "$PKGDIR"/usr/lib/helix
 mv -v "$PKGDIR"/usr/bin/hx "$PKGDIR"/usr/lib/helix
 mv -v "$SRCDIR"/runtime "$PKGDIR"/usr/lib/helix
 
-abinfo "Dropping extraneous executables ..."
-rm -fv "$PKGDIR"/usr/bin/*
-
 abinfo "Creating soft link for binaries to /usr/bin ..."
 ln -sv ../lib/helix/hx "$PKGDIR"/usr/bin/hx    # original name
 ln -sv ../lib/helix/hx "$PKGDIR"/usr/bin/helix # alias

--- a/app-editors/helix/spec
+++ b/app-editors/helix/spec
@@ -1,5 +1,5 @@
-VER=24.07
+VER=25.01.1
 SRCS="tbl::https://github.com/helix-editor/helix/releases/download/$VER/helix-${VER}-source.tar.xz"
-CHKSUMS="sha256::44d9eb113a54a80a2891ac6374c74bcd2bce63d317f1e1c69c286a6fc919922c"
+CHKSUMS="sha256::12508c4f5b9ae6342299bd40d281cd9582d3b51487bffe798f3889cb8f931609"
 CHKUPDATE="anitya::id=219661"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- helix: prevent rm from error when /usr/bin/\* is empty.
- helix: update to 25.01.1

Package(s) Affected
-------------------

- helix: 25.01.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit helix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
