### PR TITLE
aom: update to 3.12.0

### DIFF
--- a/runtime-multimedia/aom/spec
+++ b/runtime-multimedia/aom/spec
@@ -1,4 +1,4 @@
-VER=3.11.0
+VER=3.12.0
 SRCS="git::commit=tags/v$VER::https://aomedia.googlesource.com/aom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17628"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-aaa: update to 12.0.5
- gcc: backport a fix for ICE on AArch64 whilst building AOM-AV1
    Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115464
- aom: update to 3.12.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aom: 3.12.0
- aosc-aaa: 12.0.5
- gcc: 14.2.0-2
- gcc-runtime: 14.2.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit aom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
