### PR TITLE
weechat: update to 4.6.0

### DIFF
--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.5.2
+VER=4.6.0
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::1a65466dcd3edb7378f27a611e06e2f7f45a6028ae54d3e1696ca91e85ec1459"
+CHKSUMS="sha256::2681fc662996fead9d66a26d81740088e4284cf4e6dfe6b834f3b98fc703597f"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.6.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- weechat: 4.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
