### PR TITLE
libdisplay-info: update to 0.2.0

### DIFF
--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,4 +1,5 @@
 VER=0.40.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mpv-player/mpv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5348"

--- a/desktop-kde/kwin/spec
+++ b/desktop-kde/kwin/spec
@@ -2,3 +2,4 @@ VER=5.27.12
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/kwin-$VER.tar.xz"
 CHKSUMS="sha256::e9b14eab8538b8386e23757446382a2f1be505e5ccabe336020f9a13b14160b6"
 CHKUPDATE="anitya::id=8761"
+REL=1

--- a/desktop-xfce/libxfce4windowing/spec
+++ b/desktop-xfce/libxfce4windowing/spec
@@ -2,3 +2,4 @@ VER=4.20.2
 SRCS="https://archive.xfce.org/src/xfce/libxfce4windowing/${VER%.*}/libxfce4windowing-$VER.tar.bz2"
 CHKSUMS="sha256::0b9b95aee8b868a2953920c2feafc026672ad19584976f19e89119e93ab1abc8"
 CHKUPDATE="anitya::id=375258"
+REL=1

--- a/runtime-display/libdisplay-info/autobuild/defines
+++ b/runtime-display/libdisplay-info/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=libs
 PKGDES="EDID and DisplayID library"
 PKGDEP="edid-decode"
 BUILDDEP="hwdata meson ninja python-3"
+PKGBREAK="kwin<=5.27.12 libxfce4windowing<=4.20.2 mpv<=0.40.0 \
+          weston<=14.0.1 wlroots<=0.18.2"

--- a/runtime-display/libdisplay-info/spec
+++ b/runtime-display/libdisplay-info/spec
@@ -1,4 +1,4 @@
-VER=0.1.1
+VER=0.2.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/emersion/libdisplay-info"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326668"

--- a/runtime-display/weston/spec
+++ b/runtime-display/weston/spec
@@ -2,3 +2,4 @@ VER=14.0.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/weston"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13745"
+REL=1

--- a/runtime-display/wlroots/spec
+++ b/runtime-display/wlroots/spec
@@ -2,3 +2,4 @@ VER=0.18.2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wlroots/wlroots"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libxfce4windowing: bump REL due to libdisplay-info update to 0.2.0
- weston: bump REL due to libdisplay-info update to 0.2.0
- wlroots: bump REL due to libdisplay-info update to 0.2.0
- mpv: bump REL due to libdisplay-info update to 0.2.0
- libdisplay-info: update to 0.2.0

Package(s) Affected
-------------------

- libdisplay-info: 0.2.0
- libxfce4windowing: 4.20.2-1
- mpv: 0.40.0-1
- weston: 14.0.1-1
- wlroots: 0.18.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdisplay-info mpv wlroots weston libxfce4windowing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
