### PR TITLE
kicad: update to 9.0.0

### DIFF
--- a/app-electronics/kicad/autobuild/defines
+++ b/app-electronics/kicad/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=kicad
 PKGSEC=electronics
 PKGDES="A free software suite for electronic design automation"
 PKGDEP="wxgtk3 mesa glu glew libnotify curl opencascade ngspice boost cairo \
-        pixman python-3 wxpython unixodbc libgit2"
+        pixman python-3 wxpython unixodbc libgit2 nng"
 BUILDDEP="cmake bzr swig glm llvm po4a asciidoctor"
 
 ABTYPE=cmakeninja

--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -1,4 +1,4 @@
-VER=8.0.8
+VER=9.0.0
 SRCS="git::commit=tags/$VER;rename=kicad-$VER::https://gitlab.com/kicad/code/kicad \
       git::commit=tags/$VER;rename=kicad-footprints-$VER::https://gitlab.com/kicad/libraries/kicad-footprints \
       git::commit=tags/$VER;rename=kicad-symbols-$VER::https://gitlab.com/kicad/libraries/kicad-symbols \

--- a/runtime-network/nng/autobuild/defines
+++ b/runtime-network/nng/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=nng
+PKGDES="A lightweight messaging library"
+PKGDEP="mbedtls"
+PKGSEC=libs
+
+CMAKE_AFTER=(
+    '-DNNG_TESTS=OFF'
+    '-DNNG_TOOLS=ON'
+    '-DNNG_ENABLE_TLS=ON'
+    '-DNNG_TLS_ENGINE=mbed'
+    '-DBUILD_SHARED_LIBS=ON'
+)

--- a/runtime-network/nng/spec
+++ b/runtime-network/nng/spec
@@ -1,0 +1,4 @@
+VER=1.10.1
+SRCS="git::commit=tags/v${VER}::https://github.com/nanomsg/nng.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17310"


### PR DESCRIPTION
Topic Description
-----------------

- kicad: update to 9.0.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>
- nng: new, 1.10.1

Package(s) Affected
-------------------

- kicad: 9.0.0
- nng: 1.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nng kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
