### PR TITLE
musescore: update to 4.4.4

### DIFF
--- a/app-creativity/musescore/autobuild/defines
+++ b/app-creativity/musescore/autobuild/defines
@@ -1,18 +1,27 @@
 PKGNAME=musescore
 PKGSEC=sound
-PKGDEP="lame portaudio pulseaudio qt-5 shared-mime-info flac freetype"
+PKGDEP="lame portaudio pulseaudio qt-6 shared-mime-info flac freetype"
 BUILDDEP="doxygen gtk-2"
 PKGDES="Create, play and print beautiful sheet music"
 
-CMAKE_AFTER="-DMUSESCORE_BUILD_MODE=release \
-             -DMUE_ENABLE_AUDIO_JACK=ON \
-             -DMUE_DOWNLOAD_SOUNDFONT=OFF \
-             -DMUE_COMPILE_USE_SYSTEM_FLAC=ON \
-             -DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON \
-             -DMUE_BUILD_UNIT_TESTS=OFF \
-             -DMUE_BUILD_CRASHPAD_CLIENT=OFF"
+CMAKE_AFTER=(
+    '-DCMAKE_SKIP_RPATH=OFF'
+    '-DMUSESCORE_LABEL=Alpha'
+    '-DMUSESCORE_BUILD_CONFIG=release'
+    '-DMUSESCORE_REVISION='
+    '-DTELEMETRY_TRACK_ID='
+    '-DCRASH_REPORT_URL='
+    '-DBUILD_JACK=ON'
+    '-DBUILD_WEBENGINE=OFF'
+    '-DDOWNLOAD_SOUNDFONT=ON'
+    '-DUSE_SYSTEM_FREETYPE=ON'
+    '-DBUILD_UNIT_TESTS=OFF'
+    '-DMUSESCORE_BUILD_MODE=release'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+)
 
-# FIXME: No data signature found in rcc
-# See https://bugreports.qt.io/browse/QTBUG-73834
-# & https://bugs.gentoo.org/908808
+# FIXME: No data signature found in rcc.
+# See:
+#   - https://bugreports.qt.io/browse/QTBUG-73834
+#   - https://bugs.gentoo.org/908808
 NOLTO=1

--- a/app-creativity/musescore/autobuild/patches/0001-Disable-self-update.patch
+++ b/app-creativity/musescore/autobuild/patches/0001-Disable-self-update.patch
@@ -1,17 +1,17 @@
-From 1c6ceca69f81b08cd5c0954338e0ceddc8578cb6 Mon Sep 17 00:00:00 2001
+From e628aebb1f6a91d3bd692c267d75a9abd8d61543 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Mon, 13 May 2024 10:38:32 +0800
 Subject: [PATCH] Disable self update
 
 ---
- src/update/internal/updatescenario.cpp | 15 ++++++---------
+ src/framework/update/internal/updatescenario.cpp | 15 ++++++---------
  1 file changed, 6 insertions(+), 9 deletions(-)
 
-diff --git a/src/update/internal/updatescenario.cpp b/src/update/internal/updatescenario.cpp
-index 666b581f44..fc6942b925 100644
---- a/src/update/internal/updatescenario.cpp
-+++ b/src/update/internal/updatescenario.cpp
-@@ -41,20 +41,17 @@ using namespace mu::framework;
+diff --git a/src/framework/update/internal/updatescenario.cpp b/src/framework/update/internal/updatescenario.cpp
+index 209b60a66d..0b5a321889 100644
+--- a/src/framework/update/internal/updatescenario.cpp
++++ b/src/framework/update/internal/updatescenario.cpp
+@@ -40,20 +40,17 @@ using namespace muse::actions;
  
  void UpdateScenario::delayedInit()
  {
@@ -39,5 +39,5 @@ index 666b581f44..fc6942b925 100644
  
  bool UpdateScenario::isCheckStarted() const
 -- 
-2.45.0
+2.48.1
 

--- a/app-creativity/musescore/autobuild/prepare
+++ b/app-creativity/musescore/autobuild/prepare
@@ -1,2 +1,0 @@
-export CFLAGS="${CFLAGS} -Wno-narrowing"
-export CXXFLAGS="${CXXFLAGS} -Wno-narrowing"

--- a/app-creativity/musescore/spec
+++ b/app-creativity/musescore/spec
@@ -1,5 +1,4 @@
-VER=4.3.2
-REL=1
+VER=4.4.4
 SRCS="git::commit=tags/v$VER::https://github.com/musescore/MuseScore"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6093"


### PR DESCRIPTION
Topic Description
-----------------

- musescore: update to 4.4.4
    - Use Qt 6.
    - Rebase self-update disablement patch, now at AOSC-Tracking/musescore @
    aosc/v4.4.4 \(HEAD: e628aebb1f6a91d3bd692c267d75a9abd8d61543\).
    - Clean up CMake parameters and revise as an array for better readability.
    - Drop unneeded \`-Wno-narrowing' hack.
    Co-authored-by: Jiajie Chen <c@jia.je>

Package(s) Affected
-------------------

- musescore: 4.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit musescore
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
