### PR TITLE
cpu-x: new, 5.1.2

### DIFF
--- a/app-utils/cpu-x/autobuild/defines
+++ b/app-utils/cpu-x/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=cpu-x
+PKGSEC=utils
+PKGDES="A tool to present information on CPU, motherboard and more"
+PKGDEP="gtkmm-3 glibmm pangomm cairomm libsigc++ glib ncurses libcpuid \
+        pciutils libglvnd glfw vulkan libcl procps gcc-runtime glibc"
+BUILDDEP="gettext opencl-registry-api"
+BUILDDEP__AMD64="${BUILDDEP} nasm"
+
+CMAKE_AFTER="-DWITH_OPENCL=ON"

--- a/app-utils/cpu-x/spec
+++ b/app-utils/cpu-x/spec
@@ -1,0 +1,4 @@
+VER=5.1.2
+SRCS="git::commit=tags/v$VER::https://github.com/TheTumultuousUnicornOfDarkness/CPU-X"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=137672"

--- a/runtime-common/libcpuid/spec
+++ b/runtime-common/libcpuid/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
+VER=0.7.1
 SRCS="tbl::https://github.com/anrieff/libcpuid/releases/download/v$VER/libcpuid-$VER.tar.gz"
-CHKSUMS="sha256::d9f1ba17eac4364e49c07ec880242904efa4b51d703399273585052e266e7ada"
+CHKSUMS="sha256::f5fc4ba4cf19e93e62d3ed130f47045245d682b10506ad29937dacae1bdccc35"
 CHKUPDATE="anitya::id=241811"


### PR DESCRIPTION
Topic Description
-----------------

- cpu-x: new, 5.1.2
- libcpuid: update to 0.7.1

Package(s) Affected
-------------------

- cpu-x: 5.1.2
- libcpuid: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcpuid cpu-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
