### PR TITLE
solaar: add missing dependency to typing-extensions

### DIFF
--- a/app-utils/solaar/autobuild/defines
+++ b/app-utils/solaar/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=solaar
 PKGSEC=utils
 PKGDES="Linux device manager for Logitech devices"
 PKGDEP="python-3 gtk-3 libnotify dbus-python pygobject-3 pyudev pypsutil
-        python-evdev python-xlib pyyaml"
+        python-evdev python-xlib pyyaml typing-extensions"
 
 NOPYTHON2=1
 ABTYPE=python

--- a/app-utils/solaar/spec
+++ b/app-utils/solaar/spec
@@ -1,4 +1,5 @@
 VER=1.1.14
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwr-Solaar/Solaar.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11338"


### PR DESCRIPTION
Topic Description
-----------------

- solaar: add typing-extensions dep

Package(s) Affected
-------------------

- solaar: 1.1.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit solaar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
