### PR TITLE
wine: update to 10.5+gecko2.47.4+mono10.0.0

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,16 +1,16 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.4.0
-UPSTREAM_VER=10.4
+__MONO_VER=10.0.0
+UPSTREAM_VER=10.5
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::a09019ce5c42ba06ba91ec423d49d8f2a9a8eac4c1a9230c73e1d119639d5e92 \
+CHKSUMS="sha256::c036ec1ef47674774a5f994583022e9e2eb68fe8fc18b3a8c79e685b3bec89bc \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::fd772219aacf46b825fa891a647af4a9ddf8439320101c231918b2037bf13858"
+         sha256::b487c444415789a8b25b3a6542afa668a6b6d6067c648626f323884443f7b70d"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 10.5+gecko2.47.4+mono10.0.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- wine: 3:10.5+gecko2.47.4+mono10.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
