### PR TITLE
cpu-x: update to 5.1.3

### DIFF
--- a/app-utils/cpu-x/spec
+++ b/app-utils/cpu-x/spec
@@ -1,4 +1,4 @@
-VER=5.1.2
+VER=5.1.3
 SRCS="git::commit=tags/v$VER::https://github.com/TheTumultuousUnicornOfDarkness/CPU-X"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137672"


### PR DESCRIPTION
Topic Description
-----------------

- cpu-x: update to 5.1.3
    Co-authored-by: kf \(@HmnSn\)

Package(s) Affected
-------------------

- cpu-x: 5.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpu-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
