### PR TITLE
rclone, just: rework for fish completions

### DIFF
--- a/app-devel/just/autobuild/beyond
+++ b/app-devel/just/autobuild/beyond
@@ -1,10 +1,10 @@
 abinfo "Generating shell completions ..."
 mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions \
           "$PKGDIR"/usr/share/bash-completion/completions \
-          "$PKGDIR"/usr/share/fish/completions
+          "$PKGDIR"/usr/share/fish/vendor_completions.d
 "$PKGDIR"/usr/bin/just --completions zsh > "$PKGDIR"/usr/share/zsh/site-functions/_just
 "$PKGDIR"/usr/bin/just --completions bash > "$PKGDIR"/usr/share/bash-completion/completions/just
-"$PKGDIR"/usr/bin/just --completions fish > "$PKGDIR"/usr/share/fish/completions/just.fish
+"$PKGDIR"/usr/bin/just --completions fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/just.fish
 
 abinfo "Removing extraneous binaries ..."
 rm -vf "$PKGDIR"/usr/bin/{generate-book,update-contributors}

--- a/app-devel/just/spec
+++ b/app-devel/just/spec
@@ -1,4 +1,5 @@
 VER=1.39.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/casey/just"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141393"

--- a/app-shells/fish/autobuild/beyond
+++ b/app-shells/fish/autobuild/beyond
@@ -1,2 +1,2 @@
-abinfo "Removing some completions to resolve file conflicts ..."
-rm -v "$PKGDIR"/usr/share/fish/completions/{rclone,just}.fish
+abinfo "Removing completion for rclone to resolve file conflict ..."
+rm -v "$PKGDIR"/usr/share/fish/completions/rclone.fish

--- a/app-shells/fish/autobuild/beyond
+++ b/app-shells/fish/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing completion for rclone to resolve file conflict ..."
-rm -v "$PKGDIR"/usr/share/fish/completions/rclone.fish

--- a/app-shells/fish/autobuild/defines
+++ b/app-shells/fish/autobuild/defines
@@ -19,3 +19,5 @@ RECONF=0
 # FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against symbol
 # 'DW.ref.rust_eh_personality'; recompile with -fPIC
 NOLTO__LOONGSON3=1
+
+PKGBREAK="just<=1.39.0"

--- a/app-shells/fish/autobuild/defines
+++ b/app-shells/fish/autobuild/defines
@@ -20,4 +20,4 @@ RECONF=0
 # 'DW.ref.rust_eh_personality'; recompile with -fPIC
 NOLTO__LOONGSON3=1
 
-PKGBREAK="just<=1.39.0"
+PKGBREAK="just<=1.39.0 rclone<=1.68.0-1"

--- a/app-shells/fish/spec
+++ b/app-shells/fish/spec
@@ -1,5 +1,5 @@
 VER=4.0.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/fish-shell/fish-shell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=815"

--- a/app-web/rclone/autobuild/build
+++ b/app-web/rclone/autobuild/build
@@ -17,7 +17,7 @@ make TAG=v$PKGVER DESTDIR="$PKGDIR" install
 abinfo "Installing shell completions ..."
 install -Dvm644 "$SRCDIR"/rclone.bash_completion "$PKGDIR"/usr/share/bash-completion/completions/rclone
 install -Dvm644 "$SRCDIR"/rclone.zsh_completion "$PKGDIR"/usr/share/zsh/site-functions/_rclone
-install -Dvm644 "$SRCDIR"/rclone.zsh_completion "$PKGDIR"/usr/share/fish/completions/rclone.fish
+install -Dvm644 "$SRCDIR"/rclone.fish_completion "$PKGDIR"/usr/share/fish/vendor_completions.d/rclone.fish
 
 abinfo "Installing manual ..."
 install -Dvm644 "$SRCDIR"/rclone.1 "$PKGDIR"/usr/share/man/man1/rclone.1

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -2,4 +2,4 @@ VER=1.68.0
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- fish: provide builtin completion script for rclone
- rclone: fix fish shell completion installing
- just: move fish completions to vendor_completions.d
- Revert "fish: exclude the builtin completion for just"
    This reverts commit 120fb311c05be2e30a92c67b67a2a9d962861a7d.

Package(s) Affected
-------------------

- fish: 4.0.0-2
- just: 1.39.0-1
- rclone: 1.68.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rclone just fish
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
