### PR TITLE
postgresql: update to 13.19

### DIFF
--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -1,4 +1,4 @@
-VER=13.17
+VER=13.19
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::022b0a6e7bc374a777eece33708895d7b60cae07d492b286b296a49d7395d78b"
+CHKSUMS="sha256::482cce0a9f8d24c2447cfc7b2817e55f86d51afe5f7f1a85214bf93644e774ea"
 CHKUPDATE="anitya::id=5601"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: update to 13.19
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql: 1:13.19

Security Update?
----------------

Yes, #9729 

Build Order
-----------

```
#buildit postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
