### PR TITLE
lsp-plugins: update to 1.2.20

### DIFF
--- a/app-multimedia/lsp-plugins/autobuild/defines
+++ b/app-multimedia/lsp-plugins/autobuild/defines
@@ -4,4 +4,21 @@ PKGDEP="libsndfile cairo freetype gstreamer jack x11-lib libglvnd"
 BUILDDEP="php"
 PKGSEC=sound
 
+# FIXME: Cannot build with gcc on AMD64.
+# With messages:
+#	
+#	/tmp/ccCb7YFl.s: Assembler messages:
+#	/tmp/ccCb7YFl.s: Error: local label `"10" (instance number 47 of a fb label)' is not defined
+#	make[4]: *** [/tmp/ccqitsKo.mk:23: /tmp/ccbw5cwD.ltrans7.ltrans.o] Error 1
+#	make[4]: *** Waiting for unfinished jobs....
+#	/tmp/ccYSPDAL.s: Assembler messages:
+#	/tmp/ccYSPDAL.s: Error: local label `"10" (instance number 47 of a fb label)' is not defined
+#	make[4]: *** [/tmp/ccKDotND.mk:23: /tmp/cciKDdUu.ltrans7.ltrans.o] Error 1
+#	make[4]: *** Waiting for unfinished jobs....
+#	/tmp/ccSBD3rS.s: Assembler messages:
+#	/tmp/ccSBD3rS.s: Error: local label `"10" (instance number 47 of a fb label)' is not defined
+#	make[4]: *** [/tmp/ccUbNhBs.mk:23: /tmp/ccZ5rg1O.ltrans7.ltrans.o] Error 1
+#	make[4]: *** Waiting for unfinished jobs.... 
+#
+NOLTO__AMD64=1
 ABTYPE=self

--- a/app-multimedia/lsp-plugins/spec
+++ b/app-multimedia/lsp-plugins/spec
@@ -1,4 +1,4 @@
-VER=1.2.17
-SRCS="tbl::https://github.com/lsp-plugins/lsp-plugins/releases/download/${VER}/lsp-plugins-src-${VER}.7z"
-CHKSUMS="sha256::f07dff42c4ca83366fd4576cd18bcbb82c68979b4e7655dc6fc1809881da4a73"
+VER=1.2.20
+SRCS="tbl::https://github.com/lsp-plugins/lsp-plugins/releases/download/${VER}/lsp-plugins-src-${VER}.tar.gz"
+CHKSUMS="sha256::ca8860dca6bfb1e7bcaba342c153e5fc5d3a025c91db66a4433e37829fb591c9"
 CHKUPDATE="anitya::id=242897"


### PR DESCRIPTION
Topic Description
-----------------

- lsp-plugins: update to 1.2.20

Package(s) Affected
-------------------

- lsp-plugins: 1.2.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit lsp-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
