### PR TITLE
qutebrowser: add bundled pdf.js

### DIFF
--- a/extra-web/qutebrowser/autobuild/patches/0001-do-not-prune-3rdparty-files.patch
+++ b/extra-web/qutebrowser/autobuild/patches/0001-do-not-prune-3rdparty-files.patch
@@ -1,0 +1,11 @@
+diff '--color=auto' -bur qutebrowser-3.4.0/MANIFEST.in qutebrowser-3.4.0-modified/MANIFEST.in
+--- qutebrowser-3.4.0/MANIFEST.in	2024-12-14 12:52:01.000000000 -0800
++++ qutebrowser-3.4.0-modified/MANIFEST.in	2025-02-14 20:30:13.124282496 -0800
+@@ -30,7 +30,6 @@
+ recursive-exclude doc *.asciidoc
+ include doc/qutebrowser.1.asciidoc
+ include doc/changelog.asciidoc
+-prune qutebrowser/3rdparty
+ exclude mypy.ini
+ exclude pyrightconfig.json
+ exclude tox.ini

--- a/extra-web/qutebrowser/autobuild/prepare
+++ b/extra-web/qutebrowser/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Adding bundled pdf.js ..."
+mkdir -pv "$SRCDIR"/qutebrowser/3rdparty/pdfjs
+unzip "$SRCDIR"/../pdfjs.zip \
+    -d "$SRCDIR"/qutebrowser/3rdparty/pdfjs/

--- a/extra-web/qutebrowser/spec
+++ b/extra-web/qutebrowser/spec
@@ -1,4 +1,11 @@
 VER=3.4.0
-SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$VER/qutebrowser-$VER.tar.gz"
-CHKSUMS="sha256::814124c0ed337430e613a1da366d5e38904cb2049afb1505971456ca5ca6223e"
+# NOTE: Find the latest pdf.js version in
+# https://github.com/mozilla/pdf.js/releases
+PDFJS_VER=4.10.38
+REL=1
+SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$VER/qutebrowser-$VER.tar.gz \
+      file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$PDFJS_VER/pdfjs-$PDFJS_VER-dist.zip"
+CHKSUMS="sha256::814124c0ed337430e613a1da366d5e38904cb2049afb1505971456ca5ca6223e \
+         sha256::32bdd9c5198b77dbaa8f02de81f34476888b3abdd64b9fb5f607f81f01487e6a"
+SUBDIR="qutebrowser-$VER"
 CHKUPDATE="anitya::id=9759"


### PR DESCRIPTION
Topic Description
-----------------

- qutebrowser: add bundled pdf.js
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- qutebrowser: 3.4.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qutebrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
