### PR TITLE
gitui: update to 0.27.0

### DIFF
--- a/app-utils/gitui/spec
+++ b/app-utils/gitui/spec
@@ -1,4 +1,4 @@
-VER=0.26.3
+VER=0.27.0
 SRCS="git::commit=tags/v$VER::https://github.com/extrawurst/gitui"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=187553"


### PR DESCRIPTION
Topic Description
-----------------

- gitui: update to 0.27.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- gitui: 0.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
