### PR TITLE
python-2, python-3: rebuild for Autobuild flag changes

### DIFF
--- a/lang-python/python-2/spec
+++ b/lang-python/python-2/spec
@@ -1,5 +1,5 @@
 VER=2.7.18
-REL=2
+REL=3
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
 CHKSUMS="sha256::b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43"
 CHKUPDATE="anitya::id=13255"

--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,5 +1,5 @@
 VER=3.10.13
-REL=5
+REL=6
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
 CHKSUMS="sha256::5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
 CHKUPDATE="anitya::id=13254"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: rebuild for Autobuild flag changes
    Python toolchains records compiler build flags for all future module
    and extension builds at build-time. Rebuild to refresh this, as we have
    removed \`-mfix-loongson3-llsc' for loongson3.
- python-2: rebuild for Autobuild flag changes
    Python toolchains records compiler build flags for all future module
    and extension builds at build-time. Rebuild to refresh this, as we have
    removed \`-mfix-loongson3-llsc' for loongson3.

Package(s) Affected
-------------------

- python-2: 2.7.18-3
- python-3: 3.10.13-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-2 python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
