### PR TITLE
wine: update to 10.3+gecko2.47.4+mono9.4.0

### DIFF
--- a/app-emulation/wine/autobuild/build
+++ b/app-emulation/wine/autobuild/build
@@ -8,7 +8,6 @@ abinfo "Preparing to build main (native) Wine runtime ..."
 mkdir -pv "$SRCDIR"/wine
 cd "$SRCDIR"/wine
 if ! ab_match_arch i486; then
-     _WINE_SUFFIX="64"
      _WINE_WIN64="--enable-win64"
 else
      _WINE_WIN16="--enable-win16"
@@ -17,7 +16,7 @@ fi
 abinfo "Configuring main (native) Wine runtime ..."
 ../configure \
     --prefix=/usr \
-    --libdir=/usr/lib/wine${_WINE_SUFFIX} \
+    --libdir=/usr/lib \
     ${AUTOTOOLS_AFTER[@]} ${_WINE_WIN64} ${_WINE_WIN16}
 
 abinfo "Building main (native) Wine runtime ..."
@@ -26,8 +25,8 @@ make
 abinfo "Installing main (native) Wine runtime ..."
 make install \
     prefix="$PKGDIR/usr" \
-    libdir="$PKGDIR/usr/lib/wine64" \
-    dlldir="$PKGDIR/usr/lib/wine64/wine" \
+    libdir="$PKGDIR/usr/lib" \
+    dlldir="$PKGDIR/usr/lib/wine" \
     -j1
 
 if ab_match_arch amd64; then
@@ -43,7 +42,7 @@ if ab_match_arch amd64; then
     abinfo "Configuring 32-bit Wine runtime ..."
     ../configure \
         --prefix=/usr \
-        --libdir=/usr/lib/wine32 \
+        --libdir=/usr/lib \
         --with-wine64="$SRCDIR"/wine \
         --enable-win16 \
         ${AUTOTOOLS_AFTER[@]} \
@@ -60,7 +59,7 @@ if ab_match_arch amd64; then
     abinfo "Installing 32-bit Wine runtime ..."
     make install \
         prefix="$PKGDIR/usr" \
-        libdir="$PKGDIR/usr/lib/wine32" \
-        dlldir="$PKGDIR/usr/lib/wine32/wine" \
+        libdir="$PKGDIR/usr/lib" \
+        dlldir="$PKGDIR/usr/lib/wine" \
         -j1
 fi

--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -19,6 +19,7 @@ PKGSUG__RETRO=""
 PKGSUG__I486="${PKGSUG__RETRO}"
 BUILDDEP="chrpath dos2unix llvm opencl-registry-api opencl-registry-api+32 \
           wayland-protocols"
+BUILDDEP__ARM64="${BUILDDEP/opencl-registry-api+32/}"
 BUILDDEP__RETRO="chrpath dos2unix"
 BUILDDEP__I486="${BUILDDEP__RETRO}"
 PKGDES="Runtime/Compatibility Layer for running programs designed for Microsoft Windows"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=9.4.0
-UPSTREAM_VER=10.1
+UPSTREAM_VER=10.3
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::63471e37b1a515795ff3368d26a039261660e1377cb427d1b61b3a7b76091663 \
+CHKSUMS="sha256::de3d88ff0056b82ffdfca842f1119592e4914f48c4ea023768e0419c36467c3e \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 10.3+gecko2.47.4+mono9.4.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wine: 3:10.3+gecko2.47.4+mono9.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
