### PR TITLE
fcitx5-pinyin-moegirl: update to 20250309

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250209
+VER=20250309
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::f84217048bb7384e7d5699c059a96688da83e05b2fb92811afbf4e402aab80c0 \
-         sha256::f4d94e2fad4a29c43d4e7a3d68dbf34cf861a9027f5e39db64a48b797c350fd0 \
+CHKSUMS="sha256::d195e53e979ac572b7748dae1819884a908633d8ac41d3f12514dca086bbe5f8 \
+         sha256::2d42a1d14314d16548580196a20cd68ea11528263b4d3bd646e78c785c55b259 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250309

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250309
- rime-pinyin-moegirl: 20250309

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
