### PR TITLE
minetest: update to 5.11.0+irrlicht1.9.0mt10

### DIFF
--- a/app-games/minetest/spec
+++ b/app-games/minetest/spec
@@ -1,13 +1,12 @@
-UPSTREAM_VER=5.7.0
+UPSTREAM_VER=5.11.0
 # Note: For use in autobuild/.
 __GAMEVER="${UPSTREAM_VER}"
 __IRRLICHTVER=1.9.0mt10
 VER=${UPSTREAM_VER}+irrlicht${__IRRLICHTVER}
-REL=3
 SRCS="tbl::https://github.com/minetest/minetest/archive/${UPSTREAM_VER}.tar.gz \
       git::commit=tags/${UPSTREAM_VER};rename=minetest_game::https://github.com/minetest/minetest_game \
       git::commit=tags/${__IRRLICHTVER};rename=irrlichtmt::https://github.com/minetest/irrlicht"
-CHKSUMS="sha256::0cd0fd48a97f76e337a2e1284599a054f8f92906a84a4ef2122ed321e1b75fa7 \
+CHKSUMS="sha256::70e531d0776988ce6e579ea5490fdf6be3e349a4ade5281f5111aa4fdd8ee510 \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1978"


### PR DESCRIPTION
Topic Description
-----------------

- minetest: update to 5.11.0+irrlicht1.9.0mt10
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- minetest: 5.11.0+irrlicht1.9.0mt10

Security Update?
----------------

No

Build Order
-----------

```
#buildit minetest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
