### PR TITLE
ddrescue: update to 1.29.1

### DIFF
--- a/app-utils/ddrescue/spec
+++ b/app-utils/ddrescue/spec
@@ -1,4 +1,4 @@
-VER=1.29
+VER=1.29.1
 SRCS="tbl::https://ftp.gnu.org/gnu/ddrescue/ddrescue-$VER.tar.lz"
-CHKSUMS="sha256::01a414327853b39fba2fd0ece30f7bee2e9d8c8e8eb314318524adf5a60039a3"
+CHKSUMS="sha256::ddd7d45df026807835a2ec6ab9c365df2ef19e8de1a50ffe6886cd391e04dd75"
 CHKUPDATE="anitya::id=410"


### PR DESCRIPTION
Topic Description
-----------------

- ddrescue: update to 1.29.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ddrescue: 1.29.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddrescue
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
