### PR TITLE
zellij: update to 0.42.1

### DIFF
--- a/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
+++ b/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
@@ -1,6 +1,6 @@
-From a2055e30e501f32405506a42dbc3def4055e14de Mon Sep 17 00:00:00 2001
+From 9a64c11c8551e88041a0d1d839eca1c5c6c4beb5 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
-Date: Tue, 18 Mar 2025 14:34:53 -0700
+Date: Fri, 21 Mar 2025 03:27:32 -0700
 Subject: [PATCH 1/2] chore: update wasmtime to 30.0.2
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -11,7 +11,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  3 files changed, 129 insertions(+), 159 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 7d2d490c..725629d0 100644
+index 34be5fd0..cf380854 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -34,18 +34,6 @@ version = "1.0.2"
@@ -33,7 +33,7 @@ index 7d2d490c..725629d0 100644
  [[package]]
  name = "aho-corasick"
  version = "0.7.20"
-@@ -737,20 +725,35 @@ dependencies = [
+@@ -725,20 +713,35 @@ dependencies = [
   "libc",
  ]
  
@@ -73,7 +73,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "serde",
   "serde_derive",
-@@ -758,11 +761,12 @@ dependencies = [
+@@ -746,11 +749,12 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen"
@@ -88,7 +88,7 @@ index 7d2d490c..725629d0 100644
   "cranelift-bforest",
   "cranelift-bitset",
   "cranelift-codegen-meta",
-@@ -771,8 +775,9 @@ dependencies = [
+@@ -759,8 +763,9 @@ dependencies = [
   "cranelift-entity",
   "cranelift-isle",
   "gimli 0.31.1",
@@ -99,7 +99,7 @@ index 7d2d490c..725629d0 100644
   "regalloc2",
   "rustc-hash",
   "serde",
-@@ -782,33 +787,35 @@ dependencies = [
+@@ -770,33 +775,35 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen-meta"
@@ -143,7 +143,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "cranelift-bitset",
   "serde",
-@@ -817,9 +824,9 @@ dependencies = [
+@@ -805,9 +812,9 @@ dependencies = [
  
  [[package]]
  name = "cranelift-frontend"
@@ -155,7 +155,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "cranelift-codegen",
   "log",
-@@ -829,15 +836,15 @@ dependencies = [
+@@ -817,15 +824,15 @@ dependencies = [
  
  [[package]]
  name = "cranelift-isle"
@@ -175,7 +175,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "cranelift-codegen",
   "libc",
-@@ -1586,15 +1593,6 @@ version = "0.11.2"
+@@ -1550,15 +1557,6 @@ version = "0.11.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
  
@@ -191,7 +191,7 @@ index 7d2d490c..725629d0 100644
  [[package]]
  name = "hashbrown"
  version = "0.15.2"
-@@ -2940,13 +2938,12 @@ dependencies = [
+@@ -2863,13 +2861,12 @@ dependencies = [
  
  [[package]]
  name = "pulley-interpreter"
@@ -207,7 +207,7 @@ index 7d2d490c..725629d0 100644
   "wasmtime-math",
  ]
  
-@@ -2978,7 +2975,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+@@ -2901,7 +2898,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
  dependencies = [
   "rand_chacha 0.9.0",
   "rand_core 0.9.0",
@@ -216,7 +216,7 @@ index 7d2d490c..725629d0 100644
  ]
  
  [[package]]
-@@ -3017,7 +3014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -2940,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
  dependencies = [
   "getrandom 0.3.1",
@@ -225,7 +225,7 @@ index 7d2d490c..725629d0 100644
  ]
  
  [[package]]
-@@ -4243,16 +4240,6 @@ version = "0.2.87"
+@@ -4183,16 +4180,6 @@ version = "0.2.87"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
  
@@ -242,7 +242,7 @@ index 7d2d490c..725629d0 100644
  [[package]]
  name = "wasm-encoder"
  version = "0.224.0"
-@@ -4260,14 +4247,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -4200,14 +4187,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
  dependencies = [
   "leb128",
@@ -260,7 +260,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "bitflags 2.5.0",
   "hashbrown 0.15.2",
-@@ -4276,33 +4263,22 @@ dependencies = [
+@@ -4216,33 +4203,22 @@ dependencies = [
   "serde",
  ]
  
@@ -299,7 +299,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "addr2line 0.24.2",
   "anyhow",
-@@ -4314,7 +4290,7 @@ dependencies = [
+@@ -4254,7 +4230,7 @@ dependencies = [
   "encoding_rs",
   "fxprof-processed-profile",
   "gimli 0.31.1",
@@ -308,7 +308,7 @@ index 7d2d490c..725629d0 100644
   "indexmap 2.7.1",
   "ittapi",
   "libc",
-@@ -4337,8 +4313,8 @@ dependencies = [
+@@ -4277,8 +4253,8 @@ dependencies = [
   "sptr",
   "target-lexicon",
   "trait-variant",
@@ -319,7 +319,7 @@ index 7d2d490c..725629d0 100644
   "wasmtime-asm-macros",
   "wasmtime-cache",
   "wasmtime-component-macro",
-@@ -4358,18 +4334,18 @@ dependencies = [
+@@ -4298,18 +4274,18 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-asm-macros"
@@ -342,7 +342,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "base64 0.21.0",
-@@ -4387,9 +4363,9 @@ dependencies = [
+@@ -4327,9 +4303,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-macro"
@@ -354,7 +354,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "proc-macro2",
-@@ -4402,15 +4378,15 @@ dependencies = [
+@@ -4342,15 +4318,15 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-util"
@@ -374,14 +374,14 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4423,19 +4399,20 @@ dependencies = [
+@@ -4363,19 +4339,20 @@ dependencies = [
   "itertools 0.12.1",
   "log",
   "object 0.36.7",
 + "pulley-interpreter",
   "smallvec",
   "target-lexicon",
-  "thiserror",
+  "thiserror 1.0.61",
 - "wasmparser 0.221.2",
 + "wasmparser",
   "wasmtime-environ",
@@ -398,7 +398,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "cpp_demangle",
-@@ -4452,17 +4429,17 @@ dependencies = [
+@@ -4392,17 +4369,17 @@ dependencies = [
   "serde_derive",
   "smallvec",
   "target-lexicon",
@@ -420,7 +420,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "cc",
-@@ -4475,10 +4452,11 @@ dependencies = [
+@@ -4415,10 +4392,11 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-debug"
@@ -434,7 +434,7 @@ index 7d2d490c..725629d0 100644
   "object 0.36.7",
   "rustix 0.38.44",
   "wasmtime-versioned-export-macros",
-@@ -4486,9 +4464,9 @@ dependencies = [
+@@ -4426,9 +4404,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-icache-coherence"
@@ -446,7 +446,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4498,24 +4476,24 @@ dependencies = [
+@@ -4438,24 +4416,24 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-math"
@@ -477,7 +477,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4524,9 +4502,9 @@ dependencies = [
+@@ -4464,9 +4442,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wasi"
@@ -489,8 +489,8 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4546,25 +4524,38 @@ dependencies = [
-  "thiserror",
+@@ -4486,25 +4464,38 @@ dependencies = [
+  "thiserror 1.0.61",
   "tokio",
   "tracing",
 - "trait-variant",
@@ -532,7 +532,7 @@ index 7d2d490c..725629d0 100644
   "wasmtime-cranelift",
   "wasmtime-environ",
   "winch-codegen",
-@@ -4572,9 +4563,9 @@ dependencies = [
+@@ -4512,9 +4503,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wit-bindgen"
@@ -544,7 +544,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4601,7 +4592,7 @@ dependencies = [
+@@ -4541,7 +4532,7 @@ dependencies = [
   "leb128",
   "memchr",
   "unicode-width 0.2.0",
@@ -553,7 +553,7 @@ index 7d2d490c..725629d0 100644
  ]
  
  [[package]]
-@@ -4730,9 +4721,9 @@ dependencies = [
+@@ -4657,9 +4648,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle"
@@ -565,7 +565,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4745,9 +4736,9 @@ dependencies = [
+@@ -4672,9 +4663,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-generate"
@@ -577,7 +577,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4760,9 +4751,9 @@ dependencies = [
+@@ -4687,9 +4678,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-macro"
@@ -589,7 +589,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4803,9 +4794,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+@@ -4730,9 +4721,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
  
  [[package]]
  name = "winch-codegen"
@@ -601,16 +601,16 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -4814,7 +4805,7 @@ dependencies = [
+@@ -4741,7 +4732,7 @@ dependencies = [
   "smallvec",
   "target-lexicon",
-  "thiserror",
+  "thiserror 1.0.61",
 - "wasmparser 0.221.2",
 + "wasmparser",
   "wasmtime-cranelift",
   "wasmtime-environ",
  ]
-@@ -5072,9 +5063,9 @@ dependencies = [
+@@ -4999,9 +4990,9 @@ dependencies = [
  
  [[package]]
  name = "wit-parser"
@@ -622,7 +622,7 @@ index 7d2d490c..725629d0 100644
  dependencies = [
   "anyhow",
   "id-arena",
-@@ -5085,7 +5076,7 @@ dependencies = [
+@@ -5012,7 +5003,7 @@ dependencies = [
   "serde_derive",
   "serde_json",
   "unicode-xid",
@@ -631,7 +631,7 @@ index 7d2d490c..725629d0 100644
  ]
  
  [[package]]
-@@ -5288,33 +5279,13 @@ dependencies = [
+@@ -5215,33 +5206,13 @@ dependencies = [
   "vte 0.11.0",
  ]
  
@@ -667,7 +667,7 @@ index 7d2d490c..725629d0 100644
  
  [[package]]
 diff --git a/zellij-server/Cargo.toml b/zellij-server/Cargo.toml
-index f3cb3553..78bd733f 100644
+index ceaaf93f..f542cdc4 100644
 --- a/zellij-server/Cargo.toml
 +++ b/zellij-server/Cargo.toml
 @@ -19,7 +19,7 @@ daemonize = "0.5"
@@ -677,7 +677,7 @@ index f3cb3553..78bd733f 100644
 -wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
 +wasmtime-wasi = "30.0.2" # Keep in sync with wasmtime
  cassowary = "0.3.0"
- zellij-utils = { path = "../zellij-utils/", version = "0.42.0" }
+ zellij-utils = { path = "../zellij-utils/", version = "0.42.1" }
  log = "0.4.17"
 @@ -34,7 +34,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
  semver = "0.11.0"

--- a/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
+++ b/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
@@ -1,64 +1,37 @@
-From e0dbfaa9cacdb5c9150bb212f03707bd14cdbe2d Mon Sep 17 00:00:00 2001
+From 4da340d708db28d42117bced036723b902f5c302 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
-Date: Tue, 18 Mar 2025 20:23:35 -0700
+Date: Fri, 21 Mar 2025 03:27:12 -0700
 Subject: [PATCH 2/2] chore: update nix to >=0.27 to support loongarch64
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- Cargo.lock                           | 92 ++++++++++++----------------
- zellij-client/src/lib.rs             | 17 ++---
- zellij-client/src/os_input_output.rs | 24 ++++----
- zellij-server/src/os_input_output.rs | 54 ++++++++++------
- zellij-server/src/pty.rs             | 35 ++++++++---
- zellij-utils/Cargo.toml              |  4 +-
- 6 files changed, 124 insertions(+), 102 deletions(-)
+ Cargo.lock                           | 19 ++--------
+ zellij-client/src/lib.rs             | 17 ++++-----
+ zellij-client/src/os_input_output.rs | 24 ++++++-------
+ zellij-server/src/os_input_output.rs | 54 +++++++++++++++++-----------
+ zellij-server/src/pty.rs             | 35 ++++++++++++++----
+ zellij-utils/Cargo.toml              |  2 +-
+ 6 files changed, 87 insertions(+), 64 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 725629d0..ff99ac6d 100644
+index cf380854..9d147bb1 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -553,6 +553,12 @@ version = "0.1.1"
+@@ -2136,7 +2136,7 @@ version = "1.1.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
- 
-+[[package]]
-+name = "cfg_aliases"
-+version = "0.2.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-+
- [[package]]
- name = "chrono"
- version = "0.4.39"
-@@ -579,7 +585,7 @@ dependencies = [
-  "clap_lex",
-  "indexmap 1.8.2",
-  "once_cell",
-- "strsim",
-+ "strsim 0.10.0",
-  "termcolor",
-  "textwrap",
+ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+ dependencies = [
+- "nix 0.29.0",
++ "nix",
+  "winapi",
  ]
-@@ -2227,15 +2233,6 @@ dependencies = [
-  "autocfg",
+ 
+@@ -2296,19 +2296,6 @@ dependencies = [
+  "rand 0.8.5",
  ]
  
 -[[package]]
--name = "memoffset"
--version = "0.7.1"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
--dependencies = [
-- "autocfg",
--]
--
- [[package]]
- name = "memoffset"
- version = "0.9.1"
-@@ -2349,41 +2346,27 @@ dependencies = [
- 
- [[package]]
- name = "nix"
+-name = "nix"
 -version = "0.23.1"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
@@ -70,186 +43,24 @@ index 725629d0..ff99ac6d 100644
 - "memoffset 0.6.5",
 -]
 -
--[[package]]
--name = "nix"
--version = "0.26.4"
-+version = "0.28.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
- dependencies = [
-- "bitflags 1.3.2",
-+ "bitflags 2.5.0",
-  "cfg-if",
-+ "cfg_aliases 0.1.1",
-  "libc",
-- "memoffset 0.7.1",
-- "pin-utils",
-+ "memoffset 0.9.1",
- ]
- 
  [[package]]
  name = "nix"
--version = "0.28.0"
-+version = "0.29.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
- dependencies = [
-  "bitflags 2.5.0",
-  "cfg-if",
-- "cfg_aliases",
-+ "cfg_aliases 0.2.1",
-  "libc",
-- "memoffset 0.9.1",
- ]
- 
- [[package]]
-@@ -2438,13 +2421,13 @@ dependencies = [
- 
- [[package]]
- name = "num-derive"
--version = "0.3.3"
-+version = "0.4.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 1.0.96",
-+ "syn 2.0.96",
- ]
- 
- [[package]]
-@@ -3535,6 +3518,12 @@ version = "0.10.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
- 
-+[[package]]
-+name = "strsim"
-+version = "0.11.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-+
- [[package]]
- name = "strum"
- version = "0.20.0"
-@@ -3694,11 +3683,10 @@ dependencies = [
- 
- [[package]]
- name = "terminfo"
--version = "0.8.0"
-+version = "0.9.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
-+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
- dependencies = [
-- "dirs",
-  "fnv",
-  "nom",
-  "phf",
-@@ -3716,9 +3704,9 @@ dependencies = [
- 
- [[package]]
- name = "termwiz"
--version = "0.22.0"
-+version = "0.23.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1"
-+checksum = "ed32af792ae81937cb8640b03eaef737408e5c8feee47b35e8b80c49bcb64524"
- dependencies = [
-  "anyhow",
-  "base64 0.21.0",
-@@ -3732,18 +3720,16 @@ dependencies = [
+ version = "0.29.0"
+@@ -3654,7 +3641,7 @@ dependencies = [
   "libc",
   "log",
   "memmem",
-- "nix 0.26.4",
-+ "nix 0.28.0",
+- "nix 0.29.0",
++ "nix",
   "num-derive",
   "num-traits",
   "ordered-float 4.2.0",
-  "pest",
-  "pest_derive",
-  "phf",
-- "semver 0.11.0",
-  "sha2",
-  "signal-hook",
-  "siphasher",
-- "tempfile",
-  "terminfo",
-  "termios",
-  "thiserror",
-@@ -3753,7 +3739,7 @@ dependencies = [
-  "wezterm-bidi",
-  "wezterm-blob-leases",
-  "wezterm-color-types",
-- "wezterm-dynamic 0.2.0",
-+ "wezterm-dynamic 0.2.1",
-  "wezterm-input-types",
-  "winapi",
- ]
-@@ -4656,7 +4642,7 @@ dependencies = [
-  "csscolorparser",
-  "deltae",
-  "lazy_static",
-- "wezterm-dynamic 0.2.0",
-+ "wezterm-dynamic 0.2.1",
- ]
- 
- [[package]]
-@@ -4667,29 +4653,29 @@ checksum = "a75e78c0cc60a76de5d93f9dad05651105351e151b6446ab305514945d7588aa"
- dependencies = [
-  "log",
-  "ordered-float 3.3.0",
-- "strsim",
-+ "strsim 0.10.0",
-  "thiserror",
-  "wezterm-dynamic-derive",
- ]
- 
- [[package]]
- name = "wezterm-dynamic"
--version = "0.2.0"
-+version = "0.2.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "dfb128bacfa86734e07681fb6068e34c144698e84ee022d6e009145d1abb77b5"
-+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
- dependencies = [
-  "log",
-  "ordered-float 4.2.0",
-- "strsim",
-+ "strsim 0.11.1",
-  "thiserror",
-  "wezterm-dynamic-derive",
- ]
- 
- [[package]]
- name = "wezterm-dynamic-derive"
--version = "0.1.0"
-+version = "0.1.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0c9f5ef318442d07b3d071f9f43ea40b80992f87faee14bb4d017b6991c307f0"
-+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
- dependencies = [
-  "proc-macro2",
-  "quote",
-@@ -4705,7 +4691,7 @@ dependencies = [
-  "bitflags 1.3.2",
-  "euclid",
-  "lazy_static",
-- "wezterm-dynamic 0.2.0",
-+ "wezterm-dynamic 0.2.1",
- ]
- 
- [[package]]
-@@ -5254,7 +5240,7 @@ dependencies = [
+@@ -5181,7 +5168,7 @@ dependencies = [
   "log",
   "log4rs",
   "miette",
 - "nix 0.23.1",
-+ "nix 0.29.0",
++ "nix",
   "notify-debouncer-full",
   "once_cell",
   "openssl-sys",
@@ -726,7 +537,7 @@ index 3bb5f227..78822ee3 100644
                      let err_context =
                          |pane_id| format!("failed to run async task for pane {pane_id:?}");
 diff --git a/zellij-utils/Cargo.toml b/zellij-utils/Cargo.toml
-index 6e51c27d..1098a202 100644
+index 14e50b51..f62a51cc 100644
 --- a/zellij-utils/Cargo.toml
 +++ b/zellij-utils/Cargo.toml
 @@ -25,7 +25,7 @@ lazy_static = "1.4.0"
@@ -738,15 +549,6 @@ index 6e51c27d..1098a202 100644
  once_cell = "1.8.0"
  percent-encoding = "2.1.0"
  prost = "0.11.9"
-@@ -47,7 +47,7 @@ vte = { version = "0.11.0", default-features = false }
- 
- #[cfg(not(target_family = "wasm"))]
- [target.'cfg(not(target_family = "wasm"))'.dependencies]
--termwiz = "0.22"
-+termwiz = "0.23"
- log4rs = "1.2.0"
- signal-hook = "0.3"
- interprocess = "1.2.1"
 -- 
 2.49.0
 

--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.42.0
+VER=0.42.1
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.42.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.42.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
