### PR TITLE
network-manager-applet: add auto indicator patch, bump REL

### DIFF
--- a/desktop-gnome/network-manager-applet/autobuild/defines
+++ b/desktop-gnome/network-manager-applet/autobuild/defines
@@ -1,12 +1,12 @@
 PKGNAME=network-manager-applet
 PKGSEC=gnome
-PKGDEP="gnome-keyring gtk-3 iso-codes libappindicator libnma libnotify \
+PKGDEP="gnome-keyring gtk-3 iso-codes libayatana-appindicator libnma libnotify \
         libsecret mobile-broadband-provider-info modemmanager networkmanager"
 BUILDDEP="appstream-glib gobject-introspection intltool"
 PKGDES="Control and management applets and utilities for NetworkManager"
 
 ABTYPE=meson
-MESON_AFTER="-Dappindicator=yes \
+MESON_AFTER="-Dappindicator=ayatana \
              -Dwwan=true \
              -Dselinux=false \
              -Dteam=true \

--- a/desktop-gnome/network-manager-applet/autobuild/patches/0002-applet-use-AppIndicator-if-org.kde.StatusNotifierWat.patch
+++ b/desktop-gnome/network-manager-applet/autobuild/patches/0002-applet-use-AppIndicator-if-org.kde.StatusNotifierWat.patch
@@ -1,0 +1,92 @@
+From efe2fd9e682f9b0a6626f88f12878ba15f992f83 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Thu, 20 Mar 2025 19:17:40 +0800
+Subject: [PATCH] applet: use AppIndicator if org.kde.StatusNotifierWatcher is
+ detected
+
+org.kde.StatusNotifierWatcher is a D-Bus interface that allows us to determine whether AppIndicator is usable.
+This commit adds the detection for this interface to nm-applet, enabling AppIndicator if such an interface is detected.
+
+Signed-off-by: Lain "Fearyncess" Yang <fsf@live.com>
+---
+ src/applet.c | 56 +++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 51 insertions(+), 5 deletions(-)
+
+diff --git a/src/applet.c b/src/applet.c
+index 9420dd55..aaa0135a 100644
+--- a/src/applet.c
++++ b/src/applet.c
+@@ -119,6 +119,55 @@ applet_workaround_show_cb (NMApplet *applet, gpointer unused)
+ 		g_signal_handlers_disconnect_by_func (menu, applet_workaround_show_cb, applet);
+ 	}
+ }
++
++
++static gboolean
++get_is_appindicator_avail (void)
++{
++	GDBusConnection *session_bus;
++	GError *session_bus_error = NULL;
++	GError *detect_error = NULL;
++	GVariant *detect_result;
++	GVariant *indicator_avail;
++	gboolean ret = FALSE;
++
++	session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &session_bus_error);
++	if (session_bus) {
++		detect_result = g_dbus_connection_call_sync (session_bus,
++								"org.kde.StatusNotifierWatcher",
++								"/StatusNotifierWatcher",
++								"org.freedesktop.DBus.Properties",
++								"Get",
++								g_variant_new ("(ss)",
++									"org.kde.StatusNotifierWatcher",
++									"IsStatusNotifierHostRegistered"),
++								G_VARIANT_TYPE ("(v)"),
++								G_DBUS_CALL_FLAGS_NONE,
++								-1,
++								NULL,
++								&detect_error);
++		if (detect_result) {
++			g_variant_get (detect_result, "(v)", &indicator_avail);
++			ret = g_variant_get_boolean (indicator_avail);
++			if (ret) {
++				g_debug ("org.kde.StatusNotifierHost registered, using AppIndicator for system tray");
++			} else {
++				g_debug ("org.kde.StatusNotifierHost not registered, using GtkStatusIcon for system tray");
++			}
++			g_variant_unref (indicator_avail);
++			g_variant_unref (detect_result);
++		} else {
++			g_warning ("Unable to detect if org.kde.StatusNotifierHost registered: %s", detect_error->message);
++			g_clear_error (&detect_error);
++		}
++		g_object_unref (session_bus);
++	} else {
++		g_warning ("Error connecting to D-Bus session bus: %s", session_bus_error->message);
++		g_clear_error (&session_bus_error);
++	}
++	return ret;
++}
++
+ #endif
+ 
+ static inline NMADeviceClass *
+@@ -3447,12 +3496,9 @@ static void nma_init (NMApplet *applet)
+ 	applet->icon_size = 16;
+ 
+ #ifdef WITH_APPINDICATOR
+-#ifdef GDK_WINDOWING_X11
+-	if (!GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
++	if (get_is_appindicator_avail()) {
+ 		with_appindicator = TRUE;
+-#else
+-	with_appindicator = TRUE;
+-#endif
++	}
+ #endif
+ 
+ 	g_signal_connect (applet, "startup", G_CALLBACK (applet_startup), NULL);
+-- 
+2.49.0
+

--- a/desktop-gnome/network-manager-applet/autobuild/patches/0003-desktop-add-COSMIC-to-NotShowIn-field.patch
+++ b/desktop-gnome/network-manager-applet/autobuild/patches/0003-desktop-add-COSMIC-to-NotShowIn-field.patch
@@ -1,0 +1,24 @@
+From 0761fabcef91ddb3c599204e472baef08f9602a9 Mon Sep 17 00:00:00 2001
+From: Michael Aaron Murphy <michael@mmurphy.dev>
+Date: Thu, 1 Aug 2024 17:01:53 +0200
+Subject: [PATCH] desktop: add COSMIC to NotShowIn field
+
+https://gitlab.gnome.org/GNOME/network-manager-applet/-/merge_requests/146
+---
+ nm-applet.desktop.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nm-applet.desktop.in b/nm-applet.desktop.in
+index 067229f6..91f0d303 100644
+--- a/nm-applet.desktop.in
++++ b/nm-applet.desktop.in
+@@ -6,5 +6,5 @@ Exec=nm-applet
+ Terminal=false
+ Type=Application
+ NoDisplay=true
+-NotShowIn=KDE;GNOME;
++NotShowIn=KDE;GNOME;COSMIC;
+ X-GNOME-UsesNotifications=true
+-- 
+2.49.0
+

--- a/desktop-gnome/network-manager-applet/spec
+++ b/desktop-gnome/network-manager-applet/spec
@@ -1,4 +1,5 @@
 VER=1.36.0
+REL=1
 SRCS="https://download.gnome.org/sources/network-manager-applet/${VER:0:4}/network-manager-applet-$VER.tar.xz"
 CHKSUMS="sha256::a84704487ea3afe1485c47fb2ab598b8f779f540ae0dcbf0a1c5f85e64a7e253"
 CHKUPDATE="anitya::id=198502"


### PR DESCRIPTION
Topic Description
-----------------

- network-manager-applet: add auto indicator patch, bump REL

Package(s) Affected
-------------------

- network-manager-applet: 1.36.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit network-manager-applet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
