### PR TITLE
print-manager: add missing system-config-printer-runtime dep

### DIFF
--- a/desktop-kde/print-manager/autobuild/defines
+++ b/desktop-kde/print-manager/autobuild/defines
@@ -3,7 +3,8 @@ PKGSEC=kde
 PKGDEP="cups fontconfig freetype kauth kcmutils kcodecs kcompletion kconfig \
         kconfigwidgets kcoreaddons kdbusaddons ki18n kiconthemes kio \
         kitemviews kjobwidgets knotifications kpackage kservice \
-        kwidgetsaddons kwindowsystem kxmlgui plasma-framework samba solid"
+        kwidgetsaddons kwindowsystem kxmlgui plasma-framework samba \
+        solid system-config-printer-runtime"
 BUILDDEP="extra-cmake-modules kdoctools"
 PKGDES="Printer manager for KDE"
 

--- a/desktop-kde/print-manager/spec
+++ b/desktop-kde/print-manager/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/print-manager-$VER.tar.xz"
 CHKSUMS="sha256::f7ed99b3afaf8ea1faa5c0649f3a704197ac992fcfa5dfc24622e5cf2cb85a4b"
 CHKUPDATE="anitya::id=8763"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- print-manager: add missing system-config-printer-runtime dep

Package(s) Affected
-------------------

- print-manager: 23.08.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit print-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
