### PR TITLE
vkd3d: update to 1.15

### DIFF
--- a/runtime-display/vkd3d/spec
+++ b/runtime-display/vkd3d/spec
@@ -1,5 +1,4 @@
-VER=1.9
-REL=1
+VER=1.15
 SRCS="tbl::https://dl.winehq.org/vkd3d/source/vkd3d-${VER}.tar.xz"
-CHKSUMS="sha256::9d1ebc6f36cccf40cffda3176851f73a0501b90c4d04e782abe79ca703057a4b"
+CHKSUMS="sha256::c35366f6f39b5e89ed9b77ef21520f1b8d689ac9c4dcabee360e72dd9b75c471"
 CHKUPDATE="anitya::id=230555"


### PR DESCRIPTION
Topic Description
-----------------

- vkd3d: update to 1.15
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vkd3d: 1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkd3d
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
