### PR TITLE
xray: update to 25.3.6

### DIFF
--- a/app-network/xray/autobuild/beyond
+++ b/app-network/xray/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Renaming xray executable file ..."
+mv -v "$PKGDIR"/usr/bin/main \
+    "$PKGDIR"/usr/bin/xray

--- a/app-network/xray/autobuild/build
+++ b/app-network/xray/autobuild/build
@@ -1,17 +1,13 @@
 # autobuild4's go template cannot specify a specific directory
 # to run `go get`
-
 abinfo "Building xray ..."
-go build -v \
-    -ldflags "${GO_LDFLAGS[*]}" \
-    -o xray \
-    "$SRCDIR"/main
+GOBIN="$PKGDIR/usr/bin/" \
+    ab_go_build "$SRCDIR"/main
 
-abinfo "Installing xray ..."
-install -Dvm755 "$SRCDIR"/xray -t "$PKGDIR"/usr/bin/
+abinfo "Creating directory of configure ..."
 install -dv "$PKGDIR"/etc/xray
-install -dv "$PKGDIR"/usr/share/xray
 
 abinfo "Linking to geofile directory ..."
+install -dv "$PKGDIR"/usr/share/xray
 ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
     "$PKGDIR"/usr/share/xray

--- a/app-network/xray/autobuild/defines
+++ b/app-network/xray/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME="xray"
 PKGSEC=net
 PKGDES="V2Ray with XTLS support"
-PKGDEP="gcc-runtime v2ray-rules-dat"
+PKGDEP="glibc v2ray-rules-dat"
 BUILDDEP="go"
 
+# FIXME: Autobuild does not yet support splitting debug symbols
+# from Go executables.
 ABSPLITDBG=0

--- a/app-network/xray/autobuild/prepare
+++ b/app-network/xray/autobuild/prepare
@@ -2,8 +2,4 @@ abinfo "Getting build information ..."
 commit=$(git describe --always --dirty)
 
 abinfo "Setting GO_LDFLAGS ..."
-GO_LDFLAGS=(
-    -s -w
-    "-X 'github.com/xtls/xray-core/core.build=$commit'"
-    "-extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/autobuild3/specs/hardened-ld'"
-)
+GO_LDFLAGS=+("-X 'github.com/xtls/xray-core/core.build=$commit'")

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,4 @@
-VER=25.2.21
+VER=25.3.6
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/XTLS/Xray-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- xray: update to 25.3.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- xray: 25.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
