### PR TITLE
syncthing: update to 1.29.4

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,5 @@
-VER=1.29.3
+VER=1.29.4
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417"
+CHKSUMS="sha256::d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 1.29.4
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- syncthing: 1.29.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
