### PR TITLE
zenity: update to 4.0.5

### DIFF
--- a/desktop-gnome/zenity/autobuild/defines
+++ b/desktop-gnome/zenity/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=zenity
 PKGSEC=gnome
-PKGDEP="libnotify webkit2gtk"
-BUILDDEP="gtk-doc itstool yelp-tools"
+PKGDEP="libadwaita webkit2gtk"
+BUILDDEP="help2man itstool yelp-tools gtk-update-icon-cache"
 PKGDES="Display graphical dialog boxes from shell scripts"
 
-MESON_AFTER="-Dlibnotify=true \
-             -Dwebkitgtk=true"
+MESON_AFTER=(
+    '-Dwebkitgtk=true'
+    '-Dmanpage=true'
+)

--- a/desktop-gnome/zenity/spec
+++ b/desktop-gnome/zenity/spec
@@ -1,4 +1,4 @@
-VER=3.42.1
-SRCS="tbl::https://download.gnome.org/sources/zenity/${VER:0:4}/zenity-$VER.tar.xz"
-CHKSUMS="sha256::a08e0c8e626615ee2c23ff74628eba6f8b486875dd54371ca7e2d7605b72a87c"
+VER=4.0.5
+SRCS="tbl::https://download.gnome.org/sources/zenity/${VER:0:3}/zenity-$VER.tar.xz"
+CHKSUMS="sha256::8a3ffe7751bed497a758229ece07be9114ad4e46a066abae4e5f31d6da4c0e9e"
 CHKUPDATE="anitya::id=13165"


### PR DESCRIPTION
Topic Description
-----------------

- zenity: update to 4.0.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- zenity: 4.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit zenity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
