### PR TITLE
weston: update to 14.0.1

### DIFF
--- a/runtime-display/weston/autobuild/patches/0001-vnc-Allow-neatvnc-in-version-0.9.0.patch
+++ b/runtime-display/weston/autobuild/patches/0001-vnc-Allow-neatvnc-in-version-0.9.0.patch
@@ -1,0 +1,28 @@
+From 3d81fec56834ae69a3b25f946ec9c261f9113cc4 Mon Sep 17 00:00:00 2001
+From: Philipp Zabel <p.zabel@pengutronix.de>
+Date: Tue, 19 Nov 2024 17:06:19 +0100
+Subject: [PATCH] vnc: Allow neatvnc in version 0.9.0
+
+Neat VNC 0.9.0 is backwards compatible.
+
+Signed-off-by: Philipp Zabel <p.zabel@pengutronix.de>
+---
+ libweston/backend-vnc/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libweston/backend-vnc/meson.build b/libweston/backend-vnc/meson.build
+index 39b15cf9..cf67c51c 100644
+--- a/libweston/backend-vnc/meson.build
++++ b/libweston/backend-vnc/meson.build
+@@ -3,7 +3,7 @@ if not get_option('backend-vnc')
+ endif
+ 
+ config_h.set('BUILD_VNC_COMPOSITOR', '1')
+-dep_neatvnc = dependency('neatvnc', version: ['>= 0.7.0', '< 0.9.0'], required: false, fallback: ['neatvnc', 'neatvnc_dep'])
++dep_neatvnc = dependency('neatvnc', version: ['>= 0.7.0', '< 0.10.0'], required: false, fallback: ['neatvnc', 'neatvnc_dep'])
+ if not dep_neatvnc.found()
+ 	error('VNC backend requires neatvnc which was not found. Or, you can use \'-Dbackend-vnc=false\'.')
+ endif
+-- 
+2.48.1
+

--- a/runtime-display/weston/spec
+++ b/runtime-display/weston/spec
@@ -1,5 +1,4 @@
-VER=14.0.0
-REL=1
+VER=14.0.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/weston"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13745"


### PR DESCRIPTION
Topic Description
-----------------

- weston: update to 14.0.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- weston: 14.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weston
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
