### PR TITLE
sbcl: update to 2.5.2

### DIFF
--- a/app-scientific/fricas/spec
+++ b/app-scientific/fricas/spec
@@ -1,5 +1,5 @@
 VER=1.3.11
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/fricas/fricas"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376467"

--- a/app-scientific/maxima/spec
+++ b/app-scientific/maxima/spec
@@ -1,5 +1,5 @@
 VER=5.46.0
-REL=3
+REL=4
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/maxima/maxima-$VER.tar.gz"
 CHKSUMS="sha256::7390f06b48da65c9033e8b2f629b978b90056454a54022db7de70e2225aa8b07"
 CHKUPDATE="anitya::id=6365"

--- a/lang-lisp/sbcl/autobuild/defines
+++ b/lang-lisp/sbcl/autobuild/defines
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-2 fricas<=1.3.11"
+PKGBREAK="maxima<=5.46.0-3 fricas<=1.3.11-1"

--- a/lang-lisp/sbcl/autobuild/defines.stage2
+++ b/lang-lisp/sbcl/autobuild/defines.stage2
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-2 fricas<=1.3.11"
+PKGBREAK="maxima<=5.46.0-3 fricas<=1.3.11-1"

--- a/lang-lisp/sbcl/spec
+++ b/lang-lisp/sbcl/spec
@@ -1,4 +1,4 @@
-VER=2.5.1
+VER=2.5.2
 SRCS="tbl::https://downloads.sourceforge.net/project/sbcl/sbcl/$VER/sbcl-$VER-source.tar.bz2"
-CHKSUMS="sha256::4133b36cd16d14d633969c37fd51c2c89a8ea5d6e1611552819d91f71b219f8b"
+CHKSUMS="sha256::5dc27eba7dda433df53fd7441de8b11474a82cdac1689c1f6ce55fa065d65fac"
 CHKUPDATE="anitya::id=16339"


### PR DESCRIPTION
Topic Description
-----------------

- sbcl: update to 2.5.2
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- sbcl: 2.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbcl maxima fricas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
