### PR TITLE
ncmpc: update to 0.52

### DIFF
--- a/app-multimedia/ncmpc/spec
+++ b/app-multimedia/ncmpc/spec
@@ -1,4 +1,4 @@
-VER=0.51
+VER=0.52
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::e74be00e69bc3ed1268cafcc87274e78dfbde147f2480ab0aad8260881ec7271"
+CHKSUMS="sha256::3af225496fe363a8534a9780fb46ae1bd17baefd80cf4ba7430a19cddd73eb1a"
 CHKUPDATE="anitya::id=2055"


### PR DESCRIPTION
Topic Description
-----------------

- ncmpc: update to 0.52
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- ncmpc: 0.52

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
