### PR TITLE
dracut-ng: Explicitly include xhci-pci-renesas

### DIFF
--- a/app-admin/dracut-ng/autobuild/patches/0006-fix-90kernel-modules-explicitly-include-xhci-pci-ren.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0006-fix-90kernel-modules-explicitly-include-xhci-pci-ren.patch
@@ -1,0 +1,77 @@
+From d477b2ee26d727b163d168662522ca2c6a1d29f3 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sat, 1 Mar 2025 00:54:31 +0800
+Subject: [PATCH] fix(90kernel-modules): explicitly include xhci-pci-renesas
+
+Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends
+on xhci-pci-renesas, causing the Renesas driver to be omitted during
+initramfs generation (when built as a module).
+
+This makes platforms with such xHCI controllers unavailable during
+initrd, and unable to boot from a USB drive. There are SuperSpeed ports
+routed through such controller on some platforms, too, which also
+renders the USB keyboard and mouse unusable.
+
+Here's a snippet of the kernel log from such platform, showing a
+keyboard and a mouse being detected only after the initrd switched root:
+
+[    9.352608] systemd-journald[187]: Received SIGTERM from PID 1 (systemd).
+[    9.500146] systemd[1]: systemd 257.2 running in system mode (OMITTED)
+...
+[   11.187756] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
+[   11.187870] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 7
+[   11.193261] xhci-pci-renesas 0000:04:00.0: hcc params 0x014051cf hci version 0x100 quirks 0x0000000100000010
+[   11.194806] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
+[   11.196601] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 8
+[   11.196613] xhci-pci-renesas 0000:04:00.0: Host supports USB 3.0 SuperSpeed
+[   11.196927] usb usb7: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.13
+[   11.196931] usb usb7: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[   11.196935] usb usb7: Product: xHCI Host Controller
+[   11.196938] usb usb7: Manufacturer: Linux 6.13.3-aosc-main xhci-hcd
+[   11.196941] usb usb7: SerialNumber: 0000:04:00.0
+[   11.199598] hub 7-0:1.0: USB hub found
+[   11.199630] hub 7-0:1.0: 4 ports detected
+...
+[   11.439561] usb 7-2: new high-speed USB device number 2 using xhci-pci-renesas
+[   11.568361] usb 7-2: New USB device found, idVendor=1532, idProduct=0114, bcdDevice= 1.00
+[   11.568369] usb 7-2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[   11.568372] usb 7-2: Product: DeathStalker Ultimate
+[   11.568376] usb 7-2: Manufacturer: Razer
+[   11.600474] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.0/0003:1532:0114.0001/input/input12
+[   11.600686] hid-generic 0003:1532:0114.0001: input,hidraw0: USB HID v1.11 Mouse [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input0
+[   11.601137] input: Razer DeathStalker Ultimate Keyboard as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input13
+[   11.652148] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input14
+[   11.652409] hid-generic 0003:1532:0114.0002: input,hidraw1: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input1
+[   11.653054] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.2/0003:1532:0114.0003/input/input15
+[   11.703768] hid-generic 0003:1532:0114.0003: input,hidraw2: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input2
+---
+ modules.d/90kernel-modules/module-setup.sh | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/90kernel-modules/module-setup.sh b/modules.d/90kernel-modules/module-setup.sh
+index f159f0be..5b1bce75 100755
+--- a/modules.d/90kernel-modules/module-setup.sh
++++ b/modules.d/90kernel-modules/module-setup.sh
+@@ -39,12 +39,18 @@ installkernel() {
+         hostonly='' instmods \
+             hid_generic unix
+ 
++        # Explicitly include xhci-pci-renesas module.
++        # Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer
++        # depends on xhci-pci-renesas, causing the Renesas driver to be
++        # omitted during initramfs generation (when built as a module).
++        # This makes platforms with such xHCI controllers unavailable
++        # during initrd, and unable to boot from a USB drive.
+         hostonly=$(optional_hostonly) instmods \
+             ehci-hcd ehci-pci ehci-platform \
+             ohci-hcd ohci-pci \
+             uhci-hcd \
+             usbhid \
+-            xhci-hcd xhci-pci xhci-plat-hcd \
++            xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
+             "=drivers/hid" \
+             "=drivers/tty/serial" \
+             "=drivers/input/serio" \
+-- 
+2.48.1
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,5 @@
 VER=105
-REL=5
+REL=6
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut: explicitly include xhci-pci-renesas
    Since Linux v6.12-rc1 \(commit 25f51b76f90f\), xhci-pci no longer depends
    on xhci-pci-renesas, causing the Renesas driver to be omitted during
    initramfs generation \(when built as a module\).
    This makes platforms with such xHCI controllers unavailable during
    initrd, and unable to boot from a USB drive. There are SuperSpeed ports
    routed through such controller on some platforms, too, which also
    renders the USB keyboard and mouse unusable.
    We observed this on a Lenovo Loongson 3A5000 machine \(system board model
    number is unknown\).

Package(s) Affected
-------------------

- dracut-ng: 105-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
