### PR TITLE
intel-media-driver: fix segfault with Intel Battlemage

### DIFF
--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-BACKPORT-VP-Fix-OCL-FC-R8G8-Resource-Allocation.patch
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-BACKPORT-VP-Fix-OCL-FC-R8G8-Resource-Allocation.patch
@@ -1,0 +1,318 @@
+From bd807493c4c18d8d1dc5c8ff4a4a1820f4ae87cb Mon Sep 17 00:00:00 2001
+From: Gu_Peiyi <peiyi.gu@intel.com>
+Date: Mon, 9 Dec 2024 14:02:01 +0800
+Subject: [PATCH 1/3] BACKPORT: [VP] Fix OCL FC R8G8 Resource Allocation
+
+fix resource allocation fail
+
+Link: https://github.com/intel/media-driver/issues/1887
+Link: https://github.com/intel/media-driver/commit/7faa3bfe1a4cb79180eae64ccb426af5102f11e3
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ .../vp/hal/bufferMgr/vp_resource_manager.cpp  | 261 +++++++++---------
+ .../linux/common/os/mos_interface.cpp         |   6 +-
+ 2 files changed, 136 insertions(+), 131 deletions(-)
+
+diff --git a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
+index ce535d046..b5849f49f 100644
+--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
++++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_resource_manager.cpp
+@@ -1097,139 +1097,142 @@ MOS_STATUS VpResourceManager::AssignFcResources(VP_EXECUTE_CAPS &caps, std::vect
+         allocated));
+     surfSetting.surfGroup.insert(std::make_pair(SurfaceTypeDecompressionSync, m_decompressionSyncSurface));
+ 
+-    // Allocate OCL FC intermedia inputSurface
+-    for (uint32_t i = 0; i < inputSurfaces.size(); ++i)
+-    {
+-        VP_PUBLIC_CHK_NULL_RETURN(inputSurfaces[i]);
+-        VP_PUBLIC_CHK_NULL_RETURN(inputSurfaces[i]->osSurface);
+-        MOS_FORMAT fcIntermediaInputFormat                 = Format_Any;
+-        MOS_FORMAT fcSeparateIntermediaSecPlaneInputFormat = Format_Any;
+-        uint32_t   widthPL1Factor                          = 1;
+-        uint32_t   heightPL1Factor                         = 1;
+-        switch (inputSurfaces[i]->osSurface->Format)
+-        {
+-        case Format_RGBP:
+-        case Format_BGRP:
+-            fcIntermediaInputFormat = Format_A8R8G8B8;
+-            break;
+-        case Format_444P:
+-            fcIntermediaInputFormat = Format_AYUV;
+-            break;
+-        case Format_I420:
+-        case Format_YV12:
+-        case Format_IYUV:
+-        case Format_IMC3:
+-            fcIntermediaInputFormat = Format_NV12;
+-            break;
+-        case Format_422H:
+-            fcIntermediaInputFormat                 = Format_R8UN;
+-            fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
+-            widthPL1Factor                          = 2;
+-            break;
+-        case Format_422V:
+-            fcIntermediaInputFormat                 = Format_R8UN;
+-            fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
+-            heightPL1Factor                         = 2;
+-            break;
+-        case Format_411P:
+-            fcIntermediaInputFormat                 = Format_R8UN;
+-            fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
+-            widthPL1Factor                          = 4;
+-            break;
+-        default:
+-            break;
+-        }
+-        if (fcIntermediaInputFormat != Format_Any)
+-        {
+-            VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
+-                m_fcIntermediaSurfaceInput[i],
+-                "fcIntermediaSurfaceInput",
+-                fcIntermediaInputFormat,
+-                MOS_GFXRES_2D,
+-                MOS_TILE_Y,
+-                inputSurfaces[i]->osSurface->dwWidth,
+-                inputSurfaces[i]->osSurface->dwHeight,
+-                false,
+-                MOS_MMC_DISABLED,
+-                allocated,
+-                false,
+-                IsDeferredResourceDestroyNeeded(),
+-                MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
+-
+-            m_fcIntermediaSurfaceInput[i]->rcSrc         = inputSurfaces[i]->rcSrc;
+-            m_fcIntermediaSurfaceInput[i]->rcDst         = inputSurfaces[i]->rcDst;
+-            m_fcIntermediaSurfaceInput[i]->SampleType    = inputSurfaces[i]->SampleType;
+-            surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcIntermediaInput + i), m_fcIntermediaSurfaceInput[i]));
+-        }
+-        if (fcSeparateIntermediaSecPlaneInputFormat != Format_Any)
+-        {
+-            VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
+-                m_fcSeparateIntermediaSurfaceSecPlaneInput[i],
+-                "fcSeparateIntermediaSurfaceSecPlaneInput",
+-                fcSeparateIntermediaSecPlaneInputFormat,
+-                MOS_GFXRES_2D,
+-                MOS_TILE_Y,
+-                inputSurfaces[i]->osSurface->dwWidth / widthPL1Factor,
+-                inputSurfaces[i]->osSurface->dwHeight / heightPL1Factor,
+-                false,
+-                MOS_MMC_DISABLED,
+-                allocated,
+-                false,
+-                IsDeferredResourceDestroyNeeded(),
+-                MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
+-
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.top    = inputSurfaces[i]->rcSrc.top / heightPL1Factor;
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.bottom = inputSurfaces[i]->rcSrc.bottom / heightPL1Factor;
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.left   = inputSurfaces[i]->rcSrc.left / widthPL1Factor;
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.right  = inputSurfaces[i]->rcSrc.right / widthPL1Factor;
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcDst        = inputSurfaces[i]->rcDst;
+-            m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->SampleType   = inputSurfaces[i]->SampleType;
+-            surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcSeparateIntermediaInputSecPlane + i), m_fcSeparateIntermediaSurfaceSecPlaneInput[i]));
+-        }
+-    }
+-    // Allocate OCL FC intermedia outputSurface
++    if (m_vpUserFeatureControl && m_vpUserFeatureControl->EnableOclFC())
+     {
+-        MOS_FORMAT fcIntermediaSurfaceOutputFormat = Format_Any;
+-        VP_PUBLIC_CHK_NULL_RETURN(outputSurface);
+-        VP_PUBLIC_CHK_NULL_RETURN(outputSurface->osSurface);
+-        switch (outputSurface->osSurface->Format)
++        // Allocate OCL FC intermedia inputSurface
++        for (uint32_t i = 0; i < inputSurfaces.size(); ++i)
+         {
+-        case Format_RGBP:
+-        case Format_BGRP:
+-            fcIntermediaSurfaceOutputFormat = Format_A8R8G8B8;
+-            break;
+-        case Format_444P:
+-            fcIntermediaSurfaceOutputFormat = Format_AYUV;
+-            break;
+-        case Format_I420:
+-        case Format_IMC3:
+-        case Format_YV12:
+-        case Format_IYUV:
+-            fcIntermediaSurfaceOutputFormat = Format_NV12;
+-            break;
+-        default:
+-            break;
++            VP_PUBLIC_CHK_NULL_RETURN(inputSurfaces[i]);
++            VP_PUBLIC_CHK_NULL_RETURN(inputSurfaces[i]->osSurface);
++            MOS_FORMAT fcIntermediaInputFormat                 = Format_Any;
++            MOS_FORMAT fcSeparateIntermediaSecPlaneInputFormat = Format_Any;
++            uint32_t   widthPL1Factor                          = 1;
++            uint32_t   heightPL1Factor                         = 1;
++            switch (inputSurfaces[i]->osSurface->Format)
++            {
++            case Format_RGBP:
++            case Format_BGRP:
++                fcIntermediaInputFormat = Format_A8R8G8B8;
++                break;
++            case Format_444P:
++                fcIntermediaInputFormat = Format_AYUV;
++                break;
++            case Format_I420:
++            case Format_YV12:
++            case Format_IYUV:
++            case Format_IMC3:
++                fcIntermediaInputFormat = Format_NV12;
++                break;
++            case Format_422H:
++                fcIntermediaInputFormat                 = Format_R8UN;
++                fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
++                widthPL1Factor                          = 2;
++                break;
++            case Format_422V:
++                fcIntermediaInputFormat                 = Format_R8UN;
++                fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
++                heightPL1Factor                         = 2;
++                break;
++            case Format_411P:
++                fcIntermediaInputFormat                 = Format_R8UN;
++                fcSeparateIntermediaSecPlaneInputFormat = Format_R8G8UN;
++                widthPL1Factor                          = 4;
++                break;
++            default:
++                break;
++            }
++            if (fcIntermediaInputFormat != Format_Any)
++            {
++                VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
++                    m_fcIntermediaSurfaceInput[i],
++                    "fcIntermediaSurfaceInput",
++                    fcIntermediaInputFormat,
++                    MOS_GFXRES_2D,
++                    MOS_TILE_Y,
++                    inputSurfaces[i]->osSurface->dwWidth,
++                    inputSurfaces[i]->osSurface->dwHeight,
++                    false,
++                    MOS_MMC_DISABLED,
++                    allocated,
++                    false,
++                    IsDeferredResourceDestroyNeeded(),
++                    MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
++
++                m_fcIntermediaSurfaceInput[i]->rcSrc      = inputSurfaces[i]->rcSrc;
++                m_fcIntermediaSurfaceInput[i]->rcDst      = inputSurfaces[i]->rcDst;
++                m_fcIntermediaSurfaceInput[i]->SampleType = inputSurfaces[i]->SampleType;
++                surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcIntermediaInput + i), m_fcIntermediaSurfaceInput[i]));
++            }
++            if (fcSeparateIntermediaSecPlaneInputFormat != Format_Any)
++            {
++                VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
++                    m_fcSeparateIntermediaSurfaceSecPlaneInput[i],
++                    "fcSeparateIntermediaSurfaceSecPlaneInput",
++                    fcSeparateIntermediaSecPlaneInputFormat,
++                    MOS_GFXRES_2D,
++                    MOS_TILE_Y,
++                    inputSurfaces[i]->osSurface->dwWidth / widthPL1Factor,
++                    inputSurfaces[i]->osSurface->dwHeight / heightPL1Factor,
++                    false,
++                    MOS_MMC_DISABLED,
++                    allocated,
++                    false,
++                    IsDeferredResourceDestroyNeeded(),
++                    MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
++
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.top    = inputSurfaces[i]->rcSrc.top / heightPL1Factor;
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.bottom = inputSurfaces[i]->rcSrc.bottom / heightPL1Factor;
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.left   = inputSurfaces[i]->rcSrc.left / widthPL1Factor;
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcSrc.right  = inputSurfaces[i]->rcSrc.right / widthPL1Factor;
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->rcDst        = inputSurfaces[i]->rcDst;
++                m_fcSeparateIntermediaSurfaceSecPlaneInput[i]->SampleType   = inputSurfaces[i]->SampleType;
++                surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcSeparateIntermediaInputSecPlane + i), m_fcSeparateIntermediaSurfaceSecPlaneInput[i]));
++            }
+         }
+-        if (fcIntermediaSurfaceOutputFormat != Format_Any)
++        // Allocate OCL FC intermedia outputSurface
+         {
+-            VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
+-                m_fcIntermediaSurfaceOutput,
+-                "fcIntermediaSurfaceOutput",
+-                fcIntermediaSurfaceOutputFormat,
+-                MOS_GFXRES_2D,
+-                MOS_TILE_Y,
+-                outputSurface->osSurface->dwWidth,
+-                outputSurface->osSurface->dwHeight,
+-                false,
+-                MOS_MMC_DISABLED,
+-                allocated,
+-                false,
+-                IsDeferredResourceDestroyNeeded(),
+-                MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
+-            m_fcIntermediaSurfaceOutput->rcSrc      = outputSurface->rcSrc;
+-            m_fcIntermediaSurfaceOutput->rcDst      = outputSurface->rcDst;
+-            m_fcIntermediaSurfaceOutput->SampleType = outputSurface->SampleType;
+-            surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcIntermediaOutput), m_fcIntermediaSurfaceOutput));
++            MOS_FORMAT fcIntermediaSurfaceOutputFormat = Format_Any;
++            VP_PUBLIC_CHK_NULL_RETURN(outputSurface);
++            VP_PUBLIC_CHK_NULL_RETURN(outputSurface->osSurface);
++            switch (outputSurface->osSurface->Format)
++            {
++            case Format_RGBP:
++            case Format_BGRP:
++                fcIntermediaSurfaceOutputFormat = Format_A8R8G8B8;
++                break;
++            case Format_444P:
++                fcIntermediaSurfaceOutputFormat = Format_AYUV;
++                break;
++            case Format_I420:
++            case Format_IMC3:
++            case Format_YV12:
++            case Format_IYUV:
++                fcIntermediaSurfaceOutputFormat = Format_NV12;
++                break;
++            default:
++                break;
++            }
++            if (fcIntermediaSurfaceOutputFormat != Format_Any)
++            {
++                VP_PUBLIC_CHK_STATUS_RETURN(m_allocator.ReAllocateSurface(
++                    m_fcIntermediaSurfaceOutput,
++                    "fcIntermediaSurfaceOutput",
++                    fcIntermediaSurfaceOutputFormat,
++                    MOS_GFXRES_2D,
++                    MOS_TILE_Y,
++                    outputSurface->osSurface->dwWidth,
++                    outputSurface->osSurface->dwHeight,
++                    false,
++                    MOS_MMC_DISABLED,
++                    allocated,
++                    false,
++                    IsDeferredResourceDestroyNeeded(),
++                    MOS_HW_RESOURCE_USAGE_VP_INTERNAL_READ_WRITE_RENDER));
++                m_fcIntermediaSurfaceOutput->rcSrc      = outputSurface->rcSrc;
++                m_fcIntermediaSurfaceOutput->rcDst      = outputSurface->rcDst;
++                m_fcIntermediaSurfaceOutput->SampleType = outputSurface->SampleType;
++                surfSetting.surfGroup.insert(std::make_pair((SurfaceType)(SurfaceTypeFcIntermediaOutput), m_fcIntermediaSurfaceOutput));
++            }
+         }
+     }
+     return MOS_STATUS_SUCCESS;
+diff --git a/media_softlet/linux/common/os/mos_interface.cpp b/media_softlet/linux/common/os/mos_interface.cpp
+index c8ec8815e..7b2bdde9f 100644
+--- a/media_softlet/linux/common/os/mos_interface.cpp
++++ b/media_softlet/linux/common/os/mos_interface.cpp
+@@ -3848,7 +3848,8 @@ MOS_FORMAT MosInterface::GmmFmtToMosFmt(
+         {GMM_FORMAT_R24_UNORM_X8_TYPELESS, Format_D24S8UN},
+         {GMM_FORMAT_R32_FLOAT_X8X24_TYPELESS, Format_D32S8X24_FLOAT},
+         {GMM_FORMAT_R16G16_SINT_TYPE, Format_R16G16S},
+-        {GMM_FORMAT_R32G32B32A32_FLOAT, Format_R32G32B32A32F}};
++        {GMM_FORMAT_R32G32B32A32_FLOAT, Format_R32G32B32A32F},
++        {GMM_FORMAT_R8G8_UNORM_TYPE, Format_R8G8UN}};
+ 
+     auto iter = gmm2MosFmtMap.find(format);
+     if (iter != gmm2MosFmtMap.end())
+@@ -3910,7 +3911,8 @@ GMM_RESOURCE_FORMAT MosInterface::MosFmtToGmmFmt(MOS_FORMAT format)
+         {Format_R10G10B10A2,    GMM_FORMAT_R10G10B10A2_UNORM_TYPE},
+         {Format_B10G10R10A2,    GMM_FORMAT_B10G10R10A2_UNORM_TYPE},
+         {Format_A16B16G16R16F,  GMM_FORMAT_R16G16B16A16_FLOAT},
+-        {Format_R32G32B32A32F,  GMM_FORMAT_R32G32B32A32_FLOAT}
++        {Format_R32G32B32A32F,  GMM_FORMAT_R32G32B32A32_FLOAT},
++        {Format_R8G8UN,         GMM_FORMAT_R8G8_UNORM_TYPE}
+     };
+     
+     auto iter = mos2GmmFmtMap.find(format);
+-- 
+2.48.1
+

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
@@ -1,7 +1,7 @@
-From 6f83a09b218c90ee9fd457e063628459c846b648 Mon Sep 17 00:00:00 2001
+From 7521bb1006df36b69a8042444304ab1c95f8ebb2 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:23:27 +0800
-Subject: [PATCH 1/2] LOONGARCH64: FROMEXT: loongarch
+Subject: [PATCH 2/3] LOONGARCH64: FROMEXT: loongarch
 
 Link: https://github.com/FanFansfan/media-driver/commit/538521b276c2dd33a1ef80969a45b35b3d31ed3f
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -303,5 +303,5 @@ index 000000000..4379740aa
 @@ -0,0 +1 @@
 +Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 -- 
-2.47.0.windows.1
+2.48.1
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0003-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0003-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
@@ -1,7 +1,7 @@
-From dbf9ffd70239927982586a0dbc64f30629bf84ce Mon Sep 17 00:00:00 2001
+From c56feb389b985577e43cd7df1964ffdbba12a799 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 31 Mar 2024 16:00:55 +0800
-Subject: [PATCH 2/2] LOONGARCH64: FROMEXT: fix lsx
+Subject: [PATCH 3/3] LOONGARCH64: FROMEXT: fix lsx
 
 Link: https://github.com/FanFansfan/media-driver/commit/e31a1f6a7112cf789fae290df1e83ee7f5e31555
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -17,5 +17,5 @@ index 4379740aa..87cd663a9 160000
 -Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 +Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
 -- 
-2.47.0.windows.1
+2.48.1
 

--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,5 @@
 VER=24.4.4
+REL=1
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: backport an upstream patch to fix VA-API segfault with Intel Battlemage
    This patch is part of the \(under development\) 25.x branch.

Package(s) Affected
-------------------

- intel-media-driver: 24.4.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
