### PR TITLE
telegram-desktop: update to 5.12.1

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 96980ca8edce0428dc9b2c097c0d9b9f5f49d6f8 Mon Sep 17 00:00:00 2001
+From 3de3bd71c8a3166baef2413b86e3162c40160a3a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 1/9] fix(window.style): set default window width to 360px
+Subject: [PATCH 01/10] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From 73b7d248f87914d088d9997d533f367466fd1344 Mon Sep 17 00:00:00 2001
+From 07141a7a05fb2a4721e605bd008c5274b76f0638 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 2/9] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 02/10] fix(core_settings.h): use system window decoration by
  default
 
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From c330f36eae2258614d4258f8c0e0de5343b1c898 Mon Sep 17 00:00:00 2001
+From 8f6357bc009615067fa8658d28f04aee87e1fdd0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 3/9] fix(ui): fix build with Qt 5
+Subject: [PATCH 03/10] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From de568f020ced3b10c322b19efff6887a05f16fab Mon Sep 17 00:00:00 2001
+From 953db0b24af2735ae5d799ba946d4b317452622a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 4/9] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 04/10] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,7 +1,7 @@
-From e9641ddd28e55b09469cca96bdfced9fc079ab4a Mon Sep 17 00:00:00 2001
+From 17c0e1a4e2c38e6964fc5823856ef056cf3d5095 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 5/9] fix(settings): use system fonts by default
+Subject: [PATCH 05/10] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 0cf197a33f33996c2d38b29ee75197b5b52288bf Mon Sep 17 00:00:00 2001
+From cae410280b5125b3293bc8ab8571f2312fdf9da4 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 6/9] Remove the confusing "Default" option from selectable
+Subject: [PATCH 06/10] Remove the confusing "Default" option from selectable
  fonts
 
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From 96d88738e15613ff10092c4027c2903349139b56 Mon Sep 17 00:00:00 2001
+From e78e9bca69777e82ea36963a7154134ce8eb0c73 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 7/9] fix(lib_tl): add missing cstring include
+Subject: [PATCH 07/10] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From 32e2e189dd0ababf83e940f1469c1871ffdacaee Mon Sep 17 00:00:00 2001
+From 25e92738b6a59ad59122129323730d14930e88aa Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 8/9] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 08/10] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,7 +1,7 @@
-From 519b4e0fbe1e007a8c5a9fbf7636f16e46eb33e8 Mon Sep 17 00:00:00 2001
+From 4fcaca77811aee80f46b05d4ff73ba23cd6810b4 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
-Subject: [PATCH 9/9] fix(current_geo_location_linux): add missing
+Subject: [PATCH 09/10] fix(current_geo_location_linux): add missing
  QGuiApplication include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-integration_linux-include-core_settings.h-with-Q.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-integration_linux-include-core_settings.h-with-Q.patch
@@ -1,0 +1,28 @@
+From ea99e586be99cc7c61f96217079b73ce562f0f81 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sat, 8 Mar 2025 19:25:59 -0800
+Subject: [PATCH 10/10] fix(integration_linux): include core_settings.h with Qt
+ version <= 6.5.0
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Telegram/SourceFiles/platform/linux/integration_linux.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Telegram/SourceFiles/platform/linux/integration_linux.cpp b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+index e8696772ea..e3e331cd7b 100644
+--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+@@ -12,6 +12,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "base/platform/linux/base_linux_xdp_utilities.h"
+ #include "core/sandbox.h"
+ #include "core/application.h"
++#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
++#include "core/core_settings.h"
++#endif
+ #include "base/random.h"
+ 
+ #include <QtCore/QAbstractEventDispatcher>
+-- 
+2.48.1
+

--- a/app-web/telegram-desktop/autobuild/patches/1001-tg_owt_Patch-Fix-build-with-PipeWire-1.4.patch.deferred
+++ b/app-web/telegram-desktop/autobuild/patches/1001-tg_owt_Patch-Fix-build-with-PipeWire-1.4.patch.deferred
@@ -1,0 +1,35 @@
+From 0b6fc433a84df7bcfea8a478b66129c7dfc67567 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sat, 8 Mar 2025 18:44:17 -0800
+Subject: [PATCH] Patch: Fix build with PipeWire 1.4
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/modules/video_capture/linux/pipewire_session.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/modules/video_capture/linux/pipewire_session.cc b/src/modules/video_capture/linux/pipewire_session.cc
+index 4d1b200a..caf0a654 100644
+--- a/src/modules/video_capture/linux/pipewire_session.cc
++++ b/src/modules/video_capture/linux/pipewire_session.cc
+@@ -60,7 +60,7 @@ PipeWireNode::PipeWireNode(PipeWireSession* session,
+       .param = OnNodeParam,
+   };
+ 
+-  pw_node_add_listener(proxy_, &node_listener_, &node_events, this);
++  pw_node_add_listener(reinterpret_cast<pw_node*>(proxy_), &node_listener_, &node_events, this);
+ }
+ 
+ PipeWireNode::~PipeWireNode() {
+@@ -94,7 +94,7 @@ void PipeWireNode::OnNodeInfo(void* data, const pw_node_info* info) {
+       uint32_t id = info->params[i].id;
+       if (id == SPA_PARAM_EnumFormat &&
+           info->params[i].flags & SPA_PARAM_INFO_READ) {
+-        pw_node_enum_params(that->proxy_, 0, id, 0, UINT32_MAX, nullptr);
++        pw_node_enum_params(reinterpret_cast<pw_node*>(that->proxy_), 0, id, 0, UINT32_MAX, nullptr);
+         break;
+       }
+     }
+-- 
+2.48.1
+

--- a/app-web/telegram-desktop/autobuild/prepare
+++ b/app-web/telegram-desktop/autobuild/prepare
@@ -1,5 +1,8 @@
-abinfo "Making tg_owt..."
+abinfo "Patching tg_owt ..."
 cd "$SRCDIR"/../tg_owt
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.deferred
+
+abinfo "Making tg_owt ..."
 cmake -G Ninja \
       -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_BUILD_TYPE=Release \

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,9 +1,9 @@
-VER=5.11.1
+VER=5.12.1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=be39b8c8d0db1f377118f813f0c4bd331d341d5e
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::bde842b71064511c5bacb4971e3b2d539614f8dc541dffcb4ccc00e02d80924b \
+CHKSUMS="sha256::8138ff0695614070516e6321878221930b2af98478acb50193d6107e83efbcc2 \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
@@ -11,4 +11,3 @@ ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem_per_core=4"
 ENVREQ__LOONGSON3="total_mem_per_core=4"
 ENVREQ__PPC64EL="total_mem_per_core=4"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.12.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.12.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
