### PR TITLE
ddcutil: update to 2.2.0

### DIFF
--- a/app-utils/ddcutil/autobuild/defines
+++ b/app-utils/ddcutil/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=ddcutil
 PKGSEC=utils
 PKGDES="Utility for controlling monitor settings using DDC/CI and USB"
-PKGDEP="i2c-tools glib libgudev libusb systemd libdrm x11-lib hwdata"
+PKGDEP="i2c-tools glib libgudev libusb systemd libdrm x11-lib hwdata jansson"
 BUILDDEP="doxygen"
 
-# FIXME: doxyfile: No such file or directory
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     --enable-lib
     --enable-envcmds
@@ -12,5 +12,4 @@ AUTOTOOLS_AFTER=(
     --enable-usb
     --enable-drm
     --enable-x11
-    --disable-doxygen
 )

--- a/app-utils/ddcutil/autobuild/patches/0001-base-fix-shadow-build.patch
+++ b/app-utils/ddcutil/autobuild/patches/0001-base-fix-shadow-build.patch
@@ -1,0 +1,86 @@
+From 7b41ff4d7c29b04d3ac56dd42c36df1b5ab866b1 Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Fri, 7 Mar 2025 22:48:03 -0500
+Subject: [PATCH] base: fix shadow build
+
+---
+ .gitignore           |  2 ++
+ Makefile.am          |  1 +
+ src/Makefile.am      |  2 +-
+ src/base/Makefile.am | 16 +++++++++-------
+ 4 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index e93578a1..c943eec8 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -65,3 +65,5 @@ doxydoc/apidoc
+ /heaptrack*
+ *.tar.gz
+ 
++# Shadow build
++build
+diff --git a/Makefile.am b/Makefile.am
+index 38d1a4ff..fc1a011d 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -104,6 +104,7 @@ show:
+ 	@echo "  libdir                  = $(libdir)"
+ 	@echo "  libexecdir              = $(libexecdir)"
+ 	@echo "  top_srcdir              = $(top_srcdir)"
++	@echo "  top_builddir            = $(top_builddir)"
+ 	@echo "  srcdir                  = $(srcdir)"
+ 	@echo "  pkgconfigdir:           = ${pkgconfigdir}"
+ 	@echo ""
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 646ef411..a0545dbb 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -320,7 +320,7 @@ endif
+ 
+ all-local:
+ 	@echo "(src/Makefile) all-local"
+-	rm -fv base/build_details.h
++	rm -fv $(top_builddir)/src/base/build_details.h
+ 
+ 
+ # debug-install-hook:
+diff --git a/src/base/Makefile.am b/src/base/Makefile.am
+index 1fad2590..2b6aab71 100644
+--- a/src/base/Makefile.am
++++ b/src/base/Makefile.am
+@@ -1,10 +1,11 @@
+ # src/base/Makefile.am
+ 
+-AM_CPPFLAGS =         \
+-  $(LIBDRM_CFLAGS)    \
+-  $(GLIB_CFLAGS)      \
+-  -I$(top_srcdir)/src \
+-  -I$(top_srcdir)/src/public
++AM_CPPFLAGS =                \
++  $(LIBDRM_CFLAGS)           \
++  $(GLIB_CFLAGS)             \
++  -I$(top_srcdir)/src        \
++  -I$(top_srcdir)/src/public \
++  -I$(top_builddir)/src
+ 
+ AM_CFLAGS = $(AM_CFLAGS_STD)
+ 
+@@ -25,11 +26,12 @@ BUILT_SOURCES = build_details.h
+ #	echo "// Dummy include file to force rebuilding built_timestamp.c" >$0
+ 
+ build_details.h:
+-	echo "// Dummy include file to force rebuilding built_timestamp.c" > build_details.h
++	echo "// Dummy include file to force rebuilding built_timestamp.c" > \
++		$(top_builddir)/src/base/build_details.h
+ 
+ # all-local:
+ #	@echo "(src/base/Makefile) all-local"
+-#	rm -fv build_details.h
++#	rm -fv $(top_builddir)/src/ase/build_details.h
+ 	
+ clean-local:
+ 	@echo "(src/base/Makefile) clean-local"
+-- 
+2.48.1
+

--- a/app-utils/ddcutil/spec
+++ b/app-utils/ddcutil/spec
@@ -1,4 +1,4 @@
-VER=2.1.4
+VER=2.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/rockowitz/ddcutil"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242390"


### PR DESCRIPTION
Topic Description
-----------------

- ddcutil: update to 2.2.0
    - Remove --disable-doxygen. Doxygen support here is only intended
    for development uses and disabled by default. We don't have to
    worry about it. Ref: \[^1\]
    - Fix shadow build support with a custom patch.
    \[^1\]: https://www.ddcutil.com/building/#development-configuration-options

Package(s) Affected
-------------------

- ddcutil: 2.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddcutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
