### PR TITLE
keepassxc: update to 2.7.10

### DIFF
--- a/app-utils/keepassxc/spec
+++ b/app-utils/keepassxc/spec
@@ -1,5 +1,4 @@
-VER=2.7.9
-REL=1
+VER=2.7.10
 SRCS="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
-CHKSUMS="sha256::3c44e45f22c00ddac63d8bc11054b4b0ada0222ffac08d3ed70f196cb9ed46fd"
+CHKSUMS="sha256::5ce76d6440986c24842585f019d5f3cadc166fa71fc911a4fe97b8bbc4819dfa"
 CHKUPDATE="anitya::id=15656"


### PR DESCRIPTION
Topic Description
-----------------

- keepassxc: update to 2.7.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- keepassxc: 2.7.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit keepassxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
