### PR TITLE
tigervnc: update to 1.15.0+xserver21.1.13

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.14.1
+UPSTREAM_VER=1.15.0
 XORG_VER=21.1.13
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update to 1.15.0+xserver21.1.13
    Co-authored-by: multimode_Liu / 自大的刘某人 \(@Dustymind\) <dustymind@aosc.io>

Package(s) Affected
-------------------

- tigervnc: 1.15.0+xserver21.1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
