### PR TITLE
v2raya: update to 2.2.6.6

### DIFF
--- a/app-network/v2raya/spec
+++ b/app-network/v2raya/spec
@@ -1,4 +1,4 @@
-VER=2.2.6.3
+VER=2.2.6.6
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326097"


### PR DESCRIPTION
Topic Description
-----------------

- v2raya: update to 2.2.6.6
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- v2raya: 2.2.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2raya
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
