### PR TITLE
aosc-os-presets-wsl: disable systemd-networkd-wait-online.service

### DIFF
--- a/runtime-data/aosc-os-presets-wsl/autobuild/build
+++ b/runtime-data/aosc-os-presets-wsl/autobuild/build
@@ -25,4 +25,7 @@ disable systemd-tmpfiles-setup-dev-early.service
 disable systemd-tmpfiles-setup-dev.service
 disable tmp.mount
 
+# https://github.com/microsoft/WSL/blob/cbc6694cf5712426918bd82569085e2fa2e1cefd/distributions/validate-modern.py#L26C30-L26C66
+disable systemd-networkd-wait-online.service
+
 EOF

--- a/runtime-data/aosc-os-presets-wsl/spec
+++ b/runtime-data/aosc-os-presets-wsl/spec
@@ -1,2 +1,2 @@
-VER=2
+VER=3
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-presets-wsl: disable systemd-networkd-wait-online.service

Package(s) Affected
-------------------

- aosc-os-presets-wsl: 3

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-presets-wsl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
