### PR TITLE
conky: update to 1.22.0

### DIFF
--- a/app-utils/conky/spec
+++ b/app-utils/conky/spec
@@ -1,4 +1,4 @@
-VER=1.21.7
+VER=1.22.0
 SRCS="git::commit=tags/v$VER::https://github.com/brndnmtthws/conky"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8177"


### PR DESCRIPTION
Topic Description
-----------------

- conky: update to 1.22.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- conky: 1.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit conky
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
