### PR TITLE
texlive: install perl modules to fix tlmgr

### DIFF
--- a/app-doc/texlive/autobuild/build
+++ b/app-doc/texlive/autobuild/build
@@ -100,6 +100,10 @@ sed -i -e '/DO NOT EDIT/,+3 d' "$PKGDIR"/etc/texmf/tex/generic/config/language.*
 abinfo "Remove -dev engines from format lists, in order to supress warning during fmtutil-sys generation"
 sed -i '/-dev/d' "$PKGDIR"/etc/texmf/web2c/fmtutil.cnf
 
-abinfo "Phase 4. Perl hacks"
-mkdir -p "$PKGDIR"/usr/share/tlpkg
-cp -r texk/tests/TeXLive "$PKGDIR"/usr/share/tlpkg/
+abinfo "Phase 4. install tlpkg perl modules"
+tar -xvf ../texlive-$PKGVER-extra.tar.xz \
+    -C "$SRCDIR"/../extra --strip-components=1
+mkdir -vp "$PKGDIR"/usr/share/tlpkg
+cp -vr "$SRCDIR"/../extra/tlpkg/TeXLive \
+    texlive.tlpdb \
+    "$PKGDIR"/usr/share/tlpkg/

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,6 +1,9 @@
 VER=20250308
+REL=1
 SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
-      file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
+      file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz \
+      file::rename=texlive-$VER-extra.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-extra.tar.xz"
 CHKSUMS="sha512::0837c935488b96cfc8dd79f1298f283b467ab68b4163cee9cb04b79e80195982fdc5ae8a80058dc7d3e99206bfda8b3bdd11340425b08f60cbef70d5a0e22702 \
-         sha512::631a93f911437b9ebb075c09dfc592d6d8331ebaffb8cad62b6e7df55634345937342656db091dc0fb36686927131dbfdee5a03f54ef808a2a4d3ddc47cfbc17"
+         sha512::631a93f911437b9ebb075c09dfc592d6d8331ebaffb8cad62b6e7df55634345937342656db091dc0fb36686927131dbfdee5a03f54ef808a2a4d3ddc47cfbc17 \
+         sha512::a1320469be140c4c0b00a0e307a203114061087a51f6fbcff9c255a0a3ba9cb3abfccc6edb6ad1388e32072f532837ca055eeead131eccce56f785705a0c9035"
 CHKUPDATE="anitya::id=11725"


### PR DESCRIPTION
Topic Description
-----------------

- texlive: install perl modules to fix tlmgr
    Signed-off-by: xtex <xtexchooser@duck.com>

Package(s) Affected
-------------------

- texlive: 20250308-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
