### PR TITLE
libvips: new, 8.16.0

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.7.14
+VER=4.7.15
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-imaging/cgif/autobuild/defines
+++ b/runtime-imaging/cgif/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=cgif
+PKGSEC=libs
+PKGDES="GIF encoding library"
+PKGDEP="glibc"
+
+MESON_AFTER=(
+    '-Dexamples=false'
+    '-Dtests=false'
+)

--- a/runtime-imaging/cgif/spec
+++ b/runtime-imaging/cgif/spec
@@ -1,0 +1,4 @@
+VER=0.5.0
+SRCS="git::commit=tags/v$VER::https://github.com/dloebl/cgif"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=368524"

--- a/runtime-imaging/libimagequant/autobuild/build
+++ b/runtime-imaging/libimagequant/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building dynamic library ..."
+cargo cinstall \
+    --release \
+    --prefix=/usr \
+    --destdir="$PKGDIR"

--- a/runtime-imaging/libimagequant/autobuild/defines
+++ b/runtime-imaging/libimagequant/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=libimagequant
+PKGSEC=libs
+PKGDES="A library to convert RGBA images to 8-bit index-color images"
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="rustc cargo cargo-c llvm"
+
+# FIXME:
+# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/runtime-imaging/libimagequant/spec
+++ b/runtime-imaging/libimagequant/spec
@@ -1,0 +1,5 @@
+VER=4.3.4
+SRCS="git::commit=tags/$VER::https://github.com/ImageOptim/libimagequant"
+CHKSUMS="SKIP"
+SUBDIR="libimagequant/imagequant-sys"
+CHKUPDATE="anitya::id=12768"

--- a/runtime-imaging/libvips/autobuild/defines
+++ b/runtime-imaging/libvips/autobuild/defines
@@ -1,0 +1,19 @@
+PKGNAME=libvips
+PKGSEC=libs
+PKGDES="A image processing library"
+PKGDEP="gcc-runtime glibc glib expat zlib libarchive fftw cfitsio cgif \
+        libimagequant libexif libjpeg-turbo libpng libwebp pango fontconfig \
+        libtiff librsvg cairo lcms2 openexr openjpeg highway nifti"
+PKGRECOM="imagemagick openslide libheif libjxl poppler python-3"
+BUILDDEP="imagemagick openslide libheif libjxl poppler vala gtk-doc doxygen"
+
+MESON_AFTER=(
+    '-Dexamples=false'
+    '-Ddoxygen=true'
+    '-Dgtk_doc=true'
+    '-Dvapi=true'
+    '-Dnifti-prefix-dir=/usr'
+    '-Dpdfium=disabled'
+    '-Dquantizr=disabled'
+    '-Dspng=disabled'
+)

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,0 +1,4 @@
+VER=8.16.0
+SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=5097"

--- a/runtime-imaging/nifti/autobuild/defines
+++ b/runtime-imaging/nifti/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=nifti
+PKGSEC=libs
+PKGDES="NIfTI file I/O library"
+PKGDEP="glibc zlib"
+
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+    '-DDOWNLOAD_TEST_DATA=OFF'
+)

--- a/runtime-imaging/nifti/spec
+++ b/runtime-imaging/nifti/spec
@@ -1,0 +1,4 @@
+VER=3.0.1
+SRCS="git::commit=tags/v$VER::https://github.com/NIFTI-Imaging/nifti_clib/"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371318"

--- a/runtime-scientific/matio/autobuild/defines
+++ b/runtime-scientific/matio/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=matio
+PKGSEC=libs
+PKGDES="MATLAB MAT file I/O library"
+PKGDEP="glibc hdf5 zlib"
+
+CMAKE_AFTER="-DMATIO_BUILD_TESTING=OFF"

--- a/runtime-scientific/matio/spec
+++ b/runtime-scientific/matio/spec
@@ -1,0 +1,4 @@
+VER=1.5.28
+SRCS="git::commit=tags/v$VER::https://github.com/tbeu/matio"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1893"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: new, 8.16.0
- libimagequant: new, 4.3.4
- cgif: new, 0.5.0
- nifti: new, 3.0.1
- matio: new, 1.5.28
- autobuild4: update to 4.7.15

Package(s) Affected
-------------------

- cgif: 0.5.0
- libimagequant: 4.3.4
- libvips: 8.16.0
- nifti: 3.0.1
- matio: 1.5.28
- autobuild4: 4.7.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 cgif libimagequant nifti matio libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
