### PR TITLE
emacs: update to 30.1

### DIFF
--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,4 +1,4 @@
-VER=29.4
+VER=30.1
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
-CHKSUMS="sha256::1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf"
+CHKSUMS="sha256::54404782ea5de37e8fcc4391fa9d4a41359a4ba9689b541f6bc97dd1ac283f6c"
 CHKUPDATE="anitya::id=675"


### PR DESCRIPTION
Topic Description
-----------------

- emacs: update to 30.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- emacs: 30.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit emacs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
