### PR TITLE
bluecurve: new, 3.0.0

### DIFF
--- a/desktop-themes/bluecurve-gtk-themes/autobuild/defines
+++ b/desktop-themes/bluecurve-gtk-themes/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=bluecurve-gtk-themes
 PKGSEC=x11
-PKGDEP="gtk-2"
-BUILDDEP="intltool perl-xml-parser"
-PKGDES="Bluecurve GTK+ theme"
+PKGDEP="bluecurve"
+PKGDES="Bluecurve GTK+ theme (transitional package for Bluecurve)"
 
-RECONF=0
+PKGEPOCH=1
+ABHOST=noarch
+ABTYPE=dummy

--- a/desktop-themes/bluecurve-gtk-themes/spec
+++ b/desktop-themes/bluecurve-gtk-themes/spec
@@ -1,4 +1,2 @@
-VER=1.0.0
-REL=1
-SRCS="tbl::https://repo.aosc.io/aosc-repacks/bluecurve-gtk-themes-1.0.0.tar.bz2"
-CHKSUMS="sha256::fc73dee6f1bb8fd52ed2cd031cf50062b7e8c422205200c4f83134692fbe6efb"
+VER=0
+DUMMYSRC=1

--- a/desktop-themes/bluecurve/autobuild/build
+++ b/desktop-themes/bluecurve/autobuild/build
@@ -1,0 +1,24 @@
+abinfo "Creating BLDDIR ..."
+mkdir -pv "${BLDDIR}"
+
+abinfo "Installing theme assets ..."
+mkdir -pv "${PKGDIR}"/usr/share/icons/
+mkdir -pv "${PKGDIR}"/usr/share/themes/
+install -Dvm644 "${SRCDIR}"/wallpapers/* -t "${PKGDIR}"/usr/share/backgrounds/Bluecurve
+cp -av "${SRCDIR}"/icons/* "${PKGDIR}"/usr/share/icons/
+cp -av "${SRCDIR}"/themes/* "${PKGDIR}"/usr/share/themes/
+abinfo "Fixing theme assets permission ..."
+find "${PKGDIR}" -type d -exec chmod -Rv 755 {} +
+find "${PKGDIR}" -type f -exec chmod -Rv 644 {} +
+
+abinfo "Building theme engine for gtk-2 ..."
+pushd "${BLDDIR}"
+  abinfo "Running CMakeLists.txt to generate Configuration ..."
+  ab_tostringarray CMAKE_AFTER
+  cmake "$SRCDIR"/engine/src "${CMAKE_DEF[@]}" "${CMAKE_AFTER[@]}" -GNinja \
+	|| abdie "Failed to run CMakeLists.txt: $?."
+  cmake --build . \
+	|| abdie "Failed to build binaries: $?."
+  DESTDIR="$PKGDIR" cmake --install . \
+	|| abdie "Failed to install binaries: $?."
+popd

--- a/desktop-themes/bluecurve/autobuild/defines
+++ b/desktop-themes/bluecurve/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="bluecurve"
+PKGSEC=x11
+PKGDEP="gtk-2 gtk-3 gnome-icon-theme gnome-icon-theme-extras \
+        gnome-icon-theme-symbolic"
+PKGDES="Bluecurve GTK themes"
+
+CMAKE_AFTER=("-DINSTALL_SYSTEM_WIDE=ON")

--- a/desktop-themes/bluecurve/autobuild/patches/0001-Add-a-condition-in-draw_vgradient-and-draw_hgradient.patch
+++ b/desktop-themes/bluecurve/autobuild/patches/0001-Add-a-condition-in-draw_vgradient-and-draw_hgradient.patch
@@ -1,0 +1,43 @@
+From 1da82f936eb9952aef19218b20cb7fada811867d Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Tue, 1 Apr 2025 13:25:52 +0800
+Subject: [PATCH] Add a condition in `draw_vgradient` and `draw_hgradient` if
+ width or height is zero. That prevents arithmetic exceptions in some cases.
+
+---
+ engine/src/bluecurve_style.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/engine/src/bluecurve_style.c b/engine/src/bluecurve_style.c
+index 13199e2..decfece 100644
+--- a/engine/src/bluecurve_style.c
++++ b/engine/src/bluecurve_style.c
+@@ -468,9 +468,9 @@ draw_hgradient (GdkDrawable *drawable, GdkGC *gc, GdkColormap *colormap,
+   GdkGCValues old_values;
+ 
+   col = *top_color;
+-  dr = (bottom_color->red - top_color->red) / height;
+-  dg = (bottom_color->green - top_color->green) / height;
+-  db = (bottom_color->blue - top_color->blue) / height;
++  dr = (bottom_color->red - top_color->red) / (height == 0 ? 1 : height);
++  dg = (bottom_color->green - top_color->green) / (height == 0 ? 1 : height);
++  db = (bottom_color->blue - top_color->blue) / (height == 0 ? 1 : height);
+   
+   gdk_gc_get_values (gc, &old_values);
+   
+@@ -503,9 +503,9 @@ draw_vgradient (GdkDrawable *drawable, GdkGC *gc, GdkColormap *colormap,
+   GdkGCValues old_values;
+ 
+   col = *left_color;
+-  dr = (right_color->red - left_color->red) / width;
+-  dg = (right_color->green - left_color->green) / width;
+-  db = (right_color->blue - left_color->blue) / width;
++  dr = (right_color->red - left_color->red) / (width == 0 ? 1 : width);
++  dg = (right_color->green - left_color->green) / (width == 0 ? 1 : width);
++  db = (right_color->blue - left_color->blue) / (width == 0 ? 1 : width);
+   
+   gdk_gc_get_values (gc, &old_values);
+   
+-- 
+2.49.0
+

--- a/desktop-themes/bluecurve/spec
+++ b/desktop-themes/bluecurve/spec
@@ -1,0 +1,4 @@
+VER=3.0.0
+SRCS="tbl::https://github.com/neeeeow/Bluecurve/releases/download/v${VER}/bluecurve-${VER}.tar.gz"
+CHKSUMS="sha256::0f3c0000db5ad07a58dd8f676ef8cdd4be5c7095b2da703ec3d677316fdfd11f"
+CHKUPDATE="anitya::id=377477"


### PR DESCRIPTION
Topic Description
-----------------

- bluecurve-gtk-themes: became a dummy package with dependency of \`bluecurve\`
- bluecurve: new, 3.0.0

Package(s) Affected
-------------------

- bluecurve: 3.0.0
- bluecurve-gtk-themes: 1:0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bluecurve bluecurve-gtk-themes
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
