### PR TITLE
nvidia, nvidia-open: fix X11 failure when using hybrid graphics + modesetting

### DIFF
--- a/runtime-display/nvidia-open/autobuild/overrides/usr/share/X11/xorg.conf.d/10-nvidia-drm-outputclass.conf
+++ b/runtime-display/nvidia-open/autobuild/overrides/usr/share/X11/xorg.conf.d/10-nvidia-drm-outputclass.conf
@@ -1,11 +1,4 @@
 Section "OutputClass"
-    Identifier "intel"
-    MatchDriver "i915"
-    Driver "modesetting"
-    ModulePath "/usr/lib/xorg/modules"
-EndSection
-
-Section "OutputClass"
     Identifier "nvidia"
     MatchDriver "nvidia-drm"
     Driver "nvidia"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -2,6 +2,7 @@ _DRIVER_VER=570.124.04
 # Note: sometimes utilities are not updated timely
 _UTILS_VERS=570.124.04
 VER=${_DRIVER_VER}+utils${_UTILS_VERS}
+REL=1
 SRCS="git::rename=nvidia-driver;commit=tags/${_DRIVER_VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/03-kernel/overrides/usr/share/X11/xorg.conf.d/10-nvidia-drm-outputclass.conf
+++ b/runtime-display/nvidia/03-kernel/overrides/usr/share/X11/xorg.conf.d/10-nvidia-drm-outputclass.conf
@@ -1,11 +1,4 @@
 Section "OutputClass"
-    Identifier "intel"
-    MatchDriver "i915"
-    Driver "modesetting"
-    ModulePath "/usr/lib/xorg/modules"
-EndSection
-
-Section "OutputClass"
     Identifier "nvidia"
     MatchDriver "nvidia-drm"
     Driver "nvidia"

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,5 @@
 VER=570.124.04
+REL=1
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
 CHKSUMS__AMD64="sha256::1b786a4b7122d7c4216c58ae4007688a4f778c196c148d919163815ee10d53c4"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-open: nvidia: fix X11 failure when using hybrid graphics + modesetting
    Drop the top-loaded i915-modesetting matching in X11 config, which
    prompted the X server to use i915 as the primary GPU for output, when in
    fact the NVIDIA GPU's output was used for modesetting.
    Link: https://bugs.archlinux.org/task/64805
    Link: https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-utils/-/commit/1e59810c7d7ae056f7a1b2153935fc02580d0da6
- nvidia: fix X11 failure when using hybrid graphics + modesetting
    Drop the top-loaded i915-modesetting matching in X11 config, which
    prompted the X server to use i915 as the primary GPU for output, when in
    fact the NVIDIA GPU's output was used for modesetting.
    Link: https://bugs.archlinux.org/task/64805
    Link: https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-utils/-/commit/1e59810c7d7ae056f7a1b2153935fc02580d0da6

Package(s) Affected
-------------------

- nvidia: 570.124.04-1
- nvidia-firmware: 570.124.04-1
- nvidia-open: 570.124.04+utils570.124.04-1
- nvidia-utils: 570.124.04-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
