### PR TITLE
gn: update to 0+git20250311

### DIFF
--- a/app-devel/gn/spec
+++ b/app-devel/gn/spec
@@ -1,3 +1,3 @@
-VER=0+git20240313
-SRCS="git::commit=22581fb46c0c0c9530caa67149ee4dd8811063cf;copy-repo=true::https://gn.googlesource.com/gn"
+VER=0+git20250311
+SRCS="git::commit=18602f6cf1168cf78302024043edc02e8bad2ffb;copy-repo=true::https://gn.googlesource.com/gn"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- gn: update to 0+git20250311

Package(s) Affected
-------------------

- gn: 1:0+git20250311

Security Update?
----------------

No

Build Order
-----------

```
#buildit gn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
