### PR TITLE
feeluown: update to 4.1.9

### DIFF
--- a/app-multimedia/feeluown/autobuild/defines
+++ b/app-multimedia/feeluown/autobuild/defines
@@ -5,7 +5,7 @@ PKGRECOM="feeluown-bilibili feeluown-kuwo feeluown-netease feeluown-qqmusic"
 
 PKGDEP="python-3 requests tomlkit typing-extensions qasync \
 	janus pyqt5 pyopengl pydantic mpv mutagen yt-dlp \
-	secretstorage"
+	secretstorage openai-python"
 
 
 PKGBREAK="fuocore feeluown-local feeluown-xiami"

--- a/app-multimedia/feeluown/spec
+++ b/app-multimedia/feeluown/spec
@@ -1,4 +1,4 @@
-VER=4.1.8
+VER=4.1.9
 SRCS="git::commit=tags/v$VER::https://github.com/feeluown/FeelUOwn"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33791"

--- a/lang-python/anyio/autobuild/defines
+++ b/lang-python/anyio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=anyio
+PKGSEC=python
+PKGDEP="python-3 exceptiongroup typing-extensions sniffio idna"
+BUILDDEP="setuptools pep517 python-build wheel poetry python-installer \
+          setuptools-scm"
+PKGDES="A asynchronous event loop implementation for Python"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/anyio/spec
+++ b/lang-python/anyio/spec
@@ -1,0 +1,4 @@
+VER=4.8.0
+SRCS="pypi::version=$VER::anyio"
+CHKSUMS="sha256::1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"
+CHKUPDATE="anitya::id=49275"

--- a/lang-python/jiter/autobuild/defines
+++ b/lang-python/jiter/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=jiter
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools pep517 python-build wheel \
+          maturin python-installer rustc llvm"
+PKGDES="A fast iterable JSON parser for Python"
+NOPYTHON2=1
+
+# FIXME: Disable LTO for LOONGSON3/MIPS, due to throw error below
+#        ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/lang-python/jiter/spec
+++ b/lang-python/jiter/spec
@@ -1,0 +1,4 @@
+VER=0.8.2
+SRCS="pypi::version=$VER::jiter"
+CHKSUMS="sha256::cd73d3e740666d0e639f678adb176fad25c1bcbdae88d8d7b857e1783bb4212d"
+CHKUPDATE="anitya::id=374802"

--- a/lang-python/openai-python/autobuild/defines
+++ b/lang-python/openai-python/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=openai-python
+PKGSEC=python
+PKGDEP="python-3 httpx anyio typing-extensions pydantic distro sniffio \
+        tqdm jiter websockets numpy pandas"
+BUILDDEP="setuptools pep517 python-build wheel poetry python-installer \
+          hatchling hatch-fancy-pypi-readme"
+PKGDES="OpenAI library for Python"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/openai-python/spec
+++ b/lang-python/openai-python/spec
@@ -1,0 +1,4 @@
+VER=1.63.2
+SRCS="pypi::version=$VER::openai"
+CHKSUMS="sha256::aeabeec984a7d2957b4928ceaa339e2ead19c61cfcf35ae62b7c363368d26360"
+CHKUPDATE="anitya::id=76577"


### PR DESCRIPTION
Topic Description
-----------------

- anyio: new, 4.8.0
- jiter: new, 0.8.2
- openai-python: new, 1.63.2
- feeluown: update to 4.1.9
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- anyio: 4.8.0
- feeluown: 1:4.1.9
- jiter: 0.8.2
- openai-python: 1.63.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit jiter anyio openai-python feeluown
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
