### PR TITLE
linux-firmware: update to 20250211

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250208
+UPSTREAM_VER=20250211
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
-# When using a stable tag.
-# SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=4ccb15a9dbfad4490f3b40382eb1789e97115821::https://gitlab.com/kernel-firmware/linux-firmware.git \
+# When not using a stable tag.
+#SRCS="git::commit=4ccb15a9dbfad4490f3b40382eb1789e97115821::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250211
    - Update Linux Firmware to 20250211...
    - Changelog below...
    - Intel
    - i915: Update Xe2LPD DMC to v2.28.
    - Ti
    - Add TAS2781 regbin firmware by index for single device.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250211+debian20241210+1
- firmware-nonfree: 20250211+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
