### PR TITLE
perl-file-homedir:new, 1.006

### DIFF
--- a/lang-perl/perl-file-dirlist/autobuild/defines
+++ b/lang-perl/perl-file-dirlist/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-file-dirlist
+PKGSEC=perl
+PKGDEP="perl"
+PKGDES="provide a sorted list of directory content"
+
+ABHOST=noarch

--- a/lang-perl/perl-file-dirlist/spec
+++ b/lang-perl/perl-file-dirlist/spec
@@ -1,0 +1,4 @@
+VER=0.05
+SRCS="tbl::https://search.cpan.org/CPAN/authors/id/T/TP/TPABA/File-DirList/File-DirList-$VER.tar.gz"
+CHKSUMS="sha256::993b7d7662e55798448a1edaccb9abd281d2bd23be7eab99f569b8e2962d3bc3"
+CHKUPDATE="anitya::id=376735"

--- a/lang-perl/perl-file-homedir/autobuild/defines
+++ b/lang-perl/perl-file-homedir/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-file-homedir
+PKGSEC=perl
+PKGDEP="perl-file-which"
+PKGDES="Find your home and other directories on any platform"
+
+ABHOST=noarch

--- a/lang-perl/perl-file-homedir/spec
+++ b/lang-perl/perl-file-homedir/spec
@@ -1,0 +1,4 @@
+VER=1.006
+SRCS="tbl::https://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/File-HomeDir-$VER.tar.gz"
+CHKSUMS="sha256::593737c62df0f6dab5d4122e0b4476417945bb6262c33eedc009665ef1548852"
+CHKUPDATE="anitya::id=2891"

--- a/lang-perl/perl-file-touch/autobuild/defines
+++ b/lang-perl/perl-file-touch/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=perl-file-touch
+PKGSEC=perl
+PKGDEP="perl"
+PKGDES="update file access and modification times, optionally creating files if needed"
+
+ABHOST=noarch

--- a/lang-perl/perl-file-touch/spec
+++ b/lang-perl/perl-file-touch/spec
@@ -1,0 +1,4 @@
+VER=0.12
+SRCS="tbl::https://search.cpan.org/CPAN/authors/id/N/NE/NEILB/File-Touch-$VER.tar.gz"
+CHKSUMS="sha256::2a04dc424df48e98c54556c6045cab026a49e3737aa94a21cf497761b0f2e59c"
+CHKUPDATE="anitya::id=5916"


### PR DESCRIPTION
Topic Description
-----------------

- perl-file-homedir: new, 1.006

Package(s) Affected
-------------------

- perl-file-homedir: 1.006
- perl-file-dirlist: 0.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-file-homedir perl-file-dirlist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
