### PR TITLE
vscode: update to 1.98.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.97.2
+VER=1.98.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::330542e60688faf96c577d8fdce4d03b4638a4d7245189cdf717804ffb09ed40"
-CHKSUMS__ARM64="sha256::5553ae85b0799bcefdcc350a3466debb4a96893f138f373cfb47b3c83641ca59"
+CHKSUMS__AMD64="sha256::89d14c856162e23868e63ad6b40d06dd9524cac475872de013f5377c11bfcf09"
+CHKSUMS__ARM64="sha256::f6cece5f850f3afbaf24824da1847a8ad634fc8411ce3806e9977f2553e6d60f"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.98.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.98.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
