### PR TITLE
sunshine:enable cuda on amd64 and arm64

### DIFF
--- a/app-devel/cuda/autobuild/defines
+++ b/app-devel/cuda/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=cuda
 PKGSEC=non-free/devel
-PKGDEP="gcc-runtime gdb gcc glu pulseaudio qt-5"
+PKGDEP="gcc-runtime gdb gcc-13 glu pulseaudio qt-5"
 # FIXME: cuda depends on `nvidia` or `nvidia-open`, ACBS currently lacks the
 # ability to specify "or" relationship, so we default to recommend `nvidia` here
 # as it is still what we preinstall

--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -4,15 +4,14 @@ PKGSEC=video
 PKGDEP="pulseaudio libdrm libevdev icu wayland openssl ffmpeg miniupnpc \
         libnotify libappindicator libvdpau mesa nlohmann-json"
 PKGRECOM="avahi"
-BUILDDEP="boost nodejs doxygen ffmpeg-static-libs-for-sunshine"
+BUILDDEP="boost nodejs doxygen ffmpeg-static-libs-for-sunshine gcc-13"
 PKGRECOM__AMD64="${PKGRECOM} intel-media-driver"
 
-# FIXME: disable cuda for AMD64/ARM64, due to cuda needs gcc-13, cannot satisfied
-#
-#BUILDDEP__AMD64="${BUILDDEP} cuda"
-#BUILDDEP__ARM64="${BUILDDEP} cuda"
-#PKGSUG__AMD64="cuda"
-#PKGSUG__ARM64="cuda"
+
+BUILDDEP__AMD64="${BUILDDEP} cuda"
+BUILDDEP__ARM64="${BUILDDEP} cuda"
+PKGSUG__AMD64="cuda"
+PKGSUG__ARM64="cuda"
 
 ABTYPE=cmakeninja
 
@@ -27,11 +26,6 @@ CMAKE_AFTER="-DFFMPEG_USE_SYSTEM_LIBRARIES=ON \
              -DSUNSHINE_ENABLE_CUDA=OFF \
              -DSUNSHINE_ASSETS_DIR=share/sunshine"
 
-# FIXME: disable cuda for AMD64/ARM64, due to cuda needs gcc-13, cannot satisfied
-#
-#CMAKE_AFTER__AMD64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=ON"
-#CMAKE_AFTER__ARM64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=ON"
-#CMAKE_AFTER__LOONGARCH64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=OFF"
-#CMAKE_AFTER__LOONGSON3="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=OFF"
-#CMAKE_AFTER__RISCV64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=OFF"
-#CMAKE_AFTER__PPC64EL="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=OFF"
+
+CMAKE_AFTER__AMD64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=ON"
+CMAKE_AFTER__ARM64="${CMAKE_AFTER} -DSUNSHINE_ENABLE_CUDA=ON"

--- a/app-multimedia/sunshine/autobuild/prepare
+++ b/app-multimedia/sunshine/autobuild/prepare
@@ -11,3 +11,7 @@ export COMMIT="$(git rev-parse HEAD)"
 
 abinfo "Preparing NPM modules ..."
 npm install --package-lock-only
+
+abinfo "Specify gcc version 13 "
+export CC=gcc-13 
+export CXX=g++-13


### PR DESCRIPTION
Topic Description
-----------------

- cuda: fix gcc version
- sunshine: enable cuda on amd64 and arm64

Package(s) Affected
-------------------

- cuda: 12.6.3+560.35.05
- sunshine: 2025.122.141614

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda sunshine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
