### PR TITLE
ydotool: new, 1.0.4

### DIFF
--- a/app-utils/ydotool/autobuild/defines
+++ b/app-utils/ydotool/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=ydotool
+PKGSEC=x11
+PKGDEP="systemd"
+BUILDDEP="scdoc"
+PKGDES="Command-line automation tool"
+
+ABTYPE=cmakeninja

--- a/app-utils/ydotool/overrides/usr/lib/udev/rules.d/80-ydotool.rules
+++ b/app-utils/ydotool/overrides/usr/lib/udev/rules.d/80-ydotool.rules
@@ -1,0 +1,1 @@
+KERNEL=="uinput", GROUP="input", MODE="0660", OPTIONS+="static_node=uinput"

--- a/app-utils/ydotool/spec
+++ b/app-utils/ydotool/spec
@@ -1,0 +1,4 @@
+VER=1.0.4
+SRCS="git::commit=tags/v$VER::https://github.com/ReimuNotMoe/ydotool.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=137706"


### PR DESCRIPTION
Topic Description
-----------------

- ydotool: new, 1.0.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- ydotool: 1.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ydotool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
