### PR TITLE
dracut-ng: add /usr/lib/firmware to the list of trigger interests

### DIFF
--- a/app-admin/dracut-ng/autobuild/triggers
+++ b/app-admin/dracut-ng/autobuild/triggers
@@ -1,6 +1,7 @@
 interest-noawait /boot
-interest-noawait /usr/lib/modprobe.d
 interest-noawait /etc/modprobe.d
 interest-noawait /usr/lib/dracut
+interest-noawait /usr/lib/firmware
+interest-noawait /usr/lib/modprobe.d
 interest-noawait initrd-systemd-unit-update
 interest-noawait initrd-update

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,5 @@
 VER=105
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: add /usr/lib/firmware to trigger interest
    Many firmware were included as part of the early boot process.
    Add /usr/lib/firmware to the list of trigger interests to make sure that
    they are updated in the initramfs as well.

Package(s) Affected
-------------------

- dracut-ng: 105-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
