### PR TITLE
elinks: update to 0.18.0

### DIFF
--- a/app-web/elinks/autobuild/defines
+++ b/app-web/elinks/autobuild/defines
@@ -1,162 +1,109 @@
 PKGNAME=elinks
 PKGSEC=web
-PKGDEP="brotli bzip2 expat gc gpm guile libevent libidn2 lua \
-        openssl perl python-3 ruby tre x11-lib xz"
+PKGDEP="brotli bzip2 expat gc gpm libevent libidn2 lua guile \
+        openssl perl python-3 ruby tre x11-lib xz libdom libsixel curl \
+        libcss samba mujs"
 PKGDEP__RETRO="brotli bzip2 expat gc gpm libevent libidn2 openssl \
-        tre xz"
-PKGDEP__ARMV4="${PKGDEP__RETRO/js/}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
+        tre xz libdom libcss curl samba mujs"
+BUILDDEP="dblatex doxygen xmlto"
+BUILDDEP__RETRO=""
 PKGDES="An advanced and well-established feature-rich text mode web browser"
 
-# FIXME: Build mysteriously fails with parallelism.
-NOPARALLEL=1
+ABTYPE=meson
 
-AUTOTOOLS_AFTER="--enable-bookmarks \
-                 --enable-xbel \
-                 --enable-sm-scripting \
-                 --enable-nls \
-                 --enable-gettext \
-                 --enable-cookies \
-                 --enable-formhist \
-                 --enable-globhist \
-                 --enable-mailcap \
-                 --enable-mimetypes \
-                 --enable-ipv6 \
-                 --enable-bittorrent \
-                 --enable-data \
-                 --enable-uri-rewrite \
-                 --enable-cgi \
-                 --enable-finger \
-                 --enable-fsp \
-                 --enable-ftp \
-                 --enable-gemini \
-                 --enable-gopher \
-                 --enable-nntp \
-                 --enable-smb \
-                 --enable-mouse \
-                 --disable-sysmouse \
-                 --enable-88-colors \
-                 --enable-256-colors \
-                 --enable-true-color \
-                 --enable-exmode \
-                 --enable-leds \
-                 --enable-marks \
-                 --enable-css \
-                 --enable-html-highlight \
-                 --enable-backtrace \
-                 --disable-no-root \
-                 --disable-debug \
-                 --enable-fastmem \
-                 --disable-own-libc \
-                 --disable-small \
-                 --enable-utf-8 \
-                 --enable-combining \
-                 --without-static \
-                 --with-xterm \
-                 --with-gpm \
-                 --with-terminfo \
-                 --with-zlib \
-                 --with-bzlib \
-                 --with-zstd \
-                 --with-brotli \
-                 --with-lzma \
-                 --with-idn2 \
-                 --with-gssapi \
-                 --without-quickjs \
-                 --without-spidermonkey \
-                 --with-guile \
-                 --with-perl \
-                 --with-python=/usr/bin/python3 \
-                 --with-luapkg=5.1 \
-                 --with-tre \
-                 --with-ruby \
-                 --without-gnutls \
-                 --with-openssl \
-                 --without-libev \
-                 --with-libevent \
-                 --with-x"
+MESON_AFTER=(
+    '-Dlargefile=true'
+    '-Dbookmarks=true'
+    '-Dxbel=true'
+    '-Dsm-scripting=false'
+    '-Dnls=true'
+    '-Dgettext=true'
+    '-Dcookies=true'
+    '-Dformhist=true'
+    '-Dglobhist=true'
+    '-Dmailcap=true'
+    '-Dmimetypes=true'
+    '-Dipv6=true'
+    '-Dbittorrent=true'
+    '-Ddata=true'
+    '-Duri-rewrite=true'
+    '-Dcgi=true'
+    '-Dfinger=true'
+    '-Dfsp=false'
+    '-Dfsp2=true'
+    '-Dftp=true'
+    '-Dgemini=true'
+    '-Dgopher=true'
+    '-Dnntp=true'
+    '-Dsmb=true'
+    '-Dmouse=true'
+    '-Dsysmouse=false'
+    '-D88-colors=true'
+    '-D256-colors=true'
+    '-Dtrue-color=true'
+    '-Dexmode=true'
+    '-Dleds=true'
+    '-Dmarks=true'
+    '-Dcss=true'
+    '-Dhtml-highlight=true'
+    '-Dbacktrace=true'
+    '-Dno-root=false'
+    '-Dwithdebug=false'
+    '-Dfastmem=true'
+    '-Down-libc=false'
+    '-Dsmall=false'
+    '-Dutf-8=true'
+    '-Dstatic=false'
+    '-Dxterm=true'
+    '-Dgpm=true'
+    '-Dterminfo=true'
+    '-Dzlib=true'
+    '-Dbzlib=true'
+    '-Dzstd=true'
+    '-Didn=true'
+    '-Dbrotli=true'
+    '-Dlzma=true'
+    '-Dgssapi=true'
+    '-Dquickjs=false'
+    '-Dspidermonkey=false'
+    '-Dguile=true'
+    '-Dperl=true'
+    '-Dpython=true'
+    '-Dluapkg=lua'
+    '-Dtre=true'
+    '-Druby=true'
+    '-Dgnutls=false'
+    '-Dopenssl=true'
+    '-Dlibev=false'
+    '-Dlibevent=true'
+    '-Dx=true'
+    '-Dreproducible=false'
+    '-Ddgi=false'
+    '-Dmujs=true'
+    '-Dcodepoint=true'
+    '-Dtest=false'
+    '-Dtest-mailcap=false'
+    '-Ddoc=true'
+    '-Dapidoc=true'
+    '-Dhtmldoc=true'
+    '-Dpdfdoc=true'
+    '-Dlibcss=true'
+    '-Dlibsixel=true'
+    '-Dlibcurl=true'
+    '-Dsftp=true'
+)
 
-AUTOTOOLS_AFTER__RETRO=" \
-                 --enable-bookmarks \
-                 --enable-xbel \
-                 --enable-sm-scripting \
-                 --enable-nls \
-                 --enable-gettext \
-                 --enable-cookies \
-                 --enable-formhist \
-                 --enable-globhist \
-                 --enable-mailcap \
-                 --enable-mimetypes \
-                 --enable-ipv6 \
-                 --enable-bittorrent \
-                 --enable-data \
-                 --enable-uri-rewrite \
-                 --enable-cgi \
-                 --enable-finger \
-                 --enable-fsp \
-                 --enable-ftp \
-                 --enable-gemini \
-                 --enable-gopher \
-                 --enable-nntp \
-                 --enable-smb \
-                 --enable-mouse \
-                 --disable-sysmouse \
-                 --enable-88-colors \
-                 --enable-256-colors \
-                 --enable-true-color \
-                 --enable-exmode \
-                 --enable-leds \
-                 --enable-marks \
-                 --enable-css \
-                 --enable-html-highlight \
-                 --enable-backtrace \
-                 --disable-no-root \
-                 --disable-debug \
-                 --enable-fastmem \
-                 --disable-own-libc \
-                 --disable-small \
-                 --enable-utf-8 \
-                 --enable-combining \
-                 --without-static \
-                 --with-xterm \
-                 --with-gpm \
-                 --with-terminfo \
-                 --with-zlib \
-                 --with-bzlib \
-                 --with-zstd \
-                 --with-brotli \
-                 --with-lzma \
-                 --with-idn2 \
-                 --with-gssapi \
-                 --with-quickjs \
-                 --without-spidermonkey \
-                 --without-guile \
-                 --without-perl \
-                 --without-python \
-                 --without-luapkg \
-                 --with-tre \
-                 --without-ruby \
-                 --without-gnutls \
-                 --with-openssl \
-                 --without-libev \
-                 --with-libevent \
-                 --without-x"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+MESON_AFTER__RETRO=(
+    "${MESON_AFTER[@]}"
+    '-Dquickjs=false'
+    '-Dguile=false'
+    '-Dperl=false'
+    '-Dpython=false'
+    '-Dluapkg='\'''\'''
+    '-Druby=false'
+    '-Dx=false'
+    '-Ddoc=false'
+    '-Dlibsixel=false'
+)
 
 PKGEPOCH=1
-
-# FIXME: Build fails mysteriously with parallelism.
-NOPARALLEL=1

--- a/app-web/elinks/autobuild/patches/0001-Fix-Ruby-not-found-on-AOSC-OS.patch
+++ b/app-web/elinks/autobuild/patches/0001-Fix-Ruby-not-found-on-AOSC-OS.patch
@@ -1,0 +1,26 @@
+From bb3d116b4835e7df7f613aa98b1f1844a52996dc Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 31 Mar 2025 05:54:38 -0700
+Subject: [PATCH 1/4] Fix Ruby not found on AOSC OS
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 34ddb30f8..4d66a22f3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -635,7 +635,7 @@ conf_data.set('CONFIG_PERL_POPPX_WITHOUT_N_A', 1)
+ 
+ rubydeps = []
+ if conf_data.get('CONFIG_SCRIPTING_RUBY')
+-    rubydeps = dependency('ruby', static: st)
++    rubydeps = dependency('Ruby', static: st)
+     deps += rubydeps
+ endif
+ 
+-- 
+2.49.0
+

--- a/app-web/elinks/autobuild/patches/0002-guile.c-do-not-get-version.patch
+++ b/app-web/elinks/autobuild/patches/0002-guile.c-do-not-get-version.patch
@@ -1,0 +1,29 @@
+From 60b543cdb2045b68938f800315823a6297b7c1ab Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 31 Mar 2025 06:30:59 -0700
+Subject: [PATCH 2/4] guile.c: do not get version
+
+Workaround for SIGSEGV inside Guile.
+
+Link: https://github.com/rkd77/elinks/issues/373
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/scripting/guile/guile.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/scripting/guile/guile.c b/src/scripting/guile/guile.c
+index 01226169b..81c592955 100644
+--- a/src/scripting/guile/guile.c
++++ b/src/scripting/guile/guile.c
+@@ -15,7 +15,7 @@ static const char *
+ get_name_guile(struct module *xxx)
+ {
+ 	static char elguileversion[32];
+-	snprintf(elguileversion, 31, "Guile %s", scm_to_locale_string(scm_version()));
++	snprintf(elguileversion, 31, "Guile");
+ 
+ 	return elguileversion;
+ }
+-- 
+2.49.0
+

--- a/app-web/elinks/autobuild/patches/0003-ruby.c-include-ruby.h.patch
+++ b/app-web/elinks/autobuild/patches/0003-ruby.c-include-ruby.h.patch
@@ -1,0 +1,43 @@
+From a2dbae27d268b9c8e0a0595b1c2301e8ba956cc6 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 31 Mar 2025 06:50:41 -0700
+Subject: [PATCH 3/4] ruby.c: include ruby.h
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/intl/libintl.h        | 4 ++++
+ src/scripting/ruby/ruby.c | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/src/intl/libintl.h b/src/intl/libintl.h
+index c07e6e107..8efb8ff5f 100644
+--- a/src/intl/libintl.h
++++ b/src/intl/libintl.h
+@@ -48,6 +48,10 @@ intl_set_charset(struct terminal *term)
+ 
+ #ifndef DEBUG_IT
+ 
++#ifdef _
++#undef _
++#endif
++
+ /* Wraps around gettext(), employing charset multiplexing. If you don't care
+  * about charset (usually during initialization or when you don't use terminals
+  * at all), use gettext() directly. */
+diff --git a/src/scripting/ruby/ruby.c b/src/scripting/ruby/ruby.c
+index 9bc15febe..602316e89 100644
+--- a/src/scripting/ruby/ruby.c
++++ b/src/scripting/ruby/ruby.c
+@@ -4,6 +4,9 @@
+ #include "config.h"
+ #endif
+ 
++#include <ruby.h>
++#include <ruby/version.h>
++
+ #include "elinks.h"
+ 
+ #include "intl/libintl.h"
+-- 
+2.49.0
+

--- a/app-web/elinks/autobuild/patches/0004-sixel-comment-out-ormode-as-it-is-not-implemented.patch
+++ b/app-web/elinks/autobuild/patches/0004-sixel-comment-out-ormode-as-it-is-not-implemented.patch
@@ -1,0 +1,35 @@
+From 24a9740d65bf431f4965269ffad5d2967071f1ca Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 31 Mar 2025 06:54:41 -0700
+Subject: [PATCH 4/4] sixel: comment out ormode as it is not implemented
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ src/terminal/sixel.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/terminal/sixel.c b/src/terminal/sixel.c
+index 215ee5385..c993c79f2 100644
+--- a/src/terminal/sixel.c
++++ b/src/terminal/sixel.c
+@@ -83,7 +83,7 @@ struct sixel_encoder {
+     int macro_number;
+     int penetrate_multiplexer;
+     int encode_policy;
+-    int ormode;
++    //int ormode;
+     int pipe_mode;
+     int verbose;
+     int has_gri_arg_limit;
+@@ -733,7 +733,7 @@ sixel_encoder_encode_frame(
+     sixel_output_set_penetrate_multiplexer(
+         output, encoder->penetrate_multiplexer);
+     sixel_output_set_encode_policy(output, encoder->encode_policy);
+-    sixel_output_set_ormode(output, encoder->ormode);
++    //sixel_output_set_ormode(output, encoder->ormode);
+ 
+ #if 0
+     if (sixel_frame_get_multiframe(frame) && !encoder->fstatic) {
+-- 
+2.49.0
+

--- a/app-web/elinks/autobuild/prepare
+++ b/app-web/elinks/autobuild/prepare
@@ -1,4 +1,0 @@
-if ab_match_arch mips64r6el; then
-    abinfo "Setting default ld emulation for mips64r6el..."
-    export LDEMULATION="elf64ltsmip"
-fi

--- a/app-web/elinks/spec
+++ b/app-web/elinks/spec
@@ -1,4 +1,4 @@
-VER=0.17.1.1
+VER=0.18.0
 SRCS="git::commit=tags/v$VER::https://github.com/rkd77/elinks"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=672"


### PR DESCRIPTION
Topic Description
-----------------

- elinks: update to 0.18.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- elinks: 1:0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit elinks
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
