### PR TITLE
binutils: Set --enable-default-hash-style=gnu

### DIFF
--- a/app-devel/binutils/autobuild/defines
+++ b/app-devel/binutils/autobuild/defines
@@ -27,6 +27,7 @@ AUTOTOOLS_AFTER=(
     '--enable-deterministic-archives'
     '--enable-64-bit-bfd'
     '--enable-targets=all'
+    '--enable-default-hash-style=gnu'
 )
 AUTOTOOLS_AFTER__LOONGSON3=(
     "${AUTOTOOLS_AFTER}"


### PR DESCRIPTION
Override the default value "both" which causes ld to generate both DT_HASH and DT_GNU_HASH for link units.  Those hash tables are only intended for ld.so, and Glibc ld.so has got the DT_GNU_HASH support in 2006.  Since then if both DT_HASH and DT_GNU_HASH exists, the former is completely ignored thus it's just wasting disk space.

One blockage for this was the combination of MIPS and ld.gold: MIPS uses DT_MIPS_XHASH that ld.gold does not support, instead of DT_GNU_HASH. The blockage is resolved now as ld.gold is removed.

Another blockage is some closed-source non-cooperating program is (was?) (mis-)using DT_HASH for some strange purpose.  Fortunately the program seems only relying on DT_HASH in Glibc, so even if the program is still not fixed and we still have to support it, we can just enable it for Glibc instead of every package.

Link: https://wiki.linuxfromscratch.org/lfs/ticket/5401
Link: https://maskray.me/blog/2022-08-21-glibc-and-dt-gnu-hash
