### PR TITLE
fcitx5-configtool: add missing deps

### DIFF
--- a/app-i18n/fcitx5-configtool/01-configtool/defines
+++ b/app-i18n/fcitx5-configtool/01-configtool/defines
@@ -1,6 +1,7 @@
 PKGNAME="fcitx5-configtool"
 PKGSEC=x11
-PKGDEP="fcitx5-qt kwidgetsaddons kitemviews qt-5"
+PKGDEP="fcitx5 fcitx5-qt gcc-runtime glibc kdbusaddons kitemviews \
+        kwidgetsaddons kwindowsystem qt-5 x11-lib"
 BUILDDEP="extra-cmake-modules kdeclarative kirigami2 ninja plasma-framework \
           python-3"
 PKGDES="Configuration tool for Fcitx 5"

--- a/app-i18n/fcitx5-configtool/02-migrator/defines
+++ b/app-i18n/fcitx5-configtool/02-migrator/defines
@@ -1,6 +1,7 @@
 PKGNAME=fcitx5-migrator
 PKGSEC=x11
-PKGDEP="fcitx5-configtool"
+PKGDEP="fcitx5 fcitx5-configtool fcitx5-qt gcc-runtime glibc kwidgetsaddons \
+        qt-5"
 PKGDES="Migration tool for Fcitx 5"
 
 PKGREP="fcitx5-configtool<=1:5.0.12-1"

--- a/app-i18n/fcitx5-configtool/spec
+++ b/app-i18n/fcitx5-configtool/spec
@@ -2,3 +2,4 @@ VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-configtool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138233"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-configtool: add missing deps

Package(s) Affected
-------------------

- fcitx5-configtool: 1:5.1.8-1
- fcitx5-migrator: 1:5.1.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-configtool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
