### PR TITLE
incus: enhance postinst script

### DIFF
--- a/app-containers/incus/01-incus/postinst
+++ b/app-containers/incus/01-incus/postinst
@@ -1,2 +1,17 @@
 systemd-sysusers incus.conf
 systemd-tmpfiles --create incus.conf
+
+# Check if file exists and initialize it with root:1000000:1000000000
+create_file() {
+    if [ ! -f "$1" ]; then
+        echo "root:1000000:1000000000" > "$1"
+    else
+        if ! grep -q "^root:" "$1"; then
+        # Add root:1000000:1000000000 if this line doesn't exist
+            echo "root:1000000:1000000000" >> "$1"
+        fi
+    fi
+}
+
+create_file /etc/subuid
+create_file /etc/subgid

--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,5 @@
 VER=6.10.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"


### PR DESCRIPTION
Topic Description
-----------------

- incus: enhance postinst script
    - Post-installation script will now detect if /etc/sub{u,g}id exists, and add entries to make unprivileged container available without adjusting subuid and subgid settings manually.

Package(s) Affected
-------------------

- incus: 6.10.1
- incus-agent: 6.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

