### PR TITLE
xdg-desktop-portal-termfilechooser: new, 1.0.0

### DIFF
--- a/app-admin/xdg-desktop-portal-termfilechooser/autobuild/defines
+++ b/app-admin/xdg-desktop-portal-termfilechooser/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=xdg-desktop-portal-termfilechooser
+PKGSEC=admin
+PKGDEP="dbus xdg-desktop-portal systemd inih"
+BUILDDEP="scdoc"
+PKGRECOM="yazi foot"
+PKGSUG="nnn ranger vifm yazi"
+PKGDES="A xdg-desktop-portal backend for choosing files with a terminal file manager"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dsd-bus-provider=libsystemd'
+    '-Dsystemd=enabled'
+    '-Dman-pages=enabled'
+)

--- a/app-admin/xdg-desktop-portal-termfilechooser/autobuild/patches/0001-fix-allocate-null-terminator-for-empty-config_path.patch
+++ b/app-admin/xdg-desktop-portal-termfilechooser/autobuild/patches/0001-fix-allocate-null-terminator-for-empty-config_path.patch
@@ -1,0 +1,27 @@
+From 9ac31aaef99f6256a071cc14832567e5aff0b4fa Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Wed, 19 Mar 2025 23:23:41 -0700
+Subject: [PATCH] fix: allocate null terminator for empty config_path
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/core/config.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/core/config.c b/src/core/config.c
+index 663a8f3..fd2cd4d 100644
+--- a/src/core/config.c
++++ b/src/core/config.c
+@@ -241,7 +241,8 @@ static void init_wrapper_path(struct environment *env,
+             *last_slash = '\0';
+         }
+     } else {
+-        config_path = "";
++        config_path = malloc(1);
++        *config_path = '\0';
+     }
+ 
+     const char *const wrapper_paths =
+-- 
+2.49.0
+

--- a/app-admin/xdg-desktop-portal-termfilechooser/spec
+++ b/app-admin/xdg-desktop-portal-termfilechooser/spec
@@ -1,0 +1,4 @@
+VER=1.0.0
+SRCS="git::commit=tags/v$VER::https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377242"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal-termfilechooser: new, 1.0.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- xdg-desktop-portal-termfilechooser: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal-termfilechooser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
