### PR TITLE
fwupd-efi: add PKGBREAK and PKGREP

### DIFF
--- a/app-admin/fwupd-efi/autobuild/defines
+++ b/app-admin/fwupd-efi/autobuild/defines
@@ -15,3 +15,6 @@ MESON_AFTER=(
 ABSPLITDBG=0
 # Upstream only supports these architectures.
 FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+
+PKGBREAK="fwupd<=1.9.25"
+PKGREP="fwupd<=1.9.25"

--- a/app-admin/fwupd-efi/spec
+++ b/app-admin/fwupd-efi/spec
@@ -1,4 +1,5 @@
 VER=1.7
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd-efi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326081"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd-efi: add PKGBREAK and PKGREP

Package(s) Affected
-------------------

- fwupd-efi: 1.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd-efi:-pkgbreak fwupd-efi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
