### PR TITLE
libevdev: update to 1.13.4

### DIFF
--- a/runtime-devices/libevdev/spec
+++ b/runtime-devices/libevdev/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
+VER=1.13.4
 SRCS="tbl::https://www.freedesktop.org/software/libevdev/libevdev-$VER.tar.xz"
-CHKSUMS="sha256::63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0"
+CHKSUMS="sha256::f00ab8d42ad8b905296fab67e13b871f1a424839331516642100f82ad88127cd"
 CHKUPDATE="anitya::id=20540"


### PR DESCRIPTION
Topic Description
-----------------

- libevdev: update to 1.13.4

Package(s) Affected
-------------------

- libevdev: 1.13.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libevdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
