### PR TITLE
debconf: update to 1.5.91

### DIFF
--- a/app-admin/debconf/spec
+++ b/app-admin/debconf/spec
@@ -1,5 +1,4 @@
-VER=1.5.87
-REL=1
+VER=1.5.91
 SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/pkg-debconf/debconf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8130"


### PR DESCRIPTION
Topic Description
-----------------

- debconf: update to 1.5.91
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- debconf: 1.5.91

Security Update?
----------------

No

Build Order
-----------

```
#buildit debconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
