### PR TITLE
openssl: update to 3.4.1

### DIFF
--- a/runtime-cryptography/openssl/autobuild/defines
+++ b/runtime-cryptography/openssl/autobuild/defines
@@ -13,9 +13,7 @@ PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKGSEC=libs
 
-NOPARALLEL=1
 AB_FLAGS_O3=1
-NOLTO__LOONGARCH64=1
 
 PKGBREAK="""
 aircrack-ng<=1.5.2-2

--- a/runtime-cryptography/openssl/autobuild/patches/0001-LoongArch-Fix-output-file-name-detection-for-Perl-scripts.patch
+++ b/runtime-cryptography/openssl/autobuild/patches/0001-LoongArch-Fix-output-file-name-detection-for-Perl-scripts.patch
@@ -1,0 +1,90 @@
+From ac27e220d4f0d06f001072df167c28e4ee547417 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Feb 2025 16:42:00 +0800
+Subject: [PATCH] LoongArch: Fix output file name detection for Perl scripts
+
+We were using the first (or second) argument containing a '.' as the
+output name file, but it may be incorrect as -march=la64v1.0 may be in
+the command line.  If the builder specifies -march=la64v1.0 in the
+CFLAGS, the script will write to a file named "-march=la64v1.0" and
+cause a build error with cryptic message:
+
+    ld: crypto/pem/loader_attic-dso-pvkfmt.o: in function `i2b_PVK':
+    .../openssl-3.4.1/crypto/pem/pvkfmt.c:1070:(.text+0x11a8): undefined reference to `OPENSSL_cleanse'
+
+Adapt the approach of ARM and RISC-V (they have similar flags like
+-march=v8.1-a or -misa-spec=2.2) to fix the issue.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ crypto/aes/asm/vpaes-loongarch64.pl     | 6 +++---
+ crypto/chacha/asm/chacha-loongarch64.pl | 3 ++-
+ crypto/loongarch64cpuid.pl              | 7 +++----
+ crypto/md5/asm/md5-loongarch64.pl       | 3 ++-
+ 4 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/crypto/aes/asm/vpaes-loongarch64.pl b/crypto/aes/asm/vpaes-loongarch64.pl
+index c85ec40db2de5..00f3ed55bf59d 100644
+--- a/crypto/aes/asm/vpaes-loongarch64.pl
++++ b/crypto/aes/asm/vpaes-loongarch64.pl
+@@ -29,9 +29,9 @@
+ ($vr0,$vr1,$vr2,$vr3,$vr4,$vr5,$vr6,$vr7,$vr8,$vr9,$vr10,$vr11,$vr12,$vr13,$vr14,$vr15,$vr16,$vr17,$vr18,$vr19)=map("\$vr$_",(0..19));
+ ($fp)=map("\$r$_",(22));
+ 
+-for (@ARGV) {   $output=$_ if (/\w[\w\-]*\.\w+$/);      }
+-open STDOUT,">$output";
+-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
++# $output is the last argument if it looks like a file (it has an extension)
++my $output;
++$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+ open STDOUT,">$output";
+ 
+ $PREFIX="vpaes";
+diff --git a/crypto/chacha/asm/chacha-loongarch64.pl b/crypto/chacha/asm/chacha-loongarch64.pl
+index d646d86166479..4dd9780127d35 100644
+--- a/crypto/chacha/asm/chacha-loongarch64.pl
++++ b/crypto/chacha/asm/chacha-loongarch64.pl
+@@ -37,8 +37,9 @@
+     $xr20,$xr21,$xr22,$xr23,$xr24,$xr25,$xr26,$xr27,$xr28,
+     $xr29,$xr30,$xr31)=map("\$xr$_",(0..31));
+ 
++# $output is the last argument if it looks like a file (it has an extension)
+ my $output;
+-for (@ARGV) {	$output=$_ if (/\w[\w\-]*\.\w+$/);	}
++$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+ open STDOUT,">$output";
+ 
+ # Input parameter block
+diff --git a/crypto/loongarch64cpuid.pl b/crypto/loongarch64cpuid.pl
+index 8a84caca923b6..5483f8cb24762 100644
+--- a/crypto/loongarch64cpuid.pl
++++ b/crypto/loongarch64cpuid.pl
+@@ -16,10 +16,9 @@
+ ($vr0,$vr1,$vr2,$vr3,$vr4,$vr5,$vr6,$vr7,$vr8,$vr9,$vr10,$vr11,$vr12,$vr13,$vr14,$vr15,$vr16,$vr17,$vr18,$vr19)=map("\$vr$_",(0..19));
+ ($fp)=map("\$r$_",(22));
+ 
+-
+-for (@ARGV) {   $output=$_ if (/\w[\w\-]*\.\w+$/);      }
+-open STDOUT,">$output";
+-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
++# $output is the last argument if it looks like a file (it has an extension)
++my $output;
++$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+ open STDOUT,">$output";
+ 
+ {
+diff --git a/crypto/md5/asm/md5-loongarch64.pl b/crypto/md5/asm/md5-loongarch64.pl
+index 61f8749a3a4e5..b15787a3894db 100755
+--- a/crypto/md5/asm/md5-loongarch64.pl
++++ b/crypto/md5/asm/md5-loongarch64.pl
+@@ -18,8 +18,9 @@
+ my ($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$r$_",(4..11));
+ my ($t0,$t1,$t2,$t3,$t4,$t5,$t6,$t7,$t8,$x)=map("\$r$_",(12..21));
+ 
++# $output is the last argument if it looks like a file (it has an extension)
+ my $output;
+-for (@ARGV) {	$output=$_ if (/\w[\w\-]*\.\w+$/);	}
++$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+ open STDOUT,">$output";
+ 
+ # round1_step() does:

--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.4.1
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
+CHKSUMS="sha256::002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl: update to 3.4.1
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- openssl: 3.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
