### PR TITLE
php: update to 8.4.5


### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,4 @@
-VER=8.4.3
+VER=8.4.5
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::5c42173cbde7d0add8249c2e8a0c19ae271f41d8c47d67d72bdf91a88dcc7e4b"
+CHKSUMS="sha256::0d3270bbce4d9ec617befce52458b763fd461d475f1fe2ed878bb8573faed327"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.4.5

Package(s) Affected
-------------------

- php: 1:8.4.5

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/10113

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
