### PR TITLE
watchman: update to 2025.03.24.00

### DIFF
--- a/app-network/fbthrift/autobuild/patches/0001-Build-whisker-as-a-shared-library.patch
+++ b/app-network/fbthrift/autobuild/patches/0001-Build-whisker-as-a-shared-library.patch
@@ -1,8 +1,17 @@
+From 2c022620a9dde49a0553f5e39a1b3c293f3ee273 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Mon, 17 Mar 2025 15:35:14 +0800
+Subject: [PATCH] Build whisker as a shared library
+
+---
+ thrift/compiler/CMakeLists.txt | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
 diff --git a/thrift/compiler/CMakeLists.txt b/thrift/compiler/CMakeLists.txt
-index 6a33a421d6..0dde5ac4cd 100644
+index 0646111bf3..3180d5985a 100644
 --- a/thrift/compiler/CMakeLists.txt
 +++ b/thrift/compiler/CMakeLists.txt
-@@ -170,7 +170,6 @@ target_link_libraries(
+@@ -156,7 +156,6 @@ target_link_libraries(
  
  add_library(
    whisker
@@ -10,7 +19,7 @@ index 6a33a421d6..0dde5ac4cd 100644
  
    whisker/detail/string.cc
    whisker/ast.cc
-@@ -186,8 +185,8 @@ add_library(
+@@ -174,8 +173,8 @@ add_library(
  )
  target_link_libraries(
    whisker
@@ -21,12 +30,15 @@ index 6a33a421d6..0dde5ac4cd 100644
  )
  
  add_subdirectory(generate)
-@@ -241,8 +240,6 @@ endif ()
+@@ -228,8 +227,6 @@ endif ()
  install(
    TARGETS thrift1
      compiler_ast
 -    compiler_base
 -    compiler_lib
      compiler
-     mustache
      whisker
+   EXPORT fbthrift-exports
+-- 
+2.49.0
+

--- a/app-network/fbthrift/spec
+++ b/app-network/fbthrift/spec
@@ -1,4 +1,7 @@
-VER="2024.12.30.00"
+VER="2025.03.10.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/fbthrift.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138247"
+
+# The job may get killed on machines with less memory
+ENVREQ__ARM64="total_mem=12"

--- a/app-network/fizz/spec
+++ b/app-network/fizz/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebookincubator/fizz.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138222"

--- a/app-utils/watchman/spec
+++ b/app-utils/watchman/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/facebook/watchman"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15760"

--- a/groups/watchman
+++ b/groups/watchman
@@ -1,8 +1,8 @@
-app-network/fbthrift
-app-network/fizz
 runtime-common/folly
-runtime-common/edencommon
-runtime-network/wangle
-runtime-network/fb303
+app-network/fizz
 runtime-network/mvfst
+runtime-network/wangle
+app-network/fbthrift
+runtime-network/fb303
+runtime-common/edencommon
 app-utils/watchman

--- a/runtime-common/edencommon/spec
+++ b/runtime-common/edencommon/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebookexperimental/edencommon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375630"

--- a/runtime-common/folly/autobuild/patches/0001-Fix-impossible-constraint-error-for-mips-and-riscv.patch
+++ b/runtime-common/folly/autobuild/patches/0001-Fix-impossible-constraint-error-for-mips-and-riscv.patch
@@ -1,7 +1,7 @@
-From 953aac526a1623ee96e982e717e313aafa074195 Mon Sep 17 00:00:00 2001
+From 74b428ab2e31ba8144bee10caada0f5dd391fab8 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 16 Dec 2024 16:37:55 +0800
-Subject: [PATCH] Fix impossible constraint error for mips and riscv
+Subject: [PATCH 1/2] Fix impossible constraint error for mips and riscv
 
 ---
  folly/lang/Hint-inl.h | 4 ++++
@@ -24,5 +24,5 @@ index 2c207a551..63126226d 100644
  
  template <typename T>
 -- 
-2.47.1
+2.49.0
 

--- a/runtime-common/folly/autobuild/patches/0002-Use-64-byte-cacheline-alignment-on-RISC-V.patch
+++ b/runtime-common/folly/autobuild/patches/0002-Use-64-byte-cacheline-alignment-on-RISC-V.patch
@@ -1,0 +1,25 @@
+From a35b49cf5b48db65025f7e749b53feeb874fc56e Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Fri, 28 Mar 2025 16:23:27 +0800
+Subject: [PATCH 2/2] Use 64-byte cacheline alignment on RISC-V
+
+---
+ folly/lang/Align.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/folly/lang/Align.h b/folly/lang/Align.h
+index b541156e2..522c30f65 100644
+--- a/folly/lang/Align.h
++++ b/folly/lang/Align.h
+@@ -145,7 +145,7 @@ using max_align_v_ = max_align_t_<
+ constexpr std::size_t max_align_v = detail::max_align_v_::value();
+ struct alignas(max_align_v) max_align_t {};
+ 
+-#if defined(__cpp_lib_hardware_interference_size)
++#if defined(__cpp_lib_hardware_interference_size) && !defined(__riscv)
+ 
+ //  GCC unconditionally warns about uses of the std's interference-size
+ //  constants, on the basis that their uses in public ABIs is likely broken:
+-- 
+2.49.0
+

--- a/runtime-common/folly/spec
+++ b/runtime-common/folly/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/folly.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8734"

--- a/runtime-network/fb303/autobuild/patches/0001-Search-FBTHRIFT_INCLUDE_DIR-when-generating-a-python.patch
+++ b/runtime-network/fb303/autobuild/patches/0001-Search-FBTHRIFT_INCLUDE_DIR-when-generating-a-python.patch
@@ -1,0 +1,25 @@
+From 174c3d3a914a7f6f158773afdca88c00f491bb73 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Thu, 20 Mar 2025 17:25:01 +0800
+Subject: [PATCH] Search ${FBTHRIFT_INCLUDE_DIR} when generating a python
+ library
+
+---
+ build/fbcode_builder/CMake/FBThriftPyLibrary.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/fbcode_builder/CMake/FBThriftPyLibrary.cmake b/build/fbcode_builder/CMake/FBThriftPyLibrary.cmake
+index fa77cde71..1aed8fbf4 100644
+--- a/build/fbcode_builder/CMake/FBThriftPyLibrary.cmake
++++ b/build/fbcode_builder/CMake/FBThriftPyLibrary.cmake
+@@ -87,6 +87,7 @@ function(add_fbthrift_py_library LIB_NAME THRIFT_FILE)
+       --legacy-strict
+       --gen "py:${GEN_ARG_STR}"
+       "${thrift_include_options}"
++      -I "${FBTHRIFT_INCLUDE_DIR}"
+       -o "${output_dir}"
+       "${CMAKE_CURRENT_SOURCE_DIR}/${THRIFT_FILE}"
+     WORKING_DIRECTORY
+-- 
+2.49.0
+

--- a/runtime-network/fb303/spec
+++ b/runtime-network/fb303/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/fb303.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242787"

--- a/runtime-network/mvfst/spec
+++ b/runtime-network/mvfst/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/mvfst.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373578"

--- a/runtime-network/wangle/spec
+++ b/runtime-network/wangle/spec
@@ -1,4 +1,4 @@
-VER="2024.12.30.00"
+VER="2025.03.24.00"
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/wangle.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138224"


### PR DESCRIPTION
Topic Description
-----------------

- watchman: update to 2025.03.24.00
    ... and fix the order of the rebuild list
- edencommon: update to 2025.03.24.00
- fb303: update to 2025.03.24.00
    ... and fix the generation of python libraries
- fbthrift: update to 2025.03.10.00
- wangle: update to 2025.03.24.00
- mvfst: update to 2025.03.24.00
- fizz: update to 2025.03.24.00
- folly: always report 64-byte cache line size for riscv64
    Apparently Zic64b has become mandatory in RVA22U64. This should
    satisfy fbthrift's static assertion in
    thrift/lib/cpp2/gen/module_types_cpp.cpp.
- folly: update to 2025.03.24.00

Package(s) Affected
-------------------

- edencommon: 2025.03.24.00
- fb303: 2025.03.24.00
- fbthrift: 2025.03.10.00
- fizz: 2025.03.24.00
- folly: 2025.03.24.00
- mvfst: 2025.03.24.00
- wangle: 2025.03.24.00
- watchman: 2025.03.24.00

Security Update?
----------------

No

Build Order
-----------

```
#buildit folly fizz mvfst wangle fbthrift fb303 edencommon watchman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
