### PR TITLE
wiliwili: update to 1.5.1

### DIFF
--- a/app-multimedia/wiliwili/spec
+++ b/app-multimedia/wiliwili/spec
@@ -1,4 +1,4 @@
-VER=1.5.0
+VER=1.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/xfangfang/wiliwili.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376456"


### PR DESCRIPTION
Topic Description
-----------------

- wiliwili: update to 1.5.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- wiliwili: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wiliwili
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
