### PR TITLE
luanti: new, 5.11.0

### DIFF
--- a/app-games/luanti/autobuild/defines
+++ b/app-games/luanti/autobuild/defines
@@ -1,0 +1,25 @@
+PKGNAME=luanti
+PKGDES="A sandbox game inspired by Minecraft"
+PKGSEC=games
+PKGDEP="openal-soft libvorbis libogg luajit postgresql zstd libjpeg-turbo \
+        libpng sdl2 curl gmp jsoncpp"
+# FIXME: LuaJIT not available on these architectures.
+PKGDEP__LOONGARCH64="${PKGDEP/luajit/lua}"
+PKGDEP__PPC64="${PKGDEP/luajit/lua}"
+PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
+PKGDEP__RISCV64="${PKGDEP/luajit/lua}"
+BUILDDEP="doxygen leveldb postgresql sqlite gettext"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_BENCHMARKS=FALSE'
+    '-DBUILD_CLIENT=TRUE'
+    '-DBUILD_EXAMPLES=ON'
+    '-DBUILD_SERVER=TRUE'
+    '-DBUILD_UNITTESTS=FALSE'
+    '-DBUILD_DOCUMENTATION=TRUE'
+    '-DRUN_IN_PLACE=FALSE'
+)
+
+PKGBREAK="minetest-game<=0.4.16 minetest<=5.7.0+irrlicht1.9.0mt10-3"
+PKGREP="minetest-game<=0.4.16 minetest<=5.7.0+irrlicht1.9.0mt10-3"

--- a/app-games/luanti/spec
+++ b/app-games/luanti/spec
@@ -1,0 +1,4 @@
+VER=5.11.0
+SRCS="git::commit=tags/$VER::https://github.com/luanti-org/luanti.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1978"

--- a/app-games/minetest/autobuild/beyond
+++ b/app-games/minetest/autobuild/beyond
@@ -1,7 +1,0 @@
-abinfo "Installing game data..."
-cd "$SRCDIR"/../minetest_game/
-mkdir -pv "$PKGDIR"/usr/share/minetest/games/minetest_game
-cp -rv \
-    menu mods README.md game.conf game_api.txt minetest.conf \
-    minetest.conf.example settingtypes.txt \
-    "$PKGDIR"/usr/share/minetest/games/minetest_game/

--- a/app-games/minetest/autobuild/defines
+++ b/app-games/minetest/autobuild/defines
@@ -1,21 +1,8 @@
 PKGNAME=minetest
-PKGDES="A sandbox game inspired by Minecraft"
 PKGSEC=games
-PKGDEP="openal-soft libvorbis libogg luajit postgresql zstd"
-# FIXME: LuaJIT not available on these architectures.
-PKGDEP__LOONGARCH64="${PKGDEP/luajit/lua}"
-PKGDEP__MIPS64R6EL="${PKGDEP/luajit/lua}"
-PKGDEP__PPC64="${PKGDEP/luajit/lua}"
-PKGDEP__PPC64EL="${PKGDEP/luajit/lua}"
-PKGDEP__RISCV64="${PKGDEP/luajit/lua}"
-BUILDDEP="doxygen graphviz leveldb postgresql sqlite"
+PKGDEP="luanti"
+PKGDES="A sandbox game inspired by Minecraft (transitional package for luanti)"
 
-CMAKE_AFTER="-DBUILD_BENCHMARKS=OFF \
-             -DBUILD_CLIENT=ON \
-             -DBUILD_EXAMPLES=ON \
-             -DBUILD_SERVER=ON \
-             -DBUILD_UNITTESTS=OFF \
-             -DRUN_IN_PLACE=OFF"
-
-PKGBREAK="minetest-game<=0.4.16"
-PKGREP="minetest-game<=0.4.16"
+PKGEPOCH=1
+ABHOST=noarch
+ABTYPE=dummy

--- a/app-games/minetest/autobuild/prepare
+++ b/app-games/minetest/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "Deploying local irrlichmt source ..."
-mv -v "$SRCDIR"/../irrlichtmt \
-    "$SRCDIR"/lib/

--- a/app-games/minetest/spec
+++ b/app-games/minetest/spec
@@ -1,14 +1,2 @@
-UPSTREAM_VER=5.7.0
-# Note: For use in autobuild/.
-__GAMEVER="${UPSTREAM_VER}"
-__IRRLICHTVER=1.9.0mt10
-VER=${UPSTREAM_VER}+irrlicht${__IRRLICHTVER}
-REL=3
-SRCS="tbl::https://github.com/minetest/minetest/archive/${UPSTREAM_VER}.tar.gz \
-      git::commit=tags/${UPSTREAM_VER};rename=minetest_game::https://github.com/minetest/minetest_game \
-      git::commit=tags/${__IRRLICHTVER};rename=irrlichtmt::https://github.com/minetest/irrlicht"
-CHKSUMS="sha256::0cd0fd48a97f76e337a2e1284599a054f8f92906a84a4ef2122ed321e1b75fa7 \
-         SKIP \
-         SKIP"
-CHKUPDATE="anitya::id=1978"
-SUBDIR="minetest-${__GAMEVER}"
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- luanti: new, 5.11.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- minetest: mark transitional for luanti
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- luanti: 5.11.0
- minetest: 1:0

Security Update?
----------------

No

Build Order
-----------

```
#buildit luanti minetest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
