### PR TITLE
chafa: update to 1.14.5

### DIFF
--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,4 +1,4 @@
-VER=1.14.2
+VER=1.14.5
 SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17542"


### PR DESCRIPTION
Topic Description
-----------------

- chafa: update to 1.14.5
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- chafa: 1.14.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit chafa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
