### PR TITLE
linux-firmware: update to 20250220

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250211
+UPSTREAM_VER=20250220
 DEBIANVER=20241210-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
-# When not using a stable tag.
-#SRCS="git::commit=4ccb15a9dbfad4490f3b40382eb1789e97115821::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
+# When using a stable tag.
+#SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=6cf959daab2a38d074b059f73c24aab9d4dbcbc3::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250220
    - Update Linux Firmware to current \(20250220\) HEAD 6cf959daab2a38d074b059f73c24aab9d4dbcbc3...
    - Changelog below...
    - Airoha
    - Update firmware for en8811h 2.5G ethernet phy.
    - AMD
    - Update ISP FW for isp v4.1.1.
    - Update AMD SEV firmware...
    - Update AMD SEV firmware to version 1.55 build 29 for AMD family 19h processors with models in the range 00h to 0fh.
    - Update AMD SEV firmware to version 1.55 build 39 for AMD family 19h processors with models in the range 10h to 1fh.
    - Update AMD SEV firmware to version 1.55 build 39 for AMD family 19h processors with models in the range a0h to afh.
    - Add AMD SEV firmware version 1.55 build 54 for AMD family 1ah processors with models in the range 00h to 0fh.
    - Cirrus
    - Add and update firmwares for ASUS, Dell, HP, and Lenovo laptops.
    - Intel
    - Update Xe3LPD DMC to v2.17.
    - MediaTek
    - Update firmware for MT7920 WiFi device to patch_mcu version 20250210151004a, RAM_CODE version 20250210150855.
    - Qualcomm
    - Add firmware for Adreno A225, presenting in MSM8960.
    - Update WCN3988 firmware to the file present in the firmware archive released for the Qualcomm Robotics RB2 platform.
    - Ti
    - Change TAS2781 regbin firmwares for single device.
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- firmware-free: 20250220+debian20241210+1
- firmware-nonfree: 20250220+debian20241210+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
