### PR TITLE
spacebar: new, 23.01.0

### DIFF
--- a/desktop-kde/spacebar/autobuild/defines
+++ b/desktop-kde/spacebar/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=spacebar
+PKGDES="SMS/MMS application for Plasma Mobile"
+PKGSEC=kde
+PKGDEP="qt-5 kirigami2 libphonenumber qcoro kpeople ki18n knotifications kconfig kcoreaddons kdbusaddons kcontacts kio modemmanager-qt kirigami-addons qcoro"
+BUILDDEP="extra-cmake-modules"

--- a/desktop-kde/spacebar/spec
+++ b/desktop-kde/spacebar/spec
@@ -1,0 +1,4 @@
+VER=23.01.0
+SRCS="tbl::https://download.kde.org/stable/plasma-mobile/${VER}/spacebar-${VER}.tar.xz"
+CHKSUMS="sha256::545b596dca1c99010379111a149309f5c4b9320d90092ce5ec8f01b4ecda3c6b"
+CHKUPDATE="anitya::id=229048"


### PR DESCRIPTION
Topic Description
-----------------

- spacebar: new, 23.01.0
    Not its newest version, but fits other KDE applications in the
    repository \(the next version of spacebar is 24.05.0 before switching to
    follow Plasma version numbers instead of KDE application ones\).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- spacebar: 23.01.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit spacebar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
