### PR TITLE
neovim: update to 0.11.0

### DIFF
--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -1,5 +1,4 @@
-VER=0.10.4
-REL=1
+VER=0.11.0
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"

--- a/runtime-i18n/libutf8proc/spec
+++ b/runtime-i18n/libutf8proc/spec
@@ -1,4 +1,4 @@
-VER=2.9.0
+VER=2.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/JuliaStrings/utf8proc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7455"


### PR DESCRIPTION
Topic Description
-----------------

- neovim: update to 0.11.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- neovim: 1:0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libutf8proc neovim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
