### PR TITLE
unar: update to 1.10.8

### DIFF
--- a/app-utils/unar/autobuild/build
+++ b/app-utils/unar/autobuild/build
@@ -10,12 +10,12 @@ cp -av "$SRCDIR"/XADMaster/{lsar,unar} \
 
 abinfo "Installing man page ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
-cp "$SRCDIR"/Extra/{lsar,unar}.1 \
+cp "$SRCDIR"/XADMaster/Extra/{lsar,unar}.1 \
     "$PKGDIR"/usr/share/man/man1
 
 abinfo "Installing Bash completions ..."
 mkdir -p "$PKGDIR"/usr/share/bash-completion/completions/
 for i in lsar unar; do
-    cp -v Extra/$i.bash_completion \
+    cp -v "$SRCDIR"/XADMaster/Extra/$i.bash_completion \
         "$PKGDIR"/usr/share/bash-completion/completions/
 done

--- a/app-utils/unar/autobuild/defines
+++ b/app-utils/unar/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=unar
 PKGDES="General unarchiver for a variety of file formats, including FOSS decompress code for RAR"
 PKGSEC=utils
-PKGDEP="gnustep-base bzip2 icu zlib gcc-runtime"
+PKGDEP="gnustep-base bzip2 icu zlib gcc-runtime wavpack"
 
 PKGPROV="unarchiver"

--- a/app-utils/unar/autobuild/patches/0001-AOSCOS-Fix-RAR5-FTBFS-on-GCC.patch
+++ b/app-utils/unar/autobuild/patches/0001-AOSCOS-Fix-RAR5-FTBFS-on-GCC.patch
@@ -1,0 +1,12 @@
+diff --git a/XADMaster/XADRAR5Parser.h b/XADMaster/XADRAR5Parser.h
+index 7fd90f9..a14c7a3 100644
+--- a/XADMaster/XADRAR5Parser.h
++++ b/XADMaster/XADRAR5Parser.h
+@@ -67,6 +67,7 @@ typedef struct RAR5HeaderBlock
+ +(int)requiredHeaderSize;
+ +(BOOL)recognizeFileWithHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name;
+ +(NSArray *)volumesForHandle:(CSHandle *)handle firstBytes:(NSData *)data name:(NSString *)name;
+++(off_t)signatureLocationInData:(NSData *)data;
+ 
+ -(void)parse;
+ -(void)addEntryWithDictionary:(NSMutableDictionary *)dict

--- a/app-utils/unar/autobuild/patches/0002-AOSCOS-Fix-version-number.patch
+++ b/app-utils/unar/autobuild/patches/0002-AOSCOS-Fix-version-number.patch
@@ -1,0 +1,26 @@
+diff --git a/XADMaster/lsar.m b/XADMaster/lsar.m
+index 12fd742..0b29819 100644
+--- a/XADMaster/lsar.m
++++ b/XADMaster/lsar.m
+@@ -25,7 +25,7 @@
+ #import "CSJSONPrinter.h"
+ #import "CommandLineCommon.h"
+ 
+-#define VERSION_STRING @"v1.10.7"
++#define VERSION_STRING @"v1.10.8"
+ 
+ #define EntryDoesNotNeedTestingResult 0
+ #define EntryIsNotSupportedResult 1
+diff --git a/XADMaster/unar.m b/XADMaster/unar.m
+index 18828c5..564978b 100644
+--- a/XADMaster/unar.m
++++ b/XADMaster/unar.m
+@@ -24,7 +24,7 @@
+ #import "CommandLineCommon.h"
+ #import "CSFileHandle.h"
+ 
+-#define VERSION_STRING @"v1.10.7"
++#define VERSION_STRING @"v1.10.8"
+ 
+ @interface Unarchiver:NSObject {}
+ @end

--- a/app-utils/unar/spec
+++ b/app-utils/unar/spec
@@ -1,6 +1,8 @@
-VER=1.10.8
-SRCS="git::commit=tags/v${VER};rename=XADMaster::https://github.com/MacPaw/XADMaster.git \
-      git::commit=tags/1.1;rename=UniversalDetector::https://github.com/MacPaw/universal-detector.git"
+UPSTREAM_VER=1.10.8
+UNIVERSALDETECTOR_VER=1.1
+VER=${UPSTREAM_VER}+universaldetector${UNIVERSALDETECTOR_VER}
+SRCS="git::commit=tags/v${UPSTREAM_VER};rename=XADMaster::https://github.com/MacPaw/XADMaster.git \
+      git::commit=tags/${UNIVERSALDETECTOR_VER};rename=UniversalDetector::https://github.com/MacPaw/universal-detector.git"
 SUBDIR=.
 CHKSUMS="SKIP \
          SKIP"

--- a/app-utils/unar/spec
+++ b/app-utils/unar/spec
@@ -1,5 +1,7 @@
-VER=1.10.1
-REL=6
-SRCS="tbl::http://http.debian.net/debian/pool/main/u/unar/unar_$VER.orig.tar.xz"
-CHKSUMS="sha256::963bbb25d0c321c9e022336318aacbaa3197e22063dd639c467453a4af8708ee"
+VER=1.10.8
+SRCS="git::commit=tags/v${VER};rename=XADMaster::https://github.com/MacPaw/XADMaster.git \
+      git::commit=tags/1.1;rename=UniversalDetector::https://github.com/MacPaw/universal-detector.git"
+SUBDIR=.
+CHKSUMS="SKIP \
+         SKIP"
 CHKUPDATE="anitya::id=5041"


### PR DESCRIPTION
Topic Description
-----------------

- unar: update to 1.10.8
    - Switch to use GitHub source.
    - Added two patches, one to fix FTBFS and the another to fix the
    upstream version number wrongly left as 1.10.7.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- unar: 1.10.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit unar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
