### PR TITLE
libidn2: update to 2.3.8

### DIFF
--- a/runtime-network/libidn2/spec
+++ b/runtime-network/libidn2/spec
@@ -1,4 +1,4 @@
-VER=2.3.7
+VER=2.3.8
 SRCS="tbl::https://ftp.gnu.org/pub/gnu/libidn/libidn2-$VER.tar.gz"
-CHKSUMS="sha256::4c21a791b610b9519b9d0e12b8097bf2f359b12f8dd92647611a929e6bfd7d64"
+CHKSUMS="sha256::f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
 CHKUPDATE="anitya::id=5597"


### PR DESCRIPTION
Topic Description
-----------------

- libidn2: update to 2.3.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libidn2: 2.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libidn2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
