### PR TITLE
nexttrace: configuring capability of /usr/bin/nexttrace

### DIFF
--- a/app-network/nexttrace/autobuild/beyond
+++ b/app-network/nexttrace/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Renaming NTrace-core to nexttrace"
+mv -v "$PKGDIR"/usr/bin/NTrace-core "$PKGDIR"/usr/bin/nexttrace

--- a/app-network/nexttrace/autobuild/build
+++ b/app-network/nexttrace/autobuild/build
@@ -1,6 +1,0 @@
-abinfo "Building nexttrace ..."
-go build -ldflags "-s -w -buildid= -linkmode external \
-    -X 'github.com/nxtrace/NTrace-core/config.Version=$PKGVER' \
-    -X 'github.com/nxtrace/NTrace-core/config.CommitID=$commit' \
-    -X 'github.com/nxtrace/NTrace-core/config.BuildDate=$date'" \
-    -o "$PKGDIR"/usr/bin/nexttrace

--- a/app-network/nexttrace/autobuild/postinst
+++ b/app-network/nexttrace/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Configuring capability of /usr/bin/nexttrace"
+setcap cap_net_raw,cap_net_admin+eip /usr/bin/nexttrace

--- a/app-network/nexttrace/autobuild/prepare
+++ b/app-network/nexttrace/autobuild/prepare
@@ -1,3 +1,10 @@
 abinfo "Setting build information ..."
-export commit=$(git rev-parse --short HEAD)
-export date=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
+COMMIT=$(git rev-parse --short HEAD)
+DATE=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
+
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS+=(
+    "-X 'github.com/nxtrace/NTrace-core/config.Version=$PKGVER'"
+    "-X 'github.com/nxtrace/NTrace-core/config.CommitID=$COMMIT'"
+    "-X 'github.com/nxtrace/NTrace-core/config.BuildDate=$DATE'"
+)

--- a/app-network/nexttrace/spec
+++ b/app-network/nexttrace/spec
@@ -1,4 +1,5 @@
 VER=1.3.7
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/nxtrace/NTrace-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=356726"


### PR DESCRIPTION
Topic Description
-----------------

- nexttrace: configuring capability of /usr/bin/nexttrace
    - Configuring capability of /usr/bin/nexttrace
    - Use gomod template to build

Package(s) Affected
-------------------

- nexttrace: 1.3.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nexttrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
