### PR TITLE
patch: update to 2.8

### DIFF
--- a/app-devel/patch/spec
+++ b/app-devel/patch/spec
@@ -1,5 +1,4 @@
-VER=2.7.6
-REL=4
+VER=2.8
 SRCS="tbl::https://ftp.gnu.org/gnu/patch/patch-$VER.tar.xz"
-CHKSUMS="sha256::ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd"
+CHKSUMS="sha256::f87cee69eec2b4fcbf60a396b030ad6aa3415f192aa5f7ee84cad5e11f7f5ae3"
 CHKUPDATE="anitya::id=2597"


### PR DESCRIPTION
Topic Description
-----------------

- patch: update to 2.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- patch: 2.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit patch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
