### PR TITLE
bleachbit: update to 4.6.2

### DIFF
--- a/app-utils/bleachbit/spec
+++ b/app-utils/bleachbit/spec
@@ -1,4 +1,4 @@
-VER=4.6.0
+VER=4.6.2
 SRCS="tbl::https://github.com/bleachbit/bleachbit/archive/v$VER.tar.gz"
-CHKSUMS="sha256::6d32db1200fd6e89f0fa822e01ce8eaac9749e84788970b0f562d77b271db629"
+CHKSUMS="sha256::fbdf7c9f7e8aac5c8720a27c6fac934f4ea9e68f1047e772d94414a2a5e51952"
 CHKUPDATE="anitya::id=200"


### PR DESCRIPTION
Topic Description
-----------------

- bleachbit: update to 4.6.2

Package(s) Affected
-------------------

- bleachbit: 4.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bleachbit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
