### PR TITLE
rpi-firmware-boot: update to 1.20250305

### DIFF
--- a/runtime-kernel/rpi-firmware-boot/spec
+++ b/runtime-kernel/rpi-firmware-boot/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=1.20250127
+UPSTREAM_VER=1.20250305
 VER="${UPSTREAM_VER}"
-REL=1
 SRCS="tbl::https://github.com/raspberrypi/firmware/releases/download/$VER/raspi-firmware_$VER.orig.tar.xz"
-CHKSUMS="sha256::0b8e290c829f5deee53b01037e4307d9f9242ea262949043e702e033d088eeb4"
+CHKSUMS="sha256::f697079cd15389c0d8650283eb911c53a64b22550138704eb50e1145e8330b03"
 CHKUPDATE="anitya::id=21744"


### PR DESCRIPTION
Topic Description
-----------------

- rpi-firmware-boot: update to 1.20250305
    Co-authored-by: multimode_Liu / 自大的刘某人 \(@Dustymind\) <dustymind@aosc.io>

Package(s) Affected
-------------------

- rpi-firmware-boot: 1.20250305

Security Update?
----------------

No

Build Order
-----------

```
#buildit rpi-firmware-boot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
