### PR TITLE
libva-nvidia-driver: update to 0.0.13

### DIFF
--- a/runtime-multimedia/libva-nvidia-driver/autobuild/defines
+++ b/runtime-multimedia/libva-nvidia-driver/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=libva-nvidia-driver
 PKGDES="NVDEC backend for VA-API"
 PKGSEC=libs
-PKGDEP="debconf libva gstreamer"
+PKGDEP="debconf libva gstreamer libdrm"
+# FIXME: libva-nvidia-driver depends on `nvidia` or `nvidia-open`, ACBS 
+# currently lacks the ability to specify "or" relationship, so we default to
+# recommend `nvidia` here as it is still what we preinstall
+PKGRECOM="nvidia"
 BUILDDEP="ffnvcodec"
 
 PKGBREAK="libva-vdpau-driver<=0.7.4-6"

--- a/runtime-multimedia/libva-nvidia-driver/spec
+++ b/runtime-multimedia/libva-nvidia-driver/spec
@@ -1,4 +1,4 @@
-VER=0.0.12
+VER=0.0.13
 SRCS="git::commit=tags/v$VER::https://github.com/elFarto/nvidia-vaapi-driver"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=1754"
+CHKUPDATE="anitya::id=242346"


### PR DESCRIPTION
Topic Description
-----------------

- libva-nvidia-driver: update to 0.0.13
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libva-nvidia-driver: 0.0.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit libva-nvidia-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
