### PR TITLE
rmpc: new, 0.8.0

### DIFF
--- a/app-multimedia/rmpc/autobuild/beyond
+++ b/app-multimedia/rmpc/autobuild/beyond
@@ -1,0 +1,11 @@
+abinfo "Installing assets ..."
+install -Dvm644 "$SRCDIR"/target/completions/_rmpc \
+    -t "$PKGDIR"/usr/share/zsh/functions/Completion/Linux/
+install -Dvm644 "$SRCDIR"/target/completions/rmpc.fish \
+    -t "$PKGDIR"/usr/share/fish/vendor_completions.d/
+install -Dvm644 "$SRCDIR"/target/completions/rmpc.bash \
+    -t "$PKGDIR"/usr/share/bash-completion/completions/
+
+abinfo "Installing manpages ..."
+install -Dvm644 "$SRCDIR"/target/man/rmpc.1 \
+    -t "$PKGDIR"/usr/share/man/man1/

--- a/app-multimedia/rmpc/autobuild/defines
+++ b/app-multimedia/rmpc/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=rmpc
+PKGSEC=sound
+PKGDEP="glibc"
+BUILDDEP="rustc llvm"
+PKGDES="A TUI Music Player Daemon client"
+
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1

--- a/app-multimedia/rmpc/spec
+++ b/app-multimedia/rmpc/spec
@@ -1,0 +1,4 @@
+VER=0.8.0
+SRCS="git::commit=tags/v$VER::https://github.com/mierak/rmpc.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376792"


### PR DESCRIPTION
Topic Description
-----------------

- rmpc: new, 0.8.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- rmpc: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
