### PR TITLE
man-db: Depends on po4a

### DIFF
--- a/app-utils/man-db/autobuild/defines
+++ b/app-utils/man-db/autobuild/defines
@@ -11,6 +11,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__M68K}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
+BUILDDEP="po4a"
 PKGDES="A collection of utilities for reading and managing man pages"
 
 # Note: --disable-cache-owner allows man-db to use root as the default owner

--- a/app-utils/man-db/spec
+++ b/app-utils/man-db/spec
@@ -1,4 +1,5 @@
 VER=2.13.0
+REL=1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/man-db/man-db-$VER.tar.xz"
 CHKSUMS="sha256::82f0739f4f61aab5eb937d234de3b014e777b5538a28cbd31433c45ae09aefb9"
 CHKUPDATE="anitya::id=1882"


### PR DESCRIPTION
Topic Description
-----------------

Translate the man pages of itself (i.e. "man man") to multiple languages, following the "offer satisfactory out-of-the-box experience for users of different language backgrounds" principle.

Package(s) Affected
-------------------

* man-db: 2.13.0-1

Security Update?
----------------

No

Build Order
-----------------

```
#buildit man-db
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
