### PR TITLE
desktop-base: add recommend dep liberation-fonts

### DIFF
--- a/meta-bases/desktop-base/autobuild/defines
+++ b/meta-bases/desktop-base/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=desktop-base
 PKGSEC=Bases
 PKGDEP="x11-base"
-PKGRECOM="noto-fonts noto-cjk-fonts"
+PKGRECOM="noto-fonts noto-cjk-fonts liberation-fonts"
 # Note: All useful VA-API drivers and the debugging utilities should be
 # included below.
 PKGRECOM="${PKGRECOM} intel-media-driver libva-intel-driver \

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,4 @@
-VER=14
+VER=15
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: bump VER to 15, add recommend dep \`liberation-fonts\`

Package(s) Affected
-------------------

- desktop-base: 15

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
