### PR TITLE
telegram-desktop: update to 5.11.1

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 4dd553d011935fbe8bb034611ad60e346482aab6 Mon Sep 17 00:00:00 2001
+From 96980ca8edce0428dc9b2c097c0d9b9f5f49d6f8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 1/8] fix(window.style): set default window width to 360px
+Subject: [PATCH 1/9] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index 30026da2..7f7de659 100644
+index acdda31299..899bcb5827 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
@@ -31,5 +31,5 @@ index 30026da2..7f7de659 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From 6ef0b150cd0f47f2ca5bf5f73cf0643f9099475f Mon Sep 17 00:00:00 2001
+From 73b7d248f87914d088d9997d533f367466fd1344 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 2/8] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 2/9] fix(core_settings.h): use system window decoration by
  default
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 2/8] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 87fb383f..6e879b7e 100644
+index 91da7945a2..0c9713ed87 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1034,7 +1034,7 @@ private:
+@@ -1033,7 +1033,7 @@ private:
  	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
@@ -22,5 +22,5 @@ index 87fb383f..6e879b7e 100644
  	rpl::variable<bool> _systemDarkModeEnabled = true;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From b953f5c56ab128bde8e8eee4cbf01a4fb69657d7 Mon Sep 17 00:00:00 2001
+From c330f36eae2258614d4258f8c0e0de5343b1c898 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 3/8] fix(ui): fix build with Qt 5
+Subject: [PATCH 3/9] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---
@@ -12,7 +12,7 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  4 files changed, 8 insertions(+)
 
 diff --git a/Telegram/lib_ui/ui/text/text_entity.cpp b/Telegram/lib_ui/ui/text/text_entity.cpp
-index 810f5764..cd6200f5 100644
+index 810f5764ef..cd6200f555 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.cpp
 +++ b/Telegram/lib_ui/ui/text/text_entity.cpp
 @@ -2417,6 +2417,8 @@ EntityInText::EntityInText(
@@ -25,7 +25,7 @@ index 810f5764..cd6200f5 100644
  		const EntitiesInText &entities,
  		int textLength) {
 diff --git a/Telegram/lib_ui/ui/text/text_entity.h b/Telegram/lib_ui/ui/text/text_entity.h
-index 75b5e8e3..dbbd5303 100644
+index 75b5e8e39c..dbbd530345 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.h
 +++ b/Telegram/lib_ui/ui/text/text_entity.h
 @@ -71,6 +71,8 @@ public:
@@ -38,7 +38,7 @@ index 75b5e8e3..dbbd5303 100644
  		return _type;
  	}
 diff --git a/Telegram/lib_webview/CMakeLists.txt b/Telegram/lib_webview/CMakeLists.txt
-index f4e0bb84..eeed27c7 100644
+index f4e0bb8467..eeed27c7e9 100644
 --- a/Telegram/lib_webview/CMakeLists.txt
 +++ b/Telegram/lib_webview/CMakeLists.txt
 @@ -7,6 +7,7 @@
@@ -50,7 +50,7 @@ index f4e0bb84..eeed27c7 100644
  get_filename_component(src_loc . REALPATH)
  
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
-index 24274c37..a57c4fab 100644
+index 24274c3794..a57c4fab1f 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
 @@ -54,6 +54,7 @@ private:
@@ -68,5 +68,5 @@ index 24274c37..a57c4fab 100644
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From 7078e410339a70e35591df47a6aa1ea5515285fd Mon Sep 17 00:00:00 2001
+From de568f020ced3b10c322b19efff6887a05f16fab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 4/8] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 4/9] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst
@@ -13,7 +13,7 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
-index 312ce966..7a445f2c 100644
+index 312ce96673..7a445f2c8e 100644
 --- a/Telegram/SourceFiles/core/launcher.cpp
 +++ b/Telegram/SourceFiles/core/launcher.cpp
 @@ -342,7 +342,9 @@ void Launcher::initHighDpi() {
@@ -28,5 +28,5 @@ index 312ce966..7a445f2c 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,14 +1,14 @@
-From f094a07013e9952810f6abeb32560bd4dcbb039c Mon Sep 17 00:00:00 2001
+From e9641ddd28e55b09469cca96bdfced9fc079ab4a Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 5/8] fix(settings): use system fonts by default
+Subject: [PATCH 5/9] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 6e879b7e..241ef95e 100644
+index 0c9713ed87..6b1138d6fb 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
 @@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -19,7 +19,7 @@ index 6e879b7e..241ef95e 100644
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1068,7 +1069,7 @@ private:
+@@ -1067,7 +1068,7 @@ private:
  	rpl::variable<bool> _storiesClickTooltipHidden = false;
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;
@@ -29,5 +29,5 @@ index 6e879b7e..241ef95e 100644
  	std::optional<bool> _weatherInCelsius;
  	QByteArray _tonsiteStorageToken;
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 94ced89f2f2f822beafdfd803c45a4662bf67259 Mon Sep 17 00:00:00 2001
+From 0cf197a33f33996c2d38b29ee75197b5b52288bf Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 6/8] Remove the confusing "Default" option from selectable
+Subject: [PATCH 6/9] Remove the confusing "Default" option from selectable
  fonts
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 6/8] Remove the confusing "Default" option from selectable
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
-index becdc962..550ac863 100644
+index 97f65b65d9..9eff4830c3 100644
 --- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 +++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 @@ -532,7 +532,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
@@ -45,5 +45,5 @@ index becdc962..550ac863 100644
  		std::swap(result[2], *nowIt);
  		++skip;
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From 5f6c8ca90f8b19cb9077ffdab6651d800baaf5c3 Mon Sep 17 00:00:00 2001
+From 96d88738e15613ff10092c4027c2903349139b56 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 7/8] fix(lib_tl): add missing cstring include
+Subject: [PATCH 7/9] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_tl/tl/tl_basic_types.h b/Telegram/lib_tl/tl/tl_basic_types.h
-index 5eadf62a..961f7feb 100644
+index 5eadf62a93..961f7febe0 100644
 --- a/Telegram/lib_tl/tl/tl_basic_types.h
 +++ b/Telegram/lib_tl/tl/tl_basic_types.h
 @@ -10,6 +10,7 @@
@@ -21,5 +21,5 @@ index 5eadf62a..961f7feb 100644
  
  namespace tl {
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From 0175035d9eafe6f776a0de291ef8272a6e0ad5ff Mon Sep 17 00:00:00 2001
+From 32e2e189dd0ababf83e940f1469c1871ffdacaee Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 8/8] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 8/9] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_webview/webview/webview_interface.h b/Telegram/lib_webview/webview/webview_interface.h
-index d19d2534..660e5b27 100644
+index 4a92fe3020..3cf6125358 100644
 --- a/Telegram/lib_webview/webview/webview_interface.h
 +++ b/Telegram/lib_webview/webview/webview_interface.h
 @@ -12,6 +12,7 @@
@@ -21,5 +21,5 @@ index d19d2534..660e5b27 100644
  #include <rpl/never.h>
  #include <rpl/producer.h>
 -- 
-2.47.1
+2.48.1
 

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,0 +1,26 @@
+From 519b4e0fbe1e007a8c5a9fbf7636f16e46eb33e8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Thu, 13 Feb 2025 22:30:40 -0800
+Subject: [PATCH 9/9] fix(current_geo_location_linux): add missing
+ QGuiApplication include
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ .../SourceFiles/platform/linux/current_geo_location_linux.cpp    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
+index 7015af7398..d48fc7025a 100644
+--- a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
+@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "base/platform/linux/base_linux_library.h"
+ 
+ #include <gio/gio.h>
++#include <QGuiApplication>
+ 
+ namespace Platform {
+ namespace {
+-- 
+2.48.1
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,9 +1,9 @@
-VER=5.10.7
+VER=5.11.1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=be39b8c8d0db1f377118f813f0c4bd331d341d5e
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::37f5f4108ca052a670a6b28e6eecf7afbc1bccbc562997cf9c89c0c725d96c1e \
+CHKSUMS="sha256::bde842b71064511c5bacb4971e3b2d539614f8dc541dffcb4ccc00e02d80924b \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.11.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
