### PR TITLE
xz: update to 5.8.1

### DIFF
--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,4 +1,4 @@
-VER=5.8.0
+VER=5.8.1
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::05ecad9e71919f4fca9f19fbbc979ea28e230188ed123dc6f06b98031ea14542"
+CHKSUMS="sha256::0b54f79df85912504de0b14aec7971e3f964491af1812d83447005807513cd9e"
 CHKUPDATE="anitya::id=5277"


### PR DESCRIPTION
Topic Description
-----------------

- xz: update to 5.8.1
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- xz: 5.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
