### PR TITLE
xorg-server: update to 21.1.16

### DIFF
--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,5 +1,4 @@
-VER=21.1.15
-REL=2
+VER=21.1.16
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::841c82901282902725762df03adbbcd68153d4cdfb0d61df0cfd73ad677ae089"
+CHKSUMS="sha256::b14a116d2d805debc5b5b2aac505a279e69b217dae2fae2dfcb62400471a9970"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: update to 21.1.16
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xorg-server: 21.1.16

Security Update?
----------------

Yes, #9861

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
