### PR TITLE
strace: update to 6.13

### DIFF
--- a/app-devel/strace/spec
+++ b/app-devel/strace/spec
@@ -1,4 +1,4 @@
-VER=6.5
+VER=6.13
 SRCS="tbl::https://github.com/strace/strace/releases/download/v$VER/strace-$VER.tar.xz"
-CHKSUMS="sha256::dfb051702389e1979a151892b5901afc9e93bbc1c70d84c906ade3224ca91980"
+CHKSUMS="sha256::e209daf0ee038ca5adcc4c277e9273b4d51f46a2ff86da575d36742ac3508a17"
 CHKUPDATE="anitya::id=4897"


### PR DESCRIPTION
Topic Description
-----------------

- strace: update to 6.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- strace: 6.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit strace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
