### PR TITLE
synaptic: update to 0.91.5+nmu2

### DIFF
--- a/app-admin/synaptic/spec
+++ b/app-admin/synaptic/spec
@@ -1,4 +1,4 @@
-VER=0.91.3
+VER=0.91.5+nmu2
 SRCS="https://deb.debian.org/debian/pool/main/s/synaptic/synaptic_$VER.tar.xz"
-CHKSUMS="sha256::e2ed206d8d5af86417eafbeff349b99cde29b31008e21a6327f4a49a7951ed33"
+CHKSUMS="sha256::db3f7556cc1557554d217d3afe73a944f3eb8edf61acd00c7c6c5389f292b52e"
 CHKUPDATE="anitya::id=16196"


### PR DESCRIPTION
Topic Description
-----------------

- synaptic: update to 0.91.5+nmu2

Package(s) Affected
-------------------

- synaptic: 0.91.5+nmu2

Security Update?
----------------

No

Build Order
-----------

```
#buildit synaptic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
