### PR TITLE
inxi: update to 3.3.37+1

### DIFF
--- a/app-utils/inxi/autobuild/build
+++ b/app-utils/inxi/autobuild/build
@@ -1,4 +1,4 @@
 sed -i "s/B_ALLOW_UPDATE='true'/B_ALLOW_UPDATE='false'/" inxi
 
-install -p -D -m 755 inxi "$PKGDIR"/usr/bin/inxi
-install -p -D -m 644 inxi.1 "$PKGDIR"/usr/share/man/man1/inxi.1
+install -Dvm755 inxi "$PKGDIR"/usr/bin/inxi
+install -Dvm644 inxi.1 "$PKGDIR"/usr/share/man/man1/inxi.1

--- a/app-utils/inxi/autobuild/defines
+++ b/app-utils/inxi/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=inxi
 PKGSEC=utils
-PKGDEP="net-tools pciutils procps lm-sensors usbutils hddtemp x11-app bind"
+PKGDEP="net-tools pciutils procps lm-sensors usbutils hddtemp x11-app bind perl"
 PKGDES="A full featured system information script"
 
 ABHOST=noarch

--- a/app-utils/inxi/spec
+++ b/app-utils/inxi/spec
@@ -1,4 +1,4 @@
-VER=3.3.31+2
-SRCS="tbl::https://github.com/smxi/inxi/archive/${VER/+/-}.tar.gz"
-CHKSUMS="sha256::ff5d138392ac557e31ede6cf96d73d1b9f972f42f6529d47fec2c51184bff338"
+VER=3.3.37+1
+SRCS="git::commit=tags/${VER/+/-}::https://codeberg.org/smxi/inxi.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10526"


### PR DESCRIPTION
Topic Description
-----------------

- inxi: update to 3.3.37+1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- inxi: 3.3.37+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit inxi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
