### PR TITLE
ffmpeg: backport patch to support legacy HEVC FLV files

### DIFF
--- a/app-multimedia/ffmpeg/autobuild/patches/0001-UPSTREAM-doc-t2h-Support-texinfo-7.1-and-7.2-pretest.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0001-UPSTREAM-doc-t2h-Support-texinfo-7.1-and-7.2-pretest.patch
@@ -1,0 +1,304 @@
+From e6d989ee04fa7ee50a3f4fec61c74e299863df94 Mon Sep 17 00:00:00 2001
+From: Patrice Dumas <pertusus@free.fr>
+Date: Fri, 1 Nov 2024 15:57:07 +0100
+Subject: [PATCH 01/21] UPSTREAM: doc/t2h: Support texinfo 7.1 and 7.2 pretest
+
+Here is a proposed patch for portability of doc/t2h.pm for GNU Texinfo
+7.1 and 7.1.90 (7.2 pretest).  I tested against 7.1 and 7.1.90 (7.2
+pretest).  There is a difference in the headings compared to the website
+version, maybe related to FA_ICONS not being set the same, but the
+result seems correct.
+
+I also renamed $element to $output_unit in ffmpeg_heading_command as in
+new equivalent makeinfo/texi2any code the $element variable is the
+$command variable in ffmpeg_heading_command, which is very confusing.  I
+left as is the $command variable to have a patch easier to read, but it
+could make sense to rename $command as $element later on.
+
+The patch could also have effects with Texinfo 7.0, since some of the
+changes are for that version, but that probably never show up because it
+is for situations that may not exist in ffmpeg manuals (for example
+@node without sectioning command), or because the code is robust to some
+missing information (case of $heading_level in ffmpeg_heading_command
+that was not set, as far as I can tell).
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+(cherry picked from commit 4d9cdf82ee36a7da4f065821c86165fe565aeac2)
+
+(cherry picked from commit 8accee8b56a8be0485332e78b8d4cb14f6d27760)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ doc/t2h.pm | 169 ++++++++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 129 insertions(+), 40 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index b7485e1f1e5c..4875d663055b 100644
+--- a/doc/t2h.pm
++++ b/doc/t2h.pm
+@@ -54,12 +54,24 @@ sub get_formatting_function($$) {
+ }
+ 
+ # determine texinfo version
+-my $program_version_num = version->declare(ff_get_conf('PACKAGE_VERSION'))->numify;
++my $package_version = ff_get_conf('PACKAGE_VERSION');
++$package_version =~ s/\+dev$//;
++my $program_version_num = version->declare($package_version)->numify;
+ my $program_version_6_8 = $program_version_num >= 6.008000;
+ 
+ # no navigation elements
+ ff_set_from_init_file('HEADERS', 0);
+ 
++my %sectioning_commands = %Texinfo::Common::sectioning_commands;
++if (scalar(keys(%sectioning_commands)) == 0) {
++  %sectioning_commands = %Texinfo::Commands::sectioning_heading_commands;
++}
++
++my %root_commands = %Texinfo::Common::root_commands;
++if (scalar(keys(%root_commands)) == 0) {
++  %root_commands = %Texinfo::Commands::root_commands;
++}
++
+ sub ffmpeg_heading_command($$$$$)
+ {
+     my $self = shift;
+@@ -77,6 +89,9 @@ sub ffmpeg_heading_command($$$$$)
+         return $result;
+     }
+ 
++    # no need to set it as the $element_id is output unconditionally
++    my $heading_id;
++
+     my $element_id = $self->command_id($command);
+     $result .= "<a name=\"$element_id\"></a>\n"
+         if (defined($element_id) and $element_id ne '');
+@@ -84,24 +99,40 @@ sub ffmpeg_heading_command($$$$$)
+     print STDERR "Process $command "
+         .Texinfo::Structuring::_print_root_command_texi($command)."\n"
+             if ($self->get_conf('DEBUG'));
+-    my $element;
+-    if ($Texinfo::Common::root_commands{$command->{'cmdname'}}
+-        and $command->{'parent'}
+-        and $command->{'parent'}->{'type'}
+-        and $command->{'parent'}->{'type'} eq 'element') {
+-        $element = $command->{'parent'};
++    my $output_unit;
++    if ($root_commands{$command->{'cmdname'}}) {
++        if ($command->{'associated_unit'}) {
++          $output_unit = $command->{'associated_unit'};
++        } elsif ($command->{'structure'}
++                 and $command->{'structure'}->{'associated_unit'}) {
++          $output_unit = $command->{'structure'}->{'associated_unit'};
++        } elsif ($command->{'parent'}
++                 and $command->{'parent'}->{'type'}
++                 and $command->{'parent'}->{'type'} eq 'element') {
++          $output_unit = $command->{'parent'};
++        }
+     }
+-    if ($element) {
++
++    if ($output_unit) {
+         $result .= &{get_formatting_function($self, 'format_element_header')}($self, $cmdname,
+-                                                       $command, $element);
++                                                       $command, $output_unit);
+     }
+ 
+     my $heading_level;
+     # node is used as heading if there is nothing else.
+     if ($cmdname eq 'node') {
+-        if (!$element or (!$element->{'extra'}->{'section'}
+-            and $element->{'extra'}->{'node'}
+-            and $element->{'extra'}->{'node'} eq $command
++        if (!$output_unit or
++            (((!$output_unit->{'extra'}->{'section'}
++              and $output_unit->{'extra'}->{'node'}
++              and $output_unit->{'extra'}->{'node'} eq $command)
++             or
++             ((($output_unit->{'extra'}->{'unit_command'}
++                and $output_unit->{'extra'}->{'unit_command'} eq $command)
++               or
++               ($output_unit->{'unit_command'}
++                and $output_unit->{'unit_command'} eq $command))
++              and $command->{'extra'}
++              and not $command->{'extra'}->{'associated_section'}))
+              # bogus node may not have been normalized
+             and defined($command->{'extra'}->{'normalized'}))) {
+             if ($command->{'extra'}->{'normalized'} eq 'Top') {
+@@ -111,7 +142,15 @@ sub ffmpeg_heading_command($$$$$)
+             }
+         }
+     } else {
+-        $heading_level = $command->{'level'};
++        if (defined($command->{'extra'})
++            and defined($command->{'extra'}->{'section_level'})) {
++          $heading_level = $command->{'extra'}->{'section_level'};
++        } elsif ($command->{'structure'}
++                 and defined($command->{'structure'}->{'section_level'})) {
++          $heading_level = $command->{'structure'}->{'section_level'};
++        } else {
++          $heading_level = $command->{'level'};
++        }
+     }
+ 
+     my $heading = $self->command_text($command);
+@@ -119,8 +158,8 @@ sub ffmpeg_heading_command($$$$$)
+     # if there is an error in the node.
+     if (defined($heading) and $heading ne '' and defined($heading_level)) {
+ 
+-        if ($Texinfo::Common::root_commands{$cmdname}
+-            and $Texinfo::Common::sectioning_commands{$cmdname}) {
++        if ($root_commands{$cmdname}
++            and $sectioning_commands{$cmdname}) {
+             my $content_href = $self->command_contents_href($command, 'contents',
+                                                             $self->{'current_filename'});
+             if ($content_href) {
+@@ -140,7 +179,13 @@ sub ffmpeg_heading_command($$$$$)
+             }
+         }
+ 
+-        if ($self->in_preformatted()) {
++        my $in_preformatted;
++        if ($program_version_num >= 7.001090) {
++          $in_preformatted = $self->in_preformatted_context();
++        } else {
++          $in_preformatted = $self->in_preformatted();
++        }
++        if ($in_preformatted) {
+             $result .= $heading."\n";
+         } else {
+             # if the level was changed, set the command name right
+@@ -149,21 +194,25 @@ sub ffmpeg_heading_command($$$$$)
+                 $cmdname
+                     = $Texinfo::Common::level_to_structuring_command{$cmdname}->[$heading_level];
+             }
+-            # format_heading_text expects an array of headings for texinfo >= 7.0
+             if ($program_version_num >= 7.000000) {
+-                $heading = [$heading];
+-            }
+-            $result .= &{get_formatting_function($self,'format_heading_text')}(
++                $result .= &{get_formatting_function($self,'format_heading_text')}($self,
++                     $cmdname, [$cmdname], $heading,
++                     $heading_level +$self->get_conf('CHAPTER_HEADER_LEVEL') -1,
++                     $heading_id, $command);
++
++            } else {
++              $result .= &{get_formatting_function($self,'format_heading_text')}(
+                         $self, $cmdname, $heading,
+                         $heading_level +
+                         $self->get_conf('CHAPTER_HEADER_LEVEL') - 1, $command);
++            }
+         }
+     }
+     $result .= $content if (defined($content));
+     return $result;
+ }
+ 
+-foreach my $command (keys(%Texinfo::Common::sectioning_commands), 'node') {
++foreach my $command (keys(%sectioning_commands), 'node') {
+     texinfo_register_command_formatting($command, \&ffmpeg_heading_command);
+ }
+ 
+@@ -188,28 +237,56 @@ sub ffmpeg_begin_file($$$)
+     my $filename = shift;
+     my $element = shift;
+ 
+-    my $command;
+-    if ($element and $self->get_conf('SPLIT')) {
+-        $command = $self->element_command($element);
++    my ($element_command, $node_command, $command_for_title);
++    if ($element) {
++        if ($element->{'unit_command'}) {
++          $element_command = $element->{'unit_command'};
++        } elsif ($self->can('tree_unit_element_command')) {
++          $element_command = $self->tree_unit_element_command($element);
++        } elsif ($self->can('tree_unit_element_command')) {
++          $element_command = $self->element_command($element);
++        }
++
++       $node_command = $element_command;
++       if ($element_command and $element_command->{'cmdname'}
++           and $element_command->{'cmdname'} ne 'node'
++           and $element_command->{'extra'}
++           and $element_command->{'extra'}->{'associated_node'}) {
++         $node_command = $element_command->{'extra'}->{'associated_node'};
++       }
++
++       $command_for_title = $element_command if ($self->get_conf('SPLIT'));
+     }
+ 
+-    my ($title, $description, $encoding, $date, $css_lines,
+-        $doctype, $bodytext, $copying_comment, $after_body_open,
+-        $extra_head, $program_and_version, $program_homepage,
++    my ($title, $description, $keywords, $encoding, $date, $css_lines, $doctype,
++        $root_html_element_attributes, $body_attributes, $copying_comment,
++        $after_body_open, $extra_head, $program_and_version, $program_homepage,
+         $program, $generator);
+-    if ($program_version_num >= 7.000000) {
+-        ($title, $description, $encoding, $date, $css_lines,
+-         $doctype, $bodytext, $copying_comment, $after_body_open,
++    if ($program_version_num >= 7.001090) {
++        ($title, $description, $keywords, $encoding, $date, $css_lines, $doctype,
++         $root_html_element_attributes, $body_attributes, $copying_comment,
++         $after_body_open, $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_information($command_for_title,
++                                                                 $filename);
++    } elsif ($program_version_num >= 7.000000) {
++        ($title, $description, $encoding, $date, $css_lines, $doctype,
++         $root_html_element_attributes, $copying_comment, $after_body_open,
+          $extra_head, $program_and_version, $program_homepage,
+-         $program, $generator) = $self->_file_header_information($command);
++         $program, $generator) = $self->_file_header_information($command_for_title,
++                                                                 $filename);
+     } else {
+         ($title, $description, $encoding, $date, $css_lines,
+-         $doctype, $bodytext, $copying_comment, $after_body_open,
+-         $extra_head, $program_and_version, $program_homepage,
+-         $program, $generator) = $self->_file_header_informations($command);
++         $doctype, $root_html_element_attributes, $copying_comment,
++         $after_body_open, $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_informations($command_for_title);
+     }
+ 
+-    my $links = $self->_get_links ($filename, $element);
++    my $links;
++    if ($program_version_num >= 7.000000) {
++      $links = $self->_get_links($filename, $element, $node_command);
++    } else {
++      $links = $self->_get_links ($filename, $element);
++    }
+ 
+     my $head1 = $ENV{"FFMPEG_HEADER1"} || <<EOT;
+ <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+@@ -252,13 +329,25 @@ sub ffmpeg_program_string($)
+   if (defined($self->get_conf('PROGRAM'))
+       and $self->get_conf('PROGRAM') ne ''
+       and defined($self->get_conf('PACKAGE_URL'))) {
+-    return $self->convert_tree(
++    if ($program_version_num >= 7.001090) {
++     return $self->convert_tree(
++      $self->cdt('This document was generated using @uref{{program_homepage}, @emph{{program}}}.',
++         { 'program_homepage' => {'text' => $self->get_conf('PACKAGE_URL')},
++           'program' => {'text' => $self->get_conf('PROGRAM') }}));
++    } else {
++     return $self->convert_tree(
+       $self->gdt('This document was generated using @uref{{program_homepage}, @emph{{program}}}.',
+-         { 'program_homepage' => $self->get_conf('PACKAGE_URL'),
+-           'program' => $self->get_conf('PROGRAM') }));
++         { 'program_homepage' => {'text' => $self->get_conf('PACKAGE_URL')},
++           'program' => {'text' => $self->get_conf('PROGRAM') }}));
++    }
+   } else {
+-    return $self->convert_tree(
+-      $self->gdt('This document was generated automatically.'));
++    if ($program_version_num >= 7.001090) {
++      return $self->convert_tree(
++        $self->cdt('This document was generated automatically.'));
++    } else {
++      return $self->convert_tree(
++        $self->gdt('This document was generated automatically.'));
++    }
+   }
+ }
+ if ($program_version_6_8) {
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0002-UPSTREAM-avformat-flvenc-implement-support-for-multi.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0002-UPSTREAM-avformat-flvenc-implement-support-for-multi.patch
@@ -1,0 +1,319 @@
+From cea2d8d9597445aca23cfdd95fe951b59dbd3010 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dennis=20S=C3=A4dtler?= <dennis@obsproject.com>
+Date: Mon, 1 Apr 2024 18:16:49 +0200
+Subject: [PATCH 02/21] UPSTREAM: avformat/flvenc: implement support for
+ multi-track video
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Based on enhanced-rtmp v2 spec published by Veovera:
+https://veovera.github.io/enhanced-rtmp/docs/enhanced/enhanced-rtmp-v2
+
+This implementation maintains some backwards compatibility by only
+writing the track information for track indices > 0. This means that
+older FFmpeg versions - and possibly other software - can still read the
+first video track properly and skip over unsupported packets.
+
+Signed-off-by: Dennis Sädtler <dennis@obsproject.com>
+Signed-off-by: Timo Rothenpieler <timo@rothenpieler.org>
+
+(cherry picked from commit d8d0175d3a8782f84069378105520861c1bdccaf)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flv.h    |   7 ++
+ libavformat/flvenc.c | 160 ++++++++++++++++++++++++++++++-------------
+ 2 files changed, 120 insertions(+), 47 deletions(-)
+
+diff --git a/libavformat/flv.h b/libavformat/flv.h
+index f710963b9204..82eabf77497b 100644
+--- a/libavformat/flv.h
++++ b/libavformat/flv.h
+@@ -125,6 +125,13 @@ enum {
+     PacketTypeCodedFramesX          = 3,
+     PacketTypeMetadata              = 4,
+     PacketTypeMPEG2TSSequenceStart  = 5,
++    PacketTypeMultitrack            = 6,
++};
++
++enum {
++    MultitrackTypeOneTrack             = 0x00,
++    MultitrackTypeManyTracks           = 0x10,
++    MultitrackTypeManyTracksManyCodecs = 0x20,
+ };
+ 
+ enum {
+diff --git a/libavformat/flvenc.c b/libavformat/flvenc.c
+index f34df61c0e41..875d4f4a9222 100644
+--- a/libavformat/flvenc.c
++++ b/libavformat/flvenc.c
+@@ -126,8 +126,9 @@ typedef struct FLVContext {
+     AVCodecParameters *data_par;
+ 
+     int flags;
+-    int64_t last_ts[FLV_STREAM_TYPE_NB];
+-    int metadata_pkt_written;
++    int64_t *last_ts;
++    int *metadata_pkt_written;
++    int *video_track_idx_map;
+ } FLVContext;
+ 
+ static int get_audio_flags(AVFormatContext *s, AVCodecParameters *par)
+@@ -485,7 +486,7 @@ static void write_metadata(AVFormatContext *s, unsigned int ts)
+     avio_wb32(pb, flv->metadata_totalsize + 11);
+ }
+ 
+-static void flv_write_metadata_packet(AVFormatContext *s, AVCodecParameters *par, unsigned int ts)
++static void flv_write_metadata_packet(AVFormatContext *s, AVCodecParameters *par, unsigned int ts, int stream_idx)
+ {
+     AVIOContext *pb = s->pb;
+     FLVContext *flv = s->priv_data;
+@@ -495,7 +496,9 @@ static void flv_write_metadata_packet(AVFormatContext *s, AVCodecParameters *par
+     int64_t total_size = 0;
+     const AVPacketSideData *side_data = NULL;
+ 
+-    if (flv->metadata_pkt_written) return;
++    if (flv->metadata_pkt_written[stream_idx])
++        return;
++
+     if (par->codec_id == AV_CODEC_ID_HEVC || par->codec_id == AV_CODEC_ID_AV1 ||
+         par->codec_id == AV_CODEC_ID_VP9) {
+         int flags_size = 5;
+@@ -617,7 +620,7 @@ static void flv_write_metadata_packet(AVFormatContext *s, AVCodecParameters *par
+         avio_wb24(pb, total_size);
+         avio_skip(pb, total_size + 10 - 3);
+         avio_wb32(pb, total_size + 11); // previous tag size
+-        flv->metadata_pkt_written = 1;
++        flv->metadata_pkt_written[stream_idx] = 1;
+     }
+ }
+ 
+@@ -632,7 +635,7 @@ static int unsupported_codec(AVFormatContext *s,
+     return AVERROR(ENOSYS);
+ }
+ 
+-static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, int64_t ts) {
++static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, int64_t ts, int stream_index) {
+     int64_t data_size;
+     AVIOContext *pb = s->pb;
+     FLVContext *flv = s->priv_data;
+@@ -682,12 +685,32 @@ static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, i
+             }
+             avio_write(pb, par->extradata, par->extradata_size);
+         } else {
+-            if (par->codec_id == AV_CODEC_ID_HEVC) {
+-                avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeSequenceStart | FLV_FRAME_KEY); // ExVideoTagHeader mode with PacketTypeSequenceStart
+-                avio_write(pb, "hvc1", 4);
+-            } else if (par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9) {
+-                avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeSequenceStart | FLV_FRAME_KEY);
+-                avio_write(pb, par->codec_id == AV_CODEC_ID_AV1 ? "av01" : "vp09", 4);
++            int track_idx = flv->video_track_idx_map[stream_index];
++            // If video stream has track_idx > 0 we need to send H.264 as extended video packet
++            int extended_flv = (par->codec_id == AV_CODEC_ID_H264 && track_idx) ||
++                                par->codec_id == AV_CODEC_ID_HEVC ||
++                                par->codec_id == AV_CODEC_ID_AV1 ||
++                                par->codec_id == AV_CODEC_ID_VP9;
++
++            if (extended_flv) {
++                if (track_idx) {
++                    avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeMultitrack | FLV_FRAME_KEY);
++                    avio_w8(pb, MultitrackTypeOneTrack | PacketTypeSequenceStart);
++                } else {
++                    avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeSequenceStart | FLV_FRAME_KEY);
++                }
++
++                if (par->codec_id == AV_CODEC_ID_H264)
++                    avio_write(pb, "avc1", 4);
++                else if (par->codec_id == AV_CODEC_ID_HEVC)
++                    avio_write(pb, "hvc1", 4);
++                else if (par->codec_id == AV_CODEC_ID_AV1)
++                    avio_write(pb, "av01", 4);
++                else if (par->codec_id == AV_CODEC_ID_VP9)
++                    avio_write(pb, "vp09", 4);
++
++                if (track_idx)
++                    avio_w8(pb, track_idx);
+             } else {
+                 avio_w8(pb, par->codec_tag | FLV_FRAME_KEY); // flags
+                 avio_w8(pb, 0); // AVC sequence header
+@@ -770,13 +793,14 @@ static int shift_data(AVFormatContext *s)
+ static int flv_init(struct AVFormatContext *s)
+ {
+     int i;
++    int video_ctr = 0;
+     FLVContext *flv = s->priv_data;
+ 
+-    if (s->nb_streams > FLV_STREAM_TYPE_NB) {
+-        av_log(s, AV_LOG_ERROR, "invalid number of streams %d\n",
+-                s->nb_streams);
+-        return AVERROR(EINVAL);
+-    }
++    flv->last_ts = av_calloc(s->nb_streams, sizeof(*flv->last_ts));
++    flv->metadata_pkt_written = av_calloc(s->nb_streams, sizeof(*flv->metadata_pkt_written));
++    flv->video_track_idx_map = av_calloc(s->nb_streams, sizeof(*flv->video_track_idx_map));
++    if (!flv->last_ts || !flv->metadata_pkt_written || !flv->video_track_idx_map)
++        return AVERROR(ENOMEM);
+ 
+     for (i = 0; i < s->nb_streams; i++) {
+         AVCodecParameters *par = s->streams[i]->codecpar;
+@@ -787,12 +811,17 @@ static int flv_init(struct AVFormatContext *s)
+                 s->streams[i]->avg_frame_rate.num) {
+                 flv->framerate = av_q2d(s->streams[i]->avg_frame_rate);
+             }
+-            if (flv->video_par) {
++            flv->video_track_idx_map[i] = video_ctr++;
++            if (flv->video_par && flv->flags & FLV_ADD_KEYFRAME_INDEX) {
+                 av_log(s, AV_LOG_ERROR,
+-                       "at most one video stream is supported in flv\n");
++                       "at most one video stream is supported in flv with keyframe index\n");
+                 return AVERROR(EINVAL);
++            } else if (flv->video_par) {
++                av_log(s, AV_LOG_WARNING,
++                       "more than one video stream is not supported by most flv demuxers.\n");
+             }
+-            flv->video_par = par;
++            if (!flv->video_par)
++                flv->video_par = par;
+             if (!ff_codec_get_tag(flv_video_codec_ids, par->codec_id))
+                 return unsupported_codec(s, "Video", par->codec_id);
+ 
+@@ -882,7 +911,7 @@ static int flv_write_header(AVFormatContext *s)
+     }
+ 
+     for (i = 0; i < s->nb_streams; i++) {
+-        flv_write_codec_header(s, s->streams[i]->codecpar, 0);
++        flv_write_codec_header(s, s->streams[i]->codecpar, 0, i);
+     }
+ 
+     flv->datastart_offset = avio_tell(pb);
+@@ -990,6 +1019,7 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+     uint8_t frametype = pkt->flags & AV_PKT_FLAG_KEY ? FLV_FRAME_KEY : FLV_FRAME_INTER;
+     int flags = -1, flags_size, ret = 0;
+     int64_t cur_offset = avio_tell(pb);
++    int track_idx = flv->video_track_idx_map[pkt->stream_index];
+ 
+     if (par->codec_type == AVMEDIA_TYPE_AUDIO && !pkt->size) {
+         av_log(s, AV_LOG_WARNING, "Empty audio Packet\n");
+@@ -1006,7 +1036,12 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+     else
+         flags_size = 1;
+ 
+-    if (par->codec_id == AV_CODEC_ID_HEVC && pkt->pts != pkt->dts)
++    if (par->codec_type == AVMEDIA_TYPE_VIDEO && track_idx)
++        flags_size += 2; // additional header bytes for multi-track video
++
++    if ((par->codec_id == AV_CODEC_ID_HEVC ||
++        (par->codec_id == AV_CODEC_ID_H264 && track_idx))
++            && pkt->pts != pkt->dts)
+         flags_size += 3;
+ 
+     if (par->codec_id == AV_CODEC_ID_AAC || par->codec_id == AV_CODEC_ID_H264
+@@ -1019,9 +1054,9 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+             if (ret < 0)
+                 return ret;
+             memcpy(par->extradata, side, side_size);
+-            flv_write_codec_header(s, par, pkt->dts);
++            flv_write_codec_header(s, par, pkt->dts, pkt->stream_index);
+         }
+-        flv_write_metadata_packet(s, par, pkt->dts);
++        flv_write_metadata_packet(s, par, pkt->dts, pkt->stream_index);
+     }
+ 
+     if (flv->delay == AV_NOPTS_VALUE)
+@@ -1143,32 +1178,59 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+         avio_seek(pb, data_size + 10 - 3, SEEK_CUR);
+         avio_wb32(pb, data_size + 11);
+     } else {
+-        av_assert1(flags>=0);
+-        if (par->codec_id == AV_CODEC_ID_HEVC) {
+-            int pkttype = (pkt->pts != pkt->dts) ? PacketTypeCodedFrames : PacketTypeCodedFramesX;
+-            avio_w8(pb, FLV_IS_EX_HEADER | pkttype | frametype); // ExVideoTagHeader mode with PacketTypeCodedFrames(X)
+-            avio_write(pb, "hvc1", 4);
+-            if (pkttype == PacketTypeCodedFrames)
++        int extended_flv = (par->codec_id == AV_CODEC_ID_H264 && track_idx) ||
++                            par->codec_id == AV_CODEC_ID_HEVC ||
++                            par->codec_id == AV_CODEC_ID_AV1 ||
++                            par->codec_id == AV_CODEC_ID_VP9;
++
++        if (extended_flv) {
++            int h2645 = par->codec_id == AV_CODEC_ID_H264 ||
++                        par->codec_id == AV_CODEC_ID_HEVC;
++            int pkttype = PacketTypeCodedFrames;
++            // Optimisation for HEVC/H264: Do not send composition time if DTS == PTS
++            if (h2645 && pkt->pts == pkt->dts)
++                pkttype = PacketTypeCodedFramesX;
++
++            if (track_idx) {
++                avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeMultitrack | frametype);
++                avio_w8(pb, MultitrackTypeOneTrack | pkttype);
++            } else {
++                avio_w8(pb, FLV_IS_EX_HEADER | pkttype | frametype);
++            }
++
++            if (par->codec_id == AV_CODEC_ID_H264)
++                avio_write(pb, "avc1", 4);
++            else if (par->codec_id == AV_CODEC_ID_HEVC)
++                avio_write(pb, "hvc1", 4);
++            else if (par->codec_id == AV_CODEC_ID_AV1)
++                avio_write(pb, "av01", 4);
++            else if (par->codec_id == AV_CODEC_ID_VP9)
++                avio_write(pb, "vp09", 4);
++
++            if (track_idx)
++                avio_w8(pb, track_idx);
++            if (h2645 && pkttype == PacketTypeCodedFrames)
+                 avio_wb24(pb, pkt->pts - pkt->dts);
+-        } else if (par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9) {
+-            avio_w8(pb, FLV_IS_EX_HEADER | PacketTypeCodedFrames | frametype);
+-            avio_write(pb, par->codec_id == AV_CODEC_ID_AV1 ? "av01" : "vp09", 4);
+         } else {
++            av_assert1(flags >= 0);
+             avio_w8(pb, flags);
+-        }
+-        if (par->codec_id == AV_CODEC_ID_VP6)
+-            avio_w8(pb,0);
+-        if (par->codec_id == AV_CODEC_ID_VP6F || par->codec_id == AV_CODEC_ID_VP6A) {
+-            if (par->extradata_size)
+-                avio_w8(pb, par->extradata[0]);
+-            else
+-                avio_w8(pb, ((FFALIGN(par->width,  16) - par->width) << 4) |
+-                             (FFALIGN(par->height, 16) - par->height));
+-        } else if (par->codec_id == AV_CODEC_ID_AAC)
+-            avio_w8(pb, 1); // AAC raw
+-        else if (par->codec_id == AV_CODEC_ID_H264 || par->codec_id == AV_CODEC_ID_MPEG4) {
+-            avio_w8(pb, 1); // AVC NALU
+-            avio_wb24(pb, pkt->pts - pkt->dts);
++
++            if (par->codec_id == AV_CODEC_ID_VP6) {
++                avio_w8(pb,0);
++            } else if (par->codec_id == AV_CODEC_ID_VP6F ||
++                        par->codec_id == AV_CODEC_ID_VP6A) {
++                if (par->extradata_size)
++                    avio_w8(pb, par->extradata[0]);
++                else
++                    avio_w8(pb, ((FFALIGN(par->width,  16) - par->width) << 4) |
++                                (FFALIGN(par->height, 16) - par->height));
++            } else if (par->codec_id == AV_CODEC_ID_AAC) {
++                avio_w8(pb, 1); // AAC raw
++            } else if (par->codec_id == AV_CODEC_ID_H264 ||
++                        par->codec_id == AV_CODEC_ID_MPEG4) {
++                avio_w8(pb, 1); // AVC NALU
++                avio_wb24(pb, pkt->pts - pkt->dts);
++            }
+         }
+ 
+         avio_write(pb, data ? data : pkt->data, size);
+@@ -1235,6 +1297,10 @@ static void flv_deinit(AVFormatContext *s)
+     }
+     flv->filepositions = flv->head_filepositions = NULL;
+     flv->filepositions_count = 0;
++
++    av_freep(&flv->last_ts);
++    av_freep(&flv->metadata_pkt_written);
++    av_freep(&flv->video_track_idx_map);
+ }
+ 
+ static const AVOption options[] = {
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0003-UPSTREAM-avformat-flvdec-add-support-for-demuxing-mu.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0003-UPSTREAM-avformat-flvdec-add-support-for-demuxing-mu.patch
@@ -1,0 +1,539 @@
+From ffdeda4f80e73a67f88b8373e90597ed8b4c9d96 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dennis=20S=C3=A4dtler?= <dennis@obsproject.com>
+Date: Mon, 1 Apr 2024 18:16:50 +0200
+Subject: [PATCH 03/21] UPSTREAM: avformat/flvdec: add support for demuxing
+ multi-track FLV
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Based on enhanced-rtmp v2 spec published by Veovera:
+https://veovera.github.io/enhanced-rtmp/docs/enhanced/enhanced-rtmp-v2
+
+Signed-off-by: Dennis Sädtler <dennis@obsproject.com>
+Signed-off-by: Timo Rothenpieler <timo@rothenpieler.org>
+
+(cherry picked from commit 466a400b940dc1400794d52fcac2d60138b9b10a)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flv.h    |   6 ++
+ libavformat/flvdec.c | 119 +++++++++++++++++++++++++++-------
+ libavformat/flvenc.c | 149 +++++++++++++++++++++++++++++++------------
+ 3 files changed, 211 insertions(+), 63 deletions(-)
+
+diff --git a/libavformat/flv.h b/libavformat/flv.h
+index 82eabf77497b..1c0af2a51936 100644
+--- a/libavformat/flv.h
++++ b/libavformat/flv.h
+@@ -103,6 +103,7 @@ enum {
+     FLV_CODECID_NELLYMOSER           = 6 << FLV_AUDIO_CODECID_OFFSET,
+     FLV_CODECID_PCM_ALAW             = 7 << FLV_AUDIO_CODECID_OFFSET,
+     FLV_CODECID_PCM_MULAW            = 8 << FLV_AUDIO_CODECID_OFFSET,
++    FLV_CODECID_EX_HEADER            = 9 << FLV_AUDIO_CODECID_OFFSET,
+     FLV_CODECID_AAC                  = 10<< FLV_AUDIO_CODECID_OFFSET,
+     FLV_CODECID_SPEEX                = 11<< FLV_AUDIO_CODECID_OFFSET,
+ };
+@@ -128,6 +129,11 @@ enum {
+     PacketTypeMultitrack            = 6,
+ };
+ 
++enum {
++    AudioPacketTypeSequenceStart      = 0,
++    AudioPacketTypeCodedFrames        = 1,
++};
++
+ enum {
+     MultitrackTypeOneTrack             = 0x00,
+     MultitrackTypeManyTracks           = 0x10,
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 1fb3e0cd3fae..396104dda5b8 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -105,6 +105,10 @@ typedef struct FLVContext {
+ 
+     FLVMetaVideoColor *metaVideoColor;
+     int meta_color_info_flag;
++
++    uint8_t **mt_extradata;
++    int *mt_extradata_sz;
++    int mt_extradata_cnt;
+ } FLVContext;
+ 
+ /* AMF date type */
+@@ -187,13 +191,18 @@ static void add_keyframes_index(AVFormatContext *s)
+     }
+ }
+ 
+-static AVStream *create_stream(AVFormatContext *s, int codec_type)
++static AVStream *create_stream(AVFormatContext *s, int codec_type, int track_idx)
+ {
+     FLVContext *flv   = s->priv_data;
+     AVStream *st = avformat_new_stream(s, NULL);
+     if (!st)
+         return NULL;
+     st->codecpar->codec_type = codec_type;
++    st->id = track_idx;
++    avpriv_set_pts_info(st, 32, 1, 1000); /* 32 bit pts in ms */
++    if (track_idx)
++        return st;
++
+     if (s->nb_streams>=3 ||(   s->nb_streams==2
+                            && s->streams[0]->codecpar->codec_type != AVMEDIA_TYPE_SUBTITLE
+                            && s->streams[1]->codecpar->codec_type != AVMEDIA_TYPE_SUBTITLE
+@@ -210,8 +219,6 @@ static AVStream *create_stream(AVFormatContext *s, int codec_type)
+         st->avg_frame_rate = flv->framerate;
+     }
+ 
+-
+-    avpriv_set_pts_info(st, 32, 1, 1000); /* 32 bit pts in ms */
+     flv->last_keyframe_stream_index = s->nb_streams - 1;
+     add_keyframes_index(s);
+     return st;
+@@ -351,6 +358,7 @@ static int flv_same_video_codec(AVCodecParameters *vpar, uint32_t flv_codecid)
+     case FLV_CODECID_VP6A:
+         return vpar->codec_id == AV_CODEC_ID_VP6A;
+     case FLV_CODECID_H264:
++    case MKBETAG('a', 'v', 'c', '1'):
+         return vpar->codec_id == AV_CODEC_ID_H264;
+     default:
+         return vpar->codec_tag == flv_codecid;
+@@ -407,6 +415,7 @@ static int flv_set_video_codec(AVFormatContext *s, AVStream *vstream,
+         ret = 1;     // 1 byte body size adjustment for flv_read_packet()
+         break;
+     case FLV_CODECID_H264:
++    case MKBETAG('a', 'v', 'c', '1'):
+         par->codec_id = AV_CODEC_ID_H264;
+         vstreami->need_parsing = AVSTREAM_PARSE_HEADERS;
+         break;
+@@ -676,7 +685,7 @@ static int amf_parse_object(AVFormatContext *s, AVStream *astream,
+                     } else if (!strcmp(key, "height") && vpar) {
+                         vpar->height = num_val;
+                     } else if (!strcmp(key, "datastream")) {
+-                        AVStream *st = create_stream(s, AVMEDIA_TYPE_SUBTITLE);
++                        AVStream *st = create_stream(s, AVMEDIA_TYPE_SUBTITLE, 0);
+                         if (!st)
+                             return AVERROR(ENOMEM);
+                         st->codecpar->codec_id = AV_CODEC_ID_TEXT;
+@@ -883,8 +892,11 @@ static int flv_read_close(AVFormatContext *s)
+ {
+     int i;
+     FLVContext *flv = s->priv_data;
+-    for (i=0; i<FLV_STREAM_TYPE_NB; i++)
++    for (i = 0; i < FLV_STREAM_TYPE_NB; i++)
+         av_freep(&flv->new_extradata[i]);
++    for (i = 0; i < flv->mt_extradata_cnt; i++)
++        av_freep(&flv->mt_extradata[i]);
++    av_freep(&flv->mt_extradata_sz);
+     av_freep(&flv->keyframe_times);
+     av_freep(&flv->keyframe_filepositions);
+     av_freep(&flv->metaVideoColor);
+@@ -904,18 +916,47 @@ static int flv_get_extradata(AVFormatContext *s, AVStream *st, int size)
+ }
+ 
+ static int flv_queue_extradata(FLVContext *flv, AVIOContext *pb, int stream,
+-                               int size)
++                               int size, int multitrack)
+ {
+     if (!size)
+         return 0;
+ 
+-    av_free(flv->new_extradata[stream]);
+-    flv->new_extradata[stream] = av_mallocz(size +
+-                                            AV_INPUT_BUFFER_PADDING_SIZE);
+-    if (!flv->new_extradata[stream])
+-        return AVERROR(ENOMEM);
+-    flv->new_extradata_size[stream] = size;
+-    avio_read(pb, flv->new_extradata[stream], size);
++    if (!multitrack) {
++        av_free(flv->new_extradata[stream]);
++        flv->new_extradata[stream] = av_mallocz(size +
++                                                AV_INPUT_BUFFER_PADDING_SIZE);
++        if (!flv->new_extradata[stream])
++            return AVERROR(ENOMEM);
++        flv->new_extradata_size[stream] = size;
++        avio_read(pb, flv->new_extradata[stream], size);
++    } else {
++        int new_count = stream + 1;
++
++        if (flv->mt_extradata_cnt < new_count) {
++            flv->mt_extradata = av_realloc(flv->mt_extradata,
++                                           sizeof(*flv->mt_extradata) *
++                                           new_count);
++            flv->mt_extradata_sz = av_realloc(flv->mt_extradata_sz,
++                                              sizeof(*flv->mt_extradata_sz) *
++                                              new_count);
++            if (!flv->mt_extradata || !flv->mt_extradata_sz)
++                return AVERROR(ENOMEM);
++            // Set newly allocated pointers/sizes to 0
++            for (int i = flv->mt_extradata_cnt; i < new_count; i++) {
++                    flv->mt_extradata[i] = NULL;
++                    flv->mt_extradata_sz[i] = 0;
++            }
++            flv->mt_extradata_cnt = new_count;
++        }
++
++        av_free(flv->mt_extradata[stream]);
++        flv->mt_extradata[stream] = av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE);
++        if (!flv->mt_extradata[stream])
++            return AVERROR(ENOMEM);
++        flv->mt_extradata_sz[stream] = size;
++        avio_read(pb, flv->mt_extradata[stream], size);
++    }
++
+     return 0;
+ }
+ 
+@@ -1031,7 +1072,7 @@ static int flv_data_packet(AVFormatContext *s, AVPacket *pkt,
+     }
+ 
+     if (i == s->nb_streams) {
+-        st = create_stream(s, AVMEDIA_TYPE_SUBTITLE);
++        st = create_stream(s, AVMEDIA_TYPE_SUBTITLE, 0);
+         if (!st)
+             return AVERROR(ENOMEM);
+         st->codecpar->codec_id = AV_CODEC_ID_TEXT;
+@@ -1204,6 +1245,9 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+     int last = -1;
+     int orig_size;
+     int enhanced_flv = 0;
++    int multitrack = 0;
++    int pkt_type = 0;
++    uint8_t track_idx = 0;
+     uint32_t video_codec_id = 0;
+ 
+ retry:
+@@ -1257,14 +1301,33 @@ retry:
+          * https://github.com/veovera/enhanced-rtmp/blob/main/enhanced-rtmp-v1.pdf
+          * */
+         enhanced_flv = (flags >> 7) & 1;
++        pkt_type = enhanced_flv ? video_codec_id : 0;
+         size--;
++
++        if (pkt_type == PacketTypeMultitrack) {
++            uint8_t types = avio_r8(s->pb);
++            int multitrack_type = types >> 4;
++            pkt_type = types & 0xF;
++
++            if (multitrack_type != MultitrackTypeOneTrack) {
++                av_log(s, AV_LOG_ERROR, "Multitrack types other than MultitrackTypeOneTrack are unsupported!\n");
++                return AVERROR_PATCHWELCOME;
++            }
++
++            multitrack = 1;
++            size--;
++        }
++
+         if (enhanced_flv) {
+             video_codec_id = avio_rb32(s->pb);
+             size -= 4;
+         }
++        if (multitrack) {
++            track_idx = avio_r8(s->pb);
++            size--;
++        }
+ 
+-        if (enhanced_flv && stream_type == FLV_STREAM_TYPE_VIDEO && (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_VIDEO_INFO_CMD) {
+-            int pkt_type = flags & 0x0F;
++        if (enhanced_flv && (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_VIDEO_INFO_CMD) {
+             if (pkt_type == PacketTypeMetadata) {
+                 int ret = flv_parse_video_color_info(s, st, next);
+                 av_log(s, AV_LOG_DEBUG, "enhanced flv parse metadata ret %d and skip\n", ret);
+@@ -1328,7 +1391,8 @@ skip:
+                 break;
+         } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+-                (s->video_codec_id || flv_same_video_codec(st->codecpar, video_codec_id)))
++                (s->video_codec_id || flv_same_video_codec(st->codecpar, video_codec_id)) &&
++                st->id == track_idx)
+                 break;
+         } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
+@@ -1340,7 +1404,7 @@ skip:
+     }
+     if (i == s->nb_streams) {
+         static const enum AVMediaType stream_types[] = {AVMEDIA_TYPE_VIDEO, AVMEDIA_TYPE_AUDIO, AVMEDIA_TYPE_SUBTITLE, AVMEDIA_TYPE_DATA};
+-        st = create_stream(s, stream_types[stream_type]);
++        st = create_stream(s, stream_types[stream_type], track_idx);
+         if (!st)
+             return AVERROR(ENOMEM);
+     }
+@@ -1447,7 +1511,7 @@ retry_duration:
+         st->codecpar->codec_id == AV_CODEC_ID_VP9) {
+         int type = 0;
+         if (enhanced_flv && stream_type == FLV_STREAM_TYPE_VIDEO) {
+-            type = flags & 0x0F;
++            type = pkt_type;
+         } else {
+             type = avio_r8(s->pb);
+             size--;
+@@ -1463,7 +1527,8 @@ retry_duration:
+             flv->meta_color_info_flag = 0;
+         }
+ 
+-        if (st->codecpar->codec_id == AV_CODEC_ID_H264 || st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
++        if (st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
++            (st->codecpar->codec_id == AV_CODEC_ID_H264 && (!enhanced_flv || type == PacketTypeCodedFrames)) ||
+             (st->codecpar->codec_id == AV_CODEC_ID_HEVC && type == PacketTypeCodedFrames)) {
+             // sign extension
+             int32_t cts = (avio_rb24(s->pb) + 0xff800000) ^ 0xff800000;
+@@ -1486,7 +1551,7 @@ retry_duration:
+             AVDictionaryEntry *t;
+ 
+             if (st->codecpar->extradata) {
+-                if ((ret = flv_queue_extradata(flv, s->pb, stream_type, size)) < 0)
++                if ((ret = flv_queue_extradata(flv, s->pb, multitrack ? track_idx : stream_type, size, multitrack)) < 0)
+                     return ret;
+                 ret = FFERROR_REDO;
+                 goto leave;
+@@ -1517,7 +1582,7 @@ retry_duration:
+     pkt->pts          = pts == AV_NOPTS_VALUE ? dts : pts;
+     pkt->stream_index = st->index;
+     pkt->pos          = pos;
+-    if (flv->new_extradata[stream_type]) {
++    if (!multitrack && flv->new_extradata[stream_type]) {
+         int ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+                                           flv->new_extradata[stream_type],
+                                           flv->new_extradata_size[stream_type]);
+@@ -1525,6 +1590,16 @@ retry_duration:
+             flv->new_extradata[stream_type]      = NULL;
+             flv->new_extradata_size[stream_type] = 0;
+         }
++    } else if (multitrack &&
++               flv->mt_extradata_cnt > track_idx &&
++               flv->mt_extradata[track_idx]) {
++        int ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
++                                          flv->mt_extradata[track_idx],
++                                          flv->mt_extradata_sz[track_idx]);
++        if (ret >= 0) {
++            flv->mt_extradata[track_idx]      = NULL;
++            flv->mt_extradata_sz[track_idx] = 0;
++        }
+     }
+     if (stream_type == FLV_STREAM_TYPE_AUDIO &&
+                     (sample_rate != flv->last_sample_rate ||
+diff --git a/libavformat/flvenc.c b/libavformat/flvenc.c
+index 875d4f4a9222..26c8010b077f 100644
+--- a/libavformat/flvenc.c
++++ b/libavformat/flvenc.c
+@@ -69,6 +69,10 @@ static const AVCodecTag flv_audio_codec_ids[] = {
+     { AV_CODEC_ID_PCM_MULAW,  FLV_CODECID_PCM_MULAW  >> FLV_AUDIO_CODECID_OFFSET },
+     { AV_CODEC_ID_PCM_ALAW,   FLV_CODECID_PCM_ALAW   >> FLV_AUDIO_CODECID_OFFSET },
+     { AV_CODEC_ID_SPEEX,      FLV_CODECID_SPEEX      >> FLV_AUDIO_CODECID_OFFSET },
++    { AV_CODEC_ID_OPUS,       MKBETAG('O', 'p', 'u', 's') },
++    { AV_CODEC_ID_FLAC,       MKBETAG('f', 'L', 'a', 'C') },
++    { AV_CODEC_ID_AC3,        MKBETAG('a', 'c', '-', '3') },
++    { AV_CODEC_ID_EAC3,       MKBETAG('e', 'c', '-', '3') },
+     { AV_CODEC_ID_NONE,       0 }
+ };
+ 
+@@ -139,6 +143,9 @@ static int get_audio_flags(AVFormatContext *s, AVCodecParameters *par)
+     if (par->codec_id == AV_CODEC_ID_AAC) // specs force these parameters
+         return FLV_CODECID_AAC | FLV_SAMPLERATE_44100HZ |
+                FLV_SAMPLESSIZE_16BIT | FLV_STEREO;
++    if (par->codec_id == AV_CODEC_ID_OPUS || par->codec_id == AV_CODEC_ID_FLAC
++        || par->codec_id == AV_CODEC_ID_AC3 || par->codec_id == AV_CODEC_ID_EAC3)
++        return FLV_CODECID_EX_HEADER; // only needed for codec support check
+     else if (par->codec_id == AV_CODEC_ID_SPEEX) {
+         if (par->sample_rate != 16000) {
+             av_log(s, AV_LOG_ERROR,
+@@ -635,6 +642,42 @@ static int unsupported_codec(AVFormatContext *s,
+     return AVERROR(ENOSYS);
+ }
+ 
++static void flv_write_aac_header(AVFormatContext* s, AVCodecParameters* par)
++{
++    AVIOContext *pb = s->pb;
++    FLVContext *flv = s->priv_data;
++
++    if (!par->extradata_size && (flv->flags & FLV_AAC_SEQ_HEADER_DETECT)) {
++        PutBitContext pbc;
++        int samplerate_index;
++        int channels = par->ch_layout.nb_channels
++                - (par->ch_layout.nb_channels == 8 ? 1 : 0);
++        uint8_t data[2];
++
++        for (samplerate_index = 0; samplerate_index < 16;
++                samplerate_index++)
++            if (par->sample_rate
++                    == ff_mpeg4audio_sample_rates[samplerate_index])
++                break;
++
++        init_put_bits(&pbc, data, sizeof(data));
++        put_bits(&pbc, 5, par->profile + 1); //profile
++        put_bits(&pbc, 4, samplerate_index); //sample rate index
++        put_bits(&pbc, 4, channels);
++        put_bits(&pbc, 1, 0); //frame length - 1024 samples
++        put_bits(&pbc, 1, 0); //does not depend on core coder
++        put_bits(&pbc, 1, 0); //is not extension
++        flush_put_bits(&pbc);
++
++        avio_w8(pb, data[0]);
++        avio_w8(pb, data[1]);
++
++        av_log(s, AV_LOG_WARNING, "AAC sequence header: %02x %02x.\n",
++                data[0], data[1]);
++    }
++    avio_write(pb, par->extradata, par->extradata_size);
++}
++
+ static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, int64_t ts, int stream_index) {
+     int64_t data_size;
+     AVIOContext *pb = s->pb;
+@@ -642,7 +685,9 @@ static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, i
+ 
+     if (par->codec_id == AV_CODEC_ID_AAC || par->codec_id == AV_CODEC_ID_H264
+             || par->codec_id == AV_CODEC_ID_MPEG4 || par->codec_id == AV_CODEC_ID_HEVC
+-            || par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9) {
++            || par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9
++            || par->codec_id == AV_CODEC_ID_OPUS || par->codec_id == AV_CODEC_ID_FLAC
++            || par->codec_id == AV_CODEC_ID_AC3 || par->codec_id == AV_CODEC_ID_EAC3) {
+         int64_t pos;
+         avio_w8(pb,
+                 par->codec_type == AVMEDIA_TYPE_VIDEO ?
+@@ -651,39 +696,38 @@ static void flv_write_codec_header(AVFormatContext* s, AVCodecParameters* par, i
+         put_timestamp(pb, ts);
+         avio_wb24(pb, 0); // streamid
+         pos = avio_tell(pb);
+-        if (par->codec_id == AV_CODEC_ID_AAC) {
+-            avio_w8(pb, get_audio_flags(s, par));
+-            avio_w8(pb, 0); // AAC sequence header
+-
+-            if (!par->extradata_size && (flv->flags & FLV_AAC_SEQ_HEADER_DETECT)) {
+-                PutBitContext pbc;
+-                int samplerate_index;
+-                int channels = par->ch_layout.nb_channels
+-                        - (par->ch_layout.nb_channels == 8 ? 1 : 0);
+-                uint8_t data[2];
+-
+-                for (samplerate_index = 0; samplerate_index < 16;
+-                        samplerate_index++)
+-                    if (par->sample_rate
+-                            == ff_mpeg4audio_sample_rates[samplerate_index])
+-                        break;
+-
+-                init_put_bits(&pbc, data, sizeof(data));
+-                put_bits(&pbc, 5, par->profile + 1); //profile
+-                put_bits(&pbc, 4, samplerate_index); //sample rate index
+-                put_bits(&pbc, 4, channels);
+-                put_bits(&pbc, 1, 0); //frame length - 1024 samples
+-                put_bits(&pbc, 1, 0); //does not depend on core coder
+-                put_bits(&pbc, 1, 0); //is not extension
+-                flush_put_bits(&pbc);
+-
+-                avio_w8(pb, data[0]);
+-                avio_w8(pb, data[1]);
+-
+-                av_log(s, AV_LOG_WARNING, "AAC sequence header: %02x %02x.\n",
+-                        data[0], data[1]);
++        if (par->codec_type == AVMEDIA_TYPE_AUDIO) {
++            int extended_flv = par->codec_id == AV_CODEC_ID_OPUS
++                                    || par->codec_id == AV_CODEC_ID_FLAC
++                                    || par->codec_id == AV_CODEC_ID_AC3
++                                    || par->codec_id == AV_CODEC_ID_EAC3;
++
++            if (extended_flv) {
++                avio_w8(pb, FLV_CODECID_EX_HEADER | AudioPacketTypeSequenceStart);
++
++                if (par->codec_id == AV_CODEC_ID_AAC) {
++                    avio_write(pb, "mp4a", 4);
++                    flv_write_aac_header(s, par);
++                } else if (par->codec_id == AV_CODEC_ID_OPUS) {
++                    avio_write(pb, "Opus", 4);
++                    av_assert0(par->extradata_size);
++                    avio_write(pb, par->extradata, par->extradata_size);
++                } else if (par->codec_id == AV_CODEC_ID_FLAC) {
++                    avio_write(pb, "fLaC", 4);
++                    av_assert0(par->extradata_size);
++                    avio_write(pb, par->extradata, par->extradata_size);
++                } else if (par->codec_id == AV_CODEC_ID_MP3)
++                    avio_write(pb, ".mp3", 4);
++                else if (par->codec_id == AV_CODEC_ID_AC3)
++                    avio_write(pb, "ac-3", 4);
++                else if (par->codec_id == AV_CODEC_ID_EAC3)
++                    avio_write(pb, "ec-3", 4);
++            } else if (par->codec_id == AV_CODEC_ID_AAC) {
++                avio_w8(pb, get_audio_flags(s, par));
++                avio_w8(pb, 0); // AAC sequence header
++
++                flv_write_aac_header(s, par);
+             }
+-            avio_write(pb, par->extradata, par->extradata_size);
+         } else {
+             int track_idx = flv->video_track_idx_map[stream_index];
+             // If video stream has track_idx > 0 we need to send H.264 as extended video packet
+@@ -1021,13 +1065,20 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+     int64_t cur_offset = avio_tell(pb);
+     int track_idx = flv->video_track_idx_map[pkt->stream_index];
+ 
++    int extended_audio = par->codec_id == AV_CODEC_ID_OPUS
++                            || par->codec_id == AV_CODEC_ID_FLAC
++                            || par->codec_id == AV_CODEC_ID_AC3
++                            || par->codec_id == AV_CODEC_ID_EAC3;
++
+     if (par->codec_type == AVMEDIA_TYPE_AUDIO && !pkt->size) {
+         av_log(s, AV_LOG_WARNING, "Empty audio Packet\n");
+         return AVERROR(EINVAL);
+     }
+ 
+-    if (par->codec_id == AV_CODEC_ID_VP6F || par->codec_id == AV_CODEC_ID_VP6A ||
+-        par->codec_id == AV_CODEC_ID_VP6  || par->codec_id == AV_CODEC_ID_AAC)
++    if (extended_audio)
++        flags_size = 5;
++    else if (par->codec_id == AV_CODEC_ID_VP6F || par->codec_id == AV_CODEC_ID_VP6A ||
++             par->codec_id == AV_CODEC_ID_VP6  || par->codec_id == AV_CODEC_ID_AAC)
+         flags_size = 2;
+     else if (par->codec_id == AV_CODEC_ID_H264 || par->codec_id == AV_CODEC_ID_MPEG4 ||
+              par->codec_id == AV_CODEC_ID_HEVC || par->codec_id == AV_CODEC_ID_AV1 ||
+@@ -1046,7 +1097,8 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+ 
+     if (par->codec_id == AV_CODEC_ID_AAC || par->codec_id == AV_CODEC_ID_H264
+             || par->codec_id == AV_CODEC_ID_MPEG4 || par->codec_id == AV_CODEC_ID_HEVC
+-            || par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9) {
++            || par->codec_id == AV_CODEC_ID_AV1 || par->codec_id == AV_CODEC_ID_VP9
++            || par->codec_id == AV_CODEC_ID_OPUS || par->codec_id == AV_CODEC_ID_FLAC) {
+         size_t side_size;
+         uint8_t *side = av_packet_get_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA, &side_size);
+         if (side && side_size > 0 && (side_size != par->extradata_size || memcmp(side, par->extradata, side_size))) {
+@@ -1178,12 +1230,12 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+         avio_seek(pb, data_size + 10 - 3, SEEK_CUR);
+         avio_wb32(pb, data_size + 11);
+     } else {
+-        int extended_flv = (par->codec_id == AV_CODEC_ID_H264 && track_idx) ||
+-                            par->codec_id == AV_CODEC_ID_HEVC ||
+-                            par->codec_id == AV_CODEC_ID_AV1 ||
+-                            par->codec_id == AV_CODEC_ID_VP9;
++        int extended_video = (par->codec_id == AV_CODEC_ID_H264 && track_idx) ||
++                              par->codec_id == AV_CODEC_ID_HEVC ||
++                              par->codec_id == AV_CODEC_ID_AV1 ||
++                              par->codec_id == AV_CODEC_ID_VP9;
+ 
+-        if (extended_flv) {
++        if (extended_video) {
+             int h2645 = par->codec_id == AV_CODEC_ID_H264 ||
+                         par->codec_id == AV_CODEC_ID_HEVC;
+             int pkttype = PacketTypeCodedFrames;
+@@ -1211,6 +1263,21 @@ static int flv_write_packet(AVFormatContext *s, AVPacket *pkt)
+                 avio_w8(pb, track_idx);
+             if (h2645 && pkttype == PacketTypeCodedFrames)
+                 avio_wb24(pb, pkt->pts - pkt->dts);
++        } else if (extended_audio) {
++            avio_w8(pb, FLV_CODECID_EX_HEADER | AudioPacketTypeCodedFrames);
++
++            if (par->codec_id == AV_CODEC_ID_AAC)
++                avio_write(pb, "mp4a", 4);
++            else if (par->codec_id == AV_CODEC_ID_OPUS)
++                avio_write(pb, "Opus", 4);
++            else if (par->codec_id == AV_CODEC_ID_FLAC)
++                avio_write(pb, "fLaC", 4);
++            else if (par->codec_id == AV_CODEC_ID_MP3)
++                avio_write(pb, ".mp3", 4);
++            else if (par->codec_id == AV_CODEC_ID_AC3)
++                avio_write(pb, "ac-3", 4);
++            else if (par->codec_id == AV_CODEC_ID_EAC3)
++                avio_write(pb, "ec-3", 4);
+         } else {
+             av_assert1(flags >= 0);
+             avio_w8(pb, flags);
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0004-UPSTREAM-avformat-flvdec-add-enhanced-audio-codecs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0004-UPSTREAM-avformat-flvdec-add-enhanced-audio-codecs.patch
@@ -1,0 +1,257 @@
+From ac3da585011dd64080e65f2530d16cd89019eb42 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Sat, 18 May 2024 00:52:39 +0200
+Subject: [PATCH 04/21] UPSTREAM: avformat/flvdec: add enhanced audio codecs
+
+(cherry picked from commit 2f72dc33ff23de66db8f801fd3c83099a2f83444)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flv.h    |   8 +++
+ libavformat/flvdec.c | 119 +++++++++++++++++++++++++++++++++++++++----
+ 2 files changed, 116 insertions(+), 11 deletions(-)
+
+diff --git a/libavformat/flv.h b/libavformat/flv.h
+index 1c0af2a51936..1ea88ff85119 100644
+--- a/libavformat/flv.h
++++ b/libavformat/flv.h
+@@ -132,6 +132,14 @@ enum {
+ enum {
+     AudioPacketTypeSequenceStart      = 0,
+     AudioPacketTypeCodedFrames        = 1,
++    AudioPacketTypeMultichannelConfig = 4,
++    AudioPacketTypeMultitrack         = 5,
++};
++
++enum {
++    AudioChannelOrderUnspecified = 0,
++    AudioChannelOrderNative      = 1,
++    AudioChannelOrderCustom      = 2,
+ };
+ 
+ enum {
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 396104dda5b8..d7974e6b5189 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -224,12 +224,33 @@ static AVStream *create_stream(AVFormatContext *s, int codec_type, int track_idx
+     return st;
+ }
+ 
+-static int flv_same_audio_codec(AVCodecParameters *apar, int flags)
++static int flv_same_audio_codec(AVCodecParameters *apar, int flags, uint32_t codec_fourcc)
+ {
+     int bits_per_coded_sample = (flags & FLV_AUDIO_SAMPLESIZE_MASK) ? 16 : 8;
+     int flv_codecid           = flags & FLV_AUDIO_CODECID_MASK;
+     int codec_id;
+ 
++    switch (codec_fourcc) {
++    case MKBETAG('m', 'p', '4', 'a'):
++        return apar->codec_id == AV_CODEC_ID_AAC;
++    case MKBETAG('O', 'p', 'u', 's'):
++        return apar->codec_id == AV_CODEC_ID_OPUS;
++    case MKBETAG('.', 'm', 'p', '3'):
++        return apar->codec_id == AV_CODEC_ID_MP3;
++    case MKBETAG('f', 'L', 'a', 'C'):
++        return apar->codec_id == AV_CODEC_ID_FLAC;
++    case MKBETAG('a', 'c', '-', '3'):
++        return apar->codec_id == AV_CODEC_ID_AC3;
++    case MKBETAG('e', 'c', '-', '3'):
++        return apar->codec_id == AV_CODEC_ID_EAC3;
++    case 0:
++        // Not enhanced flv, continue as normal.
++        break;
++    default:
++        // Unknown FOURCC
++        return 0;
++    }
++
+     if (!apar->codec_id && !apar->codec_tag)
+         return 1;
+ 
+@@ -328,6 +349,24 @@ static void flv_set_audio_codec(AVFormatContext *s, AVStream *astream,
+         apar->sample_rate = 8000;
+         apar->codec_id    = AV_CODEC_ID_PCM_ALAW;
+         break;
++    case MKBETAG('m', 'p', '4', 'a'):
++        apar->codec_id = AV_CODEC_ID_AAC;
++        return;
++    case MKBETAG('O', 'p', 'u', 's'):
++        apar->codec_id = AV_CODEC_ID_OPUS;
++        return;
++    case MKBETAG('.', 'm', 'p', '3'):
++        apar->codec_id = AV_CODEC_ID_MP3;
++        return;
++    case MKBETAG('f', 'L', 'a', 'C'):
++        apar->codec_id = AV_CODEC_ID_FLAC;
++        return;
++    case MKBETAG('a', 'c', '-', '3'):
++        apar->codec_id = AV_CODEC_ID_AC3;
++        return;
++    case MKBETAG('e', 'c', '-', '3'):
++        apar->codec_id = AV_CODEC_ID_EAC3;
++        return;
+     default:
+         avpriv_request_sample(s, "Audio codec (%x)",
+                flv_codecid >> FLV_AUDIO_CODECID_OFFSET);
+@@ -1248,7 +1287,7 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+     int multitrack = 0;
+     int pkt_type = 0;
+     uint8_t track_idx = 0;
+-    uint32_t video_codec_id = 0;
++    uint32_t codec_id = 0;
+ 
+ retry:
+     /* pkt size is repeated at end. skip it */
+@@ -1292,16 +1331,31 @@ retry:
+         stream_type = FLV_STREAM_TYPE_AUDIO;
+         flags    = avio_r8(s->pb);
+         size--;
++
++        if ((flags & FLV_AUDIO_CODECID_MASK) == FLV_CODECID_EX_HEADER) {
++            enhanced_flv = 1;
++            pkt_type = flags & ~FLV_AUDIO_CODECID_MASK;
++
++            channels = 0;
++
++            if (pkt_type == AudioPacketTypeMultitrack) {
++                av_log(s, AV_LOG_ERROR, "Multitrack audio is unsupported!\n");
++                return AVERROR_PATCHWELCOME;
++            }
++
++            codec_id = avio_rb32(s->pb);
++            size -= 4;
++        }
+     } else if (type == FLV_TAG_TYPE_VIDEO) {
+         stream_type = FLV_STREAM_TYPE_VIDEO;
+         flags    = avio_r8(s->pb);
+-        video_codec_id = flags & FLV_VIDEO_CODECID_MASK;
++        codec_id = flags & FLV_VIDEO_CODECID_MASK;
+         /*
+          * Reference Enhancing FLV 2023-03-v1.0.0-B.8
+          * https://github.com/veovera/enhanced-rtmp/blob/main/enhanced-rtmp-v1.pdf
+          * */
+         enhanced_flv = (flags >> 7) & 1;
+-        pkt_type = enhanced_flv ? video_codec_id : 0;
++        pkt_type = enhanced_flv ? codec_id : 0;
+         size--;
+ 
+         if (pkt_type == PacketTypeMultitrack) {
+@@ -1319,7 +1373,7 @@ retry:
+         }
+ 
+         if (enhanced_flv) {
+-            video_codec_id = avio_rb32(s->pb);
++            codec_id = avio_rb32(s->pb);
+             size -= 4;
+         }
+         if (multitrack) {
+@@ -1387,11 +1441,11 @@ skip:
+         st = s->streams[i];
+         if (stream_type == FLV_STREAM_TYPE_AUDIO) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+-                (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags)))
++                (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags, codec_id)))
+                 break;
+         } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+-                (s->video_codec_id || flv_same_video_codec(st->codecpar, video_codec_id)) &&
++                (s->video_codec_id || flv_same_video_codec(st->codecpar, codec_id)) &&
+                 st->id == track_idx)
+                 break;
+         } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
+@@ -1460,7 +1514,7 @@ retry_duration:
+         flv->searched_for_end = 1;
+     }
+ 
+-    if (stream_type == FLV_STREAM_TYPE_AUDIO) {
++    if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv) {
+         int bits_per_coded_sample;
+         channels = (flags & FLV_AUDIO_CHANNEL_MASK) == FLV_STEREO ? 2 : 1;
+         sample_rate = 44100 << ((flags & FLV_AUDIO_SAMPLERATE_MASK) >>
+@@ -1492,8 +1546,48 @@ retry_duration:
+             sample_rate = par->sample_rate;
+             avcodec_parameters_free(&par);
+         }
++    } else if (stream_type == FLV_STREAM_TYPE_AUDIO) {
++        if (!st->codecpar->codec_id) {
++            flv_set_audio_codec(s, st, st->codecpar,
++                                codec_id ? codec_id : (flags & FLV_AUDIO_CODECID_MASK));
++            flv->last_sample_rate = 0;
++            flv->last_channels = 0;
++        }
++
++        // These are not signalled in the flags anymore
++        channels = 0;
++        sample_rate = 0;
++
++        if (pkt_type == AudioPacketTypeMultichannelConfig) {
++            int channel_order = avio_r8(s->pb);
++            channels = avio_r8(s->pb);
++            size -= 2;
++
++            if (channel_order == AudioChannelOrderCustom) {
++                for (i = 0; i < channels; i++) {
++                    avio_r8(s->pb); // audio channel mapping
++                    size--;
++                }
++            } else if (channel_order == AudioChannelOrderNative) {
++                avio_rb32(s->pb); // audio channel flags
++                size -= 4;
++            }
++
++            if (!av_channel_layout_check(&st->codecpar->ch_layout)) {
++                ///TODO: This can be much more sophisticated with above info.
++                av_channel_layout_default(&st->codecpar->ch_layout, channels);
++                flv->last_channels = channels;
++            }
++
++            if (channels != flv->last_channels) {
++                flv->last_channels = channels;
++                ff_add_param_change(pkt, channels, 0, 0, 0, 0);
++            }
++
++            goto leave;
++        }
+     } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+-        int ret = flv_set_video_codec(s, st, video_codec_id, 1);
++        int ret = flv_set_video_codec(s, st, codec_id, 1);
+         if (ret < 0)
+             return ret;
+         size -= ret;
+@@ -1504,13 +1598,15 @@ retry_duration:
+     }
+ 
+     if (st->codecpar->codec_id == AV_CODEC_ID_AAC ||
++        st->codecpar->codec_id == AV_CODEC_ID_OPUS ||
++        st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
+         st->codecpar->codec_id == AV_CODEC_ID_H264 ||
+         st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
+         st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
+         st->codecpar->codec_id == AV_CODEC_ID_AV1 ||
+         st->codecpar->codec_id == AV_CODEC_ID_VP9) {
+         int type = 0;
+-        if (enhanced_flv && stream_type == FLV_STREAM_TYPE_VIDEO) {
++        if (enhanced_flv) {
+             type = pkt_type;
+         } else {
+             type = avio_r8(s->pb);
+@@ -1546,6 +1642,7 @@ retry_duration:
+             size -= 3;
+         }
+         if (type == 0 && (!st->codecpar->extradata || st->codecpar->codec_id == AV_CODEC_ID_AAC ||
++            st->codecpar->codec_id == AV_CODEC_ID_OPUS || st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
+             st->codecpar->codec_id == AV_CODEC_ID_H264 || st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
+             st->codecpar->codec_id == AV_CODEC_ID_AV1 || st->codecpar->codec_id == AV_CODEC_ID_VP9)) {
+             AVDictionaryEntry *t;
+@@ -1601,7 +1698,7 @@ retry_duration:
+             flv->mt_extradata_sz[track_idx] = 0;
+         }
+     }
+-    if (stream_type == FLV_STREAM_TYPE_AUDIO &&
++    if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv &&
+                     (sample_rate != flv->last_sample_rate ||
+                      channels    != flv->last_channels)) {
+         flv->last_sample_rate = sample_rate;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0005-UPSTREAM-avformat-flvdec-parse-enhanced-rtmp-multich.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0005-UPSTREAM-avformat-flvdec-parse-enhanced-rtmp-multich.patch
@@ -1,0 +1,93 @@
+From da4bb243841b9f290ddf1039a26c45fccf9e9372 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Sat, 18 May 2024 20:30:55 +0200
+Subject: [PATCH 05/21] UPSTREAM: avformat/flvdec: parse enhanced rtmp
+ multichannel info
+
+(cherry picked from commit 67b5fb4b5980ce5386e3162d355459524e962302)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 41 +++++++++++++++++++++++++----------------
+ 1 file changed, 25 insertions(+), 16 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index d7974e6b5189..f93d7fa75f06 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1336,8 +1336,6 @@ retry:
+             enhanced_flv = 1;
+             pkt_type = flags & ~FLV_AUDIO_CODECID_MASK;
+ 
+-            channels = 0;
+-
+             if (pkt_type == AudioPacketTypeMultitrack) {
+                 av_log(s, AV_LOG_ERROR, "Multitrack audio is unsupported!\n");
+                 return AVERROR_PATCHWELCOME;
+@@ -1547,12 +1545,9 @@ retry_duration:
+             avcodec_parameters_free(&par);
+         }
+     } else if (stream_type == FLV_STREAM_TYPE_AUDIO) {
+-        if (!st->codecpar->codec_id) {
++        if (!st->codecpar->codec_id)
+             flv_set_audio_codec(s, st, st->codecpar,
+                                 codec_id ? codec_id : (flags & FLV_AUDIO_CODECID_MASK));
+-            flv->last_sample_rate = 0;
+-            flv->last_channels = 0;
+-        }
+ 
+         // These are not signalled in the flags anymore
+         channels = 0;
+@@ -1563,26 +1558,40 @@ retry_duration:
+             channels = avio_r8(s->pb);
+             size -= 2;
+ 
++            av_channel_layout_uninit(&st->codecpar->ch_layout);
++
+             if (channel_order == AudioChannelOrderCustom) {
++                ret = av_channel_layout_custom_init(&st->codecpar->ch_layout, channels);
++                if (ret < 0)
++                    return ret;
++
+                 for (i = 0; i < channels; i++) {
+-                    avio_r8(s->pb); // audio channel mapping
++                    uint8_t id = avio_r8(s->pb);
+                     size--;
++
++                    if (id < 18)
++                        st->codecpar->ch_layout.u.map[i].id = id;
++                    else if (id >= 18 && id <= 23)
++                        st->codecpar->ch_layout.u.map[i].id = id - 18 + AV_CHAN_LOW_FREQUENCY_2;
++                    else if (id == 0xFE)
++                        st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNUSED;
++                    else
++                        st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNKNOWN;
+                 }
+             } else if (channel_order == AudioChannelOrderNative) {
+-                avio_rb32(s->pb); // audio channel flags
++                uint64_t mask = avio_rb32(s->pb);
+                 size -= 4;
+-            }
+ 
+-            if (!av_channel_layout_check(&st->codecpar->ch_layout)) {
+-                ///TODO: This can be much more sophisticated with above info.
++                // The first 18 entries in the mask match ours, but the remaining 6 entries start at AV_CHAN_LOW_FREQUENCY_2
++                mask = (mask & 0x3FFFF) | ((mask & 0xFC0000) << (AV_CHAN_LOW_FREQUENCY_2 - 18));
++                ret = av_channel_layout_from_mask(&st->codecpar->ch_layout, mask);
++                if (ret < 0)
++                    return ret;
++            } else {
+                 av_channel_layout_default(&st->codecpar->ch_layout, channels);
+-                flv->last_channels = channels;
+             }
+ 
+-            if (channels != flv->last_channels) {
+-                flv->last_channels = channels;
+-                ff_add_param_change(pkt, channels, 0, 0, 0, 0);
+-            }
++            av_log(s, AV_LOG_DEBUG, "Set channel data from MultiChannel info.\n");
+ 
+             goto leave;
+         }
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0006-UPSTREAM-avformat-flvdec-add-support-for-reading-mul.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0006-UPSTREAM-avformat-flvdec-add-support-for-reading-mul.patch
@@ -1,0 +1,58 @@
+From 36cdc03058b58f77760db82da0d66a0830aeeaa0 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Sat, 18 May 2024 23:20:46 +0200
+Subject: [PATCH 06/21] UPSTREAM: avformat/flvdec: add support for reading
+ multi track audio
+
+(cherry picked from commit 25faaa311a74efdfdc4fed56996d7338ed807488)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index f93d7fa75f06..27e243cf0276 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1337,12 +1337,26 @@ retry:
+             pkt_type = flags & ~FLV_AUDIO_CODECID_MASK;
+ 
+             if (pkt_type == AudioPacketTypeMultitrack) {
+-                av_log(s, AV_LOG_ERROR, "Multitrack audio is unsupported!\n");
+-                return AVERROR_PATCHWELCOME;
++                uint8_t types = avio_r8(s->pb);
++                int multitrack_type = types >> 4;
++                pkt_type = types & 0xF;
++
++                if (multitrack_type != MultitrackTypeOneTrack) {
++                    av_log(s, AV_LOG_ERROR, "Audio multitrack types other than MultitrackTypeOneTrack are unsupported!\n");
++                    return AVERROR_PATCHWELCOME;
++                }
++
++                multitrack = 1;
++                size--;
+             }
+ 
+             codec_id = avio_rb32(s->pb);
+             size -= 4;
++
++            if (multitrack) {
++                track_idx = avio_r8(s->pb);
++                size--;
++            }
+         }
+     } else if (type == FLV_TAG_TYPE_VIDEO) {
+         stream_type = FLV_STREAM_TYPE_VIDEO;
+@@ -1439,7 +1453,8 @@ skip:
+         st = s->streams[i];
+         if (stream_type == FLV_STREAM_TYPE_AUDIO) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+-                (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags, codec_id)))
++                (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags, codec_id)) &&
++                st->id == track_idx)
+                 break;
+         } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+             if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0007-UPSTREAM-avformat-flvdec-stop-shadowing-local-variab.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0007-UPSTREAM-avformat-flvdec-stop-shadowing-local-variab.patch
@@ -1,0 +1,108 @@
+From f550c705a2e797e33981a3dfa774f0f014ed834e Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Mon, 20 May 2024 02:40:14 +0200
+Subject: [PATCH 07/21] UPSTREAM: avformat/flvdec: stop shadowing local
+ variables
+
+(cherry picked from commit da32990e8385dacf5b6320299ec2a31a4924daf1)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 44 ++++++++++++++++++++++----------------------
+ 1 file changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 27e243cf0276..5ab7c9a2b9fc 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1395,8 +1395,8 @@ retry:
+ 
+         if (enhanced_flv && (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_VIDEO_INFO_CMD) {
+             if (pkt_type == PacketTypeMetadata) {
+-                int ret = flv_parse_video_color_info(s, st, next);
+-                av_log(s, AV_LOG_DEBUG, "enhanced flv parse metadata ret %d and skip\n", ret);
++                int sret = flv_parse_video_color_info(s, st, next);
++                av_log(s, AV_LOG_DEBUG, "enhanced flv parse metadata ret %d and skip\n", sret);
+             }
+             goto skip;
+         } else if ((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_VIDEO_INFO_CMD) {
+@@ -1499,25 +1499,25 @@ skip:
+     if ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
+         (!s->duration || s->duration == AV_NOPTS_VALUE) &&
+         !flv->searched_for_end) {
+-        int size;
++        int final_size;
+         const int64_t pos   = avio_tell(s->pb);
+         // Read the last 4 bytes of the file, this should be the size of the
+         // previous FLV tag. Use the timestamp of its payload as duration.
+         int64_t fsize       = avio_size(s->pb);
+ retry_duration:
+         avio_seek(s->pb, fsize - 4, SEEK_SET);
+-        size = avio_rb32(s->pb);
+-        if (size > 0 && size < fsize) {
+-            // Seek to the start of the last FLV tag at position (fsize - 4 - size)
++        final_size = avio_rb32(s->pb);
++        if (final_size > 0 && final_size < fsize) {
++            // Seek to the start of the last FLV tag at position (fsize - 4 - final_size)
+             // but skip the byte indicating the type.
+-            avio_seek(s->pb, fsize - 3 - size, SEEK_SET);
+-            if (size == avio_rb24(s->pb) + 11) {
++            avio_seek(s->pb, fsize - 3 - final_size, SEEK_SET);
++            if (final_size == avio_rb24(s->pb) + 11) {
+                 uint32_t ts = avio_rb24(s->pb);
+                 ts         |= (unsigned)avio_r8(s->pb) << 24;
+                 if (ts)
+                     s->duration = ts * (int64_t)AV_TIME_BASE / 1000;
+-                else if (fsize >= 8 && fsize - 8 >= size) {
+-                    fsize -= size+4;
++                else if (fsize >= 8 && fsize - 8 >= final_size) {
++                    fsize -= final_size+4;
+                     goto retry_duration;
+                 }
+             }
+@@ -1611,10 +1611,10 @@ retry_duration:
+             goto leave;
+         }
+     } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+-        int ret = flv_set_video_codec(s, st, codec_id, 1);
+-        if (ret < 0)
+-            return ret;
+-        size -= ret;
++        int sret = flv_set_video_codec(s, st, codec_id, 1);
++        if (sret < 0)
++            return sret;
++        size -= sret;
+     } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
+         st->codecpar->codec_id = AV_CODEC_ID_TEXT;
+     } else if (stream_type == FLV_STREAM_TYPE_DATA) {
+@@ -1704,20 +1704,20 @@ retry_duration:
+     pkt->stream_index = st->index;
+     pkt->pos          = pos;
+     if (!multitrack && flv->new_extradata[stream_type]) {
+-        int ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+-                                          flv->new_extradata[stream_type],
+-                                          flv->new_extradata_size[stream_type]);
+-        if (ret >= 0) {
++        int sret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
++                                           flv->new_extradata[stream_type],
++                                           flv->new_extradata_size[stream_type]);
++        if (sret >= 0) {
+             flv->new_extradata[stream_type]      = NULL;
+             flv->new_extradata_size[stream_type] = 0;
+         }
+     } else if (multitrack &&
+                flv->mt_extradata_cnt > track_idx &&
+                flv->mt_extradata[track_idx]) {
+-        int ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+-                                          flv->mt_extradata[track_idx],
+-                                          flv->mt_extradata_sz[track_idx]);
+-        if (ret >= 0) {
++        int sret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
++                                           flv->mt_extradata[track_idx],
++                                           flv->mt_extradata_sz[track_idx]);
++        if (sret >= 0) {
+             flv->mt_extradata[track_idx]      = NULL;
+             flv->mt_extradata_sz[track_idx] = 0;
+         }
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0008-UPSTREAM-avformat-flvdec-support-all-multi-track-mod.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0008-UPSTREAM-avformat-flvdec-support-all-multi-track-mod.patch
@@ -1,0 +1,675 @@
+From 300a2f7ccdfdfbdd541302834dab2fc06fb911e1 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Mon, 20 May 2024 02:32:11 +0200
+Subject: [PATCH 08/21] UPSTREAM: avformat/flvdec: support all multi-track
+ modes
+
+(cherry picked from commit e2a8ece352bf72bb05be8e152b1706509706b62a)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 571 +++++++++++++++++++++++--------------------
+ 1 file changed, 310 insertions(+), 261 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 5ab7c9a2b9fc..a73a6c201238 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1274,6 +1274,7 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+ {
+     FLVContext *flv = s->priv_data;
+     int ret, i, size, flags;
++    int res = 0;
+     enum FlvTagType type;
+     int stream_type=-1;
+     int64_t next, pos, meta_pos;
+@@ -1288,6 +1289,7 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+     int pkt_type = 0;
+     uint8_t track_idx = 0;
+     uint32_t codec_id = 0;
++    int multitrack_type = MultitrackTypeOneTrack;
+ 
+ retry:
+     /* pkt size is repeated at end. skip it */
+@@ -1338,14 +1340,9 @@ retry:
+ 
+             if (pkt_type == AudioPacketTypeMultitrack) {
+                 uint8_t types = avio_r8(s->pb);
+-                int multitrack_type = types >> 4;
++                multitrack_type = types & 0xF0;
+                 pkt_type = types & 0xF;
+ 
+-                if (multitrack_type != MultitrackTypeOneTrack) {
+-                    av_log(s, AV_LOG_ERROR, "Audio multitrack types other than MultitrackTypeOneTrack are unsupported!\n");
+-                    return AVERROR_PATCHWELCOME;
+-                }
+-
+                 multitrack = 1;
+                 size--;
+             }
+@@ -1372,14 +1369,9 @@ retry:
+ 
+         if (pkt_type == PacketTypeMultitrack) {
+             uint8_t types = avio_r8(s->pb);
+-            int multitrack_type = types >> 4;
++            multitrack_type = types & 0xF0;
+             pkt_type = types & 0xF;
+ 
+-            if (multitrack_type != MultitrackTypeOneTrack) {
+-                av_log(s, AV_LOG_ERROR, "Multitrack types other than MultitrackTypeOneTrack are unsupported!\n");
+-                return AVERROR_PATCHWELCOME;
+-            }
+-
+             multitrack = 1;
+             size--;
+         }
+@@ -1448,293 +1440,350 @@ skip:
+         goto leave;
+     }
+ 
+-    /* now find stream */
+-    for (i = 0; i < s->nb_streams; i++) {
+-        st = s->streams[i];
+-        if (stream_type == FLV_STREAM_TYPE_AUDIO) {
+-            if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+-                (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags, codec_id)) &&
+-                st->id == track_idx)
+-                break;
+-        } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+-            if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+-                (s->video_codec_id || flv_same_video_codec(st->codecpar, codec_id)) &&
+-                st->id == track_idx)
+-                break;
+-        } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
+-            if (st->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
+-                break;
+-        } else if (stream_type == FLV_STREAM_TYPE_DATA) {
+-            if (st->codecpar->codec_type == AVMEDIA_TYPE_DATA)
+-                break;
++    for (;;) {
++        int track_size = size;
++
++        if (multitrack_type != MultitrackTypeOneTrack) {
++            track_size = avio_rb24(s->pb);
++            size -= 3;
+         }
+-    }
+-    if (i == s->nb_streams) {
+-        static const enum AVMediaType stream_types[] = {AVMEDIA_TYPE_VIDEO, AVMEDIA_TYPE_AUDIO, AVMEDIA_TYPE_SUBTITLE, AVMEDIA_TYPE_DATA};
+-        st = create_stream(s, stream_types[stream_type], track_idx);
+-        if (!st)
+-            return AVERROR(ENOMEM);
+-    }
+-    av_log(s, AV_LOG_TRACE, "%d %X %d \n", stream_type, flags, st->discard);
+ 
+-    if (flv->time_pos <= pos) {
+-        dts += flv->time_offset;
+-    }
++        /* now find stream */
++        for (i = 0; i < s->nb_streams; i++) {
++            st = s->streams[i];
++            if (stream_type == FLV_STREAM_TYPE_AUDIO) {
++                if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
++                    (s->audio_codec_id || flv_same_audio_codec(st->codecpar, flags, codec_id)) &&
++                    st->id == track_idx)
++                    break;
++            } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
++                if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
++                    (s->video_codec_id || flv_same_video_codec(st->codecpar, codec_id)) &&
++                    st->id == track_idx)
++                    break;
++            } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
++                if (st->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
++                    break;
++            } else if (stream_type == FLV_STREAM_TYPE_DATA) {
++                if (st->codecpar->codec_type == AVMEDIA_TYPE_DATA)
++                    break;
++            }
++        }
++        if (i == s->nb_streams) {
++            static const enum AVMediaType stream_types[] = {AVMEDIA_TYPE_VIDEO, AVMEDIA_TYPE_AUDIO, AVMEDIA_TYPE_SUBTITLE, AVMEDIA_TYPE_DATA};
++            st = create_stream(s, stream_types[stream_type], track_idx);
++            if (!st)
++                return AVERROR(ENOMEM);
++        }
++        av_log(s, AV_LOG_TRACE, "%d %X %d \n", stream_type, flags, st->discard);
+ 
+-    if ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
+-        ((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY ||
+-         stream_type == FLV_STREAM_TYPE_AUDIO))
+-        av_add_index_entry(st, pos, dts, size, 0, AVINDEX_KEYFRAME);
++        if (flv->time_pos <= pos) {
++            dts += flv->time_offset;
++        }
+ 
+-    if ((st->discard >= AVDISCARD_NONKEY && !((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY || stream_type == FLV_STREAM_TYPE_AUDIO)) ||
+-        (st->discard >= AVDISCARD_BIDIR && ((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_DISP_INTER && stream_type == FLV_STREAM_TYPE_VIDEO)) ||
+-         st->discard >= AVDISCARD_ALL) {
+-        avio_seek(s->pb, next, SEEK_SET);
+-        ret = FFERROR_REDO;
+-        goto leave;
+-    }
++        if ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
++            ((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY ||
++             stream_type == FLV_STREAM_TYPE_AUDIO))
++            av_add_index_entry(st, pos, dts, track_size, 0, AVINDEX_KEYFRAME);
++
++        if ((st->discard >= AVDISCARD_NONKEY && !((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY || stream_type == FLV_STREAM_TYPE_AUDIO)) ||
++            (st->discard >= AVDISCARD_BIDIR && ((flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_DISP_INTER && stream_type == FLV_STREAM_TYPE_VIDEO)) ||
++             st->discard >= AVDISCARD_ALL) {
++            avio_seek(s->pb, next, SEEK_SET);
++            ret = FFERROR_REDO;
++            goto leave;
++        }
+ 
+-    // if not streamed and no duration from metadata then seek to end to find
+-    // the duration from the timestamps
+-    if ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
+-        (!s->duration || s->duration == AV_NOPTS_VALUE) &&
+-        !flv->searched_for_end) {
+-        int final_size;
+-        const int64_t pos   = avio_tell(s->pb);
+-        // Read the last 4 bytes of the file, this should be the size of the
+-        // previous FLV tag. Use the timestamp of its payload as duration.
+-        int64_t fsize       = avio_size(s->pb);
++        // if not streamed and no duration from metadata then seek to end to find
++        // the duration from the timestamps
++        if ((s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&
++            (!s->duration || s->duration == AV_NOPTS_VALUE) &&
++            !flv->searched_for_end) {
++            int final_size;
++            const int64_t pos   = avio_tell(s->pb);
++            // Read the last 4 bytes of the file, this should be the size of the
++            // previous FLV tag. Use the timestamp of its payload as duration.
++            int64_t fsize       = avio_size(s->pb);
+ retry_duration:
+-        avio_seek(s->pb, fsize - 4, SEEK_SET);
+-        final_size = avio_rb32(s->pb);
+-        if (final_size > 0 && final_size < fsize) {
+-            // Seek to the start of the last FLV tag at position (fsize - 4 - final_size)
+-            // but skip the byte indicating the type.
+-            avio_seek(s->pb, fsize - 3 - final_size, SEEK_SET);
+-            if (final_size == avio_rb24(s->pb) + 11) {
+-                uint32_t ts = avio_rb24(s->pb);
+-                ts         |= (unsigned)avio_r8(s->pb) << 24;
+-                if (ts)
+-                    s->duration = ts * (int64_t)AV_TIME_BASE / 1000;
+-                else if (fsize >= 8 && fsize - 8 >= final_size) {
+-                    fsize -= final_size+4;
+-                    goto retry_duration;
++            avio_seek(s->pb, fsize - 4, SEEK_SET);
++            final_size = avio_rb32(s->pb);
++            if (final_size > 0 && final_size < fsize) {
++                // Seek to the start of the last FLV tag at position (fsize - 4 - final_size)
++                // but skip the byte indicating the type.
++                avio_seek(s->pb, fsize - 3 - final_size, SEEK_SET);
++                if (final_size == avio_rb24(s->pb) + 11) {
++                    uint32_t ts = avio_rb24(s->pb);
++                    ts         |= (unsigned)avio_r8(s->pb) << 24;
++                    if (ts)
++                        s->duration = ts * (int64_t)AV_TIME_BASE / 1000;
++                    else if (fsize >= 8 && fsize - 8 >= final_size) {
++                        fsize -= final_size+4;
++                        goto retry_duration;
++                    }
+                 }
+             }
++
++            avio_seek(s->pb, pos, SEEK_SET);
++            flv->searched_for_end = 1;
+         }
+ 
+-        avio_seek(s->pb, pos, SEEK_SET);
+-        flv->searched_for_end = 1;
+-    }
++        if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv) {
++            int bits_per_coded_sample;
++            channels = (flags & FLV_AUDIO_CHANNEL_MASK) == FLV_STEREO ? 2 : 1;
++            sample_rate = 44100 << ((flags & FLV_AUDIO_SAMPLERATE_MASK) >>
++                                    FLV_AUDIO_SAMPLERATE_OFFSET) >> 3;
++            bits_per_coded_sample = (flags & FLV_AUDIO_SAMPLESIZE_MASK) ? 16 : 8;
++            if (!av_channel_layout_check(&st->codecpar->ch_layout) ||
++                !st->codecpar->sample_rate ||
++                !st->codecpar->bits_per_coded_sample) {
++                av_channel_layout_default(&st->codecpar->ch_layout, channels);
++                st->codecpar->sample_rate           = sample_rate;
++                st->codecpar->bits_per_coded_sample = bits_per_coded_sample;
++            }
++            if (!st->codecpar->codec_id) {
++                flv_set_audio_codec(s, st, st->codecpar,
++                                    flags & FLV_AUDIO_CODECID_MASK);
++                flv->last_sample_rate =
++                sample_rate           = st->codecpar->sample_rate;
++                flv->last_channels    =
++                channels              = st->codecpar->ch_layout.nb_channels;
++            } else {
++                AVCodecParameters *par = avcodec_parameters_alloc();
++                if (!par) {
++                    ret = AVERROR(ENOMEM);
++                    goto leave;
++                }
++                par->sample_rate = sample_rate;
++                par->bits_per_coded_sample = bits_per_coded_sample;
++                flv_set_audio_codec(s, st, par, flags & FLV_AUDIO_CODECID_MASK);
++                sample_rate = par->sample_rate;
++                avcodec_parameters_free(&par);
++            }
++        } else if (stream_type == FLV_STREAM_TYPE_AUDIO) {
++            if (!st->codecpar->codec_id)
++                flv_set_audio_codec(s, st, st->codecpar,
++                                    codec_id ? codec_id : (flags & FLV_AUDIO_CODECID_MASK));
++
++            // These are not signalled in the flags anymore
++            channels = 0;
++            sample_rate = 0;
++
++            if (pkt_type == AudioPacketTypeMultichannelConfig) {
++                int channel_order = avio_r8(s->pb);
++                channels = avio_r8(s->pb);
++                size -= 2;
++                track_size -= 2;
++
++                av_channel_layout_uninit(&st->codecpar->ch_layout);
++
++                if (channel_order == AudioChannelOrderCustom) {
++                    ret = av_channel_layout_custom_init(&st->codecpar->ch_layout, channels);
++                    if (ret < 0)
++                        return ret;
++
++                    for (i = 0; i < channels; i++) {
++                        uint8_t id = avio_r8(s->pb);
++                        size--;
++
++                        if (id < 18)
++                            st->codecpar->ch_layout.u.map[i].id = id;
++                        else if (id >= 18 && id <= 23)
++                            st->codecpar->ch_layout.u.map[i].id = id - 18 + AV_CHAN_LOW_FREQUENCY_2;
++                        else if (id == 0xFE)
++                            st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNUSED;
++                        else
++                            st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNKNOWN;
++                    }
++                } else if (channel_order == AudioChannelOrderNative) {
++                    uint64_t mask = avio_rb32(s->pb);
++                    size -= 4;
++                    track_size -= 4;
++
++                    // The first 18 entries in the mask match ours, but the remaining 6 entries start at AV_CHAN_LOW_FREQUENCY_2
++                    mask = (mask & 0x3FFFF) | ((mask & 0xFC0000) << (AV_CHAN_LOW_FREQUENCY_2 - 18));
++                    ret = av_channel_layout_from_mask(&st->codecpar->ch_layout, mask);
++                    if (ret < 0)
++                        return ret;
++                } else {
++                    av_channel_layout_default(&st->codecpar->ch_layout, channels);
++                }
++
++                av_log(s, AV_LOG_DEBUG, "Set channel data from MultiChannel info.\n");
+ 
+-    if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv) {
+-        int bits_per_coded_sample;
+-        channels = (flags & FLV_AUDIO_CHANNEL_MASK) == FLV_STEREO ? 2 : 1;
+-        sample_rate = 44100 << ((flags & FLV_AUDIO_SAMPLERATE_MASK) >>
+-                                FLV_AUDIO_SAMPLERATE_OFFSET) >> 3;
+-        bits_per_coded_sample = (flags & FLV_AUDIO_SAMPLESIZE_MASK) ? 16 : 8;
+-        if (!av_channel_layout_check(&st->codecpar->ch_layout) ||
+-            !st->codecpar->sample_rate ||
+-            !st->codecpar->bits_per_coded_sample) {
+-            av_channel_layout_default(&st->codecpar->ch_layout, channels);
+-            st->codecpar->sample_rate           = sample_rate;
+-            st->codecpar->bits_per_coded_sample = bits_per_coded_sample;
+-        }
+-        if (!st->codecpar->codec_id) {
+-            flv_set_audio_codec(s, st, st->codecpar,
+-                                flags & FLV_AUDIO_CODECID_MASK);
+-            flv->last_sample_rate =
+-            sample_rate           = st->codecpar->sample_rate;
+-            flv->last_channels    =
+-            channels              = st->codecpar->ch_layout.nb_channels;
+-        } else {
+-            AVCodecParameters *par = avcodec_parameters_alloc();
+-            if (!par) {
+-                ret = AVERROR(ENOMEM);
+                 goto leave;
+             }
+-            par->sample_rate = sample_rate;
+-            par->bits_per_coded_sample = bits_per_coded_sample;
+-            flv_set_audio_codec(s, st, par, flags & FLV_AUDIO_CODECID_MASK);
+-            sample_rate = par->sample_rate;
+-            avcodec_parameters_free(&par);
++        } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
++            int sret = flv_set_video_codec(s, st, codec_id, 1);
++            if (sret < 0)
++                return sret;
++            size -= sret;
++            track_size -= sret;
++        } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
++            st->codecpar->codec_id = AV_CODEC_ID_TEXT;
++        } else if (stream_type == FLV_STREAM_TYPE_DATA) {
++            st->codecpar->codec_id = AV_CODEC_ID_NONE; // Opaque AMF data
+         }
+-    } else if (stream_type == FLV_STREAM_TYPE_AUDIO) {
+-        if (!st->codecpar->codec_id)
+-            flv_set_audio_codec(s, st, st->codecpar,
+-                                codec_id ? codec_id : (flags & FLV_AUDIO_CODECID_MASK));
+ 
+-        // These are not signalled in the flags anymore
+-        channels = 0;
+-        sample_rate = 0;
+-
+-        if (pkt_type == AudioPacketTypeMultichannelConfig) {
+-            int channel_order = avio_r8(s->pb);
+-            channels = avio_r8(s->pb);
+-            size -= 2;
++        if (st->codecpar->codec_id == AV_CODEC_ID_AAC ||
++            st->codecpar->codec_id == AV_CODEC_ID_OPUS ||
++            st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
++            st->codecpar->codec_id == AV_CODEC_ID_H264 ||
++            st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
++            st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
++            st->codecpar->codec_id == AV_CODEC_ID_AV1 ||
++            st->codecpar->codec_id == AV_CODEC_ID_VP9) {
++            int type = 0;
++            if (enhanced_flv) {
++                type = pkt_type;
++            } else {
++                type = avio_r8(s->pb);
++                size--;
++                track_size--;
++            }
+ 
+-            av_channel_layout_uninit(&st->codecpar->ch_layout);
++            if (size < 0 || track_size < 0) {
++                ret = AVERROR_INVALIDDATA;
++                goto leave;
++            }
+ 
+-            if (channel_order == AudioChannelOrderCustom) {
+-                ret = av_channel_layout_custom_init(&st->codecpar->ch_layout, channels);
+-                if (ret < 0)
+-                    return ret;
++            if (enhanced_flv && stream_type == FLV_STREAM_TYPE_VIDEO && flv->meta_color_info_flag) {
++                flv_update_video_color_info(s, st); // update av packet side data
++                flv->meta_color_info_flag = 0;
++            }
+ 
+-                for (i = 0; i < channels; i++) {
+-                    uint8_t id = avio_r8(s->pb);
+-                    size--;
+-
+-                    if (id < 18)
+-                        st->codecpar->ch_layout.u.map[i].id = id;
+-                    else if (id >= 18 && id <= 23)
+-                        st->codecpar->ch_layout.u.map[i].id = id - 18 + AV_CHAN_LOW_FREQUENCY_2;
+-                    else if (id == 0xFE)
+-                        st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNUSED;
+-                    else
+-                        st->codecpar->ch_layout.u.map[i].id = AV_CHAN_UNKNOWN;
++            if (st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
++                (st->codecpar->codec_id == AV_CODEC_ID_H264 && (!enhanced_flv || type == PacketTypeCodedFrames)) ||
++                (st->codecpar->codec_id == AV_CODEC_ID_HEVC && type == PacketTypeCodedFrames)) {
++                // sign extension
++                int32_t cts = (avio_rb24(s->pb) + 0xff800000) ^ 0xff800000;
++                pts = av_sat_add64(dts, cts);
++                if (cts < 0) { // dts might be wrong
++                    if (!flv->wrong_dts)
++                        av_log(s, AV_LOG_WARNING,
++                            "Negative cts, previous timestamps might be wrong.\n");
++                    flv->wrong_dts = 1;
++                } else if (FFABS(dts - pts) > 1000*60*15) {
++                    av_log(s, AV_LOG_WARNING,
++                           "invalid timestamps %"PRId64" %"PRId64"\n", dts, pts);
++                    dts = pts = AV_NOPTS_VALUE;
+                 }
+-            } else if (channel_order == AudioChannelOrderNative) {
+-                uint64_t mask = avio_rb32(s->pb);
+-                size -= 4;
+-
+-                // The first 18 entries in the mask match ours, but the remaining 6 entries start at AV_CHAN_LOW_FREQUENCY_2
+-                mask = (mask & 0x3FFFF) | ((mask & 0xFC0000) << (AV_CHAN_LOW_FREQUENCY_2 - 18));
+-                ret = av_channel_layout_from_mask(&st->codecpar->ch_layout, mask);
+-                if (ret < 0)
+-                    return ret;
+-            } else {
+-                av_channel_layout_default(&st->codecpar->ch_layout, channels);
++                size -= 3;
++                track_size -= 3;
+             }
++            if (type == 0 && (!st->codecpar->extradata || st->codecpar->codec_id == AV_CODEC_ID_AAC ||
++                st->codecpar->codec_id == AV_CODEC_ID_OPUS || st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
++                st->codecpar->codec_id == AV_CODEC_ID_H264 || st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
++                st->codecpar->codec_id == AV_CODEC_ID_AV1 || st->codecpar->codec_id == AV_CODEC_ID_VP9)) {
++                AVDictionaryEntry *t;
++
++                if (st->codecpar->extradata) {
++                    if ((ret = flv_queue_extradata(flv, s->pb, multitrack ? track_idx : stream_type, track_size, multitrack)) < 0)
++                        return ret;
++                    ret = FFERROR_REDO;
++                    goto leave;
++                }
++                if ((ret = flv_get_extradata(s, st, track_size)) < 0)
++                    return ret;
+ 
+-            av_log(s, AV_LOG_DEBUG, "Set channel data from MultiChannel info.\n");
+-
+-            goto leave;
+-        }
+-    } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+-        int sret = flv_set_video_codec(s, st, codec_id, 1);
+-        if (sret < 0)
+-            return sret;
+-        size -= sret;
+-    } else if (stream_type == FLV_STREAM_TYPE_SUBTITLE) {
+-        st->codecpar->codec_id = AV_CODEC_ID_TEXT;
+-    } else if (stream_type == FLV_STREAM_TYPE_DATA) {
+-        st->codecpar->codec_id = AV_CODEC_ID_NONE; // Opaque AMF data
+-    }
++                /* Workaround for buggy Omnia A/XE encoder */
++                t = av_dict_get(s->metadata, "Encoder", NULL, 0);
++                if (st->codecpar->codec_id == AV_CODEC_ID_AAC && t && !strcmp(t->value, "Omnia A/XE"))
++                    st->codecpar->extradata_size = 2;
+ 
+-    if (st->codecpar->codec_id == AV_CODEC_ID_AAC ||
+-        st->codecpar->codec_id == AV_CODEC_ID_OPUS ||
+-        st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
+-        st->codecpar->codec_id == AV_CODEC_ID_H264 ||
+-        st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
+-        st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
+-        st->codecpar->codec_id == AV_CODEC_ID_AV1 ||
+-        st->codecpar->codec_id == AV_CODEC_ID_VP9) {
+-        int type = 0;
+-        if (enhanced_flv) {
+-            type = pkt_type;
+-        } else {
+-            type = avio_r8(s->pb);
+-            size--;
++                ret = FFERROR_REDO;
++                goto leave;
++            }
+         }
+ 
+-        if (size < 0) {
+-            ret = AVERROR_INVALIDDATA;
++        /* skip empty or broken data packets */
++        if (size <= 0 || track_size < 0) {
++            ret = FFERROR_REDO;
+             goto leave;
+         }
+ 
+-        if (enhanced_flv && stream_type == FLV_STREAM_TYPE_VIDEO && flv->meta_color_info_flag) {
+-            flv_update_video_color_info(s, st); // update av packet side data
+-            flv->meta_color_info_flag = 0;
++        /* skip empty data track */
++        if (!track_size)
++            goto next_track;
++
++        ret = av_get_packet(s->pb, pkt, track_size);
++        if (ret < 0)
++            return ret;
++
++        track_size -= ret;
++        size -= ret;
++
++        pkt->dts          = dts;
++        pkt->pts          = pts == AV_NOPTS_VALUE ? dts : pts;
++        pkt->stream_index = st->index;
++        pkt->pos          = pos;
++        if (!multitrack && flv->new_extradata[stream_type]) {
++            ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
++                                          flv->new_extradata[stream_type],
++                                          flv->new_extradata_size[stream_type]);
++            if (ret >= 0) {
++                flv->new_extradata[stream_type]      = NULL;
++                flv->new_extradata_size[stream_type] = 0;
++            }
++        } else if (multitrack &&
++                   flv->mt_extradata_cnt > track_idx &&
++                   flv->mt_extradata[track_idx]) {
++            ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
++                                          flv->mt_extradata[track_idx],
++                                          flv->mt_extradata_sz[track_idx]);
++            if (ret >= 0) {
++                flv->mt_extradata[track_idx]      = NULL;
++                flv->mt_extradata_sz[track_idx] = 0;
++            }
++        }
++        if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv &&
++                        (sample_rate != flv->last_sample_rate ||
++                         channels    != flv->last_channels)) {
++            flv->last_sample_rate = sample_rate;
++            flv->last_channels    = channels;
++            ff_add_param_change(pkt, channels, 0, sample_rate, 0, 0);
+         }
+ 
+-        if (st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
+-            (st->codecpar->codec_id == AV_CODEC_ID_H264 && (!enhanced_flv || type == PacketTypeCodedFrames)) ||
+-            (st->codecpar->codec_id == AV_CODEC_ID_HEVC && type == PacketTypeCodedFrames)) {
+-            // sign extension
+-            int32_t cts = (avio_rb24(s->pb) + 0xff800000) ^ 0xff800000;
+-            pts = av_sat_add64(dts, cts);
+-            if (cts < 0) { // dts might be wrong
+-                if (!flv->wrong_dts)
+-                    av_log(s, AV_LOG_WARNING,
+-                        "Negative cts, previous timestamps might be wrong.\n");
+-                flv->wrong_dts = 1;
+-            } else if (FFABS(dts - pts) > 1000*60*15) {
+-                av_log(s, AV_LOG_WARNING,
+-                       "invalid timestamps %"PRId64" %"PRId64"\n", dts, pts);
+-                dts = pts = AV_NOPTS_VALUE;
+-            }
+-            size -= 3;
++        if (stream_type == FLV_STREAM_TYPE_AUDIO ||
++            (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY ||
++            stream_type == FLV_STREAM_TYPE_SUBTITLE ||
++            stream_type == FLV_STREAM_TYPE_DATA)
++            pkt->flags |= AV_PKT_FLAG_KEY;
++
++        ret = ff_buffer_packet(s, pkt);
++        if (ret < 0)
++            return ret;
++        res = FFERROR_REDO;
++
++        if (track_size) {
++            av_log(s, AV_LOG_WARNING, "Track size mismatch: %d!\n", track_size);
++            avio_skip(s->pb, track_size);
++            size -= track_size;
+         }
+-        if (type == 0 && (!st->codecpar->extradata || st->codecpar->codec_id == AV_CODEC_ID_AAC ||
+-            st->codecpar->codec_id == AV_CODEC_ID_OPUS || st->codecpar->codec_id == AV_CODEC_ID_FLAC ||
+-            st->codecpar->codec_id == AV_CODEC_ID_H264 || st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
+-            st->codecpar->codec_id == AV_CODEC_ID_AV1 || st->codecpar->codec_id == AV_CODEC_ID_VP9)) {
+-            AVDictionaryEntry *t;
+-
+-            if (st->codecpar->extradata) {
+-                if ((ret = flv_queue_extradata(flv, s->pb, multitrack ? track_idx : stream_type, size, multitrack)) < 0)
+-                    return ret;
+-                ret = FFERROR_REDO;
+-                goto leave;
+-            }
+-            if ((ret = flv_get_extradata(s, st, size)) < 0)
+-                return ret;
+ 
+-            /* Workaround for buggy Omnia A/XE encoder */
+-            t = av_dict_get(s->metadata, "Encoder", NULL, 0);
+-            if (st->codecpar->codec_id == AV_CODEC_ID_AAC && t && !strcmp(t->value, "Omnia A/XE"))
+-                st->codecpar->extradata_size = 2;
++        if (!size)
++            break;
+ 
++next_track:
++        if (multitrack_type == MultitrackTypeOneTrack) {
++            av_log(s, AV_LOG_ERROR, "Attempted to read next track in single-track mode.\n");
+             ret = FFERROR_REDO;
+             goto leave;
+         }
+-    }
+ 
+-    /* skip empty data packets */
+-    if (!size) {
+-        ret = FFERROR_REDO;
+-        goto leave;
+-    }
+-
+-    ret = av_get_packet(s->pb, pkt, size);
+-    if (ret < 0)
+-        return ret;
+-    pkt->dts          = dts;
+-    pkt->pts          = pts == AV_NOPTS_VALUE ? dts : pts;
+-    pkt->stream_index = st->index;
+-    pkt->pos          = pos;
+-    if (!multitrack && flv->new_extradata[stream_type]) {
+-        int sret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+-                                           flv->new_extradata[stream_type],
+-                                           flv->new_extradata_size[stream_type]);
+-        if (sret >= 0) {
+-            flv->new_extradata[stream_type]      = NULL;
+-            flv->new_extradata_size[stream_type] = 0;
++        if (multitrack_type == MultitrackTypeManyTracksManyCodecs) {
++            codec_id = avio_rb32(s->pb);
++            size -= 4;
+         }
+-    } else if (multitrack &&
+-               flv->mt_extradata_cnt > track_idx &&
+-               flv->mt_extradata[track_idx]) {
+-        int sret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+-                                           flv->mt_extradata[track_idx],
+-                                           flv->mt_extradata_sz[track_idx]);
+-        if (sret >= 0) {
+-            flv->mt_extradata[track_idx]      = NULL;
+-            flv->mt_extradata_sz[track_idx] = 0;
++
++        track_idx = avio_r8(s->pb);
++        size--;
++
++        if (avio_feof(s->pb)) {
++            av_log(s, AV_LOG_WARNING, "Premature EOF\n");
++            /* return REDO so that any potentially queued up packages can be drained first */
++            return FFERROR_REDO;
+         }
+     }
+-    if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv &&
+-                    (sample_rate != flv->last_sample_rate ||
+-                     channels    != flv->last_channels)) {
+-        flv->last_sample_rate = sample_rate;
+-        flv->last_channels    = channels;
+-        ff_add_param_change(pkt, channels, 0, sample_rate, 0, 0);
+-    }
+-
+-    if (stream_type == FLV_STREAM_TYPE_AUDIO ||
+-        (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_KEY ||
+-        stream_type == FLV_STREAM_TYPE_SUBTITLE ||
+-        stream_type == FLV_STREAM_TYPE_DATA)
+-        pkt->flags |= AV_PKT_FLAG_KEY;
+ 
+ leave:
+     last = avio_rb32(s->pb);
+@@ -1756,7 +1805,7 @@ leave:
+     if (ret >= 0)
+         flv->last_ts = pkt->dts;
+ 
+-    return ret;
++    return ret ? ret : res;
+ }
+ 
+ static int flv_read_seek(AVFormatContext *s, int stream_index,
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0009-UPSTREAM-avformat-flvdec-propagate-av_packet_add_sid.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0009-UPSTREAM-avformat-flvdec-propagate-av_packet_add_sid.patch
@@ -1,0 +1,50 @@
+From d4c15a3e5d98009c167a9e8deaba9bbe880591bf Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Sun, 22 Dec 2024 03:06:17 +0100
+Subject: [PATCH 09/21] UPSTREAM: avformat/flvdec: propagate
+ av_packet_add_side_data failure
+
+(cherry picked from commit 770f0a243419f14a56f1da76b6cf44157565f98e)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index a73a6c201238..b036204cf3b7 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1720,20 +1720,22 @@ retry_duration:
+             ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+                                           flv->new_extradata[stream_type],
+                                           flv->new_extradata_size[stream_type]);
+-            if (ret >= 0) {
+-                flv->new_extradata[stream_type]      = NULL;
+-                flv->new_extradata_size[stream_type] = 0;
+-            }
++            if (ret < 0)
++                return ret;
++
++            flv->new_extradata[stream_type]      = NULL;
++            flv->new_extradata_size[stream_type] = 0;
+         } else if (multitrack &&
+                    flv->mt_extradata_cnt > track_idx &&
+                    flv->mt_extradata[track_idx]) {
+             ret = av_packet_add_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
+                                           flv->mt_extradata[track_idx],
+                                           flv->mt_extradata_sz[track_idx]);
+-            if (ret >= 0) {
+-                flv->mt_extradata[track_idx]      = NULL;
+-                flv->mt_extradata_sz[track_idx] = 0;
+-            }
++            if (ret < 0)
++                return ret;
++
++            flv->mt_extradata[track_idx]      = NULL;
++            flv->mt_extradata_sz[track_idx] = 0;
+         }
+         if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv &&
+                         (sample_rate != flv->last_sample_rate ||
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0010-UPSTREAM-avformat-flvdec-add-missing-track_size-decr.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0010-UPSTREAM-avformat-flvdec-add-missing-track_size-decr.patch
@@ -1,0 +1,27 @@
+From e8ba136e90246e00e9abebbb95c6d5c63703e6f1 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Tue, 7 Jan 2025 17:57:52 +0100
+Subject: [PATCH 10/21] UPSTREAM: avformat/flvdec: add missing track_size
+ decrement
+
+(cherry picked from commit e9de794d7fb0d52d63a37758dc605322321e34c3)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index b036204cf3b7..e8b5ea954365 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1584,6 +1584,7 @@ retry_duration:
+                     for (i = 0; i < channels; i++) {
+                         uint8_t id = avio_r8(s->pb);
+                         size--;
++                        track_size--;
+ 
+                         if (id < 18)
+                             st->codecpar->ch_layout.u.map[i].id = id;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0011-UPSTREAM-avformat-flvdec-fix-potential-premature-ret.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0011-UPSTREAM-avformat-flvdec-fix-potential-premature-ret.patch
@@ -1,0 +1,53 @@
+From 5410fe404a8b7c3af2d33b18bd8436fffac12717 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Tue, 7 Jan 2025 18:18:02 +0100
+Subject: [PATCH 11/21] UPSTREAM: avformat/flvdec: fix potential premature
+ return on audio MultichannelConfig
+
+(cherry picked from commit 0ed34467382a35dd27da7124fae99e84eee469a5)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index e8b5ea954365..043c977e73de 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1273,7 +1273,7 @@ static int flv_update_video_color_info(AVFormatContext *s, AVStream *st)
+ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+ {
+     FLVContext *flv = s->priv_data;
+-    int ret, i, size, flags;
++    int ret = 0, i, size, flags;
+     int res = 0;
+     enum FlvTagType type;
+     int stream_type=-1;
+@@ -1611,7 +1611,7 @@ retry_duration:
+ 
+                 av_log(s, AV_LOG_DEBUG, "Set channel data from MultiChannel info.\n");
+ 
+-                goto leave;
++                goto next_track;
+             }
+         } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
+             int sret = flv_set_video_codec(s, st, codec_id, 1);
+@@ -1757,6 +1757,7 @@ retry_duration:
+             return ret;
+         res = FFERROR_REDO;
+ 
++next_track:
+         if (track_size) {
+             av_log(s, AV_LOG_WARNING, "Track size mismatch: %d!\n", track_size);
+             avio_skip(s->pb, track_size);
+@@ -1766,7 +1767,6 @@ retry_duration:
+         if (!size)
+             break;
+ 
+-next_track:
+         if (multitrack_type == MultitrackTypeOneTrack) {
+             av_log(s, AV_LOG_ERROR, "Attempted to read next track in single-track mode.\n");
+             ret = FFERROR_REDO;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0012-UPSTREAM-avformat-flvdec-clean-up-variable-initializ.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0012-UPSTREAM-avformat-flvdec-clean-up-variable-initializ.patch
@@ -1,0 +1,34 @@
+From e36dc539b0a53d9ab6b8016b9d01e67bdf3e7134 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Tue, 7 Jan 2025 18:18:38 +0100
+Subject: [PATCH 12/21] UPSTREAM: avformat/flvdec: clean up variable
+ initialization spacing
+
+(cherry picked from commit 4c2b769e53329208cbccd65c9c4143b346e7e07b)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 043c977e73de..facce7a4f677 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1276,12 +1276,12 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+     int ret = 0, i, size, flags;
+     int res = 0;
+     enum FlvTagType type;
+-    int stream_type=-1;
++    int stream_type = -1;
+     int64_t next, pos, meta_pos;
+     int64_t dts, pts = AV_NOPTS_VALUE;
+     int av_uninit(channels);
+     int av_uninit(sample_rate);
+-    AVStream *st    = NULL;
++    AVStream *st = NULL;
+     int last = -1;
+     int orig_size;
+     int enhanced_flv = 0;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0013-UPSTREAM-avformat-flvdec-properly-free-mt_extradata.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0013-UPSTREAM-avformat-flvdec-properly-free-mt_extradata.patch
@@ -1,0 +1,26 @@
+From a538b3aa39941adc82a3c549393e79d5e3f363e3 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Tue, 7 Jan 2025 19:07:43 +0100
+Subject: [PATCH 13/21] UPSTREAM: avformat/flvdec: properly free mt_extradata
+
+(cherry picked from commit 9201f872b1c4a6a73510d48c43960f6a2a62a4fe)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index facce7a4f677..88038332ea44 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -935,6 +935,7 @@ static int flv_read_close(AVFormatContext *s)
+         av_freep(&flv->new_extradata[i]);
+     for (i = 0; i < flv->mt_extradata_cnt; i++)
+         av_freep(&flv->mt_extradata[i]);
++    av_freep(&flv->mt_extradata);
+     av_freep(&flv->mt_extradata_sz);
+     av_freep(&flv->keyframe_times);
+     av_freep(&flv->keyframe_filepositions);
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0014-UPSTREAM-avformat-flvdec-don-t-leak-extradata-pointe.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0014-UPSTREAM-avformat-flvdec-don-t-leak-extradata-pointe.patch
@@ -1,0 +1,51 @@
+From a9e84a6d9a6e4c36f84543b1aa5303f99bca9b7a Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Tue, 7 Jan 2025 19:17:54 +0100
+Subject: [PATCH 14/21] UPSTREAM: avformat/flvdec: don't leak extradata pointer
+ on realloc failure
+
+(cherry picked from commit af74fe7139f4e99c12e9396b0b45c6d0c8d291cc)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 22 +++++++++++++---------
+ 1 file changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 88038332ea44..f167157a0463 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -973,18 +973,22 @@ static int flv_queue_extradata(FLVContext *flv, AVIOContext *pb, int stream,
+         int new_count = stream + 1;
+ 
+         if (flv->mt_extradata_cnt < new_count) {
+-            flv->mt_extradata = av_realloc(flv->mt_extradata,
+-                                           sizeof(*flv->mt_extradata) *
+-                                           new_count);
+-            flv->mt_extradata_sz = av_realloc(flv->mt_extradata_sz,
+-                                              sizeof(*flv->mt_extradata_sz) *
+-                                              new_count);
+-            if (!flv->mt_extradata || !flv->mt_extradata_sz)
++            void *tmp = av_realloc_array(flv->mt_extradata, new_count,
++                                         sizeof(*flv->mt_extradata));
++            if (!tmp)
+                 return AVERROR(ENOMEM);
++            flv->mt_extradata = tmp;
++
++            tmp = av_realloc_array(flv->mt_extradata_sz, new_count,
++                                   sizeof(*flv->mt_extradata_sz));
++            if (!tmp)
++                return AVERROR(ENOMEM);
++            flv->mt_extradata_sz = tmp;
++
+             // Set newly allocated pointers/sizes to 0
+             for (int i = flv->mt_extradata_cnt; i < new_count; i++) {
+-                    flv->mt_extradata[i] = NULL;
+-                    flv->mt_extradata_sz[i] = 0;
++                flv->mt_extradata[i] = NULL;
++                flv->mt_extradata_sz[i] = 0;
+             }
+             flv->mt_extradata_cnt = new_count;
+         }
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0015-BACKPORT-avformat-flvdec-add-support-for-legacy-HEVC.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0015-BACKPORT-avformat-flvdec-add-support-for-legacy-HEVC.patch
@@ -1,0 +1,62 @@
+From 59610e05a660db59d2a9ea5846648fc2f90ba39d Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Fri, 10 Jan 2025 21:41:55 +0100
+Subject: [PATCH 15/21] BACKPORT: avformat/flvdec: add support for legacy HEVC
+ files
+
+(cherry picked from commit b76053d8bf322b197a9d07bd27bbdad14fd5bc15)
+[Kexy: Resolved minor conflict in libavformat/version.h]
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flv.h    | 3 +++
+ libavformat/flvdec.c | 6 ++++--
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/flv.h b/libavformat/flv.h
+index 1ea88ff85119..74d3b8de8be9 100644
+--- a/libavformat/flv.h
++++ b/libavformat/flv.h
+@@ -117,6 +117,9 @@ enum {
+     FLV_CODECID_H264    = 7,
+     FLV_CODECID_REALH263= 8,
+     FLV_CODECID_MPEG4   = 9,
++
++    // non-standard protocol extension that is in use in the wild
++    FLV_CODECID_X_HEVC  = 12,
+ };
+ 
+ enum {
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index f167157a0463..e17e5375b242 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -380,6 +380,7 @@ static int flv_same_video_codec(AVCodecParameters *vpar, uint32_t flv_codecid)
+         return 1;
+ 
+     switch (flv_codecid) {
++    case FLV_CODECID_X_HEVC:
+     case MKBETAG('h', 'v', 'c', '1'):
+         return vpar->codec_id == AV_CODEC_ID_HEVC;
+     case MKBETAG('a', 'v', '0', '1'):
+@@ -413,6 +414,7 @@ static int flv_set_video_codec(AVFormatContext *s, AVStream *vstream,
+     enum AVCodecID old_codec_id = vstream->codecpar->codec_id;
+ 
+     switch (flv_codecid) {
++    case FLV_CODECID_X_HEVC:
+     case MKBETAG('h', 'v', 'c', '1'):
+         par->codec_id = AV_CODEC_ID_HEVC;
+         vstreami->need_parsing = AVSTREAM_PARSE_HEADERS;
+@@ -1658,8 +1660,8 @@ retry_duration:
+             }
+ 
+             if (st->codecpar->codec_id == AV_CODEC_ID_MPEG4 ||
+-                (st->codecpar->codec_id == AV_CODEC_ID_H264 && (!enhanced_flv || type == PacketTypeCodedFrames)) ||
+-                (st->codecpar->codec_id == AV_CODEC_ID_HEVC && type == PacketTypeCodedFrames)) {
++                ((st->codecpar->codec_id == AV_CODEC_ID_H264 || st->codecpar->codec_id == AV_CODEC_ID_HEVC) &&
++                 (!enhanced_flv || type == PacketTypeCodedFrames))) {
+                 // sign extension
+                 int32_t cts = (avio_rb24(s->pb) + 0xff800000) ^ 0xff800000;
+                 pts = av_sat_add64(dts, cts);
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0016-UPSTREAM-avformat-flvdec-implement-support-for-parsi.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0016-UPSTREAM-avformat-flvdec-implement-support-for-parsi.patch
@@ -1,0 +1,132 @@
+From a79bb63faa85567c21016931eb72f3f418e8a305 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Wed, 15 Jan 2025 01:19:57 +0100
+Subject: [PATCH 16/21] UPSTREAM: avformat/flvdec: implement support for
+ parsing ModEx data
+
+(cherry picked from commit ced9fddec0e45e1ce1b3425a1fed66af971e934c)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flv.h    |  5 ++++
+ libavformat/flvdec.c | 68 ++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 73 insertions(+)
+
+diff --git a/libavformat/flv.h b/libavformat/flv.h
+index 74d3b8de8be9..d8f7980f2e30 100644
+--- a/libavformat/flv.h
++++ b/libavformat/flv.h
+@@ -130,6 +130,7 @@ enum {
+     PacketTypeMetadata              = 4,
+     PacketTypeMPEG2TSSequenceStart  = 5,
+     PacketTypeMultitrack            = 6,
++    PacketTypeModEx                 = 7,
+ };
+ 
+ enum {
+@@ -139,6 +140,10 @@ enum {
+     AudioPacketTypeMultitrack         = 5,
+ };
+ 
++enum {
++    PacketModExTypeTimestampOffsetNano = 0,
++};
++
+ enum {
+     AudioChannelOrderUnspecified = 0,
+     AudioChannelOrderNative      = 1,
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index e17e5375b242..2c21911410fb 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1277,6 +1277,62 @@ static int flv_update_video_color_info(AVFormatContext *s, AVStream *st)
+     return 0;
+ }
+ 
++static int flv_parse_mod_ex_data(AVFormatContext *s, int *pkt_type, int *size, int64_t *dts)
++{
++    int ex_type, ret;
++    uint8_t *ex_data;
++
++    int ex_size = (uint8_t)avio_r8(s->pb) + 1;
++    *size -= 1;
++
++    if (ex_size == 256) {
++        ex_size = (uint16_t)avio_rb16(s->pb) + 1;
++        *size -= 2;
++    }
++
++    if (ex_size >= *size) {
++        av_log(s, AV_LOG_WARNING, "ModEx size larger than remaining data!\n");
++        return AVERROR(EINVAL);
++    }
++
++    ex_data = av_malloc(ex_size);
++    if (!ex_data)
++        return AVERROR(ENOMEM);
++
++    ret = avio_read(s->pb, ex_data, ex_size);
++    if (ret < 0) {
++        av_free(ex_data);
++        return ret;
++    }
++    *size -= ex_size;
++
++    ex_type = (uint8_t)avio_r8(s->pb);
++    *size -= 1;
++
++    *pkt_type = ex_type & 0x0f;
++    ex_type &= 0xf0;
++
++    if (ex_type == PacketModExTypeTimestampOffsetNano) {
++        uint32_t nano_offset;
++
++        if (ex_size != 3) {
++            av_log(s, AV_LOG_WARNING, "Invalid ModEx size for Type TimestampOffsetNano!\n");
++            nano_offset = 0;
++        } else {
++            nano_offset = (ex_data[0] << 16) | (ex_data[1] << 8) | ex_data[2];
++        }
++
++        // this is not likely to ever add anything, but right now timestamps are with ms precision
++        *dts += nano_offset / 1000000;
++    } else {
++        av_log(s, AV_LOG_INFO, "Unknown ModEx type: %d", ex_type);
++    }
++
++    av_free(ex_data);
++
++    return 0;
++}
++
+ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
+ {
+     FLVContext *flv = s->priv_data;
+@@ -1345,6 +1401,12 @@ retry:
+             enhanced_flv = 1;
+             pkt_type = flags & ~FLV_AUDIO_CODECID_MASK;
+ 
++            while (pkt_type == PacketTypeModEx) {
++                ret = flv_parse_mod_ex_data(s, &pkt_type, &size, &dts);
++                if (ret < 0)
++                    goto leave;
++            }
++
+             if (pkt_type == AudioPacketTypeMultitrack) {
+                 uint8_t types = avio_r8(s->pb);
+                 multitrack_type = types & 0xF0;
+@@ -1374,6 +1436,12 @@ retry:
+         pkt_type = enhanced_flv ? codec_id : 0;
+         size--;
+ 
++        while (pkt_type == PacketTypeModEx) {
++            ret = flv_parse_mod_ex_data(s, &pkt_type, &size, &dts);
++            if (ret < 0)
++                goto leave;
++        }
++
+         if (pkt_type == PacketTypeMultitrack) {
+             uint8_t types = avio_r8(s->pb);
+             multitrack_type = types & 0xF0;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0017-UPSTREAM-avformat-flvdec-correctly-skip-command-fram.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0017-UPSTREAM-avformat-flvdec-correctly-skip-command-fram.patch
@@ -1,0 +1,30 @@
+From 54342ed3e85a3848cd37e5b555c6889707063867 Mon Sep 17 00:00:00 2001
+From: Timo Rothenpieler <timo@rothenpieler.org>
+Date: Wed, 15 Jan 2025 01:28:08 +0100
+Subject: [PATCH 17/21] UPSTREAM: avformat/flvdec: correctly skip command frame
+ for enhanced flv
+
+(cherry picked from commit a3e506455e3346e3e0a7c577874fa3b83644e8f9)
+Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
+---
+ libavformat/flvdec.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
+index 2c21911410fb..83b0f2acec80 100644
+--- a/libavformat/flvdec.c
++++ b/libavformat/flvdec.c
+@@ -1442,6 +1442,10 @@ retry:
+                 goto leave;
+         }
+ 
++        if (enhanced_flv && pkt_type != PacketTypeMetadata &&
++            (flags & FLV_VIDEO_FRAMETYPE_MASK) == FLV_FRAME_VIDEO_INFO_CMD)
++            goto skip;
++
+         if (pkt_type == PacketTypeMultitrack) {
+             uint8_t types = avio_r8(s->pb);
+             multitrack_type = types & 0xF0;
+-- 
+2.48.1.windows.1
+

--- a/app-multimedia/ffmpeg/autobuild/patches/0018-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0018-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
-From 1ace584bbc51082635887013d5da6d09d8c73f7d Mon Sep 17 00:00:00 2001
+From 4b80049d59cc054eef68ee53a867feda74ee878c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 1/4] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 18/21] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
  2 files changed, 1 insertion(+), 89 deletions(-)
 
 diff --git a/libavutil/mips/asmdefs.h b/libavutil/mips/asmdefs.h
-index 659342bab9..4d3bf1f09a 100644
+index 659342bab918..4d3bf1f09af9 100644
 --- a/libavutil/mips/asmdefs.h
 +++ b/libavutil/mips/asmdefs.h
 @@ -57,48 +57,6 @@
@@ -63,7 +63,7 @@ index 659342bab9..4d3bf1f09a 100644
  union mmi_intfloat64 {
      int64_t i;
 diff --git a/libavutil/mips/cpu.c b/libavutil/mips/cpu.c
-index 2009c70f71..5002261b25 100644
+index 2009c70f7151..5002261b256a 100644
 --- a/libavutil/mips/cpu.c
 +++ b/libavutil/mips/cpu.c
 @@ -30,49 +30,6 @@
@@ -129,5 +129,5 @@ index 2009c70f71..5002261b25 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.47.1
+2.48.1.windows.1
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0019-Add-av_stream_get_first_dts-for-Chromium.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0019-Add-av_stream_get_first_dts-for-Chromium.patch
@@ -1,7 +1,7 @@
-From fe4537f7a8fbce54efae9a6734c45e84b0fcdb35 Mon Sep 17 00:00:00 2001
+From 2974e568e98d50a72fa2e72b6083dbdb314baa2f Mon Sep 17 00:00:00 2001
 From: Frank Liberato <liberato@chromium.org>
 Date: Wed, 7 Jul 2021 19:01:22 -0700
-Subject: [PATCH 2/4] Add av_stream_get_first_dts for Chromium
+Subject: [PATCH 19/21] Add av_stream_get_first_dts for Chromium
 
 ---
  libavformat/avformat.h | 4 ++++
@@ -9,7 +9,7 @@ Subject: [PATCH 2/4] Add av_stream_get_first_dts for Chromium
  2 files changed, 11 insertions(+)
 
 diff --git a/libavformat/avformat.h b/libavformat/avformat.h
-index 56c1c80289..75221d9d1a 100644
+index 56c1c8028996..75221d9d1a1e 100644
 --- a/libavformat/avformat.h
 +++ b/libavformat/avformat.h
 @@ -1202,6 +1202,10 @@ typedef struct AVStreamGroup {
@@ -24,7 +24,7 @@ index 56c1c80289..75221d9d1a 100644
  
  /**
 diff --git a/libavformat/utils.c b/libavformat/utils.c
-index e9ded627ad..399c777f2a 100644
+index e9ded627ad67..399c777f2a24 100644
 --- a/libavformat/utils.c
 +++ b/libavformat/utils.c
 @@ -44,6 +44,13 @@
@@ -42,5 +42,5 @@ index e9ded627ad..399c777f2a 100644
  #define SANE_CHUNK_SIZE (50000000)
  
 -- 
-2.47.1
+2.48.1.windows.1
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0020-fix-libavcodec-mips-constify-src-for-mmi.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0020-fix-libavcodec-mips-constify-src-for-mmi.patch
@@ -1,14 +1,14 @@
-From 6eb863465aa2ec0d88c890ddd51fdd5c0b34c071 Mon Sep 17 00:00:00 2001
+From a2183f3041cc5d9333f14d775e31af5431bce4e3 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 11:36:37 +0800
-Subject: [PATCH 3/4] fix(libavcodec/mips): constify src for mmi
+Subject: [PATCH 20/21] fix(libavcodec/mips): constify src for mmi
 
 ---
  libavcodec/mips/vp8dsp_mmi.c | 72 ++++++++++++++++++------------------
  1 file changed, 36 insertions(+), 36 deletions(-)
 
 diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
-index bc774aa365..55599e58f9 100644
+index bc774aa36586..55599e58f901 100644
 --- a/libavcodec/mips/vp8dsp_mmi.c
 +++ b/libavcodec/mips/vp8dsp_mmi.c
 @@ -1439,7 +1439,7 @@ void ff_vp8_h_loop_filter_simple_mmi(uint8_t *dst, ptrdiff_t stride, int flim)
@@ -336,5 +336,5 @@ index bc774aa365..55599e58f9 100644
  {
  #if 1
 -- 
-2.47.1
+2.48.1.windows.1
 

--- a/app-multimedia/ffmpeg/autobuild/patches/0021-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
+++ b/app-multimedia/ffmpeg/autobuild/patches/0021-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
@@ -1,7 +1,7 @@
-From 3747eb2374a4c4d489ca5080e5bd6d199b14b436 Mon Sep 17 00:00:00 2001
+From 24f9f6e18b8343248d3fed314bbbbb414ae646c8 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 16:08:58 +0800
-Subject: [PATCH 4/4] fix(libavcodec/mips): use mmi mnemonics supported by
+Subject: [PATCH 21/21] fix(libavcodec/mips): use mmi mnemonics supported by
  binutils 2.43.1
 
 Apparently Loongson's staff's proposal has never been upstreamed.
@@ -28,7 +28,7 @@ see also: https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2021-July/282542.html
  17 files changed, 397 insertions(+), 397 deletions(-)
 
 diff --git a/libavcodec/mips/blockdsp_mmi.c b/libavcodec/mips/blockdsp_mmi.c
-index 8b5c7e955c..68641e2544 100644
+index 8b5c7e955c86..68641e25448a 100644
 --- a/libavcodec/mips/blockdsp_mmi.c
 +++ b/libavcodec/mips/blockdsp_mmi.c
 @@ -76,8 +76,8 @@ void ff_clear_block_mmi(int16_t *block)
@@ -54,7 +54,7 @@ index 8b5c7e955c..68641e2544 100644
          MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x10)
          MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x20)
 diff --git a/libavcodec/mips/h264chroma_mmi.c b/libavcodec/mips/h264chroma_mmi.c
-index fe05ccd671..1a08a524cd 100644
+index fe05ccd6717e..1a08a524cded 100644
 --- a/libavcodec/mips/h264chroma_mmi.c
 +++ b/libavcodec/mips/h264chroma_mmi.c
 @@ -75,7 +75,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
@@ -148,7 +148,7 @@ index fe05ccd671..1a08a524cd 100644
              "pshufh     %[E],       %[E],           %[ftmp0]            \n\t"
              "mtc1       %[tmp0],    %[ftmp5]                            \n\t"
 diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
-index bae1052dcf..09cfbecaee 100644
+index bae1052dcf36..09cfbecaee8e 100644
 --- a/libavcodec/mips/h264dsp_mmi.c
 +++ b/libavcodec/mips/h264dsp_mmi.c
 @@ -34,7 +34,7 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
@@ -871,7 +871,7 @@ index bae1052dcf..09cfbecaee 100644
          "paddb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
  
 diff --git a/libavcodec/mips/h264pred_mmi.c b/libavcodec/mips/h264pred_mmi.c
-index 480411f5b5..3542d575be 100644
+index 480411f5b579..3542d575be98 100644
 --- a/libavcodec/mips/h264pred_mmi.c
 +++ b/libavcodec/mips/h264pred_mmi.c
 @@ -162,7 +162,7 @@ void ff_pred8x8l_top_dc_8_mmi(uint8_t *src, int has_topleft,
@@ -942,7 +942,7 @@ index 480411f5b5..3542d575be 100644
          "pshufh     %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
          "dmtc1      %[tmp1],    %[ftmp5]                                \n\t"
 diff --git a/libavcodec/mips/h264qpel_mmi.c b/libavcodec/mips/h264qpel_mmi.c
-index 3482956e13..99903a2258 100644
+index 3482956e13b6..99903a2258c4 100644
 --- a/libavcodec/mips/h264qpel_mmi.c
 +++ b/libavcodec/mips/h264qpel_mmi.c
 @@ -114,7 +114,7 @@ static void put_h264_qpel4_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
@@ -1063,7 +1063,7 @@ index 3482956e13..99903a2258 100644
          "1:                                                             \n\t"
          MMI_ULDC1(%[ftmp1], %[src], 0x00)
 diff --git a/libavcodec/mips/hevcdsp_mmi.c b/libavcodec/mips/hevcdsp_mmi.c
-index 6ff52187e5..9a412aed76 100644
+index 6ff52187e5c6..9a412aed764a 100644
 --- a/libavcodec/mips/hevcdsp_mmi.c
 +++ b/libavcodec/mips/hevcdsp_mmi.c
 @@ -47,7 +47,7 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, const uint8_t *_src, \
@@ -1198,7 +1198,7 @@ index 6ff52187e5..9a412aed76 100644
          MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
                                                                          \
 diff --git a/libavcodec/mips/hpeldsp_mmi.c b/libavcodec/mips/hpeldsp_mmi.c
-index 8e9c0fa821..ce51815ff4 100644
+index 8e9c0fa82155..ce51815ff420 100644
 --- a/libavcodec/mips/hpeldsp_mmi.c
 +++ b/libavcodec/mips/hpeldsp_mmi.c
 @@ -677,14 +677,14 @@ inline void ff_put_no_rnd_pixels8_l2_8_mmi(uint8_t *dst, const uint8_t *src1,
@@ -1253,7 +1253,7 @@ index 8e9c0fa821..ce51815ff4 100644
          "pcmpeqw    %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
          "dmtc1      %[addr0],   %[ftmp8]                                \n\t"
 diff --git a/libavcodec/mips/idctdsp_mmi.c b/libavcodec/mips/idctdsp_mmi.c
-index d96b3b1ac6..0065fdbb33 100644
+index d96b3b1ac62f..0065fdbb331c 100644
 --- a/libavcodec/mips/idctdsp_mmi.c
 +++ b/libavcodec/mips/idctdsp_mmi.c
 @@ -154,7 +154,7 @@ void ff_add_pixels_clamped_mmi(const int16_t *block,
@@ -1266,7 +1266,7 @@ index d96b3b1ac6..0065fdbb33 100644
          MMI_LDC1(%[ftmp5], %[pixels], 0x00)
          PTR_ADDU   "%[pixels],  %[pixels],  %[line_size]       \n\t"
 diff --git a/libavcodec/mips/mpegvideo_mmi.c b/libavcodec/mips/mpegvideo_mmi.c
-index 7af421db6b..f4b27fe83e 100644
+index 7af421db6b2e..f4b27fe83e59 100644
 --- a/libavcodec/mips/mpegvideo_mmi.c
 +++ b/libavcodec/mips/mpegvideo_mmi.c
 @@ -54,13 +54,13 @@ void ff_dct_unquantize_h263_intra_mmi(MpegEncContext *s, int16_t *block,
@@ -1452,7 +1452,7 @@ index 7af421db6b..f4b27fe83e 100644
          "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
          "pandn      %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
 diff --git a/libavcodec/mips/mpegvideoenc_mmi.c b/libavcodec/mips/mpegvideoenc_mmi.c
-index 65da155e9f..be4a89506d 100644
+index 65da155e9f8d..be4a89506d20 100644
 --- a/libavcodec/mips/mpegvideoenc_mmi.c
 +++ b/libavcodec/mips/mpegvideoenc_mmi.c
 @@ -37,16 +37,16 @@ void ff_denoise_dct_mmi(MpegEncContext *s, int16_t *block)
@@ -1489,7 +1489,7 @@ index 65da155e9f..be4a89506d 100644
          "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
          MMI_SDC1(%[ftmp1], %[block], 0x00)
 diff --git a/libavcodec/mips/pixblockdsp_mmi.c b/libavcodec/mips/pixblockdsp_mmi.c
-index dea85bf3fa..d4a0657d44 100644
+index dea85bf3fada..d4a0657d44d7 100644
 --- a/libavcodec/mips/pixblockdsp_mmi.c
 +++ b/libavcodec/mips/pixblockdsp_mmi.c
 @@ -33,7 +33,7 @@ void ff_get_pixels_8_mmi(int16_t *restrict block, const uint8_t *pixels,
@@ -1518,7 +1518,7 @@ index dea85bf3fa..d4a0657d44 100644
          "punpckhbh  %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
          "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
 diff --git a/libavcodec/mips/simple_idct_mmi.c b/libavcodec/mips/simple_idct_mmi.c
-index 4680520edc..7d5e271a39 100644
+index 4680520edc1f..7d5e271a39c6 100644
 --- a/libavcodec/mips/simple_idct_mmi.c
 +++ b/libavcodec/mips/simple_idct_mmi.c
 @@ -135,7 +135,7 @@ void ff_simple_idct_8_mmi(int16_t *block)
@@ -1557,7 +1557,7 @@ index 4680520edc..7d5e271a39 100644
          "bnez         $10,       1f                             \n\t"
          /* case1: In this case, row[1,3,5,7] are all zero */
 diff --git a/libavcodec/mips/vc1dsp_mmi.c b/libavcodec/mips/vc1dsp_mmi.c
-index 290b47d697..6dd3f1d494 100644
+index 290b47d697e8..6dd3f1d49436 100644
 --- a/libavcodec/mips/vc1dsp_mmi.c
 +++ b/libavcodec/mips/vc1dsp_mmi.c
 @@ -136,7 +136,7 @@ void ff_vc1_inv_trans_8x8_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
@@ -1714,7 +1714,7 @@ index 290b47d697..6dd3f1d494 100644
          "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
          "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
 diff --git a/libavcodec/mips/vp3dsp_idct_mmi.c b/libavcodec/mips/vp3dsp_idct_mmi.c
-index d505fcb765..2959c4314f 100644
+index d505fcb7652c..2959c4314fdc 100644
 --- a/libavcodec/mips/vp3dsp_idct_mmi.c
 +++ b/libavcodec/mips/vp3dsp_idct_mmi.c
 @@ -34,7 +34,7 @@ static void idct_row_mmi(int16_t *input)
@@ -2138,7 +2138,7 @@ index d505fcb765..2959c4314f 100644
              "sdc1        %[ftmp3],       0x00(%[dst])                    \n\t"
              PTR_ADDU    "%[src1],        %[src1],              %[stride] \n\t"
 diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
-index 55599e58f9..7d0eba3491 100644
+index 55599e58f901..7d0eba3491dd 100644
 --- a/libavcodec/mips/vp8dsp_mmi.c
 +++ b/libavcodec/mips/vp8dsp_mmi.c
 @@ -38,10 +38,10 @@
@@ -2427,7 +2427,7 @@ index 55599e58f9..7d0eba3491 100644
          "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
          "pshufh     %[c],       %[c],           %[ftmp0]            \n\t"
 diff --git a/libavcodec/mips/vp9_mc_mmi.c b/libavcodec/mips/vp9_mc_mmi.c
-index 495cac3d0b..06ccf2d744 100644
+index 495cac3d0b37..06ccf2d74416 100644
 --- a/libavcodec/mips/vp9_mc_mmi.c
 +++ b/libavcodec/mips/vp9_mc_mmi.c
 @@ -83,7 +83,7 @@ static void convolve_horiz_mmi(const uint8_t *src, int32_t src_stride,
@@ -2476,7 +2476,7 @@ index 495cac3d0b..06ccf2d744 100644
          "dmtc1      %[tmp0],    %[ftmp3]                  \n\t"
          "punpcklhw  %[ftmp3],   %[ftmp3],   %[ftmp3]      \n\t"
 diff --git a/libavcodec/mips/wmv2dsp_mmi.c b/libavcodec/mips/wmv2dsp_mmi.c
-index 1a6781ae77..82e16f929b 100644
+index 1a6781ae77e4..82e16f929b52 100644
 --- a/libavcodec/mips/wmv2dsp_mmi.c
 +++ b/libavcodec/mips/wmv2dsp_mmi.c
 @@ -106,7 +106,7 @@ void ff_wmv2_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
@@ -2489,5 +2489,5 @@ index 1a6781ae77..82e16f929b 100644
          // low 4 loop
          MMI_LDC1(%[ftmp1], %[block], 0x00)
 -- 
-2.47.1
+2.48.1.windows.1
 

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=4
+REL=5
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: backport patches to support legacy HEVC FLV files
    - Also fix build errors with Texinfo 7.2.
    - Track patches at https://github.com/AOSC-Tracking/FFmpeg.git aosc/n7.1, current HEAD is 24f9f6e18b8343248d3fed314bbbbb414ae646c8.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- ffmpeg: 7.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
