### PR TITLE
nas: fix lib64 => lib logic

### DIFF
--- a/runtime-multimedia/nas/autobuild/build
+++ b/runtime-multimedia/nas/autobuild/build
@@ -17,5 +17,11 @@ make install \
 
 if [ -d "$PKGDIR"/usr/lib64 ]; then
     abinfo "Moving /usr/lib64 => /usr/lib ..."
-    mv -v "$PKGDIR"/usr/lib{64,}
+    if [ -d "$PKGDIR"/usr/lib ]; then
+        mv -v "$PKGDIR"/usr/lib64/* \
+            "$PKGDIR"/usr/lib/
+        rm -rv "$PKGDIR"/usr/lib64
+    else
+        mv -v "$PKGDIR"/usr/lib{64,}
+    fi
 fi

--- a/runtime-multimedia/nas/spec
+++ b/runtime-multimedia/nas/spec
@@ -1,5 +1,5 @@
 VER=1.9.4
-REL=4
+REL=5
 SRCS="tbl::https://sourceforge.net/projects/nas/files/nas/nas%20${VER}%20%28stable%29/nas-$VER.src.tar.gz/download"
 CHKSUMS="sha256::cf36ea63751ce86cfd3b76c1659ce0d6a361a2e7cb34069854e156532703b39d"
 CHKUPDATE="anitya::id=2047"


### PR DESCRIPTION
Topic Description
-----------------

- nas: fix lib64 => lib logic
    The previous implementation did not check for the existance of /usr/lib,
    which resulted in the /usr/lib64 being moved into /usr/lib/lib64, which
    is incorrect.
    Add an extra check during the file movement.

Package(s) Affected
-------------------

- nas: 1.9.4-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit nas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
