### PR TITLE
[FLIGHT] linux-kernel: testTL-WDN6200 (MediaTek) ID

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-wifi-mt76-mt76x2u-add-TP-Link-TL-WDN6200-ID-to-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-wifi-mt76-mt76x2u-add-TP-Link-TL-WDN6200-ID-to-devic.patch
@@ -1,0 +1,30 @@
+From 34a6830365efab3d29d2b8f685f18afe7aab833e Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Mon, 17 Mar 2025 17:01:42 +0800
+Subject: [PATCH] wifi: mt76: mt76x2u: add TP-Link TL-WDN6200 ID to device
+ table
+
+Some TP-Link TL-WDN6200 cards use a MT7612U chipset.
+
+Add the USB ID to mt76x2u driver.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ drivers/net/wireless/mediatek/mt76/mt76x2/usb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c b/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c
+index e832ad53e2393..a4f4d12f904e7 100644
+--- a/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c
++++ b/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c
+@@ -22,6 +22,7 @@ static const struct usb_device_id mt76x2u_device_table[] = {
+ 	{ USB_DEVICE(0x0846, 0x9053) },	/* Netgear A6210 */
+ 	{ USB_DEVICE(0x045e, 0x02e6) },	/* XBox One Wireless Adapter */
+ 	{ USB_DEVICE(0x045e, 0x02fe) },	/* XBox One Wireless Adapter */
++	{ USB_DEVICE(0x2357, 0x0137) },	/* TP-Link TL-WDN6200 */
+ 	{ },
+ };
+ 
+-- 
+2.48.1
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.13.3
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=3
+REL=3.1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel: test TL-WDN6200 \(MediaTek\) ID
- nuclei: update to 3.3.10

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.13.3-3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
