### PR TITLE
iosevka-fonts: update to 33.2.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.1.0
+VER=33.2.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::d2ec5a9d94244d449a5bb9c3966245ada9416894f55c536830384be72c426889 \
-         sha256::9e379dfb2765a30aa1e2569037bf8d169879cc33761165a180f8b97a173ecad8 \
-         sha256::c8521f59621ed1bcec45bb7985d030e87c80169224f0290adfd001a765801f87 \
-         sha256::2562d53e5b347aef153c8129d5535c48a6ae8490ba84e612f6ff87eee2b81fa5 \
-         sha256::a0824801ec7e23972739f1007ffdbd9c0ddb6860f9da3500186ab41417097c70 \
-         sha256::b8a7d7de00d1e62056006a6fc82428c3f2c8e45e41ec3420484a585b51ead90d \
-         sha256::afcd7b5ca2a6188b0ca799d34da24e306eababb0c91657954308ce7426a6134a \
-         sha256::d20e9b801b0522da3fcc2b16ffd52ed116b22043b5051c541e7d6d6a492d9013 \
-         sha256::767025275b4f773f64060a81a6fb45c345407ca07017490c48ddb172b06d365d \
-         sha256::c5a08ab695042073b15069e1437391a151315ee68e4a9555c5b25cf09b1c1a70 \
-         sha256::133d5e1807d23c985cc49009c3c0630385c3d9a561e1deea66d2d24ba12a6182 \
-         sha256::18523c6b0234031467173ac446c9df2296a830f8a38eb1baf8417eca3477502e \
-         sha256::47496523423b286728bfdb794cd5f2c098132ce98a3eb72c74a3710709954d06 \
-         sha256::1a57c35cc28e33ea124db6b1ba998cad48c43271c8c235042fd1207d9dfdf450 \
-         sha256::2423c24e103fe1530ed3c828fcf9e03c62b3b88e18540f013c9c4a953bd4b2ec \
-         sha256::a07b08159bbd50f8b98e24659885a180ed98d04f3b41c806454373bf8d23644d \
-         sha256::1a78f4d9133e9e1bba7add5231af41283d18394e96149594c6a3b3fcab6cc3af \
-         sha256::a00eb22874fd16d2a7ce86883cb62b667d85f1af4201294d42960946d893f2f8 \
-         sha256::5173df0080b2af4e571b1ef1ee321346b0013f3da1428fb673707e5520fbd7ce \
-         sha256::0366cbe35702eb26ea975e1b0a30fd1900ef2f14fea21fcbbd276e7ffeaa2649 \
-         sha256::5e850489a256ecb26f9b285ce1ea2df8e3725cde0b11a9f0bee8a901c03e120f \
-         sha256::81997117569f67485c303aa2602d9c61b82d4874b3f9f54ef8863a41bd7824e7 \
-         sha256::478929282eac7c66b157d355f3381087a732d537635aacab8396233d83c85ab1 \
-         sha256::f390efbec14f14a88630675864c034682b77571bfdee9c4c7998354502f09836 \
+CHKSUMS="sha256::881b42d2b43d5f287a5a6ae885f632800fb2ba3040d94fbf440e4009853d2a92 \
+         sha256::63c7f77b777e497b86dd68dd85fb7a3ae67eda9af85c24de0ee05ae8e48f7cc5 \
+         sha256::3f133e48921d73159ed7d9e0660a40ee81f94fb3d166033ce8005fc3ea0305b8 \
+         sha256::65582ab2eaa2c73e287cdbf7078b2edb95814ec3969bbb17dfcb950f32aacf31 \
+         sha256::5a0c0de995df36aa0b3894ff18bfc131ec9ea55a1c8d04f58b5e607c093aa598 \
+         sha256::d301c6e343addbac5d4e2f4caeb5e08df0d7f12e14005536d89aa5d018156b2f \
+         sha256::2e1d5c4bcd2cfb03a9ddbd911cd2fcc6af4b33ee5af926c848be56f8db96c528 \
+         sha256::b452e2ce993c48ff19872f556a96748b5cac203ed45a6eb6aad7c2a7b8d8c559 \
+         sha256::c87d60a884935e0f0d14e3616f3bc3672e722e2a3802170e48bd9674d0059e25 \
+         sha256::7977ecafb8fc29050d8a386a13a1c89ac2b58b02e5b72cf421383179d9f1f94d \
+         sha256::e637b058f5b0b4a7b5a473d925404c007ba801929510eb0541ada0694ff82095 \
+         sha256::f27e3c0255dc58d58aeecb0e18d1934bccaac02a5c7624b1c207d922c9d8f54f \
+         sha256::c7f93f23f57743f3f8a57e6666eecf6a51818b3b053d26f8b9969e80431a1808 \
+         sha256::c5bde454607182fafdfc25c2acff3c24e122aeb6bcbb07c7339198fd36aa737d \
+         sha256::ee109c83fd709cd97aa169b6e150f8e8c669a3ce70068ec8111a5b3bf2a5f563 \
+         sha256::79bbdb63fdd1789d292019cdf82d2b4b442444e6871a5410b0e352ab6cdb3b92 \
+         sha256::b355977f11e58fedaafc29db6cb5228ae541030691c4c309b7087670f2bc3787 \
+         sha256::570bf8e74678ad4198b3d1704f0796b7f589d605981304f57e540646a0e8ef6e \
+         sha256::2c8ec0fbc804ed88d263fd1aaf04856e4188511af5c419d323d479be1f812842 \
+         sha256::5dcbe364ead93ee10ccd5bd154aa380cf41511f667aceb1db8c40be0664cbdb7 \
+         sha256::f2d221180d86f3317307ffd0333a31085ec5a62109333f9a5a5b95ea48cd0010 \
+         sha256::8c4fd4fe68155e329a1a9c0686e80ce8797f55eee1083db583aeefa0140af08e \
+         sha256::c4aab131330510ed55aa1e7987ce1e9db159aa7967e0d0dcf6a29301a4e1b9bf \
+         sha256::f267c8f23d786e5d0d1b1b18e9448e30b57c06d71c3f9a8f2879f3f9bc90bd1f \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
