### PR TITLE
llama.cpp: update to 4879

### DIFF
--- a/runtime-creativity/llama.cpp/autobuild/patches/0001-AOSCOS-add-system-backend-path.patch
+++ b/runtime-creativity/llama.cpp/autobuild/patches/0001-AOSCOS-add-system-backend-path.patch
@@ -1,12 +1,12 @@
 diff --git a/ggml/src/ggml-backend-reg.cpp b/ggml/src/ggml-backend-reg.cpp
-index 955ed505..cdd86eff 100644
+index 405d8e31..9e50f184 100644
 --- a/ggml/src/ggml-backend-reg.cpp
 +++ b/ggml/src/ggml-backend-reg.cpp
-@@ -489,6 +489,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
+@@ -496,6 +496,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
          // default search paths: executable directory, current directory
          search_paths.push_back(get_executable_path());
          search_paths.push_back(fs::current_path());
 +        search_paths.push_back(fs::u8path("/usr/lib/ggml/"));
      } else {
-         search_paths.push_back(user_search_path);
+         search_paths.push_back(fs::u8path(user_search_path));
      }

--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,4 +1,4 @@
-VER=4827
+VER=4879
 # The build system uses git tags to determine version number
 SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: update to 4879
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- llama.cpp: 4879

Security Update?
----------------

No

Build Order
-----------

```
#buildit llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
