### PR TITLE
setuptools-python3: update to 75.8.0

### DIFF
--- a/lang-python/setuptools-python3/spec
+++ b/lang-python/setuptools-python3/spec
@@ -1,4 +1,4 @@
-VER=69.1.0
+VER=75.8.0
 SRCS="git::commit=tags/v$VER::https://github.com/pypa/setuptools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4021"


### PR DESCRIPTION
Topic Description
-----------------

- setuptools-python3: update to 75.8.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- setuptools-python3: 75.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit setuptools-python3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
