### PR TITLE
font-manager: update to 0.9.4

### DIFF
--- a/app-utils/font-manager/spec
+++ b/app-utils/font-manager/spec
@@ -1,4 +1,4 @@
-VER=0.9.2
+VER=0.9.4
 SRCS="tbl::https://github.com/FontManager/font-manager/releases/download/$VER/font-manager-$VER.tar.xz"
-CHKSUMS="sha256::5a6ef285f6011b4661fec8561c72515b7b2dfeaebbc7e944f7f6385ce89497a6"
+CHKSUMS="sha256::6a0899ac753f50d0779751828c62fa6220024213ebd2179b6f64a3a9bff51f96"
 CHKUPDATE="anitya::id=15389"


### PR DESCRIPTION
Topic Description
-----------------

- font-manager: update to 0.9.4
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- font-manager: 0.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit font-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
