### PR TITLE
iotop: configuring capability

### DIFF
--- a/app-utils/iotop/autobuild/patches/0001-install-binary-to-bin-instead-of-sbin.patch
+++ b/app-utils/iotop/autobuild/patches/0001-install-binary-to-bin-instead-of-sbin.patch
@@ -1,0 +1,31 @@
+From c4759c8bfcbdefbd9487a37aba9a2cf7bf8097a9 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Tue, 25 Mar 2025 21:50:02 +0800
+Subject: [PATCH 1/2] install binary to bin instead of sbin
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index bffac53..7a47972 100644
+--- a/Makefile
++++ b/Makefile
+@@ -145,12 +145,12 @@ install: $(TARGET)
+ 	$(E) STRIP $(TARGET)
+ 	$(Q)$(STRIP) $(TARGET)
+ 	$(E) INSTALL $(TARGET)
+-	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/sbin/$(TARGET)
++	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/bin/$(TARGET)
+ 	$(Q)$(INSTALL) -D -m 0644 iotop.8 $(PREFIX)/share/man/man8/iotop.8
+ 
+ uninstall:
+ 	$(E) UNINSTALL $(TARGET)
+-	$(Q)rm -f $(PREFIX)/sbin/$(TARGET)
++	$(Q)rm -f $(PREFIX)/bin/$(TARGET)
+ 	$(Q)rm -f $(PREFIX)/share/man/man8/iotop.8
+ 
+ bld/.mkdir:
+-- 
+2.49.0
+

--- a/app-utils/iotop/autobuild/patches/0002-do-not-strip-during-compilation.patch
+++ b/app-utils/iotop/autobuild/patches/0002-do-not-strip-during-compilation.patch
@@ -1,0 +1,33 @@
+From 53dc9022b54212b49e9e236de5bccb681b9221c1 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Tue, 25 Mar 2025 21:50:14 +0800
+Subject: [PATCH 2/2] do not strip during compilation
+
+---
+ Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 7a47972..89abe01 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,7 +37,6 @@ endif
+ 
+ PREFIX?=$(DESTDIR)/usr
+ INSTALL?=install
+-STRIP?=strip
+ 
+ PKG_CONFIG?=pkg-config
+ NCCC?=$(shell $(PKG_CONFIG) --cflags ncursesw)
+@@ -142,8 +141,6 @@ clean:
+ 	$(Q)rm -rf ./bld $(TARGET)
+ 
+ install: $(TARGET)
+-	$(E) STRIP $(TARGET)
+-	$(Q)$(STRIP) $(TARGET)
+ 	$(E) INSTALL $(TARGET)
+ 	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/bin/$(TARGET)
+ 	$(Q)$(INSTALL) -D -m 0644 iotop.8 $(PREFIX)/share/man/man8/iotop.8
+-- 
+2.49.0
+

--- a/app-utils/iotop/autobuild/postinst
+++ b/app-utils/iotop/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Configuring capability of /usr/bin/iotop"
+setcap cap_net_admin+eip /usr/bin/iotop

--- a/app-utils/iotop/autobuild/prepare
+++ b/app-utils/iotop/autobuild/prepare
@@ -1,5 +1,0 @@
-abinfo "Tweaking Makefile, install binary to bin instead of sbin ..."
-sed -i 's/sbin/bin/g' "$SRCDIR"/Makefile
-
-abinfo "Tweaking Makefile, do not strip during compilation ..."
-sed -i '/STRIP/d' "$SRCDIR"/Makefile

--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,4 +1,5 @@
 VER=1.27
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/Tomas-M/iotop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=259120"


### PR DESCRIPTION
Topic Description
-----------------

- iotop: configuring capability
    - Configuring capability of /usr/bin/iotop
    - Use patches instead of using sed

Package(s) Affected
-------------------

- iotop: 1.27-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
