### PR TITLE
glib: update to 2.84.0

### DIFF
--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,4 +1,4 @@
-VER=2.83.3
+VER=2.84.0
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
-CHKSUMS="sha256::d0c65318bb2e3fa594277cf98a71cffaf5f666c078db39dcec121757b2ba328d"
+CHKSUMS="sha256::f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib: update to 2.84.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- glib: 2.84.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
