### PR TITLE
hidapi: Use cmake to build the package

### DIFF
--- a/runtime-devices/hidapi/autobuild/defines
+++ b/runtime-devices/hidapi/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME=hidapi
 PKGSEC=libs
 PKGDEP="libusb"
 PKGDES="Simple library for communicating with USB and Bluetooth HID devices"
+
+ABTYPE="cmake"
+BUILDDEP="cmake"

--- a/runtime-devices/hidapi/autobuild/prepare
+++ b/runtime-devices/hidapi/autobuild/prepare
@@ -1,1 +1,0 @@
-export LDFLAGS="${LDFLAGS} -lpthread"

--- a/runtime-devices/hidapi/spec
+++ b/runtime-devices/hidapi/spec
@@ -1,4 +1,5 @@
 VER=0.14.0
+REL=1
 SRCS="tbl::https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${VER}.tar.gz"
 CHKSUMS="sha256::a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd"
 CHKUPDATE="anitya::id=5594"


### PR DESCRIPTION
Topic Description
-----------------

Per https://github.com/libusb/hidapi/blob/hidapi-0.14.0/BUILD.md, using autotools to build the package is deprecated.

Also removing `export LDFLAGS="${LDFLAGS} -lpthread"` as libpthread has been merged into libc now.

Package(s) Affected
-------------------

* hidapi: 1.14.0-1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
#buildit hidapi
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
