### PR TITLE
containers-common: update shortnames to v2025.03.19


### DIFF
--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -5,7 +5,7 @@ UPSTREAM_VER=0.62.2
 __IMAGE_VER=5.34.2
 __STORAGE_VER=1.57.2
 # FIXME: the following two dependencies are not in the go.sum file above.
-__SHORTNAMES_VER=2023.02.20
+__SHORTNAMES_VER=2025.03.19
 __SKOPEO_VER=1.18.0
 
 VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update shortnames to v2025.03.19

Package(s) Affected
-------------------

- containers-common: 0.62.2+image5.34.2+shortnames2025.03.19+skopeo1.18.0+storage1.57.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
