### PR TITLE
tauri-cli: update to 2.4.1

### DIFF
--- a/lang-rust/tauri-cli/spec
+++ b/lang-rust/tauri-cli/spec
@@ -1,4 +1,4 @@
-VER=2.2.4
+VER=2.4.1
 SRCS="git::commit=tags/tauri-cli-v$VER::https://github.com/tauri-apps/tauri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371844"


### PR DESCRIPTION
Topic Description
-----------------

- tauri-cli: update to 2.4.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- tauri-cli: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tauri-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
