### PR TITLE
[SECURIYT] openh264: update to 2.6.0+gmp135

### DIFF
--- a/app-multimedia/openh264/autobuild/defines
+++ b/app-multimedia/openh264/autobuild/defines
@@ -6,12 +6,9 @@ PKGDES="Codec applications and runtime for H.264 (Cisco)"
 
 AB_FLAGS_O3=1
 
-# FIXME: lto1: fatal error: target specific builtin not available.
-NOLTO__LOONGARCH64=1
-
 PKGBREAK="""
-freerdp<=2:2.10.0-1
-gstreamer<=1.22.0-2
-libopenglrecorder<=0.1.0-4
-telegram-desktop<=4.12.2
+freerdp<=2:3.9.0
+gstreamer<=1.24.12
+libopenglrecorder<=0.1.0-6
+telegram-desktop<=5.11.1
 """

--- a/app-multimedia/openh264/spec
+++ b/app-multimedia/openh264/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=2.5.0
-GMPVER=114_2
+UPSTREAM_VER=2.6.0
+GMPVER=135
 VER=${UPSTREAM_VER}+gmp${GMPVER/_/+}
 SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/cisco/openh264 \
       git::commit=tags/Firefox${GMPVER};rename=gmp-api::https://github.com/mozilla/gmp-api"

--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -2,3 +2,4 @@ VER=3.9.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
 CHKSUMS="sha256::2eef25f2b421dbe7b6ca64a96045afe57a4b8c559339baca8cb8528c42518b83"
 CHKUPDATE="anitya::id=10442"
+REL=1

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -11,3 +11,4 @@ ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem_per_core=4"
 ENVREQ__LOONGSON3="total_mem_per_core=4"
 ENVREQ__PPC64EL="total_mem_per_core=4"
+REL=1

--- a/runtime-games/libopenglrecorder/spec
+++ b/runtime-games/libopenglrecorder/spec
@@ -1,5 +1,5 @@
 VER=0.1.0
-REL=6
+REL=7
 SRCS="tbl::https://github.com/Benau/libopenglrecorder/archive/v$VER.tar.gz"
 CHKSUMS="sha256::a90a99c23f868636f77003a8dc6ffe6c3699fc2759c47df5dbd44ff8b42d2e4f"
 CHKUPDATE="anitya::id=230119"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -2,3 +2,4 @@ VER=1.24.12
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: rebuild for OpenH264 2.6.0
- libopenglrecorder: rebuild for OpenH264 2.6.0
- freerdp: rebuild for OpenH264 2.6.0
- gstreamer: rebuild for OpenH264 2.6.0
- openh264: update to 2.6.0+gmp135
    - Update PKGBREAK information.
    - Drop LTO disablement for LoongArch.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- freerdp: 2:3.9.0-1
- gstreamer: 1.24.12-1
- libopenglrecorder: 0.1.0-7
- openh264: 2.6.0+gmp135
- telegram-desktop: 5.11.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openh264:-pkgbreak freerdp libopenglrecorder telegram-desktop gstreamer openh264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
