### PR TITLE
mpv: update to 0.40.0

### DIFF
--- a/app-multimedia/mpv/autobuild/defines
+++ b/app-multimedia/mpv/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="ffmpeg lcms2 mesa enca wayland desktop-file-utils hicolor-icon-theme \
         xdg-utils lua libdvdnav jack openjpeg-legacy libvdpau \
         libcdio-paranoia libguess samba libva libcaca uchardet rubberband \
         youtube-dl libcdio libdvbpsi openal-soft sdl2 vulkan libarchive \
-        pipewire libplacebo mujs luajit vapoursynth sndio libsixel"
+        pipewire libplacebo mujs luajit vapoursynth sndio libsixel \
+        libdisplay-info"
 # FIXME: No LuaJIT for these architectures.
 PKGDEP__NOLUAJIT="${PKGDEP/luajit/lua}"
 PKGDEP__LOONGARCH64="${PKGDEP__NOLUAJIT}"
@@ -65,7 +66,7 @@ MESON_AFTER=(
     '-Dbuild-date=false'
     '-Dtests=false'
     '-Dfuzzers=false'
-    '-Dta-leak-report=false'
+    '-Ddisable-packet-pool=false'
     '-Dcdda=enabled'
     '-Dcplugins=enabled'
     '-Ddvbin=enabled'

--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,4 +1,4 @@
-VER=0.39.0
+VER=0.40.0
 SRCS="git::commit=tags/v$VER::https://github.com/mpv-player/mpv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5348"


### PR DESCRIPTION
Topic Description
-----------------

- mpv: update to 0.40.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mpv: 0.40.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
