### PR TITLE
pinentry: update to 1.3.1

### DIFF
--- a/app-utils/pinentry/autobuild/defines
+++ b/app-utils/pinentry/autobuild/defines
@@ -1,19 +1,19 @@
 PKGNAME=pinentry
 PKGSEC=utils
 PKGDEP="libassuan libcap ncurses libsecret pcre2 gtk-2"
-BUILDDEP="gcr qt-5"
-BUILDDEP__RISCV64="${BUILDDEP/qt-5/}"
-PKGSUG="gcr qt-5"
-PKGSUG__RISCV64="${PKGSUG/qt-5/}"
+BUILDDEP="gcr qt-5 qt-6"
+PKGSUG="gcr qt-5 qt-6"
 PKGDES="A collection of simple PIN or passphrase entry dialogs"
 
-AUTOTOOLS_AFTER="--enable-pinentry-curses \
-                 --enable-fallback-curses \
-                 --enable-pinentry-tty \
-                 --enable-pinentry-emacs \
-                 --enable-pinentry-gtk2 \
-                 --enable-pinentry-gnome3 \
-                 --enable-pinentry-qt"
-AUTOTOOLS_AFTER__RISCV64="${AUTOTOOLS_AFTER/--enable-pinentry-qt/}"
+AUTOTOOLS_AFTER=(
+    '--enable-pinentry-curses'
+    '--enable-fallback-curses'
+    '--enable-pinentry-tty'
+    '--enable-pinentry-emacs'
+    '--enable-pinentry-gtk2'
+    '--enable-pinentry-gnome3'
+    '--enable-pinentry-qt'
+    '--enable-pinentry-qt5'
+)
 
 ABRPMAUTOPROVONLY=1

--- a/app-utils/pinentry/autobuild/defines.stage2
+++ b/app-utils/pinentry/autobuild/defines.stage2
@@ -3,8 +3,10 @@ PKGSEC=utils
 PKGDEP="libassuan libcap ncurses libsecret pcre2"
 PKGDES="A collection of simple PIN or passphrase entry dialogs"
 
-AUTOTOOLS_AFTER="--enable-pinentry-curses \
-                 --enable-fallback-curses \
-                 --enable-pinentry-tty"
+AUTOTOOLS_AFTER=(
+    '--enable-pinentry-curses'
+    '--enable-fallback-curses'
+    '--enable-pinentry-tty'
+)
 
 ABRPMAUTOPROVONLY=1

--- a/app-utils/pinentry/autobuild/patches/0001-avoid-unknown-version.patch
+++ b/app-utils/pinentry/autobuild/patches/0001-avoid-unknown-version.patch
@@ -1,0 +1,14 @@
+diff '--color=auto' -bur pinentry-1.3.1/autogen.sh pinentry-1.3.1-modified/autogen.sh
+--- pinentry-1.3.1/autogen.sh	2024-03-18 04:13:18.000000000 -0700
++++ pinentry-1.3.1-modified/autogen.sh	2025-03-02 14:06:05.574764358 -0800
+@@ -269,8 +269,8 @@
+       rvd=$((0x$(echo ${rev} | dd bs=1 count=4 2>/dev/null)))
+     else
+       ingit=no
+-      beta=yes
+-      tmp="-unknown"
++      beta=no
++      tmp=""
+       rev="0000000"
+       rvd="0"
+     fi

--- a/app-utils/pinentry/autobuild/prepare
+++ b/app-utils/pinentry/autobuild/prepare
@@ -1,2 +1,0 @@
-export CXXFLAGS="${CXXFLAGS} -std=c++11"
-export QT_SELECT=5

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,4 @@
-VER=1.1.0
-REL=9
+VER=1.3.1
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
-CHKSUMS="sha256::68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570"
+CHKSUMS="sha256::bc72ee27c7239007ab1896c3c2fae53b076e2c9bd2483dc2769a16902bce8c04"
 CHKUPDATE="anitya::id=3643"


### PR DESCRIPTION
Topic Description
-----------------

- pinentry: update to 1.3.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- pinentry: 1.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
