### PR TITLE
networkmanager-l2tp: update to 1.20.20

### DIFF
--- a/app-network/networkmanager-l2tp/autobuild/defines
+++ b/app-network/networkmanager-l2tp/autobuild/defines
@@ -4,8 +4,10 @@ PKGDEP="libgnome-keyring network-manager-applet ppp xl2tpd strongswan"
 BUILDDEP="intltool"
 PKGDES="L2TP support plugin for NetworkManager"
 
-AUTOTOOLS_AFTER="--with-pppd-plugin-dir=/usr/lib/pppd/2.4.9 \
+# FIXME: Add a more dynamic way to detect PPP version.
+AUTOTOOLS_AFTER="--with-pppd-plugin-dir=/usr/lib/pppd/${__PPP_VER} \
                  --enable-lto=yes \
-                 --enable-more-warnings=yes \
-                 --without-libnm-glib"
-ABSHADOW=no
+                 --enable-more-warnings=yes"
+
+# FIXME: /usr/bin/msgfmt: cannot create output file "appdata/network-manager-l2tp.metainfo.xml": No such file or directory
+ABSHADOW=0

--- a/app-network/networkmanager-l2tp/spec
+++ b/app-network/networkmanager-l2tp/spec
@@ -1,5 +1,6 @@
-VER=1.8.6
-SRCS="tbl::https://github.com/nm-l2tp/network-manager-l2tp/archive/$VER.tar.gz"
-CHKSUMS="sha256::1455b2bc0dd802522e79a176c654d1a19482b6a26d7c3a9c0fce2ee2dbb892e2"
+VER=1.20.20
+# FIXME: Add a more dynamic way to detect PPP version.
+__PPP_VER=2.5.2
+SRCS="git::commit=tags/$VER::https://github.com/nm-l2tp/network-manager-l2tp"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10788"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager-l2tp: update to 1.20.20
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- networkmanager-l2tp: 1.20.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager-l2tp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
