### PR TITLE
libedit: update to 20250104+3.1

### DIFF
--- a/runtime-common/libedit/autobuild/beyond
+++ b/runtime-common/libedit/autobuild/beyond
@@ -1,8 +1,3 @@
-abinfo "Adjusting man pages ..."
-rm -v "$PKGDIR"/usr/share/man/man3/history.3
-ln -sv editline.3 \
-    "$PKGDIR"/usr/share/man/man3/el.3
-
 # Note: Debian introduced a SONAME change in 2016 without specific
 # mentioning of an ABI breakage.
 abinfo "Creating a compatibility symlink to Debian-specific libedit.so.2 ..."

--- a/runtime-common/libedit/spec
+++ b/runtime-common/libedit/spec
@@ -1,5 +1,5 @@
-VER=20191231+3.1
-REL=2
-SRCS="tbl::https://thrysoee.dk/editline/libedit-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::dbb82cb7e116a5f8025d35ef5b4f7d4a3cdd0a3909a146a39112095a2d229071"
+UPSTREAM_VER=20250104-3.1
+VER=${UPSTREAM_VER/\-/+}
+SRCS="tbl::https://thrysoee.dk/editline/libedit-${UPSTREAM_VER}.tar.gz"
+CHKSUMS="sha256::23792701694550a53720630cd1cd6167101b5773adddcb4104f7345b73a568ac"
 CHKUPDATE="anitya::id=1599"


### PR DESCRIPTION
Topic Description
-----------------

- libedit: update to 20250104-3.1
    Use UPSTREAM_VER to fix aosc-findupdate.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libedit: 20250104+3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libedit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
