### PR TITLE
fan2go: new, 0.9.0

### DIFF
--- a/app-utils/fan2go-tui/autobuild/beyond
+++ b/app-utils/fan2go-tui/autobuild/beyond
@@ -1,0 +1,11 @@
+abinfo "Installing configuration file ..."
+install -Dvm644 "$SRCDIR"/fan2go-tui.yaml \
+    -t "$PKGDIR"/etc/fan2go-tui
+
+abinfo "Installing completion files ..."
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
+"$PKGDIR"/usr/bin/fan2go-tui completion bash > "$PKGDIR"/usr/share/bash-completion/completions/fan2go-tui
+mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
+"$PKGDIR"/usr/bin/fan2go-tui completion zsh > "$PKGDIR"/usr/share/zsh/site-functions/_fan2go-tui
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d
+"$PKGDIR"/usr/bin/fan2go-tui completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/fan2go-tui.fish

--- a/app-utils/fan2go-tui/autobuild/defines
+++ b/app-utils/fan2go-tui/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="fan2go-tui"
+PKGSEC=utils
+PKGDES="Terminal user interface for fan2go"
+PKGDEP="glibc fan2go"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of
+# Go executables.
+ABSPLITDBG=0

--- a/app-utils/fan2go-tui/autobuild/prepare
+++ b/app-utils/fan2go-tui/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Getting build infomation ..."
+COMMIT=$(git rev-parse --short HEAD)
+DATE=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
+
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS+=(
+    "-X 'fan2go-tui/cmd/global.Version=$PKGVER'"
+    "-X 'fan2go-tui/cmd/global.Commit=$COMMIT'"
+    "-X 'fan2go-tui/cmd/global.Date=$DATE'"
+)

--- a/app-utils/fan2go-tui/spec
+++ b/app-utils/fan2go-tui/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/markusressel/fan2go-tui.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376895"

--- a/app-utils/fan2go/autobuild/beyond
+++ b/app-utils/fan2go/autobuild/beyond
@@ -1,0 +1,15 @@
+abinfo "Installing systemd service ..."
+install -Dvm644 "$SRCDIR"/fan2go.service \
+    -t "$PKGDIR"/usr/lib/systemd/system
+
+abinfo "Installing configuration file ..."
+install -Dvm644 "$SRCDIR"/fan2go.yaml \
+    -t "$PKGDIR"/etc/fan2go
+
+abinfo "Installing completion files ..."
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
+"$PKGDIR"/usr/bin/fan2go completion bash > "$PKGDIR"/usr/share/bash-completion/completions/fan2go
+mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
+"$PKGDIR"/usr/bin/fan2go completion zsh > "$PKGDIR"/usr/share/zsh/site-functions/_fan2go
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d
+"$PKGDIR"/usr/bin/fan2go completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/fan2go.fish

--- a/app-utils/fan2go/autobuild/defines
+++ b/app-utils/fan2go/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="fan2go"
+PKGSEC=utils
+PKGDES="A daemon providing dynamic fan speed control based on temperature sensors"
+PKGDEP="glibc lm-sensors"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of
+# Go executables.
+ABSPLITDBG=0

--- a/app-utils/fan2go/autobuild/prepare
+++ b/app-utils/fan2go/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS+=("-X 'github.com/markusressel/fan2go/cmd/global.Version=$PKGVER'")

--- a/app-utils/fan2go/spec
+++ b/app-utils/fan2go/spec
@@ -1,0 +1,4 @@
+VER=0.9.0
+SRCS="git::commit=tags/$VER::https://github.com/markusressel/fan2go.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376893"


### PR DESCRIPTION
Topic Description
-----------------

- fan2go-tui: new, 0.2.1
- fan2go: new, 0.9.0

Package(s) Affected
-------------------

- fan2go: 0.9.0
- fan2go-tui: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fan2go fan2go-tui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
