### PR TITLE
ostree: update to 2025.2

### DIFF
--- a/app-admin/ostree/autobuild/patches/0001-Fix-build-error-with-with-ed25519-libsodium-and-with.patch
+++ b/app-admin/ostree/autobuild/patches/0001-Fix-build-error-with-with-ed25519-libsodium-and-with.patch
@@ -1,0 +1,33 @@
+From 9dd0dfec4d59d73a54fe2ba3b93be70a909d3aed Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <dueno@redhat.com>
+Date: Mon, 24 Mar 2025 21:25:12 +0900
+Subject: [PATCH] Fix build error with --with-ed25519-libsodium and
+ --with-openssl
+
+While libotcore can be configured with those options individually, the
+latter is always required for OpenSSL's EVP functions. This splits the
+ifdefs to accommodate that.
+
+Signed-off-by: Daiki Ueno <dueno@redhat.com>
+---
+ src/libotcore/otcore.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/libotcore/otcore.h b/src/libotcore/otcore.h
+index ceeb1a92..3ce8f2a3 100644
+--- a/src/libotcore/otcore.h
++++ b/src/libotcore/otcore.h
+@@ -25,7 +25,9 @@
+ #ifdef HAVE_LIBSODIUM
+ #include <sodium.h>
+ #define USE_LIBSODIUM
+-#elif defined(HAVE_OPENSSL)
++#endif
++
++#if defined(HAVE_OPENSSL)
+ #include <openssl/evp.h>
+ #include <openssl/x509.h>
+ #define USE_OPENSSL
+-- 
+2.49.0
+

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,4 @@
-VER=2025.1
+VER=2025.2
 SRCS="git::commit=tags/v$VER::https://github.com/ostreedev/ostree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: update to 2025.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- ostree: 2025.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
