### PR TITLE
power-profiles-daemon: update to 0.30

### DIFF
--- a/app-admin/power-profiles-daemon/spec
+++ b/app-admin/power-profiles-daemon/spec
@@ -1,4 +1,4 @@
-VER=0.21
+VER=0.30
 SRCS="tbl::https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/archive/$VER/power-profiles-daemon-$VER.tar.gz"
-CHKSUMS="sha256::c15a368a59f2cae1474bdfccdd9357f06b0abc9eb7638a87f68c091aaf570349"
+CHKSUMS="sha256::90f2c95024861d9f4062abedd514084939224e7a49edd468f001af7260ec8e6c"
 CHKUPDATE="anitya::id=236320"


### PR DESCRIPTION
Topic Description
-----------------

- power-profiles-daemon: update to 0.30
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- power-profiles-daemon: 0.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit power-profiles-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
