### PR TITLE
git-lfs: update to 3.6.1

### DIFF
--- a/app-devel/git-lfs/autobuild/build
+++ b/app-devel/git-lfs/autobuild/build
@@ -1,22 +1,16 @@
-# Reference: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/git-lfs
-set +e
+abinfo "Building git-lfs ..."
+go build -trimpath "$SRCDIR"
 
-abinfo "Building git-lfs..."
-pushd "$SRCDIR"
-
-go build -trimpath .
+abinfo "Installing git-lfs..."
+install -Dvm755 "$SRCDIR"/git-lfs \
+    "$PKGDIR"/usr/bin/git-lfs
 
 abinfo "Building manuals..."
 make man
 
-abinfo "Installing git-lfs..."
-install -Dm755 git-lfs "$PKGDIR"/usr/bin/git-lfs
-install -Dm644 LICENSE.md "$PKGDIR"/usr/share/doc/git-lfs/LICENSE
-
 abinfo "Installing git-lfs manuals..."
-pushd "$SRCDIR"/man
+cd "$SRCDIR"/man
 for man in man1 man5 ; do
-	find . -type f -exec install -Dvm644 {} "$PKGDIR"/usr/share/man/{} \;
+    find . -type f -exec install -Dvm644 {} \
+        "$PKGDIR"/usr/share/man/{} \;
 done
-popd
-popd

--- a/app-devel/git-lfs/autobuild/defines
+++ b/app-devel/git-lfs/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=git-lfs
 PKGSEC=devel
 PKGDEP="git"
-BUILDDEP="go ronn asciidoctor"
+BUILDDEP="go ronn-ng asciidoctor"
 PKGDES="Git extension for versioning large files"
+
+# FIXME: Autobuild doesn't support splitting symbols from Go executables.
 ABSPLITDBG=0

--- a/app-devel/git-lfs/spec
+++ b/app-devel/git-lfs/spec
@@ -1,4 +1,4 @@
-VER=3.5.1
+VER=3.6.1
 SRCS=git::commit=tags/v${VER}::https://github.com/git-lfs/git-lfs.git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11551"

--- a/topics/git-lfs-3.6.1.toml
+++ b/topics/git-lfs-3.6.1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Git LFS 3.6.1 Security Update"
+zh_CN = "Git LFS 3.6.1 安全更新"
+
+[caution]
+default = "Fixes a credential leak vulnerability - CVE-2024-53263 (Severity: High)"
+zh_CN = "修复一处身份泄漏漏洞，漏洞编号 CVE-2024-53263（严重性：高）"
+
+[packages]
+git-lfs = "3.6.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add git-lfs-3.6.1.toml
- git-lfs: update to 3.6.1
    - Use ronn-ng instead to build man pages.
    - Lint build script.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- git-lfs: 3.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-lfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
