### PR TITLE
fwupd: update to 2.0.7

### DIFF
--- a/app-admin/fwupd-efi/autobuild/defines
+++ b/app-admin/fwupd-efi/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=fwupd-efi
+PKGSEC=admin
+PKGDES="UEFI binary for installing firmware updates"
+PKGDEP="gcc-runtime"
+BUILDDEP="python-3 gnu-efi pefile"
+
+MESON_AFTER=(
+    "-Defi_sbat_distro_id=aosc"
+    "-Defi_sbat_distro_summary=AOSC OS"
+    "-Defi_sbat_distro_pkgname=${PKGNAME}"
+    "-Defi_sbat_distro_version=${PKGVER}"
+    "-Defi_sbat_distro_url=https://packages.aosc.io/packages/${PKGNAME}"
+)
+
+ABSPLITDBG=0
+# Upstream only supports these architectures.
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/app-admin/fwupd-efi/spec
+++ b/app-admin/fwupd-efi/spec
@@ -1,0 +1,4 @@
+VER=1.7
+SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd-efi.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=326081"

--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -1,80 +1,23 @@
 PKGNAME=fwupd
 PKGSEC=admin
-PKGDEP="appstream-glib colord dbus elfutils gcab glib gnutls \
-        gpgme json-glib libarchive libgpg-error libgudev libgusb libsoup \
-        libxmlb modemmanager pango pillow polkit pycairo pygobject-3 python-3 \
-        shared-mime-info sqlite systemd tpm2-tss libjcat protobuf-c libftdi"
-PKGDEP__AMD64="${PKGDEP} flashrom thunderbolt-software-user-space"
-BUILDDEP="docbook-sgml gobject-introspection gtk-doc intltool meson \
-          ninja pkg-config vala valgrind cairo dejavu-fonts fontconfig \
-          freetype gnu-efi markdown jinja2 toml typogrify pefile gi-docgen"
-# FIXME: gnu-efi is not available for these architectures.
-BUILDDEP__LOONGARCH64="${BUILDDEP/gnu-efi/}"
-BUILDDEP__LOONGSON3="${BUILDDEP/gnu-efi/}"
-BUILDDEP__PPC64EL="${BUILDDEP/gnu-efi/}"
-BUILDDEP__MIPS64R6EL="${BUILDDEP/gnu-efi/}"
-# FIXME: Valgrind is not yet available for RISC-V & LoongArch.
-BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
-BUILDDEP__LOONGARCH64="${BUILDDEP__LOONGARCH64/valgrind/}"
 PKGDES="Firmware update daemon and utilities"
+PKGDEP="bluez curl flashrom fwupd-efi gcc-runtime glib glibc gnutls \
+        hicolor-icon-theme json-glib libarchive libcbor libdrm libjcat \
+        libxmlb modemmanager passim polkit protobuf-c python-3 \
+        shared-mime-info sqlite systemd tpm2-tss udisks-2 xz zlib"
+BUILDDEP="cairo gi-docgen gobject-introspection vala valgrind"
+# FIXME: Fwupd-efi is not yet available for ppc64el & loongson3.
+PKGDEP__LOONGSON3="${PKGDEP/fwupd-efi/}"
+PKGDEP__PPC64EL="${PKGDEP/fwupd-efi/}"
+# FIXME: Valgrind is not yet available for RISC-V & LoongArch.
+BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
+BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 
-MESON_AFTER="-Dman=true \
-             -Dplugin_modem_manager=enabled \
-             -Dplugin_nvme=enabled \
-             -Dplugin_redfish=enabled \
-             -Dsystemd=enabled \
-             -Dconsolekit=enabled \
-             -Dtests=false"
-MESON_AFTER__AMD64=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=enabled"
-MESON_AFTER__ARM64=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_flashrom=disabled"
-MESON_AFTER__LOONGARCH64=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_uefi_capsule=enabled \
-             -Dplugin_uefi_capsule_splash=true \
-             -Dplugin_uefi_pk=enabled \
-             -Defi_binary=false \
-             -Dplugin_flashrom=disabled"
-MESON_AFTER__LOONGSON3=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_uefi_capsule=enabled \
-             -Dplugin_uefi_capsule_splash=true \
-             -Dplugin_uefi_pk=enabled \
-             -Defi_binary=false \
-             -Dplugin_flashrom=disabled"
-MESON_AFTER__PPC64EL=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_uefi_capsule=enabled \
-             -Dplugin_uefi_capsule_splash=true \
-             -Dplugin_uefi_pk=enabled \
-             -Defi_binary=false \
-             -Dplugin_flashrom=disabled"
-MESON_AFTER__RISCV64=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_uefi_capsule=enabled \
-             -Dplugin_uefi_capsule_splash=true \
-             -Dplugin_uefi_pk=enabled \
-             -Defi_binary=false \
-             -Dplugin_flashrom=disabled"
+MESON_AFTER=(
+    "-Ddocs=enabled"
+    "-Defi_binary=false"
+    "-Dtests=false"
+)
 
-# FIXME: disabling UEFI capsule support as python3 SIGILLS during:
-# /usr/bin/python3 ../plugins/uefi-capsule/make-images.py --podir /var/cache/acbs/build/acbs.hjpt357w/fwupd/po --label 'Installing firmware update…' --out plugins/uefi-capsule/uefi-capsule-ux.tar.xz
-MESON_AFTER__MIPS64R6EL=" \
-             ${MESON_AFTER} \
-             -Dplugin_msr=disabled \
-             -Dplugin_uefi_capsule=disabled \
-             -Dplugin_uefi_capsule_splash=false \
-             -Dplugin_uefi_pk=disabled \
-             -Defi_binary=false \
-             -Dplugin_flashrom=disabled"
-
-PKGBREAK="fwupdate<=12-2 gnome-software<=3.26.1"
+PKGBREAK="fwupdate<=12-2 discover<=5.27.12 gnome-software<=42.4-1"
 PKGREP="fwupdate<=12-2"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=1.9.25
+VER=2.0.7
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/app-network/passim/autobuild/defines
+++ b/app-network/passim/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=passim
+PKGSEC=net
+PKGDEP="gcc-runtime glib glibc libsoup-3"
+PKGDES="Local caching service"
+
+ABTYPE=meson

--- a/app-network/passim/spec
+++ b/app-network/passim/spec
@@ -1,0 +1,4 @@
+VER=0.1.9
+SRCS="tbl::https://github.com/hughsie/passim/releases/download/$VER/passim-$VER.tar.xz"
+CHKSUMS="sha256::687cbe683f2f3f19346c3df76fbcb1ea7366d3055b4142a26151fad843e9634e"
+CHKUPDATE="anitya::id=377308"

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=9.2.2
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
 CHKUPDATE="anitya::id=13607"

--- a/desktop-kde/discover/autobuild/defines
+++ b/desktop-kde/discover/autobuild/defines
@@ -16,18 +16,20 @@ PKGDES="An all-in-one software and addons manager for the Plasma desktop"
 
 # FIXME: -DCMAKE_SKIP_RPATH=OFF, Discover installs runtime libraries to a
 # private directory.
-CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
-             -DBUILD_DummyBackend=OFF \
-             -DBUILD_FlatpakBackend=ON \
-             -DBUILD_FwupdBackend=ON \
-             -DBUILD_RpmOstreeBackend=OFF \
-             -DBUILD_SnapBackend=ON \
-             -DBUILD_TESTING=OFF \
-             -DBUILD_WITH_QT6=OFF \
-             -DENABLE_BSYMBOLICFUNCTIONS=OFF \
-             -DKDE_INSTALL_PREFIX_SCRIPT=OFF \
-             -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
-             -DWITH_KCM=ON \
-             -DWITH_NOTIFIER=ON \
-             -DCMAKE_SKIP_RPATH=OFF \
-             -DCMAKE_SKIP_INSTALL_RPATH=OFF"
+CMAKE_AFTER=(
+    "-DBUILD_COVERAGE=OFF"
+    "-DBUILD_DummyBackend=OFF"
+    "-DBUILD_FlatpakBackend=ON"
+    "-DBUILD_FwupdBackend=ON"
+    "-DBUILD_RpmOstreeBackend=OFF"
+    "-DBUILD_SnapBackend=ON"
+    "-DBUILD_TESTING=OFF"
+    "-DBUILD_WITH_QT6=OFF"
+    "-DENABLE_BSYMBOLICFUNCTIONS=OFF"
+    "-DKDE_INSTALL_PREFIX_SCRIPT=OFF"
+    "-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+    "-DWITH_KCM=ON"
+    "-DWITH_NOTIFIER=ON"
+    "-DCMAKE_SKIP_RPATH=OFF"
+    "-DCMAKE_SKIP_INSTALL_RPATH=OFF"
+)

--- a/desktop-kde/discover/autobuild/patches/0001-backport-to-remove-useless-API-now-removed-in-fwupd.patch
+++ b/desktop-kde/discover/autobuild/patches/0001-backport-to-remove-useless-API-now-removed-in-fwupd.patch
@@ -1,0 +1,146 @@
+From c683db3432b5e0926912856a2722319488556c09 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Thu, 27 Mar 2025 08:44:59 +0800
+Subject: [PATCH] backport to remove useless API now removed in fwupd 2.0.x
+
+---
+ libdiscover/backends/FwupdBackend/FwupdBackend.cpp    | 11 +++++------
+ libdiscover/backends/FwupdBackend/FwupdResource.cpp   |  5 ++---
+ libdiscover/backends/FwupdBackend/FwupdResource.h     |  6 ------
+ .../backends/FwupdBackend/FwupdSourcesBackend.cpp     |  6 +++---
+ .../backends/FwupdBackend/FwupdTransaction.cpp        |  4 ----
+ 5 files changed, 10 insertions(+), 22 deletions(-)
+
+diff --git a/libdiscover/backends/FwupdBackend/FwupdBackend.cpp b/libdiscover/backends/FwupdBackend/FwupdBackend.cpp
+index 263d83d..6adc577 100644
+--- a/libdiscover/backends/FwupdBackend/FwupdBackend.cpp
++++ b/libdiscover/backends/FwupdBackend/FwupdBackend.cpp
+@@ -198,7 +198,8 @@ FwupdResource *FwupdBackend::createApp(FwupdDevice *device)
+         return nullptr;
+     }
+
+-    const QUrl update_uri(QString::fromUtf8(fwupd_release_get_uri(release)));
++    GPtrArray *locations = fwupd_release_get_locations(release);
++    const QUrl update_uri(locations->len == 0 ? QString::fromUtf8("") : QString::fromUtf8((const gchar *)g_ptr_array_index(locations, 0)));
+     if (!update_uri.isValid()) {
+         qWarning() << "Fwupd Error: No Update URI available for" << app->name() << "[" << app->id() << "]";
+         return nullptr;
+@@ -323,15 +324,13 @@ void FwupdBackend::setRemotes(GPtrArray *remotes)
+ {
+     for (uint i = 0; remotes && i < remotes->len; i++) {
+         FwupdRemote *remote = (FwupdRemote *)g_ptr_array_index(remotes, i);
+-        if (!fwupd_remote_get_enabled(remote))
++        if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
+             continue;
+-
+-        if (fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_LOCAL
+-            || fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_DIRECTORY) {
++        if (fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_LOCAL || fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_DIRECTORY) {
+             continue;
+         }
+
+-        fwupd_client_refresh_remote_async(client, remote, m_cancellable, fwupd_client_refresh_remote_cb, this);
++        fwupd_client_refresh_remote_async(client, remote, FWUPD_CLIENT_DOWNLOAD_FLAG_NONE, m_cancellable, fwupd_client_refresh_remote_cb, this);
+     }
+ }
+
+diff --git a/libdiscover/backends/FwupdBackend/FwupdResource.cpp b/libdiscover/backends/FwupdBackend/FwupdResource.cpp
+index c7fffec..4cf8d59 100644
+--- a/libdiscover/backends/FwupdBackend/FwupdResource.cpp
++++ b/libdiscover/backends/FwupdBackend/FwupdResource.cpp
+@@ -161,13 +161,13 @@ void FwupdResource::setReleaseDetails(FwupdRelease *release)
+     m_description = QString::fromUtf8((fwupd_release_get_description(release)));
+     m_homepage = QUrl(QString::fromUtf8(fwupd_release_get_homepage(release)));
+     m_license = QString::fromUtf8(fwupd_release_get_license(release));
+-    m_updateURI = QString::fromUtf8(fwupd_release_get_uri(release));
++    GPtrArray *locations = fwupd_release_get_locations(release);
++    m_updateURI = locations->len == 0 ? QString::fromUtf8("") : QString::fromUtf8((const gchar *)g_ptr_array_index(locations, 0));
+ }
+
+ void FwupdResource::setDeviceDetails(FwupdDevice *dev)
+ {
+     m_isLiveUpdatable = fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+-    m_isOnlyOffline = fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_ONLY_OFFLINE);
+     m_needsReboot = fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+
+     if (fwupd_device_get_name(dev)) {
+@@ -182,7 +182,6 @@ void FwupdResource::setDeviceDetails(FwupdDevice *dev)
+     m_vendor = QString::fromUtf8(fwupd_device_get_vendor(dev));
+     m_releaseDate = QDateTime::fromSecsSinceEpoch(fwupd_device_get_created(dev)).date();
+     m_availableVersion = QString::fromUtf8(fwupd_device_get_version(dev));
+-    m_description = QString::fromUtf8((fwupd_device_get_description(dev)));
+
+     if (fwupd_device_get_icons(dev)->len >= 1)
+         m_iconName = QString::fromUtf8((const gchar *)g_ptr_array_index(fwupd_device_get_icons(dev), 0)); // Check whether given icon exists or not!
+diff --git a/libdiscover/backends/FwupdBackend/FwupdResource.h b/libdiscover/backends/FwupdBackend/FwupdResource.h
+index db25328..98dde62 100644
+--- a/libdiscover/backends/FwupdBackend/FwupdResource.h
++++ b/libdiscover/backends/FwupdBackend/FwupdResource.h
+@@ -102,11 +102,6 @@ public:
+         return m_isDeviceLocked;
+     }
+
+-    bool isOnlyOffline() const
+-    {
+-        return m_isOnlyOffline;
+-    }
+-
+     bool isLiveUpdatable() const
+     {
+         return m_isLiveUpdatable;
+@@ -146,7 +141,6 @@ private:
+
+     QString m_updateURI;
+     bool m_isDeviceLocked = false; // True if device is locked!
+-    bool m_isOnlyOffline = false; // True if only offline updates
+     bool m_isLiveUpdatable = false; // True if device is live updatable
+     bool m_needsReboot = false; // True if device needs Reboot
+     QString m_origin;
+diff --git a/libdiscover/backends/FwupdBackend/FwupdSourcesBackend.cpp b/libdiscover/backends/FwupdBackend/FwupdSourcesBackend.cpp
+index 449c4bc..a9b4615 100644
+--- a/libdiscover/backends/FwupdBackend/FwupdSourcesBackend.cpp
++++ b/libdiscover/backends/FwupdBackend/FwupdSourcesBackend.cpp
+@@ -34,7 +34,7 @@ public:
+         case Qt::CheckStateRole: {
+             if (value == Qt::Checked) {
+                 m_backend->m_currentItem = item;
+-                if (fwupd_remote_get_approval_required(remote)) {
++                if (fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED)) {
+                     QString eulaText = i18n("The remote %1 require that you accept their license:\n %2",
+                                             QString::fromUtf8(fwupd_remote_get_title(remote)),
+                                             QString::fromUtf8(fwupd_remote_get_agreement(remote)));
+@@ -88,7 +88,7 @@ void FwupdSourcesBackend::populateSources()
+         it->setData(id, AbstractSourcesBackend::IdRole);
+         it->setData(QVariant(QString::fromUtf8(fwupd_remote_get_title(remote))), Qt::ToolTipRole);
+         it->setCheckable(true);
+-        it->setCheckState(fwupd_remote_get_enabled(remote) ? Qt::Checked : Qt::Unchecked);
++        it->setCheckState(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED) ? Qt::Checked : Qt::Unchecked);
+         m_sources->appendRow(it);
+     }
+ }
+@@ -121,7 +121,7 @@ void FwupdSourcesBackend::cancel()
+ {
+     FwupdRemote *remote =
+         fwupd_client_get_remote_by_id(backend->client, m_currentItem->data(AbstractSourcesBackend::IdRole).toString().toUtf8().constData(), nullptr, nullptr);
+-    m_currentItem->setCheckState(fwupd_remote_get_enabled(remote) ? Qt::Checked : Qt::Unchecked);
++    m_currentItem->setCheckState(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED) ? Qt::Checked : Qt::Unchecked);
+
+     m_currentItem = nullptr;
+ }
+diff --git a/libdiscover/backends/FwupdBackend/FwupdTransaction.cpp b/libdiscover/backends/FwupdBackend/FwupdTransaction.cpp
+index 8b1de23..bb5dbed 100644
+--- a/libdiscover/backends/FwupdBackend/FwupdTransaction.cpp
++++ b/libdiscover/backends/FwupdBackend/FwupdTransaction.cpp
+@@ -83,10 +83,6 @@ void FwupdTransaction::fwupdInstall(const QString &file)
+     FwupdInstallFlags install_flags = FWUPD_INSTALL_FLAG_NONE;
+     g_autoptr(GError) error = nullptr;
+
+-    /* only offline supported */
+-    if (m_app->isOnlyOffline())
+-        install_flags = static_cast<FwupdInstallFlags>(install_flags | FWUPD_INSTALL_FLAG_OFFLINE);
+-
+     if (!fwupd_client_install(m_backend->client, m_app->deviceId().toUtf8().constData(), file.toUtf8().constData(), install_flags, nullptr, &error)) {
+         m_backend->handleError(error);
+         setStatus(DoneWithErrorStatus);
+--
+2.49.0

--- a/desktop-kde/discover/spec
+++ b/desktop-kde/discover/spec
@@ -1,4 +1,5 @@
 VER=5.27.12
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/discover-$VER.tar.xz"
 CHKSUMS="sha256::4f5b3f6918b2b6a3eab3a83f8e58a97fcd2d4b5ac73d0af0e4d32696dd16a25f"
 CHKUPDATE="anitya::id=8761"

--- a/runtime-common/libcbor/autobuild/defines
+++ b/runtime-common/libcbor/autobuild/defines
@@ -3,4 +3,6 @@ PKGSEC=libs
 PKGDES="A C implementation of the CBOR protocol"
 PKGDEP="glibc"
 
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON"
+CMAKE_AFTER=("-DBUILD_SHARED_LIBS=ON")
+
+PKGBREAK="fwupd<=1.9.25 libfido2<=1.13.0 qemu<=9.2.2"

--- a/runtime-common/libcbor/spec
+++ b/runtime-common/libcbor/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
-SRCS="https://github.com/PJK/libcbor/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha384::16b5e6428f1b709550c43e6076e71bd5723953d14db5b22422a88e08cde5d98fdd4f3c19c564db58e1dbfb694047746b"
+VER=0.12.0
+SRCS="git::commit=tags/v$VER::https://github.com/PJK/libcbor.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15699"

--- a/runtime-common/libjcat/autobuild/defines
+++ b/runtime-common/libjcat/autobuild/defines
@@ -4,13 +4,10 @@ PKGDEP="json-glib gpgme"
 BUILDDEP="gtk-doc gobject-introspection vala"
 PKGDES="Library for reading and writing JSON catalog (Jcat) files"
 
-MESON_AFTER="-Dgtkdoc=true \
-             -Dintrospection=true \
-             -Dvapi=true \
-             -Dgpg=true \
-             -Dpkcs7=true \
-             -Dman=true \
-             -Dcli=true"
+MESON_AFTER=(
+    "-Dgtkdoc=true"
+    "-Dtests=false"
+)
 
 PKGBREAK="fwupd<=1.5.4-1"
 PKGREP="fwupd<=1.5.4-1"

--- a/runtime-common/libjcat/spec
+++ b/runtime-common/libjcat/spec
@@ -1,4 +1,4 @@
-VER=0.2.1
-SRCS="git::commit=tags/$VER::https://github.com/hughsie/libjcat"
-CHKSUMS="SKIP"
+VER=0.2.3
+SRCS="tbl::https://github.com/hughsie/libjcat/releases/download/$VER/libjcat-$VER.tar.xz"
+CHKSUMS="sha256::f2f115aad8a8f16b8dde1ed55de7abacb91d0878539aa29b2b60854b499db639"
 CHKUPDATE="anitya::id=229583"

--- a/runtime-common/libxmlb/autobuild/defines
+++ b/runtime-common/libxmlb/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=libxmlb
 PKGSEC=libs
 PKGDEP="glib snowball"
-BUILDDEP="meson gobject-introspection gtk-doc"
+BUILDDEP="gobject-introspection gtk-doc"
 PKGDES="A library to help create and query binary XML blobs"
 
-MESON_AFTER="-Dstemmer=true"
+MESON_AFTER=("-Dstemmer=true")
 
 PKGBREAK="fwupd<=1.2.5" # fwupd used to contain this library

--- a/runtime-common/libxmlb/spec
+++ b/runtime-common/libxmlb/spec
@@ -1,4 +1,4 @@
-VER=0.3.15
-SRCS="tbl::https://github.com/hughsie/libxmlb/archive/$VER.tar.gz"
-CHKSUMS="sha256::68ee69002cc2b792fca250d7a7df2a8e3f8e43ccd6ab7b14c8481407b95e7087"
+VER=0.3.22
+SRCS="tbl::https://github.com/hughsie/libxmlb/releases/download/$VER/libxmlb-$VER.tar.xz"
+CHKSUMS="sha256::f3c46e85588145a1a86731c77824ec343444265a457647189a43b71941b20fa0"
 CHKUPDATE="anitya::id=179028"

--- a/runtime-devices/libfido2/spec
+++ b/runtime-devices/libfido2/spec
@@ -1,4 +1,5 @@
 VER=1.13.0
+REL=1
 SRCS="https://developers.yubico.com/libfido2/Releases/libfido2-${VER}.tar.gz"
 CHKSUMS="sha256::51d43727e2a1c4544c7fd0ee47786f443e39f1388ada735a509ad4af0a2459ca"
 CHKUPDATE="anitya::id=78296"

--- a/runtime-devices/libusb/spec
+++ b/runtime-devices/libusb/spec
@@ -1,5 +1,4 @@
-VER=1.0.23
-REL=2
+VER=1.0.28
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
-CHKSUMS="sha256::db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
+CHKSUMS="sha256::966bb0d231f94a474eaae2e67da5ec844d3527a1f386456394ff432580634b29"
 CHKUPDATE="anitya::id=1749"


### PR DESCRIPTION
Topic Description
-----------------

- libfido2: bump REL due to libcbor update to 0.12.0
- qemu: bump REL due to libcbor update to 0.12.0
- discover: bump REL due to fwupd update to 2.0.7
- fwupd: update to 2.0.7
    - Remove outdated options and automatically enable features based on installed dependencies.
    - Remove options for mips64r6el.
    - gnome-software has so many breaking updates that I can't save it!
- libcbor: update to 0.12.0
- libusb: update to 1.0.28
- libjcat: update to 0.2.3
- libxmlb: update to 0.3.22
- fwupd-efi: new, 1.7
- passim: new, 0.1.9

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libxmlb libjcat libusb passim fwupd-efi fwupd:-pkgbreak discover libcbor:-pkgbreak libfido2 qemu libcbor fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
