### PR TITLE
gobject-introspection: fix compatibility with setuptools >= 74.0.0

### DIFF
--- a/app-devel/gobject-introspection/autobuild/defines
+++ b/app-devel/gobject-introspection/autobuild/defines
@@ -1,16 +1,6 @@
 PKGNAME=gobject-introspection
 PKGSEC=gnome
 PKGDEP="glib mako"
-BUILDDEP="cairo gtk-doc vim markdown sphinx meson"
-PKGDES="Introspection system for GObject-based libraries"
-PKGEPOCH=1
-
-ABTYPE=meson
-MESON_AFTER="-Dcairo=enabled \
-             -Ddoctool=enabled \
-             -Dgtk_doc=true \
-             -Dbuild_introspection_data=true"
-
 PKGDEP__RETRO="glib"
 PKGDEP__ARMV4="$PKGDEP__RETRO"
 PKGDEP__ARMV6HF="$PKGDEP__RETRO"
@@ -19,6 +9,7 @@ PKGDEP__I486="${PKGDEP__RETRO}"
 PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="$PKGDEP__RETRO"
 PKGDEP__PPC64="$PKGDEP__RETRO"
+BUILDDEP="cairo gtk-doc vim markdown sphinx meson"
 BUILDDEP__RETRO="cairo"
 BUILDDEP__ARMV4="$BUILDDEP_RETRO"
 BUILDDEP__ARMV6HF="$BUILDDEP_RETRO"
@@ -27,16 +18,25 @@ BUILDDEP__I486="${BUILDDEP__RETRO}"
 BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="$BUILDDEP_RETRO"
 BUILDDEP__PPC64="$BUILDDEP_RETRO"
+PKGDES="Introspection system for GObject-based libraries"
+PKGEPOCH=1
 
-MESON_AFTER__RETRO=" \
-             -Dcairo=enabled \
-             -Ddoctool=disabled \
-             -Dgtk_doc=false \
-             -Dbuild_introspection_data=true"
-MESON_AFTER__ARMV4="$MESON_AFTER__RETRO"
-MESON_AFTER__ARMV6HF="$MESON_AFTER__RETRO"
-MESON_AFTER__ARMV7HF="${MESON_AFTER__RETRO}"
-MESON_AFTER__I486="${MESON_AFTER__RETRO}"
-MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
-MESON_AFTER__POWERPC="$MESON_AFTER__RETRO"
-MESON_AFTER__PPC64="$MESON_AFTER__RETRO"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dcairo=enabled'
+    '-Ddoctool=enabled'
+    '-Dgtk_doc=true'
+    '-Dbuild_introspection_data=true'
+)
+MESON_AFTER__RETRO=(  
+    "${MESON_AFTER[@]}"
+    '-Ddoctool=disabled'
+    '-Dgtk_doc=false' 
+    '-Dbuild_introspection_data=true' 
+)
+
+# FIXME: glib breaks gobject-introspection <= 1:1.72.0-1 but Spiral
+# provides gobject-introspection:$ARCH = 0:$PKGVER.
+#
+# Spiral should exclude self.
+PKGEPOCH_SPIRAL=1

--- a/app-devel/gobject-introspection/autobuild/patches/0001-giscanner-remove-dependency-on-distutils.msvccompile.patch
+++ b/app-devel/gobject-introspection/autobuild/patches/0001-giscanner-remove-dependency-on-distutils.msvccompile.patch
@@ -1,0 +1,101 @@
+From 655066e898a1091b4abd4584f7a7e7ab255f18e3 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 28 Aug 2024 21:26:02 +0200
+Subject: [PATCH] giscanner: remove dependency on distutils.msvccompiler
+
+It was removed with setuptools 74.0.0. Since we still depend on the
+MSVCCompiler class use new_compiler() to get it some other way.
+
+Remove any reference to MSVC9Compiler, which was for Visual Studio 2008
+which we no longer support anyway.
+
+Fixes #515
+---
+ giscanner/ccompiler.py    |  7 +++----
+ giscanner/msvccompiler.py | 14 +++++++-------
+ 2 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index d0ed70a3..9a732cd5 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -26,7 +26,6 @@ import tempfile
+ import sys
+ import distutils
+ 
+-from distutils.msvccompiler import MSVCCompiler
+ from distutils.unixccompiler import UnixCCompiler
+ from distutils.cygwinccompiler import Mingw32CCompiler
+ from distutils.sysconfig import get_config_vars
+@@ -167,7 +166,7 @@ class CCompiler(object):
+         # Now, create the distutils ccompiler instance based on the info we have.
+         if compiler_name == 'msvc':
+             # For MSVC, we need to create a instance of a subclass of distutil's
+-            # MSVC9Compiler class, as it does not provide a preprocess()
++            # MSVCCompiler class, as it does not provide a preprocess()
+             # implementation
+             from . import msvccompiler
+             self.compiler = msvccompiler.get_msvc_compiler()
+@@ -460,7 +459,7 @@ class CCompiler(object):
+             return self.compiler.linker_exe
+ 
+     def check_is_msvc(self):
+-        return isinstance(self.compiler, MSVCCompiler)
++        return self.compiler.compiler_type == "msvc"
+ 
+     # Private APIs
+     def _set_cpp_options(self, options):
+@@ -486,7 +485,7 @@ class CCompiler(object):
+                     # macros for compiling using distutils
+                     # get dropped for MSVC builds, so
+                     # escape the escape character.
+-                    if isinstance(self.compiler, MSVCCompiler):
++                    if self.check_is_msvc():
+                         macro_value = macro_value.replace('\"', '\\\"')
+                 macros.append((macro_name, macro_value))
+             elif option.startswith('-U'):
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index 0a543982..e333a80f 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -19,30 +19,30 @@
+ #
+ 
+ import os
+-import distutils
++from typing import Type
+ 
+ from distutils.errors import DistutilsExecError, CompileError
+-from distutils.ccompiler import CCompiler, gen_preprocess_options
++from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+ 
+ # Distutil's MSVCCompiler does not provide a preprocess()
+ # Implementation, so do our own here.
+ 
+ 
++DistutilsMSVCCompiler: Type = type(new_compiler(compiler="msvc"))
++
++
+ def get_msvc_compiler():
+     return MSVCCompiler()
+ 
+ 
+-class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
++class MSVCCompiler(DistutilsMSVCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+-        super(distutils.msvccompiler.MSVCCompiler, self).__init__()
++        super(DistutilsMSVCCompiler, self).__init__()
+         CCompiler.__init__(self, verbose, dry_run, force)
+         self.__paths = []
+         self.__arch = None  # deprecated name
+-        if os.name == 'nt':
+-            if isinstance(self, distutils.msvc9compiler.MSVCCompiler):
+-                self.__version = distutils.msvc9compiler.VERSION
+         self.initialized = False
+         self.preprocess_options = None
+         if self.check_is_clang_cl():
+-- 
+2.48.1
+

--- a/app-devel/gobject-introspection/spec
+++ b/app-devel/gobject-introspection/spec
@@ -1,4 +1,5 @@
 VER=1.80.0
+REL=1
 SRCS="https://download.gnome.org/sources/gobject-introspection/${VER:0:4}/gobject-introspection-$VER.tar.xz"
 CHKSUMS="sha256::54a90b4a3cb82fd6a3e8b8a7775178ebc954af3c2bc726ed5961e6503ce62636"
 CHKUPDATE="anitya::id=1223"


### PR DESCRIPTION
Topic Description
-----------------

- gobject-introspection: backport a patch to fix setuptools >= 74.0.0
    MSVCCompiler was removed from this point on and causes build errors on all
    introspection-enabled packages:
    Traceback \(most recent call last\):
    File "/usr/bin/g-ir-scanner", line 103, in <module>
    from giscanner.scannermain import scanner_main
    File "/usr/lib/gobject-introspection/giscanner/scannermain.py", line 35, in <module>
    from giscanner.ast import Include, Namespace
    File "/usr/lib/gobject-introspection/giscanner/ast.py", line 27, in <module>
    from .sourcescanner import CTYPE_TYPEDEF, CSYMBOL_TYPE_TYPEDEF
    File "/usr/lib/gobject-introspection/giscanner/sourcescanner.py", line 25, in <module>
    from .ccompiler import CCompiler
    File "/usr/lib/gobject-introspection/giscanner/ccompiler.py", line 29, in <module>
    from distutils.msvccompiler import MSVCCompiler
    ModuleNotFoundError: No module named 'distutils.msvccompiler'
    Track this patch at AOSC-Tracking/gobject-introspection @ aosc/1.80.0
    \(HEAD: 655066e898a1091b4abd4584f7a7e7ab255f18e3\).
    Link: https://github.com/GNOME/gobject-introspection/commit/a2139dba59eac283a7f543ed737f038deebddc19

Package(s) Affected
-------------------

- gobject-introspection: 1:1.80.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gobject-introspection
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
