### PR TITLE
man-pages: update to 6.13+posix2017a

### DIFF
--- a/runtime-data/man-pages/autobuild/build
+++ b/runtime-data/man-pages/autobuild/build
@@ -9,7 +9,7 @@ for sect in 0 1 3; do
 done
 
 abinfo "Installing man pages ..."
-make install prefix="$PKGDIR"/usr
+make install -R prefix="$PKGDIR"/usr
 
 abinfo "Removing redundant pages ..."
 rm -v \

--- a/runtime-data/man-pages/spec
+++ b/runtime-data/man-pages/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=6.9.1
+UPSTREAM_VER=6.13
 POSIXVER=2017-a
 VER=${UPSTREAM_VER}+posix${POSIXVER/-a/a}
-SRCS="https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${UPSTREAM_VER}.tar.xz \
-      https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${POSIXVER}.tar.xz"
-SUBDIR="man-pages-${VER%%+posix*}"
-CHKSUMS="sha256::e23cbac29f110ba571f0da8523e79d373691466ed7f2a31301721817d34530bd \
+SRCS="tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${UPSTREAM_VER}.tar.xz \
+      tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${POSIXVER}.tar.xz"
+SUBDIR="man-pages-${UPSTREAM_VER}"
+CHKSUMS="sha256::a2c8a0c2efe8a978ce51ce800461eb9e8931f12cc7ba4b7faa3082b69ba7f12c \
          sha256::ce67bb25b5048b20dad772e405a83f4bc70faf051afa289361c81f9660318bc3"
 CHKUPDATE="anitya::id=1883"


### PR DESCRIPTION
Topic Description
-----------------

- man-pages: update to 6.13+posix2017a
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- man-pages: 6.13+posix2017a

Security Update?
----------------

No

Build Order
-----------

```
#buildit man-pages
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
