### PR TITLE
xorg-server: workaround bad firmware boot VGA reporting on MIPS Loongson devices

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,7 +1,7 @@
-From db964f598a52652c6d3d674a81e577ef3f01b46d Mon Sep 17 00:00:00 2001
+From c77be321d01ba91443845d3f5896969e0c2be546 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
-Subject: [PATCH 1/6] Use intel ddx only on pre-gen4 hw, newer ones will fall
+Subject: [PATCH 1/7] Use intel ddx only on pre-gen4 hw, newer ones will fall
  back to modesetting
 
 Co-authored-by: Timo Aaltonen <tjaalton@debian.org>
@@ -40,5 +40,5 @@ index aeeed8be6..db705bf72 100644
  			break;
          }
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,7 +1,7 @@
-From d02162ee355de18fc02474a43226bed8777f734c Mon Sep 17 00:00:00 2001
+From 4cfdf63ec7370aaf877434191035c04b7ead7c6e Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
-Subject: [PATCH 2/6] xfree86: use modesetting driver by default on GeForce 8
+Subject: [PATCH 2/7] xfree86: use modesetting driver by default on GeForce 8
  and newer
 
 Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
@@ -49,5 +49,5 @@ index db705bf72..d2e78acaa 100644
  #endif
          driverList[idx++] = "nv";
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
-From 5c1585f201bc1b75eea3416ea7cff441509be526 Mon Sep 17 00:00:00 2001
+From f918df1581bd0bc707bbfdf7be941678a7839b5d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
-Subject: [PATCH 3/6] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 3/7] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -29,7 +29,7 @@ Ref: https://gitlab.freedesktop.org/xorg/xserver/-/commit/f59871587ea678d4c49887
  3 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/hw/xfree86/common/xf86Mode.c b/hw/xfree86/common/xf86Mode.c
-index eb0885571..fec60a957 100644
+index ef3be84c3..b275ce9d8 100644
 --- a/hw/xfree86/common/xf86Mode.c
 +++ b/hw/xfree86/common/xf86Mode.c
 @@ -230,6 +230,8 @@ xf86ModeStatusToString(ModeStatus status)
@@ -85,5 +85,5 @@ index ad01b87ec..561087717 100644
      MODE_ERROR = -1             /* error condition */
  } ModeStatus;
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,7 +1,7 @@
-From b9010be23844651b133e09921993054ed9e5c1e8 Mon Sep 17 00:00:00 2001
+From 25b4c31765c73f27fa2e8f0892dd151a1c28bd43 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
-Subject: [PATCH 4/6] xf86: Accept devices with the 'hyperv_drm' driver
+Subject: [PATCH 4/7] xf86: Accept devices with the 'hyperv_drm' driver
 
 Put in a workaround to accept devices of the kernel's hyperv_drm
 driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics
@@ -28,5 +28,5 @@ index 45028f7a6..071f44b2a 100644
                      if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
                          break;
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,7 +1,7 @@
-From e98bf06b4da1a8e5791290b45eca6cb73db08ba5 Mon Sep 17 00:00:00 2001
+From edccf4dfc0dd8dbb2c75e2e4a6e10be10f31c39b Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
-Subject: [PATCH 5/6] Allows X to work on the Lemote Yeeloong laptop
+Subject: [PATCH 5/7] Allows X to work on the Lemote Yeeloong laptop
 
 ---
  hw/xfree86/common/compiler.h            | 64 ++++++++++++++++++++++++-
@@ -133,5 +133,5 @@ index fd83022f6..bacbe010b 100644
      if (ioBase == NULL) {
          ioBase = (volatile unsigned char *) mmap(0, 0x20000,
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,7 +1,7 @@
-From d57964fe30504a3618e0f4ea3f497552bb35fb5a Mon Sep 17 00:00:00 2001
+From 7258ef1c6301c99ebbe9b03eede5ca982bb8ed48 Mon Sep 17 00:00:00 2001
 From: "Liu, Chang" <cl91tp@gmail.com>
 Date: Wed, 8 Nov 2023 13:02:10 +0800
-Subject: [PATCH 6/6] modesetting: match against Multimedia Video Controllers
+Subject: [PATCH 6/7] modesetting: match against Multimedia Video Controllers
  as well
 
 Some GPU devices such as those found in the Loongson 7A2000 bridge
@@ -28,5 +28,5 @@ index 535f49d1d..54eb42d84 100644
      {0, 0, 0},
  };
 -- 
-2.47.1
+2.48.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
@@ -1,0 +1,78 @@
+From c1229340f1380149f44cbe48854afe507971aa18 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 24 Feb 2025 17:38:44 +0800
+Subject: [PATCH 7/7] hw/xfree86: workaround bad firmware boot VGA reporting on
+ MIPS Loongson devices
+
+Loongson (MIPS) platforms based on (at least) the 7A bridge chip has
+faulty firmware that does not export the correct boot VGA device to the
+operating system, causing the X server to mistake the non-connected output
+as the primary match for X output - which then causes the X server to fail
+to probe for the right driver, in turn causing X server to fail at
+startup.
+
+From our user report, this motherboard/firmware combination is known to
+have this issue (there is probably more):
+
+  BM6J74 (Kunlun 4.00.0024, OEM version LJ74B00BPS)
+
+The original patch from Loongson/UOS uses an extra call to
+`xf86platformPrimary()' to override the result from the above call to
+`xf86platformProbe()', prompting X to use the first platform device found
+on the device (the first video card/GPU probed by the kernel (for
+modesetting or simply as firmware output).
+
+This will most certainly break other platforms without this issue, so
+limit this workaround to little-endian MIPS64 with N64 ABI for now (for
+which AOSC OS only supports Loongson 3 devices).
+
+[Where this patch was first shown to the public...]
+Link: https://github.com/deepin-community/xorg-server/pull/11
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ hw/xfree86/common/xf86Bus.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/hw/xfree86/common/xf86Bus.c b/hw/xfree86/common/xf86Bus.c
+index fd144dbe7..a95096736 100644
+--- a/hw/xfree86/common/xf86Bus.c
++++ b/hw/xfree86/common/xf86Bus.c
+@@ -241,6 +241,34 @@ xf86BusProbe(void)
+ {
+ #ifdef XSERVER_PLATFORM_BUS
+     xf86platformProbe();
++/*
++ * Loongson (MIPS) platforms based on (at least) the 7A bridge chip has
++ * faulty firmware that does not export the correct boot VGA device to the
++ * operating system, causing the X server to mistake the non-connected
++ * output as the primary match for X output - which then causes the X
++ * server to fail to probe for the right driver, in turn causing X server
++ * to fail at startup.
++ *
++ * From our user report, this motherboard/firmware combination is known
++ * to have this issue (there is probably more):
++ *
++ *   BM6J74 (Kunlun 4.00.0024, OEM version LJ74B00BPS)
++ *
++ * The original patch from Loongson/UOS uses an extra call to
++ * `xf86platformPrimary()' to override the result from the above call to
++ * `xf86platformProbe()', prompting X to use the first platform device
++ * found on the device (the first video card/GPU probed by the kernel (for
++ * modesetting or simply as firmware output).
++ *
++ * This will most certainly break other platforms without this issue, so
++ * limit this workaround to little-endian MIPS64 with N64 ABI for now for
++ * which AOSC OS only supports Loongson 3 devices).
++ */
++#if (defined(__mips) && defined (_ABI64) && \
++     defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
++     (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
++    xf86platformPrimary();
++#endif
+     if (ServerIsNotSeat0() && xf86_num_platform_devices > 0)
+         return;
+ #endif
+-- 
+2.48.1
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,5 +1,5 @@
 VER=21.1.15
-REL=1
+REL=2
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
 CHKSUMS="sha256::841c82901282902725762df03adbbcd68153d4cdfb0d61df0cfd73ad677ae089"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: workaround bad firmware boot VGA reporting on MIPS Loongson devices
    Loongson \(MIPS\) platforms based on \(at least\) the 7A bridge chip has
    faulty firmware that does not export the correct boot VGA device to the
    operating system, causing the X server to mistake the non-connected output
    as the primary match for X output - which then causes the X server to fail
    to probe for the right driver, in turn causing X server to fail at
    startup.
    From our user report, this motherboard/firmware combination is known to
    have this issue \(there is probably more\):
    BM6J74 \(Kunlun 4.00.0024, OEM version LJ74B00BPS\)
    The original patch from Loongson/UOS uses an extra call to
    \`xf86platformPrimary\(\)' to override the result from the above call to
    \`xf86platformProbe\(\)', prompting X to use the first platform device found
    on the device \(the first video card/GPU probed by the kernel \(for
    modesetting or simply as firmware output\).
    This will most certainly break other platforms without this issue, so
    limit this workaround to little-endian MIPS64 with N64 ABI for now \(for
    which AOSC OS only supports Loongson 3 devices\).
    \[Where this patch was first shown to the public...\]
    Link: https://github.com/deepin-community/xorg-server/pull/11

Package(s) Affected
-------------------

- xorg-server: 21.1.15-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
