### PR TITLE
dune: update to 3.17.2

### DIFF
--- a/lang-ocaml/dune/autobuild/build
+++ b/lang-ocaml/dune/autobuild/build
@@ -8,7 +8,7 @@ pushd "$_SRCDIR"
 
 abinfo "Building Dune's core executable ..."
 ./configure --libdir /usr/lib/ocaml
-make dune.exe
+make _boot/dune.exe
 
 abinfo "Building Dune packages ..."
 DUNE_RELEASE_PKGS="dune,dune-action-plugin,dune-build-info,dune-configurator,dune-glob,dune-private-libs,dune-site,dyn,stdune,ordering,xdg,fiber"

--- a/lang-ocaml/dune/spec
+++ b/lang-ocaml/dune/spec
@@ -1,6 +1,5 @@
-VER=3.4.1
-REL=2
+VER=3.17.2
 SRCS="tbl::https://github.com/ocaml/dune/archive/$VER/dune-$VER.tar.gz"
-CHKSUMS="sha256::dc260f7f723b17cec104d394d904b402a0b0108d2d3241fe7596e6d473502cef"
+CHKSUMS="sha256::1b45e34d1eacf40be569e4d7ad055508a3242637b098327c91f7ce67772a1889"
 CHKUPDATE="anitya::id=16017"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- dune: update to 3.17.2
- modify build script.

Package(s) Affected
-------------------

- dune: 3.17.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit dune
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
