### PR TITLE
 keybinder-3.0: rebuild for Spiral markers

### DIFF
--- a/runtime-desktop/keybinder-3.0/autobuild/defines
+++ b/runtime-desktop/keybinder-3.0/autobuild/defines
@@ -4,4 +4,7 @@ PKGDEP="gtk-3"
 BUILDDEP="gtk-doc gobject-introspection"
 PKGDES="A library for registering global keyboard shortcuts"
 
+# Note: Extra Provides for Spiral.
+PKGPROV="libkeybinder-3.0_spiral"
+
 AUTOTOOLS_AFTER="--disable-gtk-doc --enable-introspection"

--- a/runtime-desktop/keybinder-3.0/spec
+++ b/runtime-desktop/keybinder-3.0/spec
@@ -1,4 +1,5 @@
 VER=0.3.2
+REL=1
 SRCS="tbl::https://github.com/engla/keybinder/releases/download/keybinder-3.0-v$VER/keybinder-3.0-$VER.tar.gz"
 CHKSUMS="sha256::e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020"
 CHKUPDATE="anitya::id=13401"


### PR DESCRIPTION
Topic Description
-----------------

- keybinder-3.0: rebuild for Spiral markers

Package(s) Affected
-------------------

- keybinder-3.0: 0.3.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit keybinder-3.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
