### PR TITLE
winetricks: update to 20250102

### DIFF
--- a/app-emulation/winetricks/spec
+++ b/app-emulation/winetricks/spec
@@ -1,5 +1,4 @@
-VER=20240105
-REL=1
-SRCS="tbl::https://github.com/Winetricks/winetricks/archive/$VER.tar.gz"
-CHKSUMS="sha256::e92929045cf9ffb1e8d16ef8fd971ea1cf63a28a73916b1951e9553c94482f61"
+VER=20250102
+SRCS="git::commit=tags/$VER::https://github.com/Winetricks/winetricks"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7258"


### PR DESCRIPTION
Topic Description
-----------------

- winetricks: update to 20250102
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- winetricks: 20250102

Security Update?
----------------

No

Build Order
-----------

```
#buildit winetricks
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
