### PR TITLE
rustc: update to 1.86.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 418737257ba80401daddc523f52b15003dfc2394 Mon Sep 17 00:00:00 2001
+From f1ff69bcb00bd3f94295db317e77a0600629c6a2 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 02962d55a6..44d7b979b9 100644
+index 794d6457cb..17da20a2c4 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1653,6 +1653,7 @@ supported_targets! {
+@@ -1676,6 +1676,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -36,5 +36,5 @@ index 0000000000..a57ef97626
 +    base
 +}
 -- 
-2.48.1
+2.49.0
 

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,4 +1,4 @@
-From aab724d56ee0d38131bba3c3e43e3b0778f8ba0f Mon Sep 17 00:00:00 2001
+From 35bcf8f8e24aeefe961d240f20d877db896a5a7b Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
 Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys
@@ -90,5 +90,5 @@ index e8fd86d03d..f3eb03ca3c 100644
  
  impl Default for ffi_cif {
 -- 
-2.48.1
+2.49.0
 

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,8 +1,8 @@
-VER=1.85.0
+VER=1.86.0
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::d542c397217b5ba5bac7eb274f5ca62d031f61842c3ba4cc5328c709c38ea1e7"
+CHKSUMS="sha256::d939eada065dc827a9d4dbb55bd48533ad14c16e7f0a42e70147029c82a7707b"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.86.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.86.0
    \(HEAD: 35bcf8f8e24aeefe961d240f20d877db896a5a7b\).

Package(s) Affected
-------------------

- rustc: 1:1.86.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
