### PR TITLE
Tree-sitter Survey Mar. 2025

### DIFF
--- a/app-devel/tree-sitter/spec
+++ b/app-devel/tree-sitter/spec
@@ -1,4 +1,4 @@
-VER=0.24.3
+VER=0.25.3
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=142464"

--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -1,5 +1,4 @@
-VER=0.10.4
-REL=1
+VER=0.11.0
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"

--- a/groups/tree-sitter
+++ b/groups/tree-sitter
@@ -1,0 +1,7 @@
+app-devel/tree-sitter
+runtime-editors/tree-sitter-c
+runtime-editors/tree-sitter-lua
+runtime-editors/tree-sitter-markdown
+runtime-editors/tree-sitter-query
+runtime-editors/tree-sitter-vim
+runtime-editors/tree-sitter-vimdoc

--- a/runtime-editors/tree-sitter-c/spec
+++ b/runtime-editors/tree-sitter-c/spec
@@ -1,4 +1,4 @@
-VER=0.23.1
+VER=0.23.5
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter-c"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242273"

--- a/runtime-editors/tree-sitter-lua/spec
+++ b/runtime-editors/tree-sitter-lua/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-lua"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=334876"

--- a/runtime-editors/tree-sitter-markdown/autobuild/defines
+++ b/runtime-editors/tree-sitter-markdown/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=tree-sitter-markdown
 PKGSEC=libs
 PKGDES="Markdown grammar for tree-sitter"
-
 PKGDEP="tree-sitter"
 
-ABTYPE=plainmake
+ABTYPE=cmake

--- a/runtime-editors/tree-sitter-markdown/spec
+++ b/runtime-editors/tree-sitter-markdown/spec
@@ -1,4 +1,4 @@
-VER=0.3.2
+VER=0.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-markdown"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371613"

--- a/runtime-editors/tree-sitter-query/spec
+++ b/runtime-editors/tree-sitter-query/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-query"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375139"

--- a/runtime-editors/tree-sitter-vim/spec
+++ b/runtime-editors/tree-sitter-vim/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-vim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375138"

--- a/runtime-editors/tree-sitter-vimdoc/spec
+++ b/runtime-editors/tree-sitter-vimdoc/spec
@@ -1,4 +1,4 @@
-VER=3.0.0
+VER=3.0.1
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/tree-sitter-vimdoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375140"

--- a/runtime-i18n/libutf8proc/spec
+++ b/runtime-i18n/libutf8proc/spec
@@ -1,4 +1,4 @@
-VER=2.9.0
+VER=2.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/JuliaStrings/utf8proc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7455"


### PR DESCRIPTION
Topic Description
-----------------

- tree-sitter-vimdoc: update to 3.0.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter-vim: update to 0.5.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter-query: update to 0.5.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter-markdown: update to 0.4.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter-lua: update to 0.3.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter-c: update to 0.23.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- tree-sitter: update to 0.25.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- groups: add tree-sitter
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- tree-sitter: 0.25.3
- tree-sitter-c: 0.23.5
- tree-sitter-lua: 0.3.0
- tree-sitter-markdown: 0.4.1
- tree-sitter-query: 0.5.1
- tree-sitter-vim: 0.5.0
- tree-sitter-vimdoc: 3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree-sitter tree-sitter-c tree-sitter-lua tree-sitter-markdown tree-sitter-query tree-sitter-vim tree-sitter-vimdoc libutf8proc neovim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
