### PR TITLE
fnm: update to 1.38.1

### DIFF
--- a/lang-js/fnm/spec
+++ b/lang-js/fnm/spec
@@ -1,4 +1,4 @@
-VER=1.37.2
+VER=1.38.1
 SRCS="git::commit=tags/v$VER::https://github.com/Schniz/fnm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374841"


### PR DESCRIPTION
Topic Description
-----------------

- fnm: update to 1.38.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- fnm: 1.38.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fnm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
