### PR TITLE
svt-av1: update to 3.0.2

### DIFF
--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,4 +1,5 @@
 VER=5.0.1
+REL=1
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,5 @@
 VER=2.10.38
-REL=1
+REL=2
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:4}/gimp-$VER.tar.bz2"
 CHKSUMS="sha256::50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e"
 CHKUPDATE="anitya::id=1161"

--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,4 +1,5 @@
 VER=5.2.9
+REL=1
 SRCS="tbl::https://download.kde.org/stable/krita/${VER:0:5}/krita-$VER.tar.xz"
 CHKSUMS="sha256::f74e710e6d93ddd593fa0b249a64006ed4121a64ce7f95ac29aaa332a7e6e53e"
 CHKUPDATE="anitya::id=10918"

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,5 +1,5 @@
 VER=4.5.0
-REL=4
+REL=5
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"

--- a/app-multimedia/ffmpeg/01-ffmpeg/build
+++ b/app-multimedia/ffmpeg/01-ffmpeg/build
@@ -26,6 +26,11 @@ fi
 if ab_match_arch amd64; then
     VPL="--enable-libvpl"
     NVENC="--enable-nvenc"
+    NVDEC="--enable-nvdec"
+    CUDA="--enable-cuda-llvm"
+elif ab_match_arch arm64; then
+    NVENC="--enable-nvenc"
+    NVDEC="--enable-nvdec"
     CUDA="--enable-cuda-llvm"
 fi
 
@@ -69,19 +74,8 @@ CONFIGURE_OPTIONS=" \
     --enable-libaom \
     --enable-libsmbclient \
     --enable-libsvtav1 \
-    --enable-libwebp"
-
-# FIXME: lto1: fatal error: target specific builtin not available
-# Potentially a compiler bug?
-#
-# See also a similar (resolved) bug for ppc64el.[^1]
-#
-# [^1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102347
-if ! ab_match_arch loongarch64; then
-    CONFIGURE_OPTIONS=" \
-        ${CONFIGURE_OPTIONS} \
-        --enable-lto"
-fi
+    --enable-libwebp \
+    --enable-lto"
 
 # Note: Minimising dependencies for Afterglow.
 if ab_match_archgroup retro; then
@@ -110,7 +104,7 @@ fi
 abinfo "Configuring FFmpeg ..."
 "$SRCDIR"/configure \
     ${CONFIGURE_OPTIONS} \
-    ${MIPSCONF} ${PPCCONF} ${ARMCONF} ${VPL} ${NVENC} ${CUDA}
+    ${MIPSCONF} ${PPCCONF} ${ARMCONF} ${VPL} ${NVENC} ${NVDEC} ${CUDA}
 
 abinfo "Building FFmpeg ..."
 make

--- a/app-multimedia/ffmpeg/01-ffmpeg/defines
+++ b/app-multimedia/ffmpeg/01-ffmpeg/defines
@@ -1,13 +1,14 @@
 PKGNAME=ffmpeg
 PKGSEC=sound
-PKGDEP="alsa-lib bzip2 fontconfig freetype fribidi gnutls gsm lame libass \
-        libbluray libmodplug pulseaudio libssh libtheora libvdpau libvorbis \
-        libvpx libxcb x264 x265 opencore-amr opus schroedinger sdl speex \
-        v4l-utils xvidcore zlib soxr libva sdl2 numactl ladspa-sdk xz aom \
-        samba dav1d avisynthplus svt-av1 libwebp"
+PKGDEP="alsa-lib aom bzip2 fontconfig freetype glibc gnutls gsm lame libass \
+        libbluray libdrm libmodplug libssh libtheora libva libvdpau libvorbis \
+        libvpx libwebp libxcb opencore-amr opus pulseaudio samba sdl2 soxr \
+        speex svt-av1 v4l-utils x11-lib x264 x265 xvidcore xz zlib"
 PKGDEP__AMD64="${PKGDEP} libvpl"
-BUILDDEP__AMD64="${BUILDDEP} yasm ffnvcodec llvm"
-BUILDDEP_ARM64="${BUILDDEP} yasm"
+PKGRECOM="avisynthplus"
+BUILDDEP="avisynthplus nasm"
+BUILDDEP__AMD64="${BUILDDEP} ffnvcodec llvm"
+BUILDDEP__ARM64="${BUILDDEP} ffnvcodec llvm"
 PKGDEP__RETRO="alsa-lib bzip2 fontconfig freetype fribidi gnutls lame libass \
               libmodplug libtheora libvdpau libvorbis libxcb x264 xvidcore \
               zlib soxr libva libcue libao libmpcdec wavpack libdiscid"
@@ -44,16 +45,8 @@ PKGBREAK="akode<=14.1.2-1 alsa-plugins<=1.2.12-1 aubio<=0.4.9-3 \
           scrcpy<=2.6.1 simplescreenrecorder<=0.4.3-3 \
           stepmania<=1:5.0.12+git20221114 telegram-desktop<=5.2.3 \
           tracker-miners<=3.3.1-2 transcode<=1.1.7-16 unpaper<=20190211-1 \
-          vlc<=3.0.21-1 xine-lib<=1.2.13-1 xjadeo<=0.8.13 xpra<=5.0.8-1"
+          vlc<=3.0.21-1 xine-lib<=1.2.13-1 xjadeo<=0.8.13 xpra<=5.0.8-1 \
+          sunshine<=2025.122.141614"
 
 AB_FLAGS_O3=1
-
-# FIXME: lto1: fatal error: target specific builtin not available
-# Potentially a compiler bug?
-#
-# See also a similar (resolved) bug for ppc64el.[^1]
-#
-# [^1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102347
-NOLTO__LOONGARCH64=1
-
 NOSTATIC=0

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0001-UPSTREAM-doc-t2h-Support-texinfo-7.1-and-7.2-pretest.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0001-UPSTREAM-doc-t2h-Support-texinfo-7.1-and-7.2-pretest.patch
@@ -1,7 +1,7 @@
 From e6d989ee04fa7ee50a3f4fec61c74e299863df94 Mon Sep 17 00:00:00 2001
 From: Patrice Dumas <pertusus@free.fr>
 Date: Fri, 1 Nov 2024 15:57:07 +0100
-Subject: [PATCH 01/21] UPSTREAM: doc/t2h: Support texinfo 7.1 and 7.2 pretest
+Subject: [PATCH 01/22] UPSTREAM: doc/t2h: Support texinfo 7.1 and 7.2 pretest
 
 Here is a proposed patch for portability of doc/t2h.pm for GNU Texinfo
 7.1 and 7.1.90 (7.2 pretest).  I tested against 7.1 and 7.1.90 (7.2
@@ -32,7 +32,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 129 insertions(+), 40 deletions(-)
 
 diff --git a/doc/t2h.pm b/doc/t2h.pm
-index b7485e1f1e5c..4875d663055b 100644
+index b7485e1f1e..4875d66305 100644
 --- a/doc/t2h.pm
 +++ b/doc/t2h.pm
 @@ -54,12 +54,24 @@ sub get_formatting_function($$) {
@@ -300,5 +300,5 @@ index b7485e1f1e5c..4875d663055b 100644
  }
  if ($program_version_6_8) {
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0002-UPSTREAM-avformat-flvenc-implement-support-for-multi.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0002-UPSTREAM-avformat-flvenc-implement-support-for-multi.patch
@@ -1,7 +1,7 @@
 From cea2d8d9597445aca23cfdd95fe951b59dbd3010 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dennis=20S=C3=A4dtler?= <dennis@obsproject.com>
 Date: Mon, 1 Apr 2024 18:16:49 +0200
-Subject: [PATCH 02/21] UPSTREAM: avformat/flvenc: implement support for
+Subject: [PATCH 02/22] UPSTREAM: avformat/flvenc: implement support for
  multi-track video
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 120 insertions(+), 47 deletions(-)
 
 diff --git a/libavformat/flv.h b/libavformat/flv.h
-index f710963b9204..82eabf77497b 100644
+index f710963b92..82eabf7749 100644
 --- a/libavformat/flv.h
 +++ b/libavformat/flv.h
 @@ -125,6 +125,13 @@ enum {
@@ -44,7 +44,7 @@ index f710963b9204..82eabf77497b 100644
  
  enum {
 diff --git a/libavformat/flvenc.c b/libavformat/flvenc.c
-index f34df61c0e41..875d4f4a9222 100644
+index f34df61c0e..875d4f4a92 100644
 --- a/libavformat/flvenc.c
 +++ b/libavformat/flvenc.c
 @@ -126,8 +126,9 @@ typedef struct FLVContext {
@@ -315,5 +315,5 @@ index f34df61c0e41..875d4f4a9222 100644
  
  static const AVOption options[] = {
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0003-UPSTREAM-avformat-flvdec-add-support-for-demuxing-mu.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0003-UPSTREAM-avformat-flvdec-add-support-for-demuxing-mu.patch
@@ -1,7 +1,7 @@
 From ffdeda4f80e73a67f88b8373e90597ed8b4c9d96 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dennis=20S=C3=A4dtler?= <dennis@obsproject.com>
 Date: Mon, 1 Apr 2024 18:16:50 +0200
-Subject: [PATCH 03/21] UPSTREAM: avformat/flvdec: add support for demuxing
+Subject: [PATCH 03/22] UPSTREAM: avformat/flvdec: add support for demuxing
  multi-track FLV
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 211 insertions(+), 63 deletions(-)
 
 diff --git a/libavformat/flv.h b/libavformat/flv.h
-index 82eabf77497b..1c0af2a51936 100644
+index 82eabf7749..1c0af2a519 100644
 --- a/libavformat/flv.h
 +++ b/libavformat/flv.h
 @@ -103,6 +103,7 @@ enum {
@@ -46,7 +46,7 @@ index 82eabf77497b..1c0af2a51936 100644
      MultitrackTypeOneTrack             = 0x00,
      MultitrackTypeManyTracks           = 0x10,
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 1fb3e0cd3fae..396104dda5b8 100644
+index 1fb3e0cd3f..396104dda5 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -105,6 +105,10 @@ typedef struct FLVContext {
@@ -312,7 +312,7 @@ index 1fb3e0cd3fae..396104dda5b8 100644
      if (stream_type == FLV_STREAM_TYPE_AUDIO &&
                      (sample_rate != flv->last_sample_rate ||
 diff --git a/libavformat/flvenc.c b/libavformat/flvenc.c
-index 875d4f4a9222..26c8010b077f 100644
+index 875d4f4a92..26c8010b07 100644
 --- a/libavformat/flvenc.c
 +++ b/libavformat/flvenc.c
 @@ -69,6 +69,10 @@ static const AVCodecTag flv_audio_codec_ids[] = {
@@ -535,5 +535,5 @@ index 875d4f4a9222..26c8010b077f 100644
              av_assert1(flags >= 0);
              avio_w8(pb, flags);
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0004-UPSTREAM-avformat-flvdec-add-enhanced-audio-codecs.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0004-UPSTREAM-avformat-flvdec-add-enhanced-audio-codecs.patch
@@ -1,7 +1,7 @@
 From ac3da585011dd64080e65f2530d16cd89019eb42 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Sat, 18 May 2024 00:52:39 +0200
-Subject: [PATCH 04/21] UPSTREAM: avformat/flvdec: add enhanced audio codecs
+Subject: [PATCH 04/22] UPSTREAM: avformat/flvdec: add enhanced audio codecs
 
 (cherry picked from commit 2f72dc33ff23de66db8f801fd3c83099a2f83444)
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 116 insertions(+), 11 deletions(-)
 
 diff --git a/libavformat/flv.h b/libavformat/flv.h
-index 1c0af2a51936..1ea88ff85119 100644
+index 1c0af2a519..1ea88ff851 100644
 --- a/libavformat/flv.h
 +++ b/libavformat/flv.h
 @@ -132,6 +132,14 @@ enum {
@@ -30,7 +30,7 @@ index 1c0af2a51936..1ea88ff85119 100644
  
  enum {
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 396104dda5b8..d7974e6b5189 100644
+index 396104dda5..d7974e6b51 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -224,12 +224,33 @@ static AVStream *create_stream(AVFormatContext *s, int codec_type, int track_idx
@@ -253,5 +253,5 @@ index 396104dda5b8..d7974e6b5189 100644
                       channels    != flv->last_channels)) {
          flv->last_sample_rate = sample_rate;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0005-UPSTREAM-avformat-flvdec-parse-enhanced-rtmp-multich.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0005-UPSTREAM-avformat-flvdec-parse-enhanced-rtmp-multich.patch
@@ -1,7 +1,7 @@
 From da4bb243841b9f290ddf1039a26c45fccf9e9372 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Sat, 18 May 2024 20:30:55 +0200
-Subject: [PATCH 05/21] UPSTREAM: avformat/flvdec: parse enhanced rtmp
+Subject: [PATCH 05/22] UPSTREAM: avformat/flvdec: parse enhanced rtmp
  multichannel info
 
 (cherry picked from commit 67b5fb4b5980ce5386e3162d355459524e962302)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 25 insertions(+), 16 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index d7974e6b5189..f93d7fa75f06 100644
+index d7974e6b51..f93d7fa75f 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1336,8 +1336,6 @@ retry:
@@ -89,5 +89,5 @@ index d7974e6b5189..f93d7fa75f06 100644
              goto leave;
          }
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0006-UPSTREAM-avformat-flvdec-add-support-for-reading-mul.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0006-UPSTREAM-avformat-flvdec-add-support-for-reading-mul.patch
@@ -1,7 +1,7 @@
 From 36cdc03058b58f77760db82da0d66a0830aeeaa0 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Sat, 18 May 2024 23:20:46 +0200
-Subject: [PATCH 06/21] UPSTREAM: avformat/flvdec: add support for reading
+Subject: [PATCH 06/22] UPSTREAM: avformat/flvdec: add support for reading
  multi track audio
 
 (cherry picked from commit 25faaa311a74efdfdc4fed56996d7338ed807488)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 18 insertions(+), 3 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index f93d7fa75f06..27e243cf0276 100644
+index f93d7fa75f..27e243cf02 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1337,12 +1337,26 @@ retry:
@@ -54,5 +54,5 @@ index f93d7fa75f06..27e243cf0276 100644
          } else if (stream_type == FLV_STREAM_TYPE_VIDEO) {
              if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0007-UPSTREAM-avformat-flvdec-stop-shadowing-local-variab.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0007-UPSTREAM-avformat-flvdec-stop-shadowing-local-variab.patch
@@ -1,7 +1,7 @@
 From f550c705a2e797e33981a3dfa774f0f014ed834e Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Mon, 20 May 2024 02:40:14 +0200
-Subject: [PATCH 07/21] UPSTREAM: avformat/flvdec: stop shadowing local
+Subject: [PATCH 07/22] UPSTREAM: avformat/flvdec: stop shadowing local
  variables
 
 (cherry picked from commit da32990e8385dacf5b6320299ec2a31a4924daf1)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+), 22 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 27e243cf0276..5ab7c9a2b9fc 100644
+index 27e243cf02..5ab7c9a2b9 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1395,8 +1395,8 @@ retry:
@@ -104,5 +104,5 @@ index 27e243cf0276..5ab7c9a2b9fc 100644
              flv->mt_extradata_sz[track_idx] = 0;
          }
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0008-UPSTREAM-avformat-flvdec-support-all-multi-track-mod.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0008-UPSTREAM-avformat-flvdec-support-all-multi-track-mod.patch
@@ -1,7 +1,7 @@
 From 300a2f7ccdfdfbdd541302834dab2fc06fb911e1 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Mon, 20 May 2024 02:32:11 +0200
-Subject: [PATCH 08/21] UPSTREAM: avformat/flvdec: support all multi-track
+Subject: [PATCH 08/22] UPSTREAM: avformat/flvdec: support all multi-track
  modes
 
 (cherry picked from commit e2a8ece352bf72bb05be8e152b1706509706b62a)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 310 insertions(+), 261 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 5ab7c9a2b9fc..a73a6c201238 100644
+index 5ab7c9a2b9..a73a6c2012 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1274,6 +1274,7 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
@@ -671,5 +671,5 @@ index 5ab7c9a2b9fc..a73a6c201238 100644
  
  static int flv_read_seek(AVFormatContext *s, int stream_index,
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0009-UPSTREAM-avformat-flvdec-propagate-av_packet_add_sid.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0009-UPSTREAM-avformat-flvdec-propagate-av_packet_add_sid.patch
@@ -1,7 +1,7 @@
 From d4c15a3e5d98009c167a9e8deaba9bbe880591bf Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Sun, 22 Dec 2024 03:06:17 +0100
-Subject: [PATCH 09/21] UPSTREAM: avformat/flvdec: propagate
+Subject: [PATCH 09/22] UPSTREAM: avformat/flvdec: propagate
  av_packet_add_side_data failure
 
 (cherry picked from commit 770f0a243419f14a56f1da76b6cf44157565f98e)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 10 insertions(+), 8 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index a73a6c201238..b036204cf3b7 100644
+index a73a6c2012..b036204cf3 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1720,20 +1720,22 @@ retry_duration:
@@ -46,5 +46,5 @@ index a73a6c201238..b036204cf3b7 100644
          if (stream_type == FLV_STREAM_TYPE_AUDIO && !enhanced_flv &&
                          (sample_rate != flv->last_sample_rate ||
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0010-UPSTREAM-avformat-flvdec-add-missing-track_size-decr.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0010-UPSTREAM-avformat-flvdec-add-missing-track_size-decr.patch
@@ -1,7 +1,7 @@
 From e8ba136e90246e00e9abebbb95c6d5c63703e6f1 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Tue, 7 Jan 2025 17:57:52 +0100
-Subject: [PATCH 10/21] UPSTREAM: avformat/flvdec: add missing track_size
+Subject: [PATCH 10/22] UPSTREAM: avformat/flvdec: add missing track_size
  decrement
 
 (cherry picked from commit e9de794d7fb0d52d63a37758dc605322321e34c3)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index b036204cf3b7..e8b5ea954365 100644
+index b036204cf3..e8b5ea9543 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1584,6 +1584,7 @@ retry_duration:
@@ -23,5 +23,5 @@ index b036204cf3b7..e8b5ea954365 100644
                          if (id < 18)
                              st->codecpar->ch_layout.u.map[i].id = id;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0011-UPSTREAM-avformat-flvdec-fix-potential-premature-ret.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0011-UPSTREAM-avformat-flvdec-fix-potential-premature-ret.patch
@@ -1,7 +1,7 @@
 From 5410fe404a8b7c3af2d33b18bd8436fffac12717 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Tue, 7 Jan 2025 18:18:02 +0100
-Subject: [PATCH 11/21] UPSTREAM: avformat/flvdec: fix potential premature
+Subject: [PATCH 11/22] UPSTREAM: avformat/flvdec: fix potential premature
  return on audio MultichannelConfig
 
 (cherry picked from commit 0ed34467382a35dd27da7124fae99e84eee469a5)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index e8b5ea954365..043c977e73de 100644
+index e8b5ea9543..043c977e73 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1273,7 +1273,7 @@ static int flv_update_video_color_info(AVFormatContext *s, AVStream *st)
@@ -49,5 +49,5 @@ index e8b5ea954365..043c977e73de 100644
              av_log(s, AV_LOG_ERROR, "Attempted to read next track in single-track mode.\n");
              ret = FFERROR_REDO;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0012-UPSTREAM-avformat-flvdec-clean-up-variable-initializ.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0012-UPSTREAM-avformat-flvdec-clean-up-variable-initializ.patch
@@ -1,7 +1,7 @@
 From e36dc539b0a53d9ab6b8016b9d01e67bdf3e7134 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Tue, 7 Jan 2025 18:18:38 +0100
-Subject: [PATCH 12/21] UPSTREAM: avformat/flvdec: clean up variable
+Subject: [PATCH 12/22] UPSTREAM: avformat/flvdec: clean up variable
  initialization spacing
 
 (cherry picked from commit 4c2b769e53329208cbccd65c9c4143b346e7e07b)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 043c977e73de..facce7a4f677 100644
+index 043c977e73..facce7a4f6 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1276,12 +1276,12 @@ static int flv_read_packet(AVFormatContext *s, AVPacket *pkt)
@@ -30,5 +30,5 @@ index 043c977e73de..facce7a4f677 100644
      int orig_size;
      int enhanced_flv = 0;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0013-UPSTREAM-avformat-flvdec-properly-free-mt_extradata.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0013-UPSTREAM-avformat-flvdec-properly-free-mt_extradata.patch
@@ -1,7 +1,7 @@
 From a538b3aa39941adc82a3c549393e79d5e3f363e3 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Tue, 7 Jan 2025 19:07:43 +0100
-Subject: [PATCH 13/21] UPSTREAM: avformat/flvdec: properly free mt_extradata
+Subject: [PATCH 13/22] UPSTREAM: avformat/flvdec: properly free mt_extradata
 
 (cherry picked from commit 9201f872b1c4a6a73510d48c43960f6a2a62a4fe)
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index facce7a4f677..88038332ea44 100644
+index facce7a4f6..88038332ea 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -935,6 +935,7 @@ static int flv_read_close(AVFormatContext *s)
@@ -22,5 +22,5 @@ index facce7a4f677..88038332ea44 100644
      av_freep(&flv->keyframe_times);
      av_freep(&flv->keyframe_filepositions);
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0014-UPSTREAM-avformat-flvdec-don-t-leak-extradata-pointe.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0014-UPSTREAM-avformat-flvdec-don-t-leak-extradata-pointe.patch
@@ -1,7 +1,7 @@
 From a9e84a6d9a6e4c36f84543b1aa5303f99bca9b7a Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Tue, 7 Jan 2025 19:17:54 +0100
-Subject: [PATCH 14/21] UPSTREAM: avformat/flvdec: don't leak extradata pointer
+Subject: [PATCH 14/22] UPSTREAM: avformat/flvdec: don't leak extradata pointer
  on realloc failure
 
 (cherry picked from commit af74fe7139f4e99c12e9396b0b45c6d0c8d291cc)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 13 insertions(+), 9 deletions(-)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 88038332ea44..f167157a0463 100644
+index 88038332ea..f167157a04 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -973,18 +973,22 @@ static int flv_queue_extradata(FLVContext *flv, AVIOContext *pb, int stream,
@@ -47,5 +47,5 @@ index 88038332ea44..f167157a0463 100644
              flv->mt_extradata_cnt = new_count;
          }
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0015-BACKPORT-avformat-flvdec-add-support-for-legacy-HEVC.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0015-BACKPORT-avformat-flvdec-add-support-for-legacy-HEVC.patch
@@ -1,7 +1,7 @@
 From 59610e05a660db59d2a9ea5846648fc2f90ba39d Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Fri, 10 Jan 2025 21:41:55 +0100
-Subject: [PATCH 15/21] BACKPORT: avformat/flvdec: add support for legacy HEVC
+Subject: [PATCH 15/22] BACKPORT: avformat/flvdec: add support for legacy HEVC
  files
 
 (cherry picked from commit b76053d8bf322b197a9d07bd27bbdad14fd5bc15)
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/libavformat/flv.h b/libavformat/flv.h
-index 1ea88ff85119..74d3b8de8be9 100644
+index 1ea88ff851..74d3b8de8b 100644
 --- a/libavformat/flv.h
 +++ b/libavformat/flv.h
 @@ -117,6 +117,9 @@ enum {
@@ -27,7 +27,7 @@ index 1ea88ff85119..74d3b8de8be9 100644
  
  enum {
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index f167157a0463..e17e5375b242 100644
+index f167157a04..e17e5375b2 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -380,6 +380,7 @@ static int flv_same_video_codec(AVCodecParameters *vpar, uint32_t flv_codecid)
@@ -58,5 +58,5 @@ index f167157a0463..e17e5375b242 100644
                  int32_t cts = (avio_rb24(s->pb) + 0xff800000) ^ 0xff800000;
                  pts = av_sat_add64(dts, cts);
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0016-UPSTREAM-avformat-flvdec-implement-support-for-parsi.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0016-UPSTREAM-avformat-flvdec-implement-support-for-parsi.patch
@@ -1,7 +1,7 @@
 From a79bb63faa85567c21016931eb72f3f418e8a305 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Wed, 15 Jan 2025 01:19:57 +0100
-Subject: [PATCH 16/21] UPSTREAM: avformat/flvdec: implement support for
+Subject: [PATCH 16/22] UPSTREAM: avformat/flvdec: implement support for
  parsing ModEx data
 
 (cherry picked from commit ced9fddec0e45e1ce1b3425a1fed66af971e934c)
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 73 insertions(+)
 
 diff --git a/libavformat/flv.h b/libavformat/flv.h
-index 74d3b8de8be9..d8f7980f2e30 100644
+index 74d3b8de8b..d8f7980f2e 100644
 --- a/libavformat/flv.h
 +++ b/libavformat/flv.h
 @@ -130,6 +130,7 @@ enum {
@@ -35,7 +35,7 @@ index 74d3b8de8be9..d8f7980f2e30 100644
      AudioChannelOrderUnspecified = 0,
      AudioChannelOrderNative      = 1,
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index e17e5375b242..2c21911410fb 100644
+index e17e5375b2..2c21911410 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1277,6 +1277,62 @@ static int flv_update_video_color_info(AVFormatContext *s, AVStream *st)
@@ -128,5 +128,5 @@ index e17e5375b242..2c21911410fb 100644
              uint8_t types = avio_r8(s->pb);
              multitrack_type = types & 0xF0;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0017-UPSTREAM-avformat-flvdec-correctly-skip-command-fram.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0017-UPSTREAM-avformat-flvdec-correctly-skip-command-fram.patch
@@ -1,7 +1,7 @@
 From 54342ed3e85a3848cd37e5b555c6889707063867 Mon Sep 17 00:00:00 2001
 From: Timo Rothenpieler <timo@rothenpieler.org>
 Date: Wed, 15 Jan 2025 01:28:08 +0100
-Subject: [PATCH 17/21] UPSTREAM: avformat/flvdec: correctly skip command frame
+Subject: [PATCH 17/22] UPSTREAM: avformat/flvdec: correctly skip command frame
  for enhanced flv
 
 (cherry picked from commit a3e506455e3346e3e0a7c577874fa3b83644e8f9)
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/libavformat/flvdec.c b/libavformat/flvdec.c
-index 2c21911410fb..83b0f2acec80 100644
+index 2c21911410..83b0f2acec 100644
 --- a/libavformat/flvdec.c
 +++ b/libavformat/flvdec.c
 @@ -1442,6 +1442,10 @@ retry:
@@ -26,5 +26,5 @@ index 2c21911410fb..83b0f2acec80 100644
              uint8_t types = avio_r8(s->pb);
              multitrack_type = types & 0xF0;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0018-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0018-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
 From 4b80049d59cc054eef68ee53a867feda74ee878c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 18/21] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 18/22] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
  2 files changed, 1 insertion(+), 89 deletions(-)
 
 diff --git a/libavutil/mips/asmdefs.h b/libavutil/mips/asmdefs.h
-index 659342bab918..4d3bf1f09af9 100644
+index 659342bab9..4d3bf1f09a 100644
 --- a/libavutil/mips/asmdefs.h
 +++ b/libavutil/mips/asmdefs.h
 @@ -57,48 +57,6 @@
@@ -63,7 +63,7 @@ index 659342bab918..4d3bf1f09af9 100644
  union mmi_intfloat64 {
      int64_t i;
 diff --git a/libavutil/mips/cpu.c b/libavutil/mips/cpu.c
-index 2009c70f7151..5002261b256a 100644
+index 2009c70f71..5002261b25 100644
 --- a/libavutil/mips/cpu.c
 +++ b/libavutil/mips/cpu.c
 @@ -30,49 +30,6 @@
@@ -129,5 +129,5 @@ index 2009c70f7151..5002261b256a 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0019-Add-av_stream_get_first_dts-for-Chromium.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0019-Add-av_stream_get_first_dts-for-Chromium.patch
@@ -1,7 +1,7 @@
 From 2974e568e98d50a72fa2e72b6083dbdb314baa2f Mon Sep 17 00:00:00 2001
 From: Frank Liberato <liberato@chromium.org>
 Date: Wed, 7 Jul 2021 19:01:22 -0700
-Subject: [PATCH 19/21] Add av_stream_get_first_dts for Chromium
+Subject: [PATCH 19/22] Add av_stream_get_first_dts for Chromium
 
 ---
  libavformat/avformat.h | 4 ++++
@@ -9,7 +9,7 @@ Subject: [PATCH 19/21] Add av_stream_get_first_dts for Chromium
  2 files changed, 11 insertions(+)
 
 diff --git a/libavformat/avformat.h b/libavformat/avformat.h
-index 56c1c8028996..75221d9d1a1e 100644
+index 56c1c80289..75221d9d1a 100644
 --- a/libavformat/avformat.h
 +++ b/libavformat/avformat.h
 @@ -1202,6 +1202,10 @@ typedef struct AVStreamGroup {
@@ -24,7 +24,7 @@ index 56c1c8028996..75221d9d1a1e 100644
  
  /**
 diff --git a/libavformat/utils.c b/libavformat/utils.c
-index e9ded627ad67..399c777f2a24 100644
+index e9ded627ad..399c777f2a 100644
 --- a/libavformat/utils.c
 +++ b/libavformat/utils.c
 @@ -44,6 +44,13 @@
@@ -42,5 +42,5 @@ index e9ded627ad67..399c777f2a24 100644
  #define SANE_CHUNK_SIZE (50000000)
  
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0020-fix-libavcodec-mips-constify-src-for-mmi.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0020-fix-libavcodec-mips-constify-src-for-mmi.patch
@@ -1,14 +1,14 @@
 From a2183f3041cc5d9333f14d775e31af5431bce4e3 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 11:36:37 +0800
-Subject: [PATCH 20/21] fix(libavcodec/mips): constify src for mmi
+Subject: [PATCH 20/22] fix(libavcodec/mips): constify src for mmi
 
 ---
  libavcodec/mips/vp8dsp_mmi.c | 72 ++++++++++++++++++------------------
  1 file changed, 36 insertions(+), 36 deletions(-)
 
 diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
-index bc774aa36586..55599e58f901 100644
+index bc774aa365..55599e58f9 100644
 --- a/libavcodec/mips/vp8dsp_mmi.c
 +++ b/libavcodec/mips/vp8dsp_mmi.c
 @@ -1439,7 +1439,7 @@ void ff_vp8_h_loop_filter_simple_mmi(uint8_t *dst, ptrdiff_t stride, int flim)
@@ -336,5 +336,5 @@ index bc774aa36586..55599e58f901 100644
  {
  #if 1
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0021-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0021-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
@@ -1,7 +1,7 @@
 From 24f9f6e18b8343248d3fed314bbbbb414ae646c8 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 16:08:58 +0800
-Subject: [PATCH 21/21] fix(libavcodec/mips): use mmi mnemonics supported by
+Subject: [PATCH 21/22] fix(libavcodec/mips): use mmi mnemonics supported by
  binutils 2.43.1
 
 Apparently Loongson's staff's proposal has never been upstreamed.
@@ -28,7 +28,7 @@ see also: https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2021-July/282542.html
  17 files changed, 397 insertions(+), 397 deletions(-)
 
 diff --git a/libavcodec/mips/blockdsp_mmi.c b/libavcodec/mips/blockdsp_mmi.c
-index 8b5c7e955c86..68641e25448a 100644
+index 8b5c7e955c..68641e2544 100644
 --- a/libavcodec/mips/blockdsp_mmi.c
 +++ b/libavcodec/mips/blockdsp_mmi.c
 @@ -76,8 +76,8 @@ void ff_clear_block_mmi(int16_t *block)
@@ -54,7 +54,7 @@ index 8b5c7e955c86..68641e25448a 100644
          MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x10)
          MMI_SQC1(%[ftmp0], %[ftmp1], %[block], 0x20)
 diff --git a/libavcodec/mips/h264chroma_mmi.c b/libavcodec/mips/h264chroma_mmi.c
-index fe05ccd6717e..1a08a524cded 100644
+index fe05ccd671..1a08a524cd 100644
 --- a/libavcodec/mips/h264chroma_mmi.c
 +++ b/libavcodec/mips/h264chroma_mmi.c
 @@ -75,7 +75,7 @@ void ff_put_h264_chroma_mc8_mmi(uint8_t *dst, const uint8_t *src, ptrdiff_t stri
@@ -148,7 +148,7 @@ index fe05ccd6717e..1a08a524cded 100644
              "pshufh     %[E],       %[E],           %[ftmp0]            \n\t"
              "mtc1       %[tmp0],    %[ftmp5]                            \n\t"
 diff --git a/libavcodec/mips/h264dsp_mmi.c b/libavcodec/mips/h264dsp_mmi.c
-index bae1052dcf36..09cfbecaee8e 100644
+index bae1052dcf..09cfbecaee 100644
 --- a/libavcodec/mips/h264dsp_mmi.c
 +++ b/libavcodec/mips/h264dsp_mmi.c
 @@ -34,7 +34,7 @@ void ff_h264_add_pixels4_8_mmi(uint8_t *dst, int16_t *src, int stride)
@@ -871,7 +871,7 @@ index bae1052dcf36..09cfbecaee8e 100644
          "paddb      %[ftmp2],   %[ftmp2],       %[ftmp6]                \n\t"
  
 diff --git a/libavcodec/mips/h264pred_mmi.c b/libavcodec/mips/h264pred_mmi.c
-index 480411f5b579..3542d575be98 100644
+index 480411f5b5..3542d575be 100644
 --- a/libavcodec/mips/h264pred_mmi.c
 +++ b/libavcodec/mips/h264pred_mmi.c
 @@ -162,7 +162,7 @@ void ff_pred8x8l_top_dc_8_mmi(uint8_t *src, int has_topleft,
@@ -942,7 +942,7 @@ index 480411f5b579..3542d575be98 100644
          "pshufh     %[ftmp0],   %[ftmp0],       %[ftmp4]                \n\t"
          "dmtc1      %[tmp1],    %[ftmp5]                                \n\t"
 diff --git a/libavcodec/mips/h264qpel_mmi.c b/libavcodec/mips/h264qpel_mmi.c
-index 3482956e13b6..99903a2258c4 100644
+index 3482956e13..99903a2258 100644
 --- a/libavcodec/mips/h264qpel_mmi.c
 +++ b/libavcodec/mips/h264qpel_mmi.c
 @@ -114,7 +114,7 @@ static void put_h264_qpel4_h_lowpass_mmi(uint8_t *dst, const uint8_t *src,
@@ -1063,7 +1063,7 @@ index 3482956e13b6..99903a2258c4 100644
          "1:                                                             \n\t"
          MMI_ULDC1(%[ftmp1], %[src], 0x00)
 diff --git a/libavcodec/mips/hevcdsp_mmi.c b/libavcodec/mips/hevcdsp_mmi.c
-index 6ff52187e5c6..9a412aed764a 100644
+index 6ff52187e5..9a412aed76 100644
 --- a/libavcodec/mips/hevcdsp_mmi.c
 +++ b/libavcodec/mips/hevcdsp_mmi.c
 @@ -47,7 +47,7 @@ void ff_hevc_put_hevc_qpel_h##w##_8_mmi(int16_t *dst, const uint8_t *_src, \
@@ -1198,7 +1198,7 @@ index 6ff52187e5c6..9a412aed764a 100644
          MMI_USWC1(%[ftmp3], %[dst], 0x00)                               \
                                                                          \
 diff --git a/libavcodec/mips/hpeldsp_mmi.c b/libavcodec/mips/hpeldsp_mmi.c
-index 8e9c0fa82155..ce51815ff420 100644
+index 8e9c0fa821..ce51815ff4 100644
 --- a/libavcodec/mips/hpeldsp_mmi.c
 +++ b/libavcodec/mips/hpeldsp_mmi.c
 @@ -677,14 +677,14 @@ inline void ff_put_no_rnd_pixels8_l2_8_mmi(uint8_t *dst, const uint8_t *src1,
@@ -1253,7 +1253,7 @@ index 8e9c0fa82155..ce51815ff420 100644
          "pcmpeqw    %[ftmp6],   %[ftmp6],       %[ftmp6]                \n\t"
          "dmtc1      %[addr0],   %[ftmp8]                                \n\t"
 diff --git a/libavcodec/mips/idctdsp_mmi.c b/libavcodec/mips/idctdsp_mmi.c
-index d96b3b1ac62f..0065fdbb331c 100644
+index d96b3b1ac6..0065fdbb33 100644
 --- a/libavcodec/mips/idctdsp_mmi.c
 +++ b/libavcodec/mips/idctdsp_mmi.c
 @@ -154,7 +154,7 @@ void ff_add_pixels_clamped_mmi(const int16_t *block,
@@ -1266,7 +1266,7 @@ index d96b3b1ac62f..0065fdbb331c 100644
          MMI_LDC1(%[ftmp5], %[pixels], 0x00)
          PTR_ADDU   "%[pixels],  %[pixels],  %[line_size]       \n\t"
 diff --git a/libavcodec/mips/mpegvideo_mmi.c b/libavcodec/mips/mpegvideo_mmi.c
-index 7af421db6b2e..f4b27fe83e59 100644
+index 7af421db6b..f4b27fe83e 100644
 --- a/libavcodec/mips/mpegvideo_mmi.c
 +++ b/libavcodec/mips/mpegvideo_mmi.c
 @@ -54,13 +54,13 @@ void ff_dct_unquantize_h263_intra_mmi(MpegEncContext *s, int16_t *block,
@@ -1452,7 +1452,7 @@ index 7af421db6b2e..f4b27fe83e59 100644
          "psubh      %[ftmp2],   %[ftmp2],       %[ftmp8]                \n\t"
          "pandn      %[ftmp5],   %[ftmp5],       %[ftmp1]                \n\t"
 diff --git a/libavcodec/mips/mpegvideoenc_mmi.c b/libavcodec/mips/mpegvideoenc_mmi.c
-index 65da155e9f8d..be4a89506d20 100644
+index 65da155e9f..be4a89506d 100644
 --- a/libavcodec/mips/mpegvideoenc_mmi.c
 +++ b/libavcodec/mips/mpegvideoenc_mmi.c
 @@ -37,16 +37,16 @@ void ff_denoise_dct_mmi(MpegEncContext *s, int16_t *block)
@@ -1489,7 +1489,7 @@ index 65da155e9f8d..be4a89506d20 100644
          "psubh      %[ftmp3],   %[ftmp3],       %[ftmp4]                \n\t"
          MMI_SDC1(%[ftmp1], %[block], 0x00)
 diff --git a/libavcodec/mips/pixblockdsp_mmi.c b/libavcodec/mips/pixblockdsp_mmi.c
-index dea85bf3fada..d4a0657d44d7 100644
+index dea85bf3fa..d4a0657d44 100644
 --- a/libavcodec/mips/pixblockdsp_mmi.c
 +++ b/libavcodec/mips/pixblockdsp_mmi.c
 @@ -33,7 +33,7 @@ void ff_get_pixels_8_mmi(int16_t *restrict block, const uint8_t *pixels,
@@ -1518,7 +1518,7 @@ index dea85bf3fada..d4a0657d44d7 100644
          "punpckhbh  %[ftmp1],   %[ftmp1],       %[ftmp4]                \n\t"
          "punpcklbh  %[ftmp2],   %[ftmp2],       %[ftmp4]                \n\t"
 diff --git a/libavcodec/mips/simple_idct_mmi.c b/libavcodec/mips/simple_idct_mmi.c
-index 4680520edc1f..7d5e271a39c6 100644
+index 4680520edc..7d5e271a39 100644
 --- a/libavcodec/mips/simple_idct_mmi.c
 +++ b/libavcodec/mips/simple_idct_mmi.c
 @@ -135,7 +135,7 @@ void ff_simple_idct_8_mmi(int16_t *block)
@@ -1557,7 +1557,7 @@ index 4680520edc1f..7d5e271a39c6 100644
          "bnez         $10,       1f                             \n\t"
          /* case1: In this case, row[1,3,5,7] are all zero */
 diff --git a/libavcodec/mips/vc1dsp_mmi.c b/libavcodec/mips/vc1dsp_mmi.c
-index 290b47d697e8..6dd3f1d49436 100644
+index 290b47d697..6dd3f1d494 100644
 --- a/libavcodec/mips/vc1dsp_mmi.c
 +++ b/libavcodec/mips/vc1dsp_mmi.c
 @@ -136,7 +136,7 @@ void ff_vc1_inv_trans_8x8_dc_mmi(uint8_t *dest, ptrdiff_t linesize, int16_t *blo
@@ -1714,7 +1714,7 @@ index 290b47d697e8..6dd3f1d49436 100644
          "pshufh     %[A],       %[A],       %[ftmp0]                    \n\t"
          "pshufh     %[B],       %[B],       %[ftmp0]                    \n\t"
 diff --git a/libavcodec/mips/vp3dsp_idct_mmi.c b/libavcodec/mips/vp3dsp_idct_mmi.c
-index d505fcb7652c..2959c4314fdc 100644
+index d505fcb765..2959c4314f 100644
 --- a/libavcodec/mips/vp3dsp_idct_mmi.c
 +++ b/libavcodec/mips/vp3dsp_idct_mmi.c
 @@ -34,7 +34,7 @@ static void idct_row_mmi(int16_t *input)
@@ -2138,7 +2138,7 @@ index d505fcb7652c..2959c4314fdc 100644
              "sdc1        %[ftmp3],       0x00(%[dst])                    \n\t"
              PTR_ADDU    "%[src1],        %[src1],              %[stride] \n\t"
 diff --git a/libavcodec/mips/vp8dsp_mmi.c b/libavcodec/mips/vp8dsp_mmi.c
-index 55599e58f901..7d0eba3491dd 100644
+index 55599e58f9..7d0eba3491 100644
 --- a/libavcodec/mips/vp8dsp_mmi.c
 +++ b/libavcodec/mips/vp8dsp_mmi.c
 @@ -38,10 +38,10 @@
@@ -2427,7 +2427,7 @@ index 55599e58f901..7d0eba3491dd 100644
          "mtc1       %[tmp0],    %[ftmp4]                            \n\t"
          "pshufh     %[c],       %[c],           %[ftmp0]            \n\t"
 diff --git a/libavcodec/mips/vp9_mc_mmi.c b/libavcodec/mips/vp9_mc_mmi.c
-index 495cac3d0b37..06ccf2d74416 100644
+index 495cac3d0b..06ccf2d744 100644
 --- a/libavcodec/mips/vp9_mc_mmi.c
 +++ b/libavcodec/mips/vp9_mc_mmi.c
 @@ -83,7 +83,7 @@ static void convolve_horiz_mmi(const uint8_t *src, int32_t src_stride,
@@ -2476,7 +2476,7 @@ index 495cac3d0b37..06ccf2d74416 100644
          "dmtc1      %[tmp0],    %[ftmp3]                  \n\t"
          "punpcklhw  %[ftmp3],   %[ftmp3],   %[ftmp3]      \n\t"
 diff --git a/libavcodec/mips/wmv2dsp_mmi.c b/libavcodec/mips/wmv2dsp_mmi.c
-index 1a6781ae77e4..82e16f929b52 100644
+index 1a6781ae77..82e16f929b 100644
 --- a/libavcodec/mips/wmv2dsp_mmi.c
 +++ b/libavcodec/mips/wmv2dsp_mmi.c
 @@ -106,7 +106,7 @@ void ff_wmv2_idct_add_mmi(uint8_t *dest, ptrdiff_t line_size, int16_t *block)
@@ -2489,5 +2489,5 @@ index 1a6781ae77e4..82e16f929b52 100644
          // low 4 loop
          MMI_LDC1(%[ftmp1], %[block], 0x00)
 -- 
-2.48.1.windows.1
+2.49.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0022-avcodec-libsvtav1-unbreak-build-with-latest-svtav1.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0022-avcodec-libsvtav1-unbreak-build-with-latest-svtav1.patch
@@ -1,0 +1,33 @@
+From 8ea8f7327ac4f1f7b81457f7f78c18f533426a90 Mon Sep 17 00:00:00 2001
+From: Gyan Doshi <ffmpeg@gyani.pro>
+Date: Sat, 22 Feb 2025 10:38:53 +0530
+Subject: [PATCH 22/22] avcodec/libsvtav1: unbreak build with latest svtav1
+
+SVT-AV1 made a change in their public API in 988e930c but without a
+version bump or any other accessible marker, thus breaking ffmpeg build
+with current versions of SVT-AV1.
+
+They have finally bumped versions a month later, so check added.
+---
+ libavcodec/libsvtav1.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libavcodec/libsvtav1.c b/libavcodec/libsvtav1.c
+index 79b28eb4df..43fe531fde 100644
+--- a/libavcodec/libsvtav1.c
++++ b/libavcodec/libsvtav1.c
+@@ -435,7 +435,11 @@ static av_cold int eb_enc_init(AVCodecContext *avctx)
+ 
+     svt_enc->eos_flag = EOS_NOT_REACHED;
+ 
++#if SVT_AV1_CHECK_VERSION(3, 0, 0)
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, &svt_enc->enc_params);
++#else
+     svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++#endif
+     if (svt_ret != EB_ErrorNone) {
+         return svt_print_error(avctx, svt_ret, "Error initializing encoder handle");
+     }
+-- 
+2.49.0
+

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=6
+REL=7
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"

--- a/app-multimedia/sunshine/autobuild/defines
+++ b/app-multimedia/sunshine/autobuild/defines
@@ -19,13 +19,15 @@ ABTYPE=cmakeninja
 # SUNSHINE_ASSETS_DIR is set to make data files follow FHS, otherwise it will
 # come at /usr/assets
 #
-CMAKE_AFTER="-DFFMPEG_USE_SYSTEM_LIBRARIES=ON \
-             -DSUNSHINE_ENABLE_DRM=ON \
-             -DSUNSHINE_ENABLE_X11=ON \
-             -DSUNSHINE_ENABLE_WAYLAND=ON \
-             -DSUNSHINE_ENABLE_VAAPI=ON \
-             -DSUNSHINE_ENABLE_CUDA=OFF \
-             -DSUNSHINE_ASSETS_DIR=share/sunshine"
+CMAKE_AFTER=(
+    "-DFFMPEG_USE_SYSTEM_LIBRARIES=ON"
+    "-DSUNSHINE_ENABLE_DRM=ON"
+    "-DSUNSHINE_ENABLE_X11=ON"
+    "-DSUNSHINE_ENABLE_WAYLAND=ON"
+    "-DSUNSHINE_ENABLE_VAAPI=ON"
+    "-DSUNSHINE_ENABLE_CUDA=OFF"
+    "-DSUNSHINE_ASSETS_DIR=share/sunshine"
+)
 
 # FIXME: disable cuda for AMD64/ARM64, due to cuda needs gcc-13, cannot satisfied
 #

--- a/app-multimedia/sunshine/spec
+++ b/app-multimedia/sunshine/spec
@@ -1,4 +1,5 @@
 VER=2025.122.141614
+REL=1
 SRCS="git::commit=tags/v${VER};copy-repo=true;submodule=false::https://github.com/LizardByte/Sunshine.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236300"

--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,4 +1,5 @@
 VER=1.14.5
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17542"

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,4 +1,5 @@
 VER=1.1.4
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369437"

--- a/desktop-kde/kimageformats/spec
+++ b/desktop-kde/kimageformats/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/kimageformats-$VER.tar.xz"
 CHKSUMS="sha256::9f61020d66f86b8b10bce14e42a39c5e8fd8e40ec9e6ca8b9e9b5ce3e1aa7283"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,5 @@
 VER=3.10.1
-REL=5
+REL=6
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::9211eac72b53f5f85d23cf6d83ee20245c6d818733405024e71f2af41e5c5f91"
 CHKUPDATE="anitya::id=881"

--- a/runtime-imaging/libgd/autobuild/defines
+++ b/runtime-imaging/libgd/autobuild/defines
@@ -12,5 +12,8 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="GD Graphics Library"
 
-AUTOTOOLS_AFTER="--with-tiff=/usr --disable-rpath"
 ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-tiff=/usr"
+    "--disable-rpath"
+)

--- a/runtime-imaging/libgd/autobuild/defines.stage2
+++ b/runtime-imaging/libgd/autobuild/defines.stage2
@@ -3,5 +3,8 @@ PKGSEC=libs
 PKGDEP="fontconfig libjpeg-turbo libpng libtiff"
 PKGDES="GD Graphics Library"
 
-AUTOTOOLS_AFTER="--with-tiff=/usr --disable-rpath"
 ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-tiff=/usr"
+    "--disable-rpath"
+)

--- a/runtime-imaging/libgd/spec
+++ b/runtime-imaging/libgd/spec
@@ -1,5 +1,5 @@
 VER=2.3.3
-REL=1
-SRCS="tbl::https://github.com/libgd/libgd/archive/gd-$VER.tar.gz"
-CHKSUMS="sha256::24429f9d0dbe0f865aaa4b1a63558242396ba9134e6cfd32ca5e486a84483350"
+REL=2
+SRCS="tbl::https://github.com/libgd/libgd/releases/download/gd-$VER/libgd-$VER.tar.xz"
+CHKSUMS="sha256::3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61"
 CHKUPDATE="anitya::id=880"

--- a/runtime-imaging/libjxl/autobuild/defines
+++ b/runtime-imaging/libjxl/autobuild/defines
@@ -3,64 +3,28 @@ PKGSEC=libs
 # Note: gperftools provides libtcmalloc.
 PKGDEP="brotli giflib gperftools highway lcms2 libjpeg-turbo libpng openexr \
         python-3"
-# FIXME: gperftools (as of 2.10) fails to build for loongarch64.
-PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 # Note: Leave gdk-pixbuf and gimp in build dep, since dependees for these
 # packages would have introduced them as dependencies anyway.
-BUILDDEP="asciidoc doxygen gdk-pixbuf gimp openjdk xdg-utils"
+BUILDDEP="asciidoc doxygen gdk-pixbuf gimp gtest llvm openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
-BUILDDEP__ARM64="$BUILDDEP llvm"
-# FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
-# FIXME: Openjdk is not yet available on mips64r6el.
-BUILDDEP__MIPS64R6EL="${BUILDDEP/gimp openjdk/}"
-
 ABTYPE=cmakeninja
-#FIXME: gcc reports ICE on arm64.
-USECLANG__ARM64=1
-# FIXME: Disabling skcms. Ain't dealing with this shit, New Year's Eve or
-# otherwise.
-CMAKE_AFTER="-DBROTLI_DISABLE_TESTS=ON \
-             -DBUILD_GMOCK=OFF \
-             -DBUILD_TESTING=OFF \
-             -DINSTALL_GTEST=OFF \
-             -DJPEGXL_BUNDLE_LIBPNG=OFF \
-             -DJPEGXL_BUNDLE_SKCMS=ON \
-             -DJPEGXL_ENABLE_BENCHMARK=ON \
-             -DJPEGXL_ENABLE_COVERAGE=OFF \
-             -DJPEGXL_ENABLE_DEVTOOLS=ON \
-             -DJPEGXL_ENABLE_DOXYGEN=ON \
-             -DJPEGXL_ENABLE_EXAMPLES=ON \
-             -DJPEGXL_ENABLE_FUZZERS=OFF \
-             -DJPEGXL_ENABLE_JNI=ON \
-             -DJPEGXL_ENABLE_MANPAGES=ON \
-             -DJPEGXL_ENABLE_OPENEXR=ON \
-             -DJPEGXL_ENABLE_PLUGINS=ON \
-             -DJPEGXL_ENABLE_PROFILER=OFF \
-             -DJPEGXL_ENABLE_SIZELESS_VECTORS=ON \
-             -DJPEGXL_ENABLE_SJPEG=ON \
-             -DJPEGXL_ENABLE_SKCMS=OFF \
-             -DJPEGXL_ENABLE_TCMALLOC=ON \
-             -DJPEGXL_ENABLE_TOOLS=ON \
-             -DJPEGXL_ENABLE_TRANSCODE_JPEG=ON \
-             -DJPEGXL_ENABLE_VIEWERS=ON \
-             -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
-             -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
-             -DJPEGXL_FORCE_SYSTEM_HWY=ON \
-             -DJPEGXL_FORCE_SYSTEM_LCMS2=ON \
-             -DJPEGXL_STATIC=OFF \
-             -DJPEGXL_WARNINGS_AS_ERRORS=OFF \
-             -DSJPEG_BUILD_EXAMPLES=ON \
-             -DSJPEG_ENABLE_SIMD=ON"
-CMAKE_AFTER__ARM64=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_FORCE_NEON=ON"
-CMAKE_AFTER__ARMV7HF=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_FORCE_NEON=ON"
-# FIXME: gperftools (as of 2.10) fails to build for loongarch64.
-CMAKE_AFTER__LOONGARCH64=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_ENABLE_TCMALLOC=OFF"
+USECLANG=1
+CMAKE_AFTER=(
+    "-DJPEGXL_BUNDLE_LIBPNG=NO"
+    "-DJPEGXL_ENABLE_FUZZERS=OFF"
+    "-DJPEGXL_ENABLE_DEVTOOLS=ON"
+    "-DJPEGXL_ENABLE_JPEGLI=ON"
+    "-DJPEGXL_ENABLE_BENCHMARK=OFF"
+    "-DJPEGXL_ENABLE_VIEWERS=ON"
+    "-DJPEGXL_ENABLE_TCMALLOC=ON"
+    "-DJPEGXL_ENABLE_PLUGINS=ON"
+    "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON"
+    "-DJPEGXL_FORCE_SYSTEM_GTEST=ON"
+    "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON"
+    "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
+)
 
-PKGBREAK="gimp<=2.10.36-1 imv<=4.5.0-2 kimageformats<=5.115.0 krita<=5.2.2 webkit2gtk<=2.42.5-1"
+PKGBREAK="chafa<=1.14.5 darktable<=1:5.0.1 gimp<=2.10.38-1 glycin<=1.1.4 \
+          imv<=4.5.0-4 kimageformats<=5.115.0-1 krita<=5.2.9 libvips<=8.16.1 \
+          webkit2gtk<=1:2.44.2-3"

--- a/runtime-imaging/libjxl/autobuild/defines.stage2
+++ b/runtime-imaging/libjxl/autobuild/defines.stage2
@@ -3,62 +3,24 @@ PKGSEC=libs
 # Note: gperftools provides libtcmalloc.
 PKGDEP="brotli giflib gperftools highway lcms2 libjpeg-turbo libpng openexr \
         python-3"
-# FIXME: gperftools (as of 2.10) fails to build for loongarch64.
-PKGDEP__LOONGARCH64="${PKGDEP/gperftools/}"
 # Note: Leave gdk-pixbuf and gimp in build dep, since dependees for these
 # packages would have introduced them as dependencies anyway.
-BUILDDEP="asciidoc doxygen gdk-pixbuf openjdk xdg-utils"
+BUILDDEP="asciidoc doxygen gdk-pixbuf llvm openjdk xdg-utils"
 PKGDES="Reference encoder and decoder implementation for the JPEG XL image format"
 
-BUILDDEP__ARM64="$BUILDDEP llvm"
-# FIXME: doxygen SIGILLs during asset rendering on mips64r6el.
-# FIXME: Openjdk is not yet available on mips64r6el.
-BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"
-
 ABTYPE=cmakeninja
-#FIXME: gcc reports ICE on arm64.
-USECLANG__ARM64=1
-# FIXME: Disabling skcms. Ain't dealing with this shit, New Year's Eve or
-# otherwise.
-CMAKE_AFTER="-DBROTLI_DISABLE_TESTS=ON \
-             -DBUILD_GMOCK=OFF \
-             -DBUILD_TESTING=OFF \
-             -DINSTALL_GTEST=OFF \
-             -DJPEGXL_BUNDLE_LIBPNG=OFF \
-             -DJPEGXL_BUNDLE_SKCMS=ON \
-             -DJPEGXL_ENABLE_BENCHMARK=ON \
-             -DJPEGXL_ENABLE_COVERAGE=OFF \
-             -DJPEGXL_ENABLE_DEVTOOLS=ON \
-             -DJPEGXL_ENABLE_DOXYGEN=ON \
-             -DJPEGXL_ENABLE_EXAMPLES=ON \
-             -DJPEGXL_ENABLE_FUZZERS=OFF \
-             -DJPEGXL_ENABLE_JNI=ON \
-             -DJPEGXL_ENABLE_MANPAGES=ON \
-             -DJPEGXL_ENABLE_OPENEXR=ON \
-             -DJPEGXL_ENABLE_PLUGINS=ON \
-             -DJPEGXL_ENABLE_PROFILER=OFF \
-             -DJPEGXL_ENABLE_SIZELESS_VECTORS=ON \
-             -DJPEGXL_ENABLE_SJPEG=ON \
-             -DJPEGXL_ENABLE_SKCMS=OFF \
-             -DJPEGXL_ENABLE_TCMALLOC=ON \
-             -DJPEGXL_ENABLE_TOOLS=ON \
-             -DJPEGXL_ENABLE_TRANSCODE_JPEG=ON \
-             -DJPEGXL_ENABLE_VIEWERS=ON \
-             -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
-             -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
-             -DJPEGXL_FORCE_SYSTEM_HWY=ON \
-             -DJPEGXL_FORCE_SYSTEM_LCMS2=ON \
-             -DJPEGXL_STATIC=OFF \
-             -DJPEGXL_WARNINGS_AS_ERRORS=OFF \
-             -DSJPEG_BUILD_EXAMPLES=ON \
-             -DSJPEG_ENABLE_SIMD=ON"
-CMAKE_AFTER__ARM64=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_FORCE_NEON=ON"
-CMAKE_AFTER__ARMV7HF=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_FORCE_NEON=ON"
-# FIXME: gperftools (as of 2.10) fails to build for loongarch64.
-CMAKE_AFTER__LOONGARCH64=" \
-             ${CMAKE_AFTER} \
-             -DJPEGXL_ENABLE_TCMALLOC=OFF"
+USECLANG=1
+CMAKE_AFTER=(
+    "-DJPEGXL_BUNDLE_LIBPNG=NO"
+    "-DJPEGXL_ENABLE_FUZZERS=OFF"
+    "-DJPEGXL_ENABLE_DEVTOOLS=ON"
+    "-DJPEGXL_ENABLE_JPEGLI=ON"
+    "-DJPEGXL_ENABLE_BENCHMARK=OFF"
+    "-DJPEGXL_ENABLE_VIEWERS=ON"
+    "-DJPEGXL_ENABLE_TCMALLOC=ON"
+    "-DJPEGXL_ENABLE_PLUGINS=ON"
+    "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON"
+    "-DJPEGXL_FORCE_SYSTEM_GTEST=ON"
+    "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON"
+    "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
+)

--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,4 +1,4 @@
-VER=0.10.2
-SRCS="git::commit=tags/v$VER::https://github.com/libjxl/libjxl"
+VER=0.11.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,4 +1,5 @@
 VER=8.16.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"

--- a/runtime-multimedia/gstreamer/autobuild/patches/0002-dots-viewer-respect-envvars.patch
+++ b/runtime-multimedia/gstreamer/autobuild/patches/0002-dots-viewer-respect-envvars.patch
@@ -1,0 +1,13 @@
+diff --git a/subprojects/gst-devtools/dots-viewer/meson.build b/subprojects/gst-devtools/dots-viewer/meson.build
+index 9802fd5..1eca920 100644
+--- a/subprojects/gst-devtools/dots-viewer/meson.build
++++ b/subprojects/gst-devtools/dots-viewer/meson.build
+@@ -11,6 +11,8 @@ endif
+ 
+ cargo_wrapper = find_program('cargo_wrapper.py')
+ extra_env = {'RUSTC': ' '.join(rustc.cmd_array())}
++rustflags_cmd = run_command('sh', '-c', 'echo $RUSTFLAGS')
++extra_env += {'RUSTFLAGS': rustflags_cmd.stdout().strip() }
+ 
+ system = host_machine.system()
+ exe_suffix = ''

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,4 +1,5 @@
 VER=1.26.0
+REL=1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/libavif/autobuild/defines
+++ b/runtime-multimedia/libavif/autobuild/defines
@@ -1,26 +1,33 @@
 PKGNAME=libavif
 PKGDES="Library for encoding and decoding AVIF files"
-PKGDEP="aom dav1d rav1e libjpeg-turbo libpng libyuv svt-av1 zlib"
-PKGDEP__MIPS64R6EL="${PKGDEP/rav1e/}"
-BUILDDEP="nasm gdk-pixbuf"
+PKGDEP="aom dav1d glibc libjpeg-turbo libpng libwebp libxml2 libyuv rav1e svt-av1"
+BUILDDEP="gdk-pixbuf nasm"
+BUILDDEP__AMD64="${BUILDDEP} pandoc"
+BUILDDEP__ARM64="${BUILDDEP} pandoc"
 PKGSEC=libs
 
-CMAKE_AFTER="
-	-DAVIF_BUILD_APPS=ON
-	-DAVIF_BUILD_GDK_PIXBUF=ON
-	-DAVIF_CODEC_AOM=ON
-	-DAVIF_CODEC_DAV1D=ON
-	-DAVIF_CODEC_RAV1E=ON
-	-DAVIF_CODEC_SVT=ON
-"
-CMAKE_AFTER__MIPS64R6EL="
-        ${CMAKE_AFTER}
-        -DAVIF_CODEC_RAV1E=OFF
-"
+CMAKE_AFTER=(
+    "-DAVIF_BUILD_APPS=ON"
+    "-DAVIF_BUILD_GDK_PIXBUF=ON"
+    "-DAVIF_BUILD_EXAMPLES=ON"
+    "-DAVIF_CODEC_AOM=SYSTEM"
+    "-DAVIF_CODEC_DAV1D=SYSTEM"
+    "-DAVIF_CODEC_RAV1E=SYSTEM"
+    "-DAVIF_CODEC_SVT=SYSTEM"
+    "-DAVIF_LIBYUV=SYSTEM"
+    "-DAVIF_LIBXML2=SYSTEM"
+)
+# FIXME: BUILD_MAN_PAGES requires pandoc as build dependencies,
+# but pandoc(3.6.3) only available on amd64 and arm64.
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER[@]}"
+    "-DAVIF_BUILD_MAN_PAGES=ON"
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    "-DAVIF_BUILD_MAN_PAGES=ON"
+)
 
-PKGBREAK="
-	darktable<=1:4.2.0
-	kimageformats<=5.96.0-1
-	libgd<=2.3.3
-	webkit2gtk<=1:2.36.7
-"
+PKGBREAK="chafa<=1.14.5 darktable<=1:5.0.1 gdal<=3.10.1-5 \
+          kimageformats<=5.115.0-1 libgd<=2.3.3-1 libjxl<=0.10.2 \
+          webkit2gtk<=1:2.44.2-3"

--- a/runtime-multimedia/libavif/spec
+++ b/runtime-multimedia/libavif/spec
@@ -1,5 +1,4 @@
-VER=0.11.1
-REL=3
-SRCS="tbl::https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::0eb49965562a0e5e5de58389650d434cff32af84c34185b6c9b7b2fccae06d4e"
+VER=1.2.1
+SRCS="git::commit=tags/v$VER::https://github.com/AOMediaCodec/libavif.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=178015"

--- a/runtime-multimedia/svt-av1/autobuild/defines
+++ b/runtime-multimedia/svt-av1/autobuild/defines
@@ -4,9 +4,9 @@ PKGDEP="glibc"
 BUILDDEP="nasm"
 PKGSEC=libs
 
-CMAKE_AFTER="
-	-DBUILD_SHARED_LIBS=ON
-	-DNATIVE=OFF
-"
+CMAKE_AFTER=(
+	"-DBUILD_SHARED_LIBS=ON"
+	"-DNATIVE=OFF"
+)
 
-PKGBREAK="libavif<=0.11.1-2"
+PKGBREAK="ffmpeg<=7.1-6 gstreamer<=1.26.0 libavif<=0.11.1-3"

--- a/runtime-multimedia/svt-av1/spec
+++ b/runtime-multimedia/svt-av1/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=3.0.2
 SRCS="git::commit=tags/v$VER::https://gitlab.com/AOMediaCodec/SVT-AV1"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=24271"

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -59,3 +59,6 @@ PKGBREAK="gnome-online-accounts<=3.40.0 devhelp<=40.1 \
           gnome-initial-setup<=40.4 gnucash<=4.10 gthumb<=3.10.4 \
           libgepub<=0.6.0 liferea<=1.13.8 midori<=9.0 remmina<=1.4.11 \
           shotwell<=0.31.3 wxgtk3<=3.0.4 xreader<=2.8.3"
+
+# Disable LTO due to OOM.
+NOLTO__LOONGSON3=1

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -4,4 +4,4 @@ CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=3
+REL=4


### PR DESCRIPTION
Topic Description
-----------------

- sunshine: bump REL due to ffmpeg update
- libvips: bump REL due to libjxl update to 0.11.1
- glycin: bump REL due to libjxl update to 0.11.1
- imv: bump REL due to libjxl update to 0.11.1
- krita: bump REL due to libjxl update to 0.11.1
- gimp: bump REL due to libjxl update to 0.11.1
- libjxl: update to 0.11.1
    - Remove useless cmake parameters
    - Gperftools is available for loongarch64
    - Build with clang according to the upstream build guide
- webkit2gtk: bump REL due to libavif update to 1.2.1
- libgd: bump REL due to libavif update to 1.2.1
- kimageformats: bump REL due to libavif update to 1.2.1

... and 7 more commits

Package(s) Affected
-------------------

- svt-av1: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit svt-av1:-pkgbreak ffmpeg:-pkgbreak sunshine ffmpeg gstreamer libavif:-pkgbreak libgd gdal libjxl:-pkgbreak chafa darktable kimageformats webkit2gtk gimp krita imv glycin libvips svt-av1 libavif libjxl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
