### PR TITLE
[FLIGHT] linux-kernel-rc: test RDNA4 FP context patch

### DIFF
--- a/runtime-kernel/linux-kernel-rc/autobuild/patches/1001-drm-amd-display-Protect-FPU-in-dml21_copy.patch
+++ b/runtime-kernel/linux-kernel-rc/autobuild/patches/1001-drm-amd-display-Protect-FPU-in-dml21_copy.patch
@@ -1,0 +1,90 @@
+From 1de422646fea9e956b4cd110dd1c40f9b678e056 Mon Sep 17 00:00:00 2001
+From: Huacai Chen <chenhuacai@loongson.cn>
+Date: Thu, 27 Mar 2025 16:01:00 +0800
+Subject: [PATCH 1/3] drm/amd/display: Protect FPU in dml21_copy()
+
+Commit 7da55c27e76749b9 ("drm/amd/display: Remove incorrect FP context
+start") removes the FP context protection of dml2_create(), and it said
+"All the DC_FP_START/END should be used before call anything from DML2".
+
+However, dml21_copy() are not protected from their callers, causing such
+errors:
+
+ do_fpu invoked from kernel context![#1]:
+ CPU: 0 UID: 0 PID: 240 Comm: kworker/0:5 Not tainted 6.14.0-rc6+ #1
+ Workqueue: events work_for_cpu_fn
+ pc ffff80000318bd2c ra ffff80000315750c tp 9000000105910000 sp 9000000105913810
+ a0 0000000000000000 a1 0000000000000002 a2 900000013140d728 a3 900000013140d720
+ a4 0000000000000000 a5 9000000131592d98 a6 0000000000017ae8 a7 00000000001312d0
+ t0 9000000130751ff0 t1 ffff800003790000 t2 ffff800003790000 t3 9000000131592e28
+ t4 000000000004c6a8 t5 00000000001b7740 t6 0000000000023e38 t7 0000000000249f00
+ t8 0000000000000002 u0 0000000000000000 s9 900000012b010000 s0 9000000131400000
+ s1 9000000130751fd8 s2 ffff800003408000 s3 9000000130752c78 s4 9000000131592da8
+ s5 9000000131592120 s6 9000000130751ff0 s7 9000000131592e28 s8 9000000131400008
+    ra: ffff80000315750c dml2_top_soc15_initialize_instance+0x20c/0x300 [amdgpu]
+   ERA: ffff80000318bd2c mcg_dcn4_build_min_clock_table+0x14c/0x600 [amdgpu]
+  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
+  PRMD: 00000004 (PPLV0 +PIE -PWE)
+  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
+  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
+ ESTAT: 000f0000 [FPD] (IS= ECode=15 EsubCode=0)
+  PRID: 0014d010 (Loongson-64bit, Loongson-3C6000/S)
+ Process kworker/0:5 (pid: 240, threadinfo=00000000f1700428, task=0000000020d2e962)
+ Stack : 0000000000000000 0000000000000000 0000000000000000 9000000130751fd8
+         9000000131400000 ffff8000031574e0 9000000130751ff0 0000000000000000
+         9000000131592e28 0000000000000000 0000000000000000 0000000000000000
+         0000000000000000 0000000000000000 0000000000000000 0000000000000000
+         0000000000000000 0000000000000000 0000000000000000 0000000000000000
+         0000000000000000 0000000000000000 0000000000000000 f9175936df5d7fd2
+         900000012b00ff08 900000012b000000 ffff800003409000 ffff8000034a1780
+         90000001019634c0 900000012b000010 90000001307beeb8 90000001306b0000
+         0000000000000001 ffff8000031942b4 9000000130780000 90000001306c0000
+         9000000130780000 ffff8000031c276c 900000012b044bd0 ffff800003408000
+         ...
+ Call Trace:
+ [<ffff80000318bd2c>] mcg_dcn4_build_min_clock_table+0x14c/0x600 [amdgpu]
+ [<ffff800003157508>] dml2_top_soc15_initialize_instance+0x208/0x300 [amdgpu]
+ [<ffff8000031942b0>] dml21_create_copy+0x30/0x60 [amdgpu]
+ [<ffff8000031c2768>] dc_state_create_copy+0x68/0xe0 [amdgpu]
+ [<ffff800002e98ea0>] amdgpu_dm_init+0x8c0/0x2060 [amdgpu]
+ [<ffff800002e9a658>] dm_hw_init+0x18/0x60 [amdgpu]
+ [<ffff800002b0a738>] amdgpu_device_init+0x1938/0x27e0 [amdgpu]
+ [<ffff800002b0ce80>] amdgpu_driver_load_kms+0x20/0xa0 [amdgpu]
+ [<ffff800002b008f0>] amdgpu_pci_probe+0x1b0/0x580 [amdgpu]
+ [<9000000003c7eae4>] local_pci_probe+0x44/0xc0
+ [<90000000032f2b18>] work_for_cpu_fn+0x18/0x40
+ [<90000000032f5da0>] process_one_work+0x160/0x300
+ [<90000000032f6718>] worker_thread+0x318/0x440
+ [<9000000003301b8c>] kthread+0x12c/0x220
+ [<90000000032b1484>] ret_from_kernel_thread+0x8/0xa4
+
+Unfortunately, protecting dml21_copy() out of DML2 causes "sleeping
+function called from invalid context", so protect them with DC_FP_START()
+and DC_FP_END() inside.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
+---
+ drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+index fb80ba9287b66..a6b8df1d96e80 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
++++ b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+@@ -412,8 +412,12 @@ void dml21_copy(struct dml2_context *dst_dml_ctx,
+ 
+ 	dst_dml_ctx->v21.mode_programming.programming = dst_dml2_programming;
+ 
++	DC_FP_START();
++
+ 	/* need to initialize copied instance for internal references to be correct */
+ 	dml2_initialize_instance(&dst_dml_ctx->v21.dml_init);
++
++	DC_FP_END();
+ }
+ 
+ bool dml21_create_copy(struct dml2_context **dst_dml_ctx,
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel-rc/autobuild/patches/1002-drm-amd-display-Protect-FPU-in-dml2_init-dml21_init.patch
+++ b/runtime-kernel/linux-kernel-rc/autobuild/patches/1002-drm-amd-display-Protect-FPU-in-dml2_init-dml21_init.patch
@@ -1,0 +1,117 @@
+From 48265d954e46164004e4c8a8a668b952eddbfa9f Mon Sep 17 00:00:00 2001
+From: Huacai Chen <chenhuacai@loongson.cn>
+Date: Thu, 27 Mar 2025 14:41:50 +0800
+Subject: [PATCH 2/3] drm/amd/display: Protect FPU in dml2_init()/dml21_init()
+
+Commit 7da55c27e76749b9 ("drm/amd/display: Remove incorrect FP context
+start") removes the FP context protection of dml2_create(), and it said
+"All the DC_FP_START/END should be used before call anything from DML2".
+
+However, dml2_init()/dml21_init() are not protected from their callers,
+causing such errors:
+
+ do_fpu invoked from kernel context![#1]:
+ CPU: 0 UID: 0 PID: 239 Comm: kworker/0:5 Not tainted 6.14.0-rc6+ #2
+ Workqueue: events work_for_cpu_fn
+ pc ffff80000319de80 ra ffff80000319de5c tp 900000010575c000 sp 900000010575f840
+ a0 0000000000000000 a1 900000012f210130 a2 900000012f000000 a3 ffff80000357e268
+ a4 ffff80000357e260 a5 900000012ea52cf0 a6 0000000400000004 a7 0000012c00001388
+ t0 00001900000015e0 t1 ffff80000379d000 t2 0000000010624dd3 t3 0000006400000014
+ t4 00000000000003e8 t5 0000005000000018 t6 0000000000000020 t7 0000000f00000064
+ t8 000000000000002f u0 5f5e9200f8901912 s9 900000012d380010 s0 900000012ea51fd8
+ s1 900000012f000000 s2 9000000109296000 s3 0000000000000001 s4 0000000000001fd8
+ s5 0000000000000001 s6 ffff800003415000 s7 900000012d390000 s8 ffff800003211f80
+    ra: ffff80000319de5c dml21_apply_soc_bb_overrides+0x3c/0x960 [amdgpu]
+   ERA: ffff80000319de80 dml21_apply_soc_bb_overrides+0x60/0x960 [amdgpu]
+  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
+  PRMD: 00000004 (PPLV0 +PIE -PWE)
+  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
+  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
+ ESTAT: 000f0000 [FPD] (IS= ECode=15 EsubCode=0)
+  PRID: 0014d010 (Loongson-64bit, Loongson-3C6000/S)
+ Process kworker/0:5 (pid: 239, threadinfo=00000000927eadc6, task=000000008fd31682)
+ Stack : 00040dc000003164 0000000000000001 900000012f210130 900000012eabeeb8
+         900000012f000000 ffff80000319fe48 900000012f210000 900000012f210130
+         900000012f000000 900000012eabeeb8 0000000000000001 ffff8000031a0064
+         900000010575f9f0 900000012f210130 900000012eac0000 900000012ea80000
+         900000012f000000 ffff8000031cefc4 900000010575f9f0 ffff8000035859c0
+         ffff800003414000 900000010575fa78 900000012f000000 ffff8000031b4c50
+         0000000000000000 9000000101c9d700 9000000109c40000 5f5e9200f8901912
+         900000012d3c4bd0 900000012d3c5000 ffff8000034aed18 900000012d380010
+         900000012d3c4bd0 ffff800003414000 900000012d380000 ffff800002ea49dc
+         0000000000000001 900000012d3c6000 00000000ffffe423 0000000000010000
+         ...
+ Call Trace:
+ [<ffff80000319de80>] dml21_apply_soc_bb_overrides+0x60/0x960 [amdgpu]
+ [<ffff80000319fe44>] dml21_init+0xa4/0x280 [amdgpu]
+ [<ffff8000031a0060>] dml21_create+0x40/0x80 [amdgpu]
+ [<ffff8000031cefc0>] dc_state_create+0x100/0x160 [amdgpu]
+ [<ffff8000031b4c4c>] dc_create+0x44c/0x640 [amdgpu]
+ [<ffff800002ea49d8>] amdgpu_dm_init+0x3f8/0x2060 [amdgpu]
+ [<ffff800002ea6658>] dm_hw_init+0x18/0x60 [amdgpu]
+ [<ffff800002b16738>] amdgpu_device_init+0x1938/0x27e0 [amdgpu]
+ [<ffff800002b18e80>] amdgpu_driver_load_kms+0x20/0xa0 [amdgpu]
+ [<ffff800002b0c8f0>] amdgpu_pci_probe+0x1b0/0x580 [amdgpu]
+ [<900000000448eae4>] local_pci_probe+0x44/0xc0
+ [<9000000003b02b18>] work_for_cpu_fn+0x18/0x40
+ [<9000000003b05da0>] process_one_work+0x160/0x300
+ [<9000000003b06718>] worker_thread+0x318/0x440
+ [<9000000003b11b8c>] kthread+0x12c/0x220
+ [<9000000003ac1484>] ret_from_kernel_thread+0x8/0xa4
+
+Unfortunately, protecting dml2_init()/dml21_init() out of DML2 causes
+"sleeping function called from invalid context", so protect them with
+DC_FP_START() and DC_FP_END() inside.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
+---
+ drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c | 4 ++++
+ drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c        | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+index a6b8df1d96e80..bbc798e039f53 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
++++ b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+@@ -86,6 +86,8 @@ static void dml21_init(const struct dc *in_dc, struct dml2_context **dml_ctx, co
+ 	/* Store configuration options */
+ 	(*dml_ctx)->config = *config;
+ 
++	DC_FP_START();
++
+ 	/*Initialize SOCBB and DCNIP params */
+ 	dml21_initialize_soc_bb_params(&(*dml_ctx)->v21.dml_init, config, in_dc);
+ 	dml21_initialize_ip_params(&(*dml_ctx)->v21.dml_init, config, in_dc);
+@@ -96,6 +98,8 @@ static void dml21_init(const struct dc *in_dc, struct dml2_context **dml_ctx, co
+ 
+ 	/*Initialize DML21 instance */
+ 	dml2_initialize_instance(&(*dml_ctx)->v21.dml_init);
++
++	DC_FP_END();
+ }
+ 
+ bool dml21_create(const struct dc *in_dc, struct dml2_context **dml_ctx, const struct dml2_configuration_options *config)
+diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
+index 68b882d281959..fc551c63c9e84 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
++++ b/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
+@@ -776,11 +776,15 @@ static void dml2_init(const struct dc *in_dc, const struct dml2_configuration_op
+ 		break;
+ 	}
+ 
++	DC_FP_START();
++
+ 	initialize_dml2_ip_params(*dml2, in_dc, &(*dml2)->v20.dml_core_ctx.ip);
+ 
+ 	initialize_dml2_soc_bbox(*dml2, in_dc, &(*dml2)->v20.dml_core_ctx.soc);
+ 
+ 	initialize_dml2_soc_states(*dml2, in_dc, &(*dml2)->v20.dml_core_ctx.soc, &(*dml2)->v20.dml_core_ctx.states);
++
++	DC_FP_END();
+ }
+ 
+ bool dml2_create(const struct dc *in_dc, const struct dml2_configuration_options *config, struct dml2_context **dml2)
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel-rc/autobuild/patches/1003-drm-amd-display-Protect-FPU-in-dml2_validate-dml21_v.patch
+++ b/runtime-kernel/linux-kernel-rc/autobuild/patches/1003-drm-amd-display-Protect-FPU-in-dml2_validate-dml21_v.patch
@@ -1,0 +1,120 @@
+From 1a9cb47897ab147319bc2d63b849d87252e9b2e0 Mon Sep 17 00:00:00 2001
+From: Huacai Chen <chenhuacai@loongson.cn>
+Date: Thu, 27 Mar 2025 14:52:37 +0800
+Subject: [PATCH 3/3] drm/amd/display: Protect FPU in
+ dml2_validate()/dml21_validate()
+
+Commit 7da55c27e76749b9 ("drm/amd/display: Remove incorrect FP context
+start") removes the FP context protection of dml2_create(), and it said
+"All the DC_FP_START/END should be used before call anything from DML2".
+
+However, dml2_validate()/dml21_validate() are not protected from their
+callers, causing such errors:
+
+ do_fpu invoked from kernel context![#1]:
+ CPU: 10 UID: 0 PID: 331 Comm: kworker/10:1H Not tainted 6.14.0-rc6+ #4
+ Workqueue: events_highpri dm_irq_work_func [amdgpu]
+ pc ffff800003191eb0 ra ffff800003191e60 tp 9000000107a94000 sp 9000000107a975b0
+ a0 9000000140ce4910 a1 0000000000000000 a2 9000000140ce49b0 a3 9000000140ce49a8
+ a4 9000000140ce49a8 a5 0000000100000000 a6 0000000000000001 a7 9000000107a97660
+ t0 ffff800003790000 t1 9000000140ce5000 t2 0000000000000001 t3 0000000000000000
+ t4 0000000000000004 t5 0000000000000000 t6 0000000000000000 t7 0000000000000000
+ t8 0000000100000000 u0 ffff8000031a3b9c s9 9000000130bc0000 s0 9000000132400000
+ s1 9000000140ec0000 s2 9000000132400000 s3 9000000140ce0000 s4 90000000057f8b88
+ s5 9000000140ec0000 s6 9000000140ce4910 s7 0000000000000001 s8 9000000130d45010
+ ra: ffff800003191e60 dml21_map_dc_state_into_dml_display_cfg+0x40/0x1140 [amdgpu]
+   ERA: ffff800003191eb0 dml21_map_dc_state_into_dml_display_cfg+0x90/0x1140 [amdgpu]
+  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
+  PRMD: 00000004 (PPLV0 +PIE -PWE)
+  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
+  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
+ ESTAT: 000f0000 [FPD] (IS= ECode=15 EsubCode=0)
+  PRID: 0014d010 (Loongson-64bit, Loongson-3C6000/S)
+ Process kworker/10:1H (pid: 331, threadinfo=000000007bf9ddb0, task=00000000cc4ab9f3)
+ Stack : 0000000100000000 0000043800000780 0000000100000001 0000000100000001
+         0000000000000000 0000078000000000 0000000000000438 0000078000000000
+         0000000000000438 0000078000000000 0000000000000438 0000000100000000
+         0000000100000000 0000000100000000 0000000100000000 0000000100000000
+         0000000000000001 9000000140ec0000 9000000132400000 9000000132400000
+         ffff800003408000 ffff800003408000 9000000132400000 9000000140ce0000
+         9000000140ce0000 ffff800003193850 0000000000000001 9000000140ec0000
+         9000000132400000 9000000140ec0860 9000000140ec0738 0000000000000001
+         90000001405e8000 9000000130bc0000 9000000140ec02a8 ffff8000031b5db8
+         0000000000000000 0000043800000780 0000000000000003 ffff8000031b79cc
+         ...
+ Call Trace:
+ [<ffff800003191eb0>] dml21_map_dc_state_into_dml_display_cfg+0x90/0x1140 [amdgpu]
+ [<ffff80000319384c>] dml21_validate+0xcc/0x520 [amdgpu]
+ [<ffff8000031b8948>] dc_validate_global_state+0x2e8/0x460 [amdgpu]
+ [<ffff800002e94034>] create_validate_stream_for_sink+0x3d4/0x420 [amdgpu]
+ [<ffff800002e940e4>] amdgpu_dm_connector_mode_valid+0x64/0x240 [amdgpu]
+ [<900000000441d6b8>] drm_connector_mode_valid+0x38/0x80
+ [<900000000441d824>] __drm_helper_update_and_validate+0x124/0x3e0
+ [<900000000441ddc0>] drm_helper_probe_single_connector_modes+0x2e0/0x620
+ [<90000000044050dc>] drm_client_modeset_probe+0x23c/0x1780
+ [<9000000004420384>] __drm_fb_helper_initial_config_and_unlock+0x44/0x5a0
+ [<9000000004403acc>] drm_client_dev_hotplug+0xcc/0x140
+ [<ffff800002e9ab50>] handle_hpd_irq_helper+0x1b0/0x1e0 [amdgpu]
+ [<90000000038f5da0>] process_one_work+0x160/0x300
+ [<90000000038f6718>] worker_thread+0x318/0x440
+ [<9000000003901b8c>] kthread+0x12c/0x220
+ [<90000000038b1484>] ret_from_kernel_thread+0x8/0xa4
+
+Unfortunately, protecting dml2_validate()/dml21_validate() out of DML2
+causes "sleeping function called from invalid context", so protect them
+with DC_FP_START() and DC_FP_END() inside.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Huacai Chen <chenhuacai@loongson.cn>
+---
+ .../gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c    | 9 +++++++--
+ drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c       | 5 +++++
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+index bbc798e039f53..d124c38fbfd3e 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
++++ b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
+@@ -273,11 +273,16 @@ bool dml21_validate(const struct dc *in_dc, struct dc_state *context, struct dml
+ {
+ 	bool out = false;
+ 
++	DC_FP_START();
++
+ 	/* Use dml_validate_only for fast_validate path */
+-	if (fast_validate) {
++	if (fast_validate)
+ 		out = dml21_check_mode_support(in_dc, context, dml_ctx);
+-	} else
++	else
+ 		out = dml21_mode_check_and_programming(in_dc, context, dml_ctx);
++
++	DC_FP_END();
++
+ 	return out;
+ }
+ 
+diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
+index fc551c63c9e84..9cd140df132ae 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
++++ b/drivers/gpu/drm/amd/display/dc/dml2/dml2_wrapper.c
+@@ -732,11 +732,16 @@ bool dml2_validate(const struct dc *in_dc, struct dc_state *context, struct dml2
+ 		return out;
+ 	}
+ 
++	DC_FP_START();
++
+ 	/* Use dml_validate_only for fast_validate path */
+ 	if (fast_validate)
+ 		out = dml2_validate_only(context);
+ 	else
+ 		out = dml2_validate_and_build_resource(in_dc, context);
++
++	DC_FP_END();
++
+ 	return out;
+ }
+ 
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel-rc/spec
+++ b/runtime-kernel/linux-kernel-rc/spec
@@ -18,7 +18,7 @@ __VER="${VER}"
 # Use this for mainline RC releases.
 RC=3
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
-REL=0.${RC}c
+REL=0.${RC}f
 SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 
 # Use this for prepatch releases.


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel-rc: test RDNA4 FP context patch
    LoongArch does not implement kernel-space FP context and, with drm/amdgpu
    lacking proper boundary marking for FP context starts/ends, it causes
    freezes during boot with RDNA4.
    Further technical digest needed with successful testing.
    Link: https://lore.kernel.org/dri-devel/20250318111717.2161235-1-chenhuacai%2540loongson.cn/

Package(s) Affected
-------------------

- linux-kernel-rc-${__VER}: 6.14.0-0.3d

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-rc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
