### PR TITLE
teams-for-linux: new, 1.13.0

### DIFF
--- a/app-web/teams-for-linux/autobuild/build
+++ b/app-web/teams-for-linux/autobuild/build
@@ -1,0 +1,19 @@
+abinfo "Installing NPM dependencies ..."
+npm_config_cache="$SRCDIR"/package-cache npm install
+
+abinfo "Building teams-for-linux ..."
+npx electron-builder build --linux dir
+
+abinfo "Installing teams-for-linux ..."
+install -dvm755 "$PKGDIR"/usr/lib/teams-for-linux
+cp -rv "$SRCDIR"/dist/linux*-unpacked/* "$PKGDIR"/usr/lib/teams-for-linux/
+
+abinfo "Creating symbolic link ..."
+mkdir -pv "$PKGDIR"/usr/bin
+ln -sv ../lib/teams-for-linux/teams-for-linux "$PKGDIR"/usr/bin/teams-for-linux
+
+abinfo "Installing application icon ..."
+for size in 16 24 32 48 64 96 128 256 512 1024
+do
+  install -Dvm644 "$SRCDIR"/build/icons/${size}x${size}.png "$PKGDIR"/usr/share/icons/hicolor/${size}x${size}/apps/teams-for-linux.png
+done

--- a/app-web/teams-for-linux/autobuild/defines
+++ b/app-web/teams-for-linux/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=teams-for-linux
+PKGSEC=web
+PKGDEP="gtk-3 x11-lib nss"
+BUILDDEP="nodejs"
+PKGDES="Unofficial Microsoft Teams client for Linux"
+
+FAIL_ARCH="!(amd64|arm64|i486|armv7hf)"

--- a/app-web/teams-for-linux/autobuild/overrides/usr/share/applications/teams-for-linux.desktop
+++ b/app-web/teams-for-linux/autobuild/overrides/usr/share/applications/teams-for-linux.desktop
@@ -1,8 +1,11 @@
 [Desktop Entry]
 Type=Application
-Name=Microsoft Teams for Linux
+Name=Microsoft Teams (Unofficial)
+Name[zh_CN]=Microsoft Teams（非官方）
+Name[zh_TW]=Microsoft Teams（非官方）
 Comment=Unofficial Microsoft Teams client for Linux
-GenericName=Teams
+Comment[zh_CN]=非官方 Linux 版 Microsoft Teams 客户端
+Comment[zh_TW]=非官方 Linux 版 Microsoft Teams 用戶端
 Exec=teams-for-linux %U
 Icon=teams-for-linux
 MimeType=x-scheme-handler/msteams;

--- a/app-web/teams-for-linux/autobuild/overrides/usr/share/applications/teams-for-linux.desktop
+++ b/app-web/teams-for-linux/autobuild/overrides/usr/share/applications/teams-for-linux.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Microsoft Teams for Linux
+Comment=Unofficial Microsoft Teams client for Linux
+GenericName=Teams
+Exec=teams-for-linux %U
+Icon=teams-for-linux
+MimeType=x-scheme-handler/msteams;
+Categories=Network;Chat;InstantMessaging;
+Terminal=false
+StartupNotify=true

--- a/app-web/teams-for-linux/spec
+++ b/app-web/teams-for-linux/spec
@@ -1,0 +1,4 @@
+VER=1.13.0
+SRCS="git::commit=tags/v${VER}::https://github.com/IsmaelMartinez/teams-for-linux"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377160"


### PR DESCRIPTION
Topic Description
-----------------

- teams-for-linux: new, 1.13.0

Package(s) Affected
-------------------

- teams-for-linux: 1.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit teams-for-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`