### PR TITLE
libtiff: move glu, jbigkit to PKGDEP

### DIFF
--- a/runtime-imaging/libtiff/autobuild/defines
+++ b/runtime-imaging/libtiff/autobuild/defines
@@ -1,11 +1,7 @@
 PKGNAME=libtiff
 PKGSEC=libs
-PKGDEP="gcc-runtime libjpeg-turbo zlib xz freeglut libwebp"
-BUILDDEP="glu jbigkit"
-PKGSUG="glu jbigkit"
+PKGDEP="freeglut gcc-runtime glu jbigkit libwebp libjpeg-turbo xz zlib"
 PKGDES="Library for manipulation of TIFF images"
-
-ABSHADOW=no
 
 # Note: For compatibility with Debian applications.
 AUTOTOOLS_AFTER="--enable-ld-version-script"

--- a/runtime-imaging/libtiff/autobuild/defines.stage2
+++ b/runtime-imaging/libtiff/autobuild/defines.stage2
@@ -2,5 +2,3 @@ PKGNAME=libtiff
 PKGSEC=libs
 PKGDEP="gcc-runtime libjpeg-turbo zlib xz"
 PKGDES="Library for manipulation of TIFF images"
-
-ABSHADOW=no

--- a/runtime-imaging/libtiff/spec
+++ b/runtime-imaging/libtiff/spec
@@ -1,5 +1,5 @@
 VER=4.4.0
-REL=1
+REL=2
 SRCS="tbl::https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
 CHKSUMS="sha256::917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed"
 CHKUPDATE="anitya::id=1738"


### PR DESCRIPTION
Topic Description
-----------------

- libtiff: move glu, jbigkit to PKGDEP
    They are bot dynamic libraries and should not be omitted as runtime
    dependencies.

Package(s) Affected
-------------------

- libtiff: 4.4.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtiff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
