### PR TITLE
[PREVIEW] ghostty: update to 1.1.3

### DIFF
--- a/app-utils/ghostty/autobuild/build
+++ b/app-utils/ghostty/autobuild/build
@@ -1,2 +1,5 @@
 abinfo "Building and installing ..."
-zig build -Doptimize=ReleaseFast -p "$PKGDIR"/usr
+# https://github.com/ghostty-org/ghostty/issues/6632
+zig build -Doptimize=ReleaseFast \
+          -p "$PKGDIR"/usr \
+          -fsys=gtk4-layer-shell

--- a/app-utils/ghostty/autobuild/defines
+++ b/app-utils/ghostty/autobuild/defines
@@ -5,4 +5,4 @@ PKGDEP="glib glibc gtk-4 libadwaita x11-lib"
 PKGDES="A GPU-accelerated terminal emulator"
 
 # FIXME: zig does not support non amd64 architecture
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-utils/ghostty/autobuild/defines
+++ b/app-utils/ghostty/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ghostty
 PKGSEC=utils
-BUILDDEP="zig"
-PKGDEP="glib glibc gtk-4 libadwaita x11-lib"
+BUILDDEP="zig blueprint-compiler"
+PKGDEP="glib glibc gtk-4 libadwaita wayland x11-lib"
 PKGDES="A GPU-accelerated terminal emulator"
 
 # FIXME: zig does not support non amd64 architecture

--- a/app-utils/ghostty/autobuild/defines
+++ b/app-utils/ghostty/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ghostty
 PKGSEC=utils
 BUILDDEP="zig blueprint-compiler"
-PKGDEP="glib glibc gtk-4 libadwaita wayland x11-lib"
+PKGDEP="glib glibc gtk-4 libadwaita wayland x11-lib gtk4-layer-shell"
 PKGDES="A GPU-accelerated terminal emulator"
 
 # FIXME: zig does not support non amd64 architecture

--- a/app-utils/ghostty/spec
+++ b/app-utils/ghostty/spec
@@ -1,4 +1,4 @@
-VER=1.1.3
-SRCS="git::commit=tags/v$VER::https://github.com/ghostty-org/ghostty"
+VER=1.1.3+git20250329
+SRCS="git::commit=1067cd3d8a061eb5b23bc1a4c46ca10af4481941::https://github.com/ghostty-org/ghostty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376250"

--- a/app-utils/ghostty/spec
+++ b/app-utils/ghostty/spec
@@ -1,4 +1,4 @@
-VER=1.1.2
+VER=1.1.3
 SRCS="git::commit=tags/v$VER::https://github.com/ghostty-org/ghostty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376250"

--- a/desktop-gnome/gtk4-layer-shell/autobuild/defines
+++ b/desktop-gnome/gtk4-layer-shell/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME="gtk4-layer-shell"
+PKGSEC=x11
+PKGDES="A library to create panels and other desktop components for Wayland"
+PKGDEP="glib glibc gtk-4 wayland"
+BUILDDEP="meson ninja vala"
+
+MESON__AFTER="--wrap-mode=nofallback \
+              --buildtype=plain \
+              -Ddocs=true \
+              -Dintrospection=true \
+              -Dvapi=true \
+              -Dexamples=true \
+              -Dsmoke-tests=false"

--- a/desktop-gnome/gtk4-layer-shell/spec
+++ b/desktop-gnome/gtk4-layer-shell/spec
@@ -1,0 +1,4 @@
+VER=1.1.1
+SRCS="git::commit=tags/v$VER::https://github.com/wmww/gtk4-layer-shell"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=359774"


### PR DESCRIPTION
Topic Description
-----------------

- ghostty: add dep gtk4-layer-shell
- gtk4-layer-shell: new, 1.1.1
- ghostty: update to 1.1.3+git20250329
- ghostty: allow more architecture build
- ghostty: update to 1.1.3
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- ghostty: 1.1.3+git20250329
- gtk4-layer-shell: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk4-layer-shell ghostty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
