### PR TITLE
lfortran: update to 0.46.0

### DIFF
--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.45.0
+VER=0.46.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::41ebda8ca5e51ebd7d2e426f60981e1f5908cd7d64c97ec6f5a2157c4bfbe9ac"
+CHKSUMS="sha256::420885b4bcfd2206bc5ae9cdb658f2382b35b0e4d145476a97bdc7d642d4a588"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.46.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.46.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
