### PR TITLE
digikam: update to 8.6.0

### DIFF
--- a/desktop-kde/digikam/spec
+++ b/desktop-kde/digikam/spec
@@ -1,4 +1,4 @@
-VER=8.5.0
+VER=8.6.0
 SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=classification_classes_ILSVRC2012.txt::https://files.kde.org/digikam/autotags/classification_classes_ILSVRC2012.txt \
       file::rename=coco.names::https://files.kde.org/digikam/autotags/coco.names \
@@ -15,7 +15,7 @@ SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=yolov3-wider_16000.weights::https://files.kde.org/digikam/facesengine/dnnface/yolov3-wider_16000.weights \
       file::rename=yolov5n_batch_16_s320.onnx::https://files.kde.org/digikam/autotags/yolov5n_batch_16_s320.onnx \
       file::rename=yolov5x_batch_16_s320.onnx::https://files.kde.org/digikam/autotags/yolov5x_batch_16_s320.onnx"
-CHKSUMS="sha256::5c4eaafbca59425a0fe8cb41e7d7a08446defbbb967528bb1148aed0e0d0e975 \
+CHKSUMS="sha256::000971e117201976cba413b6d7201720a8893799d6064bcf158d4388e829c233 \
          sha256::4eb3da435cf544e4a6f390f62c84cb9c9bb68cf8b14e97f8a063452382e5efd2 \
          sha256::634a1132eb33f8091d60f2c346ababe8b905ae08387037aed883953b7329af84 \
          sha256::f62621cac923d6f37bd669298c428bb7ee72233b5f8c3389bb893e35ebbcf795 \


### PR DESCRIPTION
Topic Description
-----------------

- digikam: update to 8.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- digikam: 8.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit digikam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
