### PR TITLE
os-prober: general fix-ups

### DIFF
--- a/app-admin/grub/autobuild/defines
+++ b/app-admin/grub/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=grub
 PKGSEC=admin
 PKGDES="GNU GRand Unified Bootloader"
 
-PKGDEP="bash debconf dosfstools freetype fuse gettext libisoburn lvm2 mtools os-prober util-linux xz"
+PKGDEP="bash debconf dosfstools freetype fuse-3 gettext libisoburn lvm2 mtools os-prober util-linux xz"
 PKGDEP__RETRO="bash dosfstools mtools os-prober"
 
 PKGDEP__AMD64="${PKGDEP} efibootmgr"

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=16.0.01
 RETROFONTVER=20200402
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=5
+REL=6
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftp.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"

--- a/app-utils/os-prober/autobuild/patches/0001-feat-linux-boot-probes-detect-old-world-kernels-and-.patch
+++ b/app-utils/os-prober/autobuild/patches/0001-feat-linux-boot-probes-detect-old-world-kernels-and-.patch
@@ -1,7 +1,7 @@
-From 77dfa9efe3271f7adcbd6a3f768057957dcdbfb7 Mon Sep 17 00:00:00 2001
+From bf9239ee4a8df7c339b998248f049b282a14bb0e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 6 Aug 2024 02:13:27 +0800
-Subject: [PATCH] feat(linux-boot-probes): detect old-world kernels and
+Subject: [PATCH 1/5] feat(linux-boot-probes): detect old-world kernels and
  bootloaders
 
 Use is_efi_stub (90fallback) to detect non-PE (non-EFI-stub) kernel images
@@ -18,12 +18,11 @@ Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.xyz>
 ---
  common.sh                                     |  9 +++
- debian/changelog                              |  9 +++
  linux-boot-probes/mounted/common/40grub2      | 11 +++-
  linux-boot-probes/mounted/common/90fallback   | 17 ++++++
  .../mounted/loong64/00_flag-loong64           | 12 ++++
  .../mounted/loong64/95old-world-grub2         | 55 +++++++++++++++++++
- 6 files changed, 112 insertions(+), 1 deletion(-)
+ 5 files changed, 103 insertions(+), 1 deletion(-)
  create mode 100755 linux-boot-probes/mounted/loong64/00_flag-loong64
  create mode 100755 linux-boot-probes/mounted/loong64/95old-world-grub2
 
@@ -44,23 +43,6 @@ index e1646d4..bbe950d 100644
 +	  return 1
 +  fi
 +}
-diff --git a/debian/changelog b/debian/changelog
-index eda67dd..ab68162 100644
---- a/debian/changelog
-+++ b/debian/changelog
-@@ -1,3 +1,12 @@
-+os-prober (1.81+1) unstable; urgency=medium
-+
-+  * loong64: filter out non-EFI-stub (old-world) kernels.
-+  * loong64: chainload old-world GRUB2 when non-EFI-stub kernels exist in a
-+    particular system rootfs, making it possible to boot from a new-world
-+    GRUB2 bootloader.
-+
-+ -- Miao Wang <shankerwangmiao@gmail.com>  Tue, 06 Aug 2024 02:12:00 +0800
-+
- os-prober (1.81) unstable; urgency=medium
- 
-   * Team upload
 diff --git a/linux-boot-probes/mounted/common/40grub2 b/linux-boot-probes/mounted/common/40grub2
 index e333a66..3d031b4 100755
 --- a/linux-boot-probes/mounted/common/40grub2
@@ -202,5 +184,5 @@ index 0000000..2af4f8a
 +fi
 +exit "$exitcode"
 -- 
-2.46.0
+2.48.1
 

--- a/app-utils/os-prober/autobuild/patches/0002-FEDORA-90fallback-include-possible-kernel-parameters.patch
+++ b/app-utils/os-prober/autobuild/patches/0002-FEDORA-90fallback-include-possible-kernel-parameters.patch
@@ -1,0 +1,59 @@
+From 6078efd7bb941b09b67b85751d7567cd4852c61d Mon Sep 17 00:00:00 2001
+From: Leo Sandoval <lsandova@redhat.com>
+Date: Thu, 27 Jun 2024 10:53:32 -0600
+Subject: [PATCH 2/5] FEDORA: 90fallback: include possible kernel parameters
+ from grub's default file
+
+Probed filesystems may include the GRUB's default
+file ($mpoint/etc/default/grub) so it desirable to source it and get
+and place either GRUB_CMDLINE_LINUX and/or GRUB_CMDLINE_LINUX_DEFAULT
+on the kernel parameters field, ultimately tools like grub2-mkconfig
+makes use of it and create menuentries with kernel parameters.
+
+Signed-off-by: Leo Sandoval <lsandova@redhat.com>
+
+Link: https://src.fedoraproject.org/rpms/os-prober/blob/3493b1e24a1092ca39136a686ed6ae3729eac01d/f/os-prober-90fallback-include-possible-kernel-parameters-from-g.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux-boot-probes/mounted/common/90fallback | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/linux-boot-probes/mounted/common/90fallback b/linux-boot-probes/mounted/common/90fallback
+index dbb9f7a..fe36530 100755
+--- a/linux-boot-probes/mounted/common/90fallback
++++ b/linux-boot-probes/mounted/common/90fallback
+@@ -18,6 +18,22 @@ mpoint="$3"
+ type="$4"
+ 
+ mappedpartition=$(mapdevfs "$partition" 2>/dev/null) || mappedpartition="$partition"
++kernparams="root=$mappedpartition"
++
++# In case there is $mpoint/etc/default/grub, source it and take into account
++# relevant command line variables. This function must be run inside a subshell
++# otherwise grub default variable may be overriden
++get_cmdline_linux_params()
++{
++    local mpoint_sysconfdir="$mpoint/etc"
++    if test -f ${mpoint_sysconfdir}/default/grub ; then
++	unset GRUB_CMDLINE_LINUX GRUB_CMDLINE_LINUX_DEFAULT
++	. ${mpoint_sysconfdir}/default/grub
++	echo "${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
++    fi
++}
++
++kernparams="$(echo $kernparams $(get_cmdline_linux_params) | sed 's/[[:space:]]\+$//')"
+ 
+ exitcode=1
+ for kernpat in /vmlinuz /vmlinux /boot/vmlinuz /boot/vmlinux "/boot/vmlinuz*" \
+@@ -57,7 +73,7 @@ for kernpat in /vmlinuz /vmlinux /boot/vmlinuz /boot/vmlinux "/boot/vmlinuz*" \
+ 			for initrd in $(eval ls "$initrdname" "$initrdname1" "$initrdname2" "$initrdname3" "$initrdname4" "$initrdname5" 2>/dev/null); do
+ 				if [ "$initrd" != "$kernfile" ] && [ -f "$initrd" ] && [ ! -L "$initrd" ]; then
+ 					initrd=$(echo "$initrd" | sed "s!^$mpoint!!")
+-					result "$partition:$kernbootpart::$kernbasefile:$initrd:root=$mappedpartition"
++					result "$partition:$kernbootpart::$kernbasefile:$initrd:$kernparams"
+ 					exitcode=0
+ 					foundinitrd=1
+ 				fi
+-- 
+2.48.1
+

--- a/app-utils/os-prober/autobuild/patches/0003-FEDORA-arm64-20microsoft-detect-Windows-11.patch
+++ b/app-utils/os-prober/autobuild/patches/0003-FEDORA-arm64-20microsoft-detect-Windows-11.patch
@@ -1,0 +1,37 @@
+From d66e824e8613a5f2d1cdaf202b33efff0ac6d28e Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 20 Feb 2025 20:46:32 +0800
+Subject: [PATCH 3/5] FEDORA: arm64/20microsoft: detect Windows 11
+
+Update to latest upstream version with better support for latest OSes,
+
+closes rhbz#2090942
+
+Add support for Win 11 on ARM 64 systems
+
+Signed-off-by: Hedayat Vatankhah <hedayat.fwd@gmail.com>
+
+Link: https://src.fedoraproject.org/rpms/os-prober/blob/56ec8a1f4b38c03f8b568c268633af6cec7e7925/f/os-prober-arm64-win11.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ os-probes/mounted/arm64/20microsoft | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/os-probes/mounted/arm64/20microsoft b/os-probes/mounted/arm64/20microsoft
+index 066918a..b69c2ba 100755
+--- a/os-probes/mounted/arm64/20microsoft
++++ b/os-probes/mounted/arm64/20microsoft
+@@ -31,7 +31,9 @@ if item_in_dir -q bootmgr "$2"; then
+ 	for boot in $(item_in_dir boot "$2"); do
+ 		bcd=$(item_in_dir bcd "$2/$boot")
+ 		if [ -n "$bcd" ]; then
+-			if   grep -aqs "W.i.n.d.o.w.s. .1.0" "$2/$boot/$bcd"; then
++			if   grep -aqs "W.i.n.d.o.w.s. .1.1" "$2/$boot/$bcd"; then
++				long="Windows 11"
++			elif grep -aqs "W.i.n.d.o.w.s. .1.0" "$2/$boot/$bcd"; then
+ 				long="Windows 10"
+ 			elif grep -aqs "W.i.n.d.o.w.s. .8" "$2/$boot/$bcd"; then
+ 				long="Windows 8"
+-- 
+2.48.1
+

--- a/app-utils/os-prober/autobuild/patches/0004-FEDORA-20macosx-do-not-count-dummy-mach_kernel-as-re.patch
+++ b/app-utils/os-prober/autobuild/patches/0004-FEDORA-20macosx-do-not-count-dummy-mach_kernel-as-re.patch
@@ -1,0 +1,31 @@
+From 8bb459b773be537b727096267d839938e910c6b5 Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Thu, 10 May 2012 14:47:35 -0400
+Subject: [PATCH 4/5] FEDORA: 20macosx: do not count dummy mach_kernel as real
+ Mac OS X
+
+Signed-off-by: Hedayat Vatankhah <hedayat.fwd@gmail.com>
+
+[Mingcong Bai: Usually found in GRUB-generated ISO images.]
+Link: https://src.fedoraproject.org/rpms/os-prober/blob/aea4f9e88e59ce3b965ae81f7037a9b01a271906/f/os-prober-no-dummy-mach-kernel.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ os-probes/mounted/powerpc/20macosx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os-probes/mounted/powerpc/20macosx b/os-probes/mounted/powerpc/20macosx
+index 2fc7e85..ce51d63 100755
+--- a/os-probes/mounted/powerpc/20macosx
++++ b/os-probes/mounted/powerpc/20macosx
+@@ -23,7 +23,7 @@ esac
+ # but I don't think it exists on Mac OS <= 9, and it's XML so parsing in
+ # shell will be nasty.
+ 
+-if [ -e "$2/mach_kernel" ]; then
++if [ -e "$2/mach_kernel" ] && ! dd if="$2/mach_kernel" count=1 bs=5 2>/dev/null | grep -aq Dummy ; then
+   label="$(count_next_label MacOSX)"
+   result "$1:Mac OS X:$label:macosx"
+   exit 0
+-- 
+2.48.1
+

--- a/app-utils/os-prober/autobuild/patches/0005-FEDORA-50mounted-tests-trap-do_unmount-function-on-e.patch
+++ b/app-utils/os-prober/autobuild/patches/0005-FEDORA-50mounted-tests-trap-do_unmount-function-on-e.patch
@@ -1,0 +1,42 @@
+From 866ac0dc27f4e54a29c618254fd0062cd8746382 Mon Sep 17 00:00:00 2001
+From: Leo Sandoval <lsandova@redhat.com>
+Date: Thu, 13 Jun 2024 17:05:44 -0600
+Subject: [PATCH 5/5] FEDORA: 50mounted-tests: trap do_unmount function on
+ errors
+
+Although previous commit unmounts a (grub2-mounted)
+partition in case of error, script continues executing
+instead of exiting, resulting in a wrong behavior when called on
+behalf of grub2-mkconfig (grub2-mkconfig -> 30_os-prober ->
+linux-boot-prober ->50mounted-tests), including extra non-bootable menu
+entries.
+
+The propose change effectively reverts previous change and traps the
+do_unmount function on error, unmounting any previous
+partition in case of error and not letting the partition to be included
+as boot entry when called on behalf of grub2-mkconfig.
+
+Signed-off-by: Leo Sandoval <lsandova@redhat.com>
+
+Link: https://src.fedoraproject.org/rpms/os-prober/blob/ae6ccd9241cf2c5d7adf1a8305d08e2227737ad6/f/os-prober-trap_unmount.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux-boot-probes/common/50mounted-tests | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/linux-boot-probes/common/50mounted-tests b/linux-boot-probes/common/50mounted-tests
+index ad68874..63b2174 100755
+--- a/linux-boot-probes/common/50mounted-tests
++++ b/linux-boot-probes/common/50mounted-tests
+@@ -13,6 +13,8 @@ do_unmount() {
+ 	rmdir "$tmpmnt" || true
+ }
+ 
++trap do_unmount ERR
++
+ partition="$1"
+ 
+ types="$(fs_type "$partition")"
+-- 
+2.48.1
+

--- a/app-utils/os-prober/spec
+++ b/app-utils/os-prober/spec
@@ -1,5 +1,4 @@
-VER=1.81
-REL=3
+VER=1.83
 SRCS="tbl::http://http.debian.net/debian/pool/main/o/os-prober/os-prober_$VER.tar.xz"
-CHKSUMS="sha256::2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883"
+CHKSUMS="sha256::8c82d5084c2b6f8935f6633612f18d16d04a0deffd6b99c264985fb7204140a6"
 CHKUPDATE="anitya::id=2574"


### PR DESCRIPTION
Topic Description
-----------------

- grub: use fuse-3 for grub-mount
    The configure script prefers FUSE 3.x over 2.x \(but only implicitly\).
    Make sure fuse-3 is present in the build environment.
- os-prober: update to 1.83
    Track patches at AOSC-Tracking/os-prober @ aosc/1.83
    \(HEAD: 866ac0dc27f4e54a29c618254fd0062cd8746382\).

Package(s) Affected
-------------------

- grub: 2:2.12+unifont16.0.01-6
- os-prober: 1.83

Security Update?
----------------

No

Build Order
-----------

```
#buildit os-prober grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
