### PR TITLE
evolution 3.44.4 plugins fixes

### DIFF
--- a/desktop-gnome/evolution-ews/autobuild/defines
+++ b/desktop-gnome/evolution-ews/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=evolution-ews
 PKGSEC=gnome
-PKGDEP="evolution-data-server evolution libmspack libsoup"
+PKGDEP="evolution-data-server evolution libmspack libsoup-3"
 BUILDDEP="gtk-doc gobject-introspection intltool itstool vim cmake"
 PKGDES="Microsoft Exchange Web Services for Evolution"
+
+ABTYPE=cmake
 
 CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DENABLE_MAINTAINER_MODE=OFF \
              -DENABLE_SCHEMAS_COMPILE=OFF \
-             -DWITH_MSPACK=ON"
+             -DWITH_MSPACK=ON \
+             -DCMAKE_SKIP_INSTALL_RPATH=OFF"

--- a/desktop-gnome/evolution-ews/spec
+++ b/desktop-gnome/evolution-ews/spec
@@ -1,5 +1,4 @@
-VER=3.42.0
-REL=1
-SRCS="https://download.gnome.org/sources/evolution-ews/${VER:0:4}/evolution-ews-$VER.tar.xz"
-CHKSUMS="sha256::585336df7829cbf965a2858d4594a2b8d8910111b2dcae1a68ccaf1af50cd1af"
+VER=3.44.4
+SRCS="https://download.gnome.org/sources/evolution-ews/${VER%.*}/evolution-ews-$VER.tar.xz"
+CHKSUMS="sha256::4f182b05a13ac1b7b33b08fb066e8395caa95ba7da808886aa91b1429d6d7db3"
 CHKUPDATE="anitya::id=18167"

--- a/desktop-gnome/evolution/autobuild/defines
+++ b/desktop-gnome/evolution/autobuild/defines
@@ -4,36 +4,37 @@ PKGDEP="gnome-desktop evolution-data-server gtkhtml libcanberra libpst \
         libytnef psmisc desktop-file-utils hicolor-icon-theme dconf \
         gtkspell3 bogofilter spamassassin gnome-autoar libcryptui protobuf \
         webkit2gtk libchamplain gspell at-spi2-core gcr libgweather libical \
-        libunity nspr nss highlight cmark"
+        libunity nspr nss highlight cmark lttng-ust"
 BUILDDEP="glade gobject-introspection gtk-doc intltool itstool vim"
 PKGDES="Manage your email, contacts, and schedule"
 
-CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
-             -DENABLE_ALARM_NOTIFY_MODULE=ON \
-             -DENABLE_AUTOAR=ON \
-             -DENABLE_CANBERRA=ON \
-             -DENABLE_CONTACT_MAPS=ON \
-             -DENABLE_GNOME_DESKTOP=ON \
-             -DENABLE_GSPELL=ON \
-             -DENABLE_GTK_DOC=ON \
-             -DENABLE_INSTALLED_TESTS=OFF \
-             -DENABLE_MAINTAINER_MODE=OFF \
-             -DENABLE_MARKDOWN=ON \
-             -DENABLE_PLUGINS=all \
-             -DENABLE_SCHEMAS_COMPILE=OFF \
-             -DENABLE_SMIME=ON \
-             -DENABLE_TEXT_HIGHLIGHT=ON \
-             -DENABLE_WEATHER=ON \
-             -DENABLE_YTNEF=ON \
-             -DWITH_BOGOFILTER=ON \
-             -DWITH_ENCHANT_VERSION=2 \
-             -DWITH_GLADE_CATALOG=ON \
-             -DWITH_GWEATHER4=ON \
-             -DWITH_HELP=ON \
-             -DWITH_OPENLDAP=ON \
-             -DWITH_SA_LEARN=ON \
-             -DWITH_SPAMASSASSIN=ON \
-             -DWITH_STATIC_LDAP=OFF \
-             -DWITH_SUNLDAP=OFF \
-             -DCMAKE_SKIP_RPATH=OFF \
-             -DCMAKE_SKIP_INSTALL_RPATH=OFF"
+CMAKE_AFTER=("-DLIB_INSTALL_DIR=/usr/lib"
+             "-DENABLE_ALARM_NOTIFY_MODULE=ON"
+             "-DENABLE_AUTOAR=ON"
+             "-DENABLE_CANBERRA=ON"
+             "-DENABLE_CONTACT_MAPS=ON"
+             "-DENABLE_GNOME_DESKTOP=ON"
+             "-DENABLE_GSPELL=ON"
+             "-DENABLE_GTK_DOC=ON"
+             "-DENABLE_INSTALLED_TESTS=OFF"
+             "-DENABLE_MAINTAINER_MODE=OFF"
+             "-DENABLE_MARKDOWN=ON"
+             "-DENABLE_PLUGINS=all"
+             "-DENABLE_SCHEMAS_COMPILE=OFF"
+             "-DENABLE_SMIME=ON"
+             "-DENABLE_TEXT_HIGHLIGHT=ON"
+             "-DENABLE_WEATHER=ON"
+             "-DENABLE_YTNEF=ON"
+             "-DWITH_BOGOFILTER=ON"
+             "-DWITH_ENCHANT_VERSION=2"
+             "-DWITH_GLADE_CATALOG=ON"
+             "-DWITH_GWEATHER4=ON"
+             "-DWITH_HELP=ON"
+             "-DWITH_OPENLDAP=ON"
+             "-DWITH_SA_LEARN=ON"
+             "-DWITH_SPAMASSASSIN=ON"
+             "-DWITH_STATIC_LDAP=OFF"
+             "-DWITH_SUNLDAP=OFF"
+             "-DCMAKE_SKIP_RPATH=OFF"
+             "-DCMAKE_SKIP_INSTALL_RPATH=OFF"
+)

--- a/desktop-gnome/evolution/autobuild/patches/0002-use-CMAKE_REQUIRED_DEFINITIONS.patch
+++ b/desktop-gnome/evolution/autobuild/patches/0002-use-CMAKE_REQUIRED_DEFINITIONS.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt	2022-08-05 15:55:17.000000000 +0800
++++ b/CMakeLists.txt	2025-03-12 20:48:27.471296264 +0800
+@@ -737,7 +737,7 @@
+ # news-to-appdata
+ # ******************************
+ 
+-set(CMAKE_REQUIRED_FLAGS ${GNOME_PLATFORM_CFLAGS})
++set(CMAKE_REQUIRED_DEFINITIONS ${GNOME_PLATFORM_CFLAGS})
+ set(CMAKE_REQUIRED_INCLUDES ${GNOME_PLATFORM_INCLUDE_DIRS})
+ set(CMAKE_REQUIRED_LIBRARIES ${GNOME_PLATFORM_LDFLAGS})
+ file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/appdata-releases.txt" _output_filename)
+@@ -752,7 +752,7 @@
+ unset(_output_filename)
+ unset(CMAKE_REQUIRED_LIBRARIES)
+ unset(CMAKE_REQUIRED_INCLUDES)
+-unset(CMAKE_REQUIRED_FLAGS)
++unset(CMAKE_REQUIRED_DEFINITIONS)
+ 
+ if(NOT "${_news_to_appdata_result}" EQUAL "1")
+ 	message(FATAL_ERROR "Failed to run news-to-appdata")

--- a/desktop-gnome/evolution/spec
+++ b/desktop-gnome/evolution/spec
@@ -1,5 +1,5 @@
 VER=3.44.4
-REL=6
+REL=7
 SRCS="https://download.gnome.org/sources/evolution/${VER:0:4}/evolution-$VER.tar.xz"
 CHKSUMS="sha256::f0b16e7abad3c7945a29c322f17dab4a08d61e99bd7cc91b8df35053c5c12e8c"
 CHKUPDATE="anitya::id=10934"

--- a/runtime-desktop/libunity/spec
+++ b/runtime-desktop/libunity/spec
@@ -1,7 +1,7 @@
 VER=7.1.4
 UBUNTUVER=19.04.20190319
 UBUNTUREL=0ubuntu1
-REL=5
+REL=6
 SRCS="tbl::https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libunity/${VER}+${UBUNTUVER}-${UBUNTUREL}/libunity_$VER+${UBUNTUVER}.orig.tar.gz"
 CHKSUMS="sha256::56ecb380d74bf74caba193d9e8ad6b0c85ccf9eeb461bc9731c2b8636e1f1492"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- libunity: rebuilt for lttng-ust, bump rel
- evolution: rebuilt, use CMAKE_REQUIRED_DEFINITIONS instead of CMAKE_REQUIRED_FLAGS in CMakeList.txt
- evolution-ews: update to 3.44.4 \(latest version used libsoup-2\)

Package(s) Affected
-------------------

- evolution: 3.44.4-7
- evolution-ews: 3.44.4
- libunity: 1:7.1.4-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libunity evolution evolution-ews
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
