### PR TITLE
Source Link Fix-ups (Feb. 22, 2025)

### DIFF
--- a/app-utils/file/spec
+++ b/app-utils/file/spec
@@ -1,4 +1,5 @@
 VER=5.45
-SRCS="tbl::http://download.openpkg.org/components/cache/file/file-$VER.tar.gz"
+# FIXME: This upstream sucks, a lot (HTTPS when???).
+SRCS="tbl::http://ftp.astron.com/pub/file/file-$VER.tar.gz"
 CHKSUMS="sha256::fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82"
 CHKUPDATE="anitya::id=807"

--- a/lang-python/pycryptodome/spec
+++ b/lang-python/pycryptodome/spec
@@ -1,4 +1,5 @@
 VER=3.21.0
-SRCS="tbl::https://github.com/Legrandin/pycryptodome/archive/v$VER.tar.gz"
-CHKSUMS="sha256::195e5cdfbb550b03f83f2af2aa4652c14b64783574d835fe61bb06c8fc06ba21"
+REL=1
+SRCS="pypi::version=$VER::pycryptodome"
+CHKSUMS="sha256::f7787e0d469bdae763b876174cf2e6c0f7be79808af26b1da96f1a64bcf47297"
 CHKUPDATE="anitya::id=36849"

--- a/runtime-network/c-ares/spec
+++ b/runtime-network/c-ares/spec
@@ -1,4 +1,4 @@
 VER=1.28.1
-SRCS="tbl::https://c-ares.haxx.se/download/c-ares-$VER.tar.gz"
+SRCS="tbl::https://github.com/c-ares/c-ares/releases/download/cares-${VER//./_}/c-ares-$VER.tar.gz"
 CHKSUMS="sha256::675a69fc54ddbf42e6830bc671eeb6cd89eeca43828eb413243fd2c0a760809d"
 CHKUPDATE="anitya::id=5840"


### PR DESCRIPTION
Topic Description
-----------------

- pycryptodome: use pypi:: source
- c-ares: \(no build\) fix src link
- file: \(no build\) fix src link

Package(s) Affected
-------------------

- pycryptodome: 3.21.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycryptodome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
