### PR TITLE
openssl-1.1: update to 1.1.1zb+p3

### DIFF
--- a/runtime-cryptography/openssl-1.1/autobuild/build
+++ b/runtime-cryptography/openssl-1.1/autobuild/build
@@ -9,6 +9,8 @@ elif ab_match_arch "i486" ; then
     ARCH_OPTS="linux-x86"
 elif ab_match_arch "loongarch64"; then
     ARCH_OPTS="linux-generic64"
+elif ab_match_arch "loongarch64_nosimd"; then
+    ARCH_OPTS="linux-generic64"
 elif ab_match_arch "+(loongson2f|loongson3)" ; then
     ARCH_OPTS="linux64-mips64"
 elif ab_match_arch "m68k" ; then

--- a/runtime-cryptography/openssl-1.1/autobuild/defines
+++ b/runtime-cryptography/openssl-1.1/autobuild/defines
@@ -3,7 +3,6 @@ PKGDEP="glibc zlib"
 PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security (1.1 compatibility runtime)"
 PKGSEC=libs
 
-NOPARALLEL=1
 AB_FLAGS_O3=1
 
 PKGBREAK="openssl<=1.1.1q-1"

--- a/runtime-cryptography/openssl-1.1/autobuild/patch
+++ b/runtime-cryptography/openssl-1.1/autobuild/patch
@@ -1,3 +1,0 @@
-if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
-	sed -i 's/-mips3/-mips64r2/g' Configure
-fi

--- a/runtime-cryptography/openssl-1.1/autobuild/patches/0001-patch-Configure-for-loongson3.patch.loongson3
+++ b/runtime-cryptography/openssl-1.1/autobuild/patches/0001-patch-Configure-for-loongson3.patch.loongson3
@@ -1,0 +1,25 @@
+From 7bc94b7861c09c5307af4dfcfdb6a3439b4d37bc Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Wed, 12 Feb 2025 13:27:40 +0800
+Subject: [PATCH] patch Configure for loongson3
+
+---
+ Configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Configure b/Configure
+index 78cc15d..d6484d5 100755
+--- a/Configure
++++ b/Configure
+@@ -1248,7 +1248,7 @@ if ($target =~ /linux.*-mips/ && !$disabled{asm}
+         # minimally required architecture flags for assembly modules
+         my $value;
+         $value = '-mips2' if ($target =~ /mips32/);
+-        $value = '-mips3' if ($target =~ /mips64/);
++        $value = '-mips64r2' if ($target =~ /mips64/);
+         unshift @{$config{cflags}}, $value;
+         unshift @{$config{cxxflags}}, $value if $config{CXX};
+ }
+-- 
+2.48.1
+

--- a/runtime-cryptography/openssl-1.1/spec
+++ b/runtime-cryptography/openssl-1.1/spec
@@ -1,4 +1,5 @@
-VER=1.1.1w
-SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8"
-CHKUPDATE="anitya::id=2566"
+UPSTREAM_VER=1.1.1ze
+VER=${UPSTREAM_VER/_/+}
+SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376743"

--- a/runtime-optenv32/openssl-1.1+32/spec
+++ b/runtime-optenv32/openssl-1.1+32/spec
@@ -1,4 +1,5 @@
-VER=1.1.1w
-SRCS="tbl::https://openssl.org/source/openssl-$VER.tar.gz"
-CHKSUMS="sha256::cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8"
-CHKUPDATE="anitya::id=2566"
+UPSTREAM_VER=1.1.1ze
+VER=${UPSTREAM_VER/_/+}
+SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376743"

--- a/topics/openssl-1.1.1ze.toml
+++ b/topics/openssl-1.1.1ze.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 1.1.1ze"
+
+[caution]
+default = "The OpenSSL project no longer provides free security updates to OpenSSL v1.1.1 - this update switches to a third-party maintained fork, which fixes numerous security vulnerabilities since OpenSSL 1.1.1w (released in 2024)"
+zh_CN = "因 OpenSSL 官方不再提供针对 v1.1.1 分支的免费安全更新，本更新改用第三方维护的源代码；修复自 2024 年以来在 OpenSSL 1.1.1w 中发现的若干安全漏洞。"
+
+[packages-v2]
+"openssl-1.1" = "< 1.1.1ze"
+"openssl-1.1+32" = "< 1.1.1ze"


### PR DESCRIPTION
Topic Description
-----------------

- openssl-1.1: update to 1.1.1zb+p3
    Switched to https://github.com/kzalewski/openssl-1.1.1 for security update backported from OpenSSL 3.
    OpenSSL no longer provide free security update to OpenSSL 1.1.1 after 1.1.1w.

Package(s) Affected
-------------------

- openssl-1.1: 1.1.1zb+p3

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl-1.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
