### PR TITLE
font-manager: update to 0.9.3

### DIFF
--- a/app-utils/font-manager/autobuild/defines
+++ b/app-utils/font-manager/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=font-manager
 PKGSEC=utils
 PKGDEP="libxml2 sqlite glib freetype fontconfig cairo gtk-4 harfbuzz json-glib \
-        cairo libsoup-3 webkit2gtk libadwaita file-roller"
+        cairo libsoup-3 webkit2gtk file-roller"
 BUILDDEP="gobject-introspection gtk-update-icon-cache gettext vala yelp-tools \
           nautilus nemo thunar gtk-doc"
 PKGDES="Simple font management for GTK+ desktop environments"
@@ -11,7 +11,7 @@ MESON_AFTER=(
     -Dmanager=true
     -Dviewer=true
     -Dsearch-provider=true
-    -Dadwaita=true
+    -Dadwaita=false
     -Dwebkit=true
     -Dyelp-doc=true
     -Denable-nls=true

--- a/app-utils/font-manager/spec
+++ b/app-utils/font-manager/spec
@@ -1,4 +1,4 @@
-VER=0.9.2
+VER=0.9.3
 SRCS="tbl::https://github.com/FontManager/font-manager/releases/download/$VER/font-manager-$VER.tar.xz"
-CHKSUMS="sha256::5a6ef285f6011b4661fec8561c72515b7b2dfeaebbc7e944f7f6385ce89497a6"
+CHKSUMS="sha256::2ec65a763ea818a1f20b39a21375649e86f358588eed887e0426283307c3662b"
 CHKUPDATE="anitya::id=15389"


### PR DESCRIPTION
Topic Description
-----------------

- font-manager: update to 0.9.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- font-manager: 0.9.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit font-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
