### PR TITLE
zellij: update to 0.42.0

### DIFF
--- a/app-utils/zellij/autobuild/beyond
+++ b/app-utils/zellij/autobuild/beyond
@@ -2,8 +2,8 @@ abinfo "Generate shell completions ..."
 install -dv "$PKGDIR"/usr/share/zsh/functions/Completion/Linux/
 "$PKGDIR"/usr/bin/zellij setup --generate-completion zsh > "$PKGDIR"/usr/share/zsh/functions/Completion/Linux/_zellij
 
-install -dv "$PKGDIR"/usr/share/fish/completions/
-"$PKGDIR"/usr/bin/zellij setup --generate-completion fish > "$PKGDIR"/usr/share/fish/completions/zellij.fish
+install -dv "$PKGDIR"/usr/share/fish/vendor_completions.d/
+"$PKGDIR"/usr/bin/zellij setup --generate-completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/zellij.fish
 
 install -dv "$PKGDIR"/usr/share/bash-completion/completions/
 "$PKGDIR"/usr/bin/zellij setup --generate-completion bash > "$PKGDIR"/usr/share/bash-completion/completions/zellij.bash

--- a/app-utils/zellij/autobuild/defines
+++ b/app-utils/zellij/autobuild/defines
@@ -5,9 +5,7 @@ BUILDDEP="rustc llvm"
 PKGDES="A terminal workspace and a terminal multiplexer"
 
 USECLANG=1
-ABSPLITDBG=0
 
-# FIXME: `cranelift-codegen` does not support ISA for other architectures.
-# More information:
-# https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/codegen/meta/src/isa/mod.rs
-FAIL_ARCH="!(amd64|arm64|riscv64)"
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local
+# symbol; recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
+++ b/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
@@ -1,0 +1,770 @@
+From a2055e30e501f32405506a42dbc3def4055e14de Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Tue, 18 Mar 2025 14:34:53 -0700
+Subject: [PATCH 1/2] chore: update wasmtime to 30.0.2
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Cargo.lock                              | 267 +++++++++++-------------
+ zellij-server/Cargo.toml                |   6 +-
+ zellij-server/src/plugins/plugin_map.rs |  15 +-
+ 3 files changed, 129 insertions(+), 159 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 7d2d490c..725629d0 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -34,18 +34,6 @@ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+ 
+-[[package]]
+-name = "ahash"
+-version = "0.8.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+-dependencies = [
+- "cfg-if",
+- "once_cell",
+- "version_check",
+- "zerocopy 0.7.34",
+-]
+-
+ [[package]]
+ name = "aho-corasick"
+ version = "0.7.20"
+@@ -737,20 +725,35 @@ dependencies = [
+  "libc",
+ ]
+ 
++[[package]]
++name = "cranelift-assembler-x64"
++version = "0.117.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d2b83fcf2fc1c8954561490d02079b496fd0c757da88129981e15bfe3a548229"
++dependencies = [
++ "cranelift-assembler-x64-meta",
++]
++
++[[package]]
++name = "cranelift-assembler-x64-meta"
++version = "0.117.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c7496a6e92b5cee48c5d772b0443df58816dee30fed6ba19b2a28e78037ecedf"
++
+ [[package]]
+ name = "cranelift-bforest"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
++checksum = "73a9dc0a8d3d49ee772101924968830f1c1937d650c571d3c2dd69dc36a68f41"
+ dependencies = [
+  "cranelift-entity",
+ ]
+ 
+ [[package]]
+ name = "cranelift-bitset"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
++checksum = "573c641174c40ef31021ae4a5a3ad78974e280633502d0dfc6e362385e0c100f"
+ dependencies = [
+  "serde",
+  "serde_derive",
+@@ -758,11 +761,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "cranelift-codegen"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
++checksum = "2d7c94d572615156f2db682181cadbd96342892c31e08cc26a757344319a9220"
+ dependencies = [
+  "bumpalo",
++ "cranelift-assembler-x64",
+  "cranelift-bforest",
+  "cranelift-bitset",
+  "cranelift-codegen-meta",
+@@ -771,8 +775,9 @@ dependencies = [
+  "cranelift-entity",
+  "cranelift-isle",
+  "gimli 0.31.1",
+- "hashbrown 0.14.5",
++ "hashbrown 0.15.2",
+  "log",
++ "pulley-interpreter",
+  "regalloc2",
+  "rustc-hash",
+  "serde",
+@@ -782,33 +787,35 @@ dependencies = [
+ 
+ [[package]]
+ name = "cranelift-codegen-meta"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
++checksum = "beecd9fcf2c3e06da436d565de61a42676097ea6eb6b4499346ac6264b6bb9ce"
+ dependencies = [
++ "cranelift-assembler-x64",
+  "cranelift-codegen-shared",
++ "pulley-interpreter",
+ ]
+ 
+ [[package]]
+ name = "cranelift-codegen-shared"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
++checksum = "0f4ff8d2e1235f2d6e7fc3c6738be6954ba972cd295f09079ebffeca2f864e22"
+ 
+ [[package]]
+ name = "cranelift-control"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
++checksum = "001312e9fbc7d9ca9517474d6fe71e29d07e52997fd7efe18f19e8836446ceb2"
+ dependencies = [
+  "arbitrary",
+ ]
+ 
+ [[package]]
+ name = "cranelift-entity"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
++checksum = "eb0fd6d4aae680275fcbceb08683416b744e65c8b607352043d3f0951d72b3b2"
+ dependencies = [
+  "cranelift-bitset",
+  "serde",
+@@ -817,9 +824,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cranelift-frontend"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
++checksum = "9fd44e7e5dcea20ca104d45894748205c51365ce4cdb18f4418e3ba955971d1b"
+ dependencies = [
+  "cranelift-codegen",
+  "log",
+@@ -829,15 +836,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "cranelift-isle"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
++checksum = "f900e0a3847d51eed0321f0777947fb852ccfce0da7fb070100357f69a2f37fc"
+ 
+ [[package]]
+ name = "cranelift-native"
+-version = "0.116.1"
++version = "0.117.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
++checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
+ dependencies = [
+  "cranelift-codegen",
+  "libc",
+@@ -1586,15 +1593,6 @@ version = "0.11.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+ 
+-[[package]]
+-name = "hashbrown"
+-version = "0.14.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+-dependencies = [
+- "ahash",
+-]
+-
+ [[package]]
+ name = "hashbrown"
+ version = "0.15.2"
+@@ -2940,13 +2938,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "pulley-interpreter"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "62d95f8575df49a2708398182f49a888cf9dc30210fb1fd2df87c889edcee75d"
++checksum = "cb0ecb9823083f71df8735f21f6c44f2f2b55986d674802831df20f27e26c907"
+ dependencies = [
+  "cranelift-bitset",
+  "log",
+- "sptr",
+  "wasmtime-math",
+ ]
+ 
+@@ -2978,7 +2975,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+ dependencies = [
+  "rand_chacha 0.9.0",
+  "rand_core 0.9.0",
+- "zerocopy 0.8.17",
++ "zerocopy",
+ ]
+ 
+ [[package]]
+@@ -3017,7 +3014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+ dependencies = [
+  "getrandom 0.3.1",
+- "zerocopy 0.8.17",
++ "zerocopy",
+ ]
+ 
+ [[package]]
+@@ -4243,16 +4240,6 @@ version = "0.2.87"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+ 
+-[[package]]
+-name = "wasm-encoder"
+-version = "0.221.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+-dependencies = [
+- "leb128",
+- "wasmparser 0.221.2",
+-]
+-
+ [[package]]
+ name = "wasm-encoder"
+ version = "0.224.0"
+@@ -4260,14 +4247,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
+ dependencies = [
+  "leb128",
+- "wasmparser 0.224.0",
++ "wasmparser",
+ ]
+ 
+ [[package]]
+ name = "wasmparser"
+-version = "0.221.2"
++version = "0.224.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
++checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
+ dependencies = [
+  "bitflags 2.5.0",
+  "hashbrown 0.15.2",
+@@ -4276,33 +4263,22 @@ dependencies = [
+  "serde",
+ ]
+ 
+-[[package]]
+-name = "wasmparser"
+-version = "0.224.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
+-dependencies = [
+- "bitflags 2.5.0",
+- "indexmap 2.7.1",
+- "semver 1.0.17",
+-]
+-
+ [[package]]
+ name = "wasmprinter"
+-version = "0.221.2"
++version = "0.224.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
++checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
+ dependencies = [
+  "anyhow",
+  "termcolor",
+- "wasmparser 0.221.2",
++ "wasmparser",
+ ]
+ 
+ [[package]]
+ name = "wasmtime"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "11976a250672556d1c4c04c6d5d7656ac9192ac9edc42a4587d6c21460010e69"
++checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
+ dependencies = [
+  "addr2line 0.24.2",
+  "anyhow",
+@@ -4314,7 +4290,7 @@ dependencies = [
+  "encoding_rs",
+  "fxprof-processed-profile",
+  "gimli 0.31.1",
+- "hashbrown 0.14.5",
++ "hashbrown 0.15.2",
+  "indexmap 2.7.1",
+  "ittapi",
+  "libc",
+@@ -4337,8 +4313,8 @@ dependencies = [
+  "sptr",
+  "target-lexicon",
+  "trait-variant",
+- "wasm-encoder 0.221.2",
+- "wasmparser 0.221.2",
++ "wasm-encoder",
++ "wasmparser",
+  "wasmtime-asm-macros",
+  "wasmtime-cache",
+  "wasmtime-component-macro",
+@@ -4358,18 +4334,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-asm-macros"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1f178b0d125201fbe9f75beaf849bd3e511891f9e45ba216a5b620802ccf64f2"
++checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
+ dependencies = [
+  "cfg-if",
+ ]
+ 
+ [[package]]
+ name = "wasmtime-cache"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b1161c8f62880deea07358bc40cceddc019f1c81d46007bc390710b2fe24ffc"
++checksum = "7a5d75ac36ee28647f6d871a93eefc7edcb729c3096590031ba50857fac44fa8"
+ dependencies = [
+  "anyhow",
+  "base64 0.21.0",
+@@ -4387,9 +4363,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-component-macro"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d74de6592ed945d0a602f71243982a304d5d02f1e501b638addf57f42d57dfaf"
++checksum = "2581ef04bf33904db9a902ffb558e7b2de534d6a4881ee985ea833f187a78fdf"
+ dependencies = [
+  "anyhow",
+  "proc-macro2",
+@@ -4402,15 +4378,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-component-util"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "707dc7b3c112ab5a366b30cfe2fb5b2f8e6a0f682f16df96a5ec582bfe6f056e"
++checksum = "9a7108498a8a0afc81c7d2d81b96cdc509cd631d7bbaa271b7db5137026f10e3"
+ 
+ [[package]]
+ name = "wasmtime-cranelift"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "366be722674d4bf153290fbcbc4d7d16895cc82fb3e869f8d550ff768f9e9e87"
++checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
+ dependencies = [
+  "anyhow",
+  "cfg-if",
+@@ -4423,19 +4399,20 @@ dependencies = [
+  "itertools 0.12.1",
+  "log",
+  "object 0.36.7",
++ "pulley-interpreter",
+  "smallvec",
+  "target-lexicon",
+  "thiserror",
+- "wasmparser 0.221.2",
++ "wasmparser",
+  "wasmtime-environ",
+  "wasmtime-versioned-export-macros",
+ ]
+ 
+ [[package]]
+ name = "wasmtime-environ"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cdadc1af7097347aa276a4f008929810f726b5b46946971c660b6d421e9994ad"
++checksum = "8e90f6cba665939381839bbf2ddf12d732fca03278867910348ef1281b700954"
+ dependencies = [
+  "anyhow",
+  "cpp_demangle",
+@@ -4452,17 +4429,17 @@ dependencies = [
+  "serde_derive",
+  "smallvec",
+  "target-lexicon",
+- "wasm-encoder 0.221.2",
+- "wasmparser 0.221.2",
++ "wasm-encoder",
++ "wasmparser",
+  "wasmprinter",
+  "wasmtime-component-util",
+ ]
+ 
+ [[package]]
+ name = "wasmtime-fiber"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ccba90d4119f081bca91190485650730a617be1fff5228f8c4757ce133d21117"
++checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
+ dependencies = [
+  "anyhow",
+  "cc",
+@@ -4475,10 +4452,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-jit-debug"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3e7b61488a5ee00c35c8c22de707c36c0aecacf419a3be803a6a2ba5e860f56a"
++checksum = "74812989369947f4f5a33f4ae8ff551eb6c8a97ff55e0269a9f5f0fac93cd755"
+ dependencies = [
++ "cc",
+  "object 0.36.7",
+  "rustix 0.38.44",
+  "wasmtime-versioned-export-macros",
+@@ -4486,9 +4464,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-jit-icache-coherence"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
++checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
+ dependencies = [
+  "anyhow",
+  "cfg-if",
+@@ -4498,24 +4476,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-math"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "29210ec2aa25e00f4d54605cedaf080f39ec01a872c5bd520ad04c67af1dde17"
++checksum = "f5f04c5dcf5b2f88f81cfb8d390294b2f67109dc4d0197ea7303c60a092df27c"
+ dependencies = [
+  "libm",
+ ]
+ 
+ [[package]]
+ name = "wasmtime-slab"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fcb5821a96fa04ac14bc7b158bb3d5cd7729a053db5a74dad396cd513a5e5ccf"
++checksum = "fe9681707f1ae9a4708ca22058722fca5c135775c495ba9b9624fe3732b94c97"
+ 
+ [[package]]
+ name = "wasmtime-versioned-export-macros"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "86ff86db216dc0240462de40c8290887a613dddf9685508eb39479037ba97b5b"
++checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4524,9 +4502,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-wasi"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8d1be69bfcab1bdac74daa7a1f9695ab992b9c8e21b9b061e7d66434097e0ca4"
++checksum = "4ce639c7d398586bc539ae9bba752084c1db7a49ab0f391a3230dcbcc6a64cfd"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+@@ -4546,25 +4524,38 @@ dependencies = [
+  "thiserror",
+  "tokio",
+  "tracing",
+- "trait-variant",
+  "url",
+  "wasmtime",
++ "wasmtime-wasi-io",
+  "wiggle",
+  "windows-sys 0.59.0",
+ ]
+ 
++[[package]]
++name = "wasmtime-wasi-io"
++version = "30.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bdcad7178fddaa07786abe8ff5e043acb4bc8c8f737eb117f11e028b48d92792"
++dependencies = [
++ "anyhow",
++ "async-trait",
++ "bytes",
++ "futures",
++ "wasmtime",
++]
++
+ [[package]]
+ name = "wasmtime-winch"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fdbabfb8f20502d5e1d81092b9ead3682ae59988487aafcd7567387b7a43cf8f"
++checksum = "5a9c8eae8395d530bb00a388030de9f543528674c382326f601de47524376975"
+ dependencies = [
+  "anyhow",
+  "cranelift-codegen",
+  "gimli 0.31.1",
+  "object 0.36.7",
+  "target-lexicon",
+- "wasmparser 0.221.2",
++ "wasmparser",
+  "wasmtime-cranelift",
+  "wasmtime-environ",
+  "winch-codegen",
+@@ -4572,9 +4563,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmtime-wit-bindgen"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8358319c2dd1e4db79e3c1c5d3a5af84956615343f9f89f4e4996a36816e06e6"
++checksum = "9a5531455e2c55994a1540355140369bb7ec0e46d2699731c5ee9f4cf9c3f7d4"
+ dependencies = [
+  "anyhow",
+  "heck 0.5.0",
+@@ -4601,7 +4592,7 @@ dependencies = [
+  "leb128",
+  "memchr",
+  "unicode-width 0.2.0",
+- "wasm-encoder 0.224.0",
++ "wasm-encoder",
+ ]
+ 
+ [[package]]
+@@ -4730,9 +4721,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wiggle"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4b9af35bc9629c52c261465320a9a07959164928b4241980ba1cf923b9e6751d"
++checksum = "c5a4ea7722c042a659dc70caab0b56d7f45220e8bae1241cf5ebc7ab7efb0dfb"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+@@ -4745,9 +4736,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wiggle-generate"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2cf267dd05673912c8138f4b54acabe6bd53407d9d1536f0fadb6520dd16e101"
++checksum = "3f786d9d3e006152a360f1145bdc18e56ea22fd5d2356f1ddc2ecfcf7529a77b"
+ dependencies = [
+  "anyhow",
+  "heck 0.5.0",
+@@ -4760,9 +4751,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wiggle-macro"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08c5c473d4198e6c2d377f3809f713ff0c110cab88a0805ae099a82119ee250c"
++checksum = "ceac9f94f22ccc0485aeab08187b9f211d1993aaf0ed6eeb8aed43314f6e717c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4803,9 +4794,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+ name = "winch-codegen"
+-version = "29.0.1"
++version = "30.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2f849ef2c5f46cb0a20af4b4487aaa239846e52e2c03f13fa3c784684552859c"
++checksum = "7dbd4e07bd92c7ddace2f3267bdd31d4197b5ec58c315751325d45c19bfb56df"
+ dependencies = [
+  "anyhow",
+  "cranelift-codegen",
+@@ -4814,7 +4805,7 @@ dependencies = [
+  "smallvec",
+  "target-lexicon",
+  "thiserror",
+- "wasmparser 0.221.2",
++ "wasmparser",
+  "wasmtime-cranelift",
+  "wasmtime-environ",
+ ]
+@@ -5072,9 +5063,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wit-parser"
+-version = "0.221.2"
++version = "0.224.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
++checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
+ dependencies = [
+  "anyhow",
+  "id-arena",
+@@ -5085,7 +5076,7 @@ dependencies = [
+  "serde_derive",
+  "serde_json",
+  "unicode-xid",
+- "wasmparser 0.221.2",
++ "wasmparser",
+ ]
+ 
+ [[package]]
+@@ -5288,33 +5279,13 @@ dependencies = [
+  "vte 0.11.0",
+ ]
+ 
+-[[package]]
+-name = "zerocopy"
+-version = "0.7.34"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+-dependencies = [
+- "zerocopy-derive 0.7.34",
+-]
+-
+ [[package]]
+ name = "zerocopy"
+ version = "0.8.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+ dependencies = [
+- "zerocopy-derive 0.8.17",
+-]
+-
+-[[package]]
+-name = "zerocopy-derive"
+-version = "0.7.34"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.96",
++ "zerocopy-derive",
+ ]
+ 
+ [[package]]
+diff --git a/zellij-server/Cargo.toml b/zellij-server/Cargo.toml
+index f3cb3553..78bd733f 100644
+--- a/zellij-server/Cargo.toml
++++ b/zellij-server/Cargo.toml
+@@ -19,7 +19,7 @@ daemonize = "0.5"
+ serde_json = "1.0"
+ unicode-width = "0.1.8"
+ url = "2.2.2"
+-wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
++wasmtime-wasi = "30.0.2" # Keep in sync with wasmtime
+ cassowary = "0.3.0"
+ zellij-utils = { path = "../zellij-utils/", version = "0.42.0" }
+ log = "0.4.17"
+@@ -34,7 +34,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
+ semver = "0.11.0"
+ 
+ [dependencies.wasmtime]
+-version = "29.0.1" # Keep in sync with wasmtime-wasi
++version = "30.0.2" # Keep in sync with wasmtime-wasi
+ default-features = false
+ features = [
+   'async',
+@@ -54,7 +54,7 @@ features = [
+ [dev-dependencies]
+ insta = "1.6.0"
+ tempfile = "3.2.0"
+-wasmtime = { version = "29.0.1", features = ["winch"] } # Keep in sync with the other wasmtime dep
++wasmtime = { version = "30.0.2", features = ["winch"] } # Keep in sync with the other wasmtime dep
+ 
+ [features]
+ singlepass = ["wasmtime/winch"]
+diff --git a/zellij-server/src/plugins/plugin_map.rs b/zellij-server/src/plugins/plugin_map.rs
+index 655aec50..bb2385fe 100644
+--- a/zellij-server/src/plugins/plugin_map.rs
++++ b/zellij-server/src/plugins/plugin_map.rs
+@@ -10,8 +10,7 @@ use std::{
+ use wasmtime::{Instance, Store};
+ use wasmtime_wasi::preview1::WasiP1Ctx;
+ use wasmtime_wasi::{
+-    HostInputStream, HostOutputStream, StdinStream, StdoutStream, StreamError, StreamResult,
+-    Subscribe,
++    InputStream, OutputStream, Pollable, StdinStream, StdoutStream, StreamError, StreamResult,
+ };
+ 
+ use crate::{thread_bus::ThreadSenders, ClientId};
+@@ -316,7 +315,7 @@ pub struct PluginEnv {
+ pub struct VecDequeInputStream(pub Arc<Mutex<VecDeque<u8>>>);
+ 
+ impl StdinStream for VecDequeInputStream {
+-    fn stream(&self) -> Box<dyn wasmtime_wasi::HostInputStream> {
++    fn stream(&self) -> Box<dyn wasmtime_wasi::InputStream> {
+         Box::new(self.clone())
+     }
+ 
+@@ -325,7 +324,7 @@ impl StdinStream for VecDequeInputStream {
+     }
+ }
+ 
+-impl HostInputStream for VecDequeInputStream {
++impl InputStream for VecDequeInputStream {
+     fn read(&mut self, size: usize) -> StreamResult<Bytes> {
+         let mut inner = self.0.lock().unwrap();
+         let len = std::cmp::min(size, inner.len());
+@@ -334,7 +333,7 @@ impl HostInputStream for VecDequeInputStream {
+ }
+ 
+ #[async_trait::async_trait]
+-impl Subscribe for VecDequeInputStream {
++impl Pollable for VecDequeInputStream {
+     async fn ready(&mut self) {}
+ }
+ 
+@@ -347,7 +346,7 @@ impl<T> Clone for WriteOutputStream<T> {
+ }
+ 
+ impl<T: Write + Send + 'static> StdoutStream for WriteOutputStream<T> {
+-    fn stream(&self) -> Box<dyn HostOutputStream> {
++    fn stream(&self) -> Box<dyn OutputStream> {
+         Box::new((*self).clone())
+     }
+ 
+@@ -356,7 +355,7 @@ impl<T: Write + Send + 'static> StdoutStream for WriteOutputStream<T> {
+     }
+ }
+ 
+-impl<T: Write + Send + 'static> HostOutputStream for WriteOutputStream<T> {
++impl<T: Write + Send + 'static> OutputStream for WriteOutputStream<T> {
+     fn write(&mut self, bytes: Bytes) -> StreamResult<()> {
+         self.0
+             .lock()
+@@ -379,7 +378,7 @@ impl<T: Write + Send + 'static> HostOutputStream for WriteOutputStream<T> {
+ }
+ 
+ #[async_trait::async_trait]
+-impl<T: Send + 'static> Subscribe for WriteOutputStream<T> {
++impl<T: Send + 'static> Pollable for WriteOutputStream<T> {
+     async fn ready(&mut self) {}
+ }
+ 
+-- 
+2.49.0
+

--- a/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
+++ b/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
@@ -1,0 +1,752 @@
+From e0dbfaa9cacdb5c9150bb212f03707bd14cdbe2d Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Tue, 18 Mar 2025 20:23:35 -0700
+Subject: [PATCH 2/2] chore: update nix to >=0.27 to support loongarch64
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Cargo.lock                           | 92 ++++++++++++----------------
+ zellij-client/src/lib.rs             | 17 ++---
+ zellij-client/src/os_input_output.rs | 24 ++++----
+ zellij-server/src/os_input_output.rs | 54 ++++++++++------
+ zellij-server/src/pty.rs             | 35 ++++++++---
+ zellij-utils/Cargo.toml              |  4 +-
+ 6 files changed, 124 insertions(+), 102 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 725629d0..ff99ac6d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -553,6 +553,12 @@ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+ 
++[[package]]
++name = "cfg_aliases"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
++
+ [[package]]
+ name = "chrono"
+ version = "0.4.39"
+@@ -579,7 +585,7 @@ dependencies = [
+  "clap_lex",
+  "indexmap 1.8.2",
+  "once_cell",
+- "strsim",
++ "strsim 0.10.0",
+  "termcolor",
+  "textwrap",
+ ]
+@@ -2227,15 +2233,6 @@ dependencies = [
+  "autocfg",
+ ]
+ 
+-[[package]]
+-name = "memoffset"
+-version = "0.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+-dependencies = [
+- "autocfg",
+-]
+-
+ [[package]]
+ name = "memoffset"
+ version = "0.9.1"
+@@ -2349,41 +2346,27 @@ dependencies = [
+ 
+ [[package]]
+ name = "nix"
+-version = "0.23.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+-dependencies = [
+- "bitflags 1.3.2",
+- "cc",
+- "cfg-if",
+- "libc",
+- "memoffset 0.6.5",
+-]
+-
+-[[package]]
+-name = "nix"
+-version = "0.26.4"
++version = "0.28.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
++checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+ dependencies = [
+- "bitflags 1.3.2",
++ "bitflags 2.5.0",
+  "cfg-if",
++ "cfg_aliases 0.1.1",
+  "libc",
+- "memoffset 0.7.1",
+- "pin-utils",
++ "memoffset 0.9.1",
+ ]
+ 
+ [[package]]
+ name = "nix"
+-version = "0.28.0"
++version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
++checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+ dependencies = [
+  "bitflags 2.5.0",
+  "cfg-if",
+- "cfg_aliases",
++ "cfg_aliases 0.2.1",
+  "libc",
+- "memoffset 0.9.1",
+ ]
+ 
+ [[package]]
+@@ -2438,13 +2421,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-derive"
+-version = "0.3.3"
++version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
++checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 1.0.96",
++ "syn 2.0.96",
+ ]
+ 
+ [[package]]
+@@ -3535,6 +3518,12 @@ version = "0.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+ 
++[[package]]
++name = "strsim"
++version = "0.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
++
+ [[package]]
+ name = "strum"
+ version = "0.20.0"
+@@ -3694,11 +3683,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "terminfo"
+-version = "0.8.0"
++version = "0.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
++checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+ dependencies = [
+- "dirs",
+  "fnv",
+  "nom",
+  "phf",
+@@ -3716,9 +3704,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "termwiz"
+-version = "0.22.0"
++version = "0.23.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1"
++checksum = "ed32af792ae81937cb8640b03eaef737408e5c8feee47b35e8b80c49bcb64524"
+ dependencies = [
+  "anyhow",
+  "base64 0.21.0",
+@@ -3732,18 +3720,16 @@ dependencies = [
+  "libc",
+  "log",
+  "memmem",
+- "nix 0.26.4",
++ "nix 0.28.0",
+  "num-derive",
+  "num-traits",
+  "ordered-float 4.2.0",
+  "pest",
+  "pest_derive",
+  "phf",
+- "semver 0.11.0",
+  "sha2",
+  "signal-hook",
+  "siphasher",
+- "tempfile",
+  "terminfo",
+  "termios",
+  "thiserror",
+@@ -3753,7 +3739,7 @@ dependencies = [
+  "wezterm-bidi",
+  "wezterm-blob-leases",
+  "wezterm-color-types",
+- "wezterm-dynamic 0.2.0",
++ "wezterm-dynamic 0.2.1",
+  "wezterm-input-types",
+  "winapi",
+ ]
+@@ -4656,7 +4642,7 @@ dependencies = [
+  "csscolorparser",
+  "deltae",
+  "lazy_static",
+- "wezterm-dynamic 0.2.0",
++ "wezterm-dynamic 0.2.1",
+ ]
+ 
+ [[package]]
+@@ -4667,29 +4653,29 @@ checksum = "a75e78c0cc60a76de5d93f9dad05651105351e151b6446ab305514945d7588aa"
+ dependencies = [
+  "log",
+  "ordered-float 3.3.0",
+- "strsim",
++ "strsim 0.10.0",
+  "thiserror",
+  "wezterm-dynamic-derive",
+ ]
+ 
+ [[package]]
+ name = "wezterm-dynamic"
+-version = "0.2.0"
++version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dfb128bacfa86734e07681fb6068e34c144698e84ee022d6e009145d1abb77b5"
++checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+ dependencies = [
+  "log",
+  "ordered-float 4.2.0",
+- "strsim",
++ "strsim 0.11.1",
+  "thiserror",
+  "wezterm-dynamic-derive",
+ ]
+ 
+ [[package]]
+ name = "wezterm-dynamic-derive"
+-version = "0.1.0"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0c9f5ef318442d07b3d071f9f43ea40b80992f87faee14bb4d017b6991c307f0"
++checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4705,7 +4691,7 @@ dependencies = [
+  "bitflags 1.3.2",
+  "euclid",
+  "lazy_static",
+- "wezterm-dynamic 0.2.0",
++ "wezterm-dynamic 0.2.1",
+ ]
+ 
+ [[package]]
+@@ -5254,7 +5240,7 @@ dependencies = [
+  "log",
+  "log4rs",
+  "miette",
+- "nix 0.23.1",
++ "nix 0.29.0",
+  "notify-debouncer-full",
+  "once_cell",
+  "openssl-sys",
+diff --git a/zellij-client/src/lib.rs b/zellij-client/src/lib.rs
+index 725ed8cd..1dacff98 100644
+--- a/zellij-client/src/lib.rs
++++ b/zellij-client/src/lib.rs
+@@ -11,6 +11,7 @@ mod stdin_handler;
+ use log::info;
+ use std::env::current_exe;
+ use std::io::{self, Write};
++use std::os::unix::io::AsFd;
+ use std::path::Path;
+ use std::process::Command;
+ use std::sync::{Arc, Mutex};
+@@ -187,7 +188,7 @@ pub fn start_client(
+     let take_snapshot = "\u{1b}[?1049h";
+     let bracketed_paste = "\u{1b}[?2004h";
+     let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+-    os_input.unset_raw_mode(0).unwrap();
++    os_input.unset_raw_mode(io::stdin().as_fd()).unwrap();
+ 
+     if !is_a_reconnect {
+         // we don't do this for a reconnect because our controlling terminal already has the
+@@ -215,7 +216,7 @@ pub fn start_client(
+         .theme_config(config_options.theme.as_ref())
+         .unwrap_or_else(|| os_input.load_palette().into());
+ 
+-    let full_screen_ws = os_input.get_terminal_size_using_fd(0);
++    let full_screen_ws = os_input.get_terminal_size_using_fd(io::stdin().as_fd());
+     let client_attributes = ClientAttributes {
+         size: full_screen_ws,
+         style: Style {
+@@ -286,7 +287,7 @@ pub fn start_client(
+ 
+     let mut command_is_executing = CommandIsExecuting::new();
+ 
+-    os_input.set_raw_mode(0);
++    os_input.set_raw_mode(io::stdin().as_fd());
+     let _ = os_input
+         .get_stdout_writer()
+         .write(bracketed_paste.as_bytes())
+@@ -307,7 +308,7 @@ pub fn start_client(
+         let send_client_instructions = send_client_instructions.clone();
+         let os_input = os_input.clone();
+         Box::new(move |info| {
+-            if let Ok(()) = os_input.unset_raw_mode(0) {
++            if let Ok(()) = os_input.unset_raw_mode(io::stdin().as_fd()) {
+                 handle_panic(info, &send_client_instructions);
+             }
+         })
+@@ -368,7 +369,7 @@ pub fn start_client(
+                         let os_api = os_input.clone();
+                         move || {
+                             os_api.send_to_server(ClientToServerMsg::TerminalResize(
+-                                os_api.get_terminal_size_using_fd(0),
++                                os_api.get_terminal_size_using_fd(io::stdin().as_fd()),
+                             ));
+                         }
+                     }),
+@@ -422,7 +423,7 @@ pub fn start_client(
+         .unwrap();
+ 
+     let handle_error = |backtrace: String| {
+-        os_input.unset_raw_mode(0).unwrap();
++        os_input.unset_raw_mode(io::stdin().as_fd()).unwrap();
+         let goto_start_of_last_line = format!("\u{1b}[{};{}H", full_screen_ws.rows, 1);
+         let restore_snapshot = "\u{1b}[?1049l";
+         os_input.disable_mouse().non_fatal();
+@@ -541,7 +542,7 @@ pub fn start_client(
+             },
+             ClientInstruction::QueryTerminalSize => {
+                 os_input.send_to_server(ClientToServerMsg::TerminalResize(
+-                    os_input.get_terminal_size_using_fd(0),
++                    os_input.get_terminal_size_using_fd(io::stdin().as_fd()),
+                 ));
+             },
+             ClientInstruction::WriteConfigToDisk { config } => {
+@@ -579,7 +580,7 @@ pub fn start_client(
+ 
+         os_input.disable_mouse().non_fatal();
+         info!("{}", exit_msg);
+-        os_input.unset_raw_mode(0).unwrap();
++        os_input.unset_raw_mode(io::stdin().as_fd()).unwrap();
+         let mut stdout = os_input.get_stdout_writer();
+         let exit_kitty_keyboard_mode = "\u{1b}[<1u";
+         if !explicitly_disable_kitty_keyboard_protocol {
+diff --git a/zellij-client/src/os_input_output.rs b/zellij-client/src/os_input_output.rs
+index 41d03b0f..c3fcb601 100644
+--- a/zellij-client/src/os_input_output.rs
++++ b/zellij-client/src/os_input_output.rs
+@@ -9,7 +9,7 @@ use nix::sys::termios;
+ use signal_hook::{consts::signal::*, iterator::Signals};
+ use std::io::prelude::*;
+ use std::io::IsTerminal;
+-use std::os::unix::io::RawFd;
++use std::os::unix::io::{AsRawFd, BorrowedFd};
+ use std::path::Path;
+ use std::sync::{Arc, Mutex};
+ use std::{io, thread, time};
+@@ -27,7 +27,7 @@ const ENABLE_MOUSE_SUPPORT: &str =
+ const DISABLE_MOUSE_SUPPORT: &str =
+     "\u{1b}[?1006l\u{1b}[?1015l\u{1b}[?1003l\u{1b}[?1002l\u{1b}[?1000l";
+ 
+-fn into_raw_mode(pid: RawFd) {
++fn into_raw_mode(pid: BorrowedFd) {
+     let mut tio = termios::tcgetattr(pid).expect("could not get terminal attribute");
+     termios::cfmakeraw(&mut tio);
+     match termios::tcsetattr(pid, termios::SetArg::TCSANOW, &tio) {
+@@ -36,11 +36,11 @@ fn into_raw_mode(pid: RawFd) {
+     };
+ }
+ 
+-fn unset_raw_mode(pid: RawFd, orig_termios: termios::Termios) -> Result<(), nix::Error> {
++fn unset_raw_mode(pid: BorrowedFd, orig_termios: termios::Termios) -> Result<(), nix::Error> {
+     termios::tcsetattr(pid, termios::SetArg::TCSANOW, &orig_termios)
+ }
+ 
+-pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> Size {
++pub(crate) fn get_terminal_size_using_fd(fd: BorrowedFd) -> Size {
+     // TODO: do this with the nix ioctl
+     use libc::ioctl;
+     use libc::TIOCGWINSZ;
+@@ -57,7 +57,7 @@ pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> Size {
+     // useless conversion.
+     #[allow(clippy::useless_conversion)]
+     unsafe {
+-        ioctl(fd, TIOCGWINSZ.into(), &mut winsize)
++        ioctl(fd.as_raw_fd(), TIOCGWINSZ.into(), &mut winsize)
+     };
+ 
+     // fallback to default values when rows/cols == 0: https://github.com/zellij-org/zellij/issues/1551
+@@ -89,13 +89,13 @@ pub struct ClientOsInputOutput {
+ /// Zellij client requires.
+ pub trait ClientOsApi: Send + Sync {
+     /// Returns the size of the terminal associated to file descriptor `fd`.
+-    fn get_terminal_size_using_fd(&self, fd: RawFd) -> Size;
++    fn get_terminal_size_using_fd(&self, fd: BorrowedFd) -> Size;
+     /// Set the terminal associated to file descriptor `fd` to
+     /// [raw mode](https://en.wikipedia.org/wiki/Terminal_mode).
+-    fn set_raw_mode(&mut self, fd: RawFd);
++    fn set_raw_mode(&mut self, fd: BorrowedFd);
+     /// Set the terminal associated to file descriptor `fd` to
+     /// [cooked mode](https://en.wikipedia.org/wiki/Terminal_mode).
+-    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), nix::Error>;
++    fn unset_raw_mode(&self, fd: BorrowedFd) -> Result<(), nix::Error>;
+     /// Returns the writer that allows writing to standard output.
+     fn get_stdout_writer(&self) -> Box<dyn io::Write>;
+     /// Returns a BufReader that allows to read from STDIN line by line, also locks STDIN
+@@ -130,13 +130,13 @@ pub trait ClientOsApi: Send + Sync {
+ }
+ 
+ impl ClientOsApi for ClientOsInputOutput {
+-    fn get_terminal_size_using_fd(&self, fd: RawFd) -> Size {
++    fn get_terminal_size_using_fd(&self, fd: BorrowedFd) -> Size {
+         get_terminal_size_using_fd(fd)
+     }
+-    fn set_raw_mode(&mut self, fd: RawFd) {
++    fn set_raw_mode(&mut self, fd: BorrowedFd) {
+         into_raw_mode(fd);
+     }
+-    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), nix::Error> {
++    fn unset_raw_mode(&self, fd: BorrowedFd) -> Result<(), nix::Error> {
+         match &self.orig_termios {
+             Some(orig_termios) => {
+                 let orig_termios = orig_termios.lock().unwrap();
+@@ -319,7 +319,7 @@ impl Clone for Box<dyn ClientOsApi> {
+ }
+ 
+ pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
+-    let current_termios = termios::tcgetattr(0).ok();
++    let current_termios = termios::tcgetattr(io::stdin()).ok();
+     let orig_termios = current_termios.map(|termios| Arc::new(Mutex::new(termios)));
+     let reading_from_stdin = Arc::new(Mutex::new(None));
+     Ok(ClientOsInputOutput {
+diff --git a/zellij-server/src/os_input_output.rs b/zellij-server/src/os_input_output.rs
+index 59c63bd6..c8feb674 100644
+--- a/zellij-server/src/os_input_output.rs
++++ b/zellij-server/src/os_input_output.rs
+@@ -1,6 +1,10 @@
+ use crate::{panes::PaneId, ClientId};
+ 
+-use async_std::{fs::File as AsyncFile, io::ReadExt, os::unix::io::FromRawFd};
++use async_std::{
++    fs::File as AsyncFile,
++    io::ReadExt,
++    os::unix::io::{AsRawFd, FromRawFd},
++};
+ use interprocess::local_socket::LocalSocketStream;
+ use nix::{
+     pty::{openpty, OpenptyResult, Winsize},
+@@ -34,8 +38,12 @@ use std::{
+     collections::{BTreeMap, BTreeSet, HashMap},
+     env,
+     fs::File,
++    io,
+     io::Write,
+-    os::unix::{io::RawFd, process::CommandExt},
++    os::unix::{
++        io::{AsFd, BorrowedFd, OwnedFd, RawFd},
++        process::CommandExt,
++    },
+     path::PathBuf,
+     process::{Child, Command},
+     sync::{Arc, Mutex},
+@@ -45,7 +53,7 @@ pub use async_trait::async_trait;
+ pub use nix::unistd::Pid;
+ 
+ fn set_terminal_size_using_fd(
+-    fd: RawFd,
++    fd: BorrowedFd,
+     columns: u16,
+     rows: u16,
+     width_in_pixels: Option<u16>,
+@@ -68,7 +76,7 @@ fn set_terminal_size_using_fd(
+     // useless conversion.
+     #[allow(clippy::useless_conversion)]
+     unsafe {
+-        ioctl(fd, TIOCSWINSZ.into(), &winsize)
++        ioctl(fd.as_raw_fd(), TIOCSWINSZ.into(), &winsize)
+     };
+ }
+ 
+@@ -155,7 +163,7 @@ fn handle_openpty(
+     cmd: RunCommand,
+     quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+     terminal_id: u32,
+-) -> Result<(RawFd, RawFd)> {
++) -> Result<(OwnedFd, i32)> {
+     let err_context = |cmd: &RunCommand| {
+         format!(
+             "failed to open PTY for command '{}'",
+@@ -165,7 +173,7 @@ fn handle_openpty(
+ 
+     // primary side of pty and child fd
+     let pid_primary = open_pty_res.master;
+-    let pid_secondary = open_pty_res.slave;
++    let pid_secondary = open_pty_res.slave.as_raw_fd();
+ 
+     if command_exists(&cmd) {
+         let mut child = unsafe {
+@@ -224,7 +232,7 @@ fn handle_terminal(
+     orig_termios: Option<termios::Termios>,
+     quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
+     terminal_id: u32,
+-) -> Result<(RawFd, RawFd)> {
++) -> Result<(OwnedFd, i32)> {
+     let err_context = || "failed to spawn child terminal".to_string();
+ 
+     // Create a pipe to allow the child the communicate the shell's pid to its
+@@ -236,7 +244,7 @@ fn handle_terminal(
+                 handle_terminal(failover_cmd, None, orig_termios, quit_cb, terminal_id)
+                     .with_context(err_context)
+             },
+-            None => Err::<(i32, i32), _>(e)
++            None => Err::<(OwnedFd, i32), _>(e)
+                 .context("failed to start pty")
+                 .with_context(err_context)
+                 .to_log(),
+@@ -283,7 +291,7 @@ fn spawn_terminal(
+     quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit_status
+     default_editor: Option<PathBuf>,
+     terminal_id: u32,
+-) -> Result<(RawFd, RawFd)> {
++) -> Result<(OwnedFd, i32)> {
+     // returns the terminal_id, the primary fd and the
+     // secondary fd
+     let mut failover_cmd_args = None;
+@@ -421,7 +429,7 @@ impl ClientSender {
+ pub struct ServerOsInputOutput {
+     orig_termios: Arc<Mutex<Option<termios::Termios>>>,
+     client_senders: Arc<Mutex<HashMap<ClientId, ClientSender>>>,
+-    terminal_id_to_raw_fd: Arc<Mutex<BTreeMap<u32, Option<RawFd>>>>, // A value of None means the
++    terminal_id_to_raw_fd: Arc<Mutex<BTreeMap<u32, Option<OwnedFd>>>>, // A value of None means the
+     // terminal_id exists but is
+     // not connected to an fd (eg.
+     // a command pane with a
+@@ -476,7 +484,7 @@ pub trait ServerOsApi: Send + Sync {
+         terminal_action: TerminalAction,
+         quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+         default_editor: Option<PathBuf>,
+-    ) -> Result<(u32, RawFd, RawFd)>;
++    ) -> Result<(u32, OwnedFd, i32)>;
+     // reserves a terminal id without actually opening a terminal
+     fn reserve_terminal_id(&self) -> Result<u32> {
+         unimplemented!()
+@@ -521,7 +529,7 @@ pub trait ServerOsApi: Send + Sync {
+         terminal_id: u32,
+         run_command: RunCommand,
+         quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+-    ) -> Result<(RawFd, RawFd)>;
++    ) -> Result<(OwnedFd, i32)>;
+     fn clear_terminal_id(&self, terminal_id: u32) -> Result<()>;
+     fn cache_resizes(&mut self) {}
+     fn apply_cached_resizes(&mut self) {}
+@@ -556,7 +564,13 @@ impl ServerOsApi for ServerOsInputOutput {
+         {
+             Some(Some(fd)) => {
+                 if cols > 0 && rows > 0 {
+-                    set_terminal_size_using_fd(*fd, cols, rows, width_in_pixels, height_in_pixels);
++                    set_terminal_size_using_fd(
++                        (*fd).as_fd(),
++                        cols,
++                        rows,
++                        width_in_pixels,
++                        height_in_pixels,
++                    );
+                 }
+             },
+             _ => {
+@@ -573,7 +587,7 @@ impl ServerOsApi for ServerOsInputOutput {
+         terminal_action: TerminalAction,
+         quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+         default_editor: Option<PathBuf>,
+-    ) -> Result<(u32, RawFd, RawFd)> {
++    ) -> Result<(u32, OwnedFd, i32)> {
+         let err_context = || "failed to spawn terminal".to_string();
+ 
+         let orig_termios = self
+@@ -610,7 +624,7 @@ impl ServerOsApi for ServerOsInputOutput {
+                     self.terminal_id_to_raw_fd
+                         .lock()
+                         .to_anyhow()?
+-                        .insert(terminal_id, Some(pid_primary));
++                        .insert(terminal_id, Some(pid_primary.try_clone()?));
+                     Ok((terminal_id, pid_primary, pid_secondary))
+                 })
+                 .with_context(err_context)
+@@ -661,7 +675,7 @@ impl ServerOsApi for ServerOsInputOutput {
+             .with_context(err_context)?
+             .get(&terminal_id)
+         {
+-            Some(Some(fd)) => unistd::write(*fd, buf).with_context(err_context),
++            Some(Some(fd)) => unistd::write(fd, buf).with_context(err_context),
+             _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
+         }
+     }
+@@ -675,7 +689,7 @@ impl ServerOsApi for ServerOsInputOutput {
+             .with_context(err_context)?
+             .get(&terminal_id)
+         {
+-            Some(Some(fd)) => termios::tcdrain(*fd).with_context(err_context),
++            Some(Some(fd)) => termios::tcdrain(fd).with_context(err_context),
+             _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
+         }
+     }
+@@ -816,7 +830,7 @@ impl ServerOsApi for ServerOsInputOutput {
+         terminal_id: u32,
+         run_command: RunCommand,
+         quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+-    ) -> Result<(RawFd, RawFd)> {
++    ) -> Result<(OwnedFd, i32)> {
+         let default_editor = None; // no need for a default editor when running an explicit command
+         self.orig_termios
+             .lock()
+@@ -834,7 +848,7 @@ impl ServerOsApi for ServerOsInputOutput {
+                 self.terminal_id_to_raw_fd
+                     .lock()
+                     .to_anyhow()?
+-                    .insert(terminal_id, Some(pid_primary));
++                    .insert(terminal_id, Some(pid_primary.try_clone()?));
+                 Ok((pid_primary, pid_secondary))
+             })
+             .with_context(|| format!("failed to rerun command in terminal id {}", terminal_id))
+@@ -877,7 +891,7 @@ impl Clone for Box<dyn ServerOsApi> {
+ }
+ 
+ pub fn get_server_os_input() -> Result<ServerOsInputOutput, nix::Error> {
+-    let current_termios = termios::tcgetattr(0).ok();
++    let current_termios = termios::tcgetattr(io::stdin()).ok();
+     if current_termios.is_none() {
+         log::warn!("Starting a server without a controlling terminal, using the default termios configuration.");
+     }
+diff --git a/zellij-server/src/pty.rs b/zellij-server/src/pty.rs
+index 3bb5f227..78822ee3 100644
+--- a/zellij-server/src/pty.rs
++++ b/zellij-server/src/pty.rs
+@@ -10,7 +10,11 @@ use crate::{
+ };
+ use async_std::task::{self, JoinHandle};
+ use std::sync::Arc;
+-use std::{collections::HashMap, os::unix::io::RawFd, path::PathBuf};
++use std::{
++    collections::HashMap,
++    os::unix::io::{IntoRawFd, OwnedFd, RawFd},
++    path::PathBuf,
++};
+ use zellij_utils::nix::unistd::Pid;
+ use zellij_utils::{
+     async_std,
+@@ -985,7 +989,7 @@ impl Pty {
+                 }
+             }
+         });
+-        let (terminal_id, pid_primary, child_fd): (u32, RawFd, RawFd) = self
++        let (terminal_id, pid_primary, child_fd): (u32, OwnedFd, RawFd) = self
+             .bus
+             .os_input
+             .as_mut()
+@@ -994,6 +998,7 @@ impl Pty {
+                 os_input.spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())
+             })
+             .with_context(err_context)?;
++        let pid_primary = pid_primary.into_raw_fd();
+         let terminal_bytes = task::spawn({
+             let err_context =
+                 |terminal_id: u32| format!("failed to run async task for terminal {terminal_id}");
+@@ -1233,7 +1238,7 @@ impl Pty {
+                                 terminal_id,
+                                 starts_held,
+                                 Some(command.clone()),
+-                                Ok(pid_primary),
++                                Ok(pid_primary.into_raw_fd()),
+                             )))
+                         },
+                         Err(err) => {
+@@ -1261,7 +1266,12 @@ impl Pty {
+                 {
+                     Ok((terminal_id, pid_primary, child_fd)) => {
+                         self.id_to_child_pid.insert(terminal_id, child_fd);
+-                        Ok(Some((terminal_id, starts_held, None, Ok(pid_primary))))
++                        Ok(Some((
++                            terminal_id,
++                            starts_held,
++                            None,
++                            Ok(pid_primary.into_raw_fd()),
++                        )))
+                     },
+                     Err(err) => match err.downcast_ref::<ZellijError>() {
+                         Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+@@ -1292,7 +1302,12 @@ impl Pty {
+                 {
+                     Ok((terminal_id, pid_primary, child_fd)) => {
+                         self.id_to_child_pid.insert(terminal_id, child_fd);
+-                        Ok(Some((terminal_id, starts_held, None, Ok(pid_primary))))
++                        Ok(Some((
++                            terminal_id,
++                            starts_held,
++                            None,
++                            Ok(pid_primary.into_raw_fd()),
++                        )))
+                     },
+                     Err(err) => match err.downcast_ref::<ZellijError>() {
+                         Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+@@ -1315,7 +1330,12 @@ impl Pty {
+                 {
+                     Ok((terminal_id, pid_primary, child_fd)) => {
+                         self.id_to_child_pid.insert(terminal_id, child_fd);
+-                        Ok(Some((terminal_id, starts_held, None, Ok(pid_primary))))
++                        Ok(Some((
++                            terminal_id,
++                            starts_held,
++                            None,
++                            Ok(pid_primary.into_raw_fd()),
++                        )))
+                     },
+                     Err(err) => match err.downcast_ref::<ZellijError>() {
+                         Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+@@ -1420,7 +1440,7 @@ impl Pty {
+                         }
+                     }
+                 });
+-                let (pid_primary, child_fd): (RawFd, RawFd) = self
++                let (pid_primary, child_fd): (OwnedFd, RawFd) = self
+                     .bus
+                     .os_input
+                     .as_mut()
+@@ -1429,6 +1449,7 @@ impl Pty {
+                         os_input.re_run_command_in_terminal(id, run_command, quit_cb)
+                     })
+                     .with_context(err_context)?;
++                let pid_primary = pid_primary.into_raw_fd();
+                 let terminal_bytes = task::spawn({
+                     let err_context =
+                         |pane_id| format!("failed to run async task for pane {pane_id:?}");
+diff --git a/zellij-utils/Cargo.toml b/zellij-utils/Cargo.toml
+index 6e51c27d..1098a202 100644
+--- a/zellij-utils/Cargo.toml
++++ b/zellij-utils/Cargo.toml
+@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
+ libc = "0.2"
+ log = "0.4.17"
+ miette = { version = "5.7.0", features = ["fancy"] }
+-nix = "0.23.1"
++nix = { version = "0.29.0", features = ["fs", "process", "signal", "term", "user"] }
+ once_cell = "1.8.0"
+ percent-encoding = "2.1.0"
+ prost = "0.11.9"
+@@ -47,7 +47,7 @@ vte = { version = "0.11.0", default-features = false }
+ 
+ #[cfg(not(target_family = "wasm"))]
+ [target.'cfg(not(target_family = "wasm"))'.dependencies]
+-termwiz = "0.22"
++termwiz = "0.23"
+ log4rs = "1.2.0"
+ signal-hook = "0.3"
+ interprocess = "1.2.1"
+-- 
+2.49.0
+

--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.41.2
+VER=0.42.0
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.42.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.42.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
