### PR TITLE
openssl+32: update to 3.4.1

### DIFF
--- a/runtime-optenv32/openssl+32/autobuild/defines
+++ b/runtime-optenv32/openssl+32/autobuild/defines
@@ -5,7 +5,6 @@ PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Securit
 BUILDDEP="linux+api+32 32subsystem"
 
 NOPARALLEL=1
-NOLTO=1
 ABHOST=noarch
 
 PKGBREAK="""

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.4.1
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
+CHKSUMS="sha256::002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl+32: update to 3.4.1

Package(s) Affected
-------------------

- openssl+32: 3.4.1

Security Update?
----------------

Yes, #9659 

Build Order
-----------

```
#buildit openssl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
