### PR TITLE
ipython: update to 8.32.0

### DIFF
--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,4 +1,4 @@
-VER=8.28.0
+VER=8.32.0
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::0d0d15ca1e01faeb868ef56bc7ee5a0de5bd66885735682e8a322ae289a13d1a"
+CHKSUMS="sha256::be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251"
 CHKUPDATE="anitya::id=1399"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 8.32.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- ipython: 8.32.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
