### PR TITLE
renpy: new, 8.3.7.25031702

### DIFF
--- a/app-doc/sphinx-rtd-dark-mode/autobuild/defines
+++ b/app-doc/sphinx-rtd-dark-mode/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=sphinx-rtd-dark-mode
+PKGSEC=python
+PKGDEP="python-3 sphinx-rtd-theme"
+BUILDDEP="python-build python-installer setuptools-scm wheel"
+PKGDES="Adds a toggleable dark mode to the Read the Docs theme"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/app-doc/sphinx-rtd-dark-mode/spec
+++ b/app-doc/sphinx-rtd-dark-mode/spec
@@ -1,0 +1,5 @@
+VER=1.3.0
+
+SRCS="git::commit=tags/v$VER::https://github.com/MrDogeBro/sphinx_rtd_dark_mode"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=196702"

--- a/lang-python/ecdsa/autobuild/defines
+++ b/lang-python/ecdsa/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=ecdsa
+PKGSEC=python
+PKGDEP="python-3 six"
+BUILDDEP="setuptools-python3"
+PKGDES="Implementation of ECDSA in Python"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/ecdsa/spec
+++ b/lang-python/ecdsa/spec
@@ -1,0 +1,5 @@
+VER=0.19.1
+
+SRCS="git::commit=tags/python-ecdsa-$VER::https://github.com/tlsfuzzer/python-ecdsa"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=8370"

--- a/lang-python/legacy-cgi/autobuild/defines
+++ b/lang-python/legacy-cgi/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=legacy-cgi
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build hatchling python-installer wheel"
+PKGDES="Fork of the standard library cgi and cgitb modules, being deprecated in PEP-594"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/legacy-cgi/spec
+++ b/lang-python/legacy-cgi/spec
@@ -1,0 +1,5 @@
+VER=2.6.3
+
+SRCS="git::commit=tags/v$VER::https://github.com/jackrosenthal/legacy-cgi"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375190"

--- a/lang-python/pygame-sdl2/autobuild/defines
+++ b/lang-python/pygame-sdl2/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pygame-sdl2
+PKGSEC=python
+PKGDEP="python-3 sdl2-image sdl2-mixer sdl2-ttf"
+BUILDDEP="setuptools cython-0.29"
+PKGDES="Reimplementation of portions of the pygame API using SDL2"
+
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/pygame-sdl2/spec
+++ b/lang-python/pygame-sdl2/spec
@@ -1,0 +1,5 @@
+VER=8.3.7.25031702
+
+SRCS="git::submodule=false;commit=tags/renpy-$VER::https://github.com/renpy/pygame_sdl2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377392"

--- a/runtime-games/renpy/autobuild/build
+++ b/runtime-games/renpy/autobuild/build
@@ -1,0 +1,49 @@
+abinfo "Appending freetype CFLAGS ..."
+export CFLAGS="${CFLAGS} $(pkg-config --cflags freetype2)"
+
+abinfo "Creating build configuration ..."
+cat > "$SRCDIR/renpy/vc_version.py" << EOF
+branch = 'master'
+nightly = False
+official = False
+version = "$PKGVER"
+version_name = 'TBD'
+EOF
+
+abinfo "Building runtime module ..."
+cd "$SRCDIR"/module
+python3 -m build --wheel --no-isolation
+
+abinfo "Building Ren'Py ..."
+cd "$SRCDIR"
+python3 -m compileall 'renpy'
+
+abinfo "Installing Ren'Py ..."
+mkdir -pv "$PKGDIR"/usr/share/renpy
+
+cp -av \
+    "$SRCDIR"/sdk-fonts \
+    "$SRCDIR"/launcher \
+    "$SRCDIR"/renpy \
+    "$SRCDIR"/renpy.py \
+    "$SRCDIR"/the_question \
+    "$SRCDIR"/tutorial \
+    "$SRCDIR"/gui \
+    "$PKGDIR"/usr/share/renpy
+install -Dvm644 "$SRCDIR"/launcher/game/images/logo.png \
+    "$PKGDIR"/usr/share/pixmaps/renpy.png
+install -Dvm644 "$SRCDIR"/sphinx/source/license.rst \
+    "$PKGDIR"/usr/share/doc/renpy/LICENSE.sphinx
+install -Dvm644 "$SRCDIR"/README.rst \
+    "$PKGDIR"/usr/share/doc/renpy/README.rst
+
+install -dvm755 \
+    "$PKGDIR"/usr/share/renpy/lib/py3-linux-$ARCH
+ln -sv ../../../../bin/renpy \
+    "$PKGDIR"/usr/share/renpy/lib/"py3-linux-$(uname -m)"
+
+cd "$SRCDIR"/module
+python3 \
+    -m installer \
+    --destdir="$PKGDIR" \
+    dist/*.whl

--- a/runtime-games/renpy/autobuild/defines
+++ b/runtime-games/renpy/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=renpy
+PKGSEC=games
+PKGDEP="ffmpeg fribidi harfbuzz freetype libpng sdl2 sdl2-image pefile future \
+        sdl2-mixer sdl2-gfx sdl2-ttf assimp pygame-sdl2 ecdsa legacy-cgi"
+BUILDDEP="cython setuptools-scm sphinx-rtd-theme wheel python-build \
+          python-installer sphinx-rtd-dark-mode"
+PKGDES="The Ren'Py Visual Novel Engine"

--- a/runtime-games/renpy/autobuild/overrides/usr/bin/renpy
+++ b/runtime-games/renpy/autobuild/overrides/usr/bin/renpy
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 '/usr/share/renpy/renpy.py' "$@"

--- a/runtime-games/renpy/autobuild/overrides/usr/share/applications/renpy.desktop
+++ b/runtime-games/renpy/autobuild/overrides/usr/share/applications/renpy.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Ren'Py
+Comment=A programming language and runtime, intended to ease the creation of visual-novel type games.
+Comment[zh_CN]=意在辅助视觉小说类游戏创作的编程语言及运行时
+Icon=renpy.png
+Exec=renpy
+Categories=Game;AdventureGame;

--- a/runtime-games/renpy/autobuild/patches/0001-ffmedia-adapt-new-ffmpeg.patch
+++ b/runtime-games/renpy/autobuild/patches/0001-ffmedia-adapt-new-ffmpeg.patch
@@ -1,0 +1,91 @@
+From b120f82f9809b98231188daacb94f22a9e69187a Mon Sep 17 00:00:00 2001
+From: Gregor Riepl <onitake@gmail.com>
+Date: Thu, 8 Aug 2024 23:56:16 +0200
+Subject: [PATCH] Replace deprecated APIs when compiling against newer FFmpeg
+
+---
+ module/ffmedia.c | 37 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/module/ffmedia.c b/module/ffmedia.c
+index d4bb346ac3..0f57e311f2 100644
+--- a/module/ffmedia.c
++++ b/module/ffmedia.c
+@@ -71,7 +71,11 @@ static int rwops_read(void *opaque, uint8_t *buf, int buf_size) {
+ 
+ }
+ 
++#if (LIBAVFORMAT_VERSION_MAJOR < 61)
+ static int rwops_write(void *opaque, uint8_t *buf, int buf_size) {
++#else
++static int rwops_write(void *opaque, const uint8_t *buf, int buf_size) {
++#endif
+     printf("Writing to an SDL_rwops is a really bad idea.\n");
+     return -1;
+ }
+@@ -690,9 +694,14 @@ static void decode_audio(MediaState *ms) {
+ 			}
+ 
+             converted_frame->sample_rate = audio_sample_rate;
++#if (LIBAVUTIL_VERSION_MAJOR < 59)
+             converted_frame->channel_layout = AV_CH_LAYOUT_STEREO;
++#else
++            converted_frame->ch_layout = (AVChannelLayout) AV_CHANNEL_LAYOUT_STEREO;
++#endif
+             converted_frame->format = AV_SAMPLE_FMT_S16;
+ 
++#if (LIBAVUTIL_VERSION_MAJOR < 59)
+ 			if (!ms->audio_decode_frame->channel_layout) {
+ 				ms->audio_decode_frame->channel_layout = av_get_default_channel_layout(ms->audio_decode_frame->channels);
+ 
+@@ -711,6 +720,26 @@ static void decode_audio(MediaState *ms) {
+ 				    swr_set_matrix(ms->swr, stereo_matrix, 1);
+ 				}
+ 			}
++#else
++			if (ms->audio_decode_frame->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
++				av_channel_layout_default(&ms->audio_decode_frame->ch_layout, ms->audio_decode_frame->ch_layout.nb_channels);
++
++				if (audio_equal_mono && (ms->audio_decode_frame->ch_layout.nb_channels == 1)) {
++				    swr_alloc_set_opts2(
++                        &ms->swr,
++                        &converted_frame->ch_layout,
++                        converted_frame->format,
++                        converted_frame->sample_rate,
++                        &ms->audio_decode_frame->ch_layout,
++                        ms->audio_decode_frame->format,
++                        ms->audio_decode_frame->sample_rate,
++                        0,
++                        NULL);
++
++				    swr_set_matrix(ms->swr, stereo_matrix, 1);
++				}
++			}
++#endif
+ 
+ 			if(swr_convert_frame(ms->swr, converted_frame, ms->audio_decode_frame)) {
+ 				av_frame_free(&converted_frame);
+@@ -1159,7 +1188,11 @@ static int decode_thread(void *arg) {
+ 
+ 	// Compute the number of samples we need to play back.
+ 	if (ms->audio_duration < 0) {
++#if (LIBAVFORMAT_VERSION_MAJOR < 62)
+ 		if (av_fmt_ctx_get_duration_estimation_method(ctx) != AVFMT_DURATION_FROM_BITRATE) {
++#else
++		if (ctx->duration_estimation_method != AVFMT_DURATION_FROM_BITRATE) {
++#endif
+ 
+ 			long long duration = ((long long) ctx->duration) * audio_sample_rate;
+ 			ms->audio_duration = (unsigned int) (duration /  AV_TIME_BASE);
+@@ -1319,7 +1352,11 @@ static int decode_sync_start(void *arg) {
+ 
+ 	// Compute the number of samples we need to play back.
+ 	if (ms->audio_duration < 0) {
++#if (LIBAVFORMAT_VERSION_MAJOR < 62)
+ 		if (av_fmt_ctx_get_duration_estimation_method(ctx) != AVFMT_DURATION_FROM_BITRATE) {
++#else
++		if (ctx->duration_estimation_method != AVFMT_DURATION_FROM_BITRATE) {
++#endif
+ 
+ 			long long duration = ((long long) ctx->duration) * audio_sample_rate;
+ 			ms->audio_duration = (unsigned int) (duration /  AV_TIME_BASE);

--- a/runtime-games/renpy/spec
+++ b/runtime-games/renpy/spec
@@ -1,0 +1,5 @@
+VER=8.3.7.25031702
+
+SRCS="git::commit=tags/$VER::https://github.com/renpy/renpy"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377378"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Ren'Py is a visual novel game engine written in python.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
ecdsa: 0.19.1
legacy-cgi: 2.6.3
pygame-sdl2: 8.3.7.25031702
sphinx-rtd-dark-mode: 1.3.0
renpy: 8.3.7.25031702

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->


```
#buildit ecdsa legacy-cgi pygame-sdl2 sphinx-rtd-dark-mode renpy
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
