### PR TITLE
rathole: rebuild for rust 1.80.5

### DIFF
--- a/app-network/rathole/autobuild/beyond
+++ b/app-network/rathole/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Installing systemd services"
+for file in "*.service"; do
+    install -Dvm644 "$SRCDIR"/examples/systemd/$file \
+        -t "$PKGDIR"/usr/lib/systemd/system
+done

--- a/app-network/rathole/autobuild/defines
+++ b/app-network/rathole/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=rathole
 PKGSEC=net
-PKGDEP="glibc"
-BUILDDEP="rustc cargo"
-PKGDES="A reverse proxy for NAT traversal, written in Rust."
+PKGDEP="gcc-runtime glibc openssl"
+BUILDDEP="rustc llvm"
+PKGDES="A reverse proxy for NAT traversal"
 
-USECLANG=0
-NOLTO=1
+USECLANG=1
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON=1

--- a/app-network/rathole/autobuild/patches/0001-fix-build-for-rust-1.18.5.patch
+++ b/app-network/rathole/autobuild/patches/0001-fix-build-for-rust-1.18.5.patch
@@ -1,0 +1,89 @@
+From 813184d35adbad0b12aa6615cb9b8cf256e75075 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Tue, 25 Feb 2025 16:21:00 +0800
+Subject: [PATCH] fix build for rust 1.18.5
+
+Patch source:
+https://raw.githubusercontent.com/Homebrew/formula-patches/bd353c6adb3601f32de0fa87f3acd34a98da6ec1/rathole/rust-1.80.patch
+---
+ Cargo.lock | 30 ++++++++++++++++++++++++------
+ 1 file changed, 24 insertions(+), 6 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 6856445..f952333 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -491,9 +491,12 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+ [[package]]
+ name = "deranged"
+-version = "0.3.8"
++version = "0.3.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
++checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
++dependencies = [
++ "powerfmt",
++]
+
+ [[package]]
+ name = "digest"
+@@ -1173,6 +1176,12 @@ dependencies = [
+  "winapi",
+ ]
+
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-traits"
+ version = "0.2.16"
+@@ -1365,6 +1374,12 @@ dependencies = [
+  "universal-hash",
+ ]
+
++[[package]]
++name = "powerfmt"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
++
+ [[package]]
+ name = "ppv-lite86"
+ version = "0.2.17"
+@@ -1894,12 +1909,14 @@ dependencies = [
+
+ [[package]]
+ name = "time"
+-version = "0.3.29"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -1913,10 +1930,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+ [[package]]
+ name = "time-macros"
+-version = "0.2.15"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+
+--
+2.48.1

--- a/app-network/rathole/spec
+++ b/app-network/rathole/spec
@@ -1,4 +1,5 @@
 VER=0.5.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/rapiz1/rathole"
 CHKSUMS="SKIP"
-CHKUPDATE="github::repo=rapiz1/rathole"
+CHKUPDATE="anitya::id=376101"


### PR DESCRIPTION
Topic Description
-----------------

- rathole: rebuild for rust 1.18.5
    - Add systemd services
    - Clean up code
- xf86-input-synaptics: update to 1.10.0
    - Added a patch that recognizes HID-connected Synaptics touchpad hardwares.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- rathole: 0.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rathole
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
