### PR TITLE
tzdata: update to 2025b

### DIFF
--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,4 +1,4 @@
-VER=2025a
+VER=2025b
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
-CHKSUMS="sha256::4d5fcbc72c7c450ebfe0b659bd0f1c02fbf52fd7f517a9ea13fe71c21eb5f0d0"
+CHKSUMS="sha256::11810413345fc7805017e27ea9fa4885fd74cd61b2911711ad038f5d28d71474"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: update to 2025b
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- tzdata: 2025b

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
