### PR TITLE
procps: generate correct version information

### DIFF
--- a/app-utils/procps/autobuild/prepare
+++ b/app-utils/procps/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Generating .tarball-version"
+echo "$PKGVER" > "$SRCDIR/.tarball-version"

--- a/app-utils/procps/spec
+++ b/app-utils/procps/spec
@@ -1,4 +1,5 @@
 VER=4.0.5
+REL=1
 SRCS="https://gitlab.com/procps-ng/procps/-/archive/v$VER/procps-v$VER.tar.gz"
 CHKSUMS="sha256::2c6d7ed9f2acde1d4dd4602c6172fe56eff86953fe8639bd633dbd22cc18f5db"
 CHKUPDATE="anitya::id=3708"


### PR DESCRIPTION
Topic Description
-----------------

- procps: generate correct version information
    procps tries to generate version information from .tarball-release
    file and git history, or will use "UNKNOWN" if both methods fail.
    Let's create a .tarball-release file from PKGVER to prevent ulities
    from taking "UNKNOWN" as their version string, which is confusing.
    Signed-off-by: Yao Zi <ziyao@disroot.org>

Package(s) Affected
-------------------

- procps: 4.0.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit procps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
