### PR TITLE
llama.cpp: update to 4827

### DIFF
--- a/runtime-creativity/llama.cpp/autobuild/patches/0001-AOSCOS-add-system-backend-path.patch
+++ b/runtime-creativity/llama.cpp/autobuild/patches/0001-AOSCOS-add-system-backend-path.patch
@@ -2,11 +2,11 @@ diff --git a/ggml/src/ggml-backend-reg.cpp b/ggml/src/ggml-backend-reg.cpp
 index 955ed505..cdd86eff 100644
 --- a/ggml/src/ggml-backend-reg.cpp
 +++ b/ggml/src/ggml-backend-reg.cpp
-@@ -493,6 +493,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
-     if (user_search_path == nullptr) {
-         search_paths.push_back(L"." + path_separator());
+@@ -489,6 +489,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
+         // default search paths: executable directory, current directory
          search_paths.push_back(get_executable_path());
-+        search_paths.push_back(L"/usr/lib/ggml/");
+         search_paths.push_back(fs::current_path());
++        search_paths.push_back(fs::u8path("/usr/lib/ggml/"));
      } else {
-         search_paths.push_back(utf8_to_utf16(user_search_path) + path_separator());
+         search_paths.push_back(user_search_path);
      }

--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,4 +1,4 @@
-VER=4615
+VER=4827
 # The build system uses git tags to determine version number
 SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: update to 4827
    - Adapted the patch that adds /usr/lib/ggml/ backend path.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- llama.cpp: 4827

Security Update?
----------------

No

Build Order
-----------

```
#buildit llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
