### PR TITLE
pango: update to 1.56.1

### DIFF
--- a/runtime-desktop/pango/autobuild/defines
+++ b/runtime-desktop/pango/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pango
 PKGSEC=libs
 PKGDEP="cairo harfbuzz mesa libthai x11-lib fribidi"
-BUILDDEP="fontconfig gi-docgen gobject-introspection help2man gtk-doc vim"
+BUILDDEP="fontconfig gi-docgen gobject-introspection help2man gtk-doc vim docutils"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -15,7 +15,7 @@ PKGDES="System for layout and rendering of internationalized text"
 
 ABSHADOW=0
 
-MESON_AFTER="-Dgtk_doc=true \
+MESON_AFTER="-Ddocumentation=true \
              -Dintrospection=enabled \
              -Dfontconfig=enabled \
              -Dsysprof=disabled \
@@ -24,7 +24,7 @@ MESON_AFTER="-Dgtk_doc=true \
              -Dxft=enabled \
              -Dfreetype=enabled"
 MESON_AFTER__RETRO=" \
-             -Dgtk_doc=false \
+             -Ddocumentation=false \
              -Dintrospection=disabled \
              -Dfontconfig=enabled \
              -Dsysprof=disabled \

--- a/runtime-desktop/pango/spec
+++ b/runtime-desktop/pango/spec
@@ -1,4 +1,4 @@
-VER=1.52.2
+VER=1.56.1
 SRCS="tbl::https://download.gnome.org/sources/pango/${VER%.*}/pango-$VER.tar.xz"
-CHKSUMS="sha256::d0076afe01082814b853deec99f9349ece5f2ce83908b8e58ff736b41f78a96b"
+CHKSUMS="sha256::426be66460c98b8378573e7f6b0b2ab450f6bb6d2ec7cecc33ae81178f246480"
 CHKUPDATE="anitya::id=11783"


### PR DESCRIPTION
Topic Description
-----------------

- pango: update to 1.56.1

Package(s) Affected
-------------------

- pango: 1.56.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pango
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
