### PR TITLE
vscode: update to 1.99.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.98.2
+VER=1.99.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::093d18576d1f20a861a3f0f9284d12665f9a29b4a71686c861f9cb5f66471514"
-CHKSUMS__ARM64="sha256::743c5f4b64106e7c90a22d8c9f6bc695e7a677c625e0e384556b90ef7b6bb9e9"
+CHKSUMS__AMD64="sha256::5ae2bd49869f6dee91d996d39c9aa7de69a8b039a5d62f299dc8bf4c6638228c"
+CHKSUMS__ARM64="sha256::23a4a4a2012f2c4b4609a04765584e8f13f47c41c42a76b815bf2206e9aa01f6"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.99.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- vscode: 1.99.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
