### PR TITLE
intel-compute-runtime: update to 25.05.32567.17

### DIFF
--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,8 +1,8 @@
-VER=2.5.6
+VER=2.7.11
 LLVM_VER=14.0.6
 OPENCL_CLANG_VER=14.0.1
 SPIRV_LLVM_TRANSLATOR_VER=14.0.7
-VS_INTRINSICS_VER=0.21.0
+VS_INTRINSICS_VER=0.22.1
 SPIRV_TOOLS_VER=1.3.290.0
 
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.19.2
+VER=1.20.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=22.6.0
+VER=22.7.0
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-devices/metee/spec
+++ b/runtime-devices/metee/spec
@@ -1,4 +1,4 @@
-VER=4.3.0
+VER=4.3.1
 SRCS="git::commit=tags/$VER::https://github.com/intel/metee.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230452"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=24.52.32224.5
+VER=25.05.32567.17
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 25.05.32567.17
- level-zero: update to 1.20.2
- intel-graphics-compiler: update to 2.7.11
- intel-gmmlib: update to 22.7.0
- metee: update to 4.3.1

Package(s) Affected
-------------------

- intel-compute-runtime: 25.05.32567.17
- intel-gmmlib: 22.7.0
- intel-graphics-compiler: 2.7.11
- level-zero: 1.20.2
- metee: 4.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit metee intel-gmmlib level-zero intel-graphics-compiler intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
