### PR TITLE
grub: guarantee 64-bit addresses for loongson3 in util/grub-mkimagexx

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/47] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/48] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/47] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/48] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/47] Don't add '*' to highlighted row
+Subject: [PATCH 03/48] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/47] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/48] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/47] Indent menu entries
+Subject: [PATCH 05/48] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/47] Fix margins
+Subject: [PATCH 06/48] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/47] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/48] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/47] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/48] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/47] Don't draw a border around the menu
+Subject: [PATCH 09/48] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/47] Use the standard margin for the timeout string
+Subject: [PATCH 10/48] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/47] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/48] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/47] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/48] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/47] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/48] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 59e7ba1bf0d63ddcd8e3d40888bcac0b7223e70e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/47] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/48] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From c23c121bde5381debb61889fb3cc94a6061628ab Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/47] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/48] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From 71cb4fcc6a76c5cdc3a629351097a73c664fb6f5 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/47] commands: add new command memsize
+Subject: [PATCH 16/48] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From b98c6eb9ba1e8f88e7d2df1c6700fef74a9b4fe2 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/47] commands: add new command 'pause'
+Subject: [PATCH 17/48] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 5855f82d979f2db3e185e75c356686f5b23943ae Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/47] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/48] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 0ec6cd51f5f49d1c2b82737279589431427f3838 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/47] po: add patch to disable parallel execution
+Subject: [PATCH 19/48] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From b69e36efa6f9745e73e9312d2db26875ce83a8fc Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/47] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/48] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 1632a45c5d4d78dea18e449b3592120cc8517bff Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/47] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/48] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 2f40e35813a4677b7409d6d6b9459c0ed3e98bca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/47] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/48] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 624eb1c0887dba508ef03385e7f49f7d951b3ac4 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 23/47] loongarch64: able to start on legacy firmware
+Subject: [PATCH 23/48] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.

--- a/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 977635494cb3f3418924842943088801ee241ee5 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 24/47] Add support for forcing EFI installation to the
+Subject: [PATCH 24/48] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI

--- a/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From 6015952363f071aacf6f5d2de607fc168daa1746 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 25/47] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 25/48] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not

--- a/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From 61a3db3ad1e300a531aaa7dcdd4bf496f1b5be65 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 26/47] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 26/48] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-

--- a/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From e4e7a42521c5b178a86caf1ac950dfc1f79e0a30 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 27/47] mips64: Add support for Loongson.
+Subject: [PATCH 27/48] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From e5d36fc00b3467b49851f20effb4e9c3400e73ce Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 28/47] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 28/48] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---

--- a/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From fb3c7be5f6bd065554321f75d65132dfd53bb2d4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 29/47] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 29/48] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---

--- a/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 828d7983742c9336e8a512b1bd4ec74cb3e4ec33 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 30/47] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 30/48] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---

--- a/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From d4942f62fdf97f922516b3e7ea3d72e7c8dcf772 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 31/47] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 31/48] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----

--- a/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,7 +1,7 @@
 From 402da3bece331169230d07b83496885cd305529a Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 32/47] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 32/48] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,7 +1,7 @@
 From 8ca095a942e8e19033c3e0dde9da7412c62f8698 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 33/47] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 33/48] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 8d9bff60ccfd4e9d67e83479df15b5c072fd7b14 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 34/47] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 34/48] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---

--- a/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
@@ -1,7 +1,7 @@
 From 1c99dd698362042f2da9e9ac7283061984405c8c Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 35/47] lib/mips64: silence werror
+Subject: [PATCH 35/48] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-

--- a/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
@@ -1,7 +1,7 @@
 From cb1215b5499cb16020d9cca639d95ca0ba31b642 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 36/47] loader/mips64: fix warnings and style
+Subject: [PATCH 36/48] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------

--- a/app-admin/grub/autobuild/patches/0037-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0037-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From c85d646b63131e14167b622b81ed5366a5b62257 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 37/47] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 37/48] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI

--- a/app-admin/grub/autobuild/patches/0038-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0038-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From 136f9eb1e60e7a6dbfdb3d0223ddcaccde4bf312 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 38/47] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 38/48] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.

--- a/app-admin/grub/autobuild/patches/0039-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0039-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 2dd46c9cc02ab810716a583838ad3d82ca0154b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 39/47] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 39/48] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken

--- a/app-admin/grub/autobuild/patches/0040-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0040-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From f64be25b3cd8255dcfaa2449fc550c62f445111e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 40/47] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 40/48] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and

--- a/app-admin/grub/autobuild/patches/0041-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0041-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From 7a26ce92adcdcbd8eca96b8d51c7cf91db01d614 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 41/47] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 41/48] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe

--- a/app-admin/grub/autobuild/patches/0042-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0042-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,7 +1,7 @@
 From 8f6d580d52d02b1187a98dab69b2635a5d6df187 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 42/47] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 42/48] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 3 ---

--- a/app-admin/grub/autobuild/patches/0044-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0044-po-update-zh_CN-translation.patch
@@ -1,7 +1,7 @@
 From bb33cdb51dc7882993ed51b0e2d36ed8fa41edb9 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 44/47] po: update zh_CN translation
+Subject: [PATCH 44/48] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------

--- a/app-admin/grub/autobuild/patches/0045-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0045-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From ac6126aec4f0231046d1e6df52ba4ee7edc2c000 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 45/47] po: update zh_TW translations
+Subject: [PATCH 45/48] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---

--- a/app-admin/grub/autobuild/patches/0046-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
+++ b/app-admin/grub/autobuild/patches/0046-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
@@ -1,7 +1,7 @@
 From 280ea0f713643a5a91cdcfbaf6e4a1be78c6cec3 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sun, 19 Jan 2025 23:18:56 +0800
-Subject: [PATCH 46/47] grub.d/30_uefi-firmware: disable fwsetup menu for
+Subject: [PATCH 46/48] grub.d/30_uefi-firmware: disable fwsetup menu for
  mips64el-efi
 
 ---

--- a/app-admin/grub/autobuild/patches/0047-loader-mips64-linux-properly-prepare-memory-for-init.patch
+++ b/app-admin/grub/autobuild/patches/0047-loader-mips64-linux-properly-prepare-memory-for-init.patch
@@ -1,7 +1,7 @@
 From 739cf9f59dfb41a68956baf8ff09c389ad66a3af Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Wed, 22 Jan 2025 21:13:13 +0800
-Subject: [PATCH 47/47] loader/mips64/linux: properly prepare memory for initrd
+Subject: [PATCH 47/48] loader/mips64/linux: properly prepare memory for initrd
 
 ... instead of allocating a fixed amount at initialization
 ---

--- a/app-admin/grub/autobuild/patches/0048-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
+++ b/app-admin/grub/autobuild/patches/0048-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
@@ -1,0 +1,137 @@
+From fc693b36ff2cda955729a00bcd34494d36c7ea01 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Fri, 14 Feb 2025 15:23:20 +0800
+Subject: [PATCH 48/48] fix(util/grub-mkimagexx): unconditionaly use 64-bit
+ addresses for mips64el-efi
+
+grub_addr_t uses host pointer size, which becomes undesirable if the host
+architecture is 32-bit, e.g. for i486 and armhf/el. Also use the ULL suffix
+for 64-bit constants.
+---
+ util/grub-mkimagexx.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index 36a30bbcd..3891ea3c9 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -1216,36 +1216,36 @@ SUFFIX (relocate_addrs) (Elf_Ehdr *e, struct section_metadata *smd,
+ 		   case R_MIPS_26:
+ 		     {
+ 		       grub_uint32_t *t32 = (grub_uint32_t *) target;
+-		       grub_addr_t addr = grub_host_to_target64 (sym_addr);
+-		       *t32 = ((*t32) & 0xfc000000U) | ((addr >> 2) & 0x3ffffffUL);
++		       grub_uint64_t addr = grub_host_to_target64 (sym_addr);
++		       *t32 = ((*t32) & 0xfc000000U) | ((addr >> 2) & 0x3ffffffULL);
+ 		     }
+ 		     break;
+ 		   case R_MIPS_LO16:
+ 		     {
+ 		       grub_int16_t *t16 = (grub_int16_t *) target;
+-		       grub_addr_t addr = grub_host_to_target64 (sym_addr);
++		       grub_uint64_t addr = grub_host_to_target64 (sym_addr);
+ 		       *t16 = (grub_int16_t) addr;
+ 		     }
+ 		     break;
+ 		   case R_MIPS_HI16:
+ 		     {
+ 		       grub_int16_t *t16 = (grub_int16_t *) target;
+-		       grub_addr_t addr = grub_host_to_target64 (sym_addr);
+-		       *t16 = (grub_int16_t) ((addr + 0x8000UL) >> 16);
++		       grub_uint64_t addr = grub_host_to_target64 (sym_addr);
++		       *t16 = (grub_int16_t) ((addr + 0x8000ULL) >> 16);
+ 		     }
+ 		     break;
+ 		   case R_MIPS_HIGHER:
+ 		     {
+ 		       grub_int16_t *t16 = (grub_int16_t *) target;
+-		       grub_addr_t addr = grub_host_to_target64 (sym_addr);
+-		       *t16 = (grub_int16_t) ((addr + 0x80008000UL) >> 32);
++		       grub_uint64_t addr = grub_host_to_target64 (sym_addr);
++		       *t16 = (grub_int16_t) ((addr + 0x80008000ULL) >> 32);
+ 		     }
+ 		     break;
+ 		   case R_MIPS_HIGHEST:
+ 		     {
+ 		       grub_uint16_t *t16 = (grub_uint16_t *) target;
+-		       grub_addr_t addr = grub_host_to_target64 (sym_addr);
+-		       *t16 = (grub_uint16_t) ((addr + 0x800080008000UL) >> 48);
++		       grub_uint64_t addr = grub_host_to_target64 (sym_addr);
++		       *t16 = (grub_uint16_t) ((addr + 0x800080008000ULL) >> 48);
+ 		     }
+ 		     break;
+ 		   default:
+@@ -1901,19 +1901,19 @@ translate_relocation_pe (struct translate_context *ctx,
+ 	    /* Hi */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x8000UL) >> 16),
++				 (grub_int16_t) ((target & 0x8000ULL) >> 16),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	    /* Higher */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x80008000UL) >> 32),
++				 (grub_int16_t) ((target & 0x80008000ULL) >> 32),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	    /* Highest */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_uint16_t) ((target & 0x800080008000UL) >> 48),
++				 (grub_uint16_t) ((target & 0x800080008000ULL) >> 48),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	  }
+@@ -1936,13 +1936,13 @@ translate_relocation_pe (struct translate_context *ctx,
+ 	    /* Higher */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x80008000UL) >> 32),
++				 (grub_int16_t) ((target & 0x80008000ULL) >> 32),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	    /* Highest */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_uint16_t) ((target & 0x800080008000UL) >> 48),
++				 (grub_uint16_t) ((target & 0x800080008000ULL) >> 48),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	  }
+@@ -1965,13 +1965,13 @@ translate_relocation_pe (struct translate_context *ctx,
+ 	    /* Hi */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x8000UL) >> 16),
++				 (grub_int16_t) ((target & 0x8000ULL) >> 16),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	    /* Highest */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_uint16_t) ((target & 0x800080008000UL) >> 48),
++				 (grub_uint16_t) ((target & 0x800080008000ULL) >> 48),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	  }
+@@ -1994,13 +1994,13 @@ translate_relocation_pe (struct translate_context *ctx,
+ 	    /* Hi */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x8000UL) >> 16),
++				 (grub_int16_t) ((target & 0x8000ULL) >> 16),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	    /* Higher */
+ 	    ctx->current_address
+ 	      = add_fixup_entry (&ctx->lst, 0,
+-				 (grub_int16_t) ((target & 0x80008000UL) >> 32),
++				 (grub_int16_t) ((target & 0x80008000ULL) >> 32),
+ 				 0, ctx->current_address,
+ 				 image_target);
+ 	  }
+-- 
+2.48.1
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=16.0.01
 RETROFONTVER=20200402
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=4
+REL=5
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftp.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: guarantee 64-bit addresses for loongson3 in util/grub-mkimagexx
    This fixes a regression caused by using host pointer size for the mips64el-efi
    support when building grub-mkimage for 32-bit hosts like i486 and armhf.

Package(s) Affected
-------------------

- grub: 2:2.12+unifont16.0.01-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
