### PR TITLE
nuclei: update to 3.3.9

### DIFF
--- a/app-utils/nuclei/spec
+++ b/app-utils/nuclei/spec
@@ -1,4 +1,4 @@
-VER=3.3.7
+VER=3.3.9
 SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/nuclei.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106029"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nuclei: update to 3.3.9

Package(s) Affected
-------------------

nuclei:3.3.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit nuclei
```


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
