### PR TITLE
yq: update to 4.45.1

### DIFF
--- a/app-devel/yq/spec
+++ b/app-devel/yq/spec
@@ -1,4 +1,4 @@
-VER=4.44.5
+VER=4.45.1
 SRCS="git::commit=tags/v${VER}::https://github.com/mikefarah/yq.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=303696"


### PR DESCRIPTION
Topic Description
-----------------

- yq: update to 4.45.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- yq: 4.45.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
