### PR TITLE
containers-common: update to 0.62.3+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2

### DIFF
--- a/runtime-containers/containers-common/autobuild/defines
+++ b/runtime-containers/containers-common/autobuild/defines
@@ -3,7 +3,6 @@ PKGSEC=admin
 PKGDES="Common dependencies, configuration and documentation for containers"
 PKGDEP="crun netavark iptables nftables"
 PKGRECOM="pasta qemu-user-static fuse-overlayfs"
-PKGSUG="slirp4netns"
 BUILDDEP="go-md2man"
 
 ABHOST=noarch

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,8 +1,8 @@
-UPSTREAM_VER=0.62.2
+UPSTREAM_VER=0.62.3
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-__IMAGE_VER=5.34.2
+__IMAGE_VER=5.34.3
 __STORAGE_VER=1.57.2
 # FIXME: the following two dependencies are not in the go.sum file above.
 __SHORTNAMES_VER=2025.03.19


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.62.3+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2
    - Update containers-common to 0.62.3
    - Remove slirp4netns from suggested packages
    as it is a rarely used backend.

Package(s) Affected
-------------------

- containers-common: 0.62.3+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
