### PR TITLE
libsoup-3: update to 3.6.5

### DIFF
--- a/runtime-web/libsoup-3/autobuild/defines
+++ b/runtime-web/libsoup-3/autobuild/defines
@@ -1,20 +1,22 @@
 PKGNAME=libsoup-3
 PKGSEC=libs
-PKGDEP="brotli glib-networking libpsl libxml2 nghttp2 python-3 samba sqlite"
-BUILDDEP="jinja2 gobject-introspection gi-docgen gtk-doc intltool typogrify \
-          vala vim"
+PKGDEP="brotli glib glibc glib-networking krb5 libpsl nghttp2 sqlite \
+        zlib libpsl libxml2 python-3 samba"
+BUILDDEP="gobject-introspection gi-docgen gtk-doc intltool typogrify vala"
 PKGDES="HTTP client/server library for GNOME (version 3)"
 
-MESON_AFTER="-Dgssapi=enabled \
-             -Dntlm=enabled \
-             -Dbrotli=enabled \
-             -Dtls_check=true \
-             -Dintrospection=enabled \
-             -Dvapi=enabled \
-             -Ddocs=enabled \
-             -Dtests=false \
-             -Dautobahn=disabled \
-             -Dinstalled_tests=false \
-             -Dsysprof=disabled \
-             -Dfuzzing=disabled \
-             -Dpkcs11_tests=disabled"
+MESON_AFTER=(
+    "-Dgssapi=enabled"
+    "-Dntlm=enabled"
+    "-Dbrotli=enabled"
+    "-Dtls_check=true"
+    "-Dintrospection=enabled"
+    "-Dvapi=enabled"
+    "-Ddocs=enabled"
+    "-Dtests=false"
+    "-Dautobahn=disabled"
+    "-Dinstalled_tests=false"
+    "-Dsysprof=disabled"
+    "-Dfuzzing=disabled"
+    "-Dpkcs11_tests=disabled"
+)

--- a/runtime-web/libsoup-3/spec
+++ b/runtime-web/libsoup-3/spec
@@ -1,4 +1,4 @@
-VER=3.2.2
+VER=3.6.5
 SRCS="https://download.gnome.org/sources/libsoup/${VER%.*}/libsoup-$VER.tar.xz"
-CHKSUMS="sha256::83673c685b910fb7d39f1f28eee5afbefb71c05798fc350ac3bf1b885e1efaa1"
+CHKSUMS="sha256::6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
 CHKUPDATE="anitya::id=11483"


### PR DESCRIPTION
Topic Description
-----------------

- libsoup-3: update to 3.6.5

Package(s) Affected
-------------------

- libsoup-3: 3.6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsoup-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
