### PR TITLE
oma: improve dependency

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME="oma"
 PKGDES="Default package management interface"
-PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp gnutls libcap \
-        libgcrypt libgpg-error lz4 nettle openssl systemd xxhash xz zlib \
-        zstd ripgrep aosc-os-repository-data aosc-os-keyring"
-PKGRECOM="apt-gen-list"
+PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp \
+        nettle openssl systemd xz glibc ripgrep zstd \
+        aosc-os-repository-data aosc-os-keyring"
+PKGDEP__LOONGSON3="${PKGDEP/gmp/} openssl"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"

--- a/app-admin/oma/autobuild/prepare
+++ b/app-admin/oma/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Set ZSTD_SYS_USE_PKG_CONFIG=1 to use system zstd ..."
+export ZSTD_SYS_USE_PKG_CONFIG=1

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,5 @@
 VER=1.15.1
+REL=1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: improve dependency

Package(s) Affected
-------------------

- oma: 1.15.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
