### PR TITLE
gzdoom: update to 4.14.0

### DIFF
--- a/app-games/gzdoom/spec
+++ b/app-games/gzdoom/spec
@@ -1,4 +1,4 @@
-VER=4.12.2
-SRCS="tbl::https://github.com/coelckers/gzdoom/archive/g$VER.zip"
-CHKSUMS="sha256::3bf0369b52da47ab0cbc8f8a0aa822b6a3024319025ff4709522ade27d714ac6"
+VER=4.14.0
+SRCS="git::commit=tags/g$VER::https://github.com/coelckers/gzdoom/"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17531"

--- a/app-games/zmusic/spec
+++ b/app-games/zmusic/spec
@@ -1,4 +1,4 @@
-VER=1.1.13
-SRCS="tbl::https://github.com/coelckers/ZMusic/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::564e210837b653013e01d67f04d0d906a9f0a923521e0c305463ec4f4a139ed4"
+VER=1.1.14
+SRCS="git::commit=tags/$VER::https://github.com/coelckers/ZMusic/"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=153600"


### PR DESCRIPTION
Topic Description
-----------------

- gzdoom: update to 4.14.0
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>
-  zmusic: update to 1.1.14 

Package(s) Affected
-------------------

- gzdoom: 4.14.0
- zmusic: 1.1.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit zmusic gzdoom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
