### PR TITLE
webkit2gtk: update to 2.48.1

### DIFF
--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=webkit2gtk
 PKGSEC=gnome
 PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 gtk-4 hyphen icu \
         libavif libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
-        openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy"
+        openjpeg sqlite woff2 wpebackend-fdo xdg-dbus-proxy flite sysprof"
 BUILDDEP="gi-docgen gobject-introspection gperf gtk-doc ruby unifdef vim"
 PKGDES="A WebKit rendering engine port for GTK"
 
@@ -26,6 +26,7 @@ CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DENABLE_WEB_AUDIO=ON \
              -DENABLE_WEB_CRYPTO=ON \
              -DENABLE_X11_TARGET=ON \
+             -DENABLE_SPEECH_SYNTHESIS=ON \
              -DPORT=GTK \
              -DSHOULD_INSTALL_JS_SHELL=OFF \
              -DUSE_ANGLE_WEBGL=OFF \
@@ -41,7 +42,8 @@ CMAKE_AFTER="-DLIB_INSTALL_DIR=/usr/lib \
              -DUSE_OPENJPEG=ON \
              -DUSE_THIN_ARCHIVES=ON \
              -DUSE_WOFF2=ON \
-             -DUSE_WPE_RENDERER=ON"
+             -DUSE_WPE_RENDERER=ON \
+             -DUSE_SYSTEM_SYSPROF_CAPTURE=ON"
 CMAKE_AFTER__ARM64=" \
              ${CMAKE_AFTER} \
              -DUSE_64KB_PAGE_BLOCK=ON"
@@ -60,5 +62,5 @@ PKGBREAK="gnome-online-accounts<=3.40.0 devhelp<=40.1 \
           libgepub<=0.6.0 liferea<=1.13.8 midori<=9.0 remmina<=1.4.11 \
           shotwell<=0.31.3 wxgtk3<=3.0.4 xreader<=2.8.3"
 
-# Disable LTO due to OOM.
+# FIXME: Insufficient RAM for LTO on all current loongson3 buildbots
 NOLTO__LOONGSON3=1

--- a/runtime-web/webkit2gtk/autobuild/patches/0001-Enable-THREADS_PREFER_PTHREAD_FLAG.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0001-Enable-THREADS_PREFER_PTHREAD_FLAG.patch
@@ -1,7 +1,7 @@
-From cb0139175d8ea3c43cbb6c0f9752891f811c0405 Mon Sep 17 00:00:00 2001
+From 5dc0b0fa5a9627a93204b1b7c821aa8f8917c419 Mon Sep 17 00:00:00 2001
 From: Alberto Garcia <berto@igalia.com>
 Date: Thu, 23 May 2024 19:48:05 +0800
-Subject: [PATCH 1/2] Enable THREADS_PREFER_PTHREAD_FLAG
+Subject: [PATCH 1/7] Enable THREADS_PREFER_PTHREAD_FLAG
 
 This fixes a FTBFS in riscv64
 
@@ -14,20 +14,20 @@ Origin: https://trac.webkit.org/changeset/231843
  2 files changed, 3 insertions(+)
 
 diff --git a/Source/cmake/OptionsGTK.cmake b/Source/cmake/OptionsGTK.cmake
-index 781267de..13b00f8c 100644
+index 60b38586..17c24ed1 100644
 --- a/Source/cmake/OptionsGTK.cmake
 +++ b/Source/cmake/OptionsGTK.cmake
-@@ -13,6 +13,8 @@ endif ()
- 
+@@ -8,6 +8,8 @@ SET_PROJECT_VERSION(2 48 0)
  set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
  
+ find_package(GLIB 2.70.0 REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
 +set(THREADS_PREFER_PTHREAD_FLAG ON)
 +
  find_package(Cairo 1.16.0 REQUIRED)
- find_package(Fontconfig 2.13.0 REQUIRED)
- find_package(Freetype 2.9.0 REQUIRED)
+ find_package(LibGcrypt 1.7.0 REQUIRED)
+ find_package(Libtasn1 REQUIRED)
 diff --git a/Source/cmake/OptionsJSCOnly.cmake b/Source/cmake/OptionsJSCOnly.cmake
-index 31e353de..7bed31f4 100644
+index 1e8837b4..826c6ec0 100644
 --- a/Source/cmake/OptionsJSCOnly.cmake
 +++ b/Source/cmake/OptionsJSCOnly.cmake
 @@ -1,3 +1,4 @@
@@ -36,5 +36,5 @@ index 31e353de..7bed31f4 100644
  
  if (MSVC)
 -- 
-2.45.1
+2.49.0
 

--- a/runtime-web/webkit2gtk/autobuild/patches/0002-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0002-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
@@ -1,7 +1,7 @@
-From f131f15361f90dd11248d980f7e1c148030765c2 Mon Sep 17 00:00:00 2001
+From 8b0534ffca9ee3b306c47871ae5125b1e3dcedb1 Mon Sep 17 00:00:00 2001
 From: Alberto Garcia <berto@igalia.com>
 Date: Thu, 23 May 2024 19:48:44 +0800
-Subject: [PATCH 2/2] Description: Use WTF_CPU_UNKNOWN when building for
+Subject: [PATCH 2/7] Description: Use WTF_CPU_UNKNOWN when building for
  riscv64
 
 WebKitGTK doesn't build on riscv64 even with the JIT disabled.
@@ -16,7 +16,7 @@ Bug: https://bugs.webkit.org/show_bug.cgi?id=271371
  2 files changed, 10 deletions(-)
 
 diff --git a/Source/WTF/wtf/PlatformCPU.h b/Source/WTF/wtf/PlatformCPU.h
-index 166262f8..5f7d2c89 100644
+index ca328a20..c88b16a2 100644
 --- a/Source/WTF/wtf/PlatformCPU.h
 +++ b/Source/WTF/wtf/PlatformCPU.h
 @@ -285,14 +285,6 @@
@@ -35,7 +35,7 @@ index 166262f8..5f7d2c89 100644
  #define WTF_CPU_UNKNOWN 1
  #endif
 diff --git a/Source/cmake/WebKitCommon.cmake b/Source/cmake/WebKitCommon.cmake
-index f20a8d06..108a001c 100644
+index 38ac0c47..9d7873e2 100644
 --- a/Source/cmake/WebKitCommon.cmake
 +++ b/Source/cmake/WebKitCommon.cmake
 @@ -125,8 +125,6 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
@@ -48,5 +48,5 @@ index f20a8d06..108a001c 100644
          set(WTF_CPU_LOONGARCH64 1)
      else ()
 -- 
-2.45.1
+2.49.0
 

--- a/runtime-web/webkit2gtk/autobuild/patches/0003-loong64-Honor-existing-LASX-LSX-settings.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0003-loong64-Honor-existing-LASX-LSX-settings.patch
@@ -1,0 +1,32 @@
+From c550e9766a9ff28e42ca8af83bf709f486fbbdbd Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 24 Mar 2025 23:50:04 -0700
+Subject: [PATCH 3/7] [loong64] Honor existing LASX/LSX settings
+
+Change-Id: I1e6183b987002ed09621b111a6012a0f186233f1
+Signed-off-by: Bingwu Zhang <xtex@aosc.io>
+
+[Kaiyang Wu: backport to webkit2gtk]
+
+Link: https://skia-review.googlesource.com/c/skia/+/948976
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+index c2a0f5af..7780566e 100644
+--- a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
++++ b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+@@ -69,7 +69,7 @@ using NoCtx = const void*;
+ 
+ #if defined(SKRP_CPU_SCALAR) || defined(SKRP_CPU_NEON) || defined(SKRP_CPU_HSW) || \
+         defined(SKRP_CPU_SKX) || defined(SKRP_CPU_AVX) || defined(SKRP_CPU_SSE41) || \
+-        defined(SKRP_CPU_SSE2)
++        defined(SKRP_CPU_SSE2) || defined(SKRP_CPU_LASX) || defined(SKRP_CPU_LSX)
+     // Honor the existing setting
+ #elif !defined(__clang__) && !defined(__GNUC__)
+     #define SKRP_CPU_SCALAR
+-- 
+2.49.0
+

--- a/runtime-web/webkit2gtk/autobuild/patches/0004-loong64-Fix-missing-rounding-in-loong64-scaled_mult-.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0004-loong64-Fix-missing-rounding-in-loong64-scaled_mult-.patch
@@ -1,0 +1,59 @@
+From 554ea2cc5122d0c9162372394dfde28b02da83ed Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 24 Mar 2025 23:50:08 -0700
+Subject: [PATCH 4/7] [loong64] Fix missing rounding in loong64 scaled_mult
+ implementation
+
+The reference semantics of scaled_mult include rounding, but the
+original implementation did not do so. This is triggering an SkASSERT
+in the unit test case FilterResult_raster_RescaleWithTransform, from
+constrained_add's debug checks.
+
+The fixed implementation bumps the cost of each scaled_mult from 2
+to 5 instruction-count-wise (5 to 8 clock-cycle-wise with the LA464
+and LA664 micro-architectures), due to unavailability of rounding
+multiply operations in current LoongArch spec. However the computation
+now matches the reference scalar semantics, and proper testing of
+debug builds is now possible.
+
+Change-Id: I45e43a7a7e6d50b4c32c5e69a6d1d7de341eccf1
+
+[Kaiyang Wu: backport to webkit2gtk]
+
+Link: https://skia-review.googlesource.com/c/skia/+/908136
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../skia/src/opts/SkRasterPipeline_opts.h        | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+index 7780566e..4d5ae84a 100644
+--- a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
++++ b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+@@ -5532,11 +5532,19 @@ SI I16 scaled_mult(I16 a, I16 b) {
+ #elif defined(SKRP_CPU_NEON)
+     return vqrdmulhq_s16(a, b);
+ #elif defined(SKRP_CPU_LASX)
+-    I16 res = __lasx_xvmuh_h(a, b);
+-    return __lasx_xvslli_h(res, 1);
++    Vec<8, int32_t> even = (Vec<8, int32_t>)__lasx_xvmulwev_w_h((__m256i)a, (__m256i)b);
++    Vec<8, int32_t> odd = (Vec<8, int32_t>)__lasx_xvmulwod_w_h((__m256i)a, (__m256i)b);
++    Vec<8, int32_t> roundingTerm = (Vec<8, int32_t>)__lasx_xvldi(-0xec0);  // v8i32(0x40 << 8)
++    even = (even + roundingTerm) >> 15;
++    odd = (odd + roundingTerm) >> 15;
++    return (I16)__lasx_xvpackev_h((__m256i)odd, (__m256i)even);
+ #elif defined(SKRP_CPU_LSX)
+-    I16 res = __lsx_vmuh_h(a, b);
+-    return __lsx_vslli_h(res, 1);
++    Vec<4, int32_t> even = (Vec<4, int32_t>)__lsx_vmulwev_w_h((__m128i)a, (__m128i)b);
++    Vec<4, int32_t> odd = (Vec<4, int32_t>)__lsx_vmulwod_w_h((__m128i)a, (__m128i)b);
++    Vec<4, int32_t> roundingTerm = (Vec<4, int32_t>)__lsx_vldi(-0xec0);  // v4i32(0x40 << 8)
++    even = (even + roundingTerm) >> 15;
++    odd = (odd + roundingTerm) >> 15;
++    return (I16)__lsx_vpackev_h((__m128i)odd, (__m128i)even);
+ #else
+     const I32 roundingTerm = I32_(1 << 14);
+     return cast<I16>((cast<I32>(a) * cast<I32>(b) + roundingTerm) >> 15);
+-- 
+2.49.0
+

--- a/runtime-web/webkit2gtk/autobuild/patches/0005-loong64-Fix-the-remaining-implicit-vector-casts.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0005-loong64-Fix-the-remaining-implicit-vector-casts.patch
@@ -1,0 +1,431 @@
+From 569b0ae65b586df0807e149f6f8e226716918494 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 24 Mar 2025 23:50:11 -0700
+Subject: [PATCH 5/7] [loong64] Fix the remaining implicit vector casts
+
+CL 909436 fixed a few implicit vector casts, but they are not tested
+with a proper Skia build (in fact it was mainly for fixing those errors
+that happen to show up in Debian packaging e.g. wpewebkit), so many of
+the implicit casts remain.
+
+The changes here are tested with GCC 14, and confirmed to not affect
+Clang builds. However, due to an issue with Clang headers [1],
+-fno-lax-vector-conversions cannot be enabled for LoongArch Clang
+builds yet, at least for Clang < 19.1.4 [2].
+
+[1]: https://github.com/llvm/llvm-project/issues/110834
+[2]: https://github.com/llvm/llvm-project/pull/114958
+
+Change-Id: I3b4e9479cb6f9628b4cf796a0ac25098bc1836a2
+
+[Kaiyang Wu: backport to webkit2gtk]
+
+Link: https://skia-review.googlesource.com/c/skia/+/908137
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../ThirdParty/skia/src/core/SkBlurEngine.cpp |  36 ++--
+ .../skia/src/opts/SkRasterPipeline_opts.h     | 172 +++++++++---------
+ 2 files changed, 103 insertions(+), 105 deletions(-)
+
+diff --git a/Source/ThirdParty/skia/src/core/SkBlurEngine.cpp b/Source/ThirdParty/skia/src/core/SkBlurEngine.cpp
+index 2c18eb0f..1c8e9bdb 100644
+--- a/Source/ThirdParty/skia/src/core/SkBlurEngine.cpp
++++ b/Source/ThirdParty/skia/src/core/SkBlurEngine.cpp
+@@ -330,61 +330,61 @@ private:
+         skvx::Vec<4, uint32_t>* buffer0Cursor = fBuffer0Cursor;
+         skvx::Vec<4, uint32_t>* buffer1Cursor = fBuffer1Cursor;
+         skvx::Vec<4, uint32_t>* buffer2Cursor = fBuffer2Cursor;
+-        v4u32 sum0 = __lsx_vld(fSum0, 0); // same as skvx::Vec<4, uint32_t>::Load(fSum0);
+-        v4u32 sum1 = __lsx_vld(fSum1, 0);
+-        v4u32 sum2 = __lsx_vld(fSum2, 0);
++        v4u32 sum0 = (v4u32)__lsx_vld(fSum0, 0); // same as skvx::Vec<4, uint32_t>::Load(fSum0);
++        v4u32 sum1 = (v4u32)__lsx_vld(fSum1, 0);
++        v4u32 sum2 = (v4u32)__lsx_vld(fSum2, 0);
+ 
+         auto processValue = [&](v4u32& vLeadingEdge){
+           sum0 += vLeadingEdge;
+           sum1 += sum0;
+           sum2 += sum1;
+ 
+-          v4u32 divisorFactor = __lsx_vreplgr2vr_w(fDivider.divisorFactor());
+-          v4u32 blurred = __lsx_vmuh_w(divisorFactor, sum2);
++          v4u32 divisorFactor = (v4u32)__lsx_vreplgr2vr_w(fDivider.divisorFactor());
++          v4u32 blurred = (v4u32)__lsx_vmuh_w((__m128i)divisorFactor, (__m128i)sum2);
+ 
+-          v4u32 buffer2Value = __lsx_vld(buffer2Cursor, 0); //Not fBuffer0Cursor, out of bounds.
++          v4u32 buffer2Value = (v4u32)__lsx_vld(buffer2Cursor, 0); // Not fBuffer0Cursor, out of bounds.
+           sum2 -= buffer2Value;
+           __lsx_vst(sum1, (void *)buffer2Cursor, 0);
+           buffer2Cursor = (buffer2Cursor + 1) < fBuffersEnd ? buffer2Cursor + 1 : fBuffer2;
+-          v4u32 buffer1Value = __lsx_vld(buffer1Cursor, 0);
++          v4u32 buffer1Value = (v4u32)__lsx_vld(buffer1Cursor, 0);
+           sum1 -= buffer1Value;
+           __lsx_vst(sum0, (void *)buffer1Cursor, 0);
+           buffer1Cursor = (buffer1Cursor + 1) < fBuffer2 ? buffer1Cursor + 1 : fBuffer1;
+-          v4u32 buffer0Value = __lsx_vld(buffer0Cursor, 0);
++          v4u32 buffer0Value = (v4u32)__lsx_vld(buffer0Cursor, 0);
+           sum0 -= buffer0Value;
+           __lsx_vst(vLeadingEdge, (void *)buffer0Cursor, 0);
+           buffer0Cursor = (buffer0Cursor + 1) < fBuffer1 ? buffer0Cursor + 1 : fBuffer0;
+ 
+           v16u8 shuf = {0x0,0x4,0x8,0xc,0x0};
+-          v16u8 ret = __lsx_vshuf_b(blurred, blurred, shuf);
++          v16u8 ret = (v16u8)__lsx_vshuf_b((__m128i)blurred, (__m128i)blurred, (__m128i)shuf);
+           return ret;
+         };
+ 
+-        v4u32 zero = __lsx_vldi(0x0);
++        v4u32 zero = (v4u32)__lsx_vldi(0x0);
+         if (!src && !dst) {
+             while (n --> 0) {
+                 (void)processValue(zero);
+             }
+         } else if (src && !dst) {
+             while (n --> 0) {
+-                v4u32 edge = __lsx_vinsgr2vr_w(zero, *src, 0);
+-                edge = __lsx_vilvl_b(zero, edge);
+-                edge = __lsx_vilvl_h(zero, edge);
++                v4u32 edge = (v4u32)__lsx_vinsgr2vr_w((__m128i)zero, *src, 0);
++                edge = (v4u32)__lsx_vilvl_b((__m128i)zero, (__m128i)edge);
++                edge = (v4u32)__lsx_vilvl_h((__m128i)zero, (__m128i)edge);
+                 (void)processValue(edge);
+                 src += srcStride;
+             }
+         } else if (!src && dst) {
+             while (n --> 0) {
+-                v4u32 ret = processValue(zero);
++                v4u32 ret = (v4u32)processValue(zero);
+                 __lsx_vstelm_w(ret, dst, 0, 0); // 3rd is offset, 4th is idx.
+                 dst += dstStride;
+             }
+         } else if (src && dst) {
+             while (n --> 0) {
+-                v4u32 edge = __lsx_vinsgr2vr_w(zero, *src, 0);
+-                edge = __lsx_vilvl_b(zero, edge);
+-                edge = __lsx_vilvl_h(zero, edge);
+-                v4u32 ret = processValue(edge);
++                v4u32 edge = (v4u32)__lsx_vinsgr2vr_w(zero, *src, 0);
++                edge = (v4u32)__lsx_vilvl_b((__m128i)zero, (__m128i)edge);
++                edge = (v4u32)__lsx_vilvl_h((__m128i)zero, (__m128i)edge);
++                v4u32 ret = (v4u32)processValue(edge);
+                 __lsx_vstelm_w(ret, dst, 0, 0);
+                 src += srcStride;
+                 dst += dstStride;
+diff --git a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+index 4d5ae84a..05623fab 100644
+--- a/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
++++ b/Source/ThirdParty/skia/src/opts/SkRasterPipeline_opts.h
+@@ -922,16 +922,16 @@ namespace SK_OPTS_NS {
+                                                              sk_bit_cast<__m256i>(c)));
+     }
+ 
+-    SI F   min(F a, F b)        { return __lasx_xvfmin_s(a,b); }
+-    SI F   max(F a, F b)        { return __lasx_xvfmax_s(a,b); }
+-    SI I32 min(I32 a, I32 b)    { return __lasx_xvmin_w(a,b);  }
+-    SI U32 min(U32 a, U32 b)    { return __lasx_xvmin_wu(a,b); }
+-    SI I32 max(I32 a, I32 b)    { return __lasx_xvmax_w(a,b);  }
+-    SI U32 max(U32 a, U32 b)    { return __lasx_xvmax_wu(a,b); }
++    SI F   min(F a, F b)        { return (F)__lasx_xvfmin_s((__m256)a, (__m256)b);     }
++    SI F   max(F a, F b)        { return (F)__lasx_xvfmax_s((__m256)a, (__m256)b);     }
++    SI I32 min(I32 a, I32 b)    { return (I32)__lasx_xvmin_w((__m256i)a, (__m256i)b);  }
++    SI U32 min(U32 a, U32 b)    { return (U32)__lasx_xvmin_wu((__m256i)a, (__m256i)b); }
++    SI I32 max(I32 a, I32 b)    { return (I32)__lasx_xvmax_w((__m256i)a, (__m256i)b);  }
++    SI U32 max(U32 a, U32 b)    { return (U32)__lasx_xvmax_wu((__m256i)a, (__m256i)b); }
+ 
+     SI F   mad(F f, F m, F a)   { return __lasx_xvfmadd_s(f, m, a);      }
+     SI F   nmad(F f, F m, F a)  { return __lasx_xvfmadd_s(-f, m, a);    }
+-    SI F   abs_  (F v)          { return (F)__lasx_xvand_v((I32)v, (I32)(0-v));     }
++    SI F   abs_(F v)            { return (F)__lasx_xvand_v((__m256i)v, (__m256i)(I32)(0-v)); }
+     SI I32 abs_(I32 v)          { return max(v, -v);                     }
+     SI F   rcp_approx(F v)      { return __lasx_xvfrecip_s(v);           }
+     SI F   rcp_precise (F v)    { F e = rcp_approx(v); return e * nmad(v, e, F() + 2.0f); }
+@@ -939,18 +939,16 @@ namespace SK_OPTS_NS {
+     SI F    sqrt_(F v)          { return __lasx_xvfsqrt_s(v);            }
+ 
+     SI U32 iround(F v) {
+-        F t = F() + 0.5f;
+-        return __lasx_xvftintrz_w_s(v + t);
++        return (U32)__lasx_xvftintrz_w_s(v + 0.5f);
+     }
+ 
+     SI U32 round(F v) {
+-        F t = F() + 0.5f;
+-        return __lasx_xvftintrz_w_s(v + t);
++        return (U32)__lasx_xvftintrz_w_s(v + 0.5f);
+     }
+ 
+     SI U16 pack(U32 v) {
+-        return __lsx_vpickev_h(__lsx_vsat_wu(emulate_lasx_d_xr2vr_h(v), 15),
+-                               __lsx_vsat_wu(emulate_lasx_d_xr2vr_l(v), 15));
++        return (U16)__lsx_vpickev_h(__lsx_vsat_wu(emulate_lasx_d_xr2vr_h((__m256i)v), 15),
++                                    __lsx_vsat_wu(emulate_lasx_d_xr2vr_l((__m256i)v), 15));
+     }
+ 
+     SI U8 pack(U16 v) {
+@@ -960,12 +958,12 @@ namespace SK_OPTS_NS {
+     }
+ 
+     SI bool any(I32 c){
+-        v8i32 retv = (v8i32)__lasx_xvmskltz_w(__lasx_xvslt_wu(__lasx_xvldi(0), c));
++        v8i32 retv = (v8i32)__lasx_xvmskltz_w(__lasx_xvslt_wu(__lasx_xvldi(0), (__m256i)c));
+         return (retv[0] | retv[4]) != 0b0000;
+     }
+ 
+     SI bool all(I32 c){
+-        v8i32 retv = (v8i32)__lasx_xvmskltz_w(__lasx_xvslt_wu(__lasx_xvldi(0), c));
++        v8i32 retv = (v8i32)__lasx_xvmskltz_w(__lasx_xvslt_wu(__lasx_xvldi(0), (__m256i)c));
+         return (retv[0] & retv[4]) == 0b1111;
+     }
+ 
+@@ -998,16 +996,16 @@ namespace SK_OPTS_NS {
+     }
+ 
+     SI void load2(const uint16_t* ptr, U16* r, U16* g) {
+-        U16 _0123 = __lsx_vld(ptr, 0),
+-            _4567 = __lsx_vld(ptr, 16);
+-        *r = __lsx_vpickev_h(__lsx_vsat_w(__lsx_vsrai_w(__lsx_vslli_w(_4567, 16), 16), 15),
+-                             __lsx_vsat_w(__lsx_vsrai_w(__lsx_vslli_w(_0123, 16), 16), 15));
+-        *g = __lsx_vpickev_h(__lsx_vsat_w(__lsx_vsrai_w(_4567, 16), 15),
+-                             __lsx_vsat_w(__lsx_vsrai_w(_0123, 16), 15));
++        U16 _0123 = (U16)__lsx_vld(ptr, 0),
++            _4567 = (U16)__lsx_vld(ptr, 16);
++        *r = (U16)__lsx_vpickev_h(__lsx_vsat_w(__lsx_vsrai_w(__lsx_vslli_w(_4567, 16), 16), 15),
++                                  __lsx_vsat_w(__lsx_vsrai_w(__lsx_vslli_w(_0123, 16), 16), 15));
++        *g = (U16)__lsx_vpickev_h(__lsx_vsat_w(__lsx_vsrai_w(_4567, 16), 15),
++                                  __lsx_vsat_w(__lsx_vsrai_w(_0123, 16), 15));
+     }
+     SI void store2(uint16_t* ptr, U16 r, U16 g) {
+-        auto _0123 = __lsx_vilvl_h(g, r),
+-             _4567 = __lsx_vilvh_h(g, r);
++        auto _0123 = __lsx_vilvl_h((__m128i)g, (__m128i)r),
++             _4567 = __lsx_vilvh_h((__m128i)g, (__m128i)r);
+         __lsx_vst(_0123, ptr, 0);
+         __lsx_vst(_4567, ptr, 16);
+     }
+@@ -1028,17 +1026,17 @@ namespace SK_OPTS_NS {
+              rg4567 = __lsx_vilvl_h(_57, _46),
+              ba4567 = __lsx_vilvh_h(_57, _46);
+ 
+-        *r = __lsx_vilvl_d(rg4567, rg0123);
+-        *g = __lsx_vilvh_d(rg4567, rg0123);
+-        *b = __lsx_vilvl_d(ba4567, ba0123);
+-        *a = __lsx_vilvh_d(ba4567, ba0123);
++        *r = (U16)__lsx_vilvl_d(rg4567, rg0123);
++        *g = (U16)__lsx_vilvh_d(rg4567, rg0123);
++        *b = (U16)__lsx_vilvl_d(ba4567, ba0123);
++        *a = (U16)__lsx_vilvh_d(ba4567, ba0123);
+     }
+ 
+     SI void store4(uint16_t* ptr, U16 r, U16 g, U16 b, U16 a) {
+-        auto rg0123 = __lsx_vilvl_h(g, r),      // r0 g0 r1 g1 r2 g2 r3 g3
+-             rg4567 = __lsx_vilvh_h(g, r),      // r4 g4 r5 g5 r6 g6 r7 g7
+-             ba0123 = __lsx_vilvl_h(a, b),
+-             ba4567 = __lsx_vilvh_h(a, b);
++        auto rg0123 = __lsx_vilvl_h((__m128i)g, (__m128i)r),    // r0 g0 r1 g1 r2 g2 r3 g3
++             rg4567 = __lsx_vilvh_h((__m128i)g, (__m128i)r),    // r4 g4 r5 g5 r6 g6 r7 g7
++             ba0123 = __lsx_vilvl_h((__m128i)a, (__m128i)b),
++             ba4567 = __lsx_vilvh_h((__m128i)a, (__m128i)b);
+ 
+         auto _01 =__lsx_vilvl_w(ba0123, rg0123),
+              _23 =__lsx_vilvh_w(ba0123, rg0123),
+@@ -1121,29 +1119,29 @@ namespace SK_OPTS_NS {
+                                                            sk_bit_cast<__m128i>(c)));
+     }
+ 
+-    SI F   min(F a, F b)        { return __lsx_vfmin_s(a,b);     }
+-    SI F   max(F a, F b)        { return __lsx_vfmax_s(a,b);     }
+-    SI I32 min(I32 a, I32 b)    { return __lsx_vmin_w(a,b);      }
+-    SI U32 min(U32 a, U32 b)    { return __lsx_vmin_wu(a,b);     }
+-    SI I32 max(I32 a, I32 b)    { return __lsx_vmax_w(a,b);      }
+-    SI U32 max(U32 a, U32 b)    { return __lsx_vmax_wu(a,b);     }
++    SI F   min(F a, F b)        { return (F)__lsx_vfmin_s((__m128)a, (__m128)b);     }
++    SI F   max(F a, F b)        { return (F)__lsx_vfmax_s((__m128)a, (__m128)b);     }
++    SI I32 min(I32 a, I32 b)    { return (I32)__lsx_vmin_w((__m128i)a, (__m128i)b);  }
++    SI U32 min(U32 a, U32 b)    { return (U32)__lsx_vmin_wu((__m128i)a, (__m128i)b); }
++    SI I32 max(I32 a, I32 b)    { return (I32)__lsx_vmax_w((__m128i)a, (__m128i)b);  }
++    SI U32 max(U32 a, U32 b)    { return (U32)__lsx_vmax_wu((__m128i)a, (__m128i)b); }
+ 
+-    SI F   mad(F f, F m, F a)   { return __lsx_vfmadd_s(f, m, a);        }
+-    SI F   nmad(F f, F m, F a)  { return __lsx_vfmadd_s(-f, m, a);      }
+-    SI F   abs_(F v)            { return (F)__lsx_vand_v((I32)v, (I32)(0-v));       }
++    SI F   mad(F f, F m, F a)   { return (F)__lsx_vfmadd_s((__m128)f, (__m128)m, (__m128)a);    }
++    SI F   nmad(F f, F m, F a)  { return (F)__lsx_vfmadd_s((__m128)(-f), (__m128)m, (__m128)a); }
++    SI F   abs_(F v)            { return (F)__lsx_vand_v((__m128i)(I32)v, (__m128i)(I32)(0-v)); }
+     SI I32 abs_(I32 v)          { return max(v, -v);                     }
+-    SI F   rcp_approx (F v)     { return __lsx_vfrecip_s(v);             }
++    SI F   rcp_approx (F v)     { return (F)__lsx_vfrecip_s((__m128)v);  }
+     SI F   rcp_precise (F v)    { F e = rcp_approx(v); return e * nmad(v, e, F() + 2.0f); }
+-    SI F   rsqrt_approx (F v)   { return __lsx_vfrsqrt_s(v);             }
+-    SI F    sqrt_(F v)          { return __lsx_vfsqrt_s (v);             }
++    SI F   rsqrt_approx (F v)   { return (F)__lsx_vfrsqrt_s((__m128)v);  }
++    SI F    sqrt_(F v)          { return (F)__lsx_vfsqrt_s ((__m128)v);  }
+ 
+     SI U32 iround(F v) {
+-        F t = F() + 0.5f;
+-        return __lsx_vftintrz_w_s(v + t); }
++        return (U32)__lsx_vftintrz_w_s(v + 0.5f);
++    }
+ 
+     SI U32 round(F v) {
+-        F t = F() + 0.5f;
+-        return __lsx_vftintrz_w_s(v + t); }
++        return (U32)__lsx_vftintrz_w_s(v + 0.5f);
++    }
+ 
+     SI U16 pack(U32 v) {
+         __m128i tmp = __lsx_vsat_wu(v, 15);
+@@ -1159,12 +1157,12 @@ namespace SK_OPTS_NS {
+     }
+ 
+     SI bool any(I32 c){
+-        v4i32 retv = (v4i32)__lsx_vmskltz_w(__lsx_vslt_wu(__lsx_vldi(0), c));
++        v4i32 retv = (v4i32)__lsx_vmskltz_w(__lsx_vslt_wu(__lsx_vldi(0), (__m128i)c));
+         return retv[0] != 0b0000;
+     }
+ 
+     SI bool all(I32 c){
+-        v4i32 retv = (v4i32)__lsx_vmskltz_w(__lsx_vslt_wu(__lsx_vldi(0), c));
++        v4i32 retv = (v4i32)__lsx_vmskltz_w(__lsx_vslt_wu(__lsx_vldi(0), (__m128i)c));
+         return retv[0] == 0b1111;
+     }
+ 
+@@ -1211,7 +1209,7 @@ namespace SK_OPTS_NS {
+     }
+ 
+     SI void store2(uint16_t* ptr, U16 r, U16 g) {
+-        U32 rg = __lsx_vilvl_h(widen_cast<__m128i>(g), widen_cast<__m128i>(r));
++        U32 rg = (U32)__lsx_vilvl_h(widen_cast<__m128i>(g), widen_cast<__m128i>(r));
+         __lsx_vst(rg, ptr, 0);
+     }
+ 
+@@ -3391,35 +3389,35 @@ SI void gradient_lookup(const SkRasterPipeline_GradientCtx* c, U32 idx, F t,
+     } else
+ #elif defined(SKRP_CPU_LASX)
+     if (c->stopCount <= 8) {
+-        fr = (__m256)__lasx_xvperm_w(__lasx_xvld(c->fs[0], 0), idx);
+-        br = (__m256)__lasx_xvperm_w(__lasx_xvld(c->bs[0], 0), idx);
+-        fg = (__m256)__lasx_xvperm_w(__lasx_xvld(c->fs[1], 0), idx);
+-        bg = (__m256)__lasx_xvperm_w(__lasx_xvld(c->bs[1], 0), idx);
+-        fb = (__m256)__lasx_xvperm_w(__lasx_xvld(c->fs[2], 0), idx);
+-        bb = (__m256)__lasx_xvperm_w(__lasx_xvld(c->bs[2], 0), idx);
+-        fa = (__m256)__lasx_xvperm_w(__lasx_xvld(c->fs[3], 0), idx);
+-        ba = (__m256)__lasx_xvperm_w(__lasx_xvld(c->bs[3], 0), idx);
++        fr = (F)__lasx_xvperm_w(__lasx_xvld(c->fs[0], 0), (__m256i)idx);
++        br = (F)__lasx_xvperm_w(__lasx_xvld(c->bs[0], 0), (__m256i)idx);
++        fg = (F)__lasx_xvperm_w(__lasx_xvld(c->fs[1], 0), (__m256i)idx);
++        bg = (F)__lasx_xvperm_w(__lasx_xvld(c->bs[1], 0), (__m256i)idx);
++        fb = (F)__lasx_xvperm_w(__lasx_xvld(c->fs[2], 0), (__m256i)idx);
++        bb = (F)__lasx_xvperm_w(__lasx_xvld(c->bs[2], 0), (__m256i)idx);
++        fa = (F)__lasx_xvperm_w(__lasx_xvld(c->fs[3], 0), (__m256i)idx);
++        ba = (F)__lasx_xvperm_w(__lasx_xvld(c->bs[3], 0), (__m256i)idx);
+     } else
+ #elif defined(SKRP_CPU_LSX)
+     if (c->stopCount <= 4) {
+         __m128i zero = __lsx_vldi(0);
+-        fr = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->fs[0], 0));
+-        br = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->bs[0], 0));
+-        fg = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->fs[1], 0));
+-        bg = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->bs[1], 0));
+-        fb = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->fs[2], 0));
+-        bb = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->bs[2], 0));
+-        fa = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->fs[3], 0));
+-        ba = (__m128)__lsx_vshuf_w(idx, zero, __lsx_vld(c->bs[3], 0));
++        fr = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->fs[0], 0));
++        br = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->bs[0], 0));
++        fg = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->fs[1], 0));
++        bg = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->bs[1], 0));
++        fb = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->fs[2], 0));
++        bb = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->bs[2], 0));
++        fa = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->fs[3], 0));
++        ba = (F)__lsx_vshuf_w((__m128i)idx, zero, __lsx_vld(c->bs[3], 0));
+     } else
+ #endif
+     {
+ #if defined(SKRP_CPU_LSX)
+         // This can reduce some vpickve2gr instructions.
+-        int i0 = __lsx_vpickve2gr_w(idx, 0);
+-        int i1 = __lsx_vpickve2gr_w(idx, 1);
+-        int i2 = __lsx_vpickve2gr_w(idx, 2);
+-        int i3 = __lsx_vpickve2gr_w(idx, 3);
++        int i0 = __lsx_vpickve2gr_w((__m128i)idx, 0);
++        int i1 = __lsx_vpickve2gr_w((__m128i)idx, 1);
++        int i2 = __lsx_vpickve2gr_w((__m128i)idx, 2);
++        int i3 = __lsx_vpickve2gr_w((__m128i)idx, 3);
+         fr = gather((int *)c->fs[0], i0, i1, i2, i3);
+         br = gather((int *)c->bs[0], i0, i1, i2, i3);
+         fg = gather((int *)c->fs[1], i0, i1, i2, i3);
+@@ -5931,7 +5929,7 @@ SI void from_8888(U32 rgba, U16* r, U16* g, U16* b, U16* a) {
+         split(v, &_02,&_13);
+         __m256i tmp0 = __lasx_xvsat_wu(_02, 15);
+         __m256i tmp1 = __lasx_xvsat_wu(_13, 15);
+-        return __lasx_xvpickev_h(tmp1, tmp0);
++        return (U16)__lasx_xvpickev_h(tmp1, tmp0);
+     };
+ #elif defined(SKRP_CPU_LSX)
+     __m128i _01, _23, rg, ba;
+@@ -5941,10 +5939,10 @@ SI void from_8888(U32 rgba, U16* r, U16* g, U16* b, U16* a) {
+ 
+     __m128i mask_00ff = __lsx_vreplgr2vr_h(0xff);
+ 
+-    *r = __lsx_vand_v(rg, mask_00ff);
+-    *g = __lsx_vsrli_h(rg, 8);
+-    *b = __lsx_vand_v(ba, mask_00ff);
+-    *a = __lsx_vsrli_h(ba, 8);
++    *r = (U16)__lsx_vand_v(rg, mask_00ff);
++    *g = (U16)__lsx_vsrli_h(rg, 8);
++    *b = (U16)__lsx_vand_v(ba, mask_00ff);
++    *a = (U16)__lsx_vsrli_h(ba, 8);
+ #else
+     auto cast_U16 = [](U32 v) -> U16 {
+         return cast<U16>(v);
+@@ -5972,26 +5970,26 @@ SI void load_8888_(const uint32_t* ptr, U16* r, U16* g, U16* b, U16* a) {
+ SI void store_8888_(uint32_t* ptr, U16 r, U16 g, U16 b, U16 a) {
+ #if defined(SKRP_CPU_LSX)
+     __m128i mask = __lsx_vreplgr2vr_h(255);
+-    r = __lsx_vmin_hu(r, mask);
+-    g = __lsx_vmin_hu(g, mask);
+-    b = __lsx_vmin_hu(b, mask);
+-    a = __lsx_vmin_hu(a, mask);
++    r = (U16)__lsx_vmin_hu((__m128i)r, mask);
++    g = (U16)__lsx_vmin_hu((__m128i)g, mask);
++    b = (U16)__lsx_vmin_hu((__m128i)b, mask);
++    a = (U16)__lsx_vmin_hu((__m128i)a, mask);
+ 
+-    g = __lsx_vslli_h(g, 8);
++    g = (U16)__lsx_vslli_h(g, 8);
+     r = r | g;
+-    a = __lsx_vslli_h(a, 8);
++    a = (U16)__lsx_vslli_h(a, 8);
+     a = a | b;
+ 
+     __m128i r_lo = __lsx_vsllwil_wu_hu(r, 0);
+-    __m128i r_hi = __lsx_vexth_wu_hu(r);
++    __m128i r_hi = __lsx_vexth_wu_hu((__m128i)r);
+     __m128i a_lo = __lsx_vsllwil_wu_hu(a, 0);
+-    __m128i a_hi = __lsx_vexth_wu_hu(a);
++    __m128i a_hi = __lsx_vexth_wu_hu((__m128i)a);
+ 
+     a_lo = __lsx_vslli_w(a_lo, 16);
+     a_hi = __lsx_vslli_w(a_hi, 16);
+ 
+-    r = r_lo | a_lo;
+-    a = r_hi | a_hi;
++    r = (U16)(r_lo | a_lo);
++    a = (U16)(r_hi | a_hi);
+     store(ptr, join<U32>(r, a));
+ #else
+     r = min(r, 255);
+@@ -6557,8 +6555,8 @@ STAGE_GP(bilerp_clamp_8888, const SkRasterPipeline_GatherCtx* ctx) {
+     qy_lo = __lsx_vxor_v(qy_lo, temp);
+     qy_hi = __lsx_vxor_v(qy_hi, temp);
+ 
+-    I16 tx = __lsx_vpickev_h(qx_hi, qx_lo);
+-    I16 ty = __lsx_vpickev_h(qy_hi, qy_lo);
++    I16 tx = (I16)__lsx_vpickev_h(qx_hi, qx_lo);
++    I16 ty = (I16)__lsx_vpickev_h(qy_hi, qy_lo);
+ #else
+     I16 tx = cast<I16>(qx ^ 0x8000),
+         ty = cast<I16>(qy ^ 0x8000);
+-- 
+2.49.0
+

--- a/runtime-web/webkit2gtk/autobuild/patches/0006-PATCH-add-lasx-sources-to-CMakeList.txt.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0006-PATCH-add-lasx-sources-to-CMakeList.txt.patch
@@ -1,0 +1,67 @@
+From 66fb0bf893dc5fb009f221b06ec01b1807f83e4d Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Wed, 26 Mar 2025 02:36:47 -0700
+Subject: [PATCH 6/7] [PATCH] add lasx sources to CMakeList.txt
+
+Signed-off-by: Zhou Qiankang <wszqkzqk@qq.com>
+
+[Kaiyang Wu: adapt to webkit2gtk 2.48.0]
+
+Link: https://github.com/WebKit/WebKit/pull/37190
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ Source/ThirdParty/skia/CMakeLists.txt | 4 ++++
+ Source/WTF/wtf/simde/arm/neon.h       | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/Source/ThirdParty/skia/CMakeLists.txt b/Source/ThirdParty/skia/CMakeLists.txt
+index 74b12c3c..92ed41cf 100644
+--- a/Source/ThirdParty/skia/CMakeLists.txt
++++ b/Source/ThirdParty/skia/CMakeLists.txt
+@@ -80,6 +80,7 @@ add_library(Skia STATIC
+     src/core/SkBitmapProcState_matrixProcs.cpp
+     src/core/SkBitmapProcState_opts.cpp
+     src/core/SkBitmapProcState_opts_ssse3.cpp
++    src/core/SkBitmapProcState_opts_lasx.cpp
+     src/core/SkBlendMode.cpp
+     src/core/SkBlendModeBlender.cpp
+     src/core/SkBlitMask_opts.cpp
+@@ -87,6 +88,7 @@ add_library(Skia STATIC
+     src/core/SkBlitRow_D32.cpp
+     src/core/SkBlitRow_opts.cpp
+     src/core/SkBlitRow_opts_hsw.cpp
++    src/core/SkBlitRow_opts_lasx.cpp
+     src/core/SkBlitter.cpp
+     src/core/SkBlitter_A8.cpp
+     src/core/SkBlitter_ARGB32.cpp
+@@ -243,6 +245,7 @@ add_library(Skia STATIC
+     src/core/SkSwizzler_opts.cpp
+     src/core/SkSwizzler_opts_hsw.cpp
+     src/core/SkSwizzler_opts_ssse3.cpp
++    src/core/SkSwizzler_opts_lasx.cpp
+     src/core/SkTaskGroup.cpp
+     src/core/SkTextBlob.cpp
+     src/core/SkTypeface.cpp
+@@ -774,6 +777,7 @@ add_library(Skia STATIC
+ 
+     src/opts/SkOpts_hsw.cpp
+     src/opts/SkOpts_skx.cpp
++    src/opts/SkOpts_lasx.cpp
+ 
+     src/ports/SkGlobalInitialization_default.cpp
+     src/ports/SkImageGenerator_skia.cpp
+diff --git a/Source/WTF/wtf/simde/arm/neon.h b/Source/WTF/wtf/simde/arm/neon.h
+index 28dc5821..0a2e96d9 100644
+--- a/Source/WTF/wtf/simde/arm/neon.h
++++ b/Source/WTF/wtf/simde/arm/neon.h
+@@ -8788,6 +8788,7 @@ SIMDE_BEGIN_DECLS_
+     !(defined(HEDLEY_MSVC_VERSION) && defined(__clang__)) && \
+     !(defined(SIMDE_ARCH_MIPS) && defined(__clang__)) && \
+     !(defined(SIMDE_ARCH_ZARCH) && defined(__clang__)) && \
++    !(defined(SIMDE_ARCH_LOONGARCH) && defined(__clang__)) && \
+     !(defined(__clang__) && defined(SIMDE_ARCH_RISCV64)) && ( \
+       defined(SIMDE_X86_AVX512FP16_NATIVE) || \
+       (defined(SIMDE_ARCH_X86_SSE2) && HEDLEY_GCC_VERSION_CHECK(12,0,0)) || \
+-- 
+2.49.0
+

--- a/runtime-web/webkit2gtk/autobuild/patches/0007-Supply-mlasx-to-enable-LASX-intrinsics-on-loongarch6.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0007-Supply-mlasx-to-enable-LASX-intrinsics-on-loongarch6.patch
@@ -1,0 +1,57 @@
+From 862714ced43f51fc3c5b3ccbf472fc79e392d269 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Fri, 28 Mar 2025 05:11:12 -0700
+Subject: [PATCH 7/7] Supply -mlasx to enable LASX intrinsics on loongarch64
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ Source/ThirdParty/skia/CMakeLists.txt | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/Source/ThirdParty/skia/CMakeLists.txt b/Source/ThirdParty/skia/CMakeLists.txt
+index 92ed41cf..44ba62f6 100644
+--- a/Source/ThirdParty/skia/CMakeLists.txt
++++ b/Source/ThirdParty/skia/CMakeLists.txt
+@@ -1067,6 +1067,7 @@ endif ()
+ #
+ set(Skia_SkCMS_HSW_OPTS FALSE)
+ set(Skia_SkCMS_SKX_OPTS FALSE)
++set(Skia_SkCMS_LASX_OPTS FALSE)
+ 
+ set(Skia_SkCMS_HSW_FLAGS
+     -ffp-contract=off
+@@ -1081,6 +1082,9 @@ set(Skia_SkCMS_SKX_FLAGS
+     -mavx512bw
+     -mavx512vl
+ )
++set(Skia_SkCMS_LASX_FLAGS
++    -mlasx
++)
+ 
+ if (WTF_CPU_X86 OR WTF_CPU_X86_64)
+     target_compile_definitions(Skia PRIVATE SK_ENABLE_AVX512_OPTS)
+@@ -1092,6 +1096,12 @@ if (WTF_CPU_X86 OR WTF_CPU_X86_64)
+     WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/opts/SkOpts_skx.cpp "-march=skylake-avx512")
+ endif ()
+ 
++if (WTF_CPU_LOONGARCH64)
++    WEBKIT_CHECK_COMPILER_FLAGS(
++        CXX Skia_SkCMS_LASX_OPTS
++        ${SKIA_SkCMS_LASX_FLAGS})
++endif ()
++
+ if (Skia_SkCMS_HSW_OPTS)
+     WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE modules/skcms/src/skcms_TransformHsw.cc ${Skia_SkCMS_HSW_FLAGS})
+ else ()
+@@ -1104,4 +1114,8 @@ else ()
+     target_compile_definitions(Skia PRIVATE SKCMS_DISABLE_SKX)
+ endif ()
+ 
++if (Skia_SkCMS_LASX_OPTS)
++    WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(${Skia_SkCMS_LASX_FLAGS})
++endif ()
++
+ add_library(Skia::Skia ALIAS Skia)
+-- 
+2.49.0
+

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,7 +1,9 @@
-VER=2.44.2
+VER=2.48.1
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521b"
+CHKSUMS="sha256::98efdf21c4cdca0fe0b73ab5a8cb52093b5aa52d9b1b016a93f71dbfa1eb258f"
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=5
+ENVREQ__RISCV64="total_mem=100"
+ENVREQ__PPC64EL="total_mem_per_core=4"
+ENVREQ__LOONGSON3="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.48.1
    Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.48.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
