### PR TITLE
typos: update to 1.31.1

### DIFF
--- a/app-utils/typos/spec
+++ b/app-utils/typos/spec
@@ -1,4 +1,4 @@
-VER=1.30.3
+VER=1.31.1
 SRCS="git::commit=tags/v$VER::https://github.com/crate-ci/typos"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373489"


### PR DESCRIPTION
Topic Description
-----------------

- typos: update to 1.31.1
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- typos: 1.31.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit typos
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
