### PR TITLE
topics: rework linux-kernel-6.14.0.toml

### DIFF
--- a/topics/linux-kernel-6.14.toml
+++ b/topics/linux-kernel-6.14.toml
@@ -9,4 +9,4 @@ default = "With enhanced support for new devices, notably AMD Radeon RX 9000 Ser
 zh_CN = "包含对新设备支持的改进，尤其是 AMD Radeon RX 9000 系列显卡及龙芯 3C6000 多处理器平台；另包含对部分 x86 笔记本电脑 ACPI 睡眠 (S3) 不可靠、部分龙芯主板上 USB 时有失灵及搭载瑞昱 RTL8723BE 无线网卡的部分华硕笔记本电脑偶发死机等问题的修复"
 
 [packages]
-linux-kernel-6.14.0 = "6.14.0-2"
+"linux-kernel-6.14.0" = "6.14.0-2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: rework linux-kernel-6.14.toml

Package(s) Affected
-------------------

- linux+kernel: 3:6.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux+kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
