### PR TITLE
rofi: update to 1.7.8

### DIFF
--- a/app-utils/rofi/autobuild/defines
+++ b/app-utils/rofi/autobuild/defines
@@ -1,8 +1,14 @@
 PKGNAME=rofi
 PKGSEC=utils
 PKGDEP="freetype libxdg-basedir libxkbcommon pango startup-notification \
-        xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf"
-BUILDDEP="check"
+        xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf \
+        xcb-util-keysyms xcb-util libxcb xcb-imdkit"
 PKGDES="A pop-up window switcher"
 
-ABTYPE=autotools
+ABTYPE=meson
+MESON_AFTER=(
+    -Ddrun=true
+    -Dwindow=true
+    -Dcheck=disabled
+    -Dimdkit=true
+)

--- a/app-utils/rofi/spec
+++ b/app-utils/rofi/spec
@@ -1,4 +1,4 @@
-VER=1.7.5
+VER=1.7.8
 SRCS="tbl::https://github.com/DaveDavenport/rofi/releases/download/$VER/rofi-$VER.tar.xz"
-CHKSUMS="sha256::caffcf66d165cb32b748c1db7f229d6d75da58c1685eb17455f65c60e8220c8d"
+CHKSUMS="sha256::2ad90a8c492e0b64202088e788795bf0b31ecfaa59fe7441ad263298d150655e"
 CHKUPDATE="anitya::id=10146"


### PR DESCRIPTION
Topic Description
-----------------

- rofi: update to 1.7.8
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- rofi: 1.7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
