### PR TITLE
apostrophe: new, 3.2

### DIFF
--- a/app-editors/apostrophe/autobuild/defines
+++ b/app-editors/apostrophe/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=apostrophe
+PKGSEC=editors
+PKGDEP="dconf glib graphene gtk-4 gtksourceview-5 hicolor-icon-theme \
+	libadwaita pango python chardet pygobject-3 webkit2gtk \
+	libspelling pypandoc"
+PKGRECOM="texlive"
+BUILDDEP="appstream"
+PKGDES="Distraction free Markdown editor"
+
+# FIXME: pypandoc is only available on these archs
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-editors/apostrophe/spec
+++ b/app-editors/apostrophe/spec
@@ -1,0 +1,4 @@
+VER=3.2
+SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/World/apostrophe.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=222624"

--- a/desktop-gnome/libspelling/autobuild/defines
+++ b/desktop-gnome/libspelling/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=libspelling
+PKGSEC=gnome
+PKGDEP="enchant-2 gcc-runtime glib glibc gtk-4 gtksourceview-5 icu pango"
+BUILDDEP="gi-docgen gobject-introspection vala sysprof"
+PKGDES="Spellcheck library for GTK 4"

--- a/desktop-gnome/libspelling/spec
+++ b/desktop-gnome/libspelling/spec
@@ -1,0 +1,4 @@
+VER=0.4.6
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libspelling.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369148"

--- a/lang-python/pypandoc/autobuild/defines
+++ b/lang-python/pypandoc/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pypandoc
+PKGSEC=python
+PKGDEP="pandoc"
+BUILDDEP="python-build python-installer poetry wheel"
+PKGDES="Thin wrapper for pandoc"
+
+ABHOST=noarch

--- a/lang-python/pypandoc/spec
+++ b/lang-python/pypandoc/spec
@@ -1,0 +1,4 @@
+VER=1.15
+SRCS="git::commit=tags/v$VER::https://github.com/JessicaTegner/pypandoc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=10570"

--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
 PKGDEP="gtk-4 libxml2"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala"
+BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala gtk-update-icon-cache"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
-MESON_AFTER="-Dinstall_tests=false \
+MESON_AFTER="-Dinstall-tests=false \
              -Dvapi=true \
-             -Dgtk_doc=true \
+             -Ddocumentation=true \
              -Dsysprof=false"

--- a/runtime-editors/gtksourceview-5/spec
+++ b/runtime-editors/gtksourceview-5/spec
@@ -1,4 +1,4 @@
-VER=5.4.2
-SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:3}/gtksourceview-$VER.tar.xz"
-CHKSUMS="sha256::ad140e07eb841910de483c092bd4885abd29baadd6e95fa22d93ed2df0b79de7"
+VER=5.14.2
+SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
+CHKSUMS="sha256::1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER%.*}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- apostrophe: new, 3.2
- libspelling: new, 0.4.6
- pypandoc: new, 1.15
- gtksourceview-5: update to 5.14.2

Package(s) Affected
-------------------

- apostrophe: 3.2
- libspelling: 0.4.6
- pypandoc: 1.15
- gtksourceview-5: update to 5.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtksourceview-5 pypandoc libspelling apostrophe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`