### PR TITLE
pyparsing: update to 3.2.1

### DIFF
--- a/lang-python/pyparsing/autobuild/defines
+++ b/lang-python/pyparsing/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pyparsing
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools flit-core"
 PKGDES="General parsing module for Python"
 
 ABHOST=noarch

--- a/lang-python/pyparsing/spec
+++ b/lang-python/pyparsing/spec
@@ -1,5 +1,4 @@
-VER=2.4.7
-REL=2
-SRCS="tbl::https://github.com/pyparsing/pyparsing/releases/download/pyparsing_${VER}/pyparsing-${VER}.tar.gz"
-CHKSUMS="sha256::c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"
+VER=3.2.1
+SRCS="tbl::https://github.com/pyparsing/pyparsing/releases/download/${VER}/pyparsing-${VER}.tar.gz"
+CHKSUMS="sha256::61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a"
 CHKUPDATE="anitya::id=3756"


### PR DESCRIPTION
Topic Description
-----------------

- pyparsing: update to 3.2.1

Package(s) Affected
-------------------

- pyparsing: 3.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyparsing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
