### PR TITLE
xdg-desktop-portal-gtk: update to 1.15.3

### DIFF
--- a/app-admin/xdg-desktop-portal-gtk/spec
+++ b/app-admin/xdg-desktop-portal-gtk/spec
@@ -1,4 +1,4 @@
-VER=1.15.2
+VER=1.15.3
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal-gtk/releases/download/$VER/xdg-desktop-portal-gtk-$VER.tar.xz"
-CHKSUMS="sha256::0295af247fc0d8c94e722731c29a2db7a045d38b132325b22e508709a235300b"
+CHKSUMS="sha256::47a3743d2419a8601e691db37e85bb5fac5ae4b26842177065cd5f22ada23b37"
 CHKUPDATE="anitya::id=11108"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal-gtk: update to 1.15.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- xdg-desktop-portal-gtk: 1.15.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
