### PR TITLE
xz+32: update to 5.8.1 (and TUM)

### DIFF
--- a/runtime-optenv32/xz+32/spec
+++ b/runtime-optenv32/xz+32/spec
@@ -1,4 +1,4 @@
-VER=5.8.0
+VER=5.8.1
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::05ecad9e71919f4fca9f19fbbc979ea28e230188ed123dc6f06b98031ea14542"
+CHKSUMS="sha256::0b54f79df85912504de0b14aec7971e3f964491af1812d83447005807513cd9e"
 CHKUPDATE="anitya::id=5277"

--- a/topics/xz-5.8.1.toml
+++ b/topics/xz-5.8.1.toml
@@ -1,0 +1,13 @@
+security = true
+
+[name]
+default = "XZ (liblzma) 5.8.1 Security Update"
+zh_CN = "XZ (liblzma) 5.8.1 安全更新"
+
+[caution]
+default = "Fixes a use-after-free vulnerability - CVE-2025-31115 (Severity: High)"
+zh_CN = "修复一处释放后使用 (use-after-free) 漏洞，漏洞编号 CVE-2025-31115（严重性：高）"
+
+[packages]
+xz = "5.8.1"
+"xz+32" = "5.8.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add xz-5.8.1
- xz+32: update to 5.8.1

Package(s) Affected
-------------------

- xz+32: 5.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
