### PR TITLE
geant4: update to 11.3.1

### DIFF
--- a/app-scientific/geant4/autobuild/defines
+++ b/app-scientific/geant4/autobuild/defines
@@ -3,23 +3,23 @@ PKGDES="A toolkit for the simulation of the passage of particles through matter"
 PKGSEC=science
 PKGDEP="cmake make llvm xerces-c zlib expat motif coin soqt qt-6 python-3 boost"
 BUILDDEP="extra-cmake-modules"
-ABTYPE=cmake
 
-CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
-             -DGEANT4_USE_G3TOG4=ON \
-             -DGEANT4_USE_GDML=ON \
-             -DGEANT4_USE_INVENTOR_QT=ON \
-             -DGEANT4_USE_OPENGL_X11=ON \
-             -DGEANT4_USE_QT=ON \
-             -DGEANT4_USE_RAYTRACER_X11=ON \
-             -DGEANT4_USE_XM=ON \
-             -DGEANT4_USE_SYSTEM_ZLIB=ON \
-             -DGEANT4_INSTALL_PACKAGE_CACHE=OFF \
-             -DGEANT4_BUILD_TLS_MODEL=global-dynamic \
-             -DGEANT4_USE_QT_QT6=ON \
-             -DGEANT4_USE_PYTHON=ON \
-             -DGEANT4_INSTALL_DATA=ON \
-             -DGEANT4_INSTALL_DATASETS_TENDL=ON"
+CMAKE_AFTER=(
+    "-DGEANT4_USE_G3TOG4=ON"
+    "-DGEANT4_USE_GDML=ON"
+    "-DGEANT4_USE_INVENTOR_QT=ON"
+    "-DGEANT4_USE_OPENGL_X11=ON"
+    "-DGEANT4_USE_QT=ON"
+    "-DGEANT4_USE_RAYTRACER_X11=ON"
+    "-DGEANT4_USE_XM=ON"
+    "-DGEANT4_USE_SYSTEM_ZLIB=ON"
+    "-DGEANT4_INSTALL_PACKAGE_CACHE=OFF"
+    "-DGEANT4_BUILD_TLS_MODEL=global-dynamic"
+    "-DGEANT4_USE_QT_QT6=ON"
+    "-DGEANT4_USE_PYTHON=ON"
+    "-DGEANT4_INSTALL_DATA=ON"
+    "-DGEANT4_INSTALL_DATASETS_TENDL=ON"
+)
 
 # FIXME: ABI change for returning aggregates with empty bases in GCC 12.1
 NOLTO__LOONGSON3=1

--- a/app-scientific/geant4/spec
+++ b/app-scientific/geant4/spec
@@ -1,5 +1,4 @@
-VER=11.3.0
-REL=1
+VER=11.3.1
 SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
-CHKSUMS="sha256::1da4318b3f96f87f4d47558a32dab269b8f3fc956708038c28e72a180b0efba6"
+CHKSUMS="sha256::c93ca996f6f35aa43f948ffcaba9603468df01deeb62f61c33ba769227c319fe"
 CHKUPDATE="anitya::id=375805"


### PR DESCRIPTION
Topic Description
-----------------

- geant4: update to 11.3.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- geant4: 11.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit geant4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
