### PR TITLE
gettext: update to 0.24

### DIFF
--- a/app-devel/gettext/spec
+++ b/app-devel/gettext/spec
@@ -1,4 +1,4 @@
-VER=0.23
+VER=0.24
 SRCS="https://ftp.gnu.org/gnu/gettext/gettext-$VER.tar.xz"
-CHKSUMS="sha256::bf31a9b6bdf3e364669c7bd9858f97e4a0c408a8d22940c5d4ab638b65460f85"
+CHKSUMS="sha256::e1620d518b26d7d3b16ac570e5018206e8b0d725fb65c02d048397718b5cf318"
 CHKUPDATE="anitya::id=898"


### PR DESCRIPTION
Topic Description
-----------------

- gettext: update to 0.24
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gettext: 1:0.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit gettext
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
