### PR TITLE
podman: update to 5.4.2+vsock0.8.4

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=5.4.1
+UPSTREAM_VER=5.4.2
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
 GVISOR_TAP_VSOCK_VER=0.8.4
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
-REL=1
 SRCS="git::commit=v${UPSTREAM_VER};rename=podman-${UPSTREAM_VER}::https://github.com/containers/podman \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.4.2+vsock0.8.4
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- podman: 5.4.2+vsock0.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
