### PR TITLE
telegram-desktop: enable video hardware acceleration by default

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From 3de3bd71c8a3166baef2413b86e3162c40160a3a Mon Sep 17 00:00:00 2001
+From 59c619ef3cba0a3ce3a78a7a3bacb0ffebadd722 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 01/10] fix(window.style): set default window width to 360px
@@ -31,5 +31,5 @@ index acdda31299..899bcb5827 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From 07141a7a05fb2a4721e605bd008c5274b76f0638 Mon Sep 17 00:00:00 2001
+From f707653d709cbe0b7c1843c4f16a1f51c34634be Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 02/10] fix(core_settings.h): use system window decoration by
@@ -22,5 +22,5 @@ index 91da7945a2..0c9713ed87 100644
  	rpl::variable<bool> _systemDarkModeEnabled = true;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 8f6357bc009615067fa8658d28f04aee87e1fdd0 Mon Sep 17 00:00:00 2001
+From bb0c2a8c91ba06f30f4b4e28fd1a3afa3a19a106 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 03/10] fix(ui): fix build with Qt 5
@@ -68,5 +68,5 @@ index 24274c3794..a57c4fab1f 100644
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From 953db0b24af2735ae5d799ba946d4b317452622a Mon Sep 17 00:00:00 2001
+From 097519b78b21614e0214f978746e5ba3f907f32f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 04/10] fix(core/launcher.cpp): revert to old HiDPI handling
@@ -28,5 +28,5 @@ index 312ce96673..7a445f2c8e 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From 17c0e1a4e2c38e6964fc5823856ef056cf3d5095 Mon Sep 17 00:00:00 2001
+From 223cab8bbf903ccbf3d74cb9c5f386277aa0b28c Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 05/10] fix(settings): use system fonts by default
@@ -29,5 +29,5 @@ index 0c9713ed87..6b1138d6fb 100644
  	std::optional<bool> _weatherInCelsius;
  	QByteArray _tonsiteStorageToken;
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From cae410280b5125b3293bc8ab8571f2312fdf9da4 Mon Sep 17 00:00:00 2001
+From 88dbf9dcbec1b2c385dfbeceeaa84ff9a006741f Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 06/10] Remove the confusing "Default" option from selectable
@@ -45,5 +45,5 @@ index 97f65b65d9..9eff4830c3 100644
  		std::swap(result[2], *nowIt);
  		++skip;
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From e78e9bca69777e82ea36963a7154134ce8eb0c73 Mon Sep 17 00:00:00 2001
+From e0bf997ed98b81fa41c97e4f584b8f6049e5f669 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 07/10] fix(lib_tl): add missing cstring include
@@ -21,5 +21,5 @@ index 5eadf62a93..961f7febe0 100644
  
  namespace tl {
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From 25e92738b6a59ad59122129323730d14930e88aa Mon Sep 17 00:00:00 2001
+From a19e5e7ba13485009d7f040ea8ae78017e5e378d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 08/10] fix(lib_webview): add missing cstdint include
@@ -21,5 +21,5 @@ index 4a92fe3020..3cf6125358 100644
  #include <rpl/never.h>
  #include <rpl/producer.h>
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,4 +1,4 @@
-From 4fcaca77811aee80f46b05d4ff73ba23cd6810b4 Mon Sep 17 00:00:00 2001
+From c85442ce847996bfc29a3772fb8f1dfeae1ede7d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
 Subject: [PATCH 09/10] fix(current_geo_location_linux): add missing
@@ -22,5 +22,5 @@ index 7015af7398..d48fc7025a 100644
  namespace Platform {
  namespace {
 -- 
-2.48.1
+2.49.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,0 +1,30 @@
+From cbf5173eeb6497a6641f4786b15e31f7fdffa85f Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Wed, 19 Mar 2025 21:30:27 -0700
+Subject: [PATCH 10/10] fix(core_settings.h): enable video hardware
+ acceleration by default
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Telegram/SourceFiles/core/core_settings.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
+index 6b1138d6fb..2a66db1a26 100644
+--- a/Telegram/SourceFiles/core/core_settings.h
++++ b/Telegram/SourceFiles/core/core_settings.h
+@@ -1049,11 +1049,7 @@ private:
+ 	rpl::variable<Media::OrderMode> _playerOrderMode;
+ 	bool _macWarnBeforeQuit = true;
+ 	std::vector<uint64> _accountsOrder;
+-#ifdef Q_OS_MAC
+ 	bool _hardwareAcceleratedVideo = true;
+-#else // Q_OS_MAC
+-	bool _hardwareAcceleratedVideo = false;
+-#endif // Q_OS_MAC
+ 	HistoryView::DoubleClickQuickAction _chatQuickAction
+ 		= HistoryView::DoubleClickQuickAction();
+ 	bool _translateButtonEnabled = false;
+-- 
+2.49.0
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.12.3
+REL=1
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=be39b8c8d0db1f377118f813f0c4bd331d341d5e
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: enable video hardware acceleration by default
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- telegram-desktop: 5.12.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
