### PR TITLE
linux-kernel: add TUM for 6.14.0-2

### DIFF
--- a/topics/linux-kernel-6.14.toml
+++ b/topics/linux-kernel-6.14.toml
@@ -1,0 +1,12 @@
+security = false
+
+[name]
+default = "Linux Kernel 6.14.0"
+zh_CN = "Linux 内核，版本 6.14"
+
+[caution]
+default = "With enhanced support for new devices, notably AMD Radeon RX 9000 Series Graphics and multi-processor Loongson 3C6000 platforms; also fixes unreliable ACPI suspend (S3) on certain x86 laptops, intermittent USB connection on some Loongson motherboards, and hangs on ASUS laptops with Realtek RTL8723BE wireless cards"
+zh_CN = "包含对新设备支持的改进，尤其是 AMD Radeon RX 9000 系列显卡及龙芯 3C6000 多处理器平台；另包含对部分 x86 笔记本电脑 ACPI 睡眠 (S3) 不可靠、部分龙芯主板上 USB 时有失灵及搭载瑞昱 RTL8723BE 无线网卡的部分华硕笔记本电脑偶发死机等问题的修复"
+
+[packages]
+linux-kernel-6.14.0 = "6.14.0-2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add linux-kernel-6.14.toml

Package(s) Affected
-------------------

- linux+kernel: 3:6.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux+kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
