### PR TITLE
expat: update to 2.7.0

### DIFF
--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.6.2
+VER=2.7.0
 SRCS="tbl::https://github.com/libexpat/libexpat/releases/download/R_${VER//./_}/expat-$VER.tar.xz"
-CHKSUMS="sha256::ee14b4c5d8908b1bec37ad937607eab183d4d9806a08adee472c3c3121d27364"
+CHKSUMS="sha256::25df13dd2819e85fb27a1ce0431772b7047d72af81ae78dc26b4c6e0805f48d1"
 CHKUPDATE="anitya::id=770"


### PR DESCRIPTION
Topic Description
-----------------

- expat: update to 2.7.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- expat: 2.7.0

Security Update?
----------------

Yes, #10110

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
