### PR TITLE
mono: update to 6.14.1

### DIFF
--- a/lang-dotnet/mono/autobuild/beyond
+++ b/lang-dotnet/mono/autobuild/beyond
@@ -16,9 +16,7 @@ ln -sv mcs \
 # Scripts from mono/linux-packaging-mono: https://github.com/mono/linux-packaging-mono/blob/master-2019-02/debian/rules#L184
 # Mono.Security.Win32.dll is only useful on windows, as it wrap the win api
 abinfo "Dropping Mono.Security.Win32.dll ..."
-rm -rv \
-    "$PKGDIR"/usr/lib/mono/gac/Mono.Security.Win32 \
-    "$PKGDIR"/usr/lib/mono/*/Mono.Security.Win32.dll
+rm -rv "$PKGDIR"/usr/lib/mono/*/Mono.Security.Win32*
 
 abinfo "Installing man pages ..."
 cp -v "$PKGDIR"/usr/share/man/man1/al.1 \

--- a/lang-dotnet/mono/autobuild/defines
+++ b/lang-dotnet/mono/autobuild/defines
@@ -2,25 +2,32 @@ PKGNAME=mono
 PKGSEC=cli-mono
 PKGDES="An open source implementation of Microsoft's .NET Framework"
 PKGDEP="libgdiplus python-3 zlib"
-BUILDDEP="curl devel-base git"
+BUILDDEP="curl"
 
+ABTYPE=autotools
 ABSHADOW=0
 
-# FTBFS with LTO
+# FIXME: FTBFS with LTO
+#
 # mono-tls.c:234: error: undefined reference to 'mono_tls_thread'
 # mono-tls.c:235: error: undefined reference to 'mono_tls_jit_tls'
 # mono-tls.c:236: error: undefined reference to 'mono_tls_domain'
 # mono-tls.c:237: error: undefined reference to 'mono_tls_lmf_addr'
 # collect2: error: ld returned 1 exit status
 NOLTO=1
-
 NOSTATIC=0
 
-AUTOTOOLS_DEF=""
+# FIXME: Upstream mess-up with default flags.
+#
+# configure: error: unrecognized options: --disable-embed-check, --with-libgc-threads
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--prefix=/usr \
-                 --sysconfdir=/etc \
-                 --disable-llvm \
-                 PYTHON=/usr/bin/python3"
+AUTOTOOLS_AFTER=(
+    '--prefix=/usr'
+    '--sysconfdir=/etc'
+    '--with-mcs-docs=no'
+)
 
+# loongarch64: vendored boringssl: Unknown processor: loongarch64
+# riscv64: fails to build gensources.exe
+# loongson3: mini-mips.h:20:2: error: #error "MIPS unsupported ABI"
 FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/lang-dotnet/mono/autobuild/patches/0001-arm64-pointer-cast-fix.patch
+++ b/lang-dotnet/mono/autobuild/patches/0001-arm64-pointer-cast-fix.patch
@@ -1,0 +1,11 @@
+--- a/mono/mini/exceptions-arm64.c	2025-04-12 05:43:09.420996006 +0000
++++ b/mono/mini/exceptions-arm64.c	2025-04-12 05:43:24.547107545 +0000
+@@ -549,7 +549,7 @@
+ 	UCONTEXT_REG_R0 (sigctx) = (gsize)obj;
+ 
+ 	gpointer addr = (gpointer)handle_signal_exception;
+-	UCONTEXT_REG_SET_PC (sigctx, addr);
++	UCONTEXT_REG_SET_PC (sigctx, (size_t)addr);
+ 	host_mgreg_t sp = UCONTEXT_REG_SP (sigctx) - MONO_ARCH_REDZONE_SIZE;
+ 	UCONTEXT_REG_SET_SP (sigctx, sp);
+ #endif

--- a/lang-dotnet/mono/spec
+++ b/lang-dotnet/mono/spec
@@ -1,5 +1,4 @@
-VER=6.12.0.206
-REL=2
-SRCS="git::commit=tags/mono-$VER::https://github.com/mono/mono.git"
-CHKSUMS="SKIP"
+VER=6.14.1
+SRCS="tbl::https://dl.winehq.org/mono/sources/mono/mono-$VER.tar.xz"
+CHKSUMS="sha256::3024c97c0bc8cbcd611c401d5f994528704108ceb31f31b28dea4783004d0820"
 CHKUPDATE="anitya::id=6360"


### PR DESCRIPTION
Topic Description
-----------------

- mono: fix runtime build issues on arm64 ...
    ... caused by missing a pointer cast
- mono: update to 6.14.1

Package(s) Affected
-------------------

- mono: 6.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mono
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
