### PR TITLE
hugo: update to 0.145.0

### DIFF
--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,4 +1,4 @@
-VER=0.143.1
+VER=0.145.0
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"


### PR DESCRIPTION
Topic Description
-----------------

- hugo: update to 0.145.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- hugo: 0.145.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hugo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
