### PR TITLE
ast-grep: update to 0.36.2

### DIFF
--- a/app-devel/ast-grep/autobuild/patches/0001-Do-not-compile-sg-binary.patch
+++ b/app-devel/ast-grep/autobuild/patches/0001-Do-not-compile-sg-binary.patch
@@ -1,36 +1,27 @@
-From 6f88c1e472786f9b9ccee08fd46bf4e542315cad Mon Sep 17 00:00:00 2001
+From a7929f19b7c94a63e40082a7779b644c80ff0664 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 16 Nov 2023 15:55:24 +0800
 Subject: [PATCH] Do not compile `sg` binary
 
 ---
- crates/cli/Cargo.toml | 6 +-----
- 1 file changed, 1 insertion(+), 5 deletions(-)
+ crates/cli/Cargo.toml | 4 ----
+ 1 file changed, 4 deletions(-)
 
 diff --git a/crates/cli/Cargo.toml b/crates/cli/Cargo.toml
-index d04444b..99cd536 100644
+index 258c2e8d..cd290c49 100644
 --- a/crates/cli/Cargo.toml
 +++ b/crates/cli/Cargo.toml
-@@ -3,7 +3,7 @@ name = "ast-grep"
- description = "Search and Rewrite code at large scale using precise AST pattern"
- keywords = ["ast", "pattern", "codemod", "search", "rewrite"]
- categories = ["command-line-utilities", "development-tools", "parsing"]
--default-run = "sg"
-+default-run = "ast-grep"
- # use relative path because maturin does not recognize
- readme = "../../README.md"
- license-file = "../../LICENSE"
-@@ -17,10 +17,6 @@ homepage.workspace = true
- repository.workspace = true
- rust-version.workspace = true
+@@ -21,10 +21,6 @@ rust-version.workspace = true
+ name = "ast-grep"
+ path = "src/main.rs"
  
 -[[bin]]
 -name = "sg"
--path = "src/main.rs"
+-path = "src/bin/alias.rs"
 -
- [[bin]]
- name = "ast-grep"
- path = "src/bin/ast-grep.rs"
+ [dependencies]
+ ast-grep-core.workspace = true
+ ast-grep-config.workspace = true
 -- 
-2.39.1
+2.49.0
 

--- a/app-devel/ast-grep/spec
+++ b/app-devel/ast-grep/spec
@@ -1,4 +1,4 @@
-VER=0.33.0
+VER=0.36.2
 SRCS="git::commit=tags/$VER::https://github.com/ast-grep/ast-grep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=361439"


### PR DESCRIPTION
Topic Description
-----------------

- ast-grep: update to 0.36.2
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- ast-grep: 0.36.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ast-grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
