### PR TITLE
spek-x: new, 0.9.4

### DIFF
--- a/app-multimedia/spek-x/autobuild/defines
+++ b/app-multimedia/spek-x/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="spek-x"
+PKGDES="Acoustic spectrum analyser"
+PKGDEP="wxgtk3 ffmpeg"
+BUILDDEP="intltool"
+PKGSEC="sound"

--- a/app-multimedia/spek-x/spec
+++ b/app-multimedia/spek-x/spec
@@ -1,0 +1,4 @@
+VER=0.9.4
+SRCS="git::commit=tags/v$VER::https://github.com/MikeWang000000/spek-X"
+CHKSUMS="SKIP"
+CHKUPDATE="antiya::id=377561"


### PR DESCRIPTION
Topic Description
-----------------

- spek-x: new, 0.9.4

Package(s) Affected
-------------------

- spek-x: 0.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit spek-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
