### PR TITLE
gtksourceview-5: update to 5.15.0

### DIFF
--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
 PKGDEP="gtk-4 libxml2"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala"
+BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala shaderc"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
-MESON_AFTER="-Dinstall_tests=false \
+MESON_AFTER="-Dinstall-tests=false \
              -Dvapi=true \
-             -Dgtk_doc=true \
+             -Ddocumentation=true \
              -Dsysprof=false"

--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
 PKGDEP="gtk-4 libxml2"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala shaderc"
+BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala shaderc libsass"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
 MESON_AFTER="-Dinstall-tests=false \

--- a/runtime-editors/gtksourceview-5/spec
+++ b/runtime-editors/gtksourceview-5/spec
@@ -1,4 +1,4 @@
-VER=5.4.2
-SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:3}/gtksourceview-$VER.tar.xz"
-CHKSUMS="sha256::ad140e07eb841910de483c092bd4885abd29baadd6e95fa22d93ed2df0b79de7"
+VER=5.15.0
+SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
+CHKSUMS="sha256::2ef21e55799253b8bdf216d5329e8025eeb1a3f1e3e2be44711ff032aaf17738"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER%.*}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- gtksourceview-5: update to 5.15.0

Package(s) Affected
-------------------

- gtksourceview-5: 5.150

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtksourceview-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
