### PR TITLE
sbcl: update to 2.5.1

### DIFF
--- a/app-scientific/fricas/autobuild/defines
+++ b/app-scientific/fricas/autobuild/defines
@@ -5,10 +5,9 @@ PKGSEC=math
 PKGDEP__SBCL="gawk x11-lib sbcl"
 PKGDEP__ECL="gawk x11-lib ecl"
 PKGDEP__AMD64="$PKGDEP__SBCL"
-
-# FIXME: Continue out of heap while build with sbcl on PPC64EL and ARM64
+PKGDEP__ARM64="$PKGDEP__SBCL"
+# FIXME: Hang while build with sbcl on PPC64EL
 #PKGDEP__PPC64EL="$PKGDEP__SBCL"
-#PKGDEP__ARM64="$PKGDEP__SBCL"
 PKGDEP="$PKGDEP__ECL"
 
 # Note: Ref. https://fricas.github.io/install.html#latex-optional
@@ -40,14 +39,13 @@ AUTOTOOLS_AFTER__SBCL=(
     --enable-gmp
 )
 AUTOTOOLS_AFTER__AMD64=("${AUTOTOOLS_AFTER__SBCL[@]}")
-
-# FIXME: Continue out of heap while build with sbcl on PPC64EL and ARM64
-#AUTOTOOLS_AFTER__ARM64="$AUTOTOOLS_AFTER__SBCL"
-#AUTOTOOLS_AFTER__PPC64EL="$AUTOTOOLS_AFTER__SBCL"
+AUTOTOOLS_AFTER__ARM64=("${AUTOTOOLS_AFTER__SBCL[@]}")
+# FIXME: Hang while build with sbcl on PPC64EL
+#AUTOTOOLS_AFTER__PPC64EL=("${AUTOTOOLS_AFTER__SBCL[@]}")
 AUTOTOOLS_AFTER=("${AUTOTOOLS_AFTER__ECL[@]}")
 
 # Note: Else sbcl version of the software will not run,
 # it seems FRICASsys got a lot of things inside.
 ABSTRIP__AMD64=0
-ABSTRIP__PPC64EL=0
+#ABSTRIP__PPC64EL=0
 ABSTRIP__ARM64=0

--- a/app-scientific/fricas/spec
+++ b/app-scientific/fricas/spec
@@ -1,4 +1,5 @@
 VER=1.3.11
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fricas/fricas"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376467"

--- a/app-scientific/maxima/spec
+++ b/app-scientific/maxima/spec
@@ -1,5 +1,5 @@
 VER=5.46.0
-REL=2
+REL=3
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/maxima/maxima-$VER.tar.gz"
 CHKSUMS="sha256::7390f06b48da65c9033e8b2f629b978b90056454a54022db7de70e2225aa8b07"
 CHKUPDATE="anitya::id=6365"

--- a/lang-lisp/sbcl/autobuild/defines
+++ b/lang-lisp/sbcl/autobuild/defines
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-1"
+PKGBREAK="maxima<=5.46.0-2 fricas<=1.3.11"

--- a/lang-lisp/sbcl/autobuild/defines.stage2
+++ b/lang-lisp/sbcl/autobuild/defines.stage2
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-1"
+PKGBREAK="maxima<=5.46.0-2 fricas<=1.3.11"

--- a/lang-lisp/sbcl/spec
+++ b/lang-lisp/sbcl/spec
@@ -1,5 +1,4 @@
-VER=2.4.5
-REL=1
+VER=2.5.1
 SRCS="tbl::https://downloads.sourceforge.net/project/sbcl/sbcl/$VER/sbcl-$VER-source.tar.bz2"
-CHKSUMS="sha256::4df68e90c9031807642b4b761988deb5bf6a1bd152c4723482834efa735a7bd1"
+CHKSUMS="sha256::4133b36cd16d14d633969c37fd51c2c89a8ea5d6e1611552819d91f71b219f8b"
 CHKUPDATE="anitya::id=16339"


### PR DESCRIPTION
Topic Description
-----------------

- sbcl: update to 2.5.1
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>
 - fricas, maxima: bump for rebuild
 - fricas: enable sbcl build for arm64

Package(s) Affected
-------------------

- sbcl: 2.5.1
- maxima: 5.46.0-3
- fricas: 1.3.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbcl maxima fricas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
