### PR TITLE
shotcut: split dbg

### DIFF
--- a/app-creativity/shotcut/autobuild/defines
+++ b/app-creativity/shotcut/autobuild/defines
@@ -2,5 +2,3 @@ PKGNAME=shotcut
 PKGSEC=video
 PKGDEP="ffmpeg frei0r-plugins ladspa-sdk lame libvpx x264 mlt qt-6"
 PKGDES="A free, open source, cross-platform video editor"
-
-ABSPLITDBG=0

--- a/app-creativity/shotcut/spec
+++ b/app-creativity/shotcut/spec
@@ -1,4 +1,5 @@
 VER=25.03.29
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/shotcut"
 CHKSUMS="sha256::SKIP"
 CHKUPDATE="anitya::id=20347"


### PR DESCRIPTION
Topic Description
-----------------

- shotcut: split dbg
- shotcut: update to 25.03.29
- mlt: update to 7.30.0
    - turn on qt-6 module

Package(s) Affected
-------------------

- shotcut: 25.03.29-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit shotcut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
