### PR TITLE
lfortran: update to 0.49.0

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -6,17 +6,16 @@ PKGDES="Interactive LLVM-based Fortran compiler"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
-    -DBUILD_SHARED_LIBS=ON \
     -DLLVM_DIR=$(llvm-config --cmakedir) \
-    -DWITH_FMT=ON \
-    -DWITH_LLVM=ON \
-    -DWITH_RUNTIME_LIBRARY=ON \
-    -DWITH_RUNTIME_STACKTRACE=ON
-    -DWITH_STACKTRACE=ON \
-    -DWITH_TARGET_WASM=OFF \
-    -DWITH_UNWIND=ON \
-    -DWITH_WHEREAMI=ON \
-    -DWITH_ZLIB=ON \
+    -DWITH_FMT=yes \
+    -DWITH_LLVM=yes \
+    -DWITH_RUNTIME_LIBRARY=yes \
+    -DWITH_RUNTIME_STACKTRACE=yes
+    -DWITH_STACKTRACE=yes \
+    -DWITH_TARGET_WASM=no \
+    -DWITH_UNWIND=yes \
+    -DWITH_WHEREAMI=yes \
+    -DWITH_ZLIB=yes \
 "
 
 # FIXME: operations on real data type may cause segfault or incorrect results on loongarch64.

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,5 +1,4 @@
-VER=0.47.0
-REL=1
+VER=0.49.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::584b0f165563d353438285a97e053b80a9c664fccd2178bd4abd26c4bc07fafa"
+CHKSUMS="sha256::a9225fd33d34ce786f72a964a1179579caff62dd176a6a1477d2594fecdc7cd6"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.49.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.49.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
