### PR TITLE
scan-base: revive

### DIFF
--- a/meta-bases/scan-base/autobuild/defines
+++ b/meta-bases/scan-base/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=scan-base
+PKGSEC=Bases
+PKGDEP="foomatic gutenprint tesseract"
+PKGDES="Meta package for AOSC OS scanning support"
+
+VER_NONE=1
+ABHOST=noarch
+
+ABTYPE=dummy

--- a/meta-bases/scan-base/spec
+++ b/meta-bases/scan-base/spec
@@ -1,0 +1,3 @@
+VER=1
+REL=1
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- scan-base: revive
    This reverts commit b59d16f5aaf9e0ec38b7cf677e49977daed209f9, which
    erroneously removed scan-base, a dependency for productivity-base.

Package(s) Affected
-------------------

- scan-base: 1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit scan-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
