### PR TITLE
apostrophe: new, 3.2

### DIFF
--- a/app-editors/apostrophe/autobuild/defines
+++ b/app-editors/apostrophe/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=apostrophe
+PKGSEC=editors
+PKGDEP="dconf glib graphene gtk-4 gtksourceview-5 hicolor-icon-theme \
+	libadwaita pango python-3 chardet pygobject-3 webkit2gtk \
+	libspelling pypandoc"
+PKGRECOM="texlive appstream fira-font"
+PKGDES="Markdown editor with distraction-free mode and support for multi-format export"
+
+ABHOST=noarch

--- a/app-editors/apostrophe/autobuild/prepare
+++ b/app-editors/apostrophe/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Deploying reveal.js ..."
+mkdir -pv /usr/share/apostrophe/libs/reveal.js/
+cp -rv "$SRCDIR"/../reveal.js/  /usr/share/apostrophe/libs/reveal.js/

--- a/app-editors/apostrophe/spec
+++ b/app-editors/apostrophe/spec
@@ -1,0 +1,9 @@
+VER=3.2
+
+# The latest Reveal.js is provided in master branch
+REVEAL_JS_COMMIT=09505903003285573dc12d971a5e4c621fe14cae
+SRCS="git::commit=tags/v$VER;rename=apostrophe::https://gitlab.gnome.org/World/apostrophe.git \
+      git::commit=$REVEAL_JS_COMMIT;rename=reveal.js::https://github.com/hakimel/reveal.js.git"
+SUBDIR="apostrophe"
+CHKSUMS="SKIP SKIP"
+CHKUPDATE="anitya::id=222624"

--- a/desktop-fonts/fira-font/autobuild/build
+++ b/desktop-fonts/fira-font/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing font file..."
+install -Dvm644 "$SRCDIR"/ttf/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF

--- a/desktop-fonts/fira-font/autobuild/defines
+++ b/desktop-fonts/fira-font/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="fira-font"
+PKGDES="Fira Sans-serif and monospace font from Mozilla"
+PKGDEP="fontconfig"
+PKGSEC="fonts"
+
+ABHOST="noarch"

--- a/desktop-fonts/fira-font/spec
+++ b/desktop-fonts/fira-font/spec
@@ -1,0 +1,4 @@
+VER=4.202
+SRCS="git::commit=tags/$VER::https://github.com/mozilla/Fira.git"
+CHKSUMS=SKIP
+CHKUPDATE="anitya::id=376769"

--- a/desktop-gnome/libspelling/autobuild/defines
+++ b/desktop-gnome/libspelling/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=libspelling
+PKGSEC=gnome
+PKGDEP="enchant-2 gcc-runtime glib glibc gtk-4 gtksourceview-5 icu pango"
+BUILDDEP="gi-docgen gobject-introspection vala sysprof"
+PKGDES="Spellcheck library for GTK 4"

--- a/desktop-gnome/libspelling/spec
+++ b/desktop-gnome/libspelling/spec
@@ -1,0 +1,4 @@
+VER=0.4.6
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libspelling.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369148"

--- a/lang-python/pypandoc/autobuild/defines
+++ b/lang-python/pypandoc/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pypandoc
+PKGSEC=python
+PKGDEP="pandoc"
+BUILDDEP="python-build python-installer poetry wheel"
+PKGDES="Python bindings for Pandoc"
+
+ABHOST=noarch

--- a/lang-python/pypandoc/spec
+++ b/lang-python/pypandoc/spec
@@ -1,0 +1,4 @@
+VER=1.15
+SRCS="git::commit=tags/v$VER::https://github.com/JessicaTegner/pypandoc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=10570"

--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
 PKGDEP="gtk-4 libxml2"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala"
+BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala gtk-update-icon-cache"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
-MESON_AFTER="-Dinstall_tests=false \
+MESON_AFTER="-Dinstall-tests=false \
              -Dvapi=true \
-             -Dgtk_doc=true \
+             -Ddocumentation=true \
              -Dsysprof=false"

--- a/runtime-editors/gtksourceview-5/spec
+++ b/runtime-editors/gtksourceview-5/spec
@@ -1,4 +1,4 @@
-VER=5.4.2
-SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:3}/gtksourceview-$VER.tar.xz"
-CHKSUMS="sha256::ad140e07eb841910de483c092bd4885abd29baadd6e95fa22d93ed2df0b79de7"
+VER=5.14.2
+SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
+CHKSUMS="sha256::1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER%.*}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- apostrophe: new, 3.2
- fira-font: new, 4.202
- libspelling: new, 0.4.6
- pypandoc: new, 1.15
- gtksourceview-5:
- add gtk-update-icon-cache build dependency;
- update MESON_AFTER parameters;
- update to 5.14.2

Package(s) Affected
-------------------

- apostrophe: 3.2
- gtksourceview-5: 5.14.2
- libspelling: 0.4.6
- fira-font: 4.202
- pypandoc: 1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit fira-font gtksourceview-5 pypandoc libspelling apostrophe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
