### PR TITLE
MPD: update to 0.24.1

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,4 @@
-VER=0.24
-SRCS="tbl::https://www.musicpd.org/download/mpd/$VER/mpd-$VER.tar.xz"
-CHKSUMS="sha256::1c828a290816d540fb2dec90f78044b55ff5ef8b49dd47a639ac34e3e5226bc5"
+VER=0.24.1
+SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
+CHKSUMS="sha256::b0920be6c63e3b857242ed168f29c3eee077f450a9f82bb9ff65f39fa587c8e8"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mpd: 0.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
