### PR TITLE
poco: new, 1.41.1

### DIFF
--- a/runtime-network/poco/autobuild/defines
+++ b/runtime-network/poco/autobuild/defines
@@ -1,0 +1,53 @@
+PKGNAME=poco
+PKGSEC=libs
+PKGDEP="apr apr-util avahi expat httpd libpng libutf8proc mariadb openssl \
+        pcre2 postgresql sqlite unixodbc"
+PKGDES="C++ libraries for building network- and Internet-based applications"
+
+# FIXME: -DENABLE_DATA_ODBC=OFF
+#
+# In file included from /usr/include/sqltypes.h:52,
+#                  from /usr/include/sql.h:19,
+#                  from /usr/include/sqlext.h:43,
+#                  from .../poco/Data/ODBC/include/Poco/Data/ODBC/Unicode.h:31,
+#                  from .../poco/Data/ODBC/include/Poco/Data/ODBC/ODBC.h:55,
+#                  from .../poco/Data/ODBC/include/Poco/Data/ODBC/ODBCMetaColumn.h:21,
+#                  from .../poco/Data/ODBC/src/ODBCMetaColumn.cpp:15:
+# .../poco/Foundation/include/Poco/NumberFormatter.h:51:17: error: expected identifier before string constant
+#    51 |                 PREFIX = 1 << 0,
+#       |                 ^~~~~~
+CMAKE_AFTER=(
+    '-DENABLE_NETSSL=ON'
+    '-DENABLE_CRYPTO=ON'
+    '-DENABLE_JWT=ON'
+    '-DENABLE_APACHECONNECTOR=ON'
+    '-DENABLE_DATA_MYSQL=ON'
+    '-DENABLE_DATA_POSTGRESQL=ON'
+    '-DENABLE_DATA_ODBC=OFF'
+    '-DENABLE_FOUNDATION=ON'
+    '-DENABLE_ENCODINGS=ON'
+    '-DENABLE_ENCODINGS_COMPILER=ON'
+    '-DENABLE_XML=ON'
+    '-DENABLE_JSON=ON'
+    '-DENABLE_MONGODB=OFF'
+    '-DENABLE_DATA_SQLITE=ON'
+    '-DENABLE_REDIS=ON'
+    '-DENABLE_DNSSD=ON'
+    '-DENABLE_DNSSD_DEFAULT=OFF'
+    '-DENABLE_DNSSD_AVAHI=ON'
+    '-DENABLE_DNSSD_BONJOUR=OFF'
+    '-DENABLE_PROMETHEUS=ON'
+    '-DENABLE_PDF=ON'
+    '-DENABLE_UTIL=ON'
+    '-DENABLE_NET=ON'
+    '-DENABLE_SEVENZIP=ON'
+    '-DENABLE_ZIP=ON'
+    '-DENABLE_CPPPARSER=ON'
+    '-DENABLE_POCODOC=ON'
+    '-DENABLE_PAGECOMPILER=ON'
+    '-DENABLE_PAGECOMPILER_FILE2PAGE=ON'
+    '-DENABLE_ACTIVERECORD=ON'
+    '-DENABLE_ACTIVERECORD_COMPILER=ON'
+    '-DENABLE_TRACE=OFF'
+    '-DPOCO_UNBUNDLED=OFF'
+)

--- a/runtime-network/poco/spec
+++ b/runtime-network/poco/spec
@@ -1,0 +1,4 @@
+VER=1.14.1
+SRCS="git::commit=tags/poco-$VER-release::https://github.com/pocoproject/poco"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=5418"


### PR DESCRIPTION
Topic Description
-----------------

- poco: new, 1.41.1

Package(s) Affected
-------------------

- poco: 1.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit poco
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
