### PR TITLE
fwupd: rework to add PKGBREAK and PKGREP

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -19,5 +19,5 @@ MESON_AFTER=(
     "-Dtests=false"
 )
 
-PKGBREAK="fwupdate<=12-2 discover<=5.27.12 gnome-software<=42.4-1"
-PKGREP="fwupdate<=12-2"
+PKGBREAK="fwupd<=2.0.7 fwupdate<=12-2 discover<=5.27.12 gnome-software<=42.4-1"
+PKGREP="fwupd<=2.0.7 fwupdate<=12-2"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,5 @@
 VER=2.0.7
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: rework to add PKGBREAK and PKGREP

Package(s) Affected
-------------------

- fwupd: 2.0.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd:-pkgbreak fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
