### PR TITLE
gdbm: update to 1.25

### DIFF
--- a/app-database/gdbm/spec
+++ b/app-database/gdbm/spec
@@ -1,4 +1,4 @@
-VER=1.24
+VER=1.25
 SRCS="https://ftp.gnu.org/gnu/gdbm/gdbm-$VER.tar.gz"
-CHKSUMS="sha256::695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf"
+CHKSUMS="sha256::d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec"
 CHKUPDATE="anitya::id=882"

--- a/runtime-optenv32/gdbm+32/spec
+++ b/runtime-optenv32/gdbm+32/spec
@@ -1,4 +1,4 @@
-VER=1.24
+VER=1.25
 SRCS="https://ftp.gnu.org/gnu/gdbm/gdbm-$VER.tar.gz"
-CHKSUMS="sha256::695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf"
+CHKSUMS="sha256::d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec"
 CHKUPDATE="anitya::id=882"


### PR DESCRIPTION
Topic Description
-----------------

- gdbm+32: update to 1.25
- gdbm: update to 1.25

Package(s) Affected
-------------------

- gdbm: 1.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdbm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
