### PR TITLE
fcft: update to 3.3.0

### DIFF
--- a/runtime-display/fcft/spec
+++ b/runtime-display/fcft/spec
@@ -1,4 +1,4 @@
-VER=3.2.0
+VER=3.3.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fcft"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143240"


### PR DESCRIPTION
Topic Description
-----------------

- fcft: update to 3.3.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fcft: 3.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcft
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
