### PR TITLE
ciel: add qemu-user-static as RECOM for user mode emulation

### DIFF
--- a/app-devel/ciel/autobuild/defines
+++ b/app-devel/ciel/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=ciel
 PKGSEC=devel
 PKGDEP="systemd libgit2 dbus openssl xz squashfs-tools"
 BUILDDEP="rustc llvm"
+PKGRECOM="qemu-user-static"
 PKGDES="An integrated packaging environment for AOSC OS"
 
 USECLANG=1

--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,5 @@
 VER=3.9.4
+REL=1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: add qemu-user-static as RECOM for user mode emulation

Package(s) Affected
-------------------

- ciel: 3.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
