### PR TITLE
broadcom-wl: update to 6.30.223.271-6

### DIFF
--- a/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
+++ b/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
@@ -19,10 +19,12 @@ PATCH[11]="013-linux518.patch"
 PATCH[12]="014-linux414.patch"
 PATCH[13]="015-linux600.patch"
 PATCH[14]="016-linux601.patch"
+PATCH[15]="017-linux612.patch"
+PATCH[16]="018-linux613.patch"
 # Debian patches
 # https://packages.debian.org/sid/broadcom-sta-dkms
-PATCH[15]="05-remove-time-and-date-macros.patch"
+PATCH[17]="05-remove-time-and-date-macros.patch"
 # AOSC OS patches
-PATCH[16]="aosc-1-wlan-ifname.patch"
-PATCH[17]="aosc-2-blob-path.patch"
+PATCH[18]="aosc-1-wlan-ifname.patch"
+PATCH[19]="aosc-2-blob-path.patch"
 AUTOINSTALL="yes"

--- a/runtime-kernel/broadcom-wl/autobuild/patches/016-linux601.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/016-linux601.patch
@@ -1,4 +1,4 @@
-diff -Nurp -u -r a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+diff -Nurp a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
 --- a/src/wl/sys/wl_cfg80211_hybrid.c	2022-12-12 00:23:30.821615599 +0000
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c	2022-12-12 00:35:47.854975024 +0000
 @@ -105,14 +105,28 @@ static s32 wl_cfg80211_get_tx_power(stru

--- a/runtime-kernel/broadcom-wl/autobuild/patches/017-linux612.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/017-linux612.patch
@@ -1,0 +1,15 @@
+diff -Nurp a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+--- a/src/wl/sys/wl_linux.c	2024-11-19 03:05:21.160736778 +0000
++++ b/src/wl/sys/wl_linux.c	2024-11-19 03:09:59.010905106 +0000
+@@ -56,7 +56,11 @@
+ #include <asm/irq.h>
+ #include <asm/pgtable.h>
+ #include <asm/uaccess.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++#include <linux/unaligned.h>
++#else
+ #include <asm/unaligned.h>
++#endif
+ 
+ #include <proto/802.1d.h>
+ 

--- a/runtime-kernel/broadcom-wl/autobuild/patches/018-linux613.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/018-linux613.patch
@@ -1,0 +1,32 @@
+From 5788a19e88aac78e6b2ec8bef7cb094fc14cfbf0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sat, 12 Oct 2024 11:54:40 +0000
+Subject: [PATCH] Tentative patch for broadcom-wl 6.30.223.271 driver for Linux
+ 6.13-rc1
+
+The net/lib80211.h header has been removed by commit
+"wifi: ipw2x00/lib80211: move remaining lib80211 into libipw"
+(Johannes Berg, 7 Oct 2024).
+The header does not appear to be actually used anywhere, so remove it.
+
+ #include <asm/irq.h>
+ #include <asm/pgtable.h>
+---
+ src/include/linuxver.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/include/linuxver.h b/src/include/linuxver.h
+index b05bc32..06e32eb 100644
+--- a/src/include/linuxver.h
++++ b/src/include/linuxver.h
+@@ -147,7 +147,7 @@ typedef irqreturn_t(*FN_ISR) (int irq, void *dev_id, struct pt_regs *ptregs);
+ #include <linux/sched.h>
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ #include <net/lib80211.h>
+ #endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+-- 
+2.47.0

--- a/runtime-kernel/broadcom-wl/spec
+++ b/runtime-kernel/broadcom-wl/spec
@@ -1,5 +1,5 @@
 VER=6.30.223.271
-REL=5
+REL=6
 SRCS="tbl::https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/hybrid-v35_64-nodebug-pcoem-${VER//./_}.tar.gz"
 CHKSUMS="sha256::5f79774d5beec8f7636b59c0fb07a03108eef1e3fd3245638b20858c714144be"
 SUBDIR=.


### PR DESCRIPTION
Bring in latest patches from Arch Linux for Linux 6.12+

Topic Description
-----------------

broadcom-wl-6.30.223.271-6
Proprietary Broadcom WiFi driver updated for Linux v6.12+

Package(s) Affected
-------------------

runtime-kernel/broadcom-wl

Build Order
-----

```
#buildit broadcom-wl
```

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
