### PR TITLE
libidn: update to 1.43

### DIFF
--- a/runtime-network/libidn/spec
+++ b/runtime-network/libidn/spec
@@ -1,4 +1,4 @@
-VER=1.42
+VER=1.43
 SRCS="tbl::https://ftp.gnu.org/gnu/libidn/libidn-$VER.tar.gz"
-CHKSUMS="sha256::d6c199dcd806e4fe279360cb4b08349a0d39560ed548ffd1ccadda8cdecb4723"
+CHKSUMS="sha256::bdc662c12d041b2539d0e638f3a6e741130cdb33a644ef3496963a443482d164"
 CHKUPDATE="anitya::id=1639"


### PR DESCRIPTION
Topic Description
-----------------

- libidn: update to 1.43
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libidn: 1.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit libidn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
