### PR TITLE
mercurial: update to 6.9.4

### DIFF
--- a/app-vcs/mercurial/spec
+++ b/app-vcs/mercurial/spec
@@ -1,4 +1,4 @@
-VER=6.8.1
+VER=6.9.4
 SRCS="tbl::https://www.mercurial-scm.org/release/mercurial-$VER.tar.gz"
-CHKSUMS="sha256::030e8a7a6d590e4eaeb403ee25675615cd80d236f3ab8a0b56dcc84181158b05"
+CHKSUMS="sha256::7ea0e839ec8345277dd19d07250b4426134dc5d6682ff880a86a2b09b4e38ecd"
 CHKUPDATE="anitya::id=1969"

--- a/topics/mercurial-6.9.4.toml
+++ b/topics/mercurial-6.9.4.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Mercurial 6.9.4 Security Update"
+zh_CN = "Mercurial 6.9.4 安全更新"
+
+[caution]
+default = "Fixes a cross-site scripting (XSS) vulnerability - CVE-2025-2361 (Severity: Moderate)"
+zh_CN = "本更新可修复一处跨站脚本攻击 (XSS)，漏洞编号 CVE-2025-2361（严重性：中等）"
+
+[packages]
+mercurial = "6.9.4"


### PR DESCRIPTION
Topic Description
-----------------

- mercurial: update to 6.9.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mercurial: 6.9.4

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/10202

Build Order
-----------

```
#buildit mercurial
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
