### PR TITLE
libcamera: update to 0.5.0

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,5 @@
 VER=1.4.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -1,10 +1,28 @@
 PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
-BUILDDEP="boost doxygen gnutls gstreamer-1-0 gtest jinja2 ply libevent libtiff \
-          libdwarf lttng-ust meson ninja openssl pyyaml qt-5 sphinx systemd \
-          texlive yaml graphviz"
+PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
+        elfutils libunwind gstreamer glib gnutls qt-6 openssl"
+BUILDDEP="doxygen jinja2 ply pyyaml sphinx texlive graphviz"
 
-PKGBREAK="pipewire<=1.2.7-1"
+PKGBREAK="pipewire<=1.4.1"
 
-MESON_AFTER="-Dv4l2=true"
+# Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
+# for the host CPU architecture.
+# Note: `-Dipas` should not be specified as it would match the pipeline names
+# during compilation.
+MESON_AFTER=(
+    '-Dandroid=disabled'
+    '-Dcam=enabled'
+    '-Ddocumentation=enabled'
+    '-Ddoc_werror=false'
+    '-Dgstreamer=enabled'
+    '-Dlc-compliance=enabled'
+    '-Dpipelines=auto'
+    '-Dpycamera=disabled'
+    '-Dqcam=enabled'
+    '-Dtest=false'
+    '-Dtracing=enabled'
+    '-Dudev=enabled'
+    '-Dv4l2=enabled'
+)

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.5.0
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: bump REL due to libcamera update to 0.5.0
- libcamera: update to 0.5.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libcamera: 0.5.0
- pipewire: 1.4.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera:-pkgbreak pipewire libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
