### PR TITLE
nvtop: update to 3.1.0+git20250220

### DIFF
--- a/app-admin/nvtop/autobuild/defines
+++ b/app-admin/nvtop/autobuild/defines
@@ -8,3 +8,40 @@ PKGSUG="libdrm"
 PKGSUG__AMD64="${PKGSUG} nvidia"
 PKGSUG__ARM64="${PKGSUG__AMD64}"
 PKGDES="A utilization monitor for GPUs"
+
+CMAKE_AFTER=(
+    '-DAMDGPU_SUPPORT=ON'
+    '-DAPPLE_SUPPORT=OFF'
+    '-DASCEND_SUPPORT=OFF'
+    '-DINTEL_SUPPORT=ON'
+    '-DMSM_SUPPORT=OFF'
+    '-DNVIDIA_SUPPORT=OFF'
+    '-DPANFROST_SUPPORT=OFF'
+    '-DPANTHOR_SUPPORT=OFF'
+    '-DUSE_LIBUDEV_OVER_LIBSYSTEMD=OFF'
+    '-DV3D_SUPPORT=OFF'
+)
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER[@]}"
+    '-DNVIDIA_SUPPORT=ON'
+)
+# Note: -DASCEND_SUPPORT=OFF
+#
+# ninja: error: '/usr/local/Ascend/driver/lib64/driver/libdcmi.so', needed by 'src/nvtop', missing and no known rule to make it
+#
+# Note: -DAPPLE_SUPPORT=OFF, they meant macOS support, not Apple DRM.
+#
+# .../nvtop/src/extract_gpuinfo_apple.m:27:10: fatal error: Metal/Metal.h: No such file or directory
+#   27 | #include <Metal/Metal.h>
+#      |          ^~~~~~~~~~~~~~~
+
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    '-DAPPLE_SUPPORT=OFF'
+    '-DASCEND_SUPPORT=OFF'
+    '-DMSM_SUPPORT=ON'
+    '-DNVIDIA_SUPPORT=ON'
+    '-DPANFROST_SUPPORT=ON'
+    '-DPANTHOR_SUPPORT=ON'
+    '-DV3D_SUPPORT=ON'
+)

--- a/app-admin/nvtop/spec
+++ b/app-admin/nvtop/spec
@@ -1,4 +1,10 @@
-VER=3.1.0
-SRCS="git::commit=tags/$VER::https://github.com/Syllo/nvtop"
+VER=3.1.0+git20250220
+# Note: The Git master includes too many useful fixes and new features
+# (such as support for Intel i915/xe kernel modules) to ignore. This is
+# also a fairly trivial component so it should be safe to go for a Git
+# snapshot at this moment.
+SRCS="git::commit=33cf46840f58975d593c743b091eb1e37e323378::https://github.com/Syllo/nvtop"
+# Go back to this when they release a new stable version.
+#SRCS="git::commit=tags/$VER::https://github.com/Syllo/nvtop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226779"


### PR DESCRIPTION
Topic Description
-----------------

- nvtop: update to 3.1.0+git20250220
    The Git master includes too many useful fixes and new features \(such as
    support for Intel i915/xe kernel modules\) to ignore. This is also a fairly
    trivial component so it should be safe to go for a Git snapshot at this
    moment.

Package(s) Affected
-------------------

- nvtop: 3.1.0+git20250220

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvtop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
