### PR TITLE
rpi-firmware-boot: update to 1.20250326

### DIFF
--- a/runtime-kernel/rpi-firmware-boot/spec
+++ b/runtime-kernel/rpi-firmware-boot/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=1.20250305
+UPSTREAM_VER=1.20250326
 VER="${UPSTREAM_VER}"
 SRCS="tbl::https://github.com/raspberrypi/firmware/releases/download/$VER/raspi-firmware_$VER.orig.tar.xz"
-CHKSUMS="sha256::f697079cd15389c0d8650283eb911c53a64b22550138704eb50e1145e8330b03"
+CHKSUMS="sha256::aa339955788c6fcee85c2626d1bd40a7e9d9a906761d60b273b291ba78ae0515"
 CHKUPDATE="anitya::id=21744"


### PR DESCRIPTION
Topic Description
-----------------

- rpi-firmware-boot: update to 1.20250326
    Co-authored-by: multimode_Liu / 自大的刘某人 \(@Dustymind\) <dustymind@aosc.io>

Package(s) Affected
-------------------

- rpi-firmware-boot: 1.20250326

Security Update?
----------------

No

Build Order
-----------

```
#buildit rpi-firmware-boot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
