### PR TITLE
htop: update to 3.4.0

### DIFF
--- a/app-admin/htop/autobuild/patches/0001-remove-dev-version.patch
+++ b/app-admin/htop/autobuild/patches/0001-remove-dev-version.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -bur htop-3.4.0/configure.ac htop-3.4.0-modified/configure.ac
+--- htop-3.4.0/configure.ac	2025-03-09 21:05:48.000000000 -0700
++++ htop-3.4.0-modified/configure.ac	2025-03-10 18:19:10.206771093 -0700
+@@ -7,7 +7,7 @@
+ 
+ m4_define([htop_git_version],
+   m4_normalize(m4_esyscmd([git describe --abbrev=7 --dirty --always --tags 2> /dev/null || echo ''])))
+-m4_define([htop_release_version], [3.4.0-dev])
++m4_define([htop_release_version], [3.4.0])
+ 
+ # ----------------------------------------------------------------------
+ # Autoconf initialization.

--- a/app-admin/htop/spec
+++ b/app-admin/htop/spec
@@ -1,5 +1,4 @@
-VER=3.3.0
-REL=1
-SRCS="git::commit=tags/$VER::https://github.com/htop-dev/htop.git"
-CHKSUMS="SKIP"
+VER=3.4.0
+SRCS="tbl::https://github.com/htop-dev/htop/releases/download/$VER/htop-$VER.tar.xz"
+CHKSUMS="sha256::feaabd2d31ca27c09c367a3b1b547ea9f96105fc41f4dfa799e2f49daad5de29"
 CHKUPDATE="anitya::id=1332"


### PR DESCRIPTION
Topic Description
-----------------

- htop: update to 3.4.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- htop: 1:3.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit htop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
