### PR TITLE
imhex: update to 1.37.0

### DIFF
--- a/app-editors/imhex/spec
+++ b/app-editors/imhex/spec
@@ -1,5 +1,4 @@
-VER=1.35.4
-REL=1
+VER=1.37.0
 SRCS="git::commit=tags/v$VER::https://github.com/WerWolv/ImHex.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141621"


### PR DESCRIPTION
Topic Description
-----------------

- imhex: update to 1.37.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- imhex: 1.37.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit imhex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
