### PR TITLE
poppler: update to 25.03.0

### DIFF
--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,5 +1,5 @@
 VER=1.4
-REL=2
+REL=3
 SRCS="git::commit=tags/INKSCAPE_${VER//./_}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,5 @@
 VER=25.2.1.2
+REL=1
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
-REL=1
+REL=2
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::0ae58ced410101e82655e3b4c20a070cf1767145ada233dcef7c20b8ba6bd487"
 CHKUPDATE="anitya::id=4773"

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=4
+REL=5
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/koffice-trinity/spec
+++ b/desktop-trinity/koffice-trinity/spec
@@ -5,4 +5,4 @@ CHKSUMS="sha256::06aa9488747a3c92a68d6a057b9bd238251465b21afc74c3c0d3faad85f58fe
          sha256::0e3d99fee00cdf3c257166dacc5c8679ad7418c8e8f22d6d71f4a5e67014387e"
 CHKUPDATE="anitya::id=16065"
 SUBDIR="koffice-trinity-$VER"
-REL=3
+REL=4

--- a/desktop-trinity/tdegraphics/spec
+++ b/desktop-trinity/tdegraphics/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=2
+REL=3
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdegraphics-trinity-$VER.tar.xz"
 CHKSUMS="sha256::8771c5c80156dd2a3747f2138d98c6a2d63fe11dc008d52022293946dd4ebe2f"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-doc/poppler/autobuild/defines
+++ b/runtime-doc/poppler/autobuild/defines
@@ -21,13 +21,13 @@ CMAKE_AFTER__RETRO=" \
              -DENABLE_GTK_DOC=OFF"
 
 PKGBREAK="atril<=1.28.1 cantor<=23.08.5 evince<=42.3-1 \
-          gdal<=3.10.1 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
-          graphviz<=12.2.1 inkscape<=1.4-1 kfilemetadata<=5.115.0-1 \
-          kitinerary<=23.08.5-3 koffice-trinity<=14.1.2-2 krita<=5.2.2-1 \
-          libcupsfilters<=2.0.0-1 libreoffice<=25.2.0.3 okular<=23.08.5-2 \
+          gdal<=3.10.1-1 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
+          graphviz<=12.2.1 inkscape<=1.4-2 kfilemetadata<=5.115.0-1 \
+          kitinerary<=23.08.5-4 koffice-trinity<=14.1.2-3 krita<=5.2.2-1 \
+          libcupsfilters<=2.0.0-1 libreoffice<=25.2.1.2 okular<=23.08.5-2 \
           openscenegraph<=3:3.6.5-4 pdfgrep<=2.1.2-4 \
           python-poppler-qt5<=21.1.0+git20210304-3 rnote<=0.11.0 \
-          sane-backends<=1.0.32-2 scribus<=1.6.3 tdegraphics<=14.1.2-1 \
+          sane-backends<=1.0.32-2 scribus<=1.6.3-1 tdegraphics<=14.1.2-2 \
           texstudio<=4.0.2-4 texworks<=0.6.6-4 tracker-miners<=3.3.1-3 \
           tumbler<=4.20.0 xournalpp<=1.2.5 xreader<=4.2.2 \
           zathura-pdf-poppler<=0.3.3"

--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -1,4 +1,4 @@
-VER=25.02.0
+VER=25.03.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
-CHKSUMS="sha256::21234cb2a9647d73c752ce4031e65a79d11a511a835f2798284c2497b8701dee"
+CHKSUMS="sha256::97da4ff88517a6bbd729529f195f85c8d7a0c3bb4a3d57cb0c685cbb052fe837"
 CHKUPDATE="anitya::id=3686"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,5 @@
 VER=3.10.1
-REL=1
+REL=2
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::9211eac72b53f5f85d23cf6d83ee20245c6d818733405024e71f2af41e5c5f91"
 CHKUPDATE="anitya::id=881"


### PR DESCRIPTION
Topic Description
-----------------

- poppler: update to 25.03.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- poppler: 1:25.03.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit poppler:-pkgbreak gdal inkscape kitinerary tdegraphics koffice-trinity libreoffice scribus poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
