### PR TITLE
reptyr: update to 0.10.0

### DIFF
--- a/app-utils/reptyr/autobuild/build
+++ b/app-utils/reptyr/autobuild/build
@@ -1,0 +1,11 @@
+abinfo "Building reptyr ..."
+make PREFIX=/usr \
+     DESTDIR="$PKGDIR" \
+     DISABLE_TESTS=1 \
+     all
+
+abinfo "Installing reptyr ..."
+make PREFIX=/usr \
+     DESTDIR="$PKGDIR" \
+     DISABLE_TESTS=1 \
+     install

--- a/app-utils/reptyr/autobuild/defines
+++ b/app-utils/reptyr/autobuild/defines
@@ -1,4 +1,8 @@
 PKGNAME=reptyr
 PKGSEC=utils
 PKGDEP="glibc"
+BUILDDEP="bash-completion"
 PKGDES="Reparent a running program to a new terminal"
+
+# FIXME: Upstream has not yet supported other architectures
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/app-utils/reptyr/autobuild/prepare
+++ b/app-utils/reptyr/autobuild/prepare
@@ -1,2 +1,0 @@
-sed -e 's|-Werror||g' \
-    -i "$SRCDIR"/Makefile

--- a/app-utils/reptyr/spec
+++ b/app-utils/reptyr/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.0
 SRCS="git::commit=tags/reptyr-${VER}::https://github.com/nelhage/reptyr"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4192"


### PR DESCRIPTION
Topic Description
-----------------

- reptyr: update to 0.10.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- reptyr: 0.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit reptyr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
