### PR TITLE
lfortran: fix oom erros when building on loongson3

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -22,3 +22,6 @@ CMAKE_AFTER=" \
 # FIXME: operations on real data type may cause segfault or incorrect results on loongarch64.
 # GitHub issue link: https://github.com/lfortran/lfortran/issues/5405
 FAIL_ARCH="loongarch64"
+
+# Note: prevent OOM errors.
+NOLTO__LOONGSON3=1

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,5 @@
 VER=0.47.0
+REL=1
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
 CHKSUMS="sha256::584b0f165563d353438285a97e053b80a9c664fccd2178bd4abd26c4bc07fafa"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: fix oom erros when building on loongson3

Package(s) Affected
-------------------

- lfortran: 0.47.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
