### PR TITLE
qemu: update to 9.2.1

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=9.2.0
-REL=1
+VER=9.2.1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::f859f0bc65e1f533d040bbe8c92bcfecee5af2c921a6687c652fb44d089bd894"
+CHKSUMS="sha256::b7b0782ead63a5373fdfe08e084d3949a9395ec196180286b841f78a464d169c"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 9.2.1

Package(s) Affected
-------------------

- qemu: 9.2.1
- qemu-aarch64-static: 9.2.1
- qemu-alpha-static: 9.2.1
- qemu-arm-static: 9.2.1
- qemu-armeb-static: 9.2.1
- qemu-guest-agent: 9.2.1
- qemu-i386-static: 9.2.1
- qemu-loongarch64-static: 9.2.1
- qemu-m68k-static: 9.2.1
- qemu-microblaze-static: 9.2.1
- qemu-microblazeel-static: 9.2.1
- qemu-mips-static: 9.2.1
- qemu-mips64-static: 9.2.1
- qemu-mips64el-static: 9.2.1
- qemu-mipsel-static: 9.2.1
- qemu-mipsn32-static: 9.2.1
- qemu-mipsn32el-static: 9.2.1
- qemu-or32-static: 9.2.1
- qemu-ppc-static: 9.2.1
- qemu-ppc64-static: 9.2.1
- qemu-ppc64le-static: 9.2.1
- qemu-riscv32-static: 9.2.1
- qemu-riscv64-static: 9.2.1
- qemu-s390x-static: 9.2.1
- qemu-sh4-static: 9.2.1
- qemu-sh4eb-static: 9.2.1
- qemu-sparc-static: 9.2.1
- qemu-sparc32plus-static: 9.2.1
- qemu-sparc64-static: 9.2.1
- qemu-user-static: 9.2.1
- qemu-x86-64-static: 9.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
