### PR TITLE
nvtop: update to 3.2.0

### DIFF
--- a/app-admin/nvtop/spec
+++ b/app-admin/nvtop/spec
@@ -1,10 +1,4 @@
-VER=3.1.0+git20250220
-# Note: The Git master includes too many useful fixes and new features
-# (such as support for Intel i915/xe kernel modules) to ignore. This is
-# also a fairly trivial component so it should be safe to go for a Git
-# snapshot at this moment.
-SRCS="git::commit=33cf46840f58975d593c743b091eb1e37e323378::https://github.com/Syllo/nvtop"
-# Go back to this when they release a new stable version.
-#SRCS="git::commit=tags/$VER::https://github.com/Syllo/nvtop"
+VER=3.2.0
+SRCS="git::commit=tags/$VER::https://github.com/Syllo/nvtop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226779"


### PR DESCRIPTION
Topic Description
-----------------

- nvtop: update to 3.2.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- nvtop: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvtop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
