### PR TITLE
oxipng: update to 9.1.4

### DIFF
--- a/app-utils/oxipng/spec
+++ b/app-utils/oxipng/spec
@@ -1,4 +1,4 @@
-VER=9.1.3
+VER=9.1.4
 SRCS="git::commit=tags/v$VER::https://github.com/shssoichiro/oxipng.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=209796"


### PR DESCRIPTION
Topic Description
-----------------

- oxipng: update to 9.1.4

Package(s) Affected
-------------------

- oxipng: 9.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit oxipng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
