### PR TITLE
mariadb: update to 11.7.2

### DIFF
--- a/app-database/mariadb/autobuild/beyond
+++ b/app-database/mariadb/autobuild/beyond
@@ -1,12 +1,16 @@
 abinfo "Dropping unneeded files ..."
-rm -rfv "$PKGDIR"/usr/{data,mariadb-test,sql-bench}
-rm -fv "$PKGDIR"/usr/share/man/man1/mysql-test-run.pl.1
+rm -rv \
+    "$PKGDIR"/usr/{mariadb-test,sql-bench}
+rm -v \
+    "$PKGDIR"/usr/share/man/man1/mysql-test-run.pl.1
 
 abinfo "Creating a compatibility symlink for libmysqlclient ..."
-ln -sv libmariadb.so.3 "$PKGDIR"/usr/lib/libmysqlclient.so.18
+ln -sv libmariadb.so.3 \
+    "$PKGDIR"/usr/lib/libmysqlclient.so.18
 
 abinfo "Creating a compatibility symlink for MariaDB headers ..."
-ln -sv mysql "$PKGDIR"/usr/include/mariadb
+ln -sv mysql \
+    "$PKGDIR"/usr/include/mariadb
 
 abinfo "Arch Linux: Moving PAM modules and configuration files to correct locations ..."
 mkdir -pv "$PKGDIR"/{etc,usr/lib}/security

--- a/app-database/mariadb/autobuild/conffiles
+++ b/app-database/mariadb/autobuild/conffiles
@@ -1,2 +1,0 @@
-/etc/mysql/my.cnf
-/etc/security/user_map.conf

--- a/app-database/mariadb/autobuild/overrides/usr/bin/mysqld-post
+++ b/app-database/mariadb/autobuild/overrides/usr/bin/mysqld-post
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 while true; do
     response=$(/usr/bin/mysqladmin -uUNKNOWN_USER ping 2>&1) && break

--- a/app-database/mariadb/autobuild/overrides/usr/bin/mysqld-pre
+++ b/app-database/mariadb/autobuild/overrides/usr/bin/mysqld-pre
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! -e /var/lib/mysql || \
+      -z "$( ls -A '/var/lib/mysql' )" ]]; then
+    echo "Initializating MariaDB at /var/lib/mysql ..."
+    /usr/bin/mysql_install_db --user=mysql \
+        --basedir=/usr --datadir=/var/lib/mysql
+fi

--- a/app-database/mariadb/autobuild/overrides/usr/lib/systemd/system/mysqld.service
+++ b/app-database/mariadb/autobuild/overrides/usr/lib/systemd/system/mysqld.service
@@ -1,10 +1,11 @@
 [Unit]
-Description=Daemon process of MariaDB (MySQL)
+Description=MariaDB (MySQL) Server Daemon
 After=syslog.target
 
 [Service]
 User=mysql
 Group=mysql
+ExecStartPre=/usr/bin/mysqld-pre
 ExecStart=/usr/bin/mysqld --pid-file=/run/mysqld/mysqld.pid
 ExecStartPost=/usr/bin/mysqld-post
 Restart=always

--- a/app-database/mariadb/autobuild/overrides/usr/lib/tmpfiles.d/mysql.conf
+++ b/app-database/mariadb/autobuild/overrides/usr/lib/tmpfiles.d/mysql.conf
@@ -1,2 +1,3 @@
 # See tmpfiles.d(5) for details
+d /var/lib/mysql 0700 mysql mysql -
 d /run/mysqld 0755 mysql mysql -

--- a/app-database/mariadb/autobuild/postinst
+++ b/app-database/mariadb/autobuild/postinst
@@ -1,15 +1,5 @@
 echo "Creating user and group for MariaDB ..."
 systemd-sysusers mysql.conf
 
-if [[ ! -e /var/lib/mysql ]]; then
-    echo "Initializating MariaDB at /var/lib/mysql ..."
-    install -dm700 /var/lib/mysql
-    /usr/bin/mysql_install_db --user=mysql \
-        --basedir=/usr --datadir=/var/lib/mysql
-fi
-
-echo "Setting ownership of /var/lib/mysql to mysql:mysql ..."
-chown -R mysql:mysql /var/lib/mysql &>/dev/null
-
-echo "Creating temporary folders for mysql ..."
+echo "Creating temporary folders for MariaDB ..."
 /usr/bin/systemd-tmpfiles --create mysql.conf

--- a/app-database/mariadb/autobuild/prepare
+++ b/app-database/mariadb/autobuild/prepare
@@ -1,6 +1,0 @@
-export CFLAGS="${CFLAGS} -fno-strict-aliasing -DBIG_JOINS=1 -fomit-frame-pointer -fno-delete-null-pointer-checks"
-export CXXFLAG="${CXXFLAGS} -fno-strict-aliasing -DBIG_JOINS=1 -felide-constructors -fno-rtti -fno-delete-null-pointer-checks"
-export LD_MYSQLD="-pie ${LDFLAGS}"
-
-ln -sv /usr/bin/ld.bfd "$SRCDIR"/ld
-export PATH="${SRCDIR}:$PATH"

--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,4 +1,4 @@
-VER=11.4.3
-SRCS="tbl::https://dlm.mariadb.com/3893044/MariaDB/mariadb-$VER/source/mariadb-$VER.tar.gz"
-CHKSUMS="sha256::6f0017b9901bb1897de0eed21caef9ffa9d66ef559345a0d8a6f011308413ece"
+VER=11.7.2
+SRCS="git::commit=tags/mariadb-$VER::https://github.com/MariaDB/server"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1887"


### PR DESCRIPTION
Topic Description
-----------------

- mariadb: update to 11.7.2
    - Handle /var/lib/mysql creation via tmpfiles.d.
    - Move database initialisation logic to /usr/bin/mysqld-pre, as
    ExecStartPre= for mysqld.service.
    - Drop conffiles, instructing Autobuild to generate it automatically.
    - Drop unneeded prerm and prepare scripts.
    - Lint beyond.

Package(s) Affected
-------------------

- mariadb: 11.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
