### PR TITLE
libcap: update to 2.73, bump PKGEPOCH_SPIRAL to 1

### DIFF
--- a/runtime-common/libcap/autobuild/defines
+++ b/runtime-common/libcap/autobuild/defines
@@ -4,3 +4,4 @@ PKGDES="POSIX 1003.1e capabilities"
 PKGDEP="attr glibc"
 
 NOPARALLEL=1
+PKGEPOCH_SPIRAL=1

--- a/runtime-common/libcap/spec
+++ b/runtime-common/libcap/spec
@@ -1,4 +1,4 @@
-VER=2.69
+VER=2.73
 SRCS="tbl::https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$VER.tar.xz"
-CHKSUMS="sha256::f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb"
+CHKSUMS="sha256::6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
 CHKUPDATE="anitya::id=1569"


### PR DESCRIPTION
Topic Description
-----------------

- libcap: update to 2.73, bump PKGEPOCH_SPIRAL to 1

Package(s) Affected
-------------------

- libcap: 2.73

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
