### PR TITLE
qtstyleplugins: rebuild for Qt 5.15.16, bump rel to 5.0.0+git20170311-4

### DIFF
--- a/groups/qt5-rebuilds
+++ b/groups/qt5-rebuilds
@@ -3,3 +3,4 @@ app-i18n/fcitx5-qt
 app-creativity/lmms
 app-web/telegram-desktop
 desktop-kde/layer-shell-qt
+runtime-desktop/qtstyleplugins

--- a/runtime-desktop/qtstyleplugins/spec
+++ b/runtime-desktop/qtstyleplugins/spec
@@ -1,5 +1,5 @@
 VER=5.0.0+git20170311
 SRCS="git::commit=335dbece103e2cbf6c7cf819ab6672c2956b17b3::https://github.com/qt/qtstyleplugins.git"
 CHKSUMS="SKIP"
-REL=3
+REL=4
 CHKUPDATE="anitya::id=8375"


### PR DESCRIPTION
Topic Description
-----------------

- qtstyleplugins: rebuild for Qt 5.15.16, bump rel to 5.0.0+git20170311-4
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- qtstyleplugins: 1:5.0.0+git20170311-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtstyleplugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
