### PR TITLE
fish: exclude the builtin completion for just

### DIFF
--- a/app-shells/fish/autobuild/beyond
+++ b/app-shells/fish/autobuild/beyond
@@ -1,2 +1,2 @@
-abinfo "Removing completion for rclone to resolve file conflict ..."
-rm -v "$PKGDIR"/usr/share/fish/completions/rclone.fish
+abinfo "Removing some completions to resolve file conflicts ..."
+rm -v "$PKGDIR"/usr/share/fish/completions/{rclone,just}.fish

--- a/app-shells/fish/spec
+++ b/app-shells/fish/spec
@@ -1,4 +1,5 @@
 VER=4.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fish-shell/fish-shell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=815"


### PR DESCRIPTION
Topic Description
-----------------

- fish: exclude the builtin completion for just
    It is also provided by the just package.

Package(s) Affected
-------------------

- fish: 4.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
