### PR TITLE
Printer Driver Compatibility Survey (Spiral), Feb. 2025

### DIFF
--- a/app-admin/cups/autobuild/defines
+++ b/app-admin/cups/autobuild/defines
@@ -26,4 +26,5 @@ RECONF=0
 # Note: Extra Provides for Spiral (Debian compatibility).
 PKGPROV="cups-bsd_spiral cups-client_spiral cups-common_spiral \
          cups-core-drivers_spiral cups-daemon_spiral cups-ipp-utils_spiral \
-         cups-ppdc_spiral cups-server-common_spiral"
+         cups-ppdc_spiral cups-server-common_spiral cupsys_spiral \
+         libcupsys2_spiral"

--- a/app-admin/cups/spec
+++ b/app-admin/cups/spec
@@ -1,4 +1,5 @@
 VER=2.4.11
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/OpenPrinting/cups"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380"

--- a/runtime-cryptography/beecrypt/autobuild/defines
+++ b/runtime-cryptography/beecrypt/autobuild/defines
@@ -1,0 +1,22 @@
+PKGNAME=beecrypt
+PKGSEC=libs
+PKGDEP="gcc-runtime"
+PKGDES="BeeCrypt cryptography library"
+
+# FIXME: Bindings are long since broken.
+#
+# rng-py.c:322:9: error: initialization of 'void (*)(void *)' from incompatible pointer type 'void (*)(PyObject *)' {aka 'void (*)(struct _object *)'} [-Wincompatible-pointer-types]
+#   322 |         (destructor) rng_free,          /* tp_free */
+#       |         ^
+# rng-py.c:322:9: note: (near initialization for 'rng_Type.tp_free')
+# make[3]: *** [Makefile:402: rng-py.lo] Error 1
+# make[3]: *** Waiting for unfinished jobs....
+# mpw-py.c:2341:9: error: initialization of 'void (*)(void *)' from incompatible pointer type 'void (*)(PyObject *)' {aka 'void (*)(struct _object *)'} [-Wincompatible-pointer-types]
+#  2341 |         (destructor) mpw_free,          /* tp_free */
+#       |         ^
+# mpw-py.c:2341:9: note: (near initialization for 'mpw_Type.tp_free')
+AUTOTOOLS_AFTER=(
+    '--with-python=no'
+)
+
+PKGPROV="libbeecrypt7_spiral libbeecrypt-dev_spiral"

--- a/runtime-cryptography/beecrypt/autobuild/patches/0001-UBUNTU-fix-wrong-debug-output-on-64-bit.patch
+++ b/runtime-cryptography/beecrypt/autobuild/patches/0001-UBUNTU-fix-wrong-debug-output-on-64-bit.patch
@@ -1,0 +1,156 @@
+From 01afc7f17b2a44adc02290aaac400778c080dfaf Mon Sep 17 00:00:00 2001
+From: "Bernhard R. Link" <brlink@debian.org>
+Date: Sat, 17 Sep 2011 19:45:38 +0200
+Subject: [PATCH 1/4] UBUNTU: fix wrong debug output on 64 bit
+
+From Ubuntu: beecrypt 4.2.1-4
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ python/mpw-py.c | 30 +++++++++++++++---------------
+ python/rng-py.c |  4 ++--
+ 2 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/python/mpw-py.c b/python/mpw-py.c
+index a833bbf..edb872f 100644
+--- a/python/mpw-py.c
++++ b/python/mpw-py.c
+@@ -332,7 +332,7 @@ static void prtmpw(const char * msg, mpwObject * x)
+ 	/*@global stderr, fileSystem @*/
+ 	/*@modifies stderr, fileSystem @*/
+ {
+-fprintf(stderr, "%5.5s %p[%d]:\t", msg, MPW_DATA(x), MPW_SIZE(x)), mpfprintln(stderr, MPW_SIZE(x), MPW_DATA(x));
++fprintf(stderr, "%5.5s %p[%lu]:\t", msg, MPW_DATA(x), (long int)(MPW_SIZE(x))), mpfprintln(stderr, MPW_SIZE(x), MPW_DATA(x));
+ }
+ 
+ static size_t
+@@ -354,7 +354,7 @@ mpsizeinbase(size_t xsize, mpw* xdata, size_t base)
+ 	res = (nbits * mp_bases[base].chars_per_bit_exactly) + 1;
+     }
+ if (_mpw_debug < -1)
+-fprintf(stderr, "*** mpsizeinbase(%p[%d], %d) res %u\n", xdata, xsize, base, (unsigned)res);
++fprintf(stderr, "*** mpsizeinbase(%p[%lu], %lu) res %u\n", xdata, (unsigned long)xsize, (unsigned long)base, (unsigned)res);
+     return res;
+ }
+ 
+@@ -408,7 +408,7 @@ mpstr(char * t, size_t nt, size_t size, mpw* data, mpw base)
+     size_t result;
+ 
+ if (_mpw_debug < -1)
+-fprintf(stderr, "*** mpstr(%p[%d], %p[%d], %d):\t", t, nt, data, size, base), mpfprintln(stderr, size, data);
++fprintf(stderr, "*** mpstr(%p[%lu], %p[%lu], %d):\t", t, (unsigned long)nt, data, (unsigned long)size, base), mpfprintln(stderr, size, data);
+ 
+     mpsetx(asize, adata, size, data);
+ 
+@@ -418,8 +418,8 @@ fprintf(stderr, "*** mpstr(%p[%d], %p[%d], %d):\t", t, nt, data, size, base), mp
+ 	mpndivmod(zdata, asize, adata, 1, &base, wksp);
+ 
+ if (_mpw_debug < -1) {
+-fprintf(stderr, "    a %p[%d]:\t", adata, asize), mpfprintln(stderr, asize, adata);
+-fprintf(stderr, "    z %p[%d]:\t", zdata, asize+1), mpfprintln(stderr, asize+1, zdata);
++fprintf(stderr, "    a %p[%lu]:\t", adata, (unsigned long)asize), mpfprintln(stderr, asize, adata);
++fprintf(stderr, "    z %p[%lu]:\t", zdata, (unsigned long)(asize+1)), mpfprintln(stderr, asize+1, zdata);
+ }
+ 	result = zdata[asize];
+ 	t[nt] = bchars[result];
+@@ -461,7 +461,7 @@ mpw_format(mpwObject * z, size_t base, int addL)
+     }
+ 
+ if (_mpw_debug < -1)
+-fprintf(stderr, "*** mpw_format(%p,%d,%d):\t", z, base, addL), mpfprintln(stderr, zsize, zdata);
++fprintf(stderr, "*** mpw_format(%p,%lu,%d):\t", z, (unsigned long)base, addL), mpfprintln(stderr, zsize, zdata);
+ 
+     assert(base >= 2 && base <= 36);
+ 
+@@ -812,7 +812,7 @@ static void mpnpow_w(mpnumber* n, size_t xsize, const mpw* xdata,
+     size = MP_ROUND_B2W(15 * xbits);
+ 
+ if (_mpw_debug < 0)
+-fprintf(stderr, "*** pbits %d xbits %d nsize %d size %d\n", pbits, xbits, nsize, size);
++fprintf(stderr, "*** pbits %lu xbits %lu nsize %lu size %lu\n", (unsigned long)pbits, (unsigned long)xbits, (unsigned long)nsize, (unsigned long)size);
+     mpnsize(n, nsize);
+ 
+     /* 1. Precompute odd powers of x (up to 2**K). */
+@@ -1588,7 +1588,7 @@ fprintf(stderr, "sub ++: borrow\n");
+     }
+ 
+ if (_mpw_debug)
+-fprintf(stderr, "*** mpw_%s %p[%d]\t", fname, MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** mpw_%s %p[%lu]\t", fname, MPW_DATA(z), (unsigned long)MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+ exit:
+     mpbfree(&b);
+@@ -1667,7 +1667,7 @@ prtmpw("c", m);
+     z = mpw_FromMPW(zsize, zdata, 1);
+ 
+ if (_mpw_debug < 0)
+-fprintf(stderr, "*** mpw_%s %p[%d]\t", fname, MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** mpw_%s %p[%lu]\t", fname, MPW_DATA(z), (unsigned long)(MPW_SIZE(z))), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+ exit:
+     mpbfree(&b);
+@@ -1949,9 +1949,9 @@ mpw_divmod(PyObject * v, PyObject * w)
+     mpndivmod(zdata, asize, adata, bsize, bdata, wksp);
+ 
+ if (_mpw_debug < 0) {
+-fprintf(stderr, "    a %p[%d]:\t", adata, asize), mpfprintln(stderr, asize, adata);
+-fprintf(stderr, "    b %p[%d]:\t", bdata, bsize), mpfprintln(stderr, bsize, bdata);
+-fprintf(stderr, "    z %p[%d]:\t", zdata, zsize), mpfprintln(stderr, zsize, zdata);
++fprintf(stderr, "    a %p[%lu]:\t", adata, (unsigned long)asize), mpfprintln(stderr, asize, adata);
++fprintf(stderr, "    b %p[%lu]:\t", bdata, (unsigned long)bsize), mpfprintln(stderr, bsize, bdata);
++fprintf(stderr, "    z %p[%lu]:\t", zdata, (unsigned long)zsize), mpfprintln(stderr, zsize, zdata);
+ }
+ 
+     zsize -= bsize;
+@@ -2026,7 +2026,7 @@ mpw_neg(mpwObject * a)
+     }
+ 
+ if (z != NULL && _mpw_debug)
+-fprintf(stderr, "*** mpw_neg %p[%d]\t", MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** mpw_neg %p[%lu]\t", MPW_DATA(z), (unsigned long)(MPW_SIZE(z))), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+     return (PyObject *)z;
+ }
+@@ -2044,7 +2044,7 @@ mpw_pos(mpwObject * a)
+ 	z = mpw_Copy(a);
+ 
+ if (z != NULL && _mpw_debug)
+-fprintf(stderr, "*** mpw_pos %p[%d]\t", MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** mpw_pos %p[%lu]\t", MPW_DATA(z), (unsigned long)MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+     return (PyObject *)z;
+ }
+@@ -2061,7 +2061,7 @@ mpw_abs(mpwObject * a)
+ 	z = (mpwObject *)mpw_pos(a);
+ 
+ if (z != NULL && _mpw_debug)
+-fprintf(stderr, "*** mpw_abs %p[%d]\t", MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** mpw_abs %p[%lu]\t", MPW_DATA(z), (unsigned long)(MPW_SIZE(z))), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+     return (PyObject *)z;
+ }
+diff --git a/python/rng-py.c b/python/rng-py.c
+index 6252ede..a59d2d7 100644
+--- a/python/rng-py.c
++++ b/python/rng-py.c
+@@ -199,7 +199,7 @@ rng_Next(rngObject * s, PyObject * args)
+     }
+ 
+ if (_rng_debug)
+-fprintf(stderr, "*** rng_Next(%p) %p[%d]\t", s, MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** rng_Next(%p) %p[%lu]\t", s, MPW_DATA(z), (unsigned long)(MPW_SIZE(z))), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+     return (PyObject *)z;
+ }
+@@ -236,7 +236,7 @@ rng_Prime(rngObject * s, PyObject * args)
+ 
+     z = mpw_FromMPW(b->size, b->modl, 1);
+ if (z != NULL && _rng_debug)
+-fprintf(stderr, "*** rng_Prime(%p) %p[%d]\t", s, MPW_DATA(z), MPW_SIZE(z)), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
++fprintf(stderr, "*** rng_Prime(%p) %p[%lu]\t", s, MPW_DATA(z), (unsigned long)(MPW_SIZE(z))), mpfprintln(stderr, MPW_SIZE(z), MPW_DATA(z));
+ 
+     return (PyObject *)z;
+ }
+-- 
+2.48.1
+

--- a/runtime-cryptography/beecrypt/autobuild/patches/0002-FEDORA-Fixes-for-C99-conformance-issues.patch
+++ b/runtime-cryptography/beecrypt/autobuild/patches/0002-FEDORA-Fixes-for-C99-conformance-issues.patch
@@ -1,0 +1,82 @@
+From d7b6b953c7cf26d52999b827034ab48395e42a9c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 18:31:02 +0800
+Subject: [PATCH 2/4] FEDORA: Fixes for C99 conformance issues
+
+https://fedoraproject.org/wiki/Toolchain/PortingToModernC
+
+Signed-off-by: Peter Fordham <peter.fordham@gmail.com>
+
+Link: https://src.fedoraproject.org/rpms/beecrypt/blob/c063d876b3ac038ba1a624cd9dc0b96bff4ebef0/f/beecrypt-4.2.1-autoconf-c99.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ acinclude.m4 | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 7df3867..2e0a41c 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -320,6 +320,9 @@ EOF
+             #if HAVE_FCNTL_H
+             # include <fcntl.h>
+             #endif
++            #if HAVE_TIME_H
++            # include <time.h>
++            #endif
+             #if HAVE_STRING_H
+             # include <string.h>
+             #endif
+@@ -338,7 +341,7 @@ EOF
+               int i, rc, fd = open("conftest.aio", O_RDONLY);
+ 
+               if (fd < 0)
+-                exit(1);
++                return 1;
+ 
+               memset(&a, 0, sizeof(struct aiocb));
+ 
+@@ -355,7 +358,7 @@ EOF
+               if (aio_read(&a) < 0)
+               {
+                 perror("aio_read");
+-                exit(1);
++                return 1;
+               }
+               if (aio_suspend(&a_list, 1, &a_timeout) < 0)
+               {
+@@ -368,25 +371,25 @@ EOF
+                   if (aio_suspend(&a_list, 1, &a_timeout) < 0)
+                   {
+                     perror("aio_suspend");
+-                    exit(1);
++                    return 1;
+                   }
+                 }
+                 else
+                 {
+                   perror("aio_suspend");
+-                  exit(1);
++                  return 1;
+                 }
+                 #else
+-                exit(1);
++                return 1;
+                 #endif
+               }
+               if (aio_error(&a) < 0)
+-                exit(1);
++                return 1;
+ 
+               if (aio_return(&a) < 0)
+-                exit(1);
++                return 1;
+ 
+-              exit(0);
++              return 0;
+           ]])],[bc_cv_working_aio=yes],[bc_cv_working_aio=no],[
+             case $target_os in
+               linux* | solaris*)
+-- 
+2.48.1
+

--- a/runtime-cryptography/beecrypt/autobuild/patches/0003-FEDORA-Fixes-for-C99-conformance-issues.patch
+++ b/runtime-cryptography/beecrypt/autobuild/patches/0003-FEDORA-Fixes-for-C99-conformance-issues.patch
@@ -1,0 +1,30 @@
+From e11d52fbe0e19caec16ccedb32a991bdf0e7e197 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 18:33:23 +0800
+Subject: [PATCH 3/4] FEDORA: Fixes for C99 conformance issues
+
+https://fedoraproject.org/wiki/Toolchain/PortingToModernC
+
+Signed-off-by: Peter Fordham <peter.fordham@gmail.com>
+
+Link: https://src.fedoraproject.org/rpms/beecrypt/blob/c063d876b3ac038ba1a624cd9dc0b96bff4ebef0/f/beecrypt-4.2.1-c99.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ blockmode.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/blockmode.c b/blockmode.c
+index 46d1fde..9998c23 100644
+--- a/blockmode.c
++++ b/blockmode.c
+@@ -29,6 +29,7 @@
+ # include "config.h"
+ #endif
+ 
++#include "beecrypt/endianness.h"
+ #include "beecrypt/blockmode.h"
+ 
+ int blockEncryptECB(const blockCipher* bc, blockCipherParam* bp, uint32_t* dst, const uint32_t* src, unsigned int nblocks)
+-- 
+2.48.1
+

--- a/runtime-cryptography/beecrypt/autobuild/patches/0004-FEDORA-disable-broken-C-bindings.patch
+++ b/runtime-cryptography/beecrypt/autobuild/patches/0004-FEDORA-disable-broken-C-bindings.patch
@@ -1,0 +1,36 @@
+From 3496d35fb4f94538c860e035a7d9920a8925e11b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 18:37:54 +0800
+Subject: [PATCH 4/4] FEDORA: disable broken C++ bindings
+
+Patch by Robert Scheck <robert@fedoraproject.org> for beecrypt >= 4.2.1 to
+avoid linking against libstdc++. This patch is based on an old by Florian
+La Roche <laroche@redhat.com> and Panu Matilainen <pmatilai@redhat.com>.
+
+For further information see Red Hat Bugzilla for bug ID #165080.
+
+Signed-off-by: Robert Scheck <robert@fedoraproject.org>
+
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=165080
+Link: https://src.fedoraproject.org/rpms/beecrypt/blob/7d7dad0a6ecb5aea44fce515f6931a941d6397ff/f/beecrypt-4.2.1-no-c++.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index b7e7869..b08bec8 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -62,7 +62,7 @@ BEECRYPT_OBJECTS = aes.lo base64.lo beecrypt.lo blockmode.lo blockpad.lo blowfis
+ 
+ lib_LTLIBRARIES = libbeecrypt.la
+ 
+-libbeecrypt_la_SOURCES = aes.c base64.c beecrypt.c blockmode.c blockpad.c blowfish.c dhies.c dldp.c dlkp.c dlpk.c dlsvdp-dh.c dsa.c elgamal.c endianness.c entropy.c fips186.c hmac.c hmacmd5.c hmacsha1.c hmacsha224.c hmacsha256.c md4.c md5.c hmacsha384.c hmacsha512.c memchunk.c mp.c mpbarrett.c mpnumber.c mpprime.c mtprng.c pkcs1.c pkcs12.c ripemd128.c ripemd160.c ripemd256.c ripemd320.c rsa.c rsakp.c rsapk.c sha1.c sha224.c sha256.c sha384.c sha512.c sha2k32.c sha2k64.c timestamp.c cppglue.cxx
++libbeecrypt_la_SOURCES = aes.c base64.c beecrypt.c blockmode.c blockpad.c blowfish.c dhies.c dldp.c dlkp.c dlpk.c dlsvdp-dh.c dsa.c elgamal.c endianness.c entropy.c fips186.c hmac.c hmacmd5.c hmacsha1.c hmacsha224.c hmacsha256.c md4.c md5.c hmacsha384.c hmacsha512.c memchunk.c mp.c mpbarrett.c mpnumber.c mpprime.c mtprng.c pkcs1.c pkcs12.c ripemd128.c ripemd160.c ripemd256.c ripemd320.c rsa.c rsakp.c rsapk.c sha1.c sha224.c sha256.c sha384.c sha512.c sha2k32.c sha2k64.c timestamp.c # cppglue.cxx
+ libbeecrypt_la_DEPENDENCIES = $(BEECRYPT_OBJECTS)
+ libbeecrypt_la_LIBADD = blowfishopt.lo mpopt.lo sha1opt.lo $(OPENMP_LIBS)
+ libbeecrypt_la_LDFLAGS = -no-undefined -version-info $(LIBBEECRYPT_LT_CURRENT):$(LIBBEECRYPT_LT_REVISION):$(LIBBEECRYPT_LT_AGE)
+-- 
+2.48.1
+

--- a/runtime-cryptography/beecrypt/spec
+++ b/runtime-cryptography/beecrypt/spec
@@ -1,0 +1,4 @@
+VER=4.2.1
+SRCS="tbl::https://sourceforge.net/projects/beecrypt/files/beecrypt/$VER/beecrypt-$VER.tar.gz/download"
+CHKSUMS="sha256::286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
+CHKUPDATE="anitya::id=174"

--- a/runtime-imaging/jbigkit/autobuild/build
+++ b/runtime-imaging/jbigkit/autobuild/build
@@ -1,20 +1,27 @@
-unset CPPFLAGS
+abinfo "Building jbigkit ..."
+make \
+    CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 
-make CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+abinfo "Installing runtime libraries ..."
+install -Dvm755 "$SRCDIR"/libjbig/libjbig*.so* \
+    -t "$PKGDIR"/usr/lib/
 
-install -D -m644 libjbig/libjbig.a "$PKGDIR"/usr/lib/libjbig.a
-install -D -m644 libjbig/libjbig85.a "$PKGDIR"/usr/lib/libjbig85.a
-install -D -m644 libjbig/jbig.h "$PKGDIR"/usr/include/jbig.h
-install -D -m644 libjbig/jbig_ar.h "$PKGDIR"/usr/include/jbig_ar.h
-install -D -m644 libjbig/jbig85.h "$PKGDIR"/usr/include/jbig85.h
+abinfo "Installing headers ..."
+install -Dvm644 \
+    "$SRCDIR"/libjbig/jbig.h \
+    "$SRCDIR"/libjbig/jbig_ar.h \
+    "$SRCDIR"/libjbig/jbig85.h \
+    -t "$PKGDIR"/usr/include/
 
-install -d -m755 "$PKGDIR"/usr/share/man/man1
-install -d -m755 "$PKGDIR"/usr/share/man/man5
-install -m644 pbmtools/*.1* "$PKGDIR"/usr/share/man/man1
-install -m644 pbmtools/*.5* "$PKGDIR"/usr/share/man/man5
+abinfo "Installing man pages ..."
+install -Dvm644 "$SRCDIR"/pbmtools/*.1* \
+    -t "$PKGDIR"/usr/share/man/man1/
+install -Dvm644 "$SRCDIR"/pbmtools/*.5* \
+    -t "$PKGDIR"/usr/share/man/man5/
 
-install -D -m755 pbmtools/jbgtopbm "$PKGDIR"/usr/bin/jbgtopbm
-install -D -m755 pbmtools/pbmtojbg "$PKGDIR"/usr/bin/pbmtojbg
-install -D -m755 pbmtools/jbgtopbm85 "$PKGDIR"/usr/bin/jbgtopbm85
-install -D -m755 pbmtools/pbmtojbg85 "$PKGDIR"/usr/bin/pbmtojbg85
-
+abinfo "Installing executables ..."
+for i in jbgtopbm pbmtojbg jbgtopbm85 pbmtojbg85; do
+    abinfo "Installing executable: $i ..."
+    install -Dvm755 "$SRCDIR"/pbmtools/$i \
+        "$PKGDIR"/usr/bin/$i
+done

--- a/runtime-imaging/jbigkit/autobuild/defines
+++ b/runtime-imaging/jbigkit/autobuild/defines
@@ -1,7 +1,4 @@
 PKGNAME=jbigkit
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="Data compression library/utilities for bi-level high resolution images"
-
-NOSTATIC=0
-NOLTO=1
+PKGDES="Data compression library/utilities for bi-level high-resolution images"

--- a/runtime-imaging/jbigkit/autobuild/patches/0001-FEDORA-pbmtools-Fix-a-number-of-compiler-warnings-pe.patch
+++ b/runtime-imaging/jbigkit/autobuild/patches/0001-FEDORA-pbmtools-Fix-a-number-of-compiler-warnings-pe.patch
@@ -1,0 +1,97 @@
+From 8619123ce3e153b6fb812ee58181d64c51e0dbf2 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 17:01:45 +0800
+Subject: [PATCH 1/5] FEDORA: pbmtools: Fix a number of compiler warnings per
+ feedback from Ubuntu security team (#840608)
+
+Signed-off-by: Fridolin Pokorny <fpokorny@redhat.com>
+
+Link: https://src.fedoraproject.org/rpms/jbigkit/blob/ff20fc858bd1fd3004d300c3c8af353f179c7d9a/f/jbigkit-2.0-warnings.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ pbmtools/pbmtojbg.c   | 24 ++++++++++++++++++++----
+ pbmtools/pbmtojbg85.c | 11 ++++++++---
+ 2 files changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/pbmtools/pbmtojbg.c b/pbmtools/pbmtojbg.c
+index 90c4581..3efefb9 100644
+--- a/pbmtools/pbmtojbg.c
++++ b/pbmtools/pbmtojbg.c
+@@ -86,7 +86,11 @@ static unsigned long getint(FILE *f)
+       while ((c = getc(f)) != EOF && !(c == 13 || c == 10)) ;
+   if (c != EOF) {
+     ungetc(c, f);
+-    fscanf(f, "%lu", &i);
++    if (fscanf(f, "%lu", &i) != 1) {
++      /* should never fail, since c must be a digit */
++      fprintf(stderr, "Unexpected failure reading digit '%c'\n", c);
++      exit(1);
++    }
+   }
+ 
+   return i;
+@@ -300,7 +304,9 @@ int main (int argc, char **argv)
+     break;
+   case '4':
+     /* PBM raw binary format */
+-    fread(bitmap[0], bitmap_size, 1, fin);
++    if (fread(bitmap[0], bitmap_size, 1, fin) != 1) {
++      /* silence compiler warnings; ferror/feof checked below */
++    }
+     break;
+   case '2':
+   case '5':
+@@ -312,8 +318,18 @@ int main (int argc, char **argv)
+ 	for (j = 0; j < bpp; j++)
+ 	  image[x * bpp + (bpp - 1) - j] = v >> (j * 8);
+       }
+-    } else
+-      fread(image, width * height, bpp, fin);
++    } else {
++      if (fread(image, width * height, bpp, fin) != (size_t) bpp) {
++	if (ferror(fin)) {
++	  fprintf(stderr, "Problem while reading input file '%s", fnin);
++	  perror("'");
++	  exit(1);
++	} else {
++	  fprintf(stderr, "Unexpected end of input file '%s'!\n", fnin);
++	  exit(1);
++	}
++      }
++    }
+     jbg_split_planes(width, height, planes, encode_planes, image, bitmap,
+ 		     use_graycode);
+     free(image);
+diff --git a/pbmtools/pbmtojbg85.c b/pbmtools/pbmtojbg85.c
+index 27bdbbd..651c075 100644
+--- a/pbmtools/pbmtojbg85.c
++++ b/pbmtools/pbmtojbg85.c
+@@ -70,9 +70,12 @@ static unsigned long getint(FILE *f)
+       while ((c = getc(f)) != EOF && !(c == 13 || c == 10)) ;
+   if (c != EOF) {
+     ungetc(c, f);
+-    fscanf(f, "%lu", &i);
++    if (fscanf(f, "%lu", &i) != 1) {
++      /* should never fail, since c must be a digit */
++      fprintf(stderr, "Unexpected failure reading digit '%c'\n", c);
++      exit(1);
++    }
+   }
+-
+   return i;
+ }
+ 
+@@ -237,7 +240,9 @@ int main (int argc, char **argv)
+       break;
+     case '4':
+       /* PBM raw binary format */
+-      fread(next_line, bpl, 1, fin);
++      if (fread(next_line, bpl, 1, fin) != 1) {
++	/* silence compiler warnings; ferror/feof checked below */
++      }
+       break;
+     default:
+       fprintf(stderr, "Unsupported PBM type P%c!\n", type);
+-- 
+2.48.1
+

--- a/runtime-imaging/jbigkit/autobuild/patches/0002-FEDORA-fix-typo-found-by-coverity.patch
+++ b/runtime-imaging/jbigkit/autobuild/patches/0002-FEDORA-fix-typo-found-by-coverity.patch
@@ -1,0 +1,47 @@
+From e753029e9a714b81fd642fb00391e6701e36afaf Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 17:13:12 +0800
+Subject: [PATCH 2/5] FEDORA: fix typo found by coverity
+
+Signed-off-by: Zdenek Dohnal <zdohnal@redhat.com>
+
+Link: https://src.fedoraproject.org/rpms/jbigkit/blob/8074600908d4abdd8cbd4bb29c027dffb3ee2c4a/f/jbigkit-covscan.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libjbig/jbig.c    | 2 +-
+ pbmtools/Makefile | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libjbig/jbig.c b/libjbig/jbig.c
+index 751ceff..3c76e07 100644
+--- a/libjbig/jbig.c
++++ b/libjbig/jbig.c
+@@ -889,7 +889,7 @@ void jbg_enc_options(struct jbg_enc_state *s, int order, int options,
+   if (order >= 0 && order <= 0x0f) s->order = order;
+   if (options >= 0) s->options = options;
+   if (l0 > 0) s->l0 = l0;
+-  if (mx >= 0 && my < 128) s->mx = mx;
++  if (mx >= 0 && mx < 128) s->mx = mx;
+   if (my >= 0 && my < 256) s->my = my;
+ 
+   return;
+diff --git a/pbmtools/Makefile b/pbmtools/Makefile
+index 6314af8..d695f69 100644
+--- a/pbmtools/Makefile
++++ b/pbmtools/Makefile
+@@ -56,9 +56,9 @@ test82: pbmtojbg jbgtopbm
+ 	make IMG=sandra    "OPTIONSP=-o 2" OPTIONSJ=       dotest2g
+ 	make IMG=multi      OPTIONSP=      OPTIONSJ=       dotest2g
+ 	make IMG=multi      OPTIONSP=-b    OPTIONSJ=-b     dotest2g
+-	make IMG=mx        "OPTIONSP=-q -s 3 -m 128"       dotest1
+-	make IMG=mx        "OPTIONSP=-q -s 3 -m 128"       dotest2b
+-	make IMG=mx        "OPTIONSP=-q -s 3 -m 128 -p 92" dotest2b
++	make IMG=mx        "OPTIONSP=-q -s 3 -m 127"       dotest1
++	make IMG=mx        "OPTIONSP=-q -s 3 -m 127"       dotest2b
++	make IMG=mx        "OPTIONSP=-q -s 3 -m 127 -p 92" dotest2b
+ 	make IMG=mx        "OPTIONSP=-q -Y -1"             dotest2b
+ 	make IMG=mx        "OPTIONSP=-Y -1"                dotest2b
+ 	rm -f test-*.jbg test-*.pbm test-*.pgm
+-- 
+2.48.1
+

--- a/runtime-imaging/jbigkit/autobuild/patches/0003-BACKPORT-jbg_newlen-check-for-end-of-file-within-MAR.patch
+++ b/runtime-imaging/jbigkit/autobuild/patches/0003-BACKPORT-jbg_newlen-check-for-end-of-file-within-MAR.patch
@@ -1,0 +1,32 @@
+From 3328e6e1df5e05e8c0e8a90e963e85e5058bc127 Mon Sep 17 00:00:00 2001
+From: Markus Kuhn <Markus.Kuhn@cl.cam.ac.uk>
+Date: Mon, 15 Feb 2021 18:27:47 +0000
+Subject: [PATCH 3/5] BACKPORT: jbg_newlen(): check for end-of-file within
+ MARKER_NEWLEN
+
+fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=969593
+reported by Casper Sun
+
+[Mingcong Bai: Cherry-picked from
+7d3c1bea895d910907e2501fe9165e353eceabae]
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libjbig/jbig.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libjbig/jbig.c b/libjbig/jbig.c
+index 3c76e07..cd29624 100644
+--- a/libjbig/jbig.c
++++ b/libjbig/jbig.c
+@@ -3267,6 +3267,8 @@ int jbg_newlen(unsigned char *bie, size_t len)
+     else if (p[0] == MARKER_ESC)
+       switch (p[1]) {
+       case MARKER_NEWLEN:
++        if (p + 5 >= bie + len)
++          return JBG_EAGAIN;
+ 	y = (((long) bie[ 8] << 24) | ((long) bie[ 9] << 16) |
+ 	     ((long) bie[10] <<  8) |  (long) bie[11]);
+ 	yn = (((long) p[2] << 24) | ((long) p[3] << 16) |
+-- 
+2.48.1
+

--- a/runtime-imaging/jbigkit/autobuild/patches/0004-DEBIAN-fix-typo-s-in-pbmtools-pbmtojbg.1.patch
+++ b/runtime-imaging/jbigkit/autobuild/patches/0004-DEBIAN-fix-typo-s-in-pbmtools-pbmtojbg.1.patch
@@ -1,0 +1,38 @@
+From ef442145a9cc516b110a8141e38785769e5e2c9d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 13 Feb 2025 17:20:47 +0800
+Subject: [PATCH 4/5] DEBIAN: fix typo's in pbmtools/pbmtojbg.1
+
+From Debian: jbigkit 2.1-6.1
+
+Signed-off-by: Michael van der Kolff <mvanderkolff@gmail.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ pbmtools/pbmtojbg.1 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pbmtools/pbmtojbg.1 b/pbmtools/pbmtojbg.1
+index c1c63cd..6d9cd02 100644
+--- a/pbmtools/pbmtojbg.1
++++ b/pbmtools/pbmtojbg.1
+@@ -130,7 +130,7 @@ encoder.)
+ .TP
+ .BI \-t " number"
+ Encode only the specified number of most significant bit planes. This
+-option allows to reduce the depth of an input PGM file if not all
++option allows one to reduce the depth of an input PGM file if not all
+ bits per pixel are needed in the output.
+ .TP
+ .BI \-o " number"
+@@ -174,7 +174,7 @@ stripe and then completes layer 0 before continuing with the next
+ layer and so on. 
+ .TP
+ .BI \-p " number"
+-This option allows to activate or deactivate various optional algorithms
++This option allows one to activate or deactivate various optional algorithms
+ defined in the
+ .I JBIG1
+ standard. Just add the numbers of the following options which you want to
+-- 
+2.48.1
+

--- a/runtime-imaging/jbigkit/autobuild/patches/0005-DEBIAN-Improve-upstream-Makefiles.patch
+++ b/runtime-imaging/jbigkit/autobuild/patches/0005-DEBIAN-Improve-upstream-Makefiles.patch
@@ -1,0 +1,190 @@
+From 30a74b9a493b53abaab7e47d14b6dc73ac3e32d5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20G=C3=B6ttsche?= <cgzones@googlemail.com>
+Date: Wed, 5 Oct 2022 18:58:28 +0200
+Subject: [PATCH 5/5] DEBIAN: Improve upstream Makefiles
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* Add install target
+* Build shared library
+* Link binaries against shared library
+* Add missing $(LDFLAGS) for hardening flags
+* Use $(AR) for cross-compilation and options s to avoid ranlib usage
+* Add additional generated files to clean target
+* Adjust LD_LIBRARY_PATH for tests, since they are now dynamically
+  linked
+
+Forwarded: no
+Signed-off-by: Christian Göttsche <cgzones@googlemail.com>
+
+From Debian: jbigkit 2.1-6.1
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile          | 17 +++++++++++++++--
+ libjbig/Makefile  | 21 ++++++++++++---------
+ pbmtools/Makefile | 33 ++++++++++++++-------------------
+ 3 files changed, 41 insertions(+), 30 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9f7e3ba..9969b06 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,15 +1,16 @@
+ # Unix makefile for JBIG-KIT
+ 
+ # Select an ANSI/ISO C compiler here, GNU gcc is recommended
+-CC = gcc
++CC ?= gcc
+ 
+ # Options for the compiler: A high optimization level is suggested
+-CFLAGS = -O2 -W -Wno-unused-result
++CFLAGS ?= -O2 -W -Wno-unused-result
+ # CFLAGS = -O -g -W -Wall -Wno-unused-result -ansi -pedantic # -DDEBUG
+ 
+ export CC CFLAGS
+ 
+ VERSION=2.1
++.PHONY: all lib pbm test clean install
+ 
+ all: lib pbm
+ 	@echo "Enter 'make test' in order to start some automatic tests."
+@@ -42,3 +43,15 @@ distribution:
+ release:
+ 	rsync -t jbigkit-$(VERSION).tar.gz $(HOME)/public_html/download/
+ 	rsync -t jbigkit-$(VERSION)/CHANGES $(HOME)/public_html/jbigkit/
++
++install: all
++	install -d $(DESTDIR)/usr/lib/$(DEB_HOST_MULTIARCH)
++	install -m 644 libjbig/*.so.* libjbig/*.a $(DESTDIR)/usr/lib/$(DEB_HOST_MULTIARCH)
++	/sbin/ldconfig -n $(DESTDIR)/usr/lib/$(DEB_HOST_MULTIARCH)
++	ln -s libjbig.so.0 $(DESTDIR)/usr/lib/$(DEB_HOST_MULTIARCH)/libjbig.so
++	install -d $(DESTDIR)/usr/include
++	install -m 644 libjbig/*.h $(DESTDIR)/usr/include
++	install -d $(DESTDIR)/usr/bin
++	install -m 755 pbmtools/jbgtopbm pbmtools/jbgtopbm85 pbmtools/pbmtojbg pbmtools/pbmtojbg85 $(DESTDIR)/usr/bin
++	install -d $(DESTDIR)/usr/share/man/man1
++	install -m 644 pbmtools/*.1 $(DESTDIR)/usr/share/man/man1
+diff --git a/libjbig/Makefile b/libjbig/Makefile
+index f2898f5..72295de 100644
+--- a/libjbig/Makefile
++++ b/libjbig/Makefile
+@@ -1,28 +1,30 @@
+ # Unix makefile for the JBIG-KIT library
+ 
+ # Select an ANSI/ISO C compiler here, GNU gcc is recommended
+-CC = gcc
++CC ?= gcc
+ 
+ # Options for the compiler: A high optimization level is suggested
+-CFLAGS = -g -O -W -Wall -ansi -pedantic # --coverage
++CFLAGS ?= -g -O -W -Wall -ansi -pedantic # --coverage
+ 
+-all: libjbig.a libjbig85.a tstcodec tstcodec85
++all: libjbig.a libjbig.so libjbig85.a tstcodec tstcodec85
+ 
+ tstcodec: tstcodec.o jbig.o jbig_ar.o
+-	$(CC) $(CFLAGS) -o tstcodec tstcodec.o jbig.o jbig_ar.o
++	$(CC) $(CFLAGS) -o tstcodec tstcodec.o jbig.o jbig_ar.o $(LDFLAGS)
+ 
+ tstcodec85: tstcodec85.o jbig85.o jbig_ar.o
+-	$(CC) $(CFLAGS) -o tstcodec85 tstcodec85.o jbig85.o jbig_ar.o
++	$(CC) $(CFLAGS) -o tstcodec85 tstcodec85.o jbig85.o jbig_ar.o $(LDFLAGS)
+ 
+ libjbig.a: jbig.o jbig_ar.o
+ 	rm -f libjbig.a
+-	ar rc libjbig.a jbig.o jbig_ar.o
+-	-ranlib libjbig.a
++	$(AR) rcs $@ jbig.o jbig_ar.o
++
++libjbig.so: jbig.o jbig_ar.o jbig85.o
++	$(CC) -shared -Wl,-soname,libjbig.so.0 -o libjbig.so.0 $+ $(LDFLAGS)
++	ln -sf libjbig.so.0 libjbig.so
+ 
+ libjbig85.a: jbig85.o jbig_ar.o
+ 	rm -f libjbig85.a
+-	ar rc libjbig85.a jbig85.o jbig_ar.o
+-	-ranlib libjbig85.a
++	$(AR) rcs $@ jbig85.o jbig_ar.o
+ 
+ jbig.o: jbig.c jbig.h jbig_ar.h
+ jbig85.o: jbig85.c jbig85.h jbig_ar.h
+@@ -51,5 +53,6 @@ t82test.pbm: tstcodec
+ 
+ clean:
+ 	rm -f *.o *.gcda *.gcno *.gcov *.plist *~ core gmon.out dbg_d\=??.pbm
++	rm -f *.so* *.a *.la
+ 	rm -f t82test.pbm
+ 	rm -f tstcodec tstcodec85
+diff --git a/pbmtools/Makefile b/pbmtools/Makefile
+index d695f69..1b8cc6d 100644
+--- a/pbmtools/Makefile
++++ b/pbmtools/Makefile
+@@ -1,11 +1,12 @@
+ # Unix makefile for the JBIG-KIT PBM tools
+ 
+ # Select an ANSI/ISO C compiler here, e.g. GNU gcc is recommended
+-CC = gcc
++CC ?= gcc
+ 
+ # Options for the compiler
+-CFLAGS = -g -O -W -Wall -Wno-unused-result -ansi -pedantic # --coverage
+-CPPFLAGS = -I../libjbig 
++CFLAGS ?= -g -O -W -Wall -Wno-unused-result -ansi -pedantic # --coverage
++override CPPFLAGS += -I../libjbig
++export LD_LIBRARY_PATH := $(if $(LD_LIBRARY_PATH),$(LD_LIBRARY_PATH):)../libjbig
+ 
+ .SUFFIXES: .1 .5 .txt $(SUFFIXES)
+ .PHONY: txt test test82 test85 clean
+@@ -14,31 +15,23 @@ all: pbmtojbg jbgtopbm pbmtojbg85 jbgtopbm85 txt
+ 
+ txt: pbmtojbg.txt jbgtopbm.txt pbm.txt pgm.txt
+ 
+-pbmtojbg: pbmtojbg.o ../libjbig/libjbig.a
+-	$(CC) $(CFLAGS) -o pbmtojbg pbmtojbg.o -L../libjbig -ljbig
++pbmtojbg: pbmtojbg.o
++	$(CC) $(CFLAGS) -o pbmtojbg pbmtojbg.o -L../libjbig -ljbig $(LDFLAGS)
+ 
+-jbgtopbm: jbgtopbm.o ../libjbig/libjbig.a
+-	$(CC) $(CFLAGS) -o jbgtopbm jbgtopbm.o -L../libjbig -ljbig
++jbgtopbm: jbgtopbm.o
++	$(CC) $(CFLAGS) -o jbgtopbm jbgtopbm.o -L../libjbig -ljbig $(LDFLAGS)
+ 
+-pbmtojbg85: pbmtojbg85.o ../libjbig/libjbig85.a
+-	$(CC) $(CFLAGS) -o pbmtojbg85 pbmtojbg85.o -L../libjbig -ljbig85
++pbmtojbg85: pbmtojbg85.o
++	$(CC) $(CFLAGS) -o pbmtojbg85 pbmtojbg85.o -L../libjbig -ljbig $(LDFLAGS)
+ 
+-jbgtopbm85: jbgtopbm85.o ../libjbig/libjbig85.a
+-	$(CC) $(CFLAGS) -o jbgtopbm85 jbgtopbm85.o -L../libjbig -ljbig85
++jbgtopbm85: jbgtopbm85.o
++	$(CC) $(CFLAGS) -o jbgtopbm85 jbgtopbm85.o -L../libjbig -ljbig $(LDFLAGS)
+ 
+ jbgtopbm.o: jbgtopbm.c ../libjbig/jbig.h
+ pbmtojbg.o: pbmtojbg.c ../libjbig/jbig.h
+ jbgtopbm85.o: jbgtopbm85.c ../libjbig/jbig85.h
+ pbmtojbg85.o: pbmtojbg85.c ../libjbig/jbig85.h
+ 
+-../libjbig/libjbig.a: ../libjbig/jbig.c ../libjbig/jbig.h \
+-	../libjbig/jbig_ar.c ../libjbig/jbig_ar.h
+-	make -C ../libjbig libjbig.a
+-
+-../libjbig/libjbig85.a: ../libjbig/jbig85.c ../libjbig/jbig85.h \
+-	../libjbig/jbig_ar.c ../libjbig/jbig_ar.h
+-	make -C ../libjbig libjbig85.a
+-
+ analyze:
+ 	clang $(CPPFLAGS) --analyze *.c
+ 
+@@ -96,6 +89,8 @@ dotest2g:
+ 	cmp test-$(IMG).pgm ../examples/$(IMG).pgm
+ 
+ test85: pbmtojbg jbgtopbm pbmtojbg85 jbgtopbm85 test-t82.pbm
++	export LD_LIBRARY_PATH=`pwd`/../libjbig
++	echo $(LD_LIBRARY_PATH)
+ 	make IMG=t82 "OPTIONSP=-p 0"      dotest85
+ 	make IMG=t82 "OPTIONSP=-p 8"      dotest85
+ 	make IMG=t82 "OPTIONSP=-p 8 -r"   dotest85b
+-- 
+2.48.1
+

--- a/runtime-imaging/jbigkit/spec
+++ b/runtime-imaging/jbigkit/spec
@@ -1,5 +1,5 @@
 VER=2.1
-REL=6
+REL=7
 SRCS="tbl::https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/jbigkit-$VER.tar.gz"
 CHKSUMS="sha256::de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"
 CHKUPDATE="anitya::id=1432"


### PR DESCRIPTION
Topic Description
-----------------

- beecrypt: new, 4.2.1
    Track patches at AOSC-Tracking/beecrypt @ aosc/v4.2.1
    \(HEAD: 3496d35fb4f94538c860e035a7d9920a8925e11b\).
- jbigkit: improve packaging
    - Import patches for shared library builds, build system improvements, and
    typos/warning fixes from Debian, Fedora, and the upstream.
    - Lint scripts in accordance with the Styling Manual.
    - Track patches at AOSC-Tracking/jbigkit @ aosc/v2.1
    \(HEAD: 30a74b9a493b53abaab7e47d14b6dc73ac3e32d5\).
- cups: add cupsys, libcupsys2 Spiral markers
    Required by Canon ufr2 drivers.

Package(s) Affected
-------------------

- beecrypt: 4.2.1
- cups: 2.4.11-1
- jbigkit: 2.1-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups jbigkit beecrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
