### PR TITLE
dsda-doom: new, 0.28.3

### DIFF
--- a/app-games/dsda-doom/autobuild/beyond
+++ b/app-games/dsda-doom/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing dsda-doom desktop entry..."
+install -Dvm644 "$SRCDIR"/ICONS/dsda-doom.png "$PKGDIR"/usr/share/pixmaps/dsda-doom.png --verbose
+install -Dvm644 "$SRCDIR"/ICONS/dsda-doom.desktop "$PKGDIR"/usr/share/applications/dsda-doom.desktop --verbose

--- a/app-games/dsda-doom/autobuild/defines
+++ b/app-games/dsda-doom/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=dsda-doom
+PKGSEC=games
+PKGDES="An engine for DOOM, Heretic and Hexen"
+PKGDEP="sdl2 sdl2-image sdl2-mixer sdl2-net fluidsynth portmidi libmad dumb libvorbis libzip glu"

--- a/app-games/dsda-doom/spec
+++ b/app-games/dsda-doom/spec
@@ -1,0 +1,5 @@
+VER=0.28.3
+SRCS="git::commit=tags/v$VER::https://github.com/kraflab/dsda-doom"
+CHKSUMS="SKIP"
+CHKUPDATE="antiya::id=337710"
+SUBDIR="dsda-doom/prboom2"

--- a/runtime-multimedia/dumb/autobuild/defines
+++ b/runtime-multimedia/dumb/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=dumb
+PKGSEC=libs
+PKGDES="IT, XM, S3M and MOD player library"
+PKGDEP="allegro"
+CMAKE_AFTER=(
+	"-DBUILD_SHARED_LIBS=ON"
+	"-DBUILD_ALLEGRO4=OFF"
+        "-DBUILD_EXAMPLES=OFF"
+)

--- a/runtime-multimedia/dumb/spec
+++ b/runtime-multimedia/dumb/spec
@@ -1,0 +1,4 @@
+VER=2.0.3
+SRCS="git::commit=tags/$VER::https://github.com/kode54/dumb"
+CHKSUMS="SKIP"
+CHKUPDATE="antiya::id=9737"


### PR DESCRIPTION
Topic Description
-----------------

- dsda-doom: new, 0.28.3
- dumb: new, 2.0.3

Package(s) Affected
-------------------

- dsda-doom: 0.28.3
- dumb: 2.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dumb dsda-doom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
