### PR TITLE
networkmanager: update to 1.50.2

### DIFF
--- a/app-network/networkmanager/autobuild/defines
+++ b/app-network/networkmanager/autobuild/defines
@@ -39,6 +39,10 @@ ABTYPE=meson
 NOLTO__MIPS64R6EL=1
 
 # Note: We still use wpa_supplicant by default, we find it more reliable.
+# FIXME: Disabling eBPF due to issues with ACB probes, which causes no IPv4 via
+# DHCP.
+# Upstream issue and resolution reference:
+# https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1485#note_2297552
 MESON_AFTER="-Dsession_tracking_consolekit=false \
              -Dsession_tracking=systemd \
              -Dsuspend_resume=systemd \
@@ -64,7 +68,7 @@ MESON_AFTER="-Dsession_tracking_consolekit=false \
              -Dnmtui=true \
              -Dnm_cloud_setup=true \
              -Dbluez5_dun=true \
-             -Debpf=true \
+             -Debpf=false \
              -Difcfg_rh=false \
              -Difupdown=false \
              -Dconfig_dhcp_default=internal \

--- a/app-network/networkmanager/spec
+++ b/app-network/networkmanager/spec
@@ -1,4 +1,4 @@
-VER=1.50.0
-SRCS="https://download.gnome.org/sources/NetworkManager/${VER:0:4}/NetworkManager-$VER.tar.xz"
-CHKSUMS="sha256::fc03e7388a656cebc454c5d89481626122b1975d7c26babc64dc7e488faa66e3"
+VER=1.50.2
+SRCS="tbl::https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/$VER/downloads/NetworkManager-$VER.tar.xz"
+CHKSUMS="sha256::10473be9d3ab89f8a27a68b7bf5bc9557851a5183b74b6241e5e0fa5c6921fef"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager: update to 1.50.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- networkmanager: 1.50.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
