### PR TITLE
TigerVNC: update builtin xorg-server to 21.1.16

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,9 +1,9 @@
 UPSTREAM_VER=1.15.0
-XORG_VER=21.1.13
+XORG_VER=21.1.16
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c"
+         sha256::b14a116d2d805debc5b5b2aac505a279e69b217dae2fae2dfcb62400471a9970"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update builtin xorg-server to 21.1.16

Package(s) Affected
-------------------

- tigervnc: 1.15.0+xserver21.1.16

Security Update?
----------------

Yes, #9861

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
