### PR TITLE
xz: update to 5.6.4

### DIFF
--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,5 +1,4 @@
-VER=5.6.3
-REL=1
+VER=5.6.4
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a"
+CHKSUMS="sha256::829ccfe79d769748f7557e7a4429a64d06858e27e1e362e25d01ab7b931d9c95"
 CHKUPDATE="anitya::id=5277"


### PR DESCRIPTION
Topic Description
-----------------

- xz: update to 5.6.4
    Co-authored-by: Kexy Biscuit a.k.a. るる \(@KexyBiscuit\) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- xz: 5.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
