### PR TITLE
imhex: move glfw from BUILDDEP to PKGDEP

### DIFF
--- a/app-editors/imhex/autobuild/defines
+++ b/app-editors/imhex/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=imhex
 PKGSEC=devel
 PKGDEP__with_dotnet="dotnet-runtime-8.0"
 PKGDES="A hex editor with Pattern and YARA Rule support"
-BUILDDEP="yara fmt nlohmann-json capstone llvm boost glfw"
+PKGDEP="glfw"
+BUILDDEP="yara fmt nlohmann-json capstone llvm boost"
 
 CMAKE_AFTER="-DUSE_SYSTEM_FMT=ON \
         -DUSE_SYSTEM_YARA=ON \


### PR DESCRIPTION
Topic Description
-----------------

- imhex: move glfw from BUILDDEP to PKGDEP

Package(s) Affected
-------------------

- imhex: 1.35.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit imhex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
