### PR TITLE
racket: update to 8.16

### DIFF
--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -5,6 +5,14 @@ BUILDDEP="ncurses lz4 zlib urw-fonts"
 PKGDES="A full-spectrum programming language"
 
 RECONF=0
+ABTYPE=autotools
 
-AUTOTOOLS_AFTER__PPC64EL="--enable-pb --enable-mach=tpb64l"
-AUTOTOOLS_AFTER__LOONGSON3="--enable-pb --enable-mach=pb64l"
+AUTOTOOLS_AFTER__PPC64EL=(
+    '--enable-pb'
+    '--enable-mach=tpb64l'
+)
+
+AUTOTOOLS_AFTER__LOONGSON3=(
+    '--enable-pb'
+    '--enable-mach=pb64l'
+)

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.15
+VER=8.16
 SRCS="tbl::https://download.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::602b848459daf1b2222a46a9094e85ae2d28e480067219957fa46af8400e1233"
+CHKSUMS="sha256::b233a968f4a561f7b005ce06f2c4c29428562f308c1a04d28e2e2286f6b945c3"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 8.16
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- racket: 8.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
