### PR TITLE
mangohud: update to 0.8.1

### DIFF
--- a/app-utils/mangohud/autobuild/defines
+++ b/app-utils/mangohud/autobuild/defines
@@ -4,13 +4,18 @@ PKGDEP="libglvnd glslang mesa dbus x11-lib wayland"
 PKGDEP__AMD64="${PKGDEP} libxnvctrl"
 PKGDEP__ARM64="${PKGDEP__AMD64}"
 BUILDDEP="mako nlohmann-json spdlog vulkan-headers"
-BUILDDEP__AMD64="${BUILDDEP} nvidia-open"
-BUILDDEP__ARM64="${BUILDDEP__AMD64}"
 PKGDES="A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more"
 
 ABTYPE=meson
-MESON_AFTER="-Dappend_libdir_mangohud=false \
-             -Ddynamic_string_tokens=false \
-             -Dwith_xnvctrl=disabled"
-MESON_AFTER__AMD64="${MESON_AFTER} -Dwith_xnvctrl=enabled"
-MESON_AFTER__ARM64="${MESON_AFTER__AMD64}"
+MESON_AFTER=(
+    '-Dappend_libdir_mangohud=false'
+    '-Ddynamic_string_tokens=false'
+    '-Dwith_xnvctrl=disabled'
+)
+MESON_AFTER__AMD64=(
+    "${MESON_AFTER[@]}"
+    '-Dwith_xnvctrl=enabled'
+)
+MESON_AFTER__ARM64=(
+    "${MESON_AFTER__AMD64[@]}"
+)

--- a/app-utils/mangohud/spec
+++ b/app-utils/mangohud/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=0.8.1
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
-CHKSUMS="sha256::c860c733b1328f0fb479fc880281110799ebc13a4183033affc591c6d10719d9"
+CHKSUMS="sha256::4c8d8098f5deff7737978d792eef909b7469933f456a47132dccc06804825482"
 CHKUPDATE="anitya::id=138139"

--- a/runtime-optenv32/mangohud+32/spec
+++ b/runtime-optenv32/mangohud+32/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=0.8.1
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
-CHKSUMS="sha256::c860c733b1328f0fb479fc880281110799ebc13a4183033affc591c6d10719d9"
+CHKSUMS="sha256::4c8d8098f5deff7737978d792eef909b7469933f456a47132dccc06804825482"
 CHKUPDATE="anitya::id=138139"


### PR DESCRIPTION
Topic Description
-----------------

- mangohud+32: update to 0.8.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- mangohud: update to 0.8.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mangohud: 0.8.1
- mangohud+32: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mangohud
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
