### PR TITLE
bash-startup: update to 0.7.0

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.6.8
+VER=0.7.0
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-startup: update to 0.7.0
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- bash-startup: 2:0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
