### PR TITLE
xf86-input-synaptics: update to 1.10.0

### DIFF
--- a/runtime-display/xf86-input-synaptics/autobuild/patches/0001-eventcomm-add-VID-0x06cb-for-Synaptics-devices.patch
+++ b/runtime-display/xf86-input-synaptics/autobuild/patches/0001-eventcomm-add-VID-0x06cb-for-Synaptics-devices.patch
@@ -1,0 +1,33 @@
+From 472c5f24f44ec2519abfe2beb4d0317cd9f74b4f Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Tue, 25 Feb 2025 14:29:31 +0800
+Subject: [PATCH] eventcomm: add VID 0x06cb for Synaptics devices
+
+The vendor ID 0x06cb is used by HID devices from Synaptics.
+
+Match it to MODEL_SYNAPTICS.
+
+Tested on a Panasonic CF-SV equipped with "Synaptics TM3136-020"
+touchpad, which previously uses MODEL_UNKNOWN to calculate edge width
+and the result is too narrow.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/eventcomm.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/eventcomm.c b/src/eventcomm.c
+index aac94d5..cfbfb74 100644
+--- a/src/eventcomm.c
++++ b/src/eventcomm.c
+@@ -345,6 +345,7 @@ struct model_lookup_t {
+ static struct model_lookup_t model_lookup_table[] = {
+     {0x0002, 0x0007, 0x0007, MODEL_SYNAPTICS},
+     {0x0002, 0x0008, 0x0008, MODEL_ALPS},
++    {0x06cb, PRODUCT_ANY, PRODUCT_ANY, MODEL_SYNAPTICS},
+     {0x05ac, PRODUCT_ANY, 0x222, MODEL_APPLETOUCH},
+     {0x05ac, 0x223, 0x228, MODEL_UNIBODY_MACBOOK},
+     {0x05ac, 0x229, 0x22b, MODEL_APPLETOUCH},
+-- 
+2.48.1
+

--- a/runtime-display/xf86-input-synaptics/spec
+++ b/runtime-display/xf86-input-synaptics/spec
@@ -1,4 +1,4 @@
-VER=1.9.2
+VER=1.10.0
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/driver/xf86-input-synaptics-$VER.tar.gz"
-CHKSUMS="sha256::ab1fd79957d680a770afa4c123deb603ea0fe843e876391387eddb6b7f29ce17"
+CHKSUMS="sha256::4d0538454c636c763731f601db0ef5164e089fc6eb0988fe6bcd53e4b5d377da"
 CHKUPDATE="anitya::id=5239"


### PR DESCRIPTION
Topic Description
-----------------

- xf86-input-synaptics: update to 1.10.0
    - Added a patch that recognizes HID-connected Synaptics touchpad hardwares.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- xf86-input-synaptics: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-input-synaptics
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
