### PR TITLE
libvips: update to 8.16.1

### DIFF
--- a/runtime-imaging/libvips/autobuild/defines
+++ b/runtime-imaging/libvips/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=libvips
 PKGSEC=libs
-PKGDES="A image processing library"
+PKGDES="An image processing library"
 PKGDEP="gcc-runtime glibc glib expat zlib libarchive fftw cfitsio cgif \
         libimagequant libexif libjpeg-turbo libpng libwebp pango fontconfig \
-        libtiff librsvg cairo lcms2 openexr openjpeg highway nifti"
+        libtiff librsvg cairo lcms2 openexr openjpeg highway nifti matio"
 PKGRECOM="imagemagick openslide libheif libjxl poppler python-3"
 BUILDDEP="imagemagick openslide libheif libjxl poppler vala gtk-doc doxygen"
 
@@ -16,4 +16,30 @@ MESON_AFTER=(
     '-Dpdfium=disabled'
     '-Dquantizr=disabled'
     '-Dspng=disabled'
+    '-Dcfitsio=enabled'
+    '-Dcgif=enabled'
+    '-Dexif=enabled'
+    '-Dfftw=enabled'
+    '-Dfontconfig=enabled'
+    '-Darchive=enabled'
+    '-Dheif=enabled'
+    '-Dimagequant=enabled'
+    '-Djpeg=enabled'
+    '-Djpeg-xl=enabled'
+    '-Dlcms=enabled'
+    '-Dmagick=enabled'
+    '-Dmatio=enabled'
+    '-Dnifti=enabled'
+    '-Dopenexr=enabled'
+    '-Dopenjpeg=enabled'
+    '-Dopenslide=enabled'
+    '-Dhighway=enabled'
+    '-Dorc=enabled'
+    '-Dpangocairo=enabled'
+    '-Dpng=enabled'
+    '-Dpoppler=enabled'
+    '-Drsvg=enabled'
+    '-Dtiff=enabled'
+    '-Dwebp=enabled'
+    '-Dzlib=enabled'
 )

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,4 +1,4 @@
-VER=8.16.0
+VER=8.16.1
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: update to 8.16.1; add matio dependency
    - Enable matio feature
    - Explicitly enable options
    - Typo PKGDES

Package(s) Affected
-------------------

- libvips: 8.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
