### PR TITLE
procps: generate correct version information

### DIFF
--- a/app-utils/procps/autobuild/prepare
+++ b/app-utils/procps/autobuild/prepare
@@ -1,0 +1,1 @@
+echo "$PKGVER" > "$SRCDIR/.tarball-version"

--- a/app-utils/procps/spec
+++ b/app-utils/procps/spec
@@ -1,4 +1,5 @@
 VER=4.0.5
+REL=1
 SRCS="https://gitlab.com/procps-ng/procps/-/archive/v$VER/procps-v$VER.tar.gz"
 CHKSUMS="sha256::2c6d7ed9f2acde1d4dd4602c6172fe56eff86953fe8639bd633dbd22cc18f5db"
 CHKUPDATE="anitya::id=3708"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

procps tries to generate version information from .tarball-release file and git history, or will use "UNKNOWN" if both methods fail.

Let's create a .tarball-release file from PKGVER to prevent ulities from taking "UNKNOWN" as their version string, which is confusing.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- procps: 4.0.5

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

No.

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

```
#buildit procps
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
