### PR TITLE
giac: update to 1.9.0+998

### DIFF
--- a/app-scientific/giac/spec
+++ b/app-scientific/giac/spec
@@ -1,4 +1,4 @@
-VER=1.9.0+93
+VER=1.9.0+998
 SRCS="tbl::https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${VER/+/-}.tar.gz"
-CHKSUMS="sha256::153fddf4a27de32300cc3e9e9497875bc52b3ad212f5ff464e711323da5b4c85"
+CHKSUMS="sha256::7f490a56af52c18cfdb53a2370f31fe05d9e96c8456090c541c3f51e049de1e4"
 CHKUPDATE="anitya::id=15278"


### PR DESCRIPTION
Topic Description
-----------------

- giac: update to 1.9.0+998

Package(s) Affected
-------------------

- giac: 1.9.0+998

Security Update?
----------------

No

Build Order
-----------

```
#buildit giac
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
