### PR TITLE
msmtp: new, 1.8.28

### DIFF
--- a/app-web/msmtp/autobuild/beyond
+++ b/app-web/msmtp/autobuild/beyond
@@ -1,0 +1,12 @@
+abinfo "Installing msmtp vendored scripts..."
+install -Dvm755 "${SRCDIR}"/scripts/find_alias/find_alias_for_msmtp.sh -t "${PKGDIR}"/usr/share/msmtp/scripts/find_alias/
+install -Dvm755 "${SRCDIR}"/scripts/msmtpq/msmtpq -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpq/
+install -Dvm755 "${SRCDIR}"/scripts/msmtpq/msmtp-queue -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpq/
+install -Dvm644 "${SRCDIR}"/scripts/msmtpq/README.msmtpq -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpq/
+install -Dvm755 "${SRCDIR}"/scripts/msmtpqueue/msmtp-enqueue.sh -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpqueue/
+install -Dvm755 "${SRCDIR}"/scripts/msmtpqueue/msmtp-listqueue.sh -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpqueue/
+install -Dvm755 "${SRCDIR}"/scripts/msmtpqueue/msmtp-runqueue.sh -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpqueue/
+install -Dvm644 "${SRCDIR}"/scripts/msmtpqueue/ChangeLog -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpqueue/
+install -Dvm644 "${SRCDIR}"/scripts/msmtpqueue/README -t "${PKGDIR}"/usr/share/msmtp/scripts/msmtpqueue/
+install -Dvm644 "${SRCDIR}"/scripts/vim/ftdetect/msmtp.vim -t "${PKGDIR}"/usr/share/vim/vimfiles/ftdetect/
+install -Dvm644 "${SRCDIR}"/scripts/vim/syntax/msmtp.vim -t "${PKGDIR}"/usr/share/vim/vimfiles/syntax/

--- a/app-web/msmtp/autobuild/defines
+++ b/app-web/msmtp/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=msmtp
+PKGSEC=mail
+PKGDES="An SMTP client"
+PKGDEP="gnutls gsasl libidn2 libsecret"
+PKGSUG="libnotify netcat"
+BUILDDEP="texinfo"

--- a/app-web/msmtp/spec
+++ b/app-web/msmtp/spec
@@ -1,0 +1,4 @@
+VER=1.8.28
+SRCS="tbl::https://marlam.de/msmtp/releases/msmtp-${VER}.tar.xz"
+CHKSUMS="sha256::3a57f155f54e4860f7dd42138d9bea1af615b99dfab5ab4cd728fc8c09a647a4"
+CHKUPDATE="anitya::id=2024"

--- a/runtime-admin/gsasl/autobuild/patches/0001-BACKPORT-GSSAPI-server-Boundary-check-gss_wrap-token.patch
+++ b/runtime-admin/gsasl/autobuild/patches/0001-BACKPORT-GSSAPI-server-Boundary-check-gss_wrap-token.patch
@@ -1,0 +1,34 @@
+From 6352e8901697b14439a8239056fa9f45a559b16c Mon Sep 17 00:00:00 2001
+From: Simon Josefsson <simon@josefsson.org>
+Date: Fri, 15 Jul 2022 16:23:58 +0200
+Subject: [PATCH] BACKPORT: GSSAPI server: Boundary check gss_wrap token (read
+ OOB).
+
+This commit fixes CVE-2022-2469, a CVE that allows server-side
+read-out-of-bounds with malicious authenticated GSS-API client.
+
+Ref: https://nvd.nist.gov/vuln/detail/CVE-2022-2469
+
+(cherry-picked from commit 796e4197f696261c1f872d7576371232330bcc30)
+Signed-off-by: Lain "Fearyncess" Yang <fsf@live.com>
+---
+ gssapi/server.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gssapi/server.c b/gssapi/server.c
+index 4a5dfd7b..a93e454a 100644
+--- a/gssapi/server.c
++++ b/gssapi/server.c
+@@ -225,6 +225,9 @@ _gsasl_gssapi_server_step (Gsasl_session * sctx,
+          FALSE, and responds with the generated output_message.  The
+          client can then consider the server authenticated. */
+ 
++      if (bufdesc2.length < 4)
++	return GSASL_AUTHENTICATION_ERROR;
++
+       if ((((char *) bufdesc2.value)[0] & GSASL_QOP_AUTH) == 0)
+ 	{
+ 	  /* Integrity or privacy unsupported */
+-- 
+2.49.0
+

--- a/runtime-admin/gsasl/spec
+++ b/runtime-admin/gsasl/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.10.0
 SRCS="tbl::https://ftp.gnu.org/gnu/gsasl/libgsasl-$VER.tar.gz"
-CHKSUMS="sha256::19e2f90525c531010918c50bb1febef0d7115d620150cc66153b9ce73ff814e6"
+CHKSUMS="sha256::f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f"
 CHKUPDATE="anitya::id=1563"


### PR DESCRIPTION
Topic Description
-----------------

- gsasl: update to 1.10.0, fixes CVE-2022-2469
- msmtp: new, 1.8.28

Package(s) Affected
-------------------

- gsasl: 1.10.0
- msmtp: 1.8.28

Security Update?
----------------

Yes, CVE-2022-2469

Build Order
-----------

```
#buildit gsasl msmtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
