### PR TITLE
bili-sync: update to 2.5.0

### DIFF
--- a/app-multimedia/bili-sync/autobuild/beyond
+++ b/app-multimedia/bili-sync/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo "Installing license file ..."
-install -Dvm644 "$SRCDIR"/Licence \
-    "$PKGDIR"/usr/share/doc/${PKGNAME}/COPYING

--- a/app-multimedia/bili-sync/spec
+++ b/app-multimedia/bili-sync/spec
@@ -1,4 +1,4 @@
-VER=2.1.1
+VER=2.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/amtoaer/bili-sync"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373498"


### PR DESCRIPTION
Topic Description
-----------------

- bili-sync: update to 2.5.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- bili-sync: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bili-sync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
