### PR TITLE
taskwarrior: update to 3.4.1

### DIFF
--- a/app-productivity/taskwarrior/autobuild/prepare
+++ b/app-productivity/taskwarrior/autobuild/prepare
@@ -1,0 +1,5 @@
+# FIXME: bfd fails to find aws-lc-sys symbols while lld breaks
+# proc-macro2, so we only enable lld here for c/c++ but not rust.
+if ab_match_arch loongson3; then
+        export LDFLAGS="${LDFLAGS} -Wl,-z,notext -fuse-ld=lld"
+fi

--- a/app-productivity/taskwarrior/spec
+++ b/app-productivity/taskwarrior/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.4.1
 SRCS="git::commit=tags/v${VER}::https://github.com/GothenburgBitFactory/taskwarrior"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5841"


### PR DESCRIPTION
Topic Description
-----------------

- taskwarrior: update to 3.4.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- taskwarrior: 3.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit taskwarrior
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
