### PR TITLE
git: fix default editor setting

### DIFF
--- a/app-vcs/git/01-git-core/defines
+++ b/app-vcs/git/01-git-core/defines
@@ -27,5 +27,8 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
 ABTYPE=meson
-MESON_AFTER="-Dcontrib=completion,contacts,subtree \
-             -Ddocs=man,html"
+MESON_AFTER=(
+    '-Dcontrib=completion,contacts,subtree'
+    '-Ddocs=man,html'
+    '-Ddefault_editor=/usr/bin/editor'
+)

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,7 +1,7 @@
 VER=2.49.0
 
 # Use this for stable releases.
-REL=1
+REL=2
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- git: fix default editor setting
    Upstream defaults to hard-coded vi, but we want to make it user-
    configurable via the /usr/bin/editor alternative entry. This was also the
    previous behaviour when we built with Makefile.

Package(s) Affected
-------------------

- git: 2.49.0-2
- git-gui: 2.49.0-2
- gitk: 2.49.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
