### PR TITLE
flac: update to 1.5.0

### DIFF
--- a/app-creativity/audacity/spec
+++ b/app-creativity/audacity/spec
@@ -1,4 +1,5 @@
 VER=3.7.3
+REL=1
 SRCS="git::commit=tags/Audacity-$VER::https://github.com/audacity/audacity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=139"

--- a/app-creativity/mixxx/spec
+++ b/app-creativity/mixxx/spec
@@ -1,4 +1,5 @@
 VER=2.5.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/mixxxdj/mixxx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8389"

--- a/app-creativity/musescore/autobuild/defines
+++ b/app-creativity/musescore/autobuild/defines
@@ -16,3 +16,8 @@ CMAKE_AFTER="-DMUSESCORE_BUILD_MODE=release \
 # See https://bugreports.qt.io/browse/QTBUG-73834
 # & https://bugs.gentoo.org/908808
 NOLTO=1
+
+# FIXME: Even with NOLTO it will still error.
+# {standard input}: Assembler messages:
+# {standard input}: 134111: Error: branch out of range
+FAIL_ARCH="loongson3"

--- a/app-creativity/musescore/spec
+++ b/app-creativity/musescore/spec
@@ -1,5 +1,5 @@
 VER=4.3.2
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/musescore/MuseScore"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6093"

--- a/app-games/scummvm/spec
+++ b/app-games/scummvm/spec
@@ -1,4 +1,5 @@
 VER=2.9.0
+REL=1
 SRCS="tbl::https://www.scummvm.org/frs/scummvm/$VER/scummvm-$VER.tar.xz"
 CHKSUMS="sha256::d5b33532bd70d247f09127719c670b4b935810f53ebb6b7b6eafacaa5da99452"
 CHKUPDATE="anitya::id=4775"

--- a/app-multimedia/audacious/spec
+++ b/app-multimedia/audacious/spec
@@ -1,5 +1,5 @@
 VER=4.4.2
-REL=1
+REL=2
 SRCS="tbl::https://distfiles.audacious-media-player.org/audacious-$VER.tar.bz2 \
       git::rename=audacious-plugins-$VER;commit=tags/audacious-plugins-$VER::https://github.com/audacious-media-player/audacious-plugins"
 CHKSUMS="sha256::34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \

--- a/app-multimedia/cmus/spec
+++ b/app-multimedia/cmus/spec
@@ -1,5 +1,5 @@
 VER=2.11.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/cmus/cmus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10147"

--- a/app-multimedia/deadbeef/spec
+++ b/app-multimedia/deadbeef/spec
@@ -1,4 +1,5 @@
 VER=1.10.0
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/deadbeef/files/deadbeef-$VER.tar.bz2/download"
 CHKSUMS="sha256::98d4247a76efb13bf65890aec9921f5c4733bfc1557906b8d6f209a66b28c363"
 CHKUPDATE="anitya::id=8406"

--- a/app-multimedia/flac/autobuild/defines
+++ b/app-multimedia/flac/autobuild/defines
@@ -1,7 +1,47 @@
 PKGNAME=flac
-PKGDES="FLAC analyzing library"
 PKGSEC=libs
 PKGDEP="libogg"
+BUILDDEP="doxygen"
+BUILDDEP__RETRO=""
+# FIXME: ACBS does not handle suffixed dependencies via archgroups properly.
+BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__M68K="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDES="Tools and runtime for the Free Lossless Audio Codec (FLAC)"
+
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--disable-asm-optimization'
+    '--enable-doxygen-docs'
+    '--enable-cpplibs'
+    '--disable-oss-fuzzers'
+    '--enable-ogg'
+    '--enable-programs'
+    '--enable-examples'
+    '--disable-version-from-git'
+    '--enable-multithreading'
+    '--disable-rpath'
+    '--enable-year2038'
+)
+# Note: From configure's help...
+#
+#   --disable-avx	Disable AVX, AVX2 optimizations. There is runtime
+# 			detection of CPU features, so disabling is only
+#			necessary when a compiler does not know about them
+AUTOTOOLS_AFTER__AMD64=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-avx'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-doxygen-docs'
+)
+
 PKGBREAK="akode<=14.1.2 allegro<=1:5.2.6.0 audacious<=4.4 audacity<=3.6.0 \
           audiocd-kio<=23.08.5 audiofile<=0.3.6git20160829-5 cmus<=2.11.0 \
           deadbeef<=1.9.6 easytag<=2.4.3-3 gstreamer<=1.24.4-1 k3b<=23.08.5 \
@@ -12,5 +52,4 @@ PKGBREAK="akode<=14.1.2 allegro<=1:5.2.6.0 audacious<=4.4 audacity<=3.6.0 \
           sfml<=2.5.1-1 sox<=14.4.2-5 tdemultimedia<=14.1.2 vlc<=3.0.21 \
           vorbis-tools<=1.4.0-3 xine-lib<=1.2.13"
 
-ABSHADOW=0
 AB_FLAGS_O3=1

--- a/app-multimedia/flac/autobuild/defines
+++ b/app-multimedia/flac/autobuild/defines
@@ -16,7 +16,6 @@ PKGDES="Tools and runtime for the Free Lossless Audio Codec (FLAC)"
 
 AUTOTOOLS_AFTER=(
     '--enable-largefile'
-    '--disable-asm-optimization'
     '--enable-doxygen-docs'
     '--enable-cpplibs'
     '--disable-oss-fuzzers'

--- a/app-multimedia/flac/autobuild/defines
+++ b/app-multimedia/flac/autobuild/defines
@@ -41,14 +41,17 @@ AUTOTOOLS_AFTER__RETRO=(
     '--disable-doxygen-docs'
 )
 
-PKGBREAK="akode<=14.1.2 allegro<=1:5.2.6.0 audacious<=4.4 audacity<=3.6.0 \
-          audiocd-kio<=23.08.5 audiofile<=0.3.6git20160829-5 cmus<=2.11.0 \
-          deadbeef<=1.9.6 easytag<=2.4.3-3 gstreamer<=1.24.4-1 k3b<=23.08.5 \
-          k3b-trinity<=14.1.2 kid3<=3.8.3-2 kwave<=23.08.5 \
-          libfishsound<=1.0.0-1 libsndfile<=1.2.0 mixxx<=2.4.1-2 \
-          mkvtoolnix<=84.0-1 mocp<=2.5.2-7 mpd<=0.23.15-3 openmpt<=0.6.4 \
-          opus-tools<=0.2 qmmp<=1.6.5 scummvm<=2.2.0 sdl-sound<=1.0.3-10 \
-          sfml<=2.5.1-1 sox<=14.4.2-5 tdemultimedia<=14.1.2 vlc<=3.0.21 \
-          vorbis-tools<=1.4.0-3 xine-lib<=1.2.13"
+PKGBREAK="akode<=14.1.2-2 allegro<=1:5.2.6.0-1 audacious<=4.4.2-1 \
+          audacity<=3.7.3 audiocd-kio<=23.08.5-1 \
+          audiofile<=0.3.6git20160829-6 cmus<=2.11.0-2 deadbeef<=1.10.0 \
+          easytag<=2.4.3-4 gstreamer<=1.26.0-1 k3b<=23.08.5-2 \
+          k3b-trinity<=14.1.2-2 kid3<=3.9.5 kwave<=23.08.5-1 \
+          libfishsound<=1.0.1 libsndfile<=1.2.0-2 mixxx<=2.5.0 \
+          mkvtoolnix<=91.0 mocp<=2.6.0~svn.r3005 mpd<=0.24.3 \
+          musescore<=4.3.2-1 musicfox<=4.6.0-1 openmpt<=0.7.13 \
+          opus-tools<=0.2-1 qmmp<=1.6.5-2 readymedia<=1.3.3 scummvm<=2.9.0 \
+          sdl-sound<=1.0.3-11 sfml<=2.5.1-2 sox<=14.4.2-6 \
+          tdemultimedia<=14.1.2-1 timidity++<=2.15.0-2 vlc<=3.0.21-5 \
+          vorbis-tools<=1.4.0-4 xine-lib<=1.2.13-3"
 
 AB_FLAGS_O3=1

--- a/app-multimedia/flac/autobuild/retro/beyond
+++ b/app-multimedia/flac/autobuild/retro/beyond
@@ -1,2 +1,0 @@
-abinfo "Dropping extra documentation..."
-rm -rfv "$PKGDIR"/usr/share/doc

--- a/app-multimedia/flac/spec
+++ b/app-multimedia/flac/spec
@@ -1,4 +1,4 @@
-VER=1.4.3
+VER=1.5.0
 SRCS="tbl::https://downloads.xiph.org/releases/flac/flac-$VER.tar.xz"
-CHKSUMS="sha256::6c58e69cd22348f441b861092b825e591d0b822e106de6eb0ee4d05d27205b70"
+CHKSUMS="sha256::f2c1c76592a82ffff8413ba3c4a1299b6c7ab06c734dee03fd88630485c2b920"
 CHKUPDATE="anitya::id=817"

--- a/app-multimedia/kid3/spec
+++ b/app-multimedia/kid3/spec
@@ -1,4 +1,5 @@
 VER=3.9.5
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/kid3/kid3-$VER.tar.gz"
 CHKSUMS="sha256::d68f6e1d7b794b991b57bf976edb8e22d3457911db654ad1fb9b124cc62057f9"
 CHKUPDATE="anitya::id=1509"

--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,4 +1,5 @@
 VER=91.0
+REL=1
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
 CHKSUMS="sha256::451320ee90a041cf85b42dbb4683316bf288d2382c54cdd8cd33b1e0258a3bb3"
 CHKUPDATE="anitya::id=1991"

--- a/app-multimedia/mocp/spec
+++ b/app-multimedia/mocp/spec
@@ -1,4 +1,5 @@
 VER=2.6.0~svn.r3005
+REL=1
 SRCS="tbl::http://deb.debian.org/debian/pool/main/m/moc/moc_${VER/\.r/-r}.orig.tar.gz"
 CHKSUMS="sha256::1fb0fb74af6178585ff50eb7679b27a01930beb99b3549748f92a7148458e24d"
 CHKUPDATE="anitya::id=230937"

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,5 @@
 VER=0.24.3
+REL=1
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
 CHKSUMS="sha256::4225680e068b2ad87e3c2de414ec3209758de93d671f89fa3bae90b70af478a2"
 CHKUPDATE="anitya::id=14864"

--- a/app-multimedia/musicfox/spec
+++ b/app-multimedia/musicfox/spec
@@ -2,4 +2,4 @@ VER=4.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/go-musicfox/go-musicfox"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376106"
-REL=1
+REL=2

--- a/app-multimedia/openmpt/spec
+++ b/app-multimedia/openmpt/spec
@@ -1,4 +1,5 @@
 VER=0.7.13
+REL=1
 SRCS="git::commit=tags/libopenmpt-$VER::https://github.com/OpenMPT/openmpt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=275563"

--- a/app-multimedia/opus-tools/spec
+++ b/app-multimedia/opus-tools/spec
@@ -1,5 +1,5 @@
 VER=0.2
-REL=1
+REL=2
 SRCS="tbl::https://archive.mozilla.org/pub/opus/opus-tools-$VER.tar.gz"
 CHKSUMS="sha256::b4e56cb00d3e509acfba9a9b627ffd8273b876b4e2408642259f6da28fa0ff86"
 CHKUPDATE="anitya::id=7905"

--- a/app-multimedia/qmmp/spec
+++ b/app-multimedia/qmmp/spec
@@ -1,5 +1,5 @@
 VER=1.6.5
-REL=2
+REL=3
 SRCS="tbl::https://qmmp.ylsoftware.com/files/qmmp/1.6/qmmp-$VER.tar.bz2"
 CHKSUMS="sha256::e0e65271beed94193dc7a470ce9727580ba3ee8b2889391efceddc219cd991e2"
 CHKUPDATE="anitya::id=4129"

--- a/app-multimedia/readymedia/spec
+++ b/app-multimedia/readymedia/spec
@@ -1,4 +1,5 @@
 VER=1.3.3
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/minidlna/files/minidlna/${VER}/minidlna-${VER}.tar.gz/download"
 CHKSUMS="sha256::39026c6d4a139b9180192d1c37225aa3376fdf4f1a74d7debbdbb693d996afa4"
 CHKUPDATE="anitya::id=12598"

--- a/app-multimedia/sox/autobuild/defines
+++ b/app-multimedia/sox/autobuild/defines
@@ -4,4 +4,7 @@ PKGDEP="file gsm lame libao libid3tag libmad libpng libsndfile \
         libtool opencore-amr opusfile pulseaudio wavpack"
 PKGDES="Swiss Army knife of sound processing programs"
 
-AUTOTOOLS_AFTER="--with-dyn-default"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-dyn-default"
+)

--- a/app-multimedia/sox/autobuild/patches/0015-add-missing-header.patch
+++ b/app-multimedia/sox/autobuild/patches/0015-add-missing-header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/sox_sample_test.h b/src/sox_sample_test.h
+index 62b55e4..17f0069 100644
+--- a/src/sox_sample_test.h
++++ b/src/sox_sample_test.h
+@@ -19,6 +19,7 @@
+ #undef NDEBUG /* Must undef above assert.h or other that might include it. */
+ #endif
+ #include <assert.h>
++#include <math.h>
+ #include "sox.h"
+
+ #define TEST_UINT(bits) \

--- a/app-multimedia/sox/spec
+++ b/app-multimedia/sox/spec
@@ -1,5 +1,5 @@
 VER=14.4.2
-REL=6
+REL=7
 SRCS="tbl::https://downloads.sourceforge.net/sox/sox-$VER.tar.bz2"
 CHKSUMS="sha256::81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c"
 CHKUPDATE="anitya::id=4858"

--- a/app-multimedia/sox/spec
+++ b/app-multimedia/sox/spec
@@ -1,5 +1,5 @@
 VER=14.4.2
 REL=7
-SRCS="tbl::https://downloads.sourceforge.net/sox/sox-$VER.tar.bz2"
+SRCS="tbl::https://sourceforge.net/projects/sox/files/sox/$VER/sox-$VER.tar.bz2/download"
 CHKSUMS="sha256::81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c"
 CHKUPDATE="anitya::id=4858"

--- a/app-multimedia/timidity++/spec
+++ b/app-multimedia/timidity++/spec
@@ -2,5 +2,5 @@ VER=2.15.0
 SRCS="tbl::https://sourceforge.net/projects/timidity/files/TiMidity++/TiMidity++-$VER/TiMidity++-$VER.tar.gz/download"
 CHKSUMS="sha256::0b6109a3c64604c8851cd9bb4cbafc014a4e13b0025f597e586d9742388f6fb7"
 SUBDIR="TiMidity++-$VER"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=10269"

--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,5 +1,5 @@
 VER=3.0.21
-REL=5
+REL=6
 SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
 CHKSUMS="sha256::24dbbe1d7dfaeea0994d5def0bbde200177347136dbfe573f5b6a4cee25afbb0"
 CHKUPDATE="anitya::id=6504"

--- a/app-multimedia/vorbis-tools/spec
+++ b/app-multimedia/vorbis-tools/spec
@@ -1,5 +1,5 @@
 VER=1.4.0
-REL=4
+REL=5
 SRCS="tbl::https://downloads.xiph.org/releases/vorbis/vorbis-tools-$VER.tar.gz"
 CHKSUMS="sha256::a389395baa43f8e5a796c99daf62397e435a7e73531c9f44d9084055a05d22bc"
 CHKUPDATE="anitya::id=5104"

--- a/desktop-gnome/easytag/spec
+++ b/desktop-gnome/easytag/spec
@@ -1,5 +1,5 @@
 VER=2.4.3
-REL=4
+REL=5
 SRCS="tbl::https://download.gnome.org/sources/easytag/${VER%.*}/easytag-${VER}.tar.xz"
 CHKSUMS="sha256::fc51ee92a705e3c5979dff1655f7496effb68b98f1ada0547e8cbbc033b67dd5"
 CHKUPDATE="anitya::id=651"

--- a/desktop-kde/audiocd-kio/spec
+++ b/desktop-kde/audiocd-kio/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/audiocd-kio-$VER.tar.xz"
 CHKSUMS="sha256::55c8bce983456532b799ad785525fbf36e3381e90388d1016b4b31c7f14023c7"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/k3b/spec
+++ b/desktop-kde/k3b/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/k3b-$VER.tar.xz"
 CHKSUMS="sha256::c789518b45c8505710fd2b66706c4826f251c5487d9b381df76cc96ffb59309a"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/kwave/spec
+++ b/desktop-kde/kwave/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kwave-$VER.tar.xz"
 CHKSUMS="sha256::c6183a93e9e545265035c589ec7d059772507e493546d9b25117a520d2cfc408"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/akode/spec
+++ b/desktop-trinity/akode/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=2
+REL=3
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/dependencies/akode-trinity-$VER.tar.xz"
 CHKSUMS="sha256::bae88bd7a6796a991860c6151a30f9d92773ed43d7e119eceb9c966820211891"
 CHKUPDATE="anitya::id=16065"

--- a/desktop-trinity/k3b-trinity/spec
+++ b/desktop-trinity/k3b-trinity/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=2
+REL=3
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/applications/multimedia/k3b-trinity-$VER.tar.xz \
       tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/applications/multimedia/k3b-i18n-trinity-$VER.tar.xz"
 CHKSUMS="sha256::f4ddc77f524686b4c6893bd2c16fd5affda9397e896700f5c2358ea91de40918 \

--- a/desktop-trinity/tdemultimedia/spec
+++ b/desktop-trinity/tdemultimedia/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=1
+REL=2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdemultimedia-trinity-$VER.tar.xz"
 CHKSUMS="sha256::b9af7e9a061e74dcefc49853863970ac4da08a51ede382b4d3653b1e46b0837c"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-games/allegro/spec
+++ b/runtime-games/allegro/spec
@@ -1,5 +1,5 @@
 VER=5.2.6.0
-REL=1
+REL=2
 SRCS="https://github.com/liballeg/allegro5/releases/download/$VER/allegro-$VER.tar.gz"
 CHKSUMS="sha256::5de8189ec051e1865f359654f86ec68e2a12a94edd00ad06d1106caa5ff27763"
 CHKUPDATE="anitya::id=13982"

--- a/runtime-multimedia/audiofile/spec
+++ b/runtime-multimedia/audiofile/spec
@@ -1,5 +1,5 @@
 VER=0.3.6git20160829
-REL=6
+REL=7
 SRCS="git::commit=b62c902dd258125cac86cd2df21fc898035a43d3::https://github.com/mpruett/audiofile"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15224"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.26.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/libfishsound/spec
+++ b/runtime-multimedia/libfishsound/spec
@@ -1,4 +1,5 @@
 VER=1.0.1
+REL=1
 SRCS="tbl::https://downloads.xiph.org/releases/libfishsound/libfishsound-$VER.tar.gz"
 CHKSUMS="sha256::03eb1601e2306adc88c776afdf212217c6547990d2d0f9ca544dad9a8a9dbb8f"
 CHKUPDATE="anitya::id=230926"

--- a/runtime-multimedia/libsndfile/spec
+++ b/runtime-multimedia/libsndfile/spec
@@ -1,5 +1,5 @@
 VER=1.2.0
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/libsndfile/libsndfile"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13277"

--- a/runtime-multimedia/sdl-sound/spec
+++ b/runtime-multimedia/sdl-sound/spec
@@ -1,5 +1,5 @@
 VER=1.0.3
-REL=11
+REL=12
 SRCS="tbl::https://www.icculus.org/SDL_sound/downloads/SDL_sound-$VER.tar.gz"
 CHKSUMS="sha256::3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
 CHKUPDATE="anitya::id=10262"

--- a/runtime-multimedia/sfml/spec
+++ b/runtime-multimedia/sfml/spec
@@ -2,5 +2,5 @@ VER=2.5.1
 SRCS="tbl::https://github.com/SFML/SFML/archive/$VER.tar.gz"
 CHKSUMS="sha256::438c91a917cc8aa19e82c6f59f8714da353c488584a007d401efac8368e1c785"
 SUBDIR="SFML-$VER"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=12315"

--- a/runtime-multimedia/xine-lib/spec
+++ b/runtime-multimedia/xine-lib/spec
@@ -1,5 +1,5 @@
 VER=1.2.13
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/xine/files/xine-lib/$VER/xine-lib-$VER.tar.xz"
 CHKSUMS="sha256::5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f"
 CHKUPDATE="anitya::id=5543"


### PR DESCRIPTION
Topic Description
-----------------

- sox: adjust sourceforge link
- sox: specify the build type
- sox: add missing header
- xine-lib: bump REL due to flac update to 1.5.0
- vorbis-tools: bump REL due to flac update to 1.5.0
- vlc: bump REL due to flac update to 1.5.0
- timidity++: bump REL due to flac update to 1.5.0
- tdemultimedia: bump REL due to flac update to 1.5.0
- sox: bump REL due to flac update to 1.5.0
- sfml: bump REL due to flac update to 1.5.0

... and 31 more commits

Package(s) Affected
-------------------

- akode: 14.1.2-3
- allegro: 1:5.2.6.0-2
- audacious: 4.4.2-2
- audacity: 3.7.3-1
- audiocd-kio: 23.08.5-2
- audiofile: 0.3.6git20160829-7
- cmus: 2.11.0-3
- deadbeef: 1.10.0-1
- easytag: 2.4.3-5
- flac: 1.5.0
- gstreamer: 1.26.0-2
- k3b: 23.08.5-3
- k3b-trinity: 14.1.2-3
- kid3: 3.9.5-1
- kwave: 23.08.5-2
- libfishsound: 1.0.1-1
- libsndfile: 1.2.0-3
- mixxx: 2.5.0-1
- mkvtoolnix: 91.0-1
- mocp: 2.6.0~svn.r3005-1
- mpd: 0.24.3-1
- musescore: 4.3.2-2
- musicfox: 4.6.0-2
- openmpt: 0.7.13-1
- opus-tools: 0.2-2
- qmmp: 1.6.5-3
- readymedia: 1.3.3-1
- scummvm: 2.9.0-1
- sdl-sound: 1.0.3-12
- sfml: 2.5.1-3
- sox: 14.4.2-7
- tdemultimedia: 14.1.2-2
- timidity++: 2.15.0-3
- vlc: 3.0.21-6
- vorbis-tools: 1.4.0-5
- xine-lib: 1.2.13-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit flac:-pkgbreak libsndfile akode allegro audacious audacity audiocd-kio audiofile cmus deadbeef easytag openmpt gstreamer k3b k3b-trinity kid3 kwave libfishsound mixxx mkvtoolnix timidity++ mocp mpd musescore musicfox opus-tools qmmp readymedia scummvm sdl-sound sfml sox xine-lib tdemultimedia vlc vorbis-tools flac
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
