### PR TITLE
[PREVIEW] clash-verge-rev: update to 2.2.1

### DIFF
--- a/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,7 +1,7 @@
-From 9839f37a776a7d8bd7f4e7af953f6267b2067755 Mon Sep 17 00:00:00 2001
+From 459c032239cd4974da4967192698177374788328 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
-Subject: [PATCH 01/18] feat(src/assets): add XDG .desktop entry
+Subject: [PATCH 01/19] feat(src/assets): add XDG .desktop entry
 
 ---
  src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++
@@ -29,5 +29,5 @@ index 00000000..1dc4106e
 +Comment=A graphical rule-based proxy manager
 +Comment[zh_CN]=图形化代理服务规则管理器
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,18 +1,18 @@
-From 2678d4cf37f7e179d471bc25d2bd6300dc8d0a70 Mon Sep 17 00:00:00 2001
+From 3721c0208311d976bc338f2f4aec0bde7aaaecee Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
-Subject: [PATCH 02/18] fix(tauri.conf.json): disable bundle distribution
+Subject: [PATCH 02/19] fix(tauri.conf.json): disable bundle distribution
 
 ---
  src-tauri/tauri.conf.json | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 223df551..ac45f544 100755
+index 39584e21..42a44d8b 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -1,7 +1,7 @@
- {
+@@ -2,7 +2,7 @@
+   "version": "2.2.1",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,
@@ -21,5 +21,5 @@ index 223df551..ac45f544 100755
      "icon": [
        "icons/32x32.png",
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,7 +1,7 @@
-From b7b72266eb909729b069af42a5a66982b220182b Mon Sep 17 00:00:00 2001
+From e22efa83be20ab20cab7a91c257e62747b9af951 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
-Subject: [PATCH 03/18] fix(scripts): use ABI2 (New-World) Mihomo binary for
+Subject: [PATCH 03/19] fix(scripts): use ABI2 (New-World) Mihomo binary for
  loongarch64
 
 Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)
@@ -24,5 +24,5 @@ index fd7a9cd0..1da884a5 100644
  
  // Fetch the latest alpha release version from the version.txt file
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
@@ -1,7 +1,7 @@
-From 6d30a0896dc8d706cbd64ae293a3bbaf82ce409a Mon Sep 17 00:00:00 2001
+From 654288bce63389139b220d56860f6c429b1db684 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
-Subject: [PATCH 04/18] feat: drop clash-meta-alpha support
+Subject: [PATCH 04/19] feat: drop clash-meta-alpha support
 
 ---
  src/components/setting/mods/clash-core-viewer.tsx | 1 -
@@ -20,5 +20,5 @@ index dbc69392..e3af7ae2 100644
  
  export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,7 +1,7 @@
-From c68b43fd3fc90da8ff3072216de7fc986e378ca2 Mon Sep 17 00:00:00 2001
+From e7ca2f3d2b9753da2af61c3c50de52063548bc16 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
-Subject: [PATCH 05/18] fix(check.mjs): do not fetch Mihomo (Clash Meta)
+Subject: [PATCH 05/19] fix(check.mjs): do not fetch Mihomo (Clash Meta)
  binaries
 
 We use a system copy for this purpose.
@@ -34,5 +34,5 @@ index 1da884a5..156035f9 100644
    { name: "service", func: resolveService, retry: 5 },
    { name: "install", func: resolveInstall, retry: 5 },
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,7 +1,7 @@
-From 2816bceb786c99a0a9867a7b337670eefb665a64 Mon Sep 17 00:00:00 2001
+From 0abd616bab1da45184efe01298c87e06c780c4ad Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
-Subject: [PATCH 06/18] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+Subject: [PATCH 06/19] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  Meta) bundling
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 06/18] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 2 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index ac45f544..53633fda 100755
+index 42a44d8b..8f196626 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -11,8 +11,6 @@
+@@ -12,8 +12,6 @@
        "icons/icon.ico"
      ],
      "resources": ["resources", "resources/locales/*"],
@@ -22,5 +22,5 @@ index ac45f544..53633fda 100755
      "category": "DeveloperTool",
      "shortDescription": "Clash Verge Rev",
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,7 +1,7 @@
-From d6ea89e96e09ea1c5e7159ac053a09be1cf7be5e Mon Sep 17 00:00:00 2001
+From 200b90cac4617a5d281f0f7540186dc0d7b29790 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:36:28 +0800
-Subject: [PATCH 07/18] fix(check.mjs): do not check Mihomo (Clash Meta)
+Subject: [PATCH 07/19] fix(check.mjs): do not check Mihomo (Clash Meta)
  platform support
 
 ---
@@ -35,5 +35,5 @@ index 156035f9..9a17ed90 100644
   * core info
   */
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
@@ -1,20 +1,20 @@
-From c8ba8cb2e7b593aa8a23f7760759d1d315e8bc00 Mon Sep 17 00:00:00 2001
+From b971cebf39ec56a2b9729677622b489ab40c0541 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:49:46 +0800
-Subject: [PATCH 08/18] Do not create any bundle package
+Subject: [PATCH 08/19] Do not create any bundle package
 
 ---
- src-tauri/tauri.linux.conf.json | 30 ------------------------------
- 1 file changed, 30 deletions(-)
+ src-tauri/tauri.linux.conf.json | 32 +-------------------------------
+ 1 file changed, 1 insertion(+), 31 deletions(-)
 
 diff --git a/src-tauri/tauri.linux.conf.json b/src-tauri/tauri.linux.conf.json
-index db6fa1a9..078896b6 100644
+index 398bff03..318d0af8 100644
 --- a/src-tauri/tauri.linux.conf.json
 +++ b/src-tauri/tauri.linux.conf.json
-@@ -1,36 +1,6 @@
+@@ -1,34 +1,4 @@
  {
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-   "identifier": "io.github.clash-verge-rev.clash-verge-rev",
+-  "identifier": "io.github.clash-verge-rev.clash-verge-rev",
 -  "bundle": {
 -    "targets": ["deb", "rpm"],
 -    "linux": {
@@ -44,10 +44,9 @@ index db6fa1a9..078896b6 100644
 -      "./sidecar/verge-mihomo",
 -      "./sidecar/verge-mihomo-alpha"
 -    ]
--  },
-   "app": {
-     "trayIcon": {
-       "iconPath": "icons/tray-icon.ico"
+-  }
++  "identifier": "io.github.clash-verge-rev.clash-verge-rev"
+ }
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
@@ -1,7 +1,7 @@
-From e062958f0aa3aca083c855e5e29cf36c10e19405 Mon Sep 17 00:00:00 2001
+From 1e38fd4386a5173f4f8c7044ad6c9a084b478bbe Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
-Subject: [PATCH 09/18] Drop check update feature
+Subject: [PATCH 09/19] Drop check update feature
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---
@@ -66,31 +66,32 @@ index 93f9c3b6..00000000
 -  );
 -};
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index e5d91ba5..b6f8898e 100644
+index aee48d76..0e5d03f8 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -8,7 +8,6 @@ import {
-   openLogsDir,
+@@ -9,7 +9,6 @@ import {
    openDevTools,
+   exportDiagnosticInfo,
  } from "@/services/cmds";
 -import { check as checkUpdate } from "@tauri-apps/plugin-updater";
  import { useVerge } from "@/hooks/use-verge";
  import { version } from "@root/package.json";
  import { DialogRef, Notice } from "@/components/base";
-@@ -18,7 +17,6 @@ import { HotkeyViewer } from "./mods/hotkey-viewer";
+@@ -19,7 +18,6 @@ import { HotkeyViewer } from "./mods/hotkey-viewer";
  import { MiscViewer } from "./mods/misc-viewer";
  import { ThemeViewer } from "./mods/theme-viewer";
  import { LayoutViewer } from "./mods/layout-viewer";
 -import { UpdateViewer } from "./mods/update-viewer";
  import { BackupViewer } from "./mods/backup-viewer";
+ import { LiteModeViewer } from "./mods/lite-mode-viewer";
  import { TooltipIcon } from "@/components/base/base-tooltip-icon";
- 
-@@ -35,21 +33,8 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -38,22 +36,9 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
 -  const updateRef = useRef<DialogRef>(null);
    const backupRef = useRef<DialogRef>(null);
+   const liteModeRef = useRef<DialogRef>(null);
  
 -  const onCheckUpdate = async () => {
 -    try {
@@ -105,17 +106,17 @@ index e5d91ba5..b6f8898e 100644
 -    }
 -  };
  
-   return (
-     <SettingList title={t("Verge Advanced Setting")}>
-@@ -58,7 +43,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+   const onExportDiagnosticInfo = useCallback(async () => {
+     await exportDiagnosticInfo();
+@@ -67,7 +52,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
 -      <UpdateViewer ref={updateRef} />
        <BackupViewer ref={backupRef} />
+       <LiteModeViewer ref={liteModeRef} />
  
-       <SettingItem
-@@ -92,8 +76,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -102,8 +86,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
  
        <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
  
@@ -125,7 +126,7 @@ index e5d91ba5..b6f8898e 100644
  
        <SettingItem
 diff --git a/src/components/setting/setting-verge-basic.tsx b/src/components/setting/setting-verge-basic.tsx
-index 5c8d1132..28465612 100644
+index 7666e9c8..03953279 100644
 --- a/src/components/setting/setting-verge-basic.tsx
 +++ b/src/components/setting/setting-verge-basic.tsx
 @@ -13,13 +13,12 @@ import { MiscViewer } from "./mods/misc-viewer";
@@ -160,7 +161,7 @@ index 5c8d1132..28465612 100644
  
        <SettingItem label={t("Language")}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index c5d6b048..b803bc8b 100644
+index b9a9eadf..6f5fcadd 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
 @@ -18,7 +18,6 @@ import { Notice } from "@/components/base";
@@ -171,7 +172,7 @@ index c5d6b048..b803bc8b 100644
  import { useCustomTheme } from "@/components/layout/use-custom-theme";
  import getSystem from "@/utils/get-system";
  import "dayjs/locale/ru";
-@@ -261,7 +260,6 @@ const Layout = () => {
+@@ -277,7 +276,6 @@ const Layout = () => {
                  />
                  <LogoSvg fill={isDark ? "white" : "black"} />
                </div>
@@ -180,5 +181,5 @@ index c5d6b048..b803bc8b 100644
  
              <List className="the-menu">
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
@@ -1,20 +1,20 @@
-From 498aee4e193179534459dd0eb1e80e266548a131 Mon Sep 17 00:00:00 2001
+From 5a420ae9da40dc69b37c136a08c41e23e2d59a11 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
-Subject: [PATCH 10/18] Set core binary name as mihomo
+Subject: [PATCH 10/19] Set core binary name as mihomo
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---
  scripts/check.mjs                             |  8 +++----
  scripts/portable-fixed-webview2.mjs           |  4 ++--
- scripts/portable.mjs                          |  4 ++--
+ scripts/portable.mjs                          |  7 +++---
  src-tauri/packages/windows/installer.nsi      | 24 +++++++++----------
  src-tauri/src/config/verge.rs                 |  2 +-
  src-tauri/src/core/core.rs                    |  6 ++---
  src-tauri/src/core/service.rs                 |  2 +-
  src-tauri/src/enhance/chain.rs                |  4 ++--
  .../setting/mods/clash-core-viewer.tsx        |  4 ++--
- 9 files changed, 29 insertions(+), 29 deletions(-)
+ 9 files changed, 31 insertions(+), 30 deletions(-)
 
 diff --git a/scripts/check.mjs b/scripts/check.mjs
 index 9a17ed90..9382fbd2 100644
@@ -58,15 +58,18 @@ index b3424fb5..b88550a4 100644
    zip.addLocalFolder(
      path.join(
 diff --git a/scripts/portable.mjs b/scripts/portable.mjs
-index 97a00d4a..5bfd2589 100644
+index 49aafdb9..ce35f689 100644
 --- a/scripts/portable.mjs
 +++ b/scripts/portable.mjs
-@@ -41,8 +41,8 @@ async function resolvePortable() {
+@@ -35,9 +35,10 @@ async function resolvePortable() {
+   }
    const zip = new AdmZip();
  
-   zip.addLocalFile(path.join(releaseDir, "Clash Verge.exe"));
+-  zip.addLocalFile(path.join(releaseDir, "clash-verge.exe"));
 -  zip.addLocalFile(path.join(releaseDir, "verge-mihomo.exe"));
 -  zip.addLocalFile(path.join(releaseDir, "verge-mihomo-alpha.exe"));
++
++  zip.addLocalFile(path.join(releaseDir, "Clash Verge.exe"));
 +  zip.addLocalFile(path.join(releaseDir, "mihomo.exe"));
 +  zip.addLocalFile(path.join(releaseDir, "mihomo-alpha.exe"));
    zip.addLocalFolder(path.join(releaseDir, "resources"), "resources");
@@ -125,10 +128,10 @@ index 8aab55fe..38d0d4ad 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index c416a4da..c664f8a0 100644
+index 26ad2368..7d536ec3 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
-@@ -238,7 +238,7 @@ impl IVerge {
+@@ -248,7 +248,7 @@ impl IVerge {
  
      pub fn template() -> Self {
          Self {
@@ -138,10 +141,19 @@ index c416a4da..c664f8a0 100644
              theme_mode: Some("system".into()),
              #[cfg(not(target_os = "windows"))]
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index 78d546b7..e3656c6d 100644
+index d1a666ee..319a69f4 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
-@@ -111,7 +111,7 @@ impl CoreManager {
+@@ -140,7 +140,7 @@ impl CoreManager {
+     /// 通过sidecar启动内核
+     async fn run_core_by_sidecar(&self, config_path: &PathBuf) -> Result<()> {
+         let clash_core = { Config::verge().latest().clash_core.clone() };
+-        let clash_core = clash_core.unwrap_or("verge-mihomo".into());
++        let clash_core = clash_core.unwrap_or("mihomo".into());
+ 
+         log::info!(target: "app", "starting core {} in sidecar mode", clash_core);
+ 
+@@ -199,7 +199,7 @@ impl CoreManager {
      /// 切换核心
      pub async fn change_core(&self, clash_core: Option<String>) -> Result<()> {
          let clash_core = clash_core.ok_or(anyhow::anyhow!("clash core is null"))?;
@@ -150,27 +162,20 @@ index 78d546b7..e3656c6d 100644
  
          if !CLASH_CORES.contains(&clash_core.as_str()) {
              bail!("invalid clash core name \"{clash_core}\"");
-@@ -177,7 +177,7 @@ impl CoreManager {
+@@ -276,7 +276,7 @@ impl CoreManager {
          println!("[core配置验证] 开始验证配置文件: {}", config_path);
-         
+ 
          let clash_core = { Config::verge().latest().clash_core.clone() };
 -        let clash_core = clash_core.unwrap_or("verge-mihomo".into());
 +        let clash_core = clash_core.unwrap_or("mihomo".into());
          println!("[core配置验证] 使用内核: {}", clash_core);
-         
+ 
          let app_handle = handle::Handle::global().app_handle().unwrap();
-@@ -477,4 +477,4 @@ impl CoreManager {
-             }
-         }
-     }
--}
-\ No newline at end of file
-+}
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 32d9b77b..7987c90c 100644
+index c58d994b..258391d6 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -229,7 +229,7 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
+@@ -241,7 +241,7 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
      }
  
      let clash_core = { Config::verge().latest().clash_core.clone() };
@@ -217,5 +222,5 @@ index e3af7ae2..ac0ba8e0 100644
    const onCoreChange = useLockFn(async (core: string) => {
      if (core === clash_core) return;
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
@@ -1,17 +1,17 @@
-From 9205c53fe462d2a55aab0133a7b224e320ad419d Mon Sep 17 00:00:00 2001
+From cb1c7ccc163ef4f622f45f38b3272855872b6cc7 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
-Subject: [PATCH 11/18] feat: always not portable
+Subject: [PATCH 11/19] feat: always not portable
 
 ---
  src-tauri/src/utils/dirs.rs | 10 ----------
  1 file changed, 10 deletions(-)
 
 diff --git a/src-tauri/src/utils/dirs.rs b/src-tauri/src/utils/dirs.rs
-index d4d8ddbf..b7e4c61d 100644
+index 72b70a2c..9ac4fda8 100644
 --- a/src-tauri/src/utils/dirs.rs
 +++ b/src-tauri/src/utils/dirs.rs
-@@ -23,16 +23,6 @@ pub static PROFILE_YAML: &str = "profiles.yaml";
+@@ -22,16 +22,6 @@ pub static PROFILE_YAML: &str = "profiles.yaml";
  
  /// init portable flag
  pub fn init_portable_flag() -> Result<()> {
@@ -29,5 +29,5 @@ index d4d8ddbf..b7e4c61d 100644
      Ok(())
  }
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
@@ -1,28 +1,28 @@
-From cc998c979ab07f4fa4c00cb73c30dd4428f857f2 Mon Sep 17 00:00:00 2001
+From c4ac58abb38076494bcbc7ffd4fc40dbb4b4f269 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:02:52 +0800
-Subject: [PATCH 12/18] find `mihomo` from `$PATH`
+Subject: [PATCH 12/19] find `mihomo` from `$PATH`
 
 ---
- src-tauri/Cargo.lock          | 15 ++++++++++++++-
- src-tauri/Cargo.toml          |  1 +
- src-tauri/src/core/service.rs | 11 ++++-------
- 3 files changed, 19 insertions(+), 8 deletions(-)
+ src-tauri/Cargo.lock          | 27 ++++++++++++++++++++++++++-
+ src-tauri/Cargo.toml          |  2 +-
+ src-tauri/src/core/service.rs | 13 ++++++-------
+ 3 files changed, 33 insertions(+), 9 deletions(-)
 
 diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index c03ed2e6..877ace4d 100644
+index e44b3c80..069a51a3 100644
 --- a/src-tauri/Cargo.lock
 +++ b/src-tauri/Cargo.lock
-@@ -1052,6 +1052,7 @@ dependencies = [
+@@ -1193,6 +1193,7 @@ dependencies = [
   "url",
   "users",
   "warp",
-+ "which 7.0.1",
++ "which 7.0.2",
   "window-shadows",
   "winreg 0.55.0",
   "zip",
-@@ -1927,6 +1928,12 @@ dependencies = [
-  "syn 2.0.98",
+@@ -2099,6 +2100,12 @@ dependencies = [
+  "regex",
  ]
  
 +[[package]]
@@ -32,9 +32,9 @@ index c03ed2e6..877ace4d 100644
 +checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 +
  [[package]]
- name = "equivalent"
- version = "1.0.1"
-@@ -5576,7 +5583,7 @@ checksum = "b96d6b6c505282b007a9b009f2aa38b2fd0359b81a0430ceacc60f69ade4c6a0"
+ name = "env_logger"
+ version = "0.11.7"
+@@ -6139,7 +6146,7 @@ checksum = "b96d6b6c505282b007a9b009f2aa38b2fd0359b81a0430ceacc60f69ade4c6a0"
  dependencies = [
   "libc",
   "security-framework-sys",
@@ -43,8 +43,27 @@ index c03ed2e6..877ace4d 100644
   "windows-sys 0.48.0",
  ]
  
-@@ -8867,6 +8874,12 @@ dependencies = [
-  "windows-sys 0.48.0",
+@@ -8886,6 +8893,18 @@ dependencies = [
+  "rustix 0.38.44",
+ ]
+ 
++[[package]]
++name = "which"
++version = "7.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
++dependencies = [
++ "either",
++ "env_home",
++ "rustix 0.38.44",
++ "winsafe",
++]
++
+ [[package]]
+ name = "wide"
+ version = "0.7.32"
+@@ -9590,6 +9609,12 @@ dependencies = [
+  "windows-sys 0.59.0",
  ]
  
 +[[package]]
@@ -54,34 +73,37 @@ index c03ed2e6..877ace4d 100644
 +checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 +
  [[package]]
- name = "winreg"
- version = "0.55.0"
+ name = "wit-bindgen-rt"
+ version = "0.39.0"
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 9dc321ae..683180bb 100755
+index 2b1c18a1..3121a215 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -67,6 +67,7 @@ getrandom = "0.2"
- tokio-tungstenite = "0.26.1"
- futures = "0.3"
- sys-locale = "0.3.1"
+@@ -72,7 +72,7 @@ async-trait = "0.1.87"
+ mihomo_api = { path = "src_crates/crate_mihomo_api" }
+ ab_glyph = "0.2.29"
+ tungstenite = "0.26.2"
+-
 +which = "7"
  
  [target.'cfg(windows)'.dependencies]
  runas = "=1.2.0"
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 7987c90c..93370c26 100644
+index 258391d6..213bf93a 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
+@@ -1,7 +1,9 @@
+ use crate::{config::Config, utils::dirs};
+ use anyhow::{bail, Context, Result};
  use serde::{Deserialize, Serialize};
- use std::collections::HashMap;
- use std::path::PathBuf;
--use std::{env::current_exe, process::Command as StdCommand};
+-use std::{collections::HashMap, env::current_exe, path::PathBuf, process::Command as StdCommand};
++use std::collections::HashMap;
++use std::path::PathBuf;
 +use std::process::Command as StdCommand;
  use tokio::time::Duration;
  
  // Windows only
-@@ -231,11 +231,6 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
+@@ -243,11 +245,6 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
      let clash_core = { Config::verge().latest().clash_core.clone() };
      let clash_core = clash_core.unwrap_or("mihomo".into());
  
@@ -93,7 +115,7 @@ index 7987c90c..93370c26 100644
      let config_dir = dirs::app_home_dir()?;
      let config_dir = dirs::path_to_str(&config_dir)?;
  
-@@ -244,9 +239,11 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
+@@ -256,9 +253,11 @@ pub(super) async fn run_core_by_service(config_file: &PathBuf) -> Result<()> {
  
      let config_file = dirs::path_to_str(config_file)?;
  
@@ -107,5 +129,5 @@ index 7987c90c..93370c26 100644
      map.insert("config_file", config_file);
      map.insert("log_file", log_path);
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,7 +1,7 @@
-From 370a2b93490b8cf1b19a9b25fb0b993b4af50a41 Mon Sep 17 00:00:00 2001
+From f86c29684bfd96ce282dffff7269e7609199dffa Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
-Subject: [PATCH 13/18] Set service install/uninstall script path to
+Subject: [PATCH 13/19] Set service install/uninstall script path to
  /usr/libexec
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 13/18] Set service install/uninstall script path to
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 93370c26..7ac1cb65 100644
+index 213bf93a..01bfc84a 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -89,11 +89,13 @@ pub async fn reinstall_service() -> Result<()> {
+@@ -88,11 +88,13 @@ pub async fn reinstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
  pub async fn reinstall_service() -> Result<()> {
      log::info!(target:"app", "reinstall service");
@@ -29,5 +29,5 @@ index 93370c26..7ac1cb65 100644
      if !install_path.exists() {
          bail!(format!("installer not found: {install_path:?}"));
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
@@ -1,17 +1,17 @@
-From a53e661b4bbd61d869f156d214187d2eb764f691 Mon Sep 17 00:00:00 2001
+From c31b0ca0733aea78f5a6467b7b1f829291a8ce33 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:52:29 +0800
-Subject: [PATCH 14/18] Unset all release profile
+Subject: [PATCH 14/19] Unset all release profile
 
 ---
  src-tauri/Cargo.toml | 7 -------
  1 file changed, 7 deletions(-)
 
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 683180bb..e36781a5 100755
+index 3121a215..dc619eed 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -91,13 +91,6 @@ default = ["custom-protocol"]
+@@ -95,13 +95,6 @@ default = ["custom-protocol"]
  custom-protocol = ["tauri/custom-protocol"]
  verge-dev = []
  
@@ -26,5 +26,5 @@ index 683180bb..e36781a5 100755
  incremental = true
  
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
@@ -1,7 +1,7 @@
-From d754625c9968552949145cd0129c18009d403778 Mon Sep 17 00:00:00 2001
+From 197b1b96dd39fee6764e2838ff0411f1f42ea563 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
-Subject: [PATCH 15/18] Do not use gcc
+Subject: [PATCH 15/19] Do not use gcc
 
 ---
  .cargo/config.toml | 5 -----
@@ -20,5 +20,5 @@ index beb596d4..00000000
 -[target.armv7-unknown-linux-gnueabihf]
 -linker = "arm-linux-gnueabihf-gcc"
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
@@ -1,7 +1,7 @@
-From 43764731bbebc642260dd93ca4c1e2eacf840459 Mon Sep 17 00:00:00 2001
+From 11d17189abce7a084b6476ae3d0a805e222434b1 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
-Subject: [PATCH 16/18] Drop "Upgrade core" button
+Subject: [PATCH 16/19] Drop "Upgrade core" button
 
 ---
  .../setting/mods/clash-core-viewer.tsx        | 25 +------------------
@@ -59,10 +59,10 @@ index ac0ba8e0..b27c55ad 100644
                variant="contained"
                size="small"
 diff --git a/src/services/api.ts b/src/services/api.ts
-index 2eec99d9..15dd899d 100644
+index 90e1ac21..9e229b96 100644
 --- a/src/services/api.ts
 +++ b/src/services/api.ts
-@@ -55,12 +55,6 @@ export const updateGeoData = async () => {
+@@ -57,12 +57,6 @@ export const updateGeoData = async () => {
    return instance.post("/configs/geo");
  };
  
@@ -76,5 +76,5 @@ index 2eec99d9..15dd899d 100644
  export const getRules = async () => {
    const instance = await getAxios();
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch.ppc64el
+++ b/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch.ppc64el
@@ -1,19 +1,18 @@
-From 5336d31db3bde5367f6323bc6db462965d7d40ac Mon Sep 17 00:00:00 2001
+From cbdad0c0c9b96cae613991dd900d62ffc75c7f47 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 12:09:38 +0800
-Subject: [PATCH 17/18] (ppc64el) Use `@rollup/wasm-node` to fix build on
+Subject: [PATCH 17/19] (ppc64el) Use `@rollup/wasm-node` to fix build on
  POWER8
 
 ---
- package.json         |  7 ++++++-
- src-tauri/Cargo.lock | 26 +++++++++++++++++++-------
- 2 files changed, 25 insertions(+), 8 deletions(-)
+ package.json | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/package.json b/package.json
-index 03b6ce9d..9791b62c 100644
+index e73558af..ec81e132 100644
 --- a/package.json
 +++ b/package.json
-@@ -102,5 +102,10 @@
+@@ -107,5 +107,10 @@
      "endOfLine": "lf"
    },
    "type": "module",
@@ -25,64 +24,6 @@ index 03b6ce9d..9791b62c 100644
 +    }
 +  }
  }
-diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index 877ace4d..5ca74e5e 100644
---- a/src-tauri/Cargo.lock
-+++ b/src-tauri/Cargo.lock
-@@ -1052,7 +1052,7 @@ dependencies = [
-  "url",
-  "users",
-  "warp",
-- "which 7.0.1",
-+ "which 7.0.2",
-  "window-shadows",
-  "winreg 0.55.0",
-  "zip",
-@@ -8273,6 +8273,18 @@ dependencies = [
-  "rustix 0.38.44",
- ]
- 
-+[[package]]
-+name = "which"
-+version = "7.0.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
-+dependencies = [
-+ "either",
-+ "env_home",
-+ "rustix 0.38.44",
-+ "winsafe",
-+]
-+
- [[package]]
- name = "wide"
- version = "0.7.32"
-@@ -8874,12 +8886,6 @@ dependencies = [
-  "windows-sys 0.48.0",
- ]
- 
--[[package]]
--name = "winsafe"
--version = "0.0.19"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
--
- [[package]]
- name = "winreg"
- version = "0.55.0"
-@@ -8890,6 +8896,12 @@ dependencies = [
-  "windows-sys 0.59.0",
- ]
- 
-+[[package]]
-+name = "winsafe"
-+version = "0.0.19"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-+
- [[package]]
- name = "wit-bindgen-rt"
- version = "0.33.0"
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
@@ -1,17 +1,17 @@
-From e10e7f4c958e8c4ebd5167a0b8fdf6e68c80d36e Mon Sep 17 00:00:00 2001
+From 2b9f43a7c319cd0cb27b09a91b16f55d0b023be9 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
-Subject: [PATCH 18/18] Do not sidecar mihomo program
+Subject: [PATCH 18/19] Do not sidecar mihomo program
 
 ---
  src-tauri/src/core/core.rs | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index e3656c6d..4db08690 100644
+index 319a69f4..e6bc4cc0 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
-@@ -189,7 +189,7 @@ impl CoreManager {
+@@ -288,7 +288,7 @@ impl CoreManager {
          println!("[core配置验证] 运行子进程验证配置");
          let output = app_handle
              .shell()
@@ -21,5 +21,5 @@ index e3656c6d..4db08690 100644
              .output()
              .await?;
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/clash-verge-rev/autobuild/patches/0019-Remove-check-config-step-from-init_config.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0019-Remove-check-config-step-from-init_config.patch
@@ -1,0 +1,385 @@
+From fad5e5b8eaa61c97a9371222fc480912515afa72 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 17 Mar 2025 10:55:23 +0800
+Subject: [PATCH 19/19] Remove check config step from `init_config`
+
+---
+ src-tauri/src/config/config.rs |  46 ++-----
+ src-tauri/src/core/core.rs     | 245 +++++++++------------------------
+ 2 files changed, 76 insertions(+), 215 deletions(-)
+
+diff --git a/src-tauri/src/config/config.rs b/src-tauri/src/config/config.rs
+index 10c37b01..7d3e90d1 100644
+--- a/src-tauri/src/config/config.rs
++++ b/src-tauri/src/config/config.rs
+@@ -1,7 +1,7 @@
+ use super::{Draft, IClashTemp, IProfiles, IRuntime, IVerge};
+ use crate::{
+     config::PrfItem,
+-    core::{handle, CoreManager},
++    core::handle,
+     enhance,
+     utils::{dirs, help},
+ };
+@@ -70,43 +70,13 @@ impl Config {
+         // 生成运行时配置
+         crate::log_err!(Self::generate().await);
+ 
+-        // 生成运行时配置文件并验证
+-        let config_result = Self::generate_file(ConfigType::Run);
+-
+-        let validation_result = if config_result.is_ok() {
+-            // 验证配置文件
+-            println!("[首次启动] 开始验证配置");
+-
+-            match CoreManager::global().validate_config().await {
+-                Ok((is_valid, error_msg)) => {
+-                    if !is_valid {
+-                        println!(
+-                            "[首次启动] 配置验证失败，使用默认最小配置启动: {}",
+-                            error_msg
+-                        );
+-                        CoreManager::global()
+-                            .use_default_config("config_validate::boot_error", &error_msg)
+-                            .await?;
+-                        Some(("config_validate::boot_error", error_msg))
+-                    } else {
+-                        println!("[首次启动] 配置验证成功");
+-                        Some(("config_validate::success", String::new()))
+-                    }
+-                }
+-                Err(err) => {
+-                    println!("[首次启动] 验证进程执行失败: {}", err);
+-                    CoreManager::global()
+-                        .use_default_config("config_validate::process_terminated", "")
+-                        .await?;
+-                    Some(("config_validate::process_terminated", String::new()))
+-                }
+-            }
+-        } else {
+-            println!("[首次启动] 生成配置文件失败，使用默认配置");
+-            CoreManager::global()
+-                .use_default_config("config_validate::error", "")
+-                .await?;
+-            Some(("config_validate::error", String::new()))
++        // 生成运行时配置文件
++        Self::generate_file(ConfigType::Run).ok();
++
++
++        let validation_result = {
++            println!("[首次启动] 配置验证成功");
++            Some(("config_validate::success", String::new()))
+         };
+ 
+         // 在单独的任务中发送通知
+diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
+index e6bc4cc0..6221865f 100644
+--- a/src-tauri/src/core/core.rs
++++ b/src-tauri/src/core/core.rs
+@@ -1,17 +1,19 @@
++use crate::config::ConfigType;
+ #[cfg(target_os = "macos")]
+ use crate::core::tray::Tray;
+-use crate::{
+-    config::*,
+-    core::{handle, service},
+-    log_err,
+-    module::mihomo::MihomoManager,
+-    utils::{dirs, help},
+-};
++use crate::module::mihomo::MihomoManager;
++use crate::{config::Config, log_err};
++use crate::utils::dirs;
+ use anyhow::{bail, Result};
+ use once_cell::sync::OnceCell;
+-use std::{path::PathBuf, sync::Arc, time::Duration};
++use tokio::time::sleep;
++use std::path::PathBuf;
++use std::sync::Arc;
++use std::time::Duration;
+ use tauri_plugin_shell::ShellExt;
+-use tokio::{sync::Mutex, time::sleep};
++use tokio::sync::Mutex;
++
++use super::{handle, service};
+ 
+ #[derive(Debug)]
+ pub struct CoreManager {
+@@ -155,7 +157,7 @@ impl CoreManager {
+         // 启动核心进程并转入后台运行
+         let (_, child) = app_handle
+             .shell()
+-            .sidecar(clash_core)?
++            .command(clash_core)
+             .args(["-d", dirs::path_to_str(&config_dir)?, "-f", config_path_str])
+             .spawn()?;
+ 
+@@ -179,23 +181,6 @@ impl CoreManager {
+         Ok(())
+     }
+ 
+-    /// 使用默认配置
+-    pub async fn use_default_config(&self, msg_type: &str, msg_content: &str) -> Result<()> {
+-        let runtime_path = dirs::app_home_dir()?.join(RUNTIME_CONFIG);
+-        *Config::runtime().draft() = IRuntime {
+-            config: Some(Config::clash().latest().0.clone()),
+-            exists_keys: vec![],
+-            chain_logs: Default::default(),
+-        };
+-        help::save_yaml(
+-            &runtime_path,
+-            &Config::clash().latest().0,
+-            Some("# Clash Verge Runtime"),
+-        )?;
+-        handle::Handle::notice_message(msg_type, msg_content);
+-        Ok(())
+-    }
+-
+     /// 切换核心
+     pub async fn change_core(&self, clash_core: Option<String>) -> Result<()> {
+         let clash_core = clash_core.ok_or(anyhow::anyhow!("clash core is null"))?;
+@@ -212,54 +197,19 @@ impl CoreManager {
+ 
+         // 2. 使用新内核验证配置
+         println!("[切换内核] 使用新内核验证配置");
+-        match self.validate_config().await {
+-            Ok((true, _)) => {
+-                println!("[切换内核] 配置验证通过，开始切换内核");
+-                // 3. 验证通过后，应用内核配置并重启
+-                Config::verge().apply();
+-                log_err!(Config::verge().latest().save_file());
+-
+-                match self.restart_core().await {
+-                    Ok(_) => {
+-                        println!("[切换内核] 内核切换成功");
+-                        Config::runtime().apply();
+-                        Ok(())
+-                    }
+-                    Err(err) => {
+-                        println!("[切换内核] 内核切换失败: {}", err);
+-                        // 即使使用服务失败，我们也尝试使用sidecar模式启动
+-                        log::info!(target: "app", "trying sidecar mode after service failure");
+-                        self.start_core().await?;
+-                        Config::runtime().apply();
+-                        Ok(())
+-                    }
+-                }
+-            }
+-            Ok((false, error_msg)) => {
+-                println!("[切换内核] 配置验证失败: {}", error_msg);
+-                // 使用默认配置并继续切换内核
+-                self.use_default_config("config_validate::core_change", &error_msg)
+-                    .await?;
+-                Config::verge().apply();
+-                log_err!(Config::verge().latest().save_file());
+-
+-                match self.restart_core().await {
+-                    Ok(_) => {
+-                        println!("[切换内核] 内核切换成功（使用默认配置）");
+-                        Ok(())
+-                    }
+-                    Err(err) => {
+-                        println!("[切换内核] 内核切换失败: {}", err);
+-                        // 即使使用服务失败，我们也尝试使用sidecar模式启动
+-                        log::info!(target: "app", "trying sidecar mode after service failure with default config");
+-                        self.start_core().await?;
+-                        Ok(())
+-                    }
+-                }
++        Config::verge().apply();
++        log_err!(Config::verge().latest().save_file());
++        
++        match self.restart_core().await {
++            Ok(_) => {
++                println!("[切换内核] 内核切换成功");
++                Config::runtime().apply();
++                Ok(())
+             }
+             Err(err) => {
+-                println!("[切换内核] 验证过程发生错误: {}", err);
++                println!("[切换内核] 内核切换失败: {}", err);
+                 Config::verge().discard();
++                Config::runtime().discard();
+                 Err(err)
+             }
+         }
+@@ -332,65 +282,6 @@ impl CoreManager {
+         }
+     }
+ 
+-    /// 验证运行时配置
+-    pub async fn validate_config(&self) -> Result<(bool, String)> {
+-        let config_path = Config::generate_file(ConfigType::Check)?;
+-        let config_path = dirs::path_to_str(&config_path)?;
+-        self.validate_config_internal(config_path).await
+-    }
+-
+-    /// 验证指定的配置文件
+-    pub async fn validate_config_file(
+-        &self,
+-        config_path: &str,
+-        is_merge_file: Option<bool>,
+-    ) -> Result<(bool, String)> {
+-        // 检查程序是否正在退出，如果是则跳过验证
+-        if handle::Handle::global().is_exiting() {
+-            println!("[core配置验证] 应用正在退出，跳过验证");
+-            return Ok((true, String::new()));
+-        }
+-
+-        // 检查文件是否存在
+-        if !std::path::Path::new(config_path).exists() {
+-            let error_msg = format!("File not found: {}", config_path);
+-            //handle::Handle::notice_message("config_validate::file_not_found", &error_msg);
+-            return Ok((false, error_msg));
+-        }
+-
+-        // 如果是合并文件且不是强制验证，执行语法检查但不进行完整验证
+-        if is_merge_file.unwrap_or(false) {
+-            println!(
+-                "[core配置验证] 检测到Merge文件，仅进行语法检查: {}",
+-                config_path
+-            );
+-            return self.validate_file_syntax(config_path).await;
+-        }
+-
+-        // 检查是否为脚本文件
+-        let is_script = if config_path.ends_with(".js") {
+-            true
+-        } else {
+-            match self.is_script_file(config_path) {
+-                Ok(result) => result,
+-                Err(err) => {
+-                    // 如果无法确定文件类型，尝试使用Clash内核验证
+-                    log::warn!(target: "app", "无法确定文件类型: {}, 错误: {}", config_path, err);
+-                    return self.validate_config_internal(config_path).await;
+-                }
+-            }
+-        };
+-
+-        if is_script {
+-            log::info!(target: "app", "检测到脚本文件，使用JavaScript验证: {}", config_path);
+-            return self.validate_script_file(config_path).await;
+-        }
+-
+-        // 对YAML配置文件使用Clash内核验证
+-        log::info!(target: "app", "使用Clash内核验证配置文件: {}", config_path);
+-        self.validate_config_internal(config_path).await
+-    }
+-
+     /// 检查文件是否为脚本文件
+     fn is_script_file(&self, path: &str) -> Result<bool> {
+         // 1. 先通过扩展名快速判断
+@@ -506,6 +397,46 @@ impl CoreManager {
+         }
+     }
+ 
++    /// 验证指定的配置文件
++    pub async fn validate_config_file(&self, config_path: &str, is_merge_file: Option<bool>) -> Result<(bool, String)> {
++        // 检查文件是否存在
++        if !std::path::Path::new(config_path).exists() {
++            let error_msg = format!("File not found: {}", config_path);
++            //handle::Handle::notice_message("config_validate::file_not_found", &error_msg);
++            return Ok((false, error_msg));
++        }
++        
++        // 如果是合并文件且不是强制验证，执行语法检查但不进行完整验证
++        if is_merge_file.unwrap_or(false) {
++            println!("[core配置验证] 检测到Merge文件，仅进行语法检查: {}", config_path);
++            return self.validate_file_syntax(config_path).await;
++        }
++        
++        // 检查是否为脚本文件
++        let is_script = if config_path.ends_with(".js") {
++            true
++        } else {
++            match self.is_script_file(config_path) {
++                Ok(result) => result,
++                Err(err) => {
++                    // 如果无法确定文件类型，尝试使用Clash内核验证
++                    log::warn!(target: "app", "无法确定文件类型: {}, 错误: {}", config_path, err);
++                    return self.validate_config_internal(config_path).await;
++                }
++            }
++        };
++        
++        if is_script {
++            log::info!(target: "app", "检测到脚本文件，使用JavaScript验证: {}", config_path);
++            return self.validate_script_file(config_path).await;
++        }
++        
++        // 对YAML配置文件使用Clash内核验证
++        log::info!(target: "app", "使用Clash内核验证配置文件: {}", config_path);
++        self.validate_config_internal(config_path).await
++    }
++    
++
+     /// 更新proxies等配置
+     pub async fn update_config(&self) -> Result<(bool, String)> {
+         // 检查程序是否正在退出，如果是则跳过完整验证流程
+@@ -519,57 +450,17 @@ impl CoreManager {
+         // 1. 先生成新的配置内容
+         println!("[core配置更新] 生成新的配置内容");
+         Config::generate().await?;
+-
+-        // 2. 生成临时文件并进行验证
++        
++        // 2. 生成临时文件
+         println!("[core配置更新] 生成临时配置文件用于验证");
+         let temp_config = Config::generate_file(ConfigType::Check)?;
+         let temp_config = dirs::path_to_str(&temp_config)?;
+         println!("[core配置更新] 临时配置文件路径: {}", temp_config);
+ 
+-        // 3. 验证配置
+-        match self.validate_config().await {
+-            Ok((true, _)) => {
+-                println!("[core配置更新] 配置验证通过");
+-                // 4. 验证通过后，生成正式的运行时配置
+-                println!("[core配置更新] 生成运行时配置");
+-                let run_path = Config::generate_file(ConfigType::Run)?;
+-                let run_path = dirs::path_to_str(&run_path)?;
+-
+-                // 5. 应用新配置
+-                println!("[core配置更新] 应用新配置");
+-                for i in 0..3 {
+-                    match MihomoManager::global().put_configs_force(run_path).await {
+-                        Ok(_) => {
+-                            println!("[core配置更新] 配置应用成功");
+-                            Config::runtime().apply();
+-                            return Ok((true, String::new()));
+-                        }
+-                        Err(err) => {
+-                            if i < 2 {
+-                                println!("[core配置更新] 第{}次重试应用配置", i + 1);
+-                                log::info!(target: "app", "{err}");
+-                                sleep(Duration::from_millis(100)).await;
+-                            } else {
+-                                println!("[core配置更新] 配置应用失败: {}", err);
+-                                Config::runtime().discard();
+-                                return Ok((false, err.to_string()));
+-                            }
+-                        }
+-                    }
+-                }
+-                Ok((true, String::new()))
+-            }
+-            Ok((false, error_msg)) => {
+-                println!("[core配置更新] 配置验证失败: {}", error_msg);
+-                Config::runtime().discard();
+-                Ok((false, error_msg))
+-            }
+-            Err(e) => {
+-                println!("[core配置更新] 验证过程发生错误: {}", e);
+-                Config::runtime().discard();
+-                Err(e)
+-            }
+-        }
++        Config::runtime().apply();
++
++
++        Ok((true, "".to_string()))
+     }
+ 
+     /// 只进行文件语法检查，不进行完整验证
+-- 
+2.49.0
+

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=2.1.2
+VER=2.2.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.2.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- clash-verge-rev: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
