### PR TITLE
xdg-desktop-portal: update to 1.20.0

### DIFF
--- a/app-admin/xdg-desktop-portal/autobuild/beyond
+++ b/app-admin/xdg-desktop-portal/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing documentations ..."
+install -dvm755 "$PKGDIR"/usr/share/doc/xdg-desktop-portal/
+cp -rv "$BLDDIR"/doc/html "$PKGDIR"/usr/share/doc/xdg-desktop-portal/

--- a/app-admin/xdg-desktop-portal/autobuild/defines
+++ b/app-admin/xdg-desktop-portal/autobuild/defines
@@ -1,15 +1,19 @@
 PKGNAME=xdg-desktop-portal
 PKGSEC=admin
 PKGDEP="fuse-3 geoclue2 glib libportal pipewire"
-BUILDDEP="flatpak xmlto docbook-xsl libportal"
+BUILDDEP="flatpak xmlto docbook-xsl libportal sphinx docutils \
+          sphinxext-opengraph sphinx-copybutton furo"
 PKGDES="Portal frontend service to flatpak"
 
-AUTOTOOLS_AFTER="--enable-nls \
-                 --enable-libportal \
-                 --enable-geoclue \
-                 --enable-pipewire \
-                 --enable-docbook-docs \
-                 --disable-coverage \
-                 --disable-installed-tests \
-                 --disable-always-build-tests \
-                 --with-systemd"
+MESON_AFTER=(
+    -Dflatpak-interfaces=enabled
+    -Dgeoclue=enabled
+    -Dgudev=enabled
+    -Dsystemd=enabled
+    -Ddocumentation=enabled
+    -Dtests=disabled
+    -Dinstalled-tests=false
+    -Dman-pages=enabled
+    -Dsandboxed-image-validation=enabled
+    -Dsandboxed-sound-validation=enabled
+)

--- a/app-admin/xdg-desktop-portal/spec
+++ b/app-admin/xdg-desktop-portal/spec
@@ -1,4 +1,4 @@
-VER=1.18.4
+VER=1.20.0
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
-CHKSUMS="sha256::b858aa1e74e80c862790dbb912906e6eab8b1e4db9339cd759473af62b461e65"
+CHKSUMS="sha256::33d666f169efdf3f3bedd531bdbd272edc8f471caf6ca6cf6752efbbab57523a"
 CHKUPDATE="anitya::id=11089"

--- a/app-doc/furo/autobuild/defines
+++ b/app-doc/furo/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=furo
+PKGSEC=python
+PKGDEP="sphinx pygments beautifulsoup4 sphinx-basic-ng"
+BUILDDEP="python-build python-installer wheel sphinx-theme-builder"
+PKGDES="A Sphinx documentation theme"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/app-doc/furo/autobuild/prepare
+++ b/app-doc/furo/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Use system node.js"
+export STB_USE_SYSTEM_NODE=1
+
+abinfo "Relax node.js version limit"
+export STB_RELAX_NODE_VERSION_CHECK=1

--- a/app-doc/furo/spec
+++ b/app-doc/furo/spec
@@ -1,0 +1,4 @@
+VER=2024.8.6
+SRCS="pypi::version=$VER::furo"
+CHKSUMS="sha256::b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01"
+CHKUPDATE="anitya::id=332855"

--- a/app-doc/sphinx-basic-ng/autobuild/defines
+++ b/app-doc/sphinx-basic-ng/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=sphinx-basic-ng
+PKGSEC=python
+PKGDEP="sphinx typing"
+BUILDDEP="setuptools-python3"
+PKGDES="A Sphinx theme skeleton"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/app-doc/sphinx-basic-ng/spec
+++ b/app-doc/sphinx-basic-ng/spec
@@ -1,0 +1,5 @@
+UPSTREAM_VER=1.0.0b2
+VER=${UPSTREAM_VER/b/\~beta}
+SRCS="pypi::version=$UPSTREAM_VER::sphinx_basic_ng"
+CHKSUMS="sha256::9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9"
+CHKUPDATE="anitya::id=332855"

--- a/app-doc/sphinx-copybutton/autobuild/defines
+++ b/app-doc/sphinx-copybutton/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=sphinx-copybutton
+PKGSEC=python
+PKGDEP="sphinx python-3"
+BUILDDEP="setuptools-python3"
+PKGDES="A Sphinx extension that adds a copy button to code blocks"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/app-doc/sphinx-copybutton/spec
+++ b/app-doc/sphinx-copybutton/spec
@@ -1,0 +1,4 @@
+VER=0.5.2
+SRCS="pypi::version=$VER::sphinx-copybutton"
+CHKSUMS="sha256::4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd"
+CHKUPDATE="anitya::id=51120"

--- a/app-doc/sphinx-theme-builder/autobuild/defines
+++ b/app-doc/sphinx-theme-builder/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=sphinx-theme-builder
+PKGSEC=python
+PKGDEP="sphinx pyproject-metadata packaging rich nodeenv setuptools-python3 \
+        tomli typing-extensions nodejs"
+BUILDDEP="python-build python-installer wheel flit-core"
+PKGDES="Tool for authoring Sphinx themes"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/app-doc/sphinx-theme-builder/autobuild/patches/0001-Force-pass-node-version-check.patch
+++ b/app-doc/sphinx-theme-builder/autobuild/patches/0001-Force-pass-node-version-check.patch
@@ -1,0 +1,27 @@
+From 7e3b658199dcf75320bdb11d40abdc94eec52676 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Thu, 20 Feb 2025 01:14:47 -0800
+Subject: [PATCH] Force pass node version check
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/sphinx_theme_builder/_internal/nodejs.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/sphinx_theme_builder/_internal/nodejs.py b/src/sphinx_theme_builder/_internal/nodejs.py
+index c8a3836..2a689e1 100644
+--- a/src/sphinx_theme_builder/_internal/nodejs.py
++++ b/src/sphinx_theme_builder/_internal/nodejs.py
+@@ -176,7 +176,8 @@ def ensure_version_matches(expected: str, got: str) -> None:
+     log("[yellow]#[/] The generated assets may be broken even if the build succeeds.")
+     log("[yellow]#[/] Continuing anyway - `STB_RELAX_NODE_VERSION_CHECK` is truthy.")
+ 
+-    rejection_reason = _relaxed_version_check(expected, got)
++    #rejection_reason = _relaxed_version_check(expected, got)
++    rejection_reason = None
+     if rejection_reason is None:
+         return
+ 
+-- 
+2.48.1
+

--- a/app-doc/sphinx-theme-builder/autobuild/prepare
+++ b/app-doc/sphinx-theme-builder/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Use system node.js"
+export STB_USE_SYSTEM_NODE=1

--- a/app-doc/sphinx-theme-builder/spec
+++ b/app-doc/sphinx-theme-builder/spec
@@ -1,0 +1,5 @@
+UPSTREAM_VER=0.2.0b2
+VER=${UPSTREAM_VER/b/\~beta}
+SRCS="pypi::version=$UPSTREAM_VER::sphinx-theme-builder"
+CHKSUMS="sha256::e9cd98c2bb35bf414fe721469a043cdcc10f0808d1ffcf606acb4a6282a6f288"
+CHKUPDATE="anitya::id=261966"

--- a/app-doc/sphinxext-opengraph/autobuild/defines
+++ b/app-doc/sphinxext-opengraph/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=sphinxext-opengraph
+PKGSEC=python
+PKGDEP="sphinx python-3"
+BUILDDEP="setuptools-python3"
+PKGDES="A Sphinx extension that generates Open Graph metadata for \
+documentation pages"
+
+ABHOST=noarch
+ABTYPE=python
+NOPYTHON2=1

--- a/app-doc/sphinxext-opengraph/spec
+++ b/app-doc/sphinxext-opengraph/spec
@@ -1,0 +1,4 @@
+VER=0.9.1
+SRCS="pypi::version=$VER::sphinxext-opengraph"
+CHKSUMS="sha256::dd2868a1e7c9497977fbbf44cc0844a42af39ca65fe1bb0272518af225d06fc5"
+CHKUPDATE="anitya::id=105598"

--- a/lang-python/nodeenv/autobuild/defines
+++ b/lang-python/nodeenv/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=nodeenv
+PKGSEC=python
+PKGDEP="python-3 nodejs openssl"
+BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-scm"
+PKGDES="Node.JS virtual environment"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/nodeenv/spec
+++ b/lang-python/nodeenv/spec
@@ -1,0 +1,4 @@
+VER=1.9.1
+SRCS="pypi::version=$VER::nodeenv"
+CHKSUMS="sha256::6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"
+CHKUPDATE="anitya::id=61153"

--- a/lang-python/pyproject-metadata/autobuild/defines
+++ b/lang-python/pyproject-metadata/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pyproject-metadata
+PKGSEC=python
+PKGDEP="packaging python-3"
+BUILDDEP="python-build python-installer wheel flit-core"
+PKGDES="Dataclass for PEP 621 metadata with support for core metadata generation"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/pyproject-metadata/spec
+++ b/lang-python/pyproject-metadata/spec
@@ -1,0 +1,4 @@
+VER=0.9.0
+SRCS="pypi::version=$VER::pyproject_metadata"
+CHKSUMS="sha256::8511c00a4cad96686af6a6b4143433298beb96105a9379afdc9b0328f4f260c9"
+CHKUPDATE="anitya::id=255630"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal: update to 1.20.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- xdg-desktop-portal: 1.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sphinxext-opengraph sphinx-copybutton sphinx-basic-ng pyproject-metadata nodeenv sphinx-theme-builder furo xdg-desktop-portal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
