### PR TITLE
openvpn: update to 2.6.14

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.5.4
+VER=2.6.14
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::f80f3c3df1b94a8892ae547df84f152583250684a24bd022ccc98ef56fa93d97"
+CHKSUMS="sha256::9eb6a6618352f9e7b771a9d38ae1631b5edfeed6d40233e243e602ddf2195e7a"
 CHKUPDATE="anitya::id=2567"

--- a/topics/openvpn-2.6.14.toml
+++ b/topics/openvpn-2.6.14.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "OpenVPN 2.6.14 Security Update"
+zh_CN = "OpenVPN 2.6.14 安全更新"
+
+[caution]
+default = "Fixes a denial of service vulnerability - CVE-2025-2704 (Severity: Medium)"
+zh_CN = "修复一处拒绝服务漏洞，漏洞编号 CVE-2025-2704（严重性：中）"
+
+[packages]
+openvpn = "2.6.14"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: update to 2.6.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openvpn: 2.6.14

Security Update?
----------------

Yes, #10335

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
