### PR TITLE
Gnome control center 42.10

### DIFF
--- a/desktop-gnome/gnome-control-center/autobuild/patches/0001-cc-input-chooser-fix-potential-nullptr-hash-table-lo.patch
+++ b/desktop-gnome/gnome-control-center/autobuild/patches/0001-cc-input-chooser-fix-potential-nullptr-hash-table-lo.patch
@@ -1,0 +1,26 @@
+From ab191f903dec4641e34fe5ea6b3048a63d8ed98e Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Tue, 11 Mar 2025 01:45:32 -0400
+Subject: [PATCH] cc-input-chooser: fix potential nullptr hash table lookup
+
+---
+ panels/keyboard/cc-input-chooser.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/panels/keyboard/cc-input-chooser.c b/panels/keyboard/cc-input-chooser.c
+index 728eb6d40..042199b0c 100644
+--- a/panels/keyboard/cc-input-chooser.c
++++ b/panels/keyboard/cc-input-chooser.c
+@@ -831,6 +831,9 @@ add_locale_to_table (GHashTable  *table,
+ 
+   language = gnome_get_language_from_code (lang_code, NULL);
+ 
++  if (!language)
++    return;
++
+   set = g_hash_table_lookup (table, language);
+   if (!set)
+     {
+-- 
+2.48.1
+

--- a/desktop-gnome/gnome-control-center/spec
+++ b/desktop-gnome/gnome-control-center/spec
@@ -1,5 +1,4 @@
-VER=42.3
-REL=2
+VER=42.10
 SRCS="https://download.gnome.org/sources/gnome-control-center/${VER%.*}/gnome-control-center-$VER.tar.xz"
-CHKSUMS="sha256::ce0ae3650de2af7ebcb0a7e1fc9912eddb6eff8d257f3fe50ff8b29c19341c7e"
+CHKSUMS="sha256::ad824e10bb5231b70cd65903a12752d362b9099b0c90aba346a6983e0a4f6d5a"
 CHKUPDATE="anitya::id=5408"

--- a/runtime-common/glib/autobuild/defines
+++ b/runtime-common/glib/autobuild/defines
@@ -33,7 +33,7 @@ MESON_AFTER="-Dselinux=disabled \
              -Dnls=enabled \
              -Doss_fuzz=disabled \
              -Dlibelf=enabled \
-             -Dglib_debug=disabled \
+             -Dglib_debug=enabled \
              -Dintrospection=enabled \
              --default-library=both"
 # FIXME: Disabling tests as some objects that links into gio/tests/resources

--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,4 +1,5 @@
 VER=2.84.0
+REL=1
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
 CHKSUMS="sha256::f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-control-center: update to 42.10
    Fix a random SEGV when attempting to add input method.
- glib: generate usable debug symbols

Package(s) Affected
-------------------

- glib: 2.84.0-1
- gnome-control-center: 42.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib gnome-control-center
```

Test Build(s) Done
------------------

