### PR TITLE
opensc: update to 0.26.1

### DIFF
--- a/app-devices/opensc/autobuild/defines
+++ b/app-devices/opensc/autobuild/defines
@@ -13,3 +13,5 @@ AUTOTOOLS_AFTER="--enable-man \
                  --enable-sm \
                  --with-xsl-stylesheetsdir=/usr/share/xml/docbook/xsl-stylesheets-1.79.2"
 ABSHADOW=0
+
+PKGBREAK="tdelibs<=14.1.2 rng-tools<=6.17"

--- a/app-devices/opensc/spec
+++ b/app-devices/opensc/spec
@@ -1,4 +1,4 @@
-VER=0.25.1
+VER=0.26.1
 SRCS="git::commit=tags/$VER::https://github.com/OpenSC/OpenSC"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2559"

--- a/app-utils/rng-tools/spec
+++ b/app-utils/rng-tools/spec
@@ -2,3 +2,4 @@ VER=6.17
 SRCS="git::commit=tags/v$VER::https://github.com/nhorman/rng-tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4202"
+REL=1

--- a/desktop-trinity/tdelibs/spec
+++ b/desktop-trinity/tdelibs/spec
@@ -2,3 +2,4 @@ VER=14.1.2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdelibs-trinity-$VER.tar.xz"
 CHKSUMS="sha256::69deb61281944c02da5d9518025c9069557025e6fc567c65cb30aa97ea725155"
 CHKUPDATE="anitya::id=16065"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- tdelibs: bump REL for opensc 0.26.1
- rng-tools: bump REL for opensc 0.26.1
- opensc: update to 0.26.1
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- opensc: 0.26.1
- rng-tools: 6.17-1
- tdelibs: 14.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opensc tdelibs rng-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
