### PR TITLE
firefox: backport HEVC hardware acceleration support

### DIFF
--- a/app-web/firefox/autobuild/patches/0001-Enable-VA-API-support-for-AMD-GPUs.patch
+++ b/app-web/firefox/autobuild/patches/0001-Enable-VA-API-support-for-AMD-GPUs.patch
@@ -1,14 +1,14 @@
 From 333c637e2ac049dece69f67ce142fb068ba09d2a Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 14 Nov 2023 18:14:20 -0800
-Subject: [PATCH 1/9] Enable VA-API support for AMD GPUs
+Subject: [PATCH 01/22] Enable VA-API support for AMD GPUs
 
 ---
  widget/gtk/GfxInfo.cpp | 8 --------
  1 file changed, 8 deletions(-)
 
 diff --git a/widget/gtk/GfxInfo.cpp b/widget/gtk/GfxInfo.cpp
-index bc26a3b373..d21714c743 100644
+index bc26a3b373c9..d21714c74316 100644
 --- a/widget/gtk/GfxInfo.cpp
 +++ b/widget/gtk/GfxInfo.cpp
 @@ -1105,14 +1105,6 @@ const nsTArray<GfxDriverInfo>& GfxInfo::GetGfxDriverInfo() {

--- a/app-web/firefox/autobuild/patches/0002-update-gn_processor.py-to-support-linux-on-loong64.patch
+++ b/app-web/firefox/autobuild/patches/0002-update-gn_processor.py-to-support-linux-on-loong64.patch
@@ -1,7 +1,7 @@
 From a2639bad696e7a4b9580b29155e43478cda02b2a Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:38:04 +0800
-Subject: [PATCH 2/9] update gn_processor.py to support linux on loong64
+Subject: [PATCH 02/22] update gn_processor.py to support linux on loong64
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/python/mozbuild/mozbuild/gn_processor.py b/python/mozbuild/mozbuild/gn_processor.py
-index db7f780a1a..3567e1d33a 100644
+index db7f780a1a17..3567e1d33a7a 100644
 --- a/python/mozbuild/mozbuild/gn_processor.py
 +++ b/python/mozbuild/mozbuild/gn_processor.py
 @@ -183,6 +183,7 @@ def filter_gn_config(path, gn_result, sandbox_vars, input_vars, gn_target):

--- a/app-web/firefox/autobuild/patches/0003-chore-regenerate-libwebrtc-moz.build-files.patch
+++ b/app-web/firefox/autobuild/patches/0003-chore-regenerate-libwebrtc-moz.build-files.patch
@@ -1,7 +1,7 @@
 From 5997a50c2dfbdeb3f7a8eb65fe253fb6f896025d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 26 Nov 2024 19:46:01 +0800
-Subject: [PATCH 3/9] chore: regenerate libwebrtc moz.build files
+Subject: [PATCH 03/22] chore: regenerate libwebrtc moz.build files
 
 Regenerate moz.build files to incorporate loong64 libwebrtc enablement in
 gn_processor.py.
@@ -457,7 +457,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  439 files changed, 1800 insertions(+)
 
 diff --git a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
-index a80e5f32ad..cde6fefd2a 100644
+index a80e5f32ade2..cde6fefd2a8d 100644
 --- a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -472,7 +472,7 @@ index a80e5f32ad..cde6fefd2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/array_view_gn/moz.build b/third_party/libwebrtc/api/array_view_gn/moz.build
-index 25221b2af7..9e0e2baa4f 100644
+index 25221b2af745..9e0e2baa4f76 100644
 --- a/third_party/libwebrtc/api/array_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/array_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -487,7 +487,7 @@ index 25221b2af7..9e0e2baa4f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
-index bf95db7b24..119da97923 100644
+index bf95db7b24ed..119da9792336 100644
 --- a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -502,7 +502,7 @@ index bf95db7b24..119da97923 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
-index 2c964a4fd0..c6f47c5e01 100644
+index 2c964a4fd025..c6f47c5e018f 100644
 --- a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -517,7 +517,7 @@ index 2c964a4fd0..c6f47c5e01 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
-index e02b226aca..fbe73e30fd 100644
+index e02b226aca7f..fbe73e30fd6a 100644
 --- a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -532,7 +532,7 @@ index e02b226aca..fbe73e30fd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
-index 0fc7d75079..4eb634da1a 100644
+index 0fc7d750796a..4eb634da1a95 100644
 --- a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -547,7 +547,7 @@ index 0fc7d75079..4eb634da1a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
-index c0e06e7a78..ce0bceeecd 100644
+index c0e06e7a7865..ce0bceeecd71 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -562,7 +562,7 @@ index c0e06e7a78..ce0bceeecd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
-index bc6ea25161..4a330e94b4 100644
+index bc6ea25161c1..4a330e94b4d8 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -577,7 +577,7 @@ index bc6ea25161..4a330e94b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
-index cedd56ac79..4b161cf7e0 100644
+index cedd56ac791e..4b161cf7e097 100644
 --- a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -592,7 +592,7 @@ index cedd56ac79..4b161cf7e0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
-index 10ae1f65fa..4b84f10ea5 100644
+index 10ae1f65fa9c..4b84f10ea54b 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -607,7 +607,7 @@ index 10ae1f65fa..4b84f10ea5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
-index 061ff48b84..576e21b323 100644
+index 061ff48b8485..576e21b323fd 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -622,7 +622,7 @@ index 061ff48b84..576e21b323 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
-index f1cfe20bed..2b424db2a8 100644
+index f1cfe20bed12..2b424db2a82b 100644
 --- a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -637,7 +637,7 @@ index f1cfe20bed..2b424db2a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
-index ff6ba51fed..49c434ebb7 100644
+index ff6ba51fed82..49c434ebb7b3 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -652,7 +652,7 @@ index ff6ba51fed..49c434ebb7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
-index 50f3967770..1e14f02b88 100644
+index 50f39677700f..1e14f02b88ba 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -667,7 +667,7 @@ index 50f3967770..1e14f02b88 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
-index 66899306c2..e36c41ab63 100644
+index 66899306c2b9..e36c41ab63bd 100644
 --- a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -682,7 +682,7 @@ index 66899306c2..e36c41ab63 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
-index 235eb30deb..03b6208676 100644
+index 235eb30debda..03b620867639 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -697,7 +697,7 @@ index 235eb30deb..03b6208676 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
-index d6edc362eb..e99d62d1e4 100644
+index d6edc362eb2f..e99d62d1e4f9 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -712,7 +712,7 @@ index d6edc362eb..e99d62d1e4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
-index cd6f3fcf49..238380a0ce 100644
+index cd6f3fcf496e..238380a0ce03 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -727,7 +727,7 @@ index cd6f3fcf49..238380a0ce 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
-index 88ab3c83b6..e1f22f02ff 100644
+index 88ab3c83b6d4..e1f22f02ff8b 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -742,7 +742,7 @@ index 88ab3c83b6..e1f22f02ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
-index 033fdb4bb6..eb013f2828 100644
+index 033fdb4bb6e2..eb013f282857 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -757,7 +757,7 @@ index 033fdb4bb6..eb013f2828 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
-index ecb9b406a2..00b7cf4f17 100644
+index ecb9b406a256..00b7cf4f17a7 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -772,7 +772,7 @@ index ecb9b406a2..00b7cf4f17 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
-index cd28eb3465..5283d734c6 100644
+index cd28eb346570..5283d734c68d 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -787,7 +787,7 @@ index cd28eb3465..5283d734c6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
-index e259a3b72e..e3dfd6dc00 100644
+index e259a3b72e60..e3dfd6dc0032 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -802,7 +802,7 @@ index e259a3b72e..e3dfd6dc00 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
-index cfa5320921..a7c7751696 100644
+index cfa532092195..a7c7751696b9 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -817,7 +817,7 @@ index cfa5320921..a7c7751696 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
-index 87b566eb9c..3d48772f5b 100644
+index 87b566eb9c63..3d48772f5b93 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -832,7 +832,7 @@ index 87b566eb9c..3d48772f5b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
-index 728c782d1a..9b0b2c2587 100644
+index 728c782d1ad9..9b0b2c2587a3 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -847,7 +847,7 @@ index 728c782d1a..9b0b2c2587 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
-index c27e08d89c..723555805b 100644
+index c27e08d89ca7..723555805b66 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -862,7 +862,7 @@ index c27e08d89c..723555805b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
-index d6fe84b97b..53041423c5 100644
+index d6fe84b97bcc..53041423c58b 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -877,7 +877,7 @@ index d6fe84b97b..53041423c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
-index 15d75c1a6d..e4087613ab 100644
+index 15d75c1a6da3..e4087613ab08 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -892,7 +892,7 @@ index 15d75c1a6d..e4087613ab 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
-index f0b9b2ddb3..b9a38d720f 100644
+index f0b9b2ddb3fe..b9a38d720f12 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -907,7 +907,7 @@ index f0b9b2ddb3..b9a38d720f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
-index e2fb4d316a..460195dcae 100644
+index e2fb4d316a84..460195dcae17 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -922,7 +922,7 @@ index e2fb4d316a..460195dcae 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_options_api_gn/moz.build b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
-index 9cddf47802..fc4ff69dec 100644
+index 9cddf47802bc..fc4ff69dec1a 100644
 --- a/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -937,7 +937,7 @@ index 9cddf47802..fc4ff69dec 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
-index a5170774bd..f11130fece 100644
+index a5170774bd1c..f11130fece12 100644
 --- a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -952,7 +952,7 @@ index a5170774bd..f11130fece 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/call_api_gn/moz.build b/third_party/libwebrtc/api/call_api_gn/moz.build
-index 439d2b4431..889b8161f3 100644
+index 439d2b44318b..889b8161f30c 100644
 --- a/third_party/libwebrtc/api/call_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/call_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -967,7 +967,7 @@ index 439d2b4431..889b8161f3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
-index 8c4ad8dd1e..41451b2349 100644
+index 8c4ad8dd1ec2..41451b2349ce 100644
 --- a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -982,7 +982,7 @@ index 8c4ad8dd1e..41451b2349 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
-index b3d5fc80f2..db4a92f2b4 100644
+index b3d5fc80f2dc..db4a92f2b412 100644
 --- a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -997,7 +997,7 @@ index b3d5fc80f2..db4a92f2b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/options_gn/moz.build b/third_party/libwebrtc/api/crypto/options_gn/moz.build
-index 5ce60513e9..c1609251bd 100644
+index 5ce60513e9dd..c1609251bd77 100644
 --- a/third_party/libwebrtc/api/crypto/options_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/options_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1012,7 +1012,7 @@ index 5ce60513e9..c1609251bd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
-index dfb310b078..25023964b5 100644
+index dfb310b07831..25023964b571 100644
 --- a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1027,7 +1027,7 @@ index dfb310b078..25023964b5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_gn/moz.build b/third_party/libwebrtc/api/environment/environment_gn/moz.build
-index 484b89746f..d5624d5933 100644
+index 484b89746fa8..d5624d593307 100644
 --- a/third_party/libwebrtc/api/environment/environment_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1042,7 +1042,7 @@ index 484b89746f..d5624d5933 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
-index e8caeb29b0..7386a6cc9b 100644
+index e8caeb29b0b5..7386a6cc9b68 100644
 --- a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1057,7 +1057,7 @@ index e8caeb29b0..7386a6cc9b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
-index ee276a6abe..4697153d47 100644
+index ee276a6abe37..4697153d4771 100644
 --- a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1072,7 +1072,7 @@ index ee276a6abe..4697153d47 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_view_gn/moz.build b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
-index 9dcf0f1332..19d8b2d7c2 100644
+index 9dcf0f1332d4..19d8b2d7c234 100644
 --- a/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1087,7 +1087,7 @@ index 9dcf0f1332..19d8b2d7c2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
-index b47d843d10..91e96d9657 100644
+index b47d843d106d..91e96d965761 100644
 --- a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1102,7 +1102,7 @@ index b47d843d10..91e96d9657 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/function_view_gn/moz.build b/third_party/libwebrtc/api/function_view_gn/moz.build
-index 6eccd0a4fd..1cc0aeedd2 100644
+index 6eccd0a4fd32..1cc0aeedd2f4 100644
 --- a/third_party/libwebrtc/api/function_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/function_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1117,7 +1117,7 @@ index 6eccd0a4fd..1cc0aeedd2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
-index 14951db5b9..228854aff2 100644
+index 14951db5b9f2..228854aff2f2 100644
 --- a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1132,7 +1132,7 @@ index 14951db5b9..228854aff2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
-index d75066b595..16c37a7bb7 100644
+index d75066b59596..16c37a7bb7e1 100644
 --- a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1147,7 +1147,7 @@ index d75066b595..16c37a7bb7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/location_gn/moz.build b/third_party/libwebrtc/api/location_gn/moz.build
-index 87a5892861..3bac98a819 100644
+index 87a58928611c..3bac98a819c9 100644
 --- a/third_party/libwebrtc/api/location_gn/moz.build
 +++ b/third_party/libwebrtc/api/location_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1162,7 +1162,7 @@ index 87a5892861..3bac98a819 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
-index 7f956665ed..9dff392de0 100644
+index 7f956665eda9..9dff392de06c 100644
 --- a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 +++ b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1177,7 +1177,7 @@ index 7f956665ed..9dff392de0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
-index fea8af2692..4cdf3121c8 100644
+index fea8af2692d4..4cdf3121c8a8 100644
 --- a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1192,7 +1192,7 @@ index fea8af2692..4cdf3121c8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
-index 57a1e2ca46..bc06a5e82e 100644
+index 57a1e2ca464e..bc06a5e82eb3 100644
 --- a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 +++ b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1207,7 +1207,7 @@ index 57a1e2ca46..bc06a5e82e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
-index 10d65f922e..06c3b44ce1 100644
+index 10d65f922ebe..06c3b44ce1ce 100644
 --- a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1222,7 +1222,7 @@ index 10d65f922e..06c3b44ce1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/default_neteq_factory_gn/moz.build b/third_party/libwebrtc/api/neteq/default_neteq_factory_gn/moz.build
-index a7d5369ee5..d594e3f0d0 100644
+index a7d5369ee523..d594e3f0d014 100644
 --- a/third_party/libwebrtc/api/neteq/default_neteq_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/default_neteq_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1237,7 +1237,7 @@ index a7d5369ee5..d594e3f0d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
-index a4512f3c1f..f23592fa02 100644
+index a4512f3c1f31..f23592fa028c 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1252,7 +1252,7 @@ index a4512f3c1f..f23592fa02 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
-index 8ca00de799..de8c078131 100644
+index 8ca00de79987..de8c07813132 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1267,7 +1267,7 @@ index 8ca00de799..de8c078131 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
-index 97f27314b0..5e92ffd880 100644
+index 97f27314b014..5e92ffd8807e 100644
 --- a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1282,7 +1282,7 @@ index 97f27314b0..5e92ffd880 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
-index 27f989b8b2..a020c5d4f2 100644
+index 27f989b8b230..a020c5d4f242 100644
 --- a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1297,7 +1297,7 @@ index 27f989b8b2..a020c5d4f2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/priority_gn/moz.build b/third_party/libwebrtc/api/priority_gn/moz.build
-index f412b0d8fb..691e36e41a 100644
+index f412b0d8fba4..691e36e41a19 100644
 --- a/third_party/libwebrtc/api/priority_gn/moz.build
 +++ b/third_party/libwebrtc/api/priority_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1312,7 +1312,7 @@ index f412b0d8fb..691e36e41a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/ref_count_gn/moz.build b/third_party/libwebrtc/api/ref_count_gn/moz.build
-index 98c49cbfca..08b95e84f5 100644
+index 98c49cbfca5e..08b95e84f5fa 100644
 --- a/third_party/libwebrtc/api/ref_count_gn/moz.build
 +++ b/third_party/libwebrtc/api/ref_count_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1327,7 +1327,7 @@ index 98c49cbfca..08b95e84f5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/refcountedbase_gn/moz.build b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
-index 7f6d1e6cf3..96e8bbb564 100644
+index 7f6d1e6cf3a1..96e8bbb5641d 100644
 --- a/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 +++ b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1342,7 +1342,7 @@ index 7f6d1e6cf3..96e8bbb564 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_error_gn/moz.build b/third_party/libwebrtc/api/rtc_error_gn/moz.build
-index fd4c614cf3..d857a8e586 100644
+index fd4c614cf3ad..d857a8e586f7 100644
 --- a/third_party/libwebrtc/api/rtc_error_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_error_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1357,7 +1357,7 @@ index fd4c614cf3..d857a8e586 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
-index 2f1418300a..2383188cf3 100644
+index 2f1418300a0c..2383188cf34a 100644
 --- a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1372,7 +1372,7 @@ index 2f1418300a..2383188cf3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_headers_gn/moz.build b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
-index 033677891b..9426659435 100644
+index 033677891b16..9426659435b9 100644
 --- a/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1387,7 +1387,7 @@ index 033677891b..9426659435 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
-index c75ba8f4c4..594b7dae70 100644
+index c75ba8f4c4db..594b7dae708a 100644
 --- a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1402,7 +1402,7 @@ index c75ba8f4c4..594b7dae70 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
-index 69412fc87e..e5c7d798a3 100644
+index 69412fc87e29..e5c7d798a332 100644
 --- a/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1417,7 +1417,7 @@ index 69412fc87e..e5c7d798a3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
-index b92b2259d0..c3905894f0 100644
+index b92b2259d02d..c3905894f01c 100644
 --- a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1432,7 +1432,7 @@ index b92b2259d0..c3905894f0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
-index fd0316a345..0d5cce701c 100644
+index fd0316a345b7..0d5cce701cfb 100644
 --- a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1447,7 +1447,7 @@ index fd0316a345..0d5cce701c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
-index 2dbb1256e4..b86a61e6d3 100644
+index 2dbb1256e4ef..b86a61e6d376 100644
 --- a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1462,7 +1462,7 @@ index 2dbb1256e4..b86a61e6d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
-index 154dc5391a..a5fe524d6b 100644
+index 154dc5391a56..a5fe524d6bd0 100644
 --- a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1477,7 +1477,7 @@ index 154dc5391a..a5fe524d6b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
-index 5dc69d00ee..a6f6302b48 100644
+index 5dc69d00eea3..a6f6302b48b7 100644
 --- a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 +++ b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1492,7 +1492,7 @@ index 5dc69d00ee..a6f6302b48 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/sequence_checker_gn/moz.build b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
-index 649a16507f..54be2add2b 100644
+index 649a16507f49..54be2add2b5d 100644
 --- a/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 +++ b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1507,7 +1507,7 @@ index 649a16507f..54be2add2b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
-index 654045dd91..a837cfd6b1 100644
+index 654045dd91a1..a837cfd6b19a 100644
 --- a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1522,7 +1522,7 @@ index 654045dd91..a837cfd6b1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
-index a0b133fad7..1a315cbc8d 100644
+index a0b133fad759..1a315cbc8dc9 100644
 --- a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1537,7 +1537,7 @@ index a0b133fad7..1a315cbc8d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
-index 00c89a68d1..2e3e936102 100644
+index 00c89a68d1cb..2e3e9361029f 100644
 --- a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1552,7 +1552,7 @@ index 00c89a68d1..2e3e936102 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
-index fad8682ae7..a0b910a663 100644
+index fad8682ae701..a0b910a6630a 100644
 --- a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1567,7 +1567,7 @@ index fad8682ae7..a0b910a663 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
-index 45a9e83269..921d0498e8 100644
+index 45a9e8326962..921d0498e8ec 100644
 --- a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1582,7 +1582,7 @@ index 45a9e83269..921d0498e8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
-index 0441698bcb..b86f6bb9e7 100644
+index 0441698bcb75..b86f6bb9e704 100644
 --- a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1597,7 +1597,7 @@ index 0441698bcb..b86f6bb9e7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
-index b66b9044f1..e366191518 100644
+index b66b9044f154..e366191518a7 100644
 --- a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1612,7 +1612,7 @@ index b66b9044f1..e366191518 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
-index 075109c58f..f27f5bcf72 100644
+index 075109c58fea..f27f5bcf7215 100644
 --- a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1627,7 +1627,7 @@ index 075109c58f..f27f5bcf72 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
-index 3b970aee2e..b348065907 100644
+index 3b970aee2e27..b34806590741 100644
 --- a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1642,7 +1642,7 @@ index 3b970aee2e..b348065907 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
-index 8255eb921f..79e78b8de8 100644
+index 8255eb921f79..79e78b8de8fb 100644
 --- a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1657,7 +1657,7 @@ index 8255eb921f..79e78b8de8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/network_control_gn/moz.build b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
-index 561baff74f..6e86e24680 100644
+index 561baff74f56..6e86e246809f 100644
 --- a/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1672,7 +1672,7 @@ index 561baff74f..6e86e24680 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
-index 5df8c9603a..f8f78e7f79 100644
+index 5df8c9603ac6..f8f78e7f79a2 100644
 --- a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1687,7 +1687,7 @@ index 5df8c9603a..f8f78e7f79 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
-index cd6ffae7d7..1ceeec366d 100644
+index cd6ffae7d73f..1ceeec366d53 100644
 --- a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1702,7 +1702,7 @@ index cd6ffae7d7..1ceeec366d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
-index 098eb72eb9..fca0939852 100644
+index 098eb72eb9ac..fca0939852d4 100644
 --- a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1717,7 +1717,7 @@ index 098eb72eb9..fca0939852 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport_api_gn/moz.build b/third_party/libwebrtc/api/transport_api_gn/moz.build
-index 3f5d0852a5..efe0e7b0ee 100644
+index 3f5d0852a58e..efe0e7b0ee76 100644
 --- a/third_party/libwebrtc/api/transport_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1732,7 +1732,7 @@ index 3f5d0852a5..efe0e7b0ee 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_rate_gn/moz.build b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
-index 19e412ef71..47c62e9a70 100644
+index 19e412ef718c..47c62e9a7048 100644
 --- a/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1747,7 +1747,7 @@ index 19e412ef71..47c62e9a70 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_size_gn/moz.build b/third_party/libwebrtc/api/units/data_size_gn/moz.build
-index d78fda4aa5..1dd1600294 100644
+index d78fda4aa54c..1dd1600294b4 100644
 --- a/third_party/libwebrtc/api/units/data_size_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_size_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1762,7 +1762,7 @@ index d78fda4aa5..1dd1600294 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/frequency_gn/moz.build b/third_party/libwebrtc/api/units/frequency_gn/moz.build
-index ff1a8c5403..322cbb95be 100644
+index ff1a8c54034e..322cbb95be97 100644
 --- a/third_party/libwebrtc/api/units/frequency_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/frequency_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1777,7 +1777,7 @@ index ff1a8c5403..322cbb95be 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/time_delta_gn/moz.build b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
-index 43f43d80d8..5ca041b863 100644
+index 43f43d80d89a..5ca041b863bc 100644
 --- a/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1792,7 +1792,7 @@ index 43f43d80d8..5ca041b863 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/timestamp_gn/moz.build b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
-index d4a9959eae..d1580c1d19 100644
+index d4a9959eae2b..d1580c1d1966 100644
 --- a/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1807,7 +1807,7 @@ index d4a9959eae..d1580c1d19 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
-index fb5c3b3250..d2776ddb28 100644
+index fb5c3b325059..d2776ddb286c 100644
 --- a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1822,7 +1822,7 @@ index fb5c3b3250..d2776ddb28 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
-index c935e11284..5917570665 100644
+index c935e1128449..59175706656e 100644
 --- a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1837,7 +1837,7 @@ index c935e11284..5917570665 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
-index 4c2d4cd0cc..b8d5da1278 100644
+index 4c2d4cd0ccbf..b8d5da1278d2 100644
 --- a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1852,7 +1852,7 @@ index 4c2d4cd0cc..b8d5da1278 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
-index 8b0f073461..5aed8ca9b0 100644
+index 8b0f07346188..5aed8ca9b00c 100644
 --- a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1867,7 +1867,7 @@ index 8b0f073461..5aed8ca9b0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
-index e23a66634e..249341c559 100644
+index e23a66634e87..249341c55999 100644
 --- a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1882,7 +1882,7 @@ index e23a66634e..249341c559 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
-index 37131d1328..e2e2bdff11 100644
+index 37131d1328f7..e2e2bdff1104 100644
 --- a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1897,7 +1897,7 @@ index 37131d1328..e2e2bdff11 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/resolution_gn/moz.build b/third_party/libwebrtc/api/video/resolution_gn/moz.build
-index 2d00ea929f..6874770119 100644
+index 2d00ea929f01..6874770119ef 100644
 --- a/third_party/libwebrtc/api/video/resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1912,7 +1912,7 @@ index 2d00ea929f..6874770119 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
-index 8b89c69dc0..7723271dd7 100644
+index 8b89c69dc003..7723271dd764 100644
 --- a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1927,7 +1927,7 @@ index 8b89c69dc0..7723271dd7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
-index cd607967c4..8f95ec8b60 100644
+index cd607967c486..8f95ec8b603c 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1942,7 +1942,7 @@ index cd607967c4..8f95ec8b60 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
-index a0531d267a..eca087577e 100644
+index a0531d267a2d..eca087577e1d 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1957,7 +1957,7 @@ index a0531d267a..eca087577e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
-index b731f61ae6..b1c3a02c5d 100644
+index b731f61ae62e..b1c3a02c5d91 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1972,7 +1972,7 @@ index b731f61ae6..b1c3a02c5d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
-index 3ac5b9efc8..d9fcc8f447 100644
+index 3ac5b9efc87e..d9fcc8f44794 100644
 --- a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1987,7 +1987,7 @@ index 3ac5b9efc8..d9fcc8f447 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
-index 4704e8482b..eb84328e3c 100644
+index 4704e8482b97..eb84328e3c4a 100644
 --- a/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2002,7 +2002,7 @@ index 4704e8482b..eb84328e3c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
-index 5534a976cf..393567c949 100644
+index 5534a976cf12..393567c94975 100644
 --- a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2017,7 +2017,7 @@ index 5534a976cf..393567c949 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
-index e129b5b4f7..dc543a70d6 100644
+index e129b5b4f7b4..dc543a70d649 100644
 --- a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2032,7 +2032,7 @@ index e129b5b4f7..dc543a70d6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
-index d1402be61a..53c110f12f 100644
+index d1402be61ac5..53c110f12faa 100644
 --- a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2047,7 +2047,7 @@ index d1402be61a..53c110f12f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
-index d6bb07ec8c..f7be1268bf 100644
+index d6bb07ec8c87..f7be1268bf38 100644
 --- a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2062,7 +2062,7 @@ index d6bb07ec8c..f7be1268bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
-index 3ce253a3e8..7756f9b710 100644
+index 3ce253a3e8cc..7756f9b710a5 100644
 --- a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2077,7 +2077,7 @@ index 3ce253a3e8..7756f9b710 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
-index d3ada0cf1d..3d5f054bf0 100644
+index d3ada0cf1d14..3d5f054bf06b 100644
 --- a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2092,7 +2092,7 @@ index d3ada0cf1d..3d5f054bf0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
-index 30278b672f..f47c3775ae 100644
+index 30278b672f20..f47c3775ae98 100644
 --- a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2107,7 +2107,7 @@ index 30278b672f..f47c3775ae 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
-index 723ee880f3..0c6764c03a 100644
+index 723ee880f3c1..0c6764c03a74 100644
 --- a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2122,7 +2122,7 @@ index 723ee880f3..0c6764c03a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
-index aca8affe68..a5c725642c 100644
+index aca8affe6867..a5c725642c31 100644
 --- a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2137,7 +2137,7 @@ index aca8affe68..a5c725642c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
-index df8d151dd4..4cd7c8debc 100644
+index df8d151dd497..4cd7c8debcc5 100644
 --- a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2152,7 +2152,7 @@ index df8d151dd4..4cd7c8debc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
-index a197fc9fdc..7b87eb0347 100644
+index a197fc9fdcc5..7b87eb034788 100644
 --- a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2167,7 +2167,7 @@ index a197fc9fdc..7b87eb0347 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
-index f6456b10c9..c9afa81820 100644
+index f6456b10c949..c9afa818201e 100644
 --- a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2182,7 +2182,7 @@ index f6456b10c9..c9afa81820 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/audio_gn/moz.build b/third_party/libwebrtc/audio/audio_gn/moz.build
-index 7e90715293..fd6e4c6c7c 100644
+index 7e907152932a..fd6e4c6c7c70 100644
 --- a/third_party/libwebrtc/audio/audio_gn/moz.build
 +++ b/third_party/libwebrtc/audio/audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2197,7 +2197,7 @@ index 7e90715293..fd6e4c6c7c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
-index 513ee2df29..e9155a44df 100644
+index 513ee2df29a4..e9155a44df5d 100644
 --- a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 +++ b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2212,7 +2212,7 @@ index 513ee2df29..e9155a44df 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
-index 9731da555b..e3d13b9a6e 100644
+index 9731da555bb5..e3d13b9a6e11 100644
 --- a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2227,7 +2227,7 @@ index 9731da555b..e3d13b9a6e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
-index af23788409..6d3568a6cc 100644
+index af23788409d9..6d3568a6cccc 100644
 --- a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2242,7 +2242,7 @@ index af23788409..6d3568a6cc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
-index eb39b9ced7..8795186ccb 100644
+index eb39b9ced731..8795186ccbc4 100644
 --- a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2257,7 +2257,7 @@ index eb39b9ced7..8795186ccb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
-index e73d888976..9380581e2a 100644
+index e73d8889769d..9380581e2a2f 100644
 --- a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2272,7 +2272,7 @@ index e73d888976..9380581e2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_gn/moz.build b/third_party/libwebrtc/call/call_gn/moz.build
-index b00caf8581..eaaa870a25 100644
+index b00caf858186..eaaa870a250d 100644
 --- a/third_party/libwebrtc/call/call_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2287,7 +2287,7 @@ index b00caf8581..eaaa870a25 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_interfaces_gn/moz.build b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
-index c5d22abe42..6c077c707c 100644
+index c5d22abe424a..6c077c707c4b 100644
 --- a/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2302,7 +2302,7 @@ index c5d22abe42..6c077c707c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
-index 15e5be29d3..0d6727403c 100644
+index 15e5be29d320..0d6727403ce8 100644
 --- a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2317,7 +2317,7 @@ index 15e5be29d3..0d6727403c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
-index 29e7a8d996..e78d967af9 100644
+index 29e7a8d99609..e78d967af94d 100644
 --- a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2332,7 +2332,7 @@ index 29e7a8d996..e78d967af9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
-index b1a295a56a..5123b15aba 100644
+index b1a295a56ae2..5123b15aba2a 100644
 --- a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2347,7 +2347,7 @@ index b1a295a56a..5123b15aba 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_sender_gn/moz.build b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
-index f488ad07c2..55a8afc7b6 100644
+index f488ad07c25a..55a8afc7b6e0 100644
 --- a/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2362,7 +2362,7 @@ index f488ad07c2..55a8afc7b6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/version_gn/moz.build b/third_party/libwebrtc/call/version_gn/moz.build
-index 485833ee2b..4a3e2689e1 100644
+index 485833ee2beb..4a3e2689e169 100644
 --- a/third_party/libwebrtc/call/version_gn/moz.build
 +++ b/third_party/libwebrtc/call/version_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2377,7 +2377,7 @@ index 485833ee2b..4a3e2689e1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/video_stream_api_gn/moz.build b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
-index 3d0b6a488c..862981ef04 100644
+index 3d0b6a488cb3..862981ef04c4 100644
 --- a/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 +++ b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2392,7 +2392,7 @@ index 3d0b6a488c..862981ef04 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
-index f87719576d..04ec6969a6 100644
+index f87719576dfa..04ec6969a6f3 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 @@ -136,6 +136,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2407,7 +2407,7 @@ index f87719576d..04ec6969a6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
-index 07660c8bb5..8ab56c3f93 100644
+index 07660c8bb56b..8ab56c3f9399 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 @@ -213,6 +213,16 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2428,7 +2428,7 @@ index 07660c8bb5..8ab56c3f93 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
-index 63d72e183f..cf801998d0 100644
+index 63d72e183fb0..cf801998d019 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2443,7 +2443,7 @@ index 63d72e183f..cf801998d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
-index 6ee6786018..f4ca343b13 100644
+index 6ee67860188c..f4ca343b13a8 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2458,7 +2458,7 @@ index 6ee6786018..f4ca343b13 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
-index 8e5b54e61d..9baa8739e8 100644
+index 8e5b54e61d96..9baa8739e8dd 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2473,7 +2473,7 @@ index 8e5b54e61d..9baa8739e8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
-index 067128609c..cb503e5f11 100644
+index 067128609c1d..cb503e5f111a 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2488,7 +2488,7 @@ index 067128609c..cb503e5f11 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
-index 8649a26e7f..4c56c96b12 100644
+index 8649a26e7f60..4c56c96b12ec 100644
 --- a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2503,7 +2503,7 @@ index 8649a26e7f..4c56c96b12 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
-index daeab1ffae..40968f7424 100644
+index daeab1ffae94..40968f742491 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2518,7 +2518,7 @@ index daeab1ffae..40968f7424 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
-index 157b77da74..30874d7c60 100644
+index 157b77da7490..30874d7c6021 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2533,7 +2533,7 @@ index 157b77da74..30874d7c60 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
-index 3acc048e7b..66cbc4b934 100644
+index 3acc048e7b55..66cbc4b93403 100644
 --- a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 @@ -147,6 +147,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2552,7 +2552,7 @@ index 3acc048e7b..66cbc4b934 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/common_video_gn/moz.build b/third_party/libwebrtc/common_video/common_video_gn/moz.build
-index e1d4464ae3..945cb852af 100644
+index e1d4464ae3bc..945cb852af7e 100644
 --- a/third_party/libwebrtc/common_video/common_video_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/common_video_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2567,7 +2567,7 @@ index e1d4464ae3..945cb852af 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
-index f840eae902..42c2d2c5d4 100644
+index f840eae9028e..42c2d2c5d4c5 100644
 --- a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2582,7 +2582,7 @@ index f840eae902..42c2d2c5d4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
-index a5877debe7..8a3bd5aecc 100644
+index a5877debe7a8..8a3bd5aecc90 100644
 --- a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2597,7 +2597,7 @@ index a5877debe7..8a3bd5aecc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
-index 9392f8ab7c..b87e5674d3 100644
+index 9392f8ab7ce1..b87e5674d3e9 100644
 --- a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 +++ b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2612,7 +2612,7 @@ index 9392f8ab7c..b87e5674d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
-index 10e20ecba0..cd337bdfa9 100644
+index 10e20ecba098..cd337bdfa920 100644
 --- a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2627,7 +2627,7 @@ index 10e20ecba0..cd337bdfa9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
-index 8f8c1c86a1..1f99e652b2 100644
+index 8f8c1c86a14c..1f99e652b204 100644
 --- a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2642,7 +2642,7 @@ index 8f8c1c86a1..1f99e652b2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
-index db8a0c7723..0795e18b26 100644
+index db8a0c7723d9..0795e18b26a0 100644
 --- a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2657,7 +2657,7 @@ index db8a0c7723..0795e18b26 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
-index c5f090ad66..cfc2fd2c5f 100644
+index c5f090ad669f..cfc2fd2c5fa4 100644
 --- a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2672,7 +2672,7 @@ index c5f090ad66..cfc2fd2c5f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
-index ae770cf7c7..0409fa399a 100644
+index ae770cf7c778..0409fa399a66 100644
 --- a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2687,7 +2687,7 @@ index ae770cf7c7..0409fa399a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
-index 080549171c..f9d4e515ce 100644
+index 080549171c71..f9d4e515ce93 100644
 --- a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2702,7 +2702,7 @@ index 080549171c..f9d4e515ce 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
-index 953ae5151c..0eee91389f 100644
+index 953ae5151ce4..0eee91389feb 100644
 --- a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2717,7 +2717,7 @@ index 953ae5151c..0eee91389f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
-index 0c31614317..9c6369a274 100644
+index 0c31614317c2..9c6369a2744f 100644
 --- a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2732,7 +2732,7 @@ index 0c31614317..9c6369a274 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
-index dbe85beeb1..2463070631 100644
+index dbe85beeb123..2463070631d1 100644
 --- a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2747,7 +2747,7 @@ index dbe85beeb1..2463070631 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
-index 84ff989167..3bb517efb3 100644
+index 84ff9891679e..3bb517efb3a3 100644
 --- a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 +++ b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2762,7 +2762,7 @@ index 84ff989167..3bb517efb3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/codec_gn/moz.build b/third_party/libwebrtc/media/codec_gn/moz.build
-index 1d9dcc538d..bee14573bf 100644
+index 1d9dcc538de5..bee14573bf0a 100644
 --- a/third_party/libwebrtc/media/codec_gn/moz.build
 +++ b/third_party/libwebrtc/media/codec_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2777,7 +2777,7 @@ index 1d9dcc538d..bee14573bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_gn/moz.build b/third_party/libwebrtc/media/media_channel_gn/moz.build
-index 9a8b4ded79..9bf393661b 100644
+index 9a8b4ded79f2..9bf393661b9e 100644
 --- a/third_party/libwebrtc/media/media_channel_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2792,7 +2792,7 @@ index 9a8b4ded79..9bf393661b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
-index c42d7c6549..960a206c3e 100644
+index c42d7c65492f..960a206c3e6e 100644
 --- a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2807,7 +2807,7 @@ index c42d7c6549..960a206c3e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_constants_gn/moz.build b/third_party/libwebrtc/media/media_constants_gn/moz.build
-index 9338f3c0f5..46fe45cd6e 100644
+index 9338f3c0f5d3..46fe45cd6e6b 100644
 --- a/third_party/libwebrtc/media/media_constants_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_constants_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2822,7 +2822,7 @@ index 9338f3c0f5..46fe45cd6e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rid_description_gn/moz.build b/third_party/libwebrtc/media/rid_description_gn/moz.build
-index d564fc86c2..a592f8078b 100644
+index d564fc86c266..a592f8078b9b 100644
 --- a/third_party/libwebrtc/media/rid_description_gn/moz.build
 +++ b/third_party/libwebrtc/media/rid_description_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2837,7 +2837,7 @@ index d564fc86c2..a592f8078b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
-index 58997370b8..6410616606 100644
+index 58997370b876..641061660667 100644
 --- a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2852,7 +2852,7 @@ index 58997370b8..6410616606 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
-index 2cfb8f9336..4fc6fb4895 100644
+index 2cfb8f933687..4fc6fb48955b 100644
 --- a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2867,7 +2867,7 @@ index 2cfb8f9336..4fc6fb4895 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
-index db2cc89a04..42df2d820c 100644
+index db2cc89a041f..42df2d820c0c 100644
 --- a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2882,7 +2882,7 @@ index db2cc89a04..42df2d820c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
-index 4fe267a97b..b7d82e789e 100644
+index 4fe267a97b64..b7d82e789e12 100644
 --- a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2897,7 +2897,7 @@ index 4fe267a97b..b7d82e789e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtp_utils_gn/moz.build b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
-index 852af58608..931193ec46 100644
+index 852af5860851..931193ec462a 100644
 --- a/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2912,7 +2912,7 @@ index 852af58608..931193ec46 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/stream_params_gn/moz.build b/third_party/libwebrtc/media/stream_params_gn/moz.build
-index 19a47f719a..e4f9ef46ed 100644
+index 19a47f719a09..e4f9ef46ed17 100644
 --- a/third_party/libwebrtc/media/stream_params_gn/moz.build
 +++ b/third_party/libwebrtc/media/stream_params_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2927,7 +2927,7 @@ index 19a47f719a..e4f9ef46ed 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_adapter_gn/moz.build b/third_party/libwebrtc/media/video_adapter_gn/moz.build
-index c64baa9d03..6a893dec65 100644
+index c64baa9d03cc..6a893dec658b 100644
 --- a/third_party/libwebrtc/media/video_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_adapter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2942,7 +2942,7 @@ index c64baa9d03..6a893dec65 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
-index 680eace514..2ff0461b9f 100644
+index 680eace5143b..2ff0461b9fa2 100644
 --- a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2957,7 +2957,7 @@ index 680eace514..2ff0461b9f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_common_gn/moz.build b/third_party/libwebrtc/media/video_common_gn/moz.build
-index c25c1a0db3..7801a01ad3 100644
+index c25c1a0db303..7801a01ad378 100644
 --- a/third_party/libwebrtc/media/video_common_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2972,7 +2972,7 @@ index c25c1a0db3..7801a01ad3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_source_base_gn/moz.build b/third_party/libwebrtc/media/video_source_base_gn/moz.build
-index cd9c32d0b0..3cddc2f507 100644
+index cd9c32d0b0f0..3cddc2f507ea 100644
 --- a/third_party/libwebrtc/media/video_source_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_source_base_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2987,7 +2987,7 @@ index cd9c32d0b0..3cddc2f507 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
-index fb495956fb..5133c9ce45 100644
+index fb495956fbeb..5133c9ce454d 100644
 --- a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3002,7 +3002,7 @@ index fb495956fb..5133c9ce45 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
-index aa9ce2702b..a0982a6d16 100644
+index aa9ce2702b25..a0982a6d1678 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3017,7 +3017,7 @@ index aa9ce2702b..a0982a6d16 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
-index f907a73217..23468f4b7a 100644
+index f907a7321765..23468f4b7a52 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3032,7 +3032,7 @@ index f907a73217..23468f4b7a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
-index 0fba540a06..157cbb1588 100644
+index 0fba540a063d..157cbb1588ce 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3047,7 +3047,7 @@ index 0fba540a06..157cbb1588 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
-index 1626d8cd6f..8ea5aa27be 100644
+index 1626d8cd6f64..8ea5aa27be68 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3062,7 +3062,7 @@ index 1626d8cd6f..8ea5aa27be 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
-index cd665a5454..ff66a80909 100644
+index cd665a5454ac..ff66a80909f2 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3077,7 +3077,7 @@ index cd665a5454..ff66a80909 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
-index 735a5e0b91..4c77db9977 100644
+index 735a5e0b91de..4c77db99778d 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3092,7 +3092,7 @@ index 735a5e0b91..4c77db9977 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
-index a207fdcb94..f90762825e 100644
+index a207fdcb944c..f90762825e88 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3107,7 +3107,7 @@ index a207fdcb94..f90762825e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
-index f58ae04841..e042a788f9 100644
+index f58ae048413e..e042a788f9f9 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3122,7 +3122,7 @@ index f58ae04841..e042a788f9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
-index aec0fb9b5e..928c466a23 100644
+index aec0fb9b5e2d..928c466a23b6 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3137,7 +3137,7 @@ index aec0fb9b5e..928c466a23 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
-index 7e6c4fa154..dbdf83e603 100644
+index 7e6c4fa154fd..dbdf83e603c4 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3152,7 +3152,7 @@ index 7e6c4fa154..dbdf83e603 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
-index f49ac18199..aa1ee79105 100644
+index f49ac18199ce..aa1ee791054f 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 @@ -222,6 +222,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3167,7 +3167,7 @@ index f49ac18199..aa1ee79105 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
-index 269e698268..1abc2cd087 100644
+index 269e69826899..1abc2cd0870d 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3182,7 +3182,7 @@ index 269e698268..1abc2cd087 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
-index de83c14d7e..6d475ff3f1 100644
+index de83c14d7e82..6d475ff3f1a0 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3197,7 +3197,7 @@ index de83c14d7e..6d475ff3f1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
-index 5fbc721158..b4efb1a545 100644
+index 5fbc721158ac..b4efb1a545dc 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3212,7 +3212,7 @@ index 5fbc721158..b4efb1a545 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
-index e4f0ed753e..1fdfb50fb0 100644
+index e4f0ed753ecd..1fdfb50fb059 100644
 --- a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3227,7 +3227,7 @@ index e4f0ed753e..1fdfb50fb0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
-index 1044a2bde9..f0263d1554 100644
+index 1044a2bde98e..f0263d155499 100644
 --- a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 @@ -189,6 +189,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3242,7 +3242,7 @@ index 1044a2bde9..f0263d1554 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
-index 790032c65a..13a5239fee 100644
+index 790032c65ac6..13a5239feea2 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3257,7 +3257,7 @@ index 790032c65a..13a5239fee 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
-index 0bdd6ed6ba..e5e3555fd2 100644
+index 0bdd6ed6ba90..e5e3555fd291 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3272,7 +3272,7 @@ index 0bdd6ed6ba..e5e3555fd2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
-index d20eee8365..c9e35f8152 100644
+index d20eee83656c..c9e35f8152f2 100644
 --- a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3287,7 +3287,7 @@ index d20eee8365..c9e35f8152 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
-index 0e2616b2a0..886c185d10 100644
+index 0e2616b2a0a1..886c185d10b2 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3302,7 +3302,7 @@ index 0e2616b2a0..886c185d10 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
-index 34a982b762..23f6d5ab6b 100644
+index 34a982b76282..23f6d5ab6b0a 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3317,7 +3317,7 @@ index 34a982b762..23f6d5ab6b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
-index 33f8d93af1..31ae2e99a8 100644
+index 33f8d93af1be..31ae2e99a8af 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 @@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3332,7 +3332,7 @@ index 33f8d93af1..31ae2e99a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
-index 45ce2083a1..241aead31d 100644
+index 45ce2083a15b..241aead31d4d 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3347,7 +3347,7 @@ index 45ce2083a1..241aead31d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
-index 6c2c91b004..5c71bac9a6 100644
+index 6c2c91b00478..5c71bac9a619 100644
 --- a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3362,7 +3362,7 @@ index 6c2c91b004..5c71bac9a6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
-index f26b5858d6..e76879885d 100644
+index f26b5858d6a0..e76879885d6f 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3377,7 +3377,7 @@ index f26b5858d6..e76879885d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
-index b998e5cf3e..cb38cdb20a 100644
+index b998e5cf3e3b..cb38cdb20a0c 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3392,7 +3392,7 @@ index b998e5cf3e..cb38cdb20a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
-index 3643adf3d9..5d17a104ef 100644
+index 3643adf3d9cd..5d17a104efa3 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3407,7 +3407,7 @@ index 3643adf3d9..5d17a104ef 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
-index cac619740b..052ea6e76d 100644
+index cac619740bc3..052ea6e76d33 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3422,7 +3422,7 @@ index cac619740b..052ea6e76d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
-index c5ec3c1cd9..3113f22bc4 100644
+index c5ec3c1cd9b6..3113f22bc463 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3437,7 +3437,7 @@ index c5ec3c1cd9..3113f22bc4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
-index a92b789398..3b67b401fe 100644
+index a92b7893981e..3b67b401fe48 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3452,7 +3452,7 @@ index a92b789398..3b67b401fe 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
-index 76eb9b374a..312d3d8946 100644
+index 76eb9b374afd..312d3d89464a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 @@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3467,7 +3467,7 @@ index 76eb9b374a..312d3d8946 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
-index bf6f884d46..2be9f19d10 100644
+index bf6f884d4657..2be9f19d1044 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3482,7 +3482,7 @@ index bf6f884d46..2be9f19d10 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
-index 3e0c262d89..ab39555296 100644
+index 3e0c262d8943..ab3955529655 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3497,7 +3497,7 @@ index 3e0c262d89..ab39555296 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
-index 5cbc1135eb..f4f11f2778 100644
+index 5cbc1135eb3f..f4f11f277855 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3512,7 +3512,7 @@ index 5cbc1135eb..f4f11f2778 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
-index c12496c562..7d6eb85525 100644
+index c12496c562d4..7d6eb85525d1 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3527,7 +3527,7 @@ index c12496c562..7d6eb85525 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
-index 454823f408..4fb0e35a67 100644
+index 454823f408ba..4fb0e35a67d1 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3542,7 +3542,7 @@ index 454823f408..4fb0e35a67 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
-index 79c47a87bc..96f7ee36a0 100644
+index 79c47a87bc96..96f7ee36a08b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3557,7 +3557,7 @@ index 79c47a87bc..96f7ee36a0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
-index ba900c1f01..75e04f7478 100644
+index ba900c1f0128..75e04f7478e7 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3572,7 +3572,7 @@ index ba900c1f01..75e04f7478 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
-index 576db07795..03c23f2594 100644
+index 576db07795fa..03c23f259465 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 @@ -179,6 +179,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3591,7 +3591,7 @@ index 576db07795..03c23f2594 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
-index e7becea289..6c81ae56ff 100644
+index e7becea28955..6c81ae56ff2e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3606,7 +3606,7 @@ index e7becea289..6c81ae56ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
-index 53e1886cef..e5c533f67e 100644
+index 53e1886cef10..e5c533f67ed9 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3621,7 +3621,7 @@ index 53e1886cef..e5c533f67e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
-index 887cc343cc..8cd05d6710 100644
+index 887cc343cc7d..8cd05d67105c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3636,7 +3636,7 @@ index 887cc343cc..8cd05d6710 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
-index 068bd7f772..3943c01c83 100644
+index 068bd7f772b6..3943c01c836c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3651,7 +3651,7 @@ index 068bd7f772..3943c01c83 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
-index a9128bc171..a8ff8f1668 100644
+index a9128bc171d6..a8ff8f1668cb 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3666,7 +3666,7 @@ index a9128bc171..a8ff8f1668 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
-index b414bac082..d21c4199a2 100644
+index b414bac082d8..d21c4199a2e6 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3681,7 +3681,7 @@ index b414bac082..d21c4199a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
-index 14b87b5cac..cee655176d 100644
+index 14b87b5cac6f..cee655176d3f 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3696,7 +3696,7 @@ index 14b87b5cac..cee655176d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
-index 79ab80ab68..ec0a458c3a 100644
+index 79ab80ab68a8..ec0a458c3af9 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3711,7 +3711,7 @@ index 79ab80ab68..ec0a458c3a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
-index 15a4901cc9..d8cfb6c244 100644
+index 15a4901cc9ea..d8cfb6c24433 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3726,7 +3726,7 @@ index 15a4901cc9..d8cfb6c244 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
-index dd306f3bb5..759c4158ac 100644
+index dd306f3bb513..759c4158aca4 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3741,7 +3741,7 @@ index dd306f3bb5..759c4158ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
-index 9f49e828dd..a6aa98540a 100644
+index 9f49e828dd7b..a6aa98540a62 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3756,7 +3756,7 @@ index 9f49e828dd..a6aa98540a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
-index fb4b57fed2..ee9c3b8c92 100644
+index fb4b57fed2bc..ee9c3b8c922e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3771,7 +3771,7 @@ index fb4b57fed2..ee9c3b8c92 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
-index 1d885a88ee..58f31d0989 100644
+index 1d885a88ee30..58f31d098932 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3786,7 +3786,7 @@ index 1d885a88ee..58f31d0989 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
-index 5825d2c670..d512de2491 100644
+index 5825d2c670b1..d512de2491fe 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3801,7 +3801,7 @@ index 5825d2c670..d512de2491 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
-index c18a6769d7..f820a1cd12 100644
+index c18a6769d7b3..f820a1cd1222 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3816,7 +3816,7 @@ index c18a6769d7..f820a1cd12 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
-index 81389ceafa..657c4a0f52 100644
+index 81389ceafa17..657c4a0f521d 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3831,7 +3831,7 @@ index 81389ceafa..657c4a0f52 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
-index 97a069e402..ec4b5e15e1 100644
+index 97a069e402f5..ec4b5e15e182 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3846,7 +3846,7 @@ index 97a069e402..ec4b5e15e1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
-index 671e7abff2..2c3364ed9c 100644
+index 671e7abff297..2c3364ed9cda 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3861,7 +3861,7 @@ index 671e7abff2..2c3364ed9c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
-index 271469362f..1009d00b3a 100644
+index 271469362fbd..1009d00b3aef 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3876,7 +3876,7 @@ index 271469362f..1009d00b3a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
-index ca0bed615c..26796e36f7 100644
+index ca0bed615c59..26796e36f772 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3891,7 +3891,7 @@ index ca0bed615c..26796e36f7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
-index 5820353de9..05df3aca36 100644
+index 5820353de9d1..05df3aca3626 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3906,7 +3906,7 @@ index 5820353de9..05df3aca36 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
-index 27fdd04949..786822725f 100644
+index 27fdd04949df..786822725f9a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3921,7 +3921,7 @@ index 27fdd04949..786822725f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
-index e42a389e6a..3bfa84c70c 100644
+index e42a389e6a3f..3bfa84c70c10 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3936,7 +3936,7 @@ index e42a389e6a..3bfa84c70c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
-index 0ff9b98abd..8a20d231ae 100644
+index 0ff9b98abd77..8a20d231aed0 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3951,7 +3951,7 @@ index 0ff9b98abd..8a20d231ae 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
-index 9f5bb53ec0..efcc54b675 100644
+index 9f5bb53ec07a..efcc54b6755b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3966,7 +3966,7 @@ index 9f5bb53ec0..efcc54b675 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
-index 79d73bb0e3..d0b7d90908 100644
+index 79d73bb0e3fa..d0b7d90908e8 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3981,7 +3981,7 @@ index 79d73bb0e3..d0b7d90908 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
-index fd27a27da1..0ff845f075 100644
+index fd27a27da1f1..0ff845f07569 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3996,7 +3996,7 @@ index fd27a27da1..0ff845f075 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
-index aedae110fd..d92c979a76 100644
+index aedae110fd46..d92c979a76ed 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4011,7 +4011,7 @@ index aedae110fd..d92c979a76 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
-index 9b40d9ff94..7316145c74 100644
+index 9b40d9ff9463..7316145c7476 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4026,7 +4026,7 @@ index 9b40d9ff94..7316145c74 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
-index 30453ba627..e202a50e9e 100644
+index 30453ba62793..e202a50e9eea 100644
 --- a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4041,7 +4041,7 @@ index 30453ba627..e202a50e9e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
-index 2fce4639d9..3878d77df8 100644
+index 2fce4639d9e3..3878d77df843 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4056,7 +4056,7 @@ index 2fce4639d9..3878d77df8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
-index 231bdb8f41..5dc4aa6c6a 100644
+index 231bdb8f4175..5dc4aa6c6af7 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4071,7 +4071,7 @@ index 231bdb8f41..5dc4aa6c6a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
-index 43ffbc502d..de06059f30 100644
+index 43ffbc502d81..de06059f3086 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4086,7 +4086,7 @@ index 43ffbc502d..de06059f30 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
-index c34635a347..f95e3976f2 100644
+index c34635a34775..f95e3976f299 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4101,7 +4101,7 @@ index c34635a347..f95e3976f2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
-index bcc0e359d2..a1b73ba6a2 100644
+index bcc0e359d23d..a1b73ba6a29b 100644
 --- a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4116,7 +4116,7 @@ index bcc0e359d2..a1b73ba6a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
-index 901a593d4e..2d453cc2e8 100644
+index 901a593d4e99..2d453cc2e8bc 100644
 --- a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4131,7 +4131,7 @@ index 901a593d4e..2d453cc2e8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
-index 767aac52bb..1c1124633f 100644
+index 767aac52bbba..1c1124633fe2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4146,7 +4146,7 @@ index 767aac52bb..1c1124633f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
-index 2880f10c6d..033a97439c 100644
+index 2880f10c6dcc..033a97439c24 100644
 --- a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4161,7 +4161,7 @@ index 2880f10c6d..033a97439c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
-index 6deed14b7f..f247004253 100644
+index 6deed14b7fdf..f24700425365 100644
 --- a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4176,7 +4176,7 @@ index 6deed14b7f..f247004253 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
-index ec295a9840..4975d07199 100644
+index ec295a9840b4..4975d07199e0 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4191,7 +4191,7 @@ index ec295a9840..4975d07199 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
-index beca78d134..ac1f1b2737 100644
+index beca78d13434..ac1f1b2737a4 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4206,7 +4206,7 @@ index beca78d134..ac1f1b2737 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
-index d118284e2c..1d80d18544 100644
+index d118284e2c2d..1d80d1854407 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4221,7 +4221,7 @@ index d118284e2c..1d80d18544 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
-index b2ff5b4798..30a54c7870 100644
+index b2ff5b479858..30a54c78703e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4236,7 +4236,7 @@ index b2ff5b4798..30a54c7870 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
-index 1f355f493b..c8956b1040 100644
+index 1f355f493b19..c8956b10403d 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4251,7 +4251,7 @@ index 1f355f493b..c8956b1040 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
-index d846e19c0b..4c15cdcf2f 100644
+index d846e19c0b4a..4c15cdcf2f40 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4266,7 +4266,7 @@ index d846e19c0b..4c15cdcf2f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
-index 7668240917..aa3081fabc 100644
+index 7668240917b8..aa3081fabccc 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4281,7 +4281,7 @@ index 7668240917..aa3081fabc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
-index 8c9acee029..400cb61311 100644
+index 8c9acee0293a..400cb61311bc 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
 @@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4296,7 +4296,7 @@ index 8c9acee029..400cb61311 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
-index b63d8b6e6f..74ddfeaeb0 100644
+index b63d8b6e6fe4..74ddfeaeb0c1 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4311,7 +4311,7 @@ index b63d8b6e6f..74ddfeaeb0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
-index 6480b5f786..45ff2eb655 100644
+index 6480b5f7867a..45ff2eb65518 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4326,7 +4326,7 @@ index 6480b5f786..45ff2eb655 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
-index a1dae5bfec..35bcbd0bc6 100644
+index a1dae5bfec71..35bcbd0bc616 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4341,7 +4341,7 @@ index a1dae5bfec..35bcbd0bc6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
-index fb157ec2ad..51ae00ed2a 100644
+index fb157ec2ad6f..51ae00ed2abd 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4356,7 +4356,7 @@ index fb157ec2ad..51ae00ed2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
-index c098912b76..fe1adb7445 100644
+index c098912b760f..fe1adb74453e 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4371,7 +4371,7 @@ index c098912b76..fe1adb7445 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
-index 46255c3242..9e81111fa3 100644
+index 46255c32429f..9e81111fa3b8 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4386,7 +4386,7 @@ index 46255c3242..9e81111fa3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
-index 3c3f10e984..5a70f16f73 100644
+index 3c3f10e984a0..5a70f16f7370 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4401,7 +4401,7 @@ index 3c3f10e984..5a70f16f73 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
-index 51a296016a..8795241631 100644
+index 51a296016ada..8795241631a3 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4416,7 +4416,7 @@ index 51a296016a..8795241631 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
-index f1c4138f12..2740485a4c 100644
+index f1c4138f12f8..2740485a4cc6 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4431,7 +4431,7 @@ index f1c4138f12..2740485a4c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
-index 442f60843d..ca72431d9e 100644
+index 442f60843dcb..ca72431d9eba 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 @@ -277,6 +277,35 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4471,7 +4471,7 @@ index 442f60843d..ca72431d9e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
-index 4414259d7e..ca1a4b681e 100644
+index 4414259d7ed7..ca1a4b681ec0 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 @@ -132,6 +132,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4487,7 +4487,7 @@ index 4414259d7e..ca1a4b681e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_gn/moz.build b/third_party/libwebrtc/modules/module_api_gn/moz.build
-index 5d16a3e7e5..035a1f304c 100644
+index 5d16a3e7e5e3..035a1f304ca5 100644
 --- a/third_party/libwebrtc/modules/module_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4502,7 +4502,7 @@ index 5d16a3e7e5..035a1f304c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_public_gn/moz.build b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
-index 38f4c929eb..2413fd7f27 100644
+index 38f4c929ebff..2413fd7f2787 100644
 --- a/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4517,7 +4517,7 @@ index 38f4c929eb..2413fd7f27 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
-index 2c8d429c92..41cab323bd 100644
+index 2c8d429c9230..41cab323bd54 100644
 --- a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4532,7 +4532,7 @@ index 2c8d429c92..41cab323bd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
-index 4b4e2e1bf4..fbc98f8eb0 100644
+index 4b4e2e1bf40e..fbc98f8eb033 100644
 --- a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4547,7 +4547,7 @@ index 4b4e2e1bf4..fbc98f8eb0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
-index f713d0737f..3d820032b1 100644
+index f713d0737f63..3d820032b1da 100644
 --- a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4562,7 +4562,7 @@ index f713d0737f..3d820032b1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
-index 2f721caab1..d7f19e195c 100644
+index 2f721caab1e2..d7f19e195cf8 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4577,7 +4577,7 @@ index 2f721caab1..d7f19e195c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
-index 70b2e3fe35..77996721f4 100644
+index 70b2e3fe3590..77996721f4f2 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4592,7 +4592,7 @@ index 70b2e3fe35..77996721f4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
-index a0d7d7e0ac..4198059909 100644
+index a0d7d7e0ac3e..4198059909a0 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4607,7 +4607,7 @@ index a0d7d7e0ac..4198059909 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
-index 3cdc29623f..9a052a61c0 100644
+index 3cdc29623f2c..9a052a61c0c9 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4622,7 +4622,7 @@ index 3cdc29623f..9a052a61c0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
-index db194c628d..9cc6ca303f 100644
+index db194c628d2d..9cc6ca303ff8 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4637,7 +4637,7 @@ index db194c628d..9cc6ca303f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
-index 82edd94526..16184b2eb9 100644
+index 82edd9452695..16184b2eb9c0 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4652,7 +4652,7 @@ index 82edd94526..16184b2eb9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
-index 335232a62b..c2a039d179 100644
+index 335232a62bbe..c2a039d17990 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 @@ -198,6 +198,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4667,7 +4667,7 @@ index 335232a62b..c2a039d179 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
-index 91531e0c5f..cb01601a3d 100644
+index 91531e0c5ff8..cb01601a3da6 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
 @@ -209,6 +209,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4682,7 +4682,7 @@ index 91531e0c5f..cb01601a3d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
-index 2c4f895923..ac96b1909b 100644
+index 2c4f89592394..ac96b1909b07 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4697,7 +4697,7 @@ index 2c4f895923..ac96b1909b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
-index 855a7c640e..2b15d9f143 100644
+index 855a7c640e94..2b15d9f1439b 100644
 --- a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4712,7 +4712,7 @@ index 855a7c640e..2b15d9f143 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
-index e49c5be296..4dd04f1c15 100644
+index e49c5be29664..4dd04f1c1594 100644
 --- a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4727,7 +4727,7 @@ index e49c5be296..4dd04f1c15 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
-index 35318f094a..e365ac87b4 100644
+index 35318f094ae1..e365ac87b42e 100644
 --- a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4742,7 +4742,7 @@ index 35318f094a..e365ac87b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/utility/utility_gn/moz.build b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
-index 08951c311a..2ed1f7e7aa 100644
+index 08951c311a33..2ed1f7e7aa74 100644
 --- a/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4757,7 +4757,7 @@ index 08951c311a..2ed1f7e7aa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
-index ce9b51191c..7e2ff67942 100644
+index ce9b51191cb9..7e2ff679429c 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 @@ -185,6 +185,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4772,7 +4772,7 @@ index ce9b51191c..7e2ff67942 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
-index c0bac40647..f85896a2dd 100644
+index c0bac4064793..f85896a2dd80 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4787,7 +4787,7 @@ index c0bac40647..f85896a2dd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
-index 4d13e69f7b..61ffeec4a9 100644
+index 4d13e69f7bff..61ffeec4a905 100644
 --- a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4802,7 +4802,7 @@ index 4d13e69f7b..61ffeec4a9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
-index 7fd4ec68f2..bc8152852e 100644
+index 7fd4ec68f2ef..bc8152852e81 100644
 --- a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4817,7 +4817,7 @@ index 7fd4ec68f2..bc8152852e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
-index 68e07db4ea..77632d3579 100644
+index 68e07db4ea7b..77632d3579fa 100644
 --- a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4832,7 +4832,7 @@ index 68e07db4ea..77632d3579 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
-index ff8f03e990..b73fff4fd1 100644
+index ff8f03e9900d..b73fff4fd1b0 100644
 --- a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4847,7 +4847,7 @@ index ff8f03e990..b73fff4fd1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
-index a353fa0c1a..ecad283906 100644
+index a353fa0c1a55..ecad28390671 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4862,7 +4862,7 @@ index a353fa0c1a..ecad283906 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
-index 23f3426af9..3901cf74ce 100644
+index 23f3426af9e8..3901cf74ce8c 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4877,7 +4877,7 @@ index 23f3426af9..3901cf74ce 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
-index 293c5a9447..29bef5e131 100644
+index 293c5a94474f..29bef5e13199 100644
 --- a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4892,7 +4892,7 @@ index 293c5a9447..29bef5e131 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
-index 61b529cd9a..1d12163a99 100644
+index 61b529cd9a1d..1d12163a9929 100644
 --- a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4907,7 +4907,7 @@ index 61b529cd9a..1d12163a99 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
-index 81bf962b05..98188de263 100644
+index 81bf962b0588..98188de26333 100644
 --- a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4922,7 +4922,7 @@ index 81bf962b05..98188de263 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
-index deb0e75d02..435cf6cacc 100644
+index deb0e75d02d7..435cf6cacc77 100644
 --- a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4937,7 +4937,7 @@ index deb0e75d02..435cf6cacc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
-index a927c85233..6a5f242d15 100644
+index a927c852333b..6a5f242d1573 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4952,7 +4952,7 @@ index a927c85233..6a5f242d15 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
-index 7d99ca631f..44fbc39c93 100644
+index 7d99ca631f7f..44fbc39c9312 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4967,7 +4967,7 @@ index 7d99ca631f..44fbc39c93 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
-index de65ae6081..04823c62b7 100644
+index de65ae6081b2..04823c62b79b 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4982,7 +4982,7 @@ index de65ae6081..04823c62b7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
-index 9ac42accf0..90d351fca9 100644
+index 9ac42accf0a2..90d351fca94e 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4997,7 +4997,7 @@ index 9ac42accf0..90d351fca9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
-index edf94ba576..dfd85219b4 100644
+index edf94ba576b4..dfd85219b4c5 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5012,7 +5012,7 @@ index edf94ba576..dfd85219b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
-index 33b768c83d..a0b90bed32 100644
+index 33b768c83d9b..a0b90bed324c 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5027,7 +5027,7 @@ index 33b768c83d..a0b90bed32 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
-index 2e60885cc8..79e7354ba8 100644
+index 2e60885cc8ad..79e7354ba8f7 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5042,7 +5042,7 @@ index 2e60885cc8..79e7354ba8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
-index 93e4dc45ce..ee28702d27 100644
+index 93e4dc45ce3b..ee28702d2713 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5057,7 +5057,7 @@ index 93e4dc45ce..ee28702d27 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
-index 38d5005afb..e207c3091a 100644
+index 38d5005afb1d..e207c3091abf 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5072,7 +5072,7 @@ index 38d5005afb..e207c3091a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
-index f8c4616bcd..a438c56d5b 100644
+index f8c4616bcda2..a438c56d5bc3 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5087,7 +5087,7 @@ index f8c4616bcd..a438c56d5b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
-index d517c26f4e..a14bd99b05 100644
+index d517c26f4ee2..a14bd99b0581 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5102,7 +5102,7 @@ index d517c26f4e..a14bd99b05 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
-index dfd036b770..ce06b2f9a3 100644
+index dfd036b7704b..ce06b2f9a333 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5117,7 +5117,7 @@ index dfd036b770..ce06b2f9a3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
-index 35788afdc0..5fec3c4088 100644
+index 35788afdc052..5fec3c40884d 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5132,7 +5132,7 @@ index 35788afdc0..5fec3c4088 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
-index 73901879e7..373ab4f712 100644
+index 73901879e767..373ab4f71295 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 @@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5147,7 +5147,7 @@ index 73901879e7..373ab4f712 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
-index e94a117cf5..e9707b69d0 100644
+index e94a117cf5ae..e9707b69d0d9 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5162,7 +5162,7 @@ index e94a117cf5..e9707b69d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
-index a0a827f8c6..af7259688c 100644
+index a0a827f8c662..af7259688c71 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5177,7 +5177,7 @@ index a0a827f8c6..af7259688c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
-index c6c24c5e66..98d44aed76 100644
+index c6c24c5e660a..98d44aed7690 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5192,7 +5192,7 @@ index c6c24c5e66..98d44aed76 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
-index 9e4b59514b..91f6e07538 100644
+index 9e4b59514b55..91f6e07538df 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5207,7 +5207,7 @@ index 9e4b59514b..91f6e07538 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
-index 79230cbf34..542704a7ea 100644
+index 79230cbf3497..542704a7ea08 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5222,7 +5222,7 @@ index 79230cbf34..542704a7ea 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
-index 2c74ca51d9..58084a8ab9 100644
+index 2c74ca51d93a..58084a8ab905 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5237,7 +5237,7 @@ index 2c74ca51d9..58084a8ab9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
-index 55f24e7c5f..b6b506bf6e 100644
+index 55f24e7c5f25..b6b506bf6ea3 100644
 --- a/third_party/libwebrtc/moz.build
 +++ b/third_party/libwebrtc/moz.build
 @@ -738,6 +738,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
@@ -5255,7 +5255,7 @@ index 55f24e7c5f..b6b506bf6e 100644
  
      DIRS += [
 diff --git a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
-index 04a6adf963..e851085ec9 100644
+index 04a6adf96394..e851085ec91d 100644
 --- a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5270,7 +5270,7 @@ index 04a6adf963..e851085ec9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
-index 9337d72a6b..9c67d5f615 100644
+index 9337d72a6bc5..9c67d5f61577 100644
 --- a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5285,7 +5285,7 @@ index 9337d72a6b..9c67d5f615 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
-index 6d057c77d7..60baff9d29 100644
+index 6d057c77d749..60baff9d293a 100644
 --- a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5300,7 +5300,7 @@ index 6d057c77d7..60baff9d29 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
-index b9848a2879..bfe0141e97 100644
+index b9848a28795a..bfe0141e97c0 100644
 --- a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5315,7 +5315,7 @@ index b9848a2879..bfe0141e97 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
-index 3019986ef2..8f182a59a6 100644
+index 3019986ef2ea..8f182a59a612 100644
 --- a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5330,7 +5330,7 @@ index 3019986ef2..8f182a59a6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
-index 08b85e88db..d7d7e3f8ee 100644
+index 08b85e88db60..d7d7e3f8eed6 100644
 --- a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5345,7 +5345,7 @@ index 08b85e88db..d7d7e3f8ee 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
-index ca6f8408cd..cf5f724f48 100644
+index ca6f8408cdc8..cf5f724f48c5 100644
 --- a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5360,7 +5360,7 @@ index ca6f8408cd..cf5f724f48 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
-index 925b6e4218..8d92cec39f 100644
+index 925b6e4218f3..8d92cec39f77 100644
 --- a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5375,7 +5375,7 @@ index 925b6e4218..8d92cec39f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
-index 44c220a2f7..0d19631abd 100644
+index 44c220a2f709..0d19631abddb 100644
 --- a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5390,7 +5390,7 @@ index 44c220a2f7..0d19631abd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/checks_gn/moz.build b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
-index ea191d0a16..9137c22c68 100644
+index ea191d0a1620..9137c22c68df 100644
 --- a/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5405,7 +5405,7 @@ index ea191d0a16..9137c22c68 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
-index 29b7e50f59..a530128302 100644
+index 29b7e50f59de..a530128302c8 100644
 --- a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5420,7 +5420,7 @@ index 29b7e50f59..a530128302 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
-index 3cf4d58b70..265d36f3cb 100644
+index 3cf4d58b7080..265d36f3cbba 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5435,7 +5435,7 @@ index 3cf4d58b70..265d36f3cb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
-index 7dbec67793..3204d866a8 100644
+index 7dbec6779333..3204d866a889 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5450,7 +5450,7 @@ index 7dbec67793..3204d866a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
-index ad3fa67255..e8d551e985 100644
+index ad3fa6725577..e8d551e9850c 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5465,7 +5465,7 @@ index ad3fa67255..e8d551e985 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
-index 9e422ff63e..512ee957bd 100644
+index 9e422ff63e7c..512ee957bdec 100644
 --- a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5480,7 +5480,7 @@ index 9e422ff63e..512ee957bd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
-index 82b4602953..581ea5572e 100644
+index 82b460295383..581ea5572e44 100644
 --- a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5495,7 +5495,7 @@ index 82b4602953..581ea5572e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
-index bcbc3682ad..2cb742076e 100644
+index bcbc3682adb0..2cb742076ee4 100644
 --- a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5510,7 +5510,7 @@ index bcbc3682ad..2cb742076e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
-index 9011068358..19ed013eff 100644
+index 90110683589b..19ed013effbf 100644
 --- a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5525,7 +5525,7 @@ index 9011068358..19ed013eff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
-index 4c41814829..0bfaae99bf 100644
+index 4c4181482928..0bfaae99bf1d 100644
 --- a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5540,7 +5540,7 @@ index 4c41814829..0bfaae99bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
-index 4e53a89a05..9a7fd22f7e 100644
+index 4e53a89a0562..9a7fd22f7ef3 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5555,7 +5555,7 @@ index 4e53a89a05..9a7fd22f7e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
-index 3ddc28da45..bf3ea6d012 100644
+index 3ddc28da45c3..bf3ea6d012ae 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5570,7 +5570,7 @@ index 3ddc28da45..bf3ea6d012 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
-index 8ab7b59f9a..a35f9a80f8 100644
+index 8ab7b59f9ac5..a35f9a80f85a 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5585,7 +5585,7 @@ index 8ab7b59f9a..a35f9a80f8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
-index 7c2115ee42..c0b6ba9ada 100644
+index 7c2115ee42eb..c0b6ba9adae0 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5600,7 +5600,7 @@ index 7c2115ee42..c0b6ba9ada 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
-index 80ee96a366..bf1a1b0a58 100644
+index 80ee96a36692..bf1a1b0a58a3 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5615,7 +5615,7 @@ index 80ee96a366..bf1a1b0a58 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
-index 237ee94c87..da3e4a9f15 100644
+index 237ee94c876c..da3e4a9f15c7 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5630,7 +5630,7 @@ index 237ee94c87..da3e4a9f15 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
-index 4f2adbf257..b299002d74 100644
+index 4f2adbf257e3..b299002d742e 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5645,7 +5645,7 @@ index 4f2adbf257..b299002d74 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
-index 0d309eb7e4..4ab9dc0a1b 100644
+index 0d309eb7e460..4ab9dc0a1b40 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5660,7 +5660,7 @@ index 0d309eb7e4..4ab9dc0a1b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
-index 59d541e6a0..6bd59f95b8 100644
+index 59d541e6a005..6bd59f95b86c 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5675,7 +5675,7 @@ index 59d541e6a0..6bd59f95b8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
-index 34a32a0e0d..9c1bcac1ad 100644
+index 34a32a0e0d68..9c1bcac1ad3b 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5690,7 +5690,7 @@ index 34a32a0e0d..9c1bcac1ad 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
-index 90de4c0afe..1a5108c256 100644
+index 90de4c0afe60..1a5108c25670 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5705,7 +5705,7 @@ index 90de4c0afe..1a5108c256 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
-index d73e4f6d7f..418cf67071 100644
+index d73e4f6d7f93..418cf67071e6 100644
 --- a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5720,7 +5720,7 @@ index d73e4f6d7f..418cf67071 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
-index 39f95b2ec8..736f4a0a5d 100644
+index 39f95b2ec843..736f4a0a5dc0 100644
 --- a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5735,7 +5735,7 @@ index 39f95b2ec8..736f4a0a5d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
-index a9e54dfe82..4cd5b3b5e7 100644
+index a9e54dfe82c8..4cd5b3b5e7df 100644
 --- a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5750,7 +5750,7 @@ index a9e54dfe82..4cd5b3b5e7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
-index c50706007b..1b0a2ad769 100644
+index c50706007bf3..1b0a2ad769ee 100644
 --- a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5765,7 +5765,7 @@ index c50706007b..1b0a2ad769 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
-index d7e6c9f293..646246bdb1 100644
+index d7e6c9f293db..646246bdb10c 100644
 --- a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5780,7 +5780,7 @@ index d7e6c9f293..646246bdb1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/logging_gn/moz.build b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
-index 56ed104e20..4c6d7abac6 100644
+index 56ed104e2002..4c6d7abac6d8 100644
 --- a/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5795,7 +5795,7 @@ index 56ed104e20..4c6d7abac6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
-index 359df288f2..63870be4cb 100644
+index 359df288f2c1..63870be4cbde 100644
 --- a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5810,7 +5810,7 @@ index 359df288f2..63870be4cb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
-index d09905b698..42a562cd6e 100644
+index d09905b69892..42a562cd6eb0 100644
 --- a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5825,7 +5825,7 @@ index d09905b698..42a562cd6e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
-index b65e15c66b..745e908c26 100644
+index b65e15c66b17..745e908c261a 100644
 --- a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5840,7 +5840,7 @@ index b65e15c66b..745e908c26 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
-index f04b67d19d..e6cab14863 100644
+index f04b67d19d4f..e6cab148631a 100644
 --- a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5855,7 +5855,7 @@ index f04b67d19d..e6cab14863 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
-index db5cf7eda3..7d6a0c1eea 100644
+index db5cf7eda3e1..7d6a0c1eea3a 100644
 --- a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5870,7 +5870,7 @@ index db5cf7eda3..7d6a0c1eea 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
-index 51dafd65f7..ff6d63a302 100644
+index 51dafd65f729..ff6d63a30259 100644
 --- a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5885,7 +5885,7 @@ index 51dafd65f7..ff6d63a302 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
-index 3871a5742f..fa37216051 100644
+index 3871a5742f23..fa3721605173 100644
 --- a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5900,7 +5900,7 @@ index 3871a5742f..fa37216051 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
-index e016c6ebf3..fab30aea18 100644
+index e016c6ebf353..fab30aea18cc 100644
 --- a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5915,7 +5915,7 @@ index e016c6ebf3..fab30aea18 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
-index d36384ccc5..0632f66dd1 100644
+index d36384ccc5e4..0632f66dd160 100644
 --- a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5930,7 +5930,7 @@ index d36384ccc5..0632f66dd1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
-index 2d37973247..76935767b3 100644
+index 2d3797324776..76935767b3a9 100644
 --- a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5945,7 +5945,7 @@ index 2d37973247..76935767b3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
-index e12f306d61..f8299c7070 100644
+index e12f306d6159..f8299c7070af 100644
 --- a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5960,7 +5960,7 @@ index e12f306d61..f8299c7070 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
-index de9df4d78a..f14d554708 100644
+index de9df4d78af5..f14d55470841 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5975,7 +5975,7 @@ index de9df4d78a..f14d554708 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
-index fa305fd318..4267bc8917 100644
+index fa305fd318ba..4267bc8917c7 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5990,7 +5990,7 @@ index fa305fd318..4267bc8917 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
-index 89ac56a987..a2f9b43c7b 100644
+index 89ac56a987e5..a2f9b43c7b55 100644
 --- a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6005,7 +6005,7 @@ index 89ac56a987..a2f9b43c7b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
-index 8fe24e9ea3..1fd412a127 100644
+index 8fe24e9ea339..1fd412a12791 100644
 --- a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6020,7 +6020,7 @@ index 8fe24e9ea3..1fd412a127 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/random_gn/moz.build b/third_party/libwebrtc/rtc_base/random_gn/moz.build
-index 3790744893..5eb27b7c0c 100644
+index 3790744893dc..5eb27b7c0c18 100644
 --- a/third_party/libwebrtc/rtc_base/random_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/random_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6035,7 +6035,7 @@ index 3790744893..5eb27b7c0c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
-index 5329a3ecff..4cd2b1b74c 100644
+index 5329a3ecff3d..4cd2b1b74c98 100644
 --- a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6050,7 +6050,7 @@ index 5329a3ecff..4cd2b1b74c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
-index dcf729ffe8..d3023fa86a 100644
+index dcf729ffe8ed..d3023fa86ac7 100644
 --- a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6065,7 +6065,7 @@ index dcf729ffe8..d3023fa86a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
-index 0c54b37a13..f705ec197f 100644
+index 0c54b37a137f..f705ec197f16 100644
 --- a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6080,7 +6080,7 @@ index 0c54b37a13..f705ec197f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
-index 9f5c572f20..2f03f163cb 100644
+index 9f5c572f202c..2f03f163cb91 100644
 --- a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6095,7 +6095,7 @@ index 9f5c572f20..2f03f163cb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
-index 879a61c336..9be5da4aa9 100644
+index 879a61c33625..9be5da4aa9ba 100644
 --- a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6110,7 +6110,7 @@ index 879a61c336..9be5da4aa9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
-index 28da0c6981..af467cb246 100644
+index 28da0c698193..af467cb246a6 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6125,7 +6125,7 @@ index 28da0c6981..af467cb246 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
-index dc606f8e63..570d06207f 100644
+index dc606f8e631b..570d06207fe5 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6140,7 +6140,7 @@ index dc606f8e63..570d06207f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
-index 6bd90aff9d..4c5fd40a3d 100644
+index 6bd90aff9d21..4c5fd40a3d0f 100644
 --- a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6155,7 +6155,7 @@ index 6bd90aff9d..4c5fd40a3d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
-index 728f9986f5..3ad4ce1611 100644
+index 728f9986f5bb..3ad4ce1611f3 100644
 --- a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6170,7 +6170,7 @@ index 728f9986f5..3ad4ce1611 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
-index 08d6ed5a08..ccb12cde91 100644
+index 08d6ed5a08e3..ccb12cde91ee 100644
 --- a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6185,7 +6185,7 @@ index 08d6ed5a08..ccb12cde91 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
-index bf6a8ed2ea..9b326e883f 100644
+index bf6a8ed2ea36..9b326e883fe7 100644
 --- a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6200,7 +6200,7 @@ index bf6a8ed2ea..9b326e883f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
-index 10412ea91e..b00a4f1ce8 100644
+index 10412ea91e8b..b00a4f1ce8e2 100644
 --- a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6215,7 +6215,7 @@ index 10412ea91e..b00a4f1ce8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
-index a519752955..a5c5910e37 100644
+index a519752955ba..a5c5910e371a 100644
 --- a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6230,7 +6230,7 @@ index a519752955..a5c5910e37 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
-index a7ffe7659d..5985c59599 100644
+index a7ffe7659d0d..5985c595994e 100644
 --- a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6245,7 +6245,7 @@ index a7ffe7659d..5985c59599 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
-index 25090bb71a..d4f5a5f72b 100644
+index 25090bb71acd..d4f5a5f72b10 100644
 --- a/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6260,7 +6260,7 @@ index 25090bb71a..d4f5a5f72b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
-index c8422272d8..52de83238d 100644
+index c8422272d86d..52de83238d75 100644
 --- a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6275,7 +6275,7 @@ index c8422272d8..52de83238d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
-index 5918111073..4eed42fbea 100644
+index 5918111073da..4eed42fbea6a 100644
 --- a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6290,7 +6290,7 @@ index 5918111073..4eed42fbea 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
-index 75921a43ab..22c1666b2a 100644
+index 75921a43ab56..22c1666b2aa4 100644
 --- a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6305,7 +6305,7 @@ index 75921a43ab..22c1666b2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build b/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
-index 04a9115ab9..33985429f0 100644
+index 04a9115ab9ef..33985429f072 100644
 --- a/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6320,7 +6320,7 @@ index 04a9115ab9..33985429f0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
-index ca2c7814e8..e37cd370de 100644
+index ca2c7814e857..e37cd370defd 100644
 --- a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6335,7 +6335,7 @@ index ca2c7814e8..e37cd370de 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
-index b643fe459c..594e4321ea 100644
+index b643fe459c81..594e4321ea81 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6350,7 +6350,7 @@ index b643fe459c..594e4321ea 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
-index bb5927b75d..ac396e7d49 100644
+index bb5927b75df3..ac396e7d49f5 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6365,7 +6365,7 @@ index bb5927b75d..ac396e7d49 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
-index 395ae6db1d..01ebb5d3b0 100644
+index 395ae6db1d66..01ebb5d3b024 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6380,7 +6380,7 @@ index 395ae6db1d..01ebb5d3b0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
-index 9b37438275..09b236427f 100644
+index 9b3743827556..09b236427faa 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6395,7 +6395,7 @@ index 9b37438275..09b236427f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
-index eab84dd331..2c2693b224 100644
+index eab84dd33140..2c2693b2247e 100644
 --- a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6410,7 +6410,7 @@ index eab84dd331..2c2693b224 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
-index 4fa2a39958..21ffa1f6c2 100644
+index 4fa2a3995855..21ffa1f6c28d 100644
 --- a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6425,7 +6425,7 @@ index 4fa2a39958..21ffa1f6c2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
-index d807d9e45d..35743644d3 100644
+index d807d9e45d42..35743644d3a5 100644
 --- a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6440,7 +6440,7 @@ index d807d9e45d..35743644d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
-index e427abf570..78f566d60b 100644
+index e427abf5700d..78f566d60b80 100644
 --- a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6455,7 +6455,7 @@ index e427abf570..78f566d60b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
-index 8003a8f5e6..9c66fb6e6c 100644
+index 8003a8f5e6ff..9c66fb6e6c96 100644
 --- a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6470,7 +6470,7 @@ index 8003a8f5e6..9c66fb6e6c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
-index d58855bc2c..e729cf85f6 100644
+index d58855bc2c57..e729cf85f60c 100644
 --- a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6485,7 +6485,7 @@ index d58855bc2c..e729cf85f6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
-index 14c87f46cf..14748b2962 100644
+index 14c87f46cf75..14748b296225 100644
 --- a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6500,7 +6500,7 @@ index 14c87f46cf..14748b2962 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
-index 639589a852..3685f98223 100644
+index 639589a8525d..3685f98223e3 100644
 --- a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6515,7 +6515,7 @@ index 639589a852..3685f98223 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
-index 330b87a2f8..64cc25cd84 100644
+index 330b87a2f876..64cc25cd8499 100644
 --- a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6530,7 +6530,7 @@ index 330b87a2f8..64cc25cd84 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
-index 813e85ca2e..02109571ff 100644
+index 813e85ca2e2a..02109571ff31 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6545,7 +6545,7 @@ index 813e85ca2e..02109571ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
-index dc375810b3..58b2ab2e02 100644
+index dc375810b3f0..58b2ab2e02e1 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6560,7 +6560,7 @@ index dc375810b3..58b2ab2e02 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/threading_gn/moz.build b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
-index 56cbe529d1..2c8fb04588 100644
+index 56cbe529d143..2c8fb04588fd 100644
 --- a/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6575,7 +6575,7 @@ index 56cbe529d1..2c8fb04588 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
-index bb37032aff..a43a48fd04 100644
+index bb37032aff82..a43a48fd040d 100644
 --- a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6590,7 +6590,7 @@ index bb37032aff..a43a48fd04 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
-index 1236cdcdc0..e6e91fb175 100644
+index 1236cdcdc0ef..e6e91fb1752a 100644
 --- a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6605,7 +6605,7 @@ index 1236cdcdc0..e6e91fb175 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
-index a3b15450a5..91dd02ba91 100644
+index a3b15450a5d8..91dd02ba91d6 100644
 --- a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6620,7 +6620,7 @@ index a3b15450a5..91dd02ba91 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
-index 4bf43cc484..a9f6528204 100644
+index 4bf43cc48410..a9f6528204da 100644
 --- a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6635,7 +6635,7 @@ index 4bf43cc484..a9f6528204 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
-index cd3c1db313..1b48412e86 100644
+index cd3c1db313a2..1b48412e8667 100644
 --- a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6650,7 +6650,7 @@ index cd3c1db313..1b48412e86 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
-index bfff36ec02..7b5eb60689 100644
+index bfff36ec02ab..7b5eb606898b 100644
 --- a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6665,7 +6665,7 @@ index bfff36ec02..7b5eb60689 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
-index e112c4874c..2a83b4c6e5 100644
+index e112c4874c1f..2a83b4c6e5a4 100644
 --- a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6680,7 +6680,7 @@ index e112c4874c..2a83b4c6e5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
-index 460a3a1137..fe7d699a57 100644
+index 460a3a113757..fe7d699a5746 100644
 --- a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6695,7 +6695,7 @@ index 460a3a1137..fe7d699a57 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
-index 29156ca219..8ab3e074dc 100644
+index 29156ca2193e..8ab3e074dced 100644
 --- a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6710,7 +6710,7 @@ index 29156ca219..8ab3e074dc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
-index 02d7c603b9..969a57e972 100644
+index 02d7c603b974..969a57e972f9 100644
 --- a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6725,7 +6725,7 @@ index 02d7c603b9..969a57e972 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
-index bedfa0c56d..307fe40fa1 100644
+index bedfa0c56dbe..307fe40fa131 100644
 --- a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 +++ b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6740,7 +6740,7 @@ index bedfa0c56d..307fe40fa1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
-index 8ce02c0e89..c7f19a51f7 100644
+index 8ce02c0e89e8..c7f19a51f7c5 100644
 --- a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 +++ b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6755,7 +6755,7 @@ index 8ce02c0e89..c7f19a51f7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
-index 32e84e422d..c189baeda4 100644
+index 32e84e422d97..c189baeda445 100644
 --- a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 @@ -133,6 +133,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6770,7 +6770,7 @@ index 32e84e422d..c189baeda4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
-index 836a04a7c7..dc7c06ffc2 100644
+index 836a04a7c723..dc7c06ffc21f 100644
 --- a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 @@ -105,6 +105,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6786,7 +6786,7 @@ index 836a04a7c7..dc7c06ffc2 100644
  
      DEFINES["PFFFT_SIMD_DISABLE"] = True
 diff --git a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
-index b10b4c330e..2dfd79a68c 100644
+index b10b4c330ef8..2dfd79a68cf7 100644
 --- a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 @@ -104,6 +104,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6801,7 +6801,7 @@ index b10b4c330e..2dfd79a68c 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
-index 92db0ecf14..733ad9677d 100644
+index 92db0ecf14f2..733ad9677d9b 100644
 --- a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6816,7 +6816,7 @@ index 92db0ecf14..733ad9677d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
-index 25d4e52bc2..4458ec919c 100644
+index 25d4e52bc234..4458ec919cef 100644
 --- a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6831,7 +6831,7 @@ index 25d4e52bc2..4458ec919c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/streams_config_gn/moz.build b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
-index 84750d67a3..60e1adc086 100644
+index 84750d67a3fd..60e1adc086dc 100644
 --- a/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6846,7 +6846,7 @@ index 84750d67a3..60e1adc086 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
-index e5b92baba4..318312bb2e 100644
+index e5b92baba40f..318312bb2e00 100644
 --- a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 +++ b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6861,7 +6861,7 @@ index e5b92baba4..318312bb2e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
-index 5817a5b68a..70b60938e7 100644
+index 5817a5b68a3c..70b60938e799 100644
 --- a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6876,7 +6876,7 @@ index 5817a5b68a..70b60938e7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
-index ae358f5489..e6d728e268 100644
+index ae358f548924..e6d728e268fe 100644
 --- a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6891,7 +6891,7 @@ index ae358f5489..e6d728e268 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
-index 0deade49e8..023979923b 100644
+index 0deade49e8f6..023979923bd7 100644
 --- a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6906,7 +6906,7 @@ index 0deade49e8..023979923b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
-index 8129c6209e..f16ee7de50 100644
+index 8129c6209e6b..f16ee7de5045 100644
 --- a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6921,7 +6921,7 @@ index 8129c6209e..f16ee7de50 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
-index 25b047e379..4bb8d34042 100644
+index 25b047e3798f..4bb8d3404281 100644
 --- a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6936,7 +6936,7 @@ index 25b047e379..4bb8d34042 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
-index 1669990518..88255d201e 100644
+index 166999051875..88255d201e1f 100644
 --- a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6951,7 +6951,7 @@ index 1669990518..88255d201e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
-index 6a9ad8451a..d7c9f30c4c 100644
+index 6a9ad8451a57..d7c9f30c4c01 100644
 --- a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6966,7 +6966,7 @@ index 6a9ad8451a..d7c9f30c4c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
-index b2df93f203..ecfe1039e6 100644
+index b2df93f20386..ecfe1039e6b5 100644
 --- a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6981,7 +6981,7 @@ index b2df93f203..ecfe1039e6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
-index edd42aa502..40c35a89cf 100644
+index edd42aa502c4..40c35a89cfcc 100644
 --- a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 +++ b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6996,7 +6996,7 @@ index edd42aa502..40c35a89cf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_gn/moz.build b/third_party/libwebrtc/video/video_gn/moz.build
-index 73a0749f29..f5efc5419d 100644
+index 73a0749f2926..f5efc5419dd3 100644
 --- a/third_party/libwebrtc/video/video_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_gn/moz.build
 @@ -174,6 +174,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7011,7 +7011,7 @@ index 73a0749f29..f5efc5419d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
-index 2ddf1cba30..cbddf5e9f5 100644
+index 2ddf1cba308d..cbddf5e9f5b3 100644
 --- a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7026,7 +7026,7 @@ index 2ddf1cba30..cbddf5e9f5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
-index f86dbd03a9..7e1915cfd5 100644
+index f86dbd03a98b..7e1915cfd541 100644
 --- a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7041,7 +7041,7 @@ index f86dbd03a9..7e1915cfd5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
-index 2c9ea4a7d6..f16aaabd07 100644
+index 2c9ea4a7d6c0..f16aaabd075e 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7056,7 +7056,7 @@ index 2c9ea4a7d6..f16aaabd07 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
-index 68109330f1..1e2b0a8a1a 100644
+index 68109330f136..1e2b0a8a1a95 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7071,7 +7071,7 @@ index 68109330f1..1e2b0a8a1a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/webrtc_gn/moz.build b/third_party/libwebrtc/webrtc_gn/moz.build
-index 50e90f5868..c8498f563f 100644
+index 50e90f5868e1..c8498f563f9d 100644
 --- a/third_party/libwebrtc/webrtc_gn/moz.build
 +++ b/third_party/libwebrtc/webrtc_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":

--- a/app-web/firefox/autobuild/patches/0004-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
+++ b/app-web/firefox/autobuild/patches/0004-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
@@ -1,7 +1,7 @@
 From 1d0b8be14f5abb654c8953bebadd26051b2a0294 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:39:18 +0800
-Subject: [PATCH 4/9] enable webrtc for loongarch64 in toolkit/moz.configure
+Subject: [PATCH 04/22] enable webrtc for loongarch64 in toolkit/moz.configure
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 1 insertion(+)
 
 diff --git a/toolkit/moz.configure b/toolkit/moz.configure
-index bd6648a89e..109aa81d04 100644
+index bd6648a89e71..109aa81d0422 100644
 --- a/toolkit/moz.configure
 +++ b/toolkit/moz.configure
 @@ -1456,6 +1456,7 @@ def webrtc_default(target):

--- a/app-web/firefox/autobuild/patches/0005-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
+++ b/app-web/firefox/autobuild/patches/0005-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
@@ -1,7 +1,7 @@
 From c37ec40fca8d9528901a1ba0bf85f372182c9a43 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Tue, 3 Sep 2024 15:47:26 +0800
-Subject: [PATCH 5/9] Fix libyuv unified-source and LoongArch SIMD build
+Subject: [PATCH 05/22] Fix libyuv unified-source and LoongArch SIMD build
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  3 files changed, 32 insertions(+)
 
 diff --git a/media/libyuv/libyuv/libyuv.gypi b/media/libyuv/libyuv/libyuv.gypi
-index 1fd1be71e3..fbe35fc42e 100644
+index 1fd1be71e341..fbe35fc42e6d 100644
 --- a/media/libyuv/libyuv/libyuv.gypi
 +++ b/media/libyuv/libyuv/libyuv.gypi
 @@ -80,11 +80,14 @@
@@ -38,7 +38,7 @@ index 1fd1be71e3..fbe35fc42e 100644
        'source/scale_rgb.cc',
        'source/scale_uv.cc',
 diff --git a/media/libyuv/libyuv/source/row_lasx.cc b/media/libyuv/libyuv/source/row_lasx.cc
-index 6d49aa5e8b..52fbde9c85 100644
+index 6d49aa5e8b39..52fbde9c854b 100644
 --- a/media/libyuv/libyuv/source/row_lasx.cc
 +++ b/media/libyuv/libyuv/source/row_lasx.cc
 @@ -2000,11 +2000,13 @@ void NV21ToARGBRow_LASX(const uint8_t* src_y,
@@ -82,7 +82,7 @@ index 6d49aa5e8b..52fbde9c85 100644
  }  // extern "C"
  }  // namespace libyuv
 diff --git a/media/libyuv/libyuv/source/row_lsx.cc b/media/libyuv/libyuv/source/row_lsx.cc
-index fa088c9e78..c32c718c78 100644
+index fa088c9e78a9..c32c718c78fe 100644
 --- a/media/libyuv/libyuv/source/row_lsx.cc
 +++ b/media/libyuv/libyuv/source/row_lsx.cc
 @@ -2769,11 +2769,13 @@ void HalfFloatRow_LSX(const uint16_t* src,

--- a/app-web/firefox/autobuild/patches/0006-Fix-missing-loongarch-subdir-in-libpng-moz.yaml.patch
+++ b/app-web/firefox/autobuild/patches/0006-Fix-missing-loongarch-subdir-in-libpng-moz.yaml.patch
@@ -1,7 +1,7 @@
 From cd29c00506458935ba600a0e753650f57bd3e700 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:45:05 +0800
-Subject: [PATCH 6/9] Fix missing loongarch subdir in libpng moz.yaml
+Subject: [PATCH 06/22] Fix missing loongarch subdir in libpng moz.yaml
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  1 file changed, 1 insertion(+)
 
 diff --git a/media/libpng/moz.yaml b/media/libpng/moz.yaml
-index 4827c47286..f7de4c6454 100644
+index 4827c47286c2..f7de4c645480 100644
 --- a/media/libpng/moz.yaml
 +++ b/media/libpng/moz.yaml
 @@ -37,6 +37,7 @@ vendoring:

--- a/app-web/firefox/autobuild/patches/0007-Vendor-missing-loongarch-files-of-libpng.patch
+++ b/app-web/firefox/autobuild/patches/0007-Vendor-missing-loongarch-files-of-libpng.patch
@@ -1,7 +1,7 @@
 From 9fab931b2219f3e85a7c98be1eb6145398fec2f3 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:50:54 +0800
-Subject: [PATCH 7/9] Vendor missing loongarch files of libpng
+Subject: [PATCH 07/22] Vendor missing loongarch files of libpng
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -13,7 +13,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 
 diff --git a/media/libpng/loongarch/filter_lsx_intrinsics.c b/media/libpng/loongarch/filter_lsx_intrinsics.c
 new file mode 100644
-index 0000000000..af6cc763a0
+index 000000000000..af6cc763a078
 --- /dev/null
 +++ b/media/libpng/loongarch/filter_lsx_intrinsics.c
 @@ -0,0 +1,412 @@
@@ -431,7 +431,7 @@ index 0000000000..af6cc763a0
 +#endif /* PNG_READ_SUPPORTED */
 diff --git a/media/libpng/loongarch/loongarch_lsx_init.c b/media/libpng/loongarch/loongarch_lsx_init.c
 new file mode 100644
-index 0000000000..2c80fe81b6
+index 000000000000..2c80fe81b687
 --- /dev/null
 +++ b/media/libpng/loongarch/loongarch_lsx_init.c
 @@ -0,0 +1,65 @@

--- a/app-web/firefox/autobuild/patches/0008-Enable-LoongArch-LSX-optimization-for-libpng.patch
+++ b/app-web/firefox/autobuild/patches/0008-Enable-LoongArch-LSX-optimization-for-libpng.patch
@@ -1,7 +1,7 @@
 From d71c3da12a6150a3a449202a6ba1dc60be8458c2 Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <xen0n@gentoo.org>
 Date: Wed, 4 Sep 2024 16:51:22 +0800
-Subject: [PATCH 8/9] Enable LoongArch LSX optimization for libpng
+Subject: [PATCH 08/22] Enable LoongArch LSX optimization for libpng
 
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
  2 files changed, 14 insertions(+)
 
 diff --git a/media/libpng/moz.build b/media/libpng/moz.build
-index 6fa28a814a..a316a06237 100644
+index 6fa28a814a75..a316a0623772 100644
 --- a/media/libpng/moz.build
 +++ b/media/libpng/moz.build
 @@ -50,6 +50,13 @@ if CONFIG['INTEL_ARCHITECTURE']:
@@ -28,7 +28,7 @@ index 6fa28a814a..a316a06237 100644
      DEFINES['MOZ_PNG_USE_MIPS_MSA'] = True
      UNIFIED_SOURCES += [
 diff --git a/media/libpng/pnglibconf.h b/media/libpng/pnglibconf.h
-index 1cbb828436..8ef91386ff 100644
+index 1cbb828436de..8ef91386ffe4 100644
 --- a/media/libpng/pnglibconf.h
 +++ b/media/libpng/pnglibconf.h
 @@ -54,6 +54,13 @@

--- a/app-web/firefox/autobuild/patches/0009-Bug-1938855-MIPS-Replace-BytecodeOffset-with-TrapSit.patch
+++ b/app-web/firefox/autobuild/patches/0009-Bug-1938855-MIPS-Replace-BytecodeOffset-with-TrapSit.patch
@@ -1,7 +1,7 @@
 From ca9cf02649e1738e9c06f407a6dd787d8aa7f72c Mon Sep 17 00:00:00 2001
 From: Xuan Chen <chenx97@aosc.io>
 Date: Tue, 14 Jan 2025 21:41:32 +0000
-Subject: [PATCH 9/9] Bug 1938855 - [MIPS] Replace BytecodeOffset with
+Subject: [PATCH 09/22] Bug 1938855 - [MIPS] Replace BytecodeOffset with
  TrapSiteDesc. r=rhunt
 
 Differential Revision: https://phabricator.services.mozilla.com/D232815
@@ -15,7 +15,7 @@ Differential Revision: https://phabricator.services.mozilla.com/D232815
  6 files changed, 45 insertions(+), 45 deletions(-)
 
 diff --git a/js/src/jit/mips-shared/CodeGenerator-mips-shared.cpp b/js/src/jit/mips-shared/CodeGenerator-mips-shared.cpp
-index 7a4047efb4..d36678a5e6 100644
+index 7a4047efb4ed..d36678a5e65e 100644
 --- a/js/src/jit/mips-shared/CodeGenerator-mips-shared.cpp
 +++ b/js/src/jit/mips-shared/CodeGenerator-mips-shared.cpp
 @@ -440,7 +440,7 @@ void CodeGenerator::visitDivI(LDivI* ins) {
@@ -94,7 +94,7 @@ index 7a4047efb4..d36678a5e6 100644
  }
  
 diff --git a/js/src/jit/mips-shared/LIR-mips-shared.h b/js/src/jit/mips-shared/LIR-mips-shared.h
-index a302be061e..9ca426b00c 100644
+index a302be061e36..9ca426b00c66 100644
 --- a/js/src/jit/mips-shared/LIR-mips-shared.h
 +++ b/js/src/jit/mips-shared/LIR-mips-shared.h
 @@ -192,12 +192,12 @@ class LUDivOrMod : public LBinaryMath<0> {
@@ -114,7 +114,7 @@ index a302be061e..9ca426b00c 100644
  };
  
 diff --git a/js/src/jit/mips32/CodeGenerator-mips32.cpp b/js/src/jit/mips32/CodeGenerator-mips32.cpp
-index 9efe8828fa..3fe833ee1b 100644
+index 9efe8828fae4..3fe833ee1b3b 100644
 --- a/js/src/jit/mips32/CodeGenerator-mips32.cpp
 +++ b/js/src/jit/mips32/CodeGenerator-mips32.cpp
 @@ -81,7 +81,7 @@ void CodeGenerator::visitDivOrModI64(LDivOrModI64* lir) {
@@ -219,7 +219,7 @@ index 9efe8828fa..3fe833ee1b 100644
      }
    }
 diff --git a/js/src/jit/mips32/LIR-mips32.h b/js/src/jit/mips32/LIR-mips32.h
-index da68ad7464..12ba54ed6e 100644
+index da68ad746449..12ba54ed6ef9 100644
 --- a/js/src/jit/mips32/LIR-mips32.h
 +++ b/js/src/jit/mips32/LIR-mips32.h
 @@ -88,12 +88,12 @@ class LDivOrModI64
@@ -255,7 +255,7 @@ index da68ad7464..12ba54ed6e 100644
  };
  
 diff --git a/js/src/jit/mips64/CodeGenerator-mips64.cpp b/js/src/jit/mips64/CodeGenerator-mips64.cpp
-index b1afee8181..03363e6fc2 100644
+index b1afee818128..03363e6fc25e 100644
 --- a/js/src/jit/mips64/CodeGenerator-mips64.cpp
 +++ b/js/src/jit/mips64/CodeGenerator-mips64.cpp
 @@ -139,7 +139,7 @@ void CodeGenerator::visitDivOrModI64(LDivOrModI64* lir) {
@@ -286,7 +286,7 @@ index b1afee8181..03363e6fc2 100644
    }
  
 diff --git a/js/src/jit/mips64/LIR-mips64.h b/js/src/jit/mips64/LIR-mips64.h
-index 4d8228418c..176c526106 100644
+index 4d8228418ce6..176c52610693 100644
 --- a/js/src/jit/mips64/LIR-mips64.h
 +++ b/js/src/jit/mips64/LIR-mips64.h
 @@ -72,12 +72,12 @@ class LDivOrModI64 : public LBinaryMath<1> {

--- a/app-web/firefox/autobuild/patches/0010-BACKPORT-Bug-1924066-part1-implement-HEVC-support-on.patch
+++ b/app-web/firefox/autobuild/patches/0010-BACKPORT-Bug-1924066-part1-implement-HEVC-support-on.patch
@@ -1,0 +1,474 @@
+From 637365a1204324587e8cd6ec9360adcd9a277a36 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Wed, 22 Jan 2025 22:35:17 +0000
+Subject: [PATCH 10/22] BACKPORT: Bug 1924066 - part1 : implement HEVC support
+ on MacOS by using the platform decoder. r=media-playback-reviewers,padenot
+
+We use the videotoolbox video decoder to support HEVC SW and HW decoding
+on MacOS. The input data needs to be feeding in HVCC format.
+
+Differential Revision: https://phabricator.services.mozilla.com/D234235
+---
+ dom/media/ipc/MediaIPCUtils.h                 |  2 +-
+ dom/media/ipc/RemoteDecoderManagerChild.cpp   |  4 +-
+ dom/media/platforms/PlatformDecoderModule.h   |  1 +
+ .../platforms/agnostic/bytestreams/H265.cpp   | 64 +++++++++++++
+ .../platforms/agnostic/bytestreams/H265.h     |  9 ++
+ .../platforms/apple/AppleDecoderModule.cpp    | 90 ++++++++++++-------
+ dom/media/platforms/apple/AppleVTDecoder.cpp  | 65 ++++++++++----
+ dom/media/platforms/apple/AppleVTDecoder.h    | 15 +++-
+ .../platforms/wrappers/MediaChangeMonitor.cpp |  8 +-
+ 9 files changed, 205 insertions(+), 53 deletions(-)
+
+diff --git a/dom/media/ipc/MediaIPCUtils.h b/dom/media/ipc/MediaIPCUtils.h
+index ffacd0fa35a0..ee618ddbeeb6 100644
+--- a/dom/media/ipc/MediaIPCUtils.h
++++ b/dom/media/ipc/MediaIPCUtils.h
+@@ -215,7 +215,7 @@ struct ParamTraits<mozilla::MediaDataDecoder::ConversionRequired>
+           mozilla::MediaDataDecoder::ConversionRequired,
+           mozilla::MediaDataDecoder::ConversionRequired(0),
+           mozilla::MediaDataDecoder::ConversionRequired(
+-              mozilla::MediaDataDecoder::ConversionRequired::kNeedAnnexB)> {};
++              mozilla::MediaDataDecoder::ConversionRequired::kNeedHVCC)> {};
+ 
+ template <>
+ struct ParamTraits<mozilla::media::TimeUnit> {
+diff --git a/dom/media/ipc/RemoteDecoderManagerChild.cpp b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+index 002cdfd3e303..6d51f954eef8 100644
+--- a/dom/media/ipc/RemoteDecoderManagerChild.cpp
++++ b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+@@ -278,8 +278,10 @@ bool RemoteDecoderManagerChild::Supports(
+         }
+         return aLocation == RemoteDecodeIn::UtilityProcess_MFMediaEngineCDM ||
+                aLocation == RemoteDecodeIn::GpuProcess;
++#elif defined(MOZ_APPLEMEDIA)
++        return trackSupport.contains(TrackSupport::Video);
+ #else
+-        // TODO : in the future, we need to add HEVC check on other platforms.
++        // TODO : still need to add support on Android and Linux.
+         return false;
+ #endif
+       }
+diff --git a/dom/media/platforms/PlatformDecoderModule.h b/dom/media/platforms/PlatformDecoderModule.h
+index 31bef53a6f83..a81bc19ab114 100644
+--- a/dom/media/platforms/PlatformDecoderModule.h
++++ b/dom/media/platforms/PlatformDecoderModule.h
+@@ -621,6 +621,7 @@ class MediaDataDecoder : public DecoderDoctorLifeLogger<MediaDataDecoder> {
+     kNeedNone = 0,
+     kNeedAVCC = 1,
+     kNeedAnnexB = 2,
++    kNeedHVCC = 3,
+   };
+ 
+   // Indicates that the decoder requires a specific format.
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.cpp b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+index bf2fe4b6b22b..fad917488a59 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.cpp
++++ b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+@@ -1294,6 +1294,70 @@ bool H265::CompareExtraData(const mozilla::MediaByteBuffer* aExtraData1,
+   return true;
+ }
+ 
++/* static */
++uint32_t H265::ComputeMaxRefFrames(const mozilla::MediaByteBuffer* aExtraData) {
++  auto rv = DecodeSPSFromHVCCExtraData(aExtraData);
++  if (rv.isErr()) {
++    return 0;
++  }
++  return rv.unwrap().sps_max_dec_pic_buffering_minus1[0] + 1;
++}
++
++/* static */
++already_AddRefed<mozilla::MediaByteBuffer> H265::CreateFakeExtraData() {
++  // Create fake VPS, SPS, PPS and append them into HVCC box
++  static const uint8_t sFakeVPS[] = {
++      0x40, 0x01, 0x0C, 0x01, 0xFF, 0xFF, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00,
++      0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x3F, 0x95, 0x98, 0x09};
++  static const uint8_t sFakeSPS[] = {
++      0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00,
++      0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x3F, 0xA0, 0x05, 0x02, 0x01,
++      0x69, 0x65, 0x95, 0x9A, 0x49, 0x32, 0xBC, 0x04, 0x04, 0x00, 0x00,
++      0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0x78, 0x20};
++  static const uint8_t sFakePPS[] = {0x44, 0x01, 0xC1, 0x72, 0xB4, 0x62, 0x40};
++  nsTArray<H265NALU> nalus;
++  nalus.AppendElement(H265NALU{sFakeVPS, sizeof(sFakeVPS)});
++  nalus.AppendElement(H265NALU{sFakeSPS, sizeof(sFakeSPS)});
++  nalus.AppendElement(H265NALU{sFakePPS, sizeof(sFakePPS)});
++
++  // HEVCDecoderConfigurationRecord (HVCC) is in ISO/IEC 14496-15 8.3.2.1.2
++  const uint8_t nalLenSize = 4;
++  auto extradata = MakeRefPtr<mozilla::MediaByteBuffer>();
++  BitWriter writer(extradata);
++  writer.WriteBits(1, 8);               // version
++  writer.WriteBits(0, 2);               // general_profile_space
++  writer.WriteBits(0, 1);               // general_tier_flag
++  writer.WriteBits(1 /* main */, 5);    // general_profile_idc
++  writer.WriteU32(0);                   // general_profile_compatibility_flags
++  writer.WriteBits(0, 48);              // general_constraint_indicator_flags
++  writer.WriteU8(1 /* level 1 */);      // general_level_idc
++  writer.WriteBits(0, 4);               // reserved
++  writer.WriteBits(0, 12);              // min_spatial_segmentation_idc
++  writer.WriteBits(0, 6);               // reserved
++  writer.WriteBits(0, 2);               // parallelismType
++  writer.WriteBits(0, 6);               // reserved
++  writer.WriteBits(0, 2);               // chroma_format_idc
++  writer.WriteBits(0, 5);               // reserved
++  writer.WriteBits(0, 3);               // bit_depth_luma_minus8
++  writer.WriteBits(0, 5);               // reserved
++  writer.WriteBits(0, 3);               // bit_depth_chroma_minus8
++  writer.WriteBits(0, 22);              // avgFrameRate + constantFrameRate +
++                                        // numTemporalLayers + temporalIdNested
++  writer.WriteBits(nalLenSize - 1, 2);  // lengthSizeMinusOne
++  writer.WriteU8(nalus.Length());       // numOfArrays
++  for (auto& nalu : nalus) {
++    writer.WriteBits(0, 2);                     // array_completeness + reserved
++    writer.WriteBits(nalu.mNalUnitType, 6);     // NAL_unit_type
++    writer.WriteBits(1, 16);                    // numNalus
++    writer.WriteBits(nalu.mNALU.Length(), 16);  // nalUnitLength
++    MOZ_ASSERT(writer.BitCount() % 8 == 0);
++    extradata->AppendElements(nalu.mNALU.Elements(), nalu.mNALU.Length());
++    writer.AdvanceBytes(nalu.mNALU.Length());
++  }
++  MOZ_ASSERT(HVCCConfig::Parse(extradata).isOk());
++  return extradata.forget();
++}
++
+ #undef LOG
+ #undef LOGV
+ 
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.h b/dom/media/platforms/agnostic/bytestreams/H265.h
+index 5aca28e5cb6f..4f46ee8af28b 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.h
++++ b/dom/media/platforms/agnostic/bytestreams/H265.h
+@@ -318,6 +318,15 @@ class H265 final {
+   static bool CompareExtraData(const mozilla::MediaByteBuffer* aExtraData1,
+                                const mozilla::MediaByteBuffer* aExtraData2);
+ 
++  // Return the value of sps_max_dec_pic_buffering_minus1[0] + 1 from a valid
++  // SPS in the extradata, otherwise return 0.
++  static uint32_t ComputeMaxRefFrames(
++      const mozilla::MediaByteBuffer* aExtraData);
++
++  // Create a dummy extradata, useful to create a decoder and test the
++  // capabilities of the decoder.
++  static already_AddRefed<mozilla::MediaByteBuffer> CreateFakeExtraData();
++
+  private:
+   // Return RAW BYTE SEQUENCE PAYLOAD (rbsp) from NAL content.
+   static already_AddRefed<mozilla::MediaByteBuffer> DecodeNALUnit(
+diff --git a/dom/media/platforms/apple/AppleDecoderModule.cpp b/dom/media/platforms/apple/AppleDecoderModule.cpp
+index b92369601ce1..5f46160aebe1 100644
+--- a/dom/media/platforms/apple/AppleDecoderModule.cpp
++++ b/dom/media/platforms/apple/AppleDecoderModule.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include "AppleATDecoder.h"
+ #include "AppleVTDecoder.h"
++#include "H265.h"
+ #include "MP4Decoder.h"
+ #include "VideoUtils.h"
+ #include "VPXDecoder.h"
+@@ -33,9 +34,20 @@ using media::DecodeSupportSet;
+ using media::MCSInfo;
+ using media::MediaCodec;
+ 
+-bool AppleDecoderModule::sInitialized = false;
+-bool AppleDecoderModule::sCanUseVP9Decoder = false;
+-bool AppleDecoderModule::sCanUseAV1Decoder = false;
++static inline CMVideoCodecType GetCMVideoCodecType(const MediaCodec& aCodec) {
++  switch (aCodec) {
++    case MediaCodec::H264:
++      return kCMVideoCodecType_H264;
++    case MediaCodec::AV1:
++      return kCMVideoCodecType_AV1;
++    case MediaCodec::VP9:
++      return kCMVideoCodecType_VP9;
++    case MediaCodec::HEVC:
++      return kCMVideoCodecType_HEVC;
++    default:
++      return static_cast<CMVideoCodecType>(0);
++  }
++}
+ 
+ /* static */
+ void AppleDecoderModule::Init() {
+@@ -43,6 +55,24 @@ void AppleDecoderModule::Init() {
+     return;
+   }
+ 
++  // Initialize all values to false first.
++  for (auto& support : sCanUseHWDecoder) {
++    support = false;
++  }
++
++  // H264 HW is supported since 10.6.
++  sCanUseHWDecoder[MediaCodec::H264] = CanCreateHWDecoder(MediaCodec::H264);
++  // HEVC HW is supported since 10.13.
++  sCanUseHWDecoder[MediaCodec::HEVC] = CanCreateHWDecoder(MediaCodec::HEVC);
++  // VP9 HW is supported since 11.0 on Apple silicon.
++  sCanUseHWDecoder[MediaCodec::VP9] =
++      RegisterSupplementalDecoder(MediaCodec::VP9) &&
++      CanCreateHWDecoder(MediaCodec::VP9);
++  // AV1 HW is supported since 14.0 on Apple silicon.
++  sCanUseHWDecoder[MediaCodec::AV1] =
++      RegisterSupplementalDecoder(MediaCodec::AV1) &&
++      CanCreateHWDecoder(MediaCodec::AV1);
++
+   sInitialized = true;
+   if (RegisterSupplementalVP9Decoder()) {
+     sCanUseVP9Decoder = CanCreateHWDecoder(MediaCodec::VP9);
+@@ -84,10 +114,10 @@ already_AddRefed<MediaDataDecoder> AppleDecoderModule::CreateAudioDecoder(
+ 
+ DecodeSupportSet AppleDecoderModule::SupportsMimeType(
+     const nsACString& aMimeType, DecoderDoctorDiagnostics* aDiagnostics) const {
+-  bool checkSupport = aMimeType.EqualsLiteral("audio/mp4a-latm") ||
+-                      MP4Decoder::IsH264(aMimeType) ||
+-                      VPXDecoder::IsVP9(aMimeType) ||
+-                      AOMDecoder::IsAV1(aMimeType);
++  bool checkSupport =
++      aMimeType.EqualsLiteral("audio/mp4a-latm") ||
++      MP4Decoder::IsH264(aMimeType) || VPXDecoder::IsVP9(aMimeType) ||
++      AOMDecoder::IsAV1(aMimeType) || MP4Decoder::IsHEVC(aMimeType);
+   DecodeSupportSet supportType{};
+ 
+   if (checkSupport) {
+@@ -146,6 +176,9 @@ bool AppleDecoderModule::IsVideoSupported(
+   if (MP4Decoder::IsH264(aConfig.mMimeType)) {
+     return true;
+   }
++  if (MP4Decoder::IsHEVC(aConfig.mMimeType)) {
++    return true;
++  }
+   if (AOMDecoder::IsAV1(aConfig.mMimeType)) {
+     if (!sCanUseAV1Decoder ||
+         aOptions.contains(
+@@ -250,29 +283,26 @@ bool AppleDecoderModule::CanCreateHWDecoder(MediaCodec aCodec) {
+       vtReportsSupport = false;
+       break;
+   }
+-  // VT reports HW decode is supported -- verify by creating an actual decoder
+-  if (vtReportsSupport) {
+-    RefPtr<AppleVTDecoder> decoder =
+-        new AppleVTDecoder(info, nullptr, {}, nullptr, Nothing());
+-    MediaResult rv = decoder->InitializeSession();
+-    if (!NS_SUCCEEDED(rv)) {
+-      MOZ_LOG(
+-          sPDMLog, LogLevel::Debug,
+-          ("Apple HW decode failure while initializing VT decoder session"));
+-      return false;
+-    }
+-    nsAutoCString failureReason;
+-    // IsHardwareAccelerated appears to return invalid results for H.264 so
+-    // we assume that the earlier VTIsHardwareDecodeSupported call is correct.
+-    // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1716196#c7
+-    bool hwSupport = decoder->IsHardwareAccelerated(failureReason) ||
+-                     aCodec == MediaCodec::H264;
+-    if (!hwSupport) {
+-      MOZ_LOG(sPDMLog, LogLevel::Debug,
+-              ("Apple HW decode failure: '%s'", failureReason.BeginReading()));
+-    }
+-    decoder->Shutdown();
+-    return hwSupport;
++
++  // Build up a fake extradata to create an actual decoder to verify
++  VideoInfo info(1920, 1080);
++  if (aCodec == MediaCodec::AV1) {
++    info.mMimeType = "video/av1";
++    bool hasSeqHdr;
++    AOMDecoder::AV1SequenceInfo seqInfo;
++    AOMDecoder::OperatingPoint op;
++    seqInfo.mOperatingPoints.AppendElement(op);
++    seqInfo.mImage = {1920, 1080};
++    AOMDecoder::WriteAV1CBox(seqInfo, info.mExtraData, hasSeqHdr);
++  } else if (aCodec == MediaCodec::VP9) {
++    info.mMimeType = "video/vp9";
++    VPXDecoder::GetVPCCBox(info.mExtraData, VPXDecoder::VPXStreamInfo());
++  } else if (aCodec == MediaCodec::HEVC) {
++    // Although HEVC hardware decoding is supported starting with macOS 10.13
++    // and we only support macOS 10.15+, Intel GPUs (Skylake and later, 2015)
++    // that support HEVC are not old enough to skip verification.
++    info.mMimeType = "video/hevc";
++    info.mExtraData = H265::CreateFakeExtraData();
+   }
+   return false;
+ }
+diff --git a/dom/media/platforms/apple/AppleVTDecoder.cpp b/dom/media/platforms/apple/AppleVTDecoder.cpp
+index 6c937eace9c1..f78de7fb9092 100644
+--- a/dom/media/platforms/apple/AppleVTDecoder.cpp
++++ b/dom/media/platforms/apple/AppleVTDecoder.cpp
+@@ -15,6 +15,7 @@
+ #include "AppleUtils.h"
+ #include "CallbackThreadRegistry.h"
+ #include "H264.h"
++#include "H265.h"
+ #include "MP4Decoder.h"
+ #include "MacIOSurfaceImage.h"
+ #include "MediaData.h"
+@@ -54,18 +55,12 @@ AppleVTDecoder::AppleVTDecoder(const VideoInfo& aConfig,
+                             : gfx::TransferFunction::BT709),
+       mColorRange(aConfig.mColorRange),
+       mColorDepth(aConfig.mColorDepth),
+-      mStreamType(MP4Decoder::IsH264(aConfig.mMimeType)  ? StreamType::H264
+-                  : VPXDecoder::IsVP9(aConfig.mMimeType) ? StreamType::VP9
+-                  : AOMDecoder::IsAV1(aConfig.mMimeType) ? StreamType::AV1
+-                                                         : StreamType::Unknown),
++      mStreamType(AppleVTDecoder::GetStreamType(aConfig.mMimeType)),
+       mTaskQueue(TaskQueue::Create(
+           GetMediaThreadPool(MediaThreadType::PLATFORM_DECODER),
+           "AppleVTDecoder")),
+-      mMaxRefFrames(
+-          mStreamType != StreamType::H264 ||
+-                  aOptions.contains(CreateDecoderParams::Option::LowLatency)
+-              ? 0
+-              : H264::ComputeMaxRefFrames(aConfig.mExtraData)),
++      mMaxRefFrames(GetMaxRefFrames(
++          aOptions.contains(CreateDecoderParams::Option::LowLatency))),
+       mImageContainer(aImageContainer),
+       mKnowsCompositor(aKnowsCompositor)
+ #ifdef MOZ_WIDGET_UIKIT
+@@ -89,9 +84,9 @@ AppleVTDecoder::AppleVTDecoder(const VideoInfo& aConfig,
+       mIsHardwareAccelerated(false) {
+   MOZ_COUNT_CTOR(AppleVTDecoder);
+   MOZ_ASSERT(mStreamType != StreamType::Unknown);
+-  // TODO: Verify aConfig.mime_type.
+-  LOG("Creating AppleVTDecoder for %dx%d %s video", mDisplayWidth,
+-      mDisplayHeight, EnumValueToString(mStreamType));
++  LOG("Creating AppleVTDecoder for %dx%d %s video, mMaxRefFrames=%u",
++      mDisplayWidth, mDisplayHeight, EnumValueToString(mStreamType),
++      mMaxRefFrames);
+ }
+ 
+ AppleVTDecoder::~AppleVTDecoder() { MOZ_COUNT_DTOR(AppleVTDecoder); }
+@@ -182,6 +177,9 @@ void AppleVTDecoder::ProcessDecode(MediaRawData* aSample) {
+       case StreamType::AV1:
+         flag |= MediaInfoFlag::VIDEO_AV1;
+         break;
++      case StreamType::HEVC:
++        flag |= MediaInfoFlag::VIDEO_HEVC;
++        break;
+       default:
+         break;
+     }
+@@ -603,6 +601,8 @@ MediaResult AppleVTDecoder::InitializeSession() {
+     streamType = kCMVideoCodecType_H264;
+   } else if (mStreamType == StreamType::VP9) {
+     streamType = CMVideoCodecType(AppleDecoderModule::kCMVideoCodecType_VP9);
++  } else if (mStreamType == StreamType::HEVC) {
++    streamType = kCMVideoCodecType_HEVC;
+   } else {
+     streamType = kCMVideoCodecType_AV1;
+   }
+@@ -661,10 +661,16 @@ CFDictionaryRef AppleVTDecoder::CreateDecoderExtensions() {
+                    AssertedCast<CFIndex>(mExtraData->Length()));
+ 
+   const void* atomsKey[1];
+-  atomsKey[0] = mStreamType == StreamType::H264  ? CFSTR("avcC")
+-                : mStreamType == StreamType::VP9 ? CFSTR("vpcC")
+-                                                 : CFSTR("av1C");
+-  ;
++  if (mStreamType == StreamType::H264) {
++    atomsKey[0] = CFSTR("avcC");
++  } else if (mStreamType == StreamType::VP9) {
++    atomsKey[0] = CFSTR("vpcC");
++  } else if (mStreamType == StreamType::HEVC) {
++    atomsKey[0] = CFSTR("hvcC");
++  } else {
++    atomsKey[0] = CFSTR("av1C");
++  }
++
+   const void* atomsValue[] = {data};
+   static_assert(std::size(atomsKey) == std::size(atomsValue),
+                 "Non matching keys/values array size");
+@@ -759,6 +765,33 @@ CFDictionaryRef AppleVTDecoder::CreateOutputConfiguration() {
+       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+ }
+ 
++AppleVTDecoder::StreamType AppleVTDecoder::GetStreamType(
++    const nsCString& aMimeType) const {
++  if (MP4Decoder::IsH264(aMimeType)) {
++    return StreamType::H264;
++  }
++  if (MP4Decoder::IsHEVC(aMimeType)) {
++    return StreamType::HEVC;
++  }
++  if (VPXDecoder::IsVP9(aMimeType)) {
++    return StreamType::VP9;
++  }
++  if (AOMDecoder::IsAV1(aMimeType)) {
++    return StreamType::AV1;
++  }
++  return StreamType::Unknown;
++}
++
++uint32_t AppleVTDecoder::GetMaxRefFrames(bool aIsLowLatency) const {
++  if (mStreamType == StreamType::H264 && !aIsLowLatency) {
++    return H264::ComputeMaxRefFrames(mExtraData);
++  }
++  if (mStreamType == StreamType::HEVC && !aIsLowLatency) {
++    return H265::ComputeMaxRefFrames(mExtraData);
++  }
++  return 0;
++}
++
+ }  // namespace mozilla
+ 
+ #undef LOG
+diff --git a/dom/media/platforms/apple/AppleVTDecoder.h b/dom/media/platforms/apple/AppleVTDecoder.h
+index 970f71d4c707..c7e5a783f79c 100644
+--- a/dom/media/platforms/apple/AppleVTDecoder.h
++++ b/dom/media/platforms/apple/AppleVTDecoder.h
+@@ -71,7 +71,13 @@ class AppleVTDecoder final : public MediaDataDecoder,
+   nsCString GetCodecName() const override;
+ 
+   ConversionRequired NeedsConversion() const override {
+-    return ConversionRequired::kNeedAVCC;
++    if (mStreamType == StreamType::H264) {
++      return ConversionRequired::kNeedAVCC;
++    }
++    if (mStreamType == StreamType::HEVC) {
++      return ConversionRequired::kNeedHVCC;
++    }
++    return ConversionRequired::kNeedNone;
+   }
+ 
+   // Access from the taskqueue and the decoder's thread.
+@@ -113,7 +119,12 @@ class AppleVTDecoder final : public MediaDataDecoder,
+   CFDictionaryRef CreateDecoderExtensions();
+ 
+   MOZ_DEFINE_ENUM_CLASS_WITH_TOSTRING_AT_CLASS_SCOPE(StreamType,
+-                                                     (Unknown, H264, VP9, AV1));
++                                                     (Unknown, H264, VP9, AV1,
++                                                      HEVC));
++
++  StreamType GetStreamType(const nsCString& aMimeType) const;
++  uint32_t GetMaxRefFrames(bool aIsLowLatency) const;
++
+   const StreamType mStreamType;
+   const RefPtr<TaskQueue> mTaskQueue;
+   const uint32_t mMaxRefFrames;
+diff --git a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+index 981d1bb23550..aa346d6ecb32 100644
+--- a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
++++ b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+@@ -246,13 +246,15 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+   MediaResult PrepareSample(MediaDataDecoder::ConversionRequired aConversion,
+                             MediaRawData* aSample,
+                             bool aNeedKeyFrame) override {
+-    MOZ_DIAGNOSTIC_ASSERT(aConversion ==
+-                          MediaDataDecoder::ConversionRequired::kNeedAnnexB);
++    MOZ_DIAGNOSTIC_ASSERT(
++        aConversion == MediaDataDecoder::ConversionRequired::kNeedAnnexB ||
++        aConversion == MediaDataDecoder::ConversionRequired::kNeedHVCC);
++    MOZ_DIAGNOSTIC_ASSERT(AnnexB::IsHVCC(aSample));
+ 
+     aSample->mExtraData = mCurrentConfig.mExtraData;
+     aSample->mTrackInfo = mTrackInfo;
+ 
+-    if (AnnexB::IsHVCC(aSample)) {
++    if (aConversion == MediaDataDecoder::ConversionRequired::kNeedAnnexB) {
+       auto res = AnnexB::ConvertHVCCSampleToAnnexB(aSample, aNeedKeyFrame);
+       if (res.isErr()) {
+         return MediaResult(res.unwrapErr(),
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0011-BACKPORT-Bug-1942404-part1-make-SPSIterator-find-the.patch
+++ b/app-web/firefox/autobuild/patches/0011-BACKPORT-Bug-1942404-part1-make-SPSIterator-find-the.patch
@@ -1,0 +1,81 @@
+From 7f72ad27209daea97abf5421b0ba91f52a2f3e76 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Tue, 28 Jan 2025 23:15:28 +0000
+Subject: [PATCH 11/22] BACKPORT: Bug 1942404 - part1 : make SPSIterator find
+ the SPS in the ctor. r=padenot
+
+The current implementation of SPSIterator is incorrect; it requires
+calling the `++` operator before accessing any SPS. The `*` operator
+should allow access to the SPS immediately after the SPSIterator is created.
+
+Differential Revision: https://phabricator.services.mozilla.com/D235526
+---
+ .../platforms/agnostic/bytestreams/H265.cpp   | 43 +++++++++++++------
+ 1 file changed, 31 insertions(+), 12 deletions(-)
+
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.cpp b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+index fad917488a59..53fbe3bb8f5f 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.cpp
++++ b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+@@ -1222,27 +1222,46 @@ already_AddRefed<mozilla::MediaByteBuffer> H265::ExtractHVCCExtraData(
+ 
+ class SPSIterator final {
+  public:
+-  explicit SPSIterator(const HVCCConfig& aConfig) : mConfig(aConfig) {}
++  explicit SPSIterator(const HVCCConfig& aConfig)
++      : mCurrentIdx(0), mConfig(aConfig) {
++    FindSPS();
++  }
+ 
+   SPSIterator& operator++() {
+-    size_t idx = 0;
+-    for (idx = mNextIdx; idx < mConfig.mNALUs.Length(); idx++) {
++    mCurrentIdx++;
++    FindSPS();
++    return *this;
++  }
++
++  explicit operator bool() const { return IsValid(); }
++
++  const H265NALU* operator*() const {
++    if (!IsValid()) {
++      return nullptr;
++    }
++    if (!mConfig.mNALUs[mCurrentIdx].IsSPS()) {
++      return nullptr;
++    }
++    return &mConfig.mNALUs[mCurrentIdx];
++  }
++
++ private:
++  void FindSPS() {
++    Maybe<size_t> spsIdx;
++    for (auto idx = mCurrentIdx; idx < mConfig.mNALUs.Length(); idx++) {
+       if (mConfig.mNALUs[idx].IsSPS()) {
+-        mSPS = &mConfig.mNALUs[idx];
++        spsIdx = Some(idx);
+         break;
+       }
+     }
+-    mNextIdx = idx + 1;
+-    return *this;
++    if (spsIdx) {
++      mCurrentIdx = *spsIdx;
++    }
+   }
+ 
+-  explicit operator bool() const { return mNextIdx < mConfig.mNALUs.Length(); }
++  bool IsValid() const { return mCurrentIdx < mConfig.mNALUs.Length(); }
+ 
+-  const H265NALU* operator*() const { return mSPS ? mSPS : nullptr; }
+-
+- private:
+-  size_t mNextIdx = 0;
+-  const H265NALU* mSPS = nullptr;
++  size_t mCurrentIdx;
+   const HVCCConfig& mConfig;
+ };
+ 
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0012-BACKPORT-Bug-1942404-part2-compare-SPS-by-its-member.patch
+++ b/app-web/firefox/autobuild/patches/0012-BACKPORT-Bug-1942404-part2-compare-SPS-by-its-member.patch
@@ -1,0 +1,148 @@
+From 4606b6bcd2ffca6224f644d2c65f5fc3574cd352 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Tue, 28 Jan 2025 23:15:29 +0000
+Subject: [PATCH 12/22] BACKPORT: Bug 1942404 - part2 : compare SPS by its
+ members, not using memcmp. r=padenot
+
+memcmp is unreliable due to (1) padding bytes (2) non-POD Members,
+so better to compare their members directly.
+
+Differential Revision: https://phabricator.services.mozilla.com/D235527
+---
+ .../platforms/agnostic/bytestreams/H265.cpp   | 74 ++++++++++++++++++-
+ .../platforms/agnostic/bytestreams/H265.h     |  6 ++
+ 2 files changed, 79 insertions(+), 1 deletion(-)
+
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.cpp b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+index 53fbe3bb8f5f..b467f24dec5b 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.cpp
++++ b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+@@ -54,6 +54,11 @@ mozilla::LazyLogModule gH265("H265");
+     }                                          \
+   } while (0)
+ 
++// For the comparison, we intended to not use memcpy due to its unreliability.
++#define COMPARE_FIELD(field) ((field) == aOther.field)
++#define COMPARE_ARRAY(field) \
++  std::equal(std::begin(field), std::end(field), std::begin(aOther.field))
++
+ namespace mozilla {
+ 
+ H265NALU::H265NALU(const uint8_t* aData, uint32_t aByteSize)
+@@ -502,6 +507,34 @@ uint32_t H265ProfileTierLevel::GetDpbMaxPicBuf() const {
+              : 7;
+ }
+ 
++bool H265ProfileTierLevel::operator==(
++    const H265ProfileTierLevel& aOther) const {
++  return COMPARE_FIELD(general_profile_space) &&
++         COMPARE_FIELD(general_tier_flag) &&
++         COMPARE_FIELD(general_profile_idc) &&
++         COMPARE_FIELD(general_profile_compatibility_flags) &&
++         COMPARE_FIELD(general_progressive_source_flag) &&
++         COMPARE_FIELD(general_interlaced_source_flag) &&
++         COMPARE_FIELD(general_non_packed_constraint_flag) &&
++         COMPARE_FIELD(general_frame_only_constraint_flag) &&
++         COMPARE_FIELD(general_level_idc);
++}
++
++bool H265StRefPicSet::operator==(const H265StRefPicSet& aOther) const {
++  return COMPARE_FIELD(num_negative_pics) && COMPARE_FIELD(num_positive_pics) &&
++         COMPARE_FIELD(numDeltaPocs) && COMPARE_ARRAY(usedByCurrPicS0) &&
++         COMPARE_ARRAY(usedByCurrPicS1) && COMPARE_ARRAY(deltaPocS0) &&
++         COMPARE_ARRAY(deltaPocS1);
++}
++
++bool H265VUIParameters::operator==(const H265VUIParameters& aOther) const {
++  return COMPARE_FIELD(sar_width) && COMPARE_FIELD(sar_height) &&
++         COMPARE_FIELD(video_full_range_flag) &&
++         COMPARE_FIELD(colour_primaries) &&
++         COMPARE_FIELD(transfer_characteristics) &&
++         COMPARE_FIELD(matrix_coeffs);
++}
++
+ /* static */
+ Result<Ok, nsresult> H265::ParseAndIgnoreScalingListData(BitReader& aReader) {
+   // H265 spec, 7.3.4 Scaling list data syntax
+@@ -862,7 +895,46 @@ Result<Ok, nsresult> H265::ParseAndIgnoreSubLayerHrdParameters(
+ }
+ 
+ bool H265SPS::operator==(const H265SPS& aOther) const {
+-  return memcmp(this, &aOther, sizeof(H265SPS)) == 0;
++  return COMPARE_FIELD(sps_video_parameter_set_id) &&
++         COMPARE_FIELD(sps_max_sub_layers_minus1) &&
++         COMPARE_FIELD(sps_temporal_id_nesting_flag) &&
++         COMPARE_FIELD(profile_tier_level) &&
++         COMPARE_FIELD(sps_seq_parameter_set_id) &&
++         COMPARE_FIELD(chroma_format_idc) &&
++         COMPARE_FIELD(separate_colour_plane_flag) &&
++         COMPARE_FIELD(pic_width_in_luma_samples) &&
++         COMPARE_FIELD(pic_height_in_luma_samples) &&
++         COMPARE_FIELD(conformance_window_flag) &&
++         COMPARE_FIELD(conf_win_left_offset) &&
++         COMPARE_FIELD(conf_win_right_offset) &&
++         COMPARE_FIELD(conf_win_top_offset) &&
++         COMPARE_FIELD(conf_win_bottom_offset) &&
++         COMPARE_FIELD(bit_depth_luma_minus8) &&
++         COMPARE_FIELD(bit_depth_chroma_minus8) &&
++         COMPARE_FIELD(log2_max_pic_order_cnt_lsb_minus4) &&
++         COMPARE_FIELD(sps_sub_layer_ordering_info_present_flag) &&
++         COMPARE_ARRAY(sps_max_dec_pic_buffering_minus1) &&
++         COMPARE_ARRAY(sps_max_num_reorder_pics) &&
++         COMPARE_ARRAY(sps_max_latency_increase_plus1) &&
++         COMPARE_FIELD(log2_min_luma_coding_block_size_minus3) &&
++         COMPARE_FIELD(log2_diff_max_min_luma_coding_block_size) &&
++         COMPARE_FIELD(log2_min_luma_transform_block_size_minus2) &&
++         COMPARE_FIELD(log2_diff_max_min_luma_transform_block_size) &&
++         COMPARE_FIELD(max_transform_hierarchy_depth_inter) &&
++         COMPARE_FIELD(max_transform_hierarchy_depth_intra) &&
++         COMPARE_FIELD(pcm_enabled_flag) &&
++         COMPARE_FIELD(pcm_sample_bit_depth_luma_minus1) &&
++         COMPARE_FIELD(pcm_sample_bit_depth_chroma_minus1) &&
++         COMPARE_FIELD(log2_min_pcm_luma_coding_block_size_minus3) &&
++         COMPARE_FIELD(log2_diff_max_min_pcm_luma_coding_block_size) &&
++         COMPARE_FIELD(pcm_loop_filter_disabled_flag) &&
++         COMPARE_FIELD(num_short_term_ref_pic_sets) &&
++         COMPARE_ARRAY(st_ref_pic_set) &&
++         COMPARE_FIELD(sps_temporal_mvp_enabled_flag) &&
++         COMPARE_FIELD(strong_intra_smoothing_enabled_flag) &&
++         COMPARE_FIELD(vui_parameters) && COMPARE_FIELD(subWidthC) &&
++         COMPARE_FIELD(subHeightC) && COMPARE_FIELD(mDisplayWidth) &&
++         COMPARE_FIELD(mDisplayHeight) && COMPARE_FIELD(maxDpbSize);
+ }
+ 
+ bool H265SPS::operator!=(const H265SPS& aOther) const {
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.h b/dom/media/platforms/agnostic/bytestreams/H265.h
+index 4f46ee8af28b..661bc98440f1 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.h
++++ b/dom/media/platforms/agnostic/bytestreams/H265.h
+@@ -130,6 +130,8 @@ class H265NALU final {
+ struct H265ProfileTierLevel final {
+   H265ProfileTierLevel() = default;
+ 
++  bool operator==(const H265ProfileTierLevel& aOther) const;
++
+   enum H265ProfileIdc {
+     kProfileIdcMain = 1,
+     kProfileIdcMain10 = 2,
+@@ -166,6 +168,8 @@ struct H265ProfileTierLevel final {
+ struct H265StRefPicSet final {
+   H265StRefPicSet() = default;
+ 
++  bool operator==(const H265StRefPicSet& aOther) const;
++
+   // Syntax elements.
+   uint32_t num_negative_pics = {};
+   uint32_t num_positive_pics = {};
+@@ -183,6 +187,8 @@ struct H265StRefPicSet final {
+ struct H265VUIParameters {
+   H265VUIParameters() = default;
+ 
++  bool operator==(const H265VUIParameters& aOther) const;
++
+   // Syntax elements.
+   uint32_t sar_width = {};
+   uint32_t sar_height = {};
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0013-BACKPORT-Bug-1942404-part3-only-update-changed-SPS-P.patch
+++ b/app-web/firefox/autobuild/patches/0013-BACKPORT-Bug-1942404-part3-only-update-changed-SPS-P.patch
@@ -1,0 +1,267 @@
+From 6ca643db02a382577bdd6368202c96d0cb8fd4d1 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Tue, 28 Jan 2025 23:15:30 +0000
+Subject: [PATCH 13/22] BACKPORT: Bug 1942404 - part3 : only update changed
+ SPS/PPS/VPS nalu for extradata. r=media-playback-reviewers,padenot
+
+When recreating a decoder, the VideoToolbox decoder requires extradata containing SPS, PPS,
+and VPS to successfully initialize a DecompressionSession.
+
+The current implementation replaces the extradata when a different SPS is detected but does
+not ensure that all three NALUs (SPS, PPS, and VPS) are present in the new extradata. For
+example, in `hevc_white_red_frames.mp4`, the initial extradata contains all required NALUs,
+but the inband extradata only includes an SPS without the PPS or VPS. Using such incomplete
+extradata to recreate the decoder will result in a failure to create the DecompressionSession.
+
+To resolve this, we should update only the differing NALUs to ensure all essential information
+is retained in the extradata.
+
+Differential Revision: https://phabricator.services.mozilla.com/D235528
+---
+ .../platforms/agnostic/bytestreams/H265.cpp   | 65 ++++++++++++++
+ .../platforms/agnostic/bytestreams/H265.h     | 15 +++-
+ .../platforms/wrappers/MediaChangeMonitor.cpp | 85 ++++++++++++++-----
+ 3 files changed, 141 insertions(+), 24 deletions(-)
+
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.cpp b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+index b467f24dec5b..be78ff393c16 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.cpp
++++ b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+@@ -199,6 +199,16 @@ bool HVCCConfig::HasSPS() const {
+   return hasSPS;
+ }
+ 
++Maybe<H265NALU> HVCCConfig::GetFirstAvaiableNALU(
++    H265NALU::NAL_TYPES aType) const {
++  for (const auto& nalu : mNALUs) {
++    if (nalu.mNalUnitType == aType) {
++      return Some(nalu);
++    }
++  }
++  return Nothing();
++}
++
+ /* static */
+ Result<H265SPS, nsresult> H265::DecodeSPSFromSPSNALU(const H265NALU& aSPSNALU) {
+   MOZ_ASSERT(aSPSNALU.IsSPS());
+@@ -1449,6 +1459,61 @@ already_AddRefed<mozilla::MediaByteBuffer> H265::CreateFakeExtraData() {
+   return extradata.forget();
+ }
+ 
++/* static */
++already_AddRefed<mozilla::MediaByteBuffer> H265::CreateNewExtraData(
++    const HVCCConfig& aConfig, const Maybe<H265NALU>& aSPS,
++    const Maybe<H265NALU>& aPPS, const Maybe<H265NALU>& aVPS) {
++  // Append essential NALUs if they exist
++  nsTArray<H265NALU> nalus;
++  if (aSPS) {
++    nalus.AppendElement(*aSPS);
++  }
++  if (aPPS) {
++    nalus.AppendElement(*aPPS);
++  }
++  if (aVPS) {
++    nalus.AppendElement(*aVPS);
++  }
++
++  // HEVCDecoderConfigurationRecord (HVCC) is in ISO/IEC 14496-15 8.3.2.1.2
++  auto extradata = MakeRefPtr<mozilla::MediaByteBuffer>();
++  BitWriter writer(extradata);
++  writer.WriteBits(aConfig.configurationVersion, 8);
++  writer.WriteBits(aConfig.general_profile_space, 2);
++  writer.WriteBits(aConfig.general_tier_flag, 1);
++  writer.WriteBits(aConfig.general_profile_idc, 5);
++  writer.WriteU32(aConfig.general_profile_compatibility_flags);
++  writer.WriteBits(aConfig.general_constraint_indicator_flags, 48);
++  writer.WriteU8(aConfig.general_level_idc);
++  writer.WriteBits(0, 4);  // reserved
++  writer.WriteBits(aConfig.min_spatial_segmentation_idc, 12);
++  writer.WriteBits(0, 6);  // reserved
++  writer.WriteBits(aConfig.parallelismType, 2);
++  writer.WriteBits(0, 6);  // reserved
++  writer.WriteBits(aConfig.chroma_format_idc, 2);
++  writer.WriteBits(0, 5);  // reserved
++  writer.WriteBits(aConfig.bit_depth_luma_minus8, 3);
++  writer.WriteBits(0, 5);  // reserved
++  writer.WriteBits(aConfig.bit_depth_chroma_minus8, 3);
++  writer.WriteBits(aConfig.avgFrameRate, 16);
++  writer.WriteBits(aConfig.constantFrameRate, 2);
++  writer.WriteBits(aConfig.numTemporalLayers, 3);
++  writer.WriteBits(aConfig.temporalIdNested, 1);
++  writer.WriteBits(aConfig.lengthSizeMinusOne, 2);
++  writer.WriteU8(nalus.Length());  // numOfArrays
++  for (auto& nalu : nalus) {
++    writer.WriteBits(0, 2);                     // array_completeness + reserved
++    writer.WriteBits(nalu.mNalUnitType, 6);     // NAL_unit_type
++    writer.WriteBits(1, 16);                    // numNalus
++    writer.WriteBits(nalu.mNALU.Length(), 16);  // nalUnitLength
++    MOZ_ASSERT(writer.BitCount() % 8 == 0);
++    extradata->AppendElements(nalu.mNALU.Elements(), nalu.mNALU.Length());
++    writer.AdvanceBytes(nalu.mNALU.Length());
++  }
++  MOZ_ASSERT(HVCCConfig::Parse(extradata).isOk());
++  return extradata.forget();
++}
++
+ #undef LOG
+ #undef LOGV
+ 
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.h b/dom/media/platforms/agnostic/bytestreams/H265.h
+index 661bc98440f1..ae4bf9e374f1 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.h
++++ b/dom/media/platforms/agnostic/bytestreams/H265.h
+@@ -32,7 +32,9 @@ enum {
+   kMaxSubLayers = 7,             // See [v/s]ps_max_sub_layers_minus1
+ };
+ 
+-// Spec 7.3.1 NAL unit syntax
++// H265NALU represents NALU data (Spec 7.3.1 NAL unit syntax) for convenient
++// access. In addition, this class does not own the raw RBSP data. Ensure that
++// the original data source remains valid when accessing `mNALU`.
+ class H265NALU final {
+  public:
+   H265NALU(const uint8_t* aData, uint32_t aByteSize);
+@@ -281,6 +283,10 @@ struct HVCCConfig final {
+   uint32_t NumSPS() const;
+   bool HasSPS() const;
+ 
++  // Returns the first available NALU of the specified type, or nothing if no
++  // such NALU is found.
++  Maybe<H265NALU> GetFirstAvaiableNALU(H265NALU::NAL_TYPES aType) const;
++
+   uint8_t configurationVersion;
+   uint8_t general_profile_space;
+   bool general_tier_flag;
+@@ -333,6 +339,13 @@ class H265 final {
+   // capabilities of the decoder.
+   static already_AddRefed<mozilla::MediaByteBuffer> CreateFakeExtraData();
+ 
++  // Create new extradata with the essential information from the given
++  // HVCCConfig, excluding its original NALUs. The NALUs will be replaced by the
++  // provided SPS, PPS, and VPS.
++  static already_AddRefed<mozilla::MediaByteBuffer> CreateNewExtraData(
++      const HVCCConfig& aConfig, const Maybe<H265NALU>& aSPS,
++      const Maybe<H265NALU>& aPPS, const Maybe<H265NALU>& aVPS);
++
+  private:
+   // Return RAW BYTE SEQUENCE PAYLOAD (rbsp) from NAL content.
+   static already_AddRefed<mozilla::MediaByteBuffer> DecodeNALUnit(
+diff --git a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+index aa346d6ecb32..a20fb64bc0db 100644
+--- a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
++++ b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+@@ -205,8 +205,9 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+     }
+ 
+     RefPtr<MediaByteBuffer> extraData =
+-        aSample->mKeyframe || !mGotSPS ? H265::ExtractHVCCExtraData(aSample)
+-                                       : nullptr;
++        aSample->mKeyframe || !mSPS.IsEmpty()
++            ? H265::ExtractHVCCExtraData(aSample)
++            : nullptr;
+     // Sample doesn't contain any SPS and we already have SPS, do nothing.
+     auto curConfig = HVCCConfig::Parse(mCurrentConfig.mExtraData);
+     if ((!extraData || extraData->IsEmpty()) && curConfig.unwrap().HasSPS()) {
+@@ -227,7 +228,6 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+       return NS_ERROR_NOT_INITIALIZED;
+     }
+ 
+-    mGotSPS = true;
+     if (H265::CompareExtraData(extraData, mCurrentConfig.mExtraData)) {
+       return NS_OK;
+     }
+@@ -271,32 +271,71 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+ 
+  private:
+   void UpdateConfigFromExtraData(MediaByteBuffer* aExtraData) {
+-    if (auto rv = H265::DecodeSPSFromHVCCExtraData(aExtraData); rv.isOk()) {
+-      const auto sps = rv.unwrap();
+-      mCurrentConfig.mImage.width = sps.GetImageSize().Width();
+-      mCurrentConfig.mImage.height = sps.GetImageSize().Height();
+-      mCurrentConfig.mDisplay.width = sps.GetDisplaySize().Width();
+-      mCurrentConfig.mDisplay.height = sps.GetDisplaySize().Height();
+-      mCurrentConfig.mColorDepth = sps.ColorDepth();
+-      mCurrentConfig.mColorSpace = Some(sps.ColorSpace());
+-      mCurrentConfig.mColorPrimaries = gfxUtils::CicpToColorPrimaries(
+-          static_cast<gfx::CICP::ColourPrimaries>(sps.ColorPrimaries()),
+-          gMediaDecoderLog);
+-      mCurrentConfig.mTransferFunction = gfxUtils::CicpToTransferFunction(
+-          static_cast<gfx::CICP::TransferCharacteristics>(
+-              sps.TransferFunction()));
+-      mCurrentConfig.mColorRange = sps.IsFullColorRange()
+-                                       ? gfx::ColorRange::FULL
+-                                       : gfx::ColorRange::LIMITED;
++    auto rv = HVCCConfig::Parse(aExtraData);
++    MOZ_ASSERT(rv.isOk());
++    const auto hvcc = rv.unwrap();
++
++    // If there are any new SPS/PPS/VPS, update the current stored ones.
++    if (auto nalu = hvcc.GetFirstAvaiableNALU(H265NALU::NAL_TYPES::SPS_NUT)) {
++      mSPS.Clear();
++      mSPS.AppendElements(nalu->mNALU);
++      if (auto rv = H265::DecodeSPSFromSPSNALU(*nalu); rv.isOk()) {
++        const auto sps = rv.unwrap();
++        mCurrentConfig.mImage.width = sps.GetImageSize().Width();
++        mCurrentConfig.mImage.height = sps.GetImageSize().Height();
++        mCurrentConfig.mDisplay.width = sps.GetDisplaySize().Width();
++        mCurrentConfig.mDisplay.height = sps.GetDisplaySize().Height();
++        mCurrentConfig.mColorDepth = sps.ColorDepth();
++        mCurrentConfig.mColorSpace = Some(sps.ColorSpace());
++        mCurrentConfig.mColorPrimaries = gfxUtils::CicpToColorPrimaries(
++            static_cast<gfx::CICP::ColourPrimaries>(sps.ColorPrimaries()),
++            gMediaDecoderLog);
++        mCurrentConfig.mTransferFunction = gfxUtils::CicpToTransferFunction(
++            static_cast<gfx::CICP::TransferCharacteristics>(
++                sps.TransferFunction()));
++        mCurrentConfig.mColorRange = sps.IsFullColorRange()
++                                         ? gfx::ColorRange::FULL
++                                         : gfx::ColorRange::LIMITED;
++      }
+     }
+-    MOZ_ASSERT(HVCCConfig::Parse(aExtraData).isOk());
+-    mCurrentConfig.mExtraData = aExtraData;
++    if (auto nalu = hvcc.GetFirstAvaiableNALU(H265NALU::NAL_TYPES::PPS_NUT)) {
++      mPPS.Clear();
++      mPPS.AppendElements(nalu->mNALU);
++    }
++    if (auto nalu = hvcc.GetFirstAvaiableNALU(H265NALU::NAL_TYPES::VPS_NUT)) {
++      mVPS.Clear();
++      mVPS.AppendElements(nalu->mNALU);
++    }
++
++    // Construct a new extradata. A situation we encountered previously involved
++    // the initial extradata containing all required NALUs, while the inband
++    // extradata included only an SPS without the PPS or VPS. If we replace the
++    // extradata with the inband version alone, we risk losing the VPS and PPS,
++    // leading to decoder initialization failure on macOS. To avoid this, we
++    // should update only the differing NALUs, ensuring all essential
++    // information remains in the extradata.
++    MOZ_ASSERT(!mSPS.IsEmpty());  // SPS is something MUST to have
++    Maybe<H265NALU> sps = Some(H265NALU(mSPS.Elements(), mSPS.Length()));
++    Maybe<H265NALU> pps = !mPPS.IsEmpty()
++                              ? Some(H265NALU(mPPS.Elements(), mPPS.Length()))
++                              : Nothing();
++    Maybe<H265NALU> vps = !mVPS.IsEmpty()
++                              ? Some(H265NALU(mVPS.Elements(), mVPS.Length()))
++                              : Nothing();
++    mCurrentConfig.mExtraData = H265::CreateNewExtraData(hvcc, sps, pps, vps);
+     mTrackInfo = new TrackInfoSharedPtr(mCurrentConfig, mStreamID++);
++    LOG("Updated extradata, hasSPS=%d, hasPPS=%d, hasVPS=%d", !!sps, !!pps,
++        !!vps);
+   }
+ 
+   VideoInfo mCurrentConfig;
++
++  // Full bytes content for nalu.
++  nsTArray<uint8_t> mSPS;
++  nsTArray<uint8_t> mPPS;
++  nsTArray<uint8_t> mVPS;
++
+   uint32_t mStreamID = 0;
+-  bool mGotSPS = false;
+   RefPtr<TrackInfoSharedPtr> mTrackInfo;
+ };
+ 
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0014-BACKPORT-Bug-1941945-create-a-new-pref-media.hevc.en.patch
+++ b/app-web/firefox/autobuild/patches/0014-BACKPORT-Bug-1941945-create-a-new-pref-media.hevc.en.patch
@@ -1,0 +1,342 @@
+From ac65bab19ed55438104d1a98486425c7e5d9f182 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Thu, 6 Feb 2025 21:38:27 +0000
+Subject: [PATCH 14/22] BACKPORT: Bug 1941945 - create a new pref
+ `media.hevc.enabled` to replace old pref and remove unnecessary checks and
+ tests. r=media-playback-reviewers,padenot
+
+We'd like to have a general pref to control hevc on all platforms, not
+just on Windows.
+
+Differential Revision: https://phabricator.services.mozilla.com/D236981
+
+[Henry Chen: Resolved minor conflicts in:
+dom/media/mp4/MP4Decoder.cpp]
+
+Signed-off-by: Henry Chen <chenx97@aosc.io>
+---
+ dom/media/ipc/MFCDMParent.cpp                 |  4 +-
+ dom/media/ipc/RemoteDecoderManagerChild.cpp   |  8 ++--
+ .../mediacapabilities/MediaCapabilities.cpp   | 16 --------
+ .../mediasource/test/mochitest_compat.toml    |  2 +-
+ dom/media/mp4/MP4Decoder.cpp                  |  8 +---
+ .../wmf/MFMediaEngineDecoderModule.cpp        |  2 +-
+ dom/media/platforms/wmf/WMFDecoderModule.cpp  |  2 +-
+ dom/media/test/crashtests/crashtests.list     |  6 +--
+ dom/media/test/mochitest_compat.toml          |  2 +-
+ dom/media/test/test_hevc_support.html         | 38 -------------------
+ gfx/ipc/GPUChild.cpp                          |  2 +-
+ gfx/ipc/GPUParent.cpp                         |  2 +-
+ modules/libpref/init/StaticPrefList.yaml      | 21 ++++++----
+ .../UserCharacteristicsPageService.sys.mjs    |  2 +-
+ 14 files changed, 31 insertions(+), 84 deletions(-)
+
+diff --git a/dom/media/ipc/MFCDMParent.cpp b/dom/media/ipc/MFCDMParent.cpp
+index 42d4d48efb81..2bf96acb037a 100644
+--- a/dom/media/ipc/MFCDMParent.cpp
++++ b/dom/media/ipc/MFCDMParent.cpp
+@@ -862,7 +862,7 @@ void MFCDMParent::GetCapabilities(const nsString& aKeySystem,
+   if (aFlags.contains(CapabilitesFlag::NeedClearLeadCheck)) {
+     for (const auto& codec : kVideoCodecs) {
+       if (codec == KeySystemConfig::EME_CODEC_HEVC &&
+-          !StaticPrefs::media_wmf_hevc_enabled()) {
++          !StaticPrefs::media_hevc_enabled()) {
+         continue;
+       }
+       CryptoSchemeSet supportedScheme;
+@@ -927,7 +927,7 @@ void MFCDMParent::GetCapabilities(const nsString& aKeySystem,
+     // Non clearlead situation for video codecs
+     for (const auto& codec : kVideoCodecs) {
+       if (codec == KeySystemConfig::EME_CODEC_HEVC &&
+-          !StaticPrefs::media_wmf_hevc_enabled()) {
++          !StaticPrefs::media_hevc_enabled()) {
+         continue;
+       }
+       if (FactorySupports(factory, aKeySystem, convertCodecToFourCC(codec),
+diff --git a/dom/media/ipc/RemoteDecoderManagerChild.cpp b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+index 6d51f954eef8..add1695facef 100644
+--- a/dom/media/ipc/RemoteDecoderManagerChild.cpp
++++ b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+@@ -272,16 +272,16 @@ bool RemoteDecoderManagerChild::Supports(
+       // process. As HEVC support is still a experimental feature, we don't want
+       // to report support for it arbitrarily.
+       if (MP4Decoder::IsHEVC(aParams.mConfig.mMimeType)) {
+-#if defined(XP_WIN)
+-        if (!StaticPrefs::media_wmf_hevc_enabled()) {
++        if (!StaticPrefs::media_hevc_enabled()) {
+           return false;
+         }
++#if defined(XP_WIN)
+         return aLocation == RemoteDecodeIn::UtilityProcess_MFMediaEngineCDM ||
+                aLocation == RemoteDecodeIn::GpuProcess;
+-#elif defined(MOZ_APPLEMEDIA)
++#elif defined(MOZ_APPLEMEDIA) || defined(MOZ_WIDGET_ANDROID)
+         return trackSupport.contains(TrackSupport::Video);
+ #else
+-        // TODO : still need to add support on Android and Linux.
++        // TODO : not support on Linux yet
+         return false;
+ #endif
+       }
+diff --git a/dom/media/mediacapabilities/MediaCapabilities.cpp b/dom/media/mediacapabilities/MediaCapabilities.cpp
+index e9d3cd99f224..8a80f6cbfb34 100644
+--- a/dom/media/mediacapabilities/MediaCapabilities.cpp
++++ b/dom/media/mediacapabilities/MediaCapabilities.cpp
+@@ -422,22 +422,6 @@ void MediaCapabilities::CreateMediaCapabilitiesDecodingInfo(
+       continue;
+     }
+ 
+-// Early return for non-encrypted HEVC if the pref is off.
+-#ifdef MOZ_WMF
+-    if (MP4Decoder::IsHEVC(config->mMimeType) &&
+-        StaticPrefs::media_wmf_hevc_enabled() != 1) {
+-      MediaCapabilitiesDecodingInfo info;
+-      info.mSupported = false;
+-      info.mSmooth = false;
+-      info.mPowerEfficient = false;
+-      LOG("Pref is disabled : %s -> %s",
+-          MediaDecodingConfigurationToStr(aConfiguration).get(),
+-          MediaCapabilitiesInfoToStr(info).get());
+-      aPromise->MaybeResolve(std::move(info));
+-      return;
+-    }
+-#endif
+-
+     // On Windows, the MediaDataDecoder expects to be created on a thread
+     // supporting MTA, which the main thread doesn't. So we use our task queue
+     // to create such decoder and perform initialization.
+diff --git a/dom/media/mediasource/test/mochitest_compat.toml b/dom/media/mediasource/test/mochitest_compat.toml
+index c7bdb0ea4a77..1d2ae6f9a5da 100644
+--- a/dom/media/mediasource/test/mochitest_compat.toml
++++ b/dom/media/mediasource/test/mochitest_compat.toml
+@@ -1,7 +1,7 @@
+ [DEFAULT]
+ subsuite = "media"
+ tags = "media-engine-compatible media-gpu"
+-prefs = ["media.wmf.hevc.enabled=1"] # for test_MediaSource_hevc_mp4
++prefs = ["media.hevc.enabled=1"] # for test_MediaSource_hevc_mp4
+ support-files = [
+   "mediasource.js",
+   "seek.webm",
+diff --git a/dom/media/mp4/MP4Decoder.cpp b/dom/media/mp4/MP4Decoder.cpp
+index 47614b0c4945..9fce45c08fe6 100644
+--- a/dom/media/mp4/MP4Decoder.cpp
++++ b/dom/media/mp4/MP4Decoder.cpp
+@@ -124,15 +124,13 @@ nsTArray<UniquePtr<TrackInfo>> MP4Decoder::GetTracksInfo(
+       continue;
+     }
+ #endif
+-#ifdef MOZ_WMF
+-    if (StaticPrefs::media_wmf_hevc_enabled() && IsH265CodecString(codec)) {
++    if (StaticPrefs::media_hevc_enabled() && IsH265CodecString(codec)) {
+       auto trackInfo =
+           CreateTrackInfoWithMIMETypeAndContainerTypeExtraParameters(
+               "video/hevc"_ns, aType);
+       tracks.AppendElement(std::move(trackInfo));
+       continue;
+     }
+-#endif
+     if (isVideo && IsWhitelistedH264Codec(codec)) {
+       auto trackInfo =
+           CreateTrackInfoWithMIMETypeAndContainerTypeExtraParameters(
+@@ -199,13 +197,11 @@ bool MP4Decoder::IsSupportedType(const MediaContainerType& aType,
+           CreateTrackInfoWithMIMETypeAndContainerTypeExtraParameters(
+               "video/av1"_ns, aType));
+     }
+-#ifdef MOZ_WMF
+-    if (StaticPrefs::media_wmf_hevc_enabled()) {
++    if (StaticPrefs::media_hevc_enabled()) {
+       tracks.AppendElement(
+           CreateTrackInfoWithMIMETypeAndContainerTypeExtraParameters(
+               "video/hevc"_ns, aType));
+     }
+-#endif
+   }
+ 
+   // Check that something is supported at least.
+diff --git a/dom/media/platforms/wmf/MFMediaEngineDecoderModule.cpp b/dom/media/platforms/wmf/MFMediaEngineDecoderModule.cpp
+index e291ab6a5452..ee17e058a94b 100644
+--- a/dom/media/platforms/wmf/MFMediaEngineDecoderModule.cpp
++++ b/dom/media/platforms/wmf/MFMediaEngineDecoderModule.cpp
+@@ -162,7 +162,7 @@ static bool CreateMFTDecoderOnMTA(const WMFStreamType& aType) {
+       break;
+ #endif
+     case WMFStreamType::HEVC:
+-      if (StaticPrefs::media_wmf_hevc_enabled()) {
++      if (StaticPrefs::media_hevc_enabled()) {
+         result =
+             SUCCEEDED(decoder->Create(MFT_CATEGORY_VIDEO_DECODER,
+                                       MFVideoFormat_HEVC, MFVideoFormat_NV12));
+diff --git a/dom/media/platforms/wmf/WMFDecoderModule.cpp b/dom/media/platforms/wmf/WMFDecoderModule.cpp
+index b61e1862b5fc..6e2ac974f6dc 100644
+--- a/dom/media/platforms/wmf/WMFDecoderModule.cpp
++++ b/dom/media/platforms/wmf/WMFDecoderModule.cpp
+@@ -482,7 +482,7 @@ media::DecodeSupportSet WMFDecoderModule::SupportsMimeType(
+ 
+ /* static */
+ bool WMFDecoderModule::IsHEVCSupported() {
+-  return sForceEnableHEVC || StaticPrefs::media_wmf_hevc_enabled() == 1;
++  return sForceEnableHEVC || StaticPrefs::media_hevc_enabled();
+ }
+ 
+ /* static */
+diff --git a/dom/media/test/crashtests/crashtests.list b/dom/media/test/crashtests/crashtests.list
+index e349de571774..f2718e8e98ad 100644
+--- a/dom/media/test/crashtests/crashtests.list
++++ b/dom/media/test/crashtests/crashtests.list
+@@ -173,9 +173,9 @@ load 1835118.adts
+ load trimming_needed_and_last_sample_invalid_duration.ogg
+ load 1839193.html
+ load 1850453.html
+-test-pref(media.wmf.hevc.enabled,1) load 1859384.mp4
+-test-pref(media.wmf.hevc.enabled,1) load 1859600.mp4
+-test-pref(media.wmf.hevc.enabled,1) load 1860840.mp4
++test-pref(media.hevc.enabled,true) load 1859384.mp4
++test-pref(media.hevc.enabled,true) load 1859600.mp4
++test-pref(media.hevc.enabled,true) load 1860840.mp4
+ load 1864450.html
+ load 1872787.html
+ load small-timebase.html
+diff --git a/dom/media/test/mochitest_compat.toml b/dom/media/test/mochitest_compat.toml
+index 9c7e67e2428d..1cee40b20543 100644
+--- a/dom/media/test/mochitest_compat.toml
++++ b/dom/media/test/mochitest_compat.toml
+@@ -31,7 +31,7 @@
+ [DEFAULT]
+ subsuite = "media"
+ tags = "media-engine-compatible media-gpu"
+-prefs = ["media.wmf.hevc.enabled=1"] # for test_hevc_playback
++prefs = ["media.hevc.enabled=1"] # for test_hevc_playback
+ support-files = [
+   "16bit_wave_extrametadata.wav",
+   "16bit_wave_extrametadata.wav^headers^",
+diff --git a/dom/media/test/test_hevc_support.html b/dom/media/test/test_hevc_support.html
+index 69c17167a772..53eee6a763aa 100644
+--- a/dom/media/test/test_hevc_support.html
++++ b/dom/media/test/test_hevc_support.html
+@@ -47,44 +47,6 @@ add_task(async function testHEVCSupport() {
+   }
+ });
+ 
+-add_task(async function testHEVCPrefSupportOnWindows() {
+-  if (SpecialPowers.Services.appinfo.OS != "WINNT") {
+-    ok(true, "No need to run this task");
+-    return;
+-  }
+-
+-  // Enable HEVC for normal playback and media engine playback
+-  await SpecialPowers.pushPrefEnv({
+-    set: [
+-      ["media.wmf.hevc.enabled", 1],
+-    ],
+-  });
+-  let capability = await navigator.mediaCapabilities.decodingInfo(videoConfiguration);
+-  ok(capability.supported, `HEVC is supported`);
+-
+-  // Enable HEVC for only media engine encrypted playback, which makes
+-  // non-encrypted HEVC unsupported, but encrypted HEVC is still supported.
+-  info(`Turn off HEVC for normal non-encrypted playback`);
+-  await SpecialPowers.pushPrefEnv({
+-    set: [
+-      ["media.wmf.hevc.enabled", 2],
+-      ["media.wmf.media-engine.enabled", 2],
+-      ["media.eme.playready.enabled", true],
+-      ["media.eme.mfcdm.origin-filter.enabled", 0],
+-    ],
+-  });
+-  capability = await navigator.mediaCapabilities.decodingInfo(videoConfiguration);
+-  ok(!capability.supported, "Non-encrypted HEVC is not supported");
+-
+-  info(`Encrypted HEVC should still be supported via the media engine`);
+-  const videoEncryptedConfig = {...videoConfiguration};
+-  videoEncryptedConfig.keySystemConfiguration = {
+-    keySystem: "com.microsoft.playready.recommendation",
+-  };
+-  capability = await navigator.mediaCapabilities.decodingInfo(videoEncryptedConfig);
+-  ok(capability.supported, `Encrypted HEVC is supported`);
+-});
+-
+ </script>
+ </head>
+ <body>
+diff --git a/gfx/ipc/GPUChild.cpp b/gfx/ipc/GPUChild.cpp
+index ea7025977436..ef1437adccd8 100644
+--- a/gfx/ipc/GPUChild.cpp
++++ b/gfx/ipc/GPUChild.cpp
+@@ -385,7 +385,7 @@ mozilla::ipc::IPCResult GPUChild::RecvUpdateMediaCodecsSupported(
+   media::MediaCodecsSupported trimedSupported = aSupported;
+   if (aSupported.contains(
+           mozilla::media::MediaCodecsSupport::HEVCHardwareDecode) &&
+-      StaticPrefs::media_wmf_hevc_enabled() != 1) {
++      !StaticPrefs::media_hevc_enabled()) {
+     trimedSupported -= mozilla::media::MediaCodecsSupport::HEVCHardwareDecode;
+   }
+   dom::ContentParent::BroadcastMediaCodecsSupportedUpdate(
+diff --git a/gfx/ipc/GPUParent.cpp b/gfx/ipc/GPUParent.cpp
+index 44c5d31af068..3fe0f3bc0f57 100644
+--- a/gfx/ipc/GPUParent.cpp
++++ b/gfx/ipc/GPUParent.cpp
+@@ -115,7 +115,7 @@ static media::MediaCodecsSupported GetFullMediaCodecSupport(
+     WMFDecoderModule::Init(WMFDecoderModule::Config::ForceEnableHEVC);
+   }
+   auto disableHEVCIfNeeded = MakeScopeExit([]() {
+-    if (StaticPrefs::media_wmf_hevc_enabled() != 1) {
++    if (!StaticPrefs::media_hevc_enabled()) {
+       WMFDecoderModule::DisableForceEnableHEVC();
+     }
+   });
+diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
+index 7364514f7470..5f9ed7023b2c 100644
+--- a/modules/libpref/init/StaticPrefList.yaml
++++ b/modules/libpref/init/StaticPrefList.yaml
+@@ -11296,14 +11296,6 @@
+     value: true
+     mirror: always
+ 
+-# Enable HEVC support via the windows media foundation
+-# 0 : disable, 1 : enable for media engine and MFT,
+-# 2 : enable for media engine only
+--   name: media.wmf.hevc.enabled
+-    type: RelaxedAtomicUint32
+-    value: 1
+-    mirror: always
+-
+ # Enable Widevine experiment DRM for EME
+ -   name: media.eme.widevine.experiment.enabled
+     type: RelaxedAtomicBool
+@@ -11323,6 +11315,19 @@
+ 
+ #endif  # MOZ_WMF
+ 
++- name: media.hevc.enabled
++  type: RelaxedAtomicBool
++#if defined(XP_WIN)
++  value: true
++#elif defined(XP_MACOSX)
++  value: true
++#elif defined(ANDROID)
++  value: true
++#else
++  value: false
++#endif
++  mirror: always
++
+ - name: media.decoder-doctor.testing
+   type: bool
+   value: false
+diff --git a/toolkit/components/resistfingerprinting/UserCharacteristicsPageService.sys.mjs b/toolkit/components/resistfingerprinting/UserCharacteristicsPageService.sys.mjs
+index 7bb2938a88df..fc88f3c50de2 100644
+--- a/toolkit/components/resistfingerprinting/UserCharacteristicsPageService.sys.mjs
++++ b/toolkit/components/resistfingerprinting/UserCharacteristicsPageService.sys.mjs
+@@ -907,7 +907,7 @@ export class UserCharacteristicsPageService {
+       "media.ogg.enabled",
+       "media.opus.enabled",
+       "media.mp4.enabled",
+-      "media.wmf.hevc.enabled",
++      "media.hevc.enabled",
+       "media.webm.enabled",
+       "media.av1.enabled",
+       "media.encoder.webm.enabled",
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0015-BACKPORT-Bug-1894818-part1-support-HEVC-via-VAAPI.-r.patch
+++ b/app-web/firefox/autobuild/patches/0015-BACKPORT-Bug-1894818-part1-support-HEVC-via-VAAPI.-r.patch
@@ -1,0 +1,69 @@
+From fd5a809ebdaf6dc20e04aea2be053b98f32cc416 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:14 +0000
+Subject: [PATCH 15/22] BACKPORT: Bug 1894818 - part1 : support HEVC via VAAPI.
+ r=stransky
+
+Differential Revision: https://phabricator.services.mozilla.com/D238153
+---
+ widget/gtk/GfxInfo.cpp             | 5 +++++
+ widget/gtk/vaapitest/vaapitest.cpp | 6 ++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/widget/gtk/GfxInfo.cpp b/widget/gtk/GfxInfo.cpp
+index d21714c74316..d6a17d73e775 100644
+--- a/widget/gtk/GfxInfo.cpp
++++ b/widget/gtk/GfxInfo.cpp
+@@ -60,6 +60,7 @@ constexpr int CODEC_HW_H264 = 1 << 4;
+ constexpr int CODEC_HW_VP8 = 1 << 5;
+ constexpr int CODEC_HW_VP9 = 1 << 6;
+ constexpr int CODEC_HW_AV1 = 1 << 7;
++constexpr int CODEC_HW_HEVC = 1 << 8;
+ 
+ nsresult GfxInfo::Init() {
+   mGLMajorVersion = 0;
+@@ -704,6 +705,10 @@ void GfxInfo::GetDataVAAPI() {
+         media::MCSInfo::AddSupport(
+             media::MediaCodecsSupport::AV1HardwareDecode);
+       }
++      if (mVAAPISupportedCodecs & CODEC_HW_HEVC) {
++        media::MCSInfo::AddSupport(
++            media::MediaCodecsSupport::HEVCHardwareDecode);
++      }
+     } else if (!strcmp(line, "WARNING") || !strcmp(line, "ERROR")) {
+       gfxCriticalNote << "vaapitest: " << line;
+       line = NS_strtok("\n", &bufptr);
+diff --git a/widget/gtk/vaapitest/vaapitest.cpp b/widget/gtk/vaapitest/vaapitest.cpp
+index 6c824a5895c7..45463d28ad0f 100644
+--- a/widget/gtk/vaapitest/vaapitest.cpp
++++ b/widget/gtk/vaapitest/vaapitest.cpp
+@@ -41,6 +41,7 @@ constexpr int CODEC_HW_H264 = 1 << 4;
+ constexpr int CODEC_HW_VP8 = 1 << 5;
+ constexpr int CODEC_HW_VP9 = 1 << 6;
+ constexpr int CODEC_HW_AV1 = 1 << 7;
++constexpr int CODEC_HW_HEVC = 1 << 8;
+ 
+ // childgltest is declared inside extern "C" so that the name is not mangled.
+ // The name is used in build/valgrind/x86_64-pc-linux-gnu.sup to suppress
+@@ -61,6 +62,9 @@ static constexpr struct {
+     MAP(VP9Profile2),
+     MAP(AV1Profile0),
+     MAP(AV1Profile1),
++    MAP(HEVCMain),
++    MAP(HEVCMain10),
++    MAP(HEVCMain12),
+ #undef MAP
+ };
+ 
+@@ -183,6 +187,8 @@ static void vaapitest(const char* aRenderDevicePath) {
+           codecs |= CODEC_HW_VP9;
+         } else if (!strncmp(profstr, "AV1", 3)) {
+           codecs |= CODEC_HW_AV1;
++        } else if (!strncmp(profstr, "HEVC", 4)) {
++          codecs |= CODEC_HW_HEVC;
+         } else {
+           record_warning("VA-API test unknown profile.");
+         }
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0016-BACKPORT-Bug-1894818-part2-add-gfx-feature-for-hevc..patch
+++ b/app-web/firefox/autobuild/patches/0016-BACKPORT-Bug-1894818-part2-add-gfx-feature-for-hevc..patch
@@ -1,0 +1,98 @@
+From 8f550551bb9a8c37efae9e392745e1f8010dd317 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:14 +0000
+Subject: [PATCH 16/22] BACKPORT: Bug 1894818 - part2 : add gfx feature for
+ hevc. r=stransky
+
+Differential Revision: https://phabricator.services.mozilla.com/D238154
+---
+ gfx/config/gfxFeature.h     |  1 +
+ gfx/config/gfxVars.h        |  1 +
+ gfx/thebes/gfxPlatform.cpp  | 11 ++++++++++-
+ widget/GfxInfoFeatureDefs.h |  2 ++
+ widget/gtk/GfxInfo.cpp      |  3 ++-
+ 5 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/gfx/config/gfxFeature.h b/gfx/config/gfxFeature.h
+index 71cb222278ab..28aa86c8f245 100644
+--- a/gfx/config/gfxFeature.h
++++ b/gfx/config/gfxFeature.h
+@@ -52,6 +52,7 @@ namespace gfx {
+   _(ACCELERATED_CANVAS2D, Feature, "Accelerated Canvas2D")                   \
+   _(H264_HW_DECODE, Feature, "H.264 hardware decoding")                      \
+   _(AV1_HW_DECODE, Feature, "AV1 hardware decoding")                         \
++  _(HEVC_HW_DECODE, Feature, "HEVC hardware decoding")                       \
+   _(REMOTE_CANVAS, Feature, "Remote canvas")                                 \
+   _(DMABUF_WEBGL, Feature, "DMABuf for WebGL")                               \
+   /* Add new entries above this comment */
+diff --git a/gfx/config/gfxVars.h b/gfx/config/gfxVars.h
+index 496efcb0d025..4307bf1d3095 100644
+--- a/gfx/config/gfxVars.h
++++ b/gfx/config/gfxVars.h
+@@ -93,6 +93,7 @@ class gfxVarReceiver;
+   _(UseVP9HwDecode, bool, false)                                   \
+   _(UseAV1HwDecode, bool, false)                                   \
+   _(UseH264HwDecode, bool, false)                                  \
++  _(UseHEVCHwDecode, bool, false)                                  \
+   _(HwDecodedVideoZeroCopy, bool, false)                           \
+   _(UseDMABufSurfaceExport, bool, true)                            \
+   _(ReuseDecoderDevice, bool, false)                               \
+diff --git a/gfx/thebes/gfxPlatform.cpp b/gfx/thebes/gfxPlatform.cpp
+index 91e783e0ed8b..21de58185086 100644
+--- a/gfx/thebes/gfxPlatform.cpp
++++ b/gfx/thebes/gfxPlatform.cpp
+@@ -3009,7 +3009,7 @@ void gfxPlatform::InitHardwareVideoConfig() {
+   }
+   gfxVars::SetUseVP9HwDecode(featureVP9.IsEnabled());
+ 
+-  // H264_HW_DECODE/AV1_HW_DECODE is used on Linux only right now.
++  // H264/AV1/HEVC_HW_DECODE are used on Linux only right now.
+ #ifdef MOZ_WIDGET_GTK
+   FeatureState& featureH264 = gfxConfig::GetFeature(Feature::H264_HW_DECODE);
+   featureH264.EnableByDefault();
+@@ -3028,6 +3028,15 @@ void gfxPlatform::InitHardwareVideoConfig() {
+     featureAV1.Disable(FeatureStatus::Blocklisted, message.get(), failureId);
+   }
+   gfxVars::SetUseAV1HwDecode(featureAV1.IsEnabled());
++
++  FeatureState& featureHEVC = gfxConfig::GetFeature(Feature::HEVC_HW_DECODE);
++  featureHEVC.EnableByDefault();
++
++  if (!IsGfxInfoStatusOkay(nsIGfxInfo::FEATURE_HEVC_HW_DECODE, &message,
++                           failureId)) {
++    featureHEVC.Disable(FeatureStatus::Blocklisted, message.get(), failureId);
++  }
++  gfxVars::SetUseHEVCHwDecode(featureHEVC.IsEnabled());
+ #endif
+ }
+ 
+diff --git a/widget/GfxInfoFeatureDefs.h b/widget/GfxInfoFeatureDefs.h
+index f489dde5fed0..985a5d89aa9d 100644
+--- a/widget/GfxInfoFeatureDefs.h
++++ b/widget/GfxInfoFeatureDefs.h
+@@ -103,6 +103,8 @@ GFXINFO_FEATURE(ACCELERATED_CANVAS2D, "ACCELERATED_CANVAS2D", "accelerated-canva
+ GFXINFO_FEATURE(H264_HW_DECODE, "H264_HW_DECODE", "h264.hw-decode")
+ /* Whether hardware AV1 decoding is supported, starting in 114; downloadable blocking in 132. */
+ GFXINFO_FEATURE(AV1_HW_DECODE, "AV1_HW_DECODE", "av1.hw-decode")
++/* Whether hardware HEVC decoding is supported, starting and downloadable blocking in 137. */
++GFXINFO_FEATURE(HEVC_HW_DECODE, "HEVC_HW_DECODE", "hevc.hw-decode")
+ /* Whether video overlay of software decoded video is supported, starting in 116; downloadable blocking in 132. */
+ GFXINFO_FEATURE(VIDEO_SOFTWARE_OVERLAY, "VIDEO_SOFTWARE_OVERLAY", "video-software-overlay")
+ /* Whether WebGL is allowed to use hardware rendering, otherwise software fallbacks, starting in 120 (115esr); downloadable blocking in 132. */
+diff --git a/widget/gtk/GfxInfo.cpp b/widget/gtk/GfxInfo.cpp
+index d6a17d73e775..fd4fd375b144 100644
+--- a/widget/gtk/GfxInfo.cpp
++++ b/widget/gtk/GfxInfo.cpp
+@@ -1297,7 +1297,8 @@ nsresult GfxInfo::GetFeatureStatusImpl(
+   } kFeatureToCodecs[] = {{nsIGfxInfo::FEATURE_H264_HW_DECODE, CODEC_HW_H264},
+                           {nsIGfxInfo::FEATURE_VP8_HW_DECODE, CODEC_HW_VP8},
+                           {nsIGfxInfo::FEATURE_VP9_HW_DECODE, CODEC_HW_VP9},
+-                          {nsIGfxInfo::FEATURE_AV1_HW_DECODE, CODEC_HW_AV1}};
++                          {nsIGfxInfo::FEATURE_AV1_HW_DECODE, CODEC_HW_AV1},
++                          {nsIGfxInfo::FEATURE_HEVC_HW_DECODE, CODEC_HW_HEVC}};
+ 
+   for (const auto& pair : kFeatureToCodecs) {
+     if (aFeature != pair.mFeature) {
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0017-BACKPORT-Bug-1894818-part3-support-HEVC-for-ffmpeg-v.patch
+++ b/app-web/firefox/autobuild/patches/0017-BACKPORT-Bug-1894818-part3-support-HEVC-for-ffmpeg-v.patch
@@ -1,0 +1,117 @@
+From feea6ed13580daf56b736ce69dfc776313339665 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:15 +0000
+Subject: [PATCH 17/22] BACKPORT: Bug 1894818 - part3 : support HEVC for ffmpeg
+ video decoder. r=stransky
+
+Differential Revision: https://phabricator.services.mozilla.com/D238155
+---
+ dom/media/platforms/ffmpeg/FFmpegUtils.h      |  1 +
+ .../platforms/ffmpeg/FFmpegVideoDecoder.cpp   | 23 ++++++++++++++++++-
+ .../platforms/ffmpeg/FFmpegVideoDecoder.h     |  8 ++++++-
+ 3 files changed, 30 insertions(+), 2 deletions(-)
+
+diff --git a/dom/media/platforms/ffmpeg/FFmpegUtils.h b/dom/media/platforms/ffmpeg/FFmpegUtils.h
+index 1b2ca67e7642..8260e88b9673 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegUtils.h
++++ b/dom/media/platforms/ffmpeg/FFmpegUtils.h
+@@ -41,6 +41,7 @@ inline bool IsVideoCodec(AVCodecID aCodecID) {
+ #endif
+ #if LIBAVCODEC_VERSION_MAJOR >= 55
+     case AV_CODEC_ID_VP9:
++    case AV_CODEC_ID_HEVC:
+ #endif
+ #if LIBAVCODEC_VERSION_MAJOR >= 59
+     case AV_CODEC_ID_AV1:
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
+index a47dd3a6b033..8c4fa73857f4 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
+@@ -21,8 +21,11 @@
+ #if LIBAVCODEC_VERSION_MAJOR >= 58
+ #  include "mozilla/ProfilerMarkers.h"
+ #endif
+-#if defined(MOZ_USE_HWDECODE) && defined(MOZ_WIDGET_GTK)
++#ifdef MOZ_USE_HWDECODE
+ #  include "H264.h"
++#  include "H265.h"
++#endif
++#if defined(MOZ_USE_HWDECODE) && defined(MOZ_WIDGET_GTK)
+ #  include "mozilla/gfx/gfxVars.h"
+ #  include "mozilla/layers/DMABUFSurfaceImage.h"
+ #  include "mozilla/widget/DMABufLibWrapper.h"
+@@ -548,6 +551,9 @@ bool FFmpegVideoDecoder<LIBAV_VER>::ShouldEnableLinuxHWDecoding() const {
+     case AV_CODEC_ID_AV1:
+       supported = gfx::gfxVars::UseAV1HwDecode();
+       break;
++    case AV_CODEC_ID_HEVC:
++      supported = gfx::gfxVars::UseHEVCHwDecode();
++      break;
+     default:
+       break;
+   }
+@@ -993,6 +999,9 @@ void FFmpegVideoDecoder<LIBAV_VER>::InitHWCodecContext(ContextType aType) {
+   if (mCodecID == AV_CODEC_ID_H264) {
+     mCodecContext->extra_hw_frames =
+         H264::ComputeMaxRefFrames(mInfo.mExtraData);
++  } else if (mCodecID == AV_CODEC_ID_HEVC) {
++    mCodecContext->extra_hw_frames =
++        H265::ComputeMaxRefFrames(mInfo.mExtraData);
+   } else {
+     mCodecContext->extra_hw_frames = EXTRA_HW_FRAMES;
+   }
+@@ -1118,6 +1127,9 @@ MediaResult FFmpegVideoDecoder<LIBAV_VER>::DoDecode(
+       case AV_CODEC_ID_VP9:
+         flag |= MediaInfoFlag::VIDEO_VP9;
+         break;
++      case AV_CODEC_ID_HEVC:
++        flag |= MediaInfoFlag::VIDEO_HEVC;
++        break;
+ #endif
+ #ifdef FFMPEG_AV1_DECODE
+       case AV_CODEC_ID_AV1:
+@@ -1727,6 +1739,12 @@ AVCodecID FFmpegVideoDecoder<LIBAV_VER>::GetCodecId(
+     return AV_CODEC_ID_H264;
+   }
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 55
++  if (MP4Decoder::IsHEVC(aMimeType)) {
++    return AV_CODEC_ID_HEVC;
++  }
++#endif
++
+   if (aMimeType.EqualsLiteral("video/x-vnd.on2.vp6")) {
+     return AV_CODEC_ID_VP6F;
+   }
+@@ -1805,6 +1823,9 @@ static const struct {
+     MAP(VP9, VP9Profile2, "VP9Profile2"),
+     MAP(AV1, AV1Profile0, "AV1Profile0"),
+     MAP(AV1, AV1Profile1, "AV1Profile1"),
++    MAP(HEVC, HEVCMain, "HEVCMain"),
++    MAP(HEVC, HEVCMain10, "HEVCMain10"),
++    MAP(HEVC, HEVCMain10, "HEVCMain12"),
+ #  undef MAP
+ };
+ 
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
+index 14f483c14c8b..1f2ea229724d 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
+@@ -73,7 +73,13 @@ class FFmpegVideoDecoder<LIBAV_VER>
+   }
+   nsCString GetCodecName() const override;
+   ConversionRequired NeedsConversion() const override {
+-    return ConversionRequired::kNeedAVCC;
++#if LIBAVCODEC_VERSION_MAJOR >= 55
++    if (mCodecID == AV_CODEC_ID_HEVC) {
++      return ConversionRequired::kNeedHVCC;
++    }
++#endif
++    return mCodecID == AV_CODEC_ID_H264 ? ConversionRequired::kNeedAVCC
++                                        : ConversionRequired::kNeedNone;
+   }
+ 
+   static AVCodecID GetCodecId(const nsACString& aMimeType);
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0018-BACKPORT-Bug-1894818-part4-enable-hevc-check-on-Linu.patch
+++ b/app-web/firefox/autobuild/patches/0018-BACKPORT-Bug-1894818-part4-enable-hevc-check-on-Linu.patch
@@ -1,0 +1,31 @@
+From 54ef54fb7f0f94e38546a1184e68ca4ed2e2b042 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:15 +0000
+Subject: [PATCH 18/22] BACKPORT: Bug 1894818 - part4 : enable hevc check on
+ Linux. r=media-playback-reviewers,padenot
+
+Differential Revision: https://phabricator.services.mozilla.com/D238156
+---
+ dom/media/ipc/RemoteDecoderManagerChild.cpp | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/dom/media/ipc/RemoteDecoderManagerChild.cpp b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+index add1695facef..2ddd82a73634 100644
+--- a/dom/media/ipc/RemoteDecoderManagerChild.cpp
++++ b/dom/media/ipc/RemoteDecoderManagerChild.cpp
+@@ -278,11 +278,8 @@ bool RemoteDecoderManagerChild::Supports(
+ #if defined(XP_WIN)
+         return aLocation == RemoteDecodeIn::UtilityProcess_MFMediaEngineCDM ||
+                aLocation == RemoteDecodeIn::GpuProcess;
+-#elif defined(MOZ_APPLEMEDIA) || defined(MOZ_WIDGET_ANDROID)
+-        return trackSupport.contains(TrackSupport::Video);
+ #else
+-        // TODO : not support on Linux yet
+-        return false;
++        return trackSupport.contains(TrackSupport::Video);
+ #endif
+       }
+       return trackSupport.contains(TrackSupport::Video);
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0019-BACKPORT-Bug-1894818-part5-append-SEI-and-ensure-the.patch
+++ b/app-web/firefox/autobuild/patches/0019-BACKPORT-Bug-1894818-part5-append-SEI-and-ensure-the.patch
@@ -1,0 +1,138 @@
+From afd996fe389e71652c985608ff65047ae1fa1c6c Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:16 +0000
+Subject: [PATCH 19/22] BACKPORT: Bug 1894818 - part5 : append SEI and ensure
+ the NALUs are appended in the order of nalu's type.
+ r=media-playback-reviewers,padenot
+
+The FFmpeg HEVC decoder requires NAL units to be appended in the correct order
+based on their NALU type. Failure to do so results in errors and playback
+failure.
+
+Differential Revision: https://phabricator.services.mozilla.com/D238157
+
+[Henry Chen: Skipped changes in:
+dom/media/platforms/agnostic/bytestreams/gtest/TestByteStreams.cpp]
+
+Signed-off-by: Henry Chen <henry.chen@oss.cipunited.com>
+---
+ .../platforms/agnostic/bytestreams/H265.cpp   | 19 ++---------
+ .../platforms/agnostic/bytestreams/H265.h     |  5 ++-
+ .../platforms/wrappers/MediaChangeMonitor.cpp | 32 +++++++++++++------
+ 3 files changed, 27 insertions(+), 29 deletions(-)
+
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.cpp b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+index be78ff393c16..3b147d6085da 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.cpp
++++ b/dom/media/platforms/agnostic/bytestreams/H265.cpp
+@@ -1461,20 +1461,7 @@ already_AddRefed<mozilla::MediaByteBuffer> H265::CreateFakeExtraData() {
+ 
+ /* static */
+ already_AddRefed<mozilla::MediaByteBuffer> H265::CreateNewExtraData(
+-    const HVCCConfig& aConfig, const Maybe<H265NALU>& aSPS,
+-    const Maybe<H265NALU>& aPPS, const Maybe<H265NALU>& aVPS) {
+-  // Append essential NALUs if they exist
+-  nsTArray<H265NALU> nalus;
+-  if (aSPS) {
+-    nalus.AppendElement(*aSPS);
+-  }
+-  if (aPPS) {
+-    nalus.AppendElement(*aPPS);
+-  }
+-  if (aVPS) {
+-    nalus.AppendElement(*aVPS);
+-  }
+-
++    const HVCCConfig& aConfig, const nsTArray<H265NALU>& aNALUs) {
+   // HEVCDecoderConfigurationRecord (HVCC) is in ISO/IEC 14496-15 8.3.2.1.2
+   auto extradata = MakeRefPtr<mozilla::MediaByteBuffer>();
+   BitWriter writer(extradata);
+@@ -1500,8 +1487,8 @@ already_AddRefed<mozilla::MediaByteBuffer> H265::CreateNewExtraData(
+   writer.WriteBits(aConfig.numTemporalLayers, 3);
+   writer.WriteBits(aConfig.temporalIdNested, 1);
+   writer.WriteBits(aConfig.lengthSizeMinusOne, 2);
+-  writer.WriteU8(nalus.Length());  // numOfArrays
+-  for (auto& nalu : nalus) {
++  writer.WriteU8(aNALUs.Length());  // numOfArrays
++  for (auto& nalu : aNALUs) {
+     writer.WriteBits(0, 2);                     // array_completeness + reserved
+     writer.WriteBits(nalu.mNalUnitType, 6);     // NAL_unit_type
+     writer.WriteBits(1, 16);                    // numNalus
+diff --git a/dom/media/platforms/agnostic/bytestreams/H265.h b/dom/media/platforms/agnostic/bytestreams/H265.h
+index ae4bf9e374f1..6f6ef1f77d54 100644
+--- a/dom/media/platforms/agnostic/bytestreams/H265.h
++++ b/dom/media/platforms/agnostic/bytestreams/H265.h
+@@ -341,10 +341,9 @@ class H265 final {
+ 
+   // Create new extradata with the essential information from the given
+   // HVCCConfig, excluding its original NALUs. The NALUs will be replaced by the
+-  // provided SPS, PPS, and VPS.
++  // given NALUS, which are usually SPS, PPS, VPS and SEI.
+   static already_AddRefed<mozilla::MediaByteBuffer> CreateNewExtraData(
+-      const HVCCConfig& aConfig, const Maybe<H265NALU>& aSPS,
+-      const Maybe<H265NALU>& aPPS, const Maybe<H265NALU>& aVPS);
++      const HVCCConfig& aConfig, const nsTArray<H265NALU>& aNALUs);
+ 
+  private:
+   // Return RAW BYTE SEQUENCE PAYLOAD (rbsp) from NAL content.
+diff --git a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+index a20fb64bc0db..99f3e3e2576e 100644
+--- a/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
++++ b/dom/media/platforms/wrappers/MediaChangeMonitor.cpp
+@@ -306,6 +306,11 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+       mVPS.Clear();
+       mVPS.AppendElements(nalu->mNALU);
+     }
++    if (auto nalu =
++            hvcc.GetFirstAvaiableNALU(H265NALU::NAL_TYPES::PREFIX_SEI_NUT)) {
++      mSEI.Clear();
++      mSEI.AppendElements(nalu->mNALU);
++    }
+ 
+     // Construct a new extradata. A situation we encountered previously involved
+     // the initial extradata containing all required NALUs, while the inband
+@@ -315,17 +320,23 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+     // should update only the differing NALUs, ensuring all essential
+     // information remains in the extradata.
+     MOZ_ASSERT(!mSPS.IsEmpty());  // SPS is something MUST to have
+-    Maybe<H265NALU> sps = Some(H265NALU(mSPS.Elements(), mSPS.Length()));
+-    Maybe<H265NALU> pps = !mPPS.IsEmpty()
+-                              ? Some(H265NALU(mPPS.Elements(), mPPS.Length()))
+-                              : Nothing();
+-    Maybe<H265NALU> vps = !mVPS.IsEmpty()
+-                              ? Some(H265NALU(mVPS.Elements(), mVPS.Length()))
+-                              : Nothing();
+-    mCurrentConfig.mExtraData = H265::CreateNewExtraData(hvcc, sps, pps, vps);
++    nsTArray<H265NALU> nalus;
++    // Append NALU by the order of NALU type. If we don't do so, it would cause
++    // an error on the FFmpeg decoder on Linux.
++    if (!mVPS.IsEmpty()) {
++      nalus.AppendElement(H265NALU(mVPS.Elements(), mVPS.Length()));
++    }
++    nalus.AppendElement(H265NALU(mSPS.Elements(), mSPS.Length()));
++    if (!mPPS.IsEmpty()) {
++      nalus.AppendElement(H265NALU(mPPS.Elements(), mPPS.Length()));
++    }
++    if (!mSEI.IsEmpty()) {
++      nalus.AppendElement(H265NALU(mSEI.Elements(), mSEI.Length()));
++    }
++    mCurrentConfig.mExtraData = H265::CreateNewExtraData(hvcc, nalus);
+     mTrackInfo = new TrackInfoSharedPtr(mCurrentConfig, mStreamID++);
+-    LOG("Updated extradata, hasSPS=%d, hasPPS=%d, hasVPS=%d", !!sps, !!pps,
+-        !!vps);
++    LOG("Updated extradata, hasSPS=%d, hasPPS=%d, hasVPS=%d, hasSEI=%d",
++        !mSPS.IsEmpty(), !mPPS.IsEmpty(), !mVPS.IsEmpty(), !mSEI.IsEmpty());
+   }
+ 
+   VideoInfo mCurrentConfig;
+@@ -334,6 +345,7 @@ class HEVCChangeMonitor : public MediaChangeMonitor::CodecChangeMonitor {
+   nsTArray<uint8_t> mSPS;
+   nsTArray<uint8_t> mPPS;
+   nsTArray<uint8_t> mVPS;
++  nsTArray<uint8_t> mSEI;
+ 
+   uint32_t mStreamID = 0;
+   RefPtr<TrackInfoSharedPtr> mTrackInfo;
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0020-BACKPORT-Bug-1894818-part6-properly-report-the-codec.patch
+++ b/app-web/firefox/autobuild/patches/0020-BACKPORT-Bug-1894818-part6-properly-report-the-codec.patch
@@ -1,0 +1,208 @@
+From acc46bece72148a7ee58685b75ddfa3d47064ccf Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:16 +0000
+Subject: [PATCH 20/22] BACKPORT: Bug 1894818 - part6 : properly report the
+ codec support for FFmpegDecoderModule. r=stransky
+
+On Linux, we have two decoder modules: ffmpeg and ffvpx, both utilizing ffmpeg.
+
+* ffmpeg uses the system-installed ffmpeg.
+* ffvpx is our bundled, trimmed version of ffmpeg.
+
+For proprietary codecs like H.264 and HEVC, hardware decoding is only possible
+through the system ffmpeg.
+
+For open codecs like VP8, VP9, and AV1, hardware decoding is supported by both
+decoder modules, but ffvpx is always preferred over the system ffmpeg.
+
+Differential Revision: https://phabricator.services.mozilla.com/D238158
+---
+ .../platforms/ffmpeg/FFmpegDecoderModule.h    | 61 ++++++++++++++++---
+ .../platforms/ffmpeg/FFmpegRuntimeLinker.cpp  | 28 +++++++++
+ dom/media/platforms/ffmpeg/FFmpegUtils.cpp    | 11 +++-
+ modules/libpref/init/StaticPrefList.yaml      |  4 ++
+ 4 files changed, 94 insertions(+), 10 deletions(-)
+
+diff --git a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+index 66c524f2e318..a619cd5be4a3 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
++++ b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+@@ -23,7 +23,8 @@ template <int V>
+ class FFmpegDecoderModule : public PlatformDecoderModule {
+  public:
+   static void Init(FFmpegLibWrapper* aLib) {
+-#if defined(XP_WIN) && !defined(MOZ_FFVPX_AUDIOONLY)
++#if defined(MOZ_USE_HWDECODE)
++#  if defined(XP_WIN) && !defined(MOZ_FFVPX_AUDIOONLY)
+     if (!XRE_IsGPUProcess()) {
+       return;
+     }
+@@ -51,7 +52,45 @@ class FFmpegDecoderModule : public PlatformDecoderModule {
+         }
+       }
+     }
+-#endif
++#  elif MOZ_WIDGET_GTK
++    // Hardware decoding on Linux should only happen on the RDD process for now.
++    if (!XRE_IsRDDProcess()) {
++      return;
++    }
++
++// UseXXXHWDecode are already set in gfxPlatform at the startup.
++#    define ADD_HW_CODEC(codec)                                \
++      if (gfx::gfxVars::Use##codec##HwDecode()) {              \
++        sSupportedHWCodecs.AppendElement(AV_CODEC_ID_##codec); \
++      }
++
++// These proprietary video codecs can only be decoded via hardware by using the
++// system ffmpeg, not supported by ffvpx.
++#    ifndef FFVPX_VERSION
++    ADD_HW_CODEC(H264);
++#      if LIBAVCODEC_VERSION_MAJOR >= 55
++    ADD_HW_CODEC(HEVC);
++#      endif
++#    endif  // !FFVPX_VERSION
++
++// The following open video codecs can be decoded via hardware using ffvpx.
++#    if LIBAVCODEC_VERSION_MAJOR >= 54
++    ADD_HW_CODEC(VP8);
++#    endif
++#    if LIBAVCODEC_VERSION_MAJOR >= 55
++    ADD_HW_CODEC(VP9);
++#    endif
++#    if LIBAVCODEC_VERSION_MAJOR >= 59
++    ADD_HW_CODEC(AV1);
++#    endif
++
++    for (const auto& codec : sSupportedHWCodecs) {
++      MOZ_LOG(sPDMLog, LogLevel::Debug,
++              ("Support %s for hw decoding", AVCodecToString(codec)));
++    }
++#    undef ADD_HW_CODEC
++#  endif  // XP_WIN, MOZ_WIDGET_GTK
++#endif    // MOZ_USE_HWDECODE
+   }
+ 
+   static already_AddRefed<PlatformDecoderModule> Create(
+@@ -177,11 +216,11 @@ class FFmpegDecoderModule : public PlatformDecoderModule {
+               ("FFmpeg decoder rejects as openh264 disabled by pref"));
+       return media::DecodeSupportSet{};
+     }
+-    // TODO : note, currently on Linux, hardware decoding is reported in its own
+-    // path (in widget/gtk/GfxInfo.cpp) Make it correct on Linux as well in bug
+-    // 1935572.
+-    return XRE_IsGPUProcess() ? media::DecodeSupport::HardwareDecode
+-                              : media::DecodeSupport::SoftwareDecode;
++    media::DecodeSupportSet support = media::DecodeSupport::SoftwareDecode;
++    if (IsHWDecodingSupported(mimeType)) {
++      support += media::DecodeSupport::HardwareDecode;
++    }
++    return support;
+   }
+ 
+  protected:
+@@ -196,10 +235,14 @@ class FFmpegDecoderModule : public PlatformDecoderModule {
+ 
+   bool IsHWDecodingSupported(const nsACString& aMimeType) const {
+     if (!gfx::gfxVars::IsInitialized() ||
+-        !gfx::gfxVars::CanUseHardwareVideoDecoding() ||
+-        !StaticPrefs::media_ffvpx_hw_enabled()) {
++        !gfx::gfxVars::CanUseHardwareVideoDecoding()) {
+       return false;
+     }
++#ifdef FFVPX_VERSION
++    if (!StaticPrefs::media_ffvpx_hw_enabled()) {
++      return false;
++    }
++#endif
+     AVCodecID videoCodec = FFmpegVideoDecoder<V>::GetCodecId(aMimeType);
+     return sSupportedHWCodecs.Contains(videoCodec);
+   }
+diff --git a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+index 01e78090453c..189b063cdb82 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+@@ -19,6 +19,7 @@ const char* FFmpegRuntimeLinker::sLinkStatusLibraryName = "";
+ template <int V>
+ class FFmpegDecoderModule {
+  public:
++  static void Init(FFmpegLibWrapper*);
+   static already_AddRefed<PlatformDecoderModule> Create(FFmpegLibWrapper*);
+ };
+ 
+@@ -90,6 +91,33 @@ bool FFmpegRuntimeLinker::Init() {
+         case FFmpegLibWrapper::LinkResult::Success:
+           sLinkStatus = LinkStatus_SUCCEEDED;
+           sLinkStatusLibraryName = lib;
++          switch (sLibAV.mVersion) {
++            case 53:
++              FFmpegDecoderModule<53>::Init(&sLibAV);
++              break;
++            case 54:
++              FFmpegDecoderModule<54>::Init(&sLibAV);
++              break;
++            case 55:
++            case 56:
++              FFmpegDecoderModule<55>::Init(&sLibAV);
++              break;
++            case 57:
++              FFmpegDecoderModule<57>::Init(&sLibAV);
++              break;
++            case 58:
++              FFmpegDecoderModule<58>::Init(&sLibAV);
++              break;
++            case 59:
++              FFmpegDecoderModule<59>::Init(&sLibAV);
++              break;
++            case 60:
++              FFmpegDecoderModule<60>::Init(&sLibAV);
++              break;
++            case 61:
++              FFmpegDecoderModule<61>::Init(&sLibAV);
++              break;
++          }
+           return true;
+         case FFmpegLibWrapper::LinkResult::NoProvidedLib:
+           MOZ_ASSERT_UNREACHABLE("Incorrectly-setup sLibAV");
+diff --git a/dom/media/platforms/ffmpeg/FFmpegUtils.cpp b/dom/media/platforms/ffmpeg/FFmpegUtils.cpp
+index 169a0656d2d1..1762a6d350ea 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegUtils.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegUtils.cpp
+@@ -26,8 +26,17 @@ nsCString MakeErrorString(const FFmpegLibWrapper* aLib, int aErrNum) {
+   }
+ 
+ const char* AVCodecToString(const AVCodecID& aCodec) {
+-  ENUM_TO_STR(AV_CODEC_ID_AV1);
++  ENUM_TO_STR(AV_CODEC_ID_H264);
++#if LIBAVCODEC_VERSION_MAJOR >= 54
++  ENUM_TO_STR(AV_CODEC_ID_VP8);
++#endif
++#if LIBAVCODEC_VERSION_MAJOR >= 55
+   ENUM_TO_STR(AV_CODEC_ID_VP9);
++  ENUM_TO_STR(AV_CODEC_ID_HEVC);
++#endif
++#if LIBAVCODEC_VERSION_MAJOR >= 59
++  ENUM_TO_STR(AV_CODEC_ID_AV1);
++#endif
+   return "unknown";
+ }
+ 
+diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
+index 5f9ed7023b2c..b00d24a723eb 100644
+--- a/modules/libpref/init/StaticPrefList.yaml
++++ b/modules/libpref/init/StaticPrefList.yaml
+@@ -10792,7 +10792,11 @@
+ 
+ - name: media.ffvpx-hw.enabled
+   type: RelaxedAtomicBool
++#if defined(MOZ_WIDGET_GTK)
++  value: true
++#else
+   value: false
++#endif
+   mirror: always
+ 
+ # The codecs in the vendored ffmpeg copy are usually prefered to the other
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0021-BACKPORT-Bug-1894818-part7-guard-HEVC-support-by-the.patch
+++ b/app-web/firefox/autobuild/patches/0021-BACKPORT-Bug-1894818-part7-guard-HEVC-support-by-the.patch
@@ -1,0 +1,37 @@
+From c48d034e9f40d433f3825741b592e8506293f372 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Fri, 21 Feb 2025 06:50:16 +0000
+Subject: [PATCH 21/22] BACKPORT: Bug 1894818 - part7 : guard HEVC support by
+ the pref. r=media-playback-reviewers,stransky
+
+Differential Revision: https://phabricator.services.mozilla.com/D238341
+---
+ dom/media/platforms/ffmpeg/FFmpegDecoderModule.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+index a619cd5be4a3..ae4f4ed2732d 100644
+--- a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
++++ b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+@@ -11,6 +11,7 @@
+ #include "FFmpegLibWrapper.h"
+ #include "FFmpegUtils.h"
+ #include "FFmpegVideoDecoder.h"
++#include "MP4Decoder.h"
+ #include "PlatformDecoderModule.h"
+ #include "VideoUtils.h"
+ #include "VPXDecoder.h"
+@@ -187,6 +188,10 @@ class FFmpegDecoderModule : public PlatformDecoderModule {
+       return media::DecodeSupportSet{};
+     }
+ 
++    if (MP4Decoder::IsHEVC(mimeType) && !StaticPrefs::media_hevc_enabled()) {
++      return media::DecodeSupportSet{};
++    }
++
+     AVCodecID videoCodec = FFmpegVideoDecoder<V>::GetCodecId(mimeType);
+     AVCodecID audioCodec = FFmpegAudioDecoder<V>::GetCodecId(
+         mimeType,
+-- 
+2.48.1
+

--- a/app-web/firefox/autobuild/patches/0022-BACKPORT-Bug-1950032-enable-HEVC-playback-by-default.patch
+++ b/app-web/firefox/autobuild/patches/0022-BACKPORT-Bug-1950032-enable-HEVC-playback-by-default.patch
@@ -1,0 +1,34 @@
+From 9ed99f65b86c6add26bbcbd424e766ab776a7178 Mon Sep 17 00:00:00 2001
+From: alwu <alwu@mozilla.com>
+Date: Mon, 24 Feb 2025 04:27:01 +0000
+Subject: [PATCH 22/22] BACKPORT: Bug 1950032 - enable HEVC playback by default
+ on Linux.
+
+Differential Revision: https://phabricator.services.mozilla.com/D239286
+---
+ modules/libpref/init/StaticPrefList.yaml | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
+index b00d24a723eb..4f4ce6e56d61 100644
+--- a/modules/libpref/init/StaticPrefList.yaml
++++ b/modules/libpref/init/StaticPrefList.yaml
+@@ -11321,15 +11321,7 @@
+ 
+ - name: media.hevc.enabled
+   type: RelaxedAtomicBool
+-#if defined(XP_WIN)
+-  value: true
+-#elif defined(XP_MACOSX)
+-  value: true
+-#elif defined(ANDROID)
+   value: true
+-#else
+-  value: false
+-#endif
+   mirror: always
+ 
+ - name: media.decoder-doctor.testing
+-- 
+2.48.1
+

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,4 +1,5 @@
 VER=135.0.1
+REL=1
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- firefox: backport HEVC hardware acceleration patches
    Track patches at AOSC-Tracking/firefox @ aosc/v135.0.1
    \(HEAD: c9715cfaaf3e02c3a3c15d196c090244e80d98cd\).

Package(s) Affected
-------------------

- firefox: 135.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
