### PR TITLE
memcached: update to 1.6.36

### DIFF
--- a/app-admin/memcached/spec
+++ b/app-admin/memcached/spec
@@ -1,4 +1,4 @@
-VER=1.6.29
+VER=1.6.36
 SRCS="git::commit=$VER;copy-repo=true::https://github.com/memcached/memcached"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1965"


### PR DESCRIPTION
Topic Description
-----------------

- memcached: update to 1.6.36
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- memcached: 1.6.36

Security Update?
----------------

No

Build Order
-----------

```
#buildit memcached
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
