### PR TITLE
dpkg: update to 1.22.18

### DIFF
--- a/app-admin/dpkg/01-update-alternatives/patches/0001-AOSCOS-feat-data-add-AOSC-OS-specific-armv4-architec.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0001-AOSCOS-feat-data-add-AOSC-OS-specific-armv4-architec.patch
@@ -1,4 +1,4 @@
-From cf5752894109e053ef9b21425a5c56e0497415e5 Mon Sep 17 00:00:00 2001
+From dfc84f93cef30763a024e52affb4d6066d29425a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:42:36 -0700
 Subject: [PATCH 1/8] AOSCOS: feat(data): add AOSC OS-specific armv4

--- a/app-admin/dpkg/01-update-alternatives/patches/0002-AOSCOS-ARMV6HF-fix-data-rename-armhf-as-AOSC-OS-spec.patch.armv6hf
+++ b/app-admin/dpkg/01-update-alternatives/patches/0002-AOSCOS-ARMV6HF-fix-data-rename-armhf-as-AOSC-OS-spec.patch.armv6hf
@@ -1,4 +1,4 @@
-From 3a05287a5fd4476fdd65e2df02beafbec29315c4 Mon Sep 17 00:00:00 2001
+From 12ebb986e30d0f86680e329afb35f3a6f63601c1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:43:52 -0700
 Subject: [PATCH 2/8] AOSCOS: [ARMV6HF] fix(data): rename armhf as AOSC

--- a/app-admin/dpkg/01-update-alternatives/patches/0003-AOSCOS-fix-data-rename-i-86-as-AOSC-OS-specific-i486.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0003-AOSCOS-fix-data-rename-i-86-as-AOSC-OS-specific-i486.patch
@@ -1,4 +1,4 @@
-From 1a4449c92dca7b3ad7311915328d5c10136232b4 Mon Sep 17 00:00:00 2001
+From 2e6961c0451516ee209cc09c69dd4c5fa51f14c4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:45:44 -0700
 Subject: [PATCH 3/8] AOSCOS: fix(data): rename i*86 as AOSC OS-specific i486
@@ -8,7 +8,7 @@ Subject: [PATCH 3/8] AOSCOS: fix(data): rename i*86 as AOSC OS-specific i486
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/cputable b/data/cputable
-index 72d065af0..b7c81a297 100644
+index 72d065af0..ca2d6b308 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -27,7 +27,7 @@ arm		arm		arm.*			32	little
@@ -16,7 +16,7 @@ index 72d065af0..b7c81a297 100644
  hppa		hppa		hppa.*			32	big
  loong64		loongarch64	loongarch64		64	little
 -i386		i686		(i[34567]86|pentium)	32	little
-+i486		i486		(i[34567]86|pentium)	32	little
++i486		i486		i486			32	little
  ia64		ia64		ia64			64	little
  m68k		m68k		m68k			32	big
  mips		mips		mips(eb)?		32	big

--- a/app-admin/dpkg/01-update-alternatives/patches/0004-AOSCOS-fix-data-rename-loong64-as-AOSC-OS-specific-l.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0004-AOSCOS-fix-data-rename-loong64-as-AOSC-OS-specific-l.patch
@@ -1,4 +1,4 @@
-From 261cb05812e26eee3514c657f61380a588da0769 Mon Sep 17 00:00:00 2001
+From 8be22896090f68a2d14a92107610b6cca01a2f4a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:46:13 -0700
 Subject: [PATCH 4/8] AOSCOS: fix(data): rename loong64 as AOSC OS-specific
@@ -9,7 +9,7 @@ Subject: [PATCH 4/8] AOSCOS: fix(data): rename loong64 as AOSC OS-specific
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/data/cputable b/data/cputable
-index b7c81a297..2d23d32b5 100644
+index ca2d6b308..9d79de9a7 100644
 --- a/data/cputable
 +++ b/data/cputable
 @@ -26,7 +26,7 @@ armeb		armeb		arm.*b			32	big
@@ -18,7 +18,7 @@ index b7c81a297..2d23d32b5 100644
  hppa		hppa		hppa.*			32	big
 -loong64		loongarch64	loongarch64		64	little
 +loongarch64	loongarch64	loongarch64		64	little
- i486		i486		(i[34567]86|pentium)	32	little
+ i486		i486		i486			32	little
  ia64		ia64		ia64			64	little
  m68k		m68k		m68k			32	big
 -- 

--- a/app-admin/dpkg/01-update-alternatives/patches/0005-AOSCOS-LOONGSON3-fix-data-rename-mips64el-as-AOSC-O.patch.loongson3
+++ b/app-admin/dpkg/01-update-alternatives/patches/0005-AOSCOS-LOONGSON3-fix-data-rename-mips64el-as-AOSC-O.patch.loongson3
@@ -1,4 +1,4 @@
-From 18b651d3a9f19e17aca699276e21b8d5cc09df61 Mon Sep 17 00:00:00 2001
+From 0457f89aef4cace71824038100215febe8129bd9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Apr 2024 00:47:00 -0700
 Subject: [PATCH 5/8] AOSCOS: [LOONGSON3] fix(data): rename mips64el as AOSC

--- a/app-admin/dpkg/01-update-alternatives/patches/0006-AOSCOS-feat-drop-multiarch-features-add-remove-archi.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0006-AOSCOS-feat-drop-multiarch-features-add-remove-archi.patch
@@ -1,4 +1,4 @@
-From 523d4ea240bbea4983b4bdeec8ee78f8a2ffda52 Mon Sep 17 00:00:00 2001
+From 40758f5cea9e449ab8757fe587b08c80729edc12 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 5 May 2024 16:06:18 +0800
 Subject: [PATCH 6/8] AOSCOS: feat: drop multiarch features

--- a/app-admin/dpkg/01-update-alternatives/patches/0007-AOSCOS-po-update-translation-catalogue.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0007-AOSCOS-po-update-translation-catalogue.patch
@@ -1,6 +1,6 @@
-From 6d8c1c1c1dec728f7da4d9450e9f416adda36b72 Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.io>
-Date: Sun, 19 Jan 2025 23:50:54 +0800
+From b1404ad99c65d03e2b86402969dfa8bf91593aa4 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Fri, 14 Mar 2025 16:27:48 +0800
 Subject: [PATCH 7/8] AOSCOS: po: update translation catalogue
 
 This is done with `make update-po', re-generate this patch in future versions.
@@ -42,7 +42,6 @@ Co-authored-by: Mingcong bai <jeffbai@aosc.io>
  dselect/po/vi.po        |  2 +-
  dselect/po/zh_CN.po     |  2 +-
  dselect/po/zh_TW.po     |  2 +-
- man/po/dpkg-man.pot     |  4 +--
  po/ast.po               | 33 +++++++++----------------
  po/bs.po                | 27 ++++++--------------
  po/ca.po                | 53 ++++++++++++++++++++++-----------------
@@ -96,444 +95,428 @@ Co-authored-by: Mingcong bai <jeffbai@aosc.io>
  scripts/po/pt.po        |  2 +-
  scripts/po/ru.po        |  2 +-
  scripts/po/sv.po        |  2 +-
- 85 files changed, 931 insertions(+), 972 deletions(-)
+ 84 files changed, 929 insertions(+), 970 deletions(-)
 
 diff --git a/dselect/po/bs.po b/dselect/po/bs.po
-index 0f90a50c8..aa2d18d3f 100644
+index 9fa7b1e39..a422e0057 100644
 --- a/dselect/po/bs.po
 +++ b/dselect/po/bs.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-02-17 08:55+0200\n"
  "Last-Translator: Safir Šećerović <sapphire@linux.org.ba>\n"
  "Language-Team: Bosnian <lokal@linux.org.ba>\n"
 diff --git a/dselect/po/ca.po b/dselect/po/ca.po
-index 105168617..5bccdab58 100644
+index a39198c63..511493150 100644
 --- a/dselect/po/ca.po
 +++ b/dselect/po/ca.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-12-17 19:34+0100\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
 diff --git a/dselect/po/cs.po b/dselect/po/cs.po
-index 55e75cf30..5722d887e 100644
+index 64475ffac..696512178 100644
 --- a/dselect/po/cs.po
 +++ b/dselect/po/cs.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.11\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2024-11-04 12:21+0100\n"
  "Last-Translator: Miroslav Kure <kurem@debian.cz>\n"
  "Language-Team: Czech <debian-l10n-czech@lists.debian.org>\n"
 diff --git a/dselect/po/da.po b/dselect/po/da.po
-index 8330b4e0c..77b2b866d 100644
+index 1fc7af8bb..59333cd4d 100644
 --- a/dselect/po/da.po
 +++ b/dselect/po/da.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2014-11-27 02:33+0200\n"
  "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
  "Language-Team: Danish <debian-l10n-danish@lists.debian.org>\n"
 diff --git a/dselect/po/de.po b/dselect/po/de.po
-index ab7634c7b..33b365969 100644
+index bbafd72de..d99e5db5b 100644
 --- a/dselect/po/de.po
 +++ b/dselect/po/de.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.12~\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2024-12-25 09:07+0100\n"
  "Last-Translator: Sven Joachim <svenjoac@gmx.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
 diff --git a/dselect/po/dselect.pot b/dselect/po/dselect.pot
-index e588ab6fe..c442af2f5 100644
+index 75ee69e4d..ba17f40de 100644
 --- a/dselect/po/dselect.pot
 +++ b/dselect/po/dselect.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.14\n"
-+"Project-Id-Version: dpkg 1.22.14-7-gfe853\n"
+-"Project-Id-Version: dpkg 1.22.18\n"
++"Project-Id-Version: dpkg 1.22.18-6-g4075\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/dselect/po/el.po b/dselect/po/el.po
-index 73f0d1f5e..85e611f0f 100644
+index bbfca47c7..dfb4146ed 100644
 --- a/dselect/po/el.po
 +++ b/dselect/po/el.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-02-17 08:56+0200\n"
  "Last-Translator: quad-nrg.net <galaxico@quad-nrg.net>\n"
  "Language-Team: Greek <debian-l10n-greek@lists.debian.org>\n"
 diff --git a/dselect/po/es.po b/dselect/po/es.po
-index 8db652e0c..87368fb44 100644
+index 1152067b1..f936024bf 100644
 --- a/dselect/po/es.po
 +++ b/dselect/po/es.po
 @@ -40,7 +40,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-01-27 22:48+0100\n"
  "Last-Translator: Javier Fernández-Sanguino <jfs@debian.org>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
 diff --git a/dselect/po/et.po b/dselect/po/et.po
-index 288af3801..9f6b3d6d1 100644
+index 550088220..9d95cb56a 100644
 --- a/dselect/po/et.po
 +++ b/dselect/po/et.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.14.5\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2007-07-13 08:22+0300\n"
  "Last-Translator: Ivar Smolin <okul@linux.ee>\n"
  "Language-Team: Estonian <et@li.org>\n"
 diff --git a/dselect/po/eu.po b/dselect/po/eu.po
-index 2774768fc..1422352c5 100644
+index 76fb3892e..fcfa621a3 100644
 --- a/dselect/po/eu.po
 +++ b/dselect/po/eu.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.16.8\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2012-09-01 12:21+0200\n"
  "Last-Translator: Iñaki Larrañaga Murgoitio <dooteo@zundan.com>\n"
  "Language-Team: Basque <debian-l10n-basque@lists.debian.org>\n"
 diff --git a/dselect/po/fr.po b/dselect/po/fr.po
-index 1eb8a6067..40b1372aa 100644
+index a62ed29cf..b99b974ed 100644
 --- a/dselect/po/fr.po
 +++ b/dselect/po/fr.po
 @@ -49,7 +49,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-02-05 23:47+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
 diff --git a/dselect/po/gl.po b/dselect/po/gl.po
-index ddf6dc6d0..ead066a34 100644
+index 24915ffc1..b65ab6b32 100644
 --- a/dselect/po/gl.po
 +++ b/dselect/po/gl.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2008-12-27 15:56+0100\n"
  "Last-Translator: mvillarino <mvillarino@users.sourceforge.net>\n"
  "Language-Team: Galician <proxecto@trasno.net>\n"
 diff --git a/dselect/po/hu.po b/dselect/po/hu.po
-index e2306e813..a6c202ac4 100644
+index 9c198c2e5..434c8b4f6 100644
 --- a/dselect/po/hu.po
 +++ b/dselect/po/hu.po
 @@ -4,7 +4,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-10-06 03:48+0100\n"
  "Last-Translator: SZERVÁC Attila <sas@321.hu>\n"
  "Language-Team: Hungarian <debian-l10n-hungarian@lists.debian.org>\n"
 diff --git a/dselect/po/id.po b/dselect/po/id.po
-index 8a379b7c7..55d102c9c 100644
+index a6dee2770..abde05d8c 100644
 --- a/dselect/po/id.po
 +++ b/dselect/po/id.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-10-06 20:20+0700\n"
  "Last-Translator: Arief S Fitrianto <arief@gurame.fisika.ui.ac.id>\n"
  "Language-Team: Indonesian <debian-l10n-indonesian@lists.debian.org>\n"
 diff --git a/dselect/po/it.po b/dselect/po/it.po
-index 88b8e2ff7..effce387c 100644
+index 012296ba3..50b1522ff 100644
 --- a/dselect/po/it.po
 +++ b/dselect/po/it.po
 @@ -42,7 +42,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.10.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-10-06 22:01+0200\n"
  "Last-Translator: Stefano Canepa <sc@linux.it>\n"
  "Language-Team: Italian <debian-l10n-italian@lists.debian.org>\n"
 diff --git a/dselect/po/ja.po b/dselect/po/ja.po
-index cae51d402..03a09316f 100644
+index 7c88736db..482c60b7c 100644
 --- a/dselect/po/ja.po
 +++ b/dselect/po/ja.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2016-03-31 12:44+0900\n"
  "Last-Translator: Takuma Yamada <tyamada@takumayamada.com>\n"
  "Language-Team: Japanese <debian-japanese@lists.debian.org>\n"
 diff --git a/dselect/po/ko.po b/dselect/po/ko.po
-index 3cc454855..a0dff4cdd 100644
+index ffb5635ff..7fe224253 100644
 --- a/dselect/po/ko.po
 +++ b/dselect/po/ko.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-01-29 11:18+0100\n"
  "Last-Translator: Sangdo Jun <sebuls@gmail.com>\n"
  "Language-Team: Korean <debian-l10n-korean@lists.debian.org>\n"
 diff --git a/dselect/po/nb.po b/dselect/po/nb.po
-index 42140db67..ac5d41004 100644
+index 6a7d825a3..605c2d5ac 100644
 --- a/dselect/po/nb.po
 +++ b/dselect/po/nb.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2014-12-05 13:25+0200\n"
  "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
  "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
 diff --git a/dselect/po/nl.po b/dselect/po/nl.po
-index 1c20ecbad..fde5c5060 100644
+index a0508c22a..4ef07eed8 100644
 --- a/dselect/po/nl.po
 +++ b/dselect/po/nl.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-09-11 21:13+0200\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: Debian Dutch l10n Team <debian-l10n-dutch@lists.debian.org>\n"
 diff --git a/dselect/po/nn.po b/dselect/po/nn.po
-index 8f95aa083..1a5a877d9 100644
+index c627828ce..23069ed79 100644
 --- a/dselect/po/nn.po
 +++ b/dselect/po/nn.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-02-17 08:57+0200\n"
  "Last-Translator: Håvard Korsvoll <korsvoll@skulelinux.no>\n"
  "Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
 diff --git a/dselect/po/pl.po b/dselect/po/pl.po
-index 14f745f5c..ff1690451 100644
+index 15981c336..eebbc8901 100644
 --- a/dselect/po/pl.po
 +++ b/dselect/po/pl.po
 @@ -14,7 +14,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.15.4\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2014-12-21 20:58+0100\n"
  "Last-Translator: Łukasz Dulny <bartekchom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
 diff --git a/dselect/po/pt.po b/dselect/po/pt.po
-index 2deb13f2a..c3aaf224c 100644
+index 83cf8cbe6..f871e3496 100644
 --- a/dselect/po/pt.po
 +++ b/dselect/po/pt.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2014-11-30 13:28+0000\n"
  "Last-Translator: Miguel Figueiredo <elmig@debianpt.org>\n"
  "Language-Team: Portuguese <traduz@debianpt.org>\n"
 diff --git a/dselect/po/pt_BR.po b/dselect/po/pt_BR.po
-index e8355b836..b73f41a8e 100644
+index f94a25219..9dc7dbfd4 100644
 --- a/dselect/po/pt_BR.po
 +++ b/dselect/po/pt_BR.po
 @@ -14,7 +14,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dselect 1.22.11\n"
+ "Project-Id-Version: dselect_1.22.15\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
- "PO-Revision-Date: 2025-01-16 03:03+0100\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
+ "PO-Revision-Date: 2025-02-23 18:00-0300\n"
  "Last-Translator: Paulo Henrique de Lima Santana (phls) <phls@debian.org>\n"
  "Language-Team: Brazilian Portuguese <debian-l10n-"
 diff --git a/dselect/po/ro.po b/dselect/po/ro.po
-index 3beadbcce..f93702e25 100644
+index 0fc315339..3d1104365 100644
 --- a/dselect/po/ro.po
 +++ b/dselect/po/ro.po
 @@ -18,7 +18,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-09-13 20:15+0200\n"
  "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
  "Language-Team: Romanian <debian-l10n-romanian@lists.debian.org>\n"
 diff --git a/dselect/po/ru.po b/dselect/po/ru.po
-index 4a7f7df06..45a7495ee 100644
+index 51f2542c9..e8881fd81 100644
 --- a/dselect/po/ru.po
 +++ b/dselect/po/ru.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-01-31 22:38+0100\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
 diff --git a/dselect/po/sk.po b/dselect/po/sk.po
-index 55e649879..760dfb5a8 100644
+index 85f182669..e2f0f3113 100644
 --- a/dselect/po/sk.po
 +++ b/dselect/po/sk.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2012-07-03 01:09+0100\n"
  "Last-Translator: Ivan Masár <helix84@centrum.sk>\n"
  "Language-Team: Slovak <debian-l10n-slovak@lists.debian.org>\n"
 diff --git a/dselect/po/sv.po b/dselect/po/sv.po
-index 2f49896f3..aedccb294 100644
+index 89b4a1b64..fa396807d 100644
 --- a/dselect/po/sv.po
 +++ b/dselect/po/sv.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-10-24 18:29+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 diff --git a/dselect/po/tl.po b/dselect/po/tl.po
-index 208f72508..c675e26c0 100644
+index 98dda639d..a4d0aa76c 100644
 --- a/dselect/po/tl.po
 +++ b/dselect/po/tl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2006-02-17 08:58+0200\n"
  "Last-Translator: Eric Pareja <xenos@upm.edu.ph>\n"
  "Language-Team: Tagalog <debian-tl@banwa.upm.edu.ph>\n"
 diff --git a/dselect/po/vi.po b/dselect/po/vi.po
-index bac061747..476ab9359 100644
+index b9a7c2145..fc20c9cfb 100644
 --- a/dselect/po/vi.po
 +++ b/dselect/po/vi.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2014-12-01 08:20+0700\n"
  "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
  "Language-Team: Vietnamese <debian-l10n-vietnamese@lists.debian.org>\n"
 diff --git a/dselect/po/zh_CN.po b/dselect/po/zh_CN.po
-index a8f28e657..24bfb49e5 100644
+index feef225f6..305b4f110 100644
 --- a/dselect/po/zh_CN.po
 +++ b/dselect/po/zh_CN.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-01-27 15:29-0500\n"
  "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
  "Language-Team: Chinese (simplified) <debian-l10n-chinese@lists.debian.org>\n"
 diff --git a/dselect/po/zh_TW.po b/dselect/po/zh_TW.po
-index 481fe378c..c76f2848a 100644
+index 1e528bb79..41d05f3b2 100644
 --- a/dselect/po/zh_TW.po
 +++ b/dselect/po/zh_TW.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dselect 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-01-02 21:41+0800\n"
  "PO-Revision-Date: 2023-01-28 15:57+0800\n"
  "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
  "Language-Team: Chinese (traditional) <debian-l10n-chinese@lists.debian.org>\n"
-diff --git a/man/po/dpkg-man.pot b/man/po/dpkg-man.pot
-index 9b9ca3485..9d8640770 100644
---- a/man/po/dpkg-man.pot
-+++ b/man/po/dpkg-man.pot
-@@ -6,9 +6,9 @@
- #, fuzzy
- msgid ""
- msgstr ""
--"Project-Id-Version: dpkg-man 1.22.14\n"
-+"Project-Id-Version: dpkg-man 1.22.14-7-gfe853\n"
- "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
- "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
- "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
- "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/po/ast.po b/po/ast.po
-index ee80ea9f6..4ba11ca96 100644
+index 91123da08..0b0eb1176 100644
 --- a/po/ast.po
 +++ b/po/ast.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.14.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:47+0200\n"
  "Last-Translator: Marcos Alvarez Costales "
  "<marcos.alvarez.costales@gmail.com>\n"
-@@ -6231,29 +6231,15 @@ msgid "status logger"
+@@ -6242,29 +6242,15 @@ msgid "status logger"
  msgstr "estáu"
  
  #: src/main/main.c
@@ -569,7 +552,7 @@ index ee80ea9f6..4ba11ca96 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7833,6 +7819,11 @@ msgstr ""
+@@ -7844,6 +7830,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -582,19 +565,19 @@ index ee80ea9f6..4ba11ca96 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/bs.po b/po/bs.po
-index 802dfb477..85cf2ecb9 100644
+index 326b2f9a1..93bd054c8 100644
 --- a/po/bs.po
 +++ b/po/bs.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 10:02+0200\n"
  "Last-Translator: Safir Šećerović <sapphire@linux.org.ba>\n"
  "Language-Team: Bosnian <lokal@linux.org.ba>\n"
-@@ -5282,28 +5282,15 @@ msgid "status logger"
+@@ -5292,28 +5292,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -630,19 +613,19 @@ index 802dfb477..85cf2ecb9 100644
  
  #: src/main/main.c
 diff --git a/po/ca.po b/po/ca.po
-index 0fd5316f7..7568f922c 100644
+index 1ba77bb5d..24d92cf4e 100644
 --- a/po/ca.po
 +++ b/po/ca.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.18\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2024-07-21 19:57+0200\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
-@@ -5824,29 +5824,16 @@ msgid "status logger"
+@@ -5837,29 +5837,16 @@ msgid "status logger"
  msgstr "registre d'estat"
  
  #: src/main/main.c
@@ -680,7 +663,7 @@ index 0fd5316f7..7568f922c 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7273,6 +7260,28 @@ msgstr ""
+@@ -7286,6 +7273,28 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Es requereix autenticació per a executar update-alternatives"
  
@@ -710,19 +693,19 @@ index 0fd5316f7..7568f922c 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/cs.po b/po/cs.po
-index e07fce3cc..317ea6e34 100644
+index d2250ef89..37e6bbf81 100644
 --- a/po/cs.po
 +++ b/po/cs.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.11\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2024-11-04 20:37+0100\n"
  "Last-Translator: Miroslav Kure <kurem@debian.cz>\n"
  "Language-Team: Czech <debian-l10n-czech@lists.debian.org>\n"
-@@ -5585,29 +5585,16 @@ msgid "status logger"
+@@ -5597,29 +5597,16 @@ msgid "status logger"
  msgstr "záznam stavů"
  
  #: src/main/main.c
@@ -760,7 +743,7 @@ index e07fce3cc..317ea6e34 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6973,6 +6960,26 @@ msgstr "Spustí update-alternatives pro úpravu systémových alternativ"
+@@ -6985,6 +6972,26 @@ msgstr "Spustí update-alternatives pro úpravu systémových alternativ"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Pro spuštění update-alternatives je vyžadováno ověření"
  
@@ -788,19 +771,19 @@ index e07fce3cc..317ea6e34 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/da.po b/po/da.po
-index 94ee69251..ce489b5f1 100644
+index 9799c32e0..e1c77cbe3 100644
 --- a/po/da.po
 +++ b/po/da.po
 @@ -22,7 +22,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
  "Language-Team: Danish <debian-l10n-danish@lists.debian.org>\n"
-@@ -6040,29 +6040,16 @@ msgid "status logger"
+@@ -6051,29 +6051,16 @@ msgid "status logger"
  msgstr "statuslogger"
  
  #: src/main/main.c
@@ -838,7 +821,7 @@ index 94ee69251..ce489b5f1 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7506,6 +7493,26 @@ msgstr ""
+@@ -7517,6 +7504,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -866,19 +849,19 @@ index 94ee69251..ce489b5f1 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/de.po b/po/de.po
-index e4af30a0a..eceee5200 100644
+index 04be184fb..0b5ef48a7 100644
 --- a/po/de.po
 +++ b/po/de.po
 @@ -13,7 +13,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dpkg 1.22.13\n"
+ "Project-Id-Version: dpkg 1.22.16~\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
- "PO-Revision-Date: 2025-01-05 08:34+0100\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
+ "PO-Revision-Date: 2025-02-20 17:56+0100\n"
  "Last-Translator: Sven Joachim <svenjoac@gmx.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
-@@ -5752,31 +5752,16 @@ msgid "status logger"
+@@ -5759,31 +5759,16 @@ msgid "status logger"
  msgstr "Statuslogger"
  
  #: src/main/main.c
@@ -917,7 +900,7 @@ index e4af30a0a..eceee5200 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7197,6 +7182,29 @@ msgstr ""
+@@ -7204,6 +7189,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Authentifizierung ist erforderlich, um update-alternatives auszuführen"
  
@@ -948,22 +931,22 @@ index e4af30a0a..eceee5200 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/dpkg.pot b/po/dpkg.pot
-index 32136361c..22afef202 100644
+index 89a706730..2dfd0ca48 100644
 --- a/po/dpkg.pot
 +++ b/po/dpkg.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.14\n"
-+"Project-Id-Version: dpkg 1.22.14-7-gfe853\n"
+-"Project-Id-Version: dpkg 1.22.18\n"
++"Project-Id-Version: dpkg 1.22.18-6-g4075\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
-@@ -5038,28 +5038,15 @@ msgid "status logger"
+@@ -5048,28 +5048,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -999,19 +982,19 @@ index 32136361c..22afef202 100644
  
  #: src/main/main.c
 diff --git a/po/dz.po b/po/dz.po
-index 063b39e44..cfa374ece 100644
+index 82ca7b911..49fed4e99 100644
 --- a/po/dz.po
 +++ b/po/dz.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: Tshewang Norbu <bumthap2006@hotmail.com>\n"
  "Language-Team: Dzongkha <pgeyleg@dit.gov.bt>\n"
-@@ -5938,29 +5938,15 @@ msgid "status logger"
+@@ -5949,29 +5949,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1047,7 +1030,7 @@ index 063b39e44..cfa374ece 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7430,6 +7416,11 @@ msgstr ""
+@@ -7441,6 +7427,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1060,19 +1043,19 @@ index 063b39e44..cfa374ece 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/el.po b/po/el.po
-index 0f800cc03..eba119c51 100644
+index 9fe29260e..a848c8b55 100644
 --- a/po/el.po
 +++ b/po/el.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:48+0200\n"
  "Last-Translator: quad-nrg.net <yodesy@quad-nrg.net>\n"
  "Language-Team: Greek <debian-l10n-greek@lists.debian.org>\n"
-@@ -6217,29 +6217,15 @@ msgid "status logger"
+@@ -6228,29 +6228,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1108,7 +1091,7 @@ index 0f800cc03..eba119c51 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7794,6 +7780,11 @@ msgstr ""
+@@ -7805,6 +7791,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1121,19 +1104,19 @@ index 0f800cc03..eba119c51 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/eo.po b/po/eo.po
-index 836bef053..b7505985b 100644
+index e149d7280..e2e04b933 100644
 --- a/po/eo.po
 +++ b/po/eo.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Felipe Castro <fefcas@gmail.com>\n"
  "Language-Team: Esperanto <debian-l10n-esperanto@lists.debian.org>\n"
-@@ -6000,29 +6000,16 @@ msgid "status logger"
+@@ -6011,29 +6011,16 @@ msgid "status logger"
  msgstr "stat-registrilo"
  
  #: src/main/main.c
@@ -1171,7 +1154,7 @@ index 836bef053..b7505985b 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7468,6 +7455,26 @@ msgstr ""
+@@ -7479,6 +7466,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1199,19 +1182,19 @@ index 836bef053..b7505985b 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "malfermi elementon '%.255s' (en %.255s) malsukcesis neatendite"
 diff --git a/po/es.po b/po/es.po
-index c5ef9213a..6d45b09f5 100644
+index e4bcdba59..a4f136ba3 100644
 --- a/po/es.po
 +++ b/po/es.po
 @@ -38,7 +38,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.16.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2017-11-08 00:59+0100\n"
  "Last-Translator: Javier Fernandez-Sanguino <jfs@debian.org>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
-@@ -6228,32 +6228,16 @@ msgid "status logger"
+@@ -6240,32 +6240,16 @@ msgid "status logger"
  msgstr "registro de estado"
  
  #: src/main/main.c
@@ -1250,7 +1233,7 @@ index c5ef9213a..6d45b09f5 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7736,6 +7720,29 @@ msgstr ""
+@@ -7748,6 +7732,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Es necesario autenticarse para ejecutar `update-alternatives'"
  
@@ -1281,19 +1264,19 @@ index c5ef9213a..6d45b09f5 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/et.po b/po/et.po
-index 7cace9560..888c39749 100644
+index 9596027bc..49e7d1bb8 100644
 --- a/po/et.po
 +++ b/po/et.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.14.5\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Ivar Smolin <okul@linux.ee>\n"
  "Language-Team: Estonian <et@li.org>\n"
-@@ -5577,28 +5577,15 @@ msgid "status logger"
+@@ -5588,28 +5588,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1329,19 +1312,19 @@ index 7cace9560..888c39749 100644
  
  #: src/main/main.c
 diff --git a/po/eu.po b/po/eu.po
-index 5ebd946f7..d113a527b 100644
+index 2fb959642..5eee67345 100644
 --- a/po/eu.po
 +++ b/po/eu.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.22\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: Iñaki Larrañaga Murgoitio <dooteo@zundan.com>\n"
  "Language-Team: Basque <debian-l10n-basque@lists.debian.org>\n"
-@@ -6116,29 +6116,16 @@ msgid "status logger"
+@@ -6127,29 +6127,16 @@ msgid "status logger"
  msgstr "egoeraren egunkaria"
  
  #: src/main/main.c
@@ -1379,7 +1362,7 @@ index 5ebd946f7..d113a527b 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7601,6 +7588,26 @@ msgstr ""
+@@ -7612,6 +7599,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1407,19 +1390,19 @@ index 5ebd946f7..d113a527b 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/fr.po b/po/fr.po
-index e9a02cccf..505477cc8 100644
+index af620333b..fd3c248c5 100644
 --- a/po/fr.po
 +++ b/po/fr.po
 @@ -12,7 +12,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-05 23:47+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
-@@ -5948,33 +5948,16 @@ msgid "status logger"
+@@ -5960,33 +5960,16 @@ msgid "status logger"
  msgstr "journaliseur de l'état"
  
  #: src/main/main.c
@@ -1459,7 +1442,7 @@ index e9a02cccf..505477cc8 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7416,6 +7399,30 @@ msgstr ""
+@@ -7428,6 +7411,30 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Une authentification est requise pour exécuter update-alternatives"
  
@@ -1491,19 +1474,19 @@ index e9a02cccf..505477cc8 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/gl.po b/po/gl.po
-index a8dedbbb6..e37f817b1 100644
+index 85ec1a40a..e26e283d0 100644
 --- a/po/gl.po
 +++ b/po/gl.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:49+0200\n"
  "Last-Translator: mvillarino <mvillarino@users.sourceforge.net>\n"
  "Language-Team: Galician <proxecto@trasno.net>\n"
-@@ -6178,29 +6178,15 @@ msgid "status logger"
+@@ -6189,29 +6189,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1539,7 +1522,7 @@ index a8dedbbb6..e37f817b1 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7750,6 +7736,11 @@ msgstr ""
+@@ -7761,6 +7747,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1552,19 +1535,19 @@ index a8dedbbb6..e37f817b1 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/hu.po b/po/hu.po
-index 9dcfe6cea..b63261b88 100644
+index 6d668ce81..8518e85fd 100644
 --- a/po/hu.po
 +++ b/po/hu.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-05 23:44+0100\n"
  "Last-Translator: Nagy Elemér Károly <nagy.elemer.karoly@gmail.com>\n"
  "Language-Team: Hungarian <debian-l10n-hungarian@lists.debian.org>\n"
-@@ -5801,29 +5801,15 @@ msgid "status logger"
+@@ -5812,29 +5812,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1600,7 +1583,7 @@ index 9dcfe6cea..b63261b88 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7248,6 +7234,11 @@ msgstr ""
+@@ -7259,6 +7245,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1613,19 +1596,19 @@ index 9dcfe6cea..b63261b88 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/id.po b/po/id.po
-index bf0540512..0fe2582fc 100644
+index ac52a302f..705a98923 100644
 --- a/po/id.po
 +++ b/po/id.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.15\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-06-26 16:12+0200\n"
  "Last-Translator: Arief S Fitrianto <arief@gurame.fisika.ui.ac.id>\n"
  "Language-Team: Indonesian <debian-l10n-indonesian@lists.debian.org>\n"
-@@ -6205,28 +6205,15 @@ msgid "status logger"
+@@ -6216,28 +6216,15 @@ msgid "status logger"
  msgstr "status"
  
  #: src/main/main.c
@@ -1661,19 +1644,19 @@ index bf0540512..0fe2582fc 100644
  
  #: src/main/main.c
 diff --git a/po/it.po b/po/it.po
-index 3c0d519db..a9e209710 100644
+index 3de815512..3b65b4945 100644
 --- a/po/it.po
 +++ b/po/it.po
 @@ -26,7 +26,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.19.3\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2018-12-04 12:15+0100\n"
  "Last-Translator: Milo Casagrande <milo@milo.name>\n"
  "Language-Team: Italian <tp@lists.linux.it>\n"
-@@ -6116,30 +6116,16 @@ msgid "status logger"
+@@ -6127,30 +6127,16 @@ msgid "status logger"
  msgstr "logger di stato"
  
  #: src/main/main.c
@@ -1711,7 +1694,7 @@ index 3c0d519db..a9e209710 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7612,6 +7598,28 @@ msgstr ""
+@@ -7623,6 +7609,28 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1741,19 +1724,19 @@ index 3c0d519db..a9e209710 100644
  # se fosse: il componente aperto ... ?
  #, c-format
 diff --git a/po/ja.po b/po/ja.po
-index a604cca09..b22aa1ad7 100644
+index 53340787c..accc846af 100644
 --- a/po/ja.po
 +++ b/po/ja.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.18.3\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2022-11-03 20:08+0100\n"
  "Last-Translator: Takuma Yamada <tyamada@takumayamada.com>\n"
  "Language-Team: Japanese <debian-japanese@lists.debian.org>\n"
-@@ -6051,29 +6051,16 @@ msgid "status logger"
+@@ -6062,29 +6062,16 @@ msgid "status logger"
  msgstr "状態記録"
  
  #: src/main/main.c
@@ -1791,7 +1774,7 @@ index a604cca09..b22aa1ad7 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7527,6 +7514,26 @@ msgstr ""
+@@ -7538,6 +7525,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1819,19 +1802,19 @@ index a604cca09..b22aa1ad7 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/km.po b/po/km.po
-index 02f20fede..0a0ac8030 100644
+index 6f7040573..19f88caec 100644
 --- a/po/km.po
 +++ b/po/km.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
  "Language-Team: Khmer <support@khmeros.info>\n"
-@@ -5848,29 +5848,15 @@ msgid "status logger"
+@@ -5859,29 +5859,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1867,7 +1850,7 @@ index 02f20fede..0a0ac8030 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7314,6 +7300,11 @@ msgstr ""
+@@ -7325,6 +7311,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -1880,19 +1863,19 @@ index 02f20fede..0a0ac8030 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "បើក​សមាសភាគ​`%.255s' (នៅ %.255s)​ បានបរាជ័យ​តាម​វិធី​ដែលមិន​បាន​រំពឹង​ទុក"
 diff --git a/po/ko.po b/po/ko.po
-index 9484c48c4..f270ecfb7 100644
+index a953fad1b..1e85825dc 100644
 --- a/po/ko.po
 +++ b/po/ko.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-06-26 16:12+0200\n"
  "Last-Translator: Changwoo Ryu <cwryu@debian.org>\n"
  "Language-Team: Korean <debian-l10n-korean@lists.debian.org>\n"
-@@ -6231,28 +6231,15 @@ msgid "status logger"
+@@ -6242,28 +6242,15 @@ msgid "status logger"
  msgstr "상태"
  
  #: src/main/main.c
@@ -1928,19 +1911,19 @@ index 9484c48c4..f270ecfb7 100644
  
  # fdopen() 실패 상황
 diff --git a/po/ku.po b/po/ku.po
-index 0700cf0f8..990fba6fe 100644
+index b202f786c..777d30c19 100644
 --- a/po/ku.po
 +++ b/po/ku.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Erdal Ronahi <erdal.ronahi@gmail.com>\n"
  "Language-Team: Kurdish <ku@li.org>\n"
-@@ -5212,28 +5212,15 @@ msgid "status logger"
+@@ -5222,28 +5222,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -1976,19 +1959,19 @@ index 0700cf0f8..990fba6fe 100644
  
  #: src/main/main.c
 diff --git a/po/lt.po b/po/lt.po
-index bf09ec5fe..1dcd8c476 100644
+index 66a7e0dde..c27fb8213 100644
 --- a/po/lt.po
 +++ b/po/lt.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:50+0200\n"
  "Last-Translator: Gintautas Miliauskas <gintas@akl.lt>\n"
  "Language-Team: Lithuanian <komp_lt@konferencijos.lt>\n"
-@@ -5734,28 +5734,15 @@ msgid "status logger"
+@@ -5745,28 +5745,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2024,19 +2007,19 @@ index bf09ec5fe..1dcd8c476 100644
  
  #: src/main/main.c
 diff --git a/po/mr.po b/po/mr.po
-index 293e8d932..d3ae717a0 100644
+index b8169dfd2..0b63a74fa 100644
 --- a/po/mr.po
 +++ b/po/mr.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Priti Patil <prithisd@gmail.com>\n"
  "Language-Team: Marathi <janabhaaratii@cdacmumbai.in>\n"
-@@ -5807,29 +5807,15 @@ msgid "status logger"
+@@ -5818,29 +5818,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2072,7 +2055,7 @@ index 293e8d932..d3ae717a0 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7290,6 +7276,11 @@ msgstr ""
+@@ -7301,6 +7287,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2085,19 +2068,19 @@ index 293e8d932..d3ae717a0 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "चालू असलेला घटक `%.255s' (%.255s मधील) अनपेक्षित रित्या बंद पडला"
 diff --git a/po/nb.po b/po/nb.po
-index bd8d46c1c..a9efb0dad 100644
+index a52201645..7d9db85b9 100644
 --- a/po/nb.po
 +++ b/po/nb.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
  "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
-@@ -6216,29 +6216,15 @@ msgid "status logger"
+@@ -6227,29 +6227,15 @@ msgid "status logger"
  msgstr "status"
  
  #: src/main/main.c
@@ -2133,7 +2116,7 @@ index bd8d46c1c..a9efb0dad 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7814,6 +7800,11 @@ msgstr ""
+@@ -7825,6 +7811,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2146,19 +2129,19 @@ index bd8d46c1c..a9efb0dad 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/ne.po b/po/ne.po
-index 241bb9489..398f482ba 100644
+index 30e9ead4f..f40cdb443 100644
 --- a/po/ne.po
 +++ b/po/ne.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Nabin Gautam <nabin@mpp.org.np>\n"
  "Language-Team: Nepali <info@mpp.org.np>\n"
-@@ -5894,29 +5894,15 @@ msgid "status logger"
+@@ -5905,29 +5905,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2194,7 +2177,7 @@ index 241bb9489..398f482ba 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7370,6 +7356,11 @@ msgstr ""
+@@ -7381,6 +7367,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2207,19 +2190,19 @@ index 241bb9489..398f482ba 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "अवयव`%.255s' (in %.255s)खोल्न अप्रत्यासित रुपले असफल"
 diff --git a/po/nl.po b/po/nl.po
-index d372a22cf..e72b4ad13 100644
+index bed528adc..5cc482571 100644
 --- a/po/nl.po
 +++ b/po/nl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.11\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2024-11-05 18:04+0100\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: Debian Dutch l10n Team <debian-l10n-dutch@lists.debian.org>\n"
-@@ -5749,33 +5749,16 @@ msgid "status logger"
+@@ -5761,33 +5761,16 @@ msgid "status logger"
  msgstr "statuslogger"
  
  #: src/main/main.c
@@ -2259,7 +2242,7 @@ index d372a22cf..e72b4ad13 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7206,3 +7189,27 @@ msgstr ""
+@@ -7218,3 +7201,27 @@ msgstr ""
  #: utils/update-alternatives.polkit.in
  msgid "Authentication is required to run update-alternatives"
  msgstr "Authenticatie is nodig voor het uitvoeren van update-alternatives"
@@ -2288,19 +2271,19 @@ index d372a22cf..e72b4ad13 100644
 +#~ "kan architectuur '%s' die momenteel door de database gebruikt wordt, niet "
 +#~ "verwijderen"
 diff --git a/po/nn.po b/po/nn.po
-index 939b8aa73..861a628bf 100644
+index ecb62fae8..a04a20642 100644
 --- a/po/nn.po
 +++ b/po/nn.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: Håvard Korsvoll <korsvoll@skulelinux.no>\n"
  "Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
-@@ -5756,29 +5756,15 @@ msgid "status logger"
+@@ -5766,29 +5766,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2336,7 +2319,7 @@ index 939b8aa73..861a628bf 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7164,6 +7150,11 @@ msgstr ""
+@@ -7174,6 +7160,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2349,19 +2332,19 @@ index 939b8aa73..861a628bf 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/oc.po b/po/oc.po
-index d641982ab..e6f7bcb49 100644
+index 720d21ece..11ae92ae4 100644
 --- a/po/oc.po
 +++ b/po/oc.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-05 23:42+0100\n"
  "Last-Translator: Quentin PAGÈS <quentinantonin@free.fr>\n"
  "Language-Team: Occitan\n"
-@@ -5221,28 +5221,15 @@ msgid "status logger"
+@@ -5232,28 +5232,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2396,7 +2379,7 @@ index d641982ab..e6f7bcb49 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -6544,6 +6531,14 @@ msgstr ""
+@@ -6555,6 +6542,14 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2412,19 +2395,19 @@ index d641982ab..e6f7bcb49 100644
  #~ msgid "cannot open '%.255s' (in '%.255s')"
  #~ msgstr "impossible de dobrir « %.255s » (dins « %.255s »)"
 diff --git a/po/pa.po b/po/pa.po
-index 67068a60b..e4f3a3e33 100644
+index 763f69013..8bdffcbbf 100644
 --- a/po/pa.po
 +++ b/po/pa.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:51+0200\n"
  "Last-Translator: A S Alam <apbrar@gmail.com>\n"
  "Language-Team: Punjabi <punjabi-users@lists.sf.net>\n"
-@@ -5477,28 +5477,15 @@ msgid "status logger"
+@@ -5488,28 +5488,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -2460,19 +2443,19 @@ index 67068a60b..e4f3a3e33 100644
  
  #: src/main/main.c
 diff --git a/po/pl.po b/po/pl.po
-index e25207f00..fb78b2c38 100644
+index 38155b822..862bd4b4f 100644
 --- a/po/pl.po
 +++ b/po/pl.po
 @@ -16,7 +16,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.20.7\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2021-04-24 19:50+0200\n"
  "Last-Translator: Łukasz Dulny <bartekchom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
-@@ -5918,30 +5918,16 @@ msgid "status logger"
+@@ -5931,30 +5931,16 @@ msgid "status logger"
  msgstr "status programu logującego"
  
  #: src/main/main.c
@@ -2510,7 +2493,7 @@ index e25207f00..fb78b2c38 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7393,6 +7379,27 @@ msgstr "Uruchom update-alternatives, aby zmienić wybór alternatyw w systemie"
+@@ -7406,6 +7392,27 @@ msgstr "Uruchom update-alternatives, aby zmienić wybór alternatyw w systemie"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Uruchomienie update-alternatives wymaga uwierzytelnienia"
  
@@ -2539,19 +2522,19 @@ index e25207f00..fb78b2c38 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/pt.po b/po/pt.po
-index d15c7717d..4627dad2b 100644
+index e5755cb04..9756dd3b1 100644
 --- a/po/pt.po
 +++ b/po/pt.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-04 14:11+0000\n"
  "Last-Translator: Miguel Figueiredo <elmig@debianpt.org>\n"
  "Language-Team: Portuguese <traduz@debianpt.org>\n"
-@@ -5746,32 +5746,16 @@ msgid "status logger"
+@@ -5758,32 +5758,16 @@ msgid "status logger"
  msgstr "registador de estado"
  
  #: src/main/main.c
@@ -2590,7 +2573,7 @@ index d15c7717d..4627dad2b 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7176,6 +7160,29 @@ msgstr ""
+@@ -7188,6 +7172,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "É necessária autenticação para correr update-alternatives"
  
@@ -2621,19 +2604,19 @@ index d15c7717d..4627dad2b 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/pt_BR.po b/po/pt_BR.po
-index cc3eaaa3b..7f520c3a8 100644
+index 22575c76a..8a26a31ed 100644
 --- a/po/pt_BR.po
 +++ b/po/pt_BR.po
 @@ -17,7 +17,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dpkg 1.22.11\n"
+ "Project-Id-Version: dpkg 1.22.15\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
- "PO-Revision-Date: 2024-12-31 23:42+0100\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
+ "PO-Revision-Date: 2025-03-06 15:45-0300\n"
  "Last-Translator: Paulo Henrique de Lima Santana (phls) <phls@debian.org>\n"
  "Language-Team: Brazilian Portuguese <debian-l10n-"
-@@ -5769,31 +5769,16 @@ msgid "status logger"
+@@ -5751,31 +5751,16 @@ msgid "status logger"
  msgstr "registrador de estado"
  
  #: src/main/main.c
@@ -2649,7 +2632,7 @@ index cc3eaaa3b..7f520c3a8 100644
 -#: src/main/main.c
 -#, c-format
 -msgid "cannot remove non-foreign architecture '%s'"
--msgstr "não foi possível remover a arquitetura não exótica '%s'"
+-msgstr "não é possível remover a arquitetura não exótica '%s'"
 -
 -#: src/main/main.c
 -#, c-format
@@ -2667,15 +2650,16 @@ index cc3eaaa3b..7f520c3a8 100644
 +"--remove-architecture is not supported in AOSC OS. Please contact AOSC OS "
 +"maintainers for any problems encountered."
  msgstr ""
--"não foi possível remover a arquitetura '%s' atualmente em uso pelo banco de "
+-"não é possível remover a arquitetura '%s' atualmente em uso pelo banco de "
 -"dados"
  
  #: src/main/main.c
  #, c-format
-@@ -7199,6 +7184,28 @@ msgstr ""
+@@ -7181,3 +7166,25 @@ msgstr ""
+ #: utils/update-alternatives.polkit.in
  msgid "Authentication is required to run update-alternatives"
  msgstr "Autenticação é necessária para executar update-alternatives"
- 
++
 +#, c-format
 +#~ msgid "architecture '%s' is illegal: %s"
 +#~ msgstr "arquitetura '%s' é ilegal: %s"
@@ -2686,7 +2670,7 @@ index cc3eaaa3b..7f520c3a8 100644
 +
 +#, c-format
 +#~ msgid "cannot remove non-foreign architecture '%s'"
-+#~ msgstr "não foi possível remover a arquitetura não exótica '%s'"
++#~ msgstr "não é possível remover a arquitetura não exótica '%s'"
 +
 +#, c-format
 +#~ msgid "removing architecture '%s' currently in use by database"
@@ -2695,26 +2679,22 @@ index cc3eaaa3b..7f520c3a8 100644
 +#, c-format
 +#~ msgid "cannot remove architecture '%s' currently in use by the database"
 +#~ msgstr ""
-+#~ "não foi possível remover a arquitetura '%s' atualmente em uso pelo banco "
-+#~ "de dados"
-+
- #~ msgid "failed to open diversions file"
- #~ msgstr "falhou ao abrir arquivo de desvios"
- 
++#~ "não é possível remover a arquitetura '%s' atualmente em uso pelo banco de "
++#~ "dados"
 diff --git a/po/ro.po b/po/ro.po
-index e2d59bce3..090981979 100644
+index 9fd6c47d7..d5139faa4 100644
 --- a/po/ro.po
 +++ b/po/ro.po
 @@ -23,7 +23,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.11\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2024-12-03 03:57+0100\n"
  "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
  "Language-Team: Romanian <debian-l10n-romanian@lists.debian.org>\n"
-@@ -6079,30 +6079,16 @@ msgid "status logger"
+@@ -6093,30 +6093,16 @@ msgid "status logger"
  msgstr "jurnalul de stare"
  
  #: src/main/main.c
@@ -2752,7 +2732,7 @@ index e2d59bce3..090981979 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7533,6 +7519,27 @@ msgstr ""
+@@ -7547,6 +7533,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Autentificarea este necesară pentru a rula «update-alternatives»"
  
@@ -2781,19 +2761,19 @@ index e2d59bce3..090981979 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/ru.po b/po/ru.po
-index 776565814..2c04a5a8b 100644
+index eb6f000a4..11b5a29eb 100644
 --- a/po/ru.po
 +++ b/po/ru.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-06 00:01+0100\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
-@@ -5772,31 +5772,16 @@ msgid "status logger"
+@@ -5785,31 +5785,16 @@ msgid "status logger"
  msgstr "протоколировщик состояния"
  
  #: src/main/main.c
@@ -2832,7 +2812,7 @@ index 776565814..2c04a5a8b 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7195,6 +7180,29 @@ msgstr ""
+@@ -7208,6 +7193,29 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr "Для запуска update-alternatives требуется аутентификация"
  
@@ -2863,19 +2843,19 @@ index 776565814..2c04a5a8b 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/sk.po b/po/sk.po
-index 919665dc3..79783291e 100644
+index 155caa2d9..231ac2587 100644
 --- a/po/sk.po
 +++ b/po/sk.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 10:01+0200\n"
  "Last-Translator: Ivan Masár <helix84@centrum.sk>\n"
  "Language-Team: Slovak <debian-l10n-slovak@lists.debian.org>\n"
-@@ -6091,29 +6091,16 @@ msgid "status logger"
+@@ -6102,29 +6102,16 @@ msgid "status logger"
  msgstr "záznam stavu"
  
  #: src/main/main.c
@@ -2913,7 +2893,7 @@ index 919665dc3..79783291e 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7587,6 +7574,27 @@ msgstr ""
+@@ -7598,6 +7585,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -2942,19 +2922,19 @@ index 919665dc3..79783291e 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "otvorenie zložky „%.255s“ (v %.255s) zlyhalo neočakávaným spôsobom"
 diff --git a/po/sv.po b/po/sv.po
-index fae3c93de..7b3435106 100644
+index 14f13e117..a37bafd8b 100644
 --- a/po/sv.po
 +++ b/po/sv.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2024-09-29 17:15+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
-@@ -5602,30 +5602,16 @@ msgid "status logger"
+@@ -5614,30 +5614,16 @@ msgid "status logger"
  msgstr "statusloggare"
  
  #: src/main/main.c
@@ -2992,7 +2972,7 @@ index fae3c93de..7b3435106 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6998,6 +6984,27 @@ msgstr "Kör update-alternatives för att ändra systemets val av alternativ"
+@@ -7010,6 +6996,27 @@ msgstr "Kör update-alternatives för att ändra systemets val av alternativ"
  msgid "Authentication is required to run update-alternatives"
  msgstr "Autentisering krävs för att köra update-alternatives"
  
@@ -3021,19 +3001,19 @@ index fae3c93de..7b3435106 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/th.po b/po/th.po
-index 08898bbc8..2ba70bc69 100644
+index 51c0834e8..d400dc056 100644
 --- a/po/th.po
 +++ b/po/th.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-02-05 23:45+0100\n"
  "Last-Translator: Theppitak Karoonboonyanan <thep@debian.org>\n"
  "Language-Team: Thai <thai-l10n@googlegroups.com>\n"
-@@ -5535,29 +5535,16 @@ msgid "status logger"
+@@ -5547,29 +5547,16 @@ msgid "status logger"
  msgstr "เครื่องมือบันทึกปูมของสถานะ"
  
  #: src/main/main.c
@@ -3071,7 +3051,7 @@ index 08898bbc8..2ba70bc69 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6901,6 +6888,26 @@ msgstr "เรียก update-alternatives เพื่อเปลี่ยน
+@@ -6913,6 +6900,26 @@ msgstr "เรียก update-alternatives เพื่อเปลี่ยน
  msgid "Authentication is required to run update-alternatives"
  msgstr "ต้องยืนยันตัวบุคคลเพื่อเรียกทำงาน update-alternatives"
  
@@ -3099,19 +3079,19 @@ index 08898bbc8..2ba70bc69 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "เปิดองค์ประกอบ '%.255s' (ใน %.255s) ไม่สำเร็จ โดยได้ผลลัพธ์ที่ไม่คาดคิด"
 diff --git a/po/tl.po b/po/tl.po
-index 5309049eb..a778cfa6a 100644
+index 523769b04..8e5dae268 100644
 --- a/po/tl.po
 +++ b/po/tl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2015-04-07 09:53+0200\n"
  "Last-Translator: Eric Pareja <xenos@upm.edu.ph>\n"
  "Language-Team: Tagalog <debian-tl@banwa.upm.edu.ph>\n"
-@@ -5881,29 +5881,15 @@ msgid "status logger"
+@@ -5891,29 +5891,15 @@ msgid "status logger"
  msgstr ""
  
  #: src/main/main.c
@@ -3147,7 +3127,7 @@ index 5309049eb..a778cfa6a 100644
  msgstr ""
  
  #: src/main/main.c
-@@ -7312,6 +7298,11 @@ msgstr ""
+@@ -7322,6 +7308,11 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3160,19 +3140,19 @@ index 5309049eb..a778cfa6a 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/tr.po b/po/tr.po
-index 98d05fb5a..2f71522f1 100644
+index ec1ecb11a..4d5dcc51d 100644
 --- a/po/tr.po
 +++ b/po/tr.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.17.10\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2018-01-03 16:44+0300\n"
  "Last-Translator: Mert Dirik <mertdirik@gmail.com>\n"
  "Language-Team: Turkish <debian-l10n-turkish@lists.debian.org>\n"
-@@ -6015,30 +6015,16 @@ msgid "status logger"
+@@ -6026,30 +6026,16 @@ msgid "status logger"
  msgstr "durum günlükçüsü"
  
  #: src/main/main.c
@@ -3210,7 +3190,7 @@ index 98d05fb5a..2f71522f1 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7505,6 +7491,27 @@ msgid "Authentication is required to run update-alternatives"
+@@ -7516,6 +7502,27 @@ msgid "Authentication is required to run update-alternatives"
  msgstr ""
  "update-alternatives komutunu çalıştırmak için kimlik doğrulama gerekmektedir"
  
@@ -3239,19 +3219,19 @@ index 98d05fb5a..2f71522f1 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/vi.po b/po/vi.po
-index dedf44392..34456dd96 100644
+index 644a75c94..91279ef8d 100644
 --- a/po/vi.po
 +++ b/po/vi.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.18.2\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2016-01-14 08:22+0700\n"
  "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
  "Language-Team: Vietnamese <debian-l10n-vietnamese@lists.debian.org>\n"
-@@ -6067,30 +6067,16 @@ msgid "status logger"
+@@ -6078,30 +6078,16 @@ msgid "status logger"
  msgstr "bộ ghi nhật ký trạng thái"
  
  #: src/main/main.c
@@ -3289,7 +3269,7 @@ index dedf44392..34456dd96 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7525,6 +7511,27 @@ msgstr ""
+@@ -7536,6 +7522,27 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3318,19 +3298,19 @@ index dedf44392..34456dd96 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr ""
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index 8b60f11f3..a81efd85e 100644
+index 95b4edd5f..9879a81d0 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
 @@ -16,7 +16,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2023-01-27 15:39-0500\n"
  "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
  "Language-Team: Chinese (simplified) <debian-l10n-chinese@lists.debian.org>\n"
-@@ -5520,29 +5520,16 @@ msgid "status logger"
+@@ -5532,29 +5532,16 @@ msgid "status logger"
  msgstr "状态日志记录器"
  
  #: src/main/main.c
@@ -3368,7 +3348,7 @@ index 8b60f11f3..a81efd85e 100644
  
  #: src/main/main.c
  #, c-format
-@@ -6882,6 +6869,26 @@ msgstr "运行 update-alternatives 工具以修改系统可选项的选择情况
+@@ -6894,6 +6881,26 @@ msgstr "运行 update-alternatives 工具以修改系统可选项的选择情况
  msgid "Authentication is required to run update-alternatives"
  msgstr "需要认证后才能执行 update-alternatives"
  
@@ -3396,19 +3376,19 @@ index 8b60f11f3..a81efd85e 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "打开组件 %.255s (于 %.255s 目录)出乎意料地失败"
 diff --git a/po/zh_TW.po b/po/zh_TW.po
-index 4ec35c430..20b683b43 100644
+index a08607479..ff5a90e22 100644
 --- a/po/zh_TW.po
 +++ b/po/zh_TW.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg 1.13\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:55+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-14 16:20+0800\n"
  "PO-Revision-Date: 2018-04-15 07:06+0800\n"
  "Last-Translator: 林博仁 <Buo.Ren.Lin@gmail.com>\n"
  "Language-Team: Chinese (traditional) <debian-l10n-chinese@lists.debian.org>\n"
-@@ -5843,29 +5843,16 @@ msgid "status logger"
+@@ -5855,29 +5855,16 @@ msgid "status logger"
  msgstr "狀態記錄器"
  
  #: src/main/main.c
@@ -3446,7 +3426,7 @@ index 4ec35c430..20b683b43 100644
  
  #: src/main/main.c
  #, c-format
-@@ -7272,6 +7259,26 @@ msgstr ""
+@@ -7284,6 +7271,26 @@ msgstr ""
  msgid "Authentication is required to run update-alternatives"
  msgstr ""
  
@@ -3474,135 +3454,135 @@ index 4ec35c430..20b683b43 100644
  #~ msgid "open component '%.255s' (in %.255s) failed in an unexpected way"
  #~ msgstr "在開啟元件 `%.255s'（位於 %.255s）時以意想不到的方式失敗了"
 diff --git a/scripts/po/ca.po b/scripts/po/ca.po
-index 8aeea0759..af13df977 100644
+index 138dc0cf0..c883f2df6 100644
 --- a/scripts/po/ca.po
 +++ b/scripts/po/ca.po
 @@ -9,7 +9,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.18\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2024-07-21 19:57+0200\n"
  "Last-Translator: Guillem Jover <guillem@debian.org>\n"
  "Language-Team: Catalan <debian-l10n-catalan@lists.debian.org>\n"
 diff --git a/scripts/po/de.po b/scripts/po/de.po
-index ba7a16780..6f6dde705 100644
+index 865977c3f..15f935f7e 100644
 --- a/scripts/po/de.po
 +++ b/scripts/po/de.po
 @@ -6,7 +6,7 @@ msgid ""
  msgstr ""
- "Project-Id-Version: dpkg-dev 1.22.14\n"
+ "Project-Id-Version: dpkg-dev 1.22.18\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
- "PO-Revision-Date: 2025-01-04 21:38+0100\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
+ "PO-Revision-Date: 2025-03-07 16:22+0100\n"
  "Last-Translator: Helge Kreutzmann <debian@helgefjell.de>\n"
  "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
 diff --git a/scripts/po/dpkg-dev.pot b/scripts/po/dpkg-dev.pot
-index f1c601854..a6d29dead 100644
+index 93673a293..6c84e1bf3 100644
 --- a/scripts/po/dpkg-dev.pot
 +++ b/scripts/po/dpkg-dev.pot
 @@ -6,9 +6,9 @@
  #, fuzzy
  msgid ""
  msgstr ""
--"Project-Id-Version: dpkg 1.22.14\n"
-+"Project-Id-Version: dpkg 1.22.14-7-gfe853\n"
+-"Project-Id-Version: dpkg 1.22.18\n"
++"Project-Id-Version: dpkg 1.22.18-6-g4075\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
  "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
  "Language-Team: LANGUAGE <LL@li.org>\n"
 diff --git a/scripts/po/es.po b/scripts/po/es.po
-index 019ef7b2d..1f46f44c5 100644
+index 4b7ce8f5c..4e2541c4a 100644
 --- a/scripts/po/es.po
 +++ b/scripts/po/es.po
 @@ -31,7 +31,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.16.8\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2014-12-02 20:24+0100\n"
  "Last-Translator: Omar Campagne <ocampagne@gmail.com>\n"
  "Language-Team: Spanish <debian-l10n-spanish@lists.debian.org>\n"
 diff --git a/scripts/po/fr.po b/scripts/po/fr.po
-index 265de01ac..8ab5c8b90 100644
+index 4b33de2bd..dc775399c 100644
 --- a/scripts/po/fr.po
 +++ b/scripts/po/fr.po
 @@ -11,7 +11,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.20\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2023-02-10 02:16+0100\n"
  "Last-Translator: Sébastien Poher <sebastien@volted.net>\n"
  "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
 diff --git a/scripts/po/nl.po b/scripts/po/nl.po
-index 7df969e2e..8ae6ab668 100644
+index e0be604be..d79d51eb2 100644
 --- a/scripts/po/nl.po
 +++ b/scripts/po/nl.po
 @@ -8,7 +8,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.21.19\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2023-02-02 17:51+0100\n"
  "Last-Translator: Frans Spiesschaert <Frans.Spiesschaert@yucom.be>\n"
  "Language-Team: \n"
 diff --git a/scripts/po/pl.po b/scripts/po/pl.po
-index fb372b911..ec0fb10b5 100644
+index a043b2891..57622ce3c 100644
 --- a/scripts/po/pl.po
 +++ b/scripts/po/pl.po
 @@ -10,7 +10,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.15.4\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2015-04-07 07:05+0200\n"
  "Last-Translator: Łukasz Dulny <BartekChom@poczta.onet.pl>\n"
  "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
 diff --git a/scripts/po/pt.po b/scripts/po/pt.po
-index ce10796e5..b89455785 100644
+index 3270e055b..d672fbe3b 100644
 --- a/scripts/po/pt.po
 +++ b/scripts/po/pt.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2023-03-08 22:31+0000\n"
  "Last-Translator: Américo Monteiro <a_monteiro@gmx.com>\n"
  "Language-Team: Portuguese <>\n"
 diff --git a/scripts/po/ru.po b/scripts/po/ru.po
-index 6c5c29899..f68d697b1 100644
+index 26495112e..e5242a1fa 100644
 --- a/scripts/po/ru.po
 +++ b/scripts/po/ru.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.17.23\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2015-04-07 07:02+0200\n"
  "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
  "Language-Team: Russian <debian-l10n-russian@lists.debian.org>\n"
 diff --git a/scripts/po/sv.po b/scripts/po/sv.po
-index c258e7f32..0c6c32094 100644
+index 65c6c7138..7032b6c84 100644
 --- a/scripts/po/sv.po
 +++ b/scripts/po/sv.po
 @@ -7,7 +7,7 @@ msgid ""
  msgstr ""
  "Project-Id-Version: dpkg-dev 1.22.0\n"
  "Report-Msgid-Bugs-To: debian-dpkg@lists.debian.org\n"
--"POT-Creation-Date: 2025-01-16 03:56+0100\n"
-+"POT-Creation-Date: 2025-01-19 23:50+0800\n"
+-"POT-Creation-Date: 2025-03-09 18:59+0100\n"
++"POT-Creation-Date: 2025-03-10 01:47+0800\n"
  "PO-Revision-Date: 2024-09-29 17:34+0100\n"
  "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
  "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"

--- a/app-admin/dpkg/01-update-alternatives/patches/0008-AOSCOS-po-add-translation-for-AOSC-OS-add-remove-arc.patch
+++ b/app-admin/dpkg/01-update-alternatives/patches/0008-AOSCOS-po-add-translation-for-AOSC-OS-add-remove-arc.patch
@@ -1,4 +1,4 @@
-From 18d7019e5705d493d1abe5d145b4e724a48bdda8 Mon Sep 17 00:00:00 2001
+From 86bc8c9036059810b5b6ebc5016ed22a8ac35f20 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 7 May 2024 17:55:11 +0800
 Subject: [PATCH 8/8] AOSCOS: po: add translation for AOSC OS
@@ -10,7 +10,7 @@ Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index a81efd85e..8a4ecfc50 100644
+index 9879a81d0..8bc97a20e 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
 @@ -25,7 +25,7 @@ msgstr ""
@@ -22,7 +22,7 @@ index a81efd85e..8a4ecfc50 100644
  
  #: lib/dpkg/ar.c
  msgid "failed to fstat archive"
-@@ -5524,12 +5524,15 @@ msgid ""
+@@ -5536,12 +5536,15 @@ msgid ""
  "--add-architecture is not supported in AOSC OS. Please contact AOSC OS "
  "maintainers for any problems encountered."
  msgstr ""

--- a/app-admin/dpkg/spec
+++ b/app-admin/dpkg/spec
@@ -1,5 +1,4 @@
-VER=1.22.14
-REL=1
+VER=1.22.18
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"


### PR DESCRIPTION
Topic Description
-----------------

- dpkg: update to 1.22.18
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- dpkg: 1.22.18
- update-alternatives: 1.22.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit dpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
