### PR TITLE
mangohud: update to 0.8.0

### DIFF
--- a/app-utils/mangohud/autobuild/defines
+++ b/app-utils/mangohud/autobuild/defines
@@ -3,8 +3,8 @@ PKGSEC=utils
 PKGDEP="libglvnd glslang mesa dbus x11-lib wayland"
 PKGDEP__AMD64="${PKGDEP} libxnvctrl"
 PKGDEP__ARM64="${PKGDEP__AMD64}"
-BUILDDEP="mako nlohmann-json"
-BUILDDEP__AMD64="${BUILDDEP} nvidia"
+BUILDDEP="mako nlohmann-json spdlog vulkan-headers"
+BUILDDEP__AMD64="${BUILDDEP} nvidia-open"
 BUILDDEP__ARM64="${BUILDDEP__AMD64}"
 PKGDES="A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more"
 

--- a/app-utils/mangohud/spec
+++ b/app-utils/mangohud/spec
@@ -1,4 +1,4 @@
-VER=0.7.2
+VER=0.8.0
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
-CHKSUMS="sha256::114ad3ea87b1db7358816c7b8e7843aaee356ff048b9e15d6fff02d89414841b"
+CHKSUMS="sha256::c860c733b1328f0fb479fc880281110799ebc13a4183033affc591c6d10719d9"
 CHKUPDATE="anitya::id=138139"


### PR DESCRIPTION
Topic Description
-----------------

- mangohud: update to 0.8.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- mangohud: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mangohud
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
