### PR TITLE
telegram-desktop: update to 5.13.0

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From 59c619ef3cba0a3ce3a78a7a3bacb0ffebadd722 Mon Sep 17 00:00:00 2001
+From 9fce4174d1fea1cf2c312a3fcf4ee5a477d183df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 01/10] fix(window.style): set default window width to 360px

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From f707653d709cbe0b7c1843c4f16a1f51c34634be Mon Sep 17 00:00:00 2001
+From 8f917af4efd84266a54f6a009fd3f451e84d112d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 02/10] fix(core_settings.h): use system window decoration by
@@ -9,10 +9,10 @@ Subject: [PATCH 02/10] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 91da7945a2..0c9713ed87 100644
+index 8ce8d72818..a116d04020 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1033,7 +1033,7 @@ private:
+@@ -1037,7 +1037,7 @@ private:
  	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From bb0c2a8c91ba06f30f4b4e28fd1a3afa3a19a106 Mon Sep 17 00:00:00 2001
+From 5168fa2ee8b394ed62570f63f73757af1d8a00c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 03/10] fix(ui): fix build with Qt 5

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From 097519b78b21614e0214f978746e5ba3f907f32f Mon Sep 17 00:00:00 2001
+From b78c0d49e427ab0aaf6e395ac4cca1d80213b31f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 04/10] fix(core/launcher.cpp): revert to old HiDPI handling
@@ -13,7 +13,7 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
-index 312ce96673..7a445f2c8e 100644
+index e844acf9ee..adb4b80fb6 100644
 --- a/Telegram/SourceFiles/core/launcher.cpp
 +++ b/Telegram/SourceFiles/core/launcher.cpp
 @@ -342,7 +342,9 @@ void Launcher::initHighDpi() {

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From 223cab8bbf903ccbf3d74cb9c5f386277aa0b28c Mon Sep 17 00:00:00 2001
+From 577d6712b17d0b2a920618eca7b1f7f1770343eb Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 05/10] fix(settings): use system fonts by default
@@ -8,18 +8,18 @@ Subject: [PATCH 05/10] fix(settings): use system fonts by default
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 0c9713ed87..6b1138d6fb 100644
+index a116d04020..ad75558a52 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
- #include "media/media_common.h"
+@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "dialogs/ui/dialogs_quick_action.h"
  #include "window/themes/window_themes_embedded.h"
  #include "ui/chat/attach/attach_send_files_way.h"
 +#include "ui/style/style_core_font.h"
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1067,7 +1068,7 @@ private:
+@@ -1071,7 +1072,7 @@ private:
  	rpl::variable<bool> _storiesClickTooltipHidden = false;
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 88dbf9dcbec1b2c385dfbeceeaa84ff9a006741f Mon Sep 17 00:00:00 2001
+From 1fcadf9ea6d97d6e190cd3ff1bf7bbedb2c61a92 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 06/10] Remove the confusing "Default" option from selectable

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From e0bf997ed98b81fa41c97e4f584b8f6049e5f669 Mon Sep 17 00:00:00 2001
+From 106288ed994d63f8f0485ee9cc3243b7a7d1437a Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 07/10] fix(lib_tl): add missing cstring include

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From a19e5e7ba13485009d7f040ea8ae78017e5e378d Mon Sep 17 00:00:00 2001
+From 19fd9e0f6b06b2a704ba16c8c6471bed8e59cf13 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 08/10] fix(lib_webview): add missing cstdint include

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,4 +1,4 @@
-From c85442ce847996bfc29a3772fb8f1dfeae1ede7d Mon Sep 17 00:00:00 2001
+From b6251b1959f69caac07d88f998b01a60d7cc8529 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
 Subject: [PATCH 09/10] fix(current_geo_location_linux): add missing

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,4 +1,4 @@
-From cbf5173eeb6497a6641f4786b15e31f7fdffa85f Mon Sep 17 00:00:00 2001
+From e95d05e0d0174840da2023a5c924704960205b15 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
 Subject: [PATCH 10/10] fix(core_settings.h): enable video hardware
@@ -10,10 +10,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 6b1138d6fb..2a66db1a26 100644
+index ad75558a52..e9fb514bff 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1049,11 +1049,7 @@ private:
+@@ -1053,11 +1053,7 @@ private:
  	rpl::variable<Media::OrderMode> _playerOrderMode;
  	bool _macWarnBeforeQuit = true;
  	std::vector<uint64> _accountsOrder;

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,10 +1,9 @@
-VER=5.12.3
-REL=1
+VER=5.13.0
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=be39b8c8d0db1f377118f813f0c4bd331d341d5e
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt"
-CHKSUMS="sha256::050a19e74632eff02737f078b02d78e11faa108d0932371f3d64122b225d3034 \
+CHKSUMS="sha256::4a75fe1a768f9d8bef23f754822a7b711a256d581db2f8c54fdb4306a947c162 \
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.13.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
