### PR TITLE
qemu: update to 9.2.2

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,4 @@
-VER=9.2.1
+VER=9.2.2
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::b7b0782ead63a5373fdfe08e084d3949a9395ec196180286b841f78a464d169c"
+CHKSUMS="sha256::752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 9.2.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qemu: 9.2.2
- qemu-aarch64-static: 9.2.2
- qemu-alpha-static: 9.2.2
- qemu-arm-static: 9.2.2
- qemu-armeb-static: 9.2.2
- qemu-guest-agent: 9.2.2
- qemu-i386-static: 9.2.2
- qemu-loongarch64-static: 9.2.2
- qemu-m68k-static: 9.2.2
- qemu-microblaze-static: 9.2.2
- qemu-microblazeel-static: 9.2.2
- qemu-mips-static: 9.2.2
- qemu-mips64-static: 9.2.2
- qemu-mips64el-static: 9.2.2
- qemu-mipsel-static: 9.2.2
- qemu-mipsn32-static: 9.2.2
- qemu-mipsn32el-static: 9.2.2
- qemu-or32-static: 9.2.2
- qemu-ppc-static: 9.2.2
- qemu-ppc64-static: 9.2.2
- qemu-ppc64le-static: 9.2.2
- qemu-riscv32-static: 9.2.2
- qemu-riscv64-static: 9.2.2
- qemu-s390x-static: 9.2.2
- qemu-sh4-static: 9.2.2
- qemu-sh4eb-static: 9.2.2
- qemu-sparc-static: 9.2.2
- qemu-sparc32plus-static: 9.2.2
- qemu-sparc64-static: 9.2.2
- qemu-user-static: 9.2.2
- qemu-x86-64-static: 9.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
