### PR TITLE
texlive: update to 20250308

### DIFF
--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,7 +1,6 @@
-VER=20240312
-REL=2
+VER=20250308
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
       file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
-CHKSUMS="sha256::7b6d87cf01661670fac45c93126bed97b9843139ed510f975d047ea938b6fe96 \
-         sha256::c8eae2deaaf51e86d93baa6bbcc4e94c12aa06a0d92893df474cc7d2a012c7a7"
+CHKSUMS="sha512::0837c935488b96cfc8dd79f1298f283b467ab68b4163cee9cb04b79e80195982fdc5ae8a80058dc7d3e99206bfda8b3bdd11340425b08f60cbef70d5a0e22702 \
+         sha512::631a93f911437b9ebb075c09dfc592d6d8331ebaffb8cad62b6e7df55634345937342656db091dc0fb36686927131dbfdee5a03f54ef808a2a4d3ddc47cfbc17"
 CHKUPDATE="anitya::id=11725"


### PR DESCRIPTION
Topic Description
-----------------

- texlive: update to 20250308

Package(s) Affected
-------------------

- texlive: 20250308

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
