### PR TITLE
bitwarden: update to 2025.3.0

### DIFF
--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,4 +1,4 @@
-From 673b5596719e3f45892059e09191d2ba8935248e Mon Sep 17 00:00:00 2001
+From 9137a94f5cbced3074f8846522bae96506af14f2 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
 Subject: [PATCH 1/2] napi: prefer glibc instead of musl libc
@@ -36,5 +36,5 @@ index acfd0dffb8..bfb0e4aa69 100644
          );
          localFileExisted = existsSync(join(__dirname, "desktop_napi.linux-arm-gnueabihf.node"));
 -- 
-2.48.1
+2.49.0
 

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,4 +1,4 @@
-From 0bbdd4e700cdfbffd711a56d7fe95b550a7f5370 Mon Sep 17 00:00:00 2001
+From c70e792aea6608037859d549e1d0850051b2e7bf Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
 Subject: [PATCH 2/2] napi: enable lto
@@ -9,13 +9,13 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index 8e19d62c1e..c5adc87414 100644
+index f5b6d6b7c0..960cb4c96f 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -31,3 +31,9 @@ windows-registry = "=0.3.0"
+@@ -31,3 +31,9 @@ windows-registry = { workspace = true }
  
  [build-dependencies]
- napi-build = "=2.1.4"
+ napi-build = { workspace = true }
 +
 +[profile.release]
 +lto = true
@@ -23,5 +23,5 @@ index 8e19d62c1e..c5adc87414 100644
 +strip = false
 +incremental = false
 -- 
-2.48.1
+2.49.0
 

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2025.2.1
+VER=2025.3.0
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2025.3.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- bitwarden: 2025.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
