### PR TITLE
weechat: update to 4.5.2

### DIFF
--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,5 +1,4 @@
-VER=4.5.1
-REL=1
+VER=4.5.2
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::67c143c7bc70e689b9ea86df674c9a9ff3cf44ccc9cdff21be6a561d5eafc528"
+CHKSUMS="sha256::1a65466dcd3edb7378f27a611e06e2f7f45a6028ae54d3e1696ca91e85ec1459"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.5.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- weechat: 4.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
