### PR TITLE
sphinx-basic-ng: fix anitya id

### DIFF
--- a/app-doc/sphinx-basic-ng/spec
+++ b/app-doc/sphinx-basic-ng/spec
@@ -2,4 +2,4 @@ UPSTREAM_VER=1.0.0b2
 VER=${UPSTREAM_VER/b/\~beta}
 SRCS="pypi::version=$UPSTREAM_VER::sphinx_basic_ng"
 CHKSUMS="sha256::9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9"
-CHKUPDATE="anitya::id=332855"
+CHKUPDATE="anitya::id=179541"


### PR DESCRIPTION
Topic Description
-----------------

- sphinx-basic-ng: fix anitya id
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
