### PR TITLE
cpu-x: update to 5.2.0

### DIFF
--- a/app-utils/cpu-x/autobuild/defines
+++ b/app-utils/cpu-x/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=cpu-x
 PKGSEC=utils
 PKGDES="A tool to present information on CPU, motherboard and more"
 PKGDEP="gtkmm-3 glibmm pangomm cairomm libsigc++ glib ncurses libcpuid \
-        pciutils libglvnd glfw vulkan libcl procps gcc-runtime glibc"
+        pciutils libglvnd vulkan libcl procps gcc-runtime glibc"
 BUILDDEP="gettext opencl-registry-api"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
 

--- a/app-utils/cpu-x/autobuild/patches/0001-CMake-remove-processor-check-to-support-more-platfor.patch
+++ b/app-utils/cpu-x/autobuild/patches/0001-CMake-remove-processor-check-to-support-more-platfor.patch
@@ -1,0 +1,30 @@
+From 5891f3f216a8d3d352be6c9d6322a6a73bf3c314 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Mon, 24 Mar 2025 14:01:29 +0800
+Subject: [PATCH] [CMake] remove processor check to support more platform
+
+Revert part of commit 3c32a9171be7 ("[CMake] Check CPU and system support")
+to support more platforms.
+
+Signed-off-by: Qing Yun <kf@aosc.io>
+---
+ CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f72b93f..6122000c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,9 +11,6 @@ project(cpu-x
+ if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+ 	message(WARNING "'${CMAKE_SYSTEM_NAME}' system is not officially supported by CPU-X, some features will not be available.")
+ endif(NOT CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|^armv.*|aarch64")
+-	message(FATAL_ERROR "'${CMAKE_SYSTEM_PROCESSOR}' processor is not supported by CPU-X.")
+-endif(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|^armv.*|aarch64")
+ 
+ 
+ ### DEFAULT CONFIG
+-- 
+2.49.0
+

--- a/app-utils/cpu-x/spec
+++ b/app-utils/cpu-x/spec
@@ -1,4 +1,4 @@
-VER=5.1.3
+VER=5.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/TheTumultuousUnicornOfDarkness/CPU-X"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137672"


### PR DESCRIPTION
Topic Description
-----------------

- cpu-x: update to 5.2.0
    - Remove glfw in depends
    - Link: https://github.com/TheTumultuousUnicornOfDarkness/CPU-X/pull/374

Package(s) Affected
-------------------

- cpu-x: 5.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpu-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
