### PR TITLE
fprintd: update to 1.94.5

### DIFF
--- a/app-admin/fprintd/autobuild/defines
+++ b/app-admin/fprintd/autobuild/defines
@@ -4,3 +4,12 @@ PKGDEP="libfprint polkit dbus-glib"
 BUILDDEP="dbus-python gtk-doc intltool pygobject-3 pycairo pam-wrapper \
           python-dbusmock"
 PKGDES="Application for accessing fingerprint readers and fingerprint authentication"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dpam=true'
+    '-Dman=true'
+    '-Dsystemd=true'
+    '-Dlibsystemd=libsystemd'
+    '-Dgtk_doc=true'
+)

--- a/app-admin/fprintd/spec
+++ b/app-admin/fprintd/spec
@@ -1,4 +1,4 @@
-VER=1.94.4
+VER=1.94.5
 SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/libfprint/fprintd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=835"

--- a/runtime-devices/libfprint/autobuild/defines
+++ b/runtime-devices/libfprint/autobuild/defines
@@ -5,3 +5,14 @@ BUILDDEP="gobject-introspection gtk-doc"
 PKGDES="Library for fingerprint readers"
 
 PKGBREAK="fingerprint-gui<=1.09+git20181110 fprintd<=0.8.1-1"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Ddrivers=all'
+    '-Dintrospection=true'
+    '-Dudev_rules=enabled'
+    '-Dudev_hwdb=enabled'
+    '-Dgtk-examples=false'
+    '-Ddoc=true'
+    '-Dinstalled-tests=false'
+)

--- a/runtime-devices/libfprint/spec
+++ b/runtime-devices/libfprint/spec
@@ -1,4 +1,4 @@
-VER=1.94.4
+VER=1.94.9
 SRCS="https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v$VER/libfprint-v$VER.tar.gz"
-CHKSUMS="sha256::abb7ae563822dfbf565139d05765b374b3b2d95d3734904c89cd2727ca5fabe4"
+CHKSUMS="sha256::6398e7a28c91b3a16ff17e6a577c7a03692a5de509e8def817396f1120823ecf"
 CHKUPDATE="anitya::id=1615"


### PR DESCRIPTION
Topic Description
-----------------

- fprintd: update to 1.94.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fprintd: 1.94.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfprint fprintd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
