### PR TITLE
bash-startup: Update to 0.7.1

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,4 @@
-VER=0.7.0
+VER=0.7.1
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-startup: update to v0.7.1
    This minor update adds a helper function to detect Mercurial repository
    in the ancestors of the current path.

Package(s) Affected
-------------------

- bash-startup: 2:0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
