### PR TITLE
wsl-default-settings: fix useradd parameters

### DIFF
--- a/runtime-data/wsl-default-settings/autobuild/overrides/usr/share/wsl/wsl-oobe.sh
+++ b/runtime-data/wsl-default-settings/autobuild/overrides/usr/share/wsl/wsl-oobe.sh
@@ -18,7 +18,7 @@ while true; do
   read -p 'Enter new UNIX username: ' username
 
   # Create the user
-  if /usr/bin/useradd --create-home --shell /bin/bash --uid "$DEFAULT_UID" --quiet --comment ''  "$username"; then
+  if /usr/bin/useradd --create-home --shell /bin/bash --uid "$DEFAULT_UID" --comment ''  "$username"; then
     if /usr/bin/usermod "$username" -aG "$DEFAULT_GROUPS"; then
       break
     else

--- a/runtime-data/wsl-default-settings/spec
+++ b/runtime-data/wsl-default-settings/spec
@@ -1,2 +1,3 @@
 VER=2
+REL=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- wsl-default-settings: fix useradd parameters
    Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

Package(s) Affected
-------------------

- wsl-default-settings: 2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wsl-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
