### PR TITLE
zfs: update to 2.3.1

### DIFF
--- a/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
+++ b/app-admin/zfs/autobuild/patches/0001-Block-manual-building-in-the-DKMS-source-tree.patch
@@ -1,7 +1,7 @@
-From 3b0d92f922141d12dac1a9b52ba7a2f989037f86 Mon Sep 17 00:00:00 2001
+From 141392d67832c72b6c5c119c7e4c86d2e8704216 Mon Sep 17 00:00:00 2001
 From: Shengqi Chen <harry-chen@outlook.com>
 Date: Tue, 16 Jul 2024 15:28:03 +0800
-Subject: [PATCH 1/4] Block manual building in the DKMS source tree.
+Subject: [PATCH 1/5] Block manual building in the DKMS source tree.
 
 To avoid messing up future DKMS builds and the zfs installation, block manual building of the DKMS source tree.
 
@@ -35,7 +35,7 @@ index 000000000..cfa115296
 +        ])
 +])
 diff --git a/config/user.m4 b/config/user.m4
-index 4e31745a2..40ae55ac3 100644
+index badd920d2..a8a5fda3c 100644
 --- a/config/user.m4
 +++ b/config/user.m4
 @@ -2,6 +2,7 @@ dnl #

--- a/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
+++ b/app-admin/zfs/autobuild/patches/0002-Enable-zed-emails.patch
@@ -1,7 +1,7 @@
-From a4f109f5a5810b1c7851fc1d923bb39073fa42e8 Mon Sep 17 00:00:00 2001
+From 973fba5bdfda65762cf6684ebb4fda0247e1fe86 Mon Sep 17 00:00:00 2001
 From: Richard Laager <rlaager@wiktel.com>
 Date: Tue, 16 Jul 2024 15:30:50 +0800
-Subject: [PATCH 2/4] Enable zed emails
+Subject: [PATCH 2/5] Enable zed emails
 
 The OpenZFS event daemon monitors pools. This patch enables the email sending function by default (if zed is installed). This is consistent with the default behavior of mdadm.
 
@@ -11,7 +11,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmd/zed/zed.d/zed.rc b/cmd/zed/zed.d/zed.rc
-index 859c6f9cb..9d1ee1560 100644
+index af56147a9..47fb01631 100644
 --- a/cmd/zed/zed.d/zed.rc
 +++ b/cmd/zed/zed.d/zed.rc
 @@ -41,7 +41,7 @@ ZED_EMAIL_ADDR="root"

--- a/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
+++ b/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
@@ -1,7 +1,7 @@
-From 57b0027f7ecb4c53f845da8c59d6eca604ee1d2b Mon Sep 17 00:00:00 2001
+From 0d0e174f826a655bbb90840f026d4513efbfe539 Mon Sep 17 00:00:00 2001
 From: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Date: Tue, 16 Jul 2024 15:35:34 +0800
-Subject: [PATCH 3/4] Explicitly load the ZFS module via systemd service
+Subject: [PATCH 3/5] Explicitly load the ZFS module via systemd service
 
 See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/2100-zfs-load-module.patch
 ---

--- a/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
+++ b/app-admin/zfs/autobuild/patches/0004-Force-libtool-to-produce-verbose-output.patch
@@ -1,7 +1,7 @@
-From 24bff057ef8cea4f58482e3157e2eb57629dba6e Mon Sep 17 00:00:00 2001
+From 8e64d17ff23bba6bd4aa2e84f3bc29bfafd6e2ab Mon Sep 17 00:00:00 2001
 From: Mo Zhou <lumin@debian.org>
 Date: Tue, 16 Jul 2024 15:37:19 +0800
-Subject: [PATCH 4/4] Force libtool to produce verbose output
+Subject: [PATCH 4/5] Force libtool to produce verbose output
 
 See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/force-verbose-rules.patch
 ---
@@ -9,7 +9,7 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/config/Rules.am b/config/Rules.am
-index cb4066b7c..5445f6b26 100644
+index 9c0714c82..70b1579f7 100644
 --- a/config/Rules.am
 +++ b/config/Rules.am
 @@ -13,7 +13,7 @@ AM_CPPFLAGS = \

--- a/app-admin/zfs/autobuild/patches/0005-linux-zvols-correctly-detect-flush-requests.patch
+++ b/app-admin/zfs/autobuild/patches/0005-linux-zvols-correctly-detect-flush-requests.patch
@@ -1,0 +1,58 @@
+From 01e98e69264afe4a3f71cd92516c20127928d7f1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fabian=20Gr=C3=BCnbichler?= <f.gruenbichler@proxmox.com>
+Date: Mon, 10 Mar 2025 15:51:09 +0100
+Subject: [PATCH 5/5] linux: zvols: correctly detect flush requests
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+since 4.10, bio->bi_opf needs to be checked to determine all kinds of
+flush requests. this was the case prior to the commit referenced below,
+but the order of ifdefs was not the usual one (newest up top), which
+might have caused this to slip through.
+
+this fixes a regression when using zvols as Qemu block devices, but
+might have broken other use cases as well. the symptoms are that all
+sync writes from within a VM configured to use such a virtual block
+devices are ignored and treated as async writes by the host ZFS layer.
+
+this can be verified using fio in sync mode inside the VM, for example
+with
+
+ fio \
+ --filename=/dev/sda --ioengine=libaio --loops=1 --size=10G \
+ --time_based --runtime=60 --group_reporting --stonewall --name=cc1 \
+ --description="CC1" --rw=write --bs=4k --direct=1 --iodepth=1 \
+ --numjobs=1 --sync=1
+
+which shows an IOPS number way above what the physical device underneath
+supports, with "zpool iostat -r 1" on the hypervisor side showing no
+sync IO occuring during the benchmark.
+
+with the regression fixed, both fio inside the VM and the IO stats on
+the host show the expected numbers.
+
+Fixes: 846b5985192467acabf5484ae610b4b37b7f8162
+"config: remove HAVE_REQ_OP_* and HAVE_REQ_*"
+
+Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
+---
+ include/os/linux/kernel/linux/blkdev_compat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/os/linux/kernel/linux/blkdev_compat.h b/include/os/linux/kernel/linux/blkdev_compat.h
+index d96708c60..9af496e87 100644
+--- a/include/os/linux/kernel/linux/blkdev_compat.h
++++ b/include/os/linux/kernel/linux/blkdev_compat.h
+@@ -383,7 +383,7 @@ bio_set_flush(struct bio *bio)
+ static inline boolean_t
+ bio_is_flush(struct bio *bio)
+ {
+-	return (bio_op(bio) == REQ_OP_FLUSH);
++	return (bio_op(bio) == REQ_OP_FLUSH || op_is_flush(bio->bi_opf));
+ }
+ 
+ /*
+-- 
+2.39.5
+

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=2.3.1
 SRCS="tbl::https://github.com/openzfs/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
-CHKSUMS="sha256::6e8787eab55f24c6b9c317f3fe9b0da9a665eb34c31df88ff368d9a92e9356a6"
+CHKSUMS="sha256::053233799386920bdc636e22d0e19a8c2c3e642e8bd847ff87e108f8bb1f9006"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: refresh patches, backport patch to fix flushing of zvols
    Signed-off-by: Shengqi Chen <harry-chen@outlook.com>
- zfs: update to 2.3.1
    Signed-off-by: Shengqi Chen <harry-chen@outlook.com>

Package(s) Affected
-------------------

- zfs: 2.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
