### PR TITLE
mesa: update to 25.0.3+dxheaders1.615.0

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
-From fcbb9780661906ca0bd7143cdab037b633ea96fd Mon Sep 17 00:00:00 2001
+From bb1fcd450306cc92176fbcad17f3e448de7d82db Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 01/12] AOSCOS: r600: disable buggy VC-1 hardware decoding
+Subject: [PATCH 01/14] AOSCOS: r600: disable buggy VC-1 hardware decoding
 
 Per commit 6cd30f5d730c ("radeon/uvd: disable VC-1 simple/main on UVD
 2.x"), VC-1 simple/main decoding was broken on at least UVD-1. According

--- a/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,7 +1,7 @@
-From 52f9c0aea8f87d95e30ead8a08fe64e001e0545a Mon Sep 17 00:00:00 2001
+From feb25f36a7d9b2de1942d376d8230f9b9fda36f4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 02/12] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
+Subject: [PATCH 02/14] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
  LoongArch (LP64)
 
 16KiB is the most commonly found kernel page size on LoongArch

--- a/runtime-display/mesa/autobuild/patches/0003-FROMLIST-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-FROMLIST-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,7 +1,7 @@
-From 07440bad4a6332b68d58b9b2f277ba1a7ce84f40 Mon Sep 17 00:00:00 2001
+From dd47ecb753711bed2206f4ae6d21e8628cf57dbb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
-Subject: [PATCH 03/12] FROMLIST: zink: Do not use demote on IMG blobs
+Subject: [PATCH 03/14] FROMLIST: zink: Do not use demote on IMG blobs
 
 The implementation of demote in IMG blobs seems to be a piece of hack,
 and the current use of it in Zink leads to assertion failure with

--- a/runtime-display/mesa/autobuild/patches/0004-ASAHI-DO-NOT-UPSTREAM-Probe-unstable-UAPI.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-ASAHI-DO-NOT-UPSTREAM-Probe-unstable-UAPI.patch
@@ -1,7 +1,7 @@
-From 892189911af796af653dc79b53c9de7fd478f22e Mon Sep 17 00:00:00 2001
+From 8e4ad814141f887b964efac27793822ac6274e0c Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:28:42 -0500
-Subject: [PATCH 04/12] ASAHI: DO NOT UPSTREAM: Probe unstable UAPI
+Subject: [PATCH 04/14] ASAHI: DO NOT UPSTREAM: Probe unstable UAPI
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 

--- a/runtime-display/mesa/autobuild/patches/0005-ASAHI-gallium-wire-up-asahi-driver.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-ASAHI-gallium-wire-up-asahi-driver.patch
@@ -1,7 +1,7 @@
-From e8ae484030b64aed39fa55ef1620cebeae4ee07e Mon Sep 17 00:00:00 2001
+From 85bdff906a9d5a43f4b6a4962b38a78325b7ea8f Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:29:28 -0500
-Subject: [PATCH 05/12] ASAHI: gallium: wire up asahi driver
+Subject: [PATCH 05/14] ASAHI: gallium: wire up asahi driver
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 27 insertions(+)
 
 diff --git a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
-index 985ace997bd..b56b0081749 100644
+index 945c447d272..6f5eaf8fb77 100644
 --- a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
 +++ b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
 @@ -88,6 +88,7 @@ static const struct drm_driver_descriptor *driver_descriptors[] = {
@@ -26,7 +26,7 @@ index 985ace997bd..b56b0081749 100644
     &etnaviv_driver_descriptor,
     &tegra_driver_descriptor,
     &lima_driver_descriptor,
-@@ -313,6 +314,9 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
+@@ -331,6 +332,9 @@ pipe_loader_get_compatible_render_capable_device_fds(int kms_only_fd, unsigned i
     bool is_platform_device;
     struct pipe_loader_device *dev;
     const char * const drivers[] = {

--- a/runtime-display/mesa/autobuild/patches/0006-ASAHI-hk-advertise-semaphore-extensions.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-ASAHI-hk-advertise-semaphore-extensions.patch
@@ -1,7 +1,7 @@
-From cb97e1b29c7d0d9ef86a4c266b6beedf0edacf6e Mon Sep 17 00:00:00 2001
+From ae6ff786db31d5e596a506459ea29c16f7058f9b Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Wed, 5 Mar 2025 15:06:09 -0500
-Subject: [PATCH 06/12] ASAHI: hk: advertise semaphore extensions
+Subject: [PATCH 06/14] ASAHI: hk: advertise semaphore extensions
 
 works on current kernels.
 

--- a/runtime-display/mesa/autobuild/patches/0007-ASAHI-libagx-clean-up-query-copy-bug-fix.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-ASAHI-libagx-clean-up-query-copy-bug-fix.patch
@@ -1,7 +1,7 @@
-From 6370584e0f21a15e1488c861220b4ee5bb067928 Mon Sep 17 00:00:00 2001
+From 922a33df93b35aecfbacdafa2096a569c900bc31 Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Wed, 5 Mar 2025 17:54:52 -0500
-Subject: [PATCH 07/12] ASAHI: libagx: clean up query copy; bug fix
+Subject: [PATCH 07/14] ASAHI: libagx: clean up query copy; bug fix
 
 oops.
 -      .partial = flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT,

--- a/runtime-display/mesa/autobuild/patches/0008-ASAHI-hk-advertise-bufferDeviceAddressCaptureReplayE.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-ASAHI-hk-advertise-bufferDeviceAddressCaptureReplayE.patch
@@ -1,7 +1,7 @@
-From bb55264b3becbf24217badf9a4dd5c4239fd772a Mon Sep 17 00:00:00 2001
+From d7c65a86cf89c8b2da037495e0a5ce692db35679 Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:17:57 -0500
-Subject: [PATCH 08/12] ASAHI: hk: advertise
+Subject: [PATCH 08/14] ASAHI: hk: advertise
  bufferDeviceAddressCaptureReplayEXT
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>

--- a/runtime-display/mesa/autobuild/patches/0009-ASAHI-asahi-fix-depth-buffer-feedback-loops.patch
+++ b/runtime-display/mesa/autobuild/patches/0009-ASAHI-asahi-fix-depth-buffer-feedback-loops.patch
@@ -1,7 +1,7 @@
-From 9ff19043d310819976c34feda07b3fd4c4930fb0 Mon Sep 17 00:00:00 2001
+From 5a3b15da3a8d9d3371589985c4bb0ea865e44a4c Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Tue, 11 Mar 2025 15:26:48 -0400
-Subject: [PATCH 09/13] ASAHI: asahi: fix depth buffer feedback loops
+Subject: [PATCH 09/14] ASAHI: asahi: fix depth buffer feedback loops
 
 fixes supertuxkart without the old hack.
 

--- a/runtime-display/mesa/autobuild/patches/0010-BACKPORT-frontends-va-Support-A8R8G8B8-format-for-pr.patch
+++ b/runtime-display/mesa/autobuild/patches/0010-BACKPORT-frontends-va-Support-A8R8G8B8-format-for-pr.patch
@@ -1,7 +1,7 @@
-From 6e2d2914f67ffbcc6fdd3a04a536215024d96d46 Mon Sep 17 00:00:00 2001
+From 7fb92b5b30193fa2377e3606b71a7f5068478a5b Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:41:30 +0100
-Subject: [PATCH 10/12] BACKPORT: frontends/va: Support A8R8G8B8 format for
+Subject: [PATCH 10/14] BACKPORT: frontends/va: Support A8R8G8B8 format for
  processing
 
 Reviewed-by: Ruijing Dong <ruijing.dong@amd.com>

--- a/runtime-display/mesa/autobuild/patches/0011-BACKPORT-frontends-va-Use-ARGB-as-default-fourcc-for.patch
+++ b/runtime-display/mesa/autobuild/patches/0011-BACKPORT-frontends-va-Use-ARGB-as-default-fourcc-for.patch
@@ -1,7 +1,7 @@
-From 78d0fdc094f18294c8c25ed5efa712ab9a8d6d54 Mon Sep 17 00:00:00 2001
+From dc6bf1fafc76640787b9c208e55b65a724658478 Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:41:54 +0100
-Subject: [PATCH 11/12] BACKPORT: frontends/va: Use ARGB as default fourcc for
+Subject: [PATCH 11/14] BACKPORT: frontends/va: Use ARGB as default fourcc for
  RGB32 RT format
 
 This matches Intel driver and is what Chromium expects.

--- a/runtime-display/mesa/autobuild/patches/0012-BACKPORT-frontends-va-Don-t-filter-supported-formats.patch
+++ b/runtime-display/mesa/autobuild/patches/0012-BACKPORT-frontends-va-Don-t-filter-supported-formats.patch
@@ -1,7 +1,7 @@
-From 05485b3056039ab8b9e6051fa888e1a77e952f3b Mon Sep 17 00:00:00 2001
+From faf8d66fdc9e27e8682b4e7ebb313c25f2eda05b Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:58:48 +0100
-Subject: [PATCH 12/12] BACKPORT: frontends/va: Don't filter supported formats
+Subject: [PATCH 12/14] BACKPORT: frontends/va: Don't filter supported formats
  according to config RT format
 
 This matches Intel driver. Chromium always sets RT format to YUV420

--- a/runtime-display/mesa/autobuild/patches/0013-BACKPORT-libcl-vk-add-common-query-copy-write-routin.patch
+++ b/runtime-display/mesa/autobuild/patches/0013-BACKPORT-libcl-vk-add-common-query-copy-write-routin.patch
@@ -1,7 +1,7 @@
-From b38d1a59137d1a21c2ecb144c10c8a84f4a5bb91 Mon Sep 17 00:00:00 2001
+From b17737355b1462183b7d5f7b45311ba12e2fe99a Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Mon, 3 Feb 2025 14:52:00 -0500
-Subject: [PATCH 13/13] BACKPORT: libcl/vk: add common query copy write routine
+Subject: [PATCH 13/14] BACKPORT: libcl/vk: add common query copy write routine
 
 every VK driver ends up wanting this.
 

--- a/runtime-display/mesa/autobuild/patches/0014-FROMLIST-radv-only-enable-DCC-for-invisible-VRAM-on-.patch
+++ b/runtime-display/mesa/autobuild/patches/0014-FROMLIST-radv-only-enable-DCC-for-invisible-VRAM-on-.patch
@@ -1,0 +1,53 @@
+From de918e02f7709f16f7ee38ece32883e982010aff Mon Sep 17 00:00:00 2001
+From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Date: Wed, 2 Apr 2025 14:21:11 +0200
+Subject: [PATCH 14/14] FROMLIST: radv: only enable DCC for invisible VRAM on
+ GFX12
+
+DCC should only be allowed on invisible VRAM, otherwise the CPU could
+read the data and it will read garbage if it's compressed.
+
+This also caused GPU hangs after suspend/resume probably because
+some buffers were compressed when moved back from GTT to VRAM.
+
+Fixes: 9af11bf306c ("radv: add initial DCC support on GFX12")
+Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+
+Link: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34347
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/amd/vulkan/radv_device_memory.c           | 3 ++-
+ src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/amd/vulkan/radv_device_memory.c b/src/amd/vulkan/radv_device_memory.c
+index dc43dcfc5af..855979edf68 100644
+--- a/src/amd/vulkan/radv_device_memory.c
++++ b/src/amd/vulkan/radv_device_memory.c
+@@ -224,7 +224,8 @@ radv_alloc_memory(struct radv_device *device, const VkMemoryAllocateInfo *pAlloc
+        * (see DCC tiling flags).
+        */
+       if (pdev->info.gfx_level >= GFX12 && pdev->info.gfx12_supports_dcc_write_compress_disable &&
+-          domain == RADEON_DOMAIN_VRAM && !(instance->debug_flags & RADV_DEBUG_NO_DCC)) {
++          domain == RADEON_DOMAIN_VRAM && (flags & RADEON_FLAG_NO_CPU_ACCESS) &&
++          !(instance->debug_flags & RADV_DEBUG_NO_DCC)) {
+          flags |= RADEON_FLAG_GFX12_ALLOW_DCC;
+       }
+ 
+diff --git a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
+index c2546fcc0c5..da8b155eaa6 100644
+--- a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
++++ b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
+@@ -513,7 +513,8 @@ radv_amdgpu_winsys_bo_create(struct radeon_winsys *_ws, uint64_t size, unsigned
+       request.flags |= AMDGPU_GEM_CREATE_DISCARDABLE;
+ 
+    if (flags & RADEON_FLAG_GFX12_ALLOW_DCC && ws->info.drm_minor >= 58) {
+-      assert(ws->info.gfx_level >= GFX12 && (initial_domain & RADEON_DOMAIN_VRAM));
++      assert(ws->info.gfx_level >= GFX12 && (initial_domain & RADEON_DOMAIN_VRAM) &&
++             (flags & RADEON_FLAG_NO_CPU_ACCESS));
+       bo->base.gfx12_allow_dcc = true;
+       request.flags |= AMDGPU_GEM_CREATE_GFX12_DCC;
+    }
+-- 
+2.49.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=25.0.2
+UPSTREAM_VER=25.0.3
 DXHEADERS_VER=1.615.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::adf904d083b308df95898600ffed435f4b5c600d95fb6ec6d4c45638627fdc97 \
+CHKSUMS="sha256::5ff426ed6ce0588fd96d18975bdff451ae2ab2fe98b5d1528842ee71ec66711b \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
-From fcbb9780661906ca0bd7143cdab037b633ea96fd Mon Sep 17 00:00:00 2001
+From bb1fcd450306cc92176fbcad17f3e448de7d82db Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 01/12] AOSCOS: r600: disable buggy VC-1 hardware decoding
+Subject: [PATCH 01/14] AOSCOS: r600: disable buggy VC-1 hardware decoding
 
 Per commit 6cd30f5d730c ("radeon/uvd: disable VC-1 simple/main on UVD
 2.x"), VC-1 simple/main decoding was broken on at least UVD-1. According

--- a/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,7 +1,7 @@
-From 52f9c0aea8f87d95e30ead8a08fe64e001e0545a Mon Sep 17 00:00:00 2001
+From feb25f36a7d9b2de1942d376d8230f9b9fda36f4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 02/12] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
+Subject: [PATCH 02/14] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
  LoongArch (LP64)
 
 16KiB is the most commonly found kernel page size on LoongArch

--- a/runtime-optenv32/mesa+32/autobuild/patches/0003-FROMLIST-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0003-FROMLIST-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,7 +1,7 @@
-From 07440bad4a6332b68d58b9b2f277ba1a7ce84f40 Mon Sep 17 00:00:00 2001
+From dd47ecb753711bed2206f4ae6d21e8628cf57dbb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
-Subject: [PATCH 03/12] FROMLIST: zink: Do not use demote on IMG blobs
+Subject: [PATCH 03/14] FROMLIST: zink: Do not use demote on IMG blobs
 
 The implementation of demote in IMG blobs seems to be a piece of hack,
 and the current use of it in Zink leads to assertion failure with

--- a/runtime-optenv32/mesa+32/autobuild/patches/0004-ASAHI-DO-NOT-UPSTREAM-Probe-unstable-UAPI.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0004-ASAHI-DO-NOT-UPSTREAM-Probe-unstable-UAPI.patch
@@ -1,7 +1,7 @@
-From 892189911af796af653dc79b53c9de7fd478f22e Mon Sep 17 00:00:00 2001
+From 8e4ad814141f887b964efac27793822ac6274e0c Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:28:42 -0500
-Subject: [PATCH 04/12] ASAHI: DO NOT UPSTREAM: Probe unstable UAPI
+Subject: [PATCH 04/14] ASAHI: DO NOT UPSTREAM: Probe unstable UAPI
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0005-ASAHI-gallium-wire-up-asahi-driver.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0005-ASAHI-gallium-wire-up-asahi-driver.patch
@@ -1,7 +1,7 @@
-From e8ae484030b64aed39fa55ef1620cebeae4ee07e Mon Sep 17 00:00:00 2001
+From 85bdff906a9d5a43f4b6a4962b38a78325b7ea8f Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:29:28 -0500
-Subject: [PATCH 05/12] ASAHI: gallium: wire up asahi driver
+Subject: [PATCH 05/14] ASAHI: gallium: wire up asahi driver
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 27 insertions(+)
 
 diff --git a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
-index 985ace997bd..b56b0081749 100644
+index 945c447d272..6f5eaf8fb77 100644
 --- a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
 +++ b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
 @@ -88,6 +88,7 @@ static const struct drm_driver_descriptor *driver_descriptors[] = {
@@ -26,7 +26,7 @@ index 985ace997bd..b56b0081749 100644
     &etnaviv_driver_descriptor,
     &tegra_driver_descriptor,
     &lima_driver_descriptor,
-@@ -313,6 +314,9 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
+@@ -331,6 +332,9 @@ pipe_loader_get_compatible_render_capable_device_fds(int kms_only_fd, unsigned i
     bool is_platform_device;
     struct pipe_loader_device *dev;
     const char * const drivers[] = {

--- a/runtime-optenv32/mesa+32/autobuild/patches/0006-ASAHI-hk-advertise-semaphore-extensions.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0006-ASAHI-hk-advertise-semaphore-extensions.patch
@@ -1,7 +1,7 @@
-From cb97e1b29c7d0d9ef86a4c266b6beedf0edacf6e Mon Sep 17 00:00:00 2001
+From ae6ff786db31d5e596a506459ea29c16f7058f9b Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Wed, 5 Mar 2025 15:06:09 -0500
-Subject: [PATCH 06/12] ASAHI: hk: advertise semaphore extensions
+Subject: [PATCH 06/14] ASAHI: hk: advertise semaphore extensions
 
 works on current kernels.
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0007-ASAHI-libagx-clean-up-query-copy-bug-fix.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0007-ASAHI-libagx-clean-up-query-copy-bug-fix.patch
@@ -1,7 +1,7 @@
-From 6370584e0f21a15e1488c861220b4ee5bb067928 Mon Sep 17 00:00:00 2001
+From 922a33df93b35aecfbacdafa2096a569c900bc31 Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Wed, 5 Mar 2025 17:54:52 -0500
-Subject: [PATCH 07/12] ASAHI: libagx: clean up query copy; bug fix
+Subject: [PATCH 07/14] ASAHI: libagx: clean up query copy; bug fix
 
 oops.
 -      .partial = flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT,

--- a/runtime-optenv32/mesa+32/autobuild/patches/0008-ASAHI-hk-advertise-bufferDeviceAddressCaptureReplayE.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0008-ASAHI-hk-advertise-bufferDeviceAddressCaptureReplayE.patch
@@ -1,7 +1,7 @@
-From bb55264b3becbf24217badf9a4dd5c4239fd772a Mon Sep 17 00:00:00 2001
+From d7c65a86cf89c8b2da037495e0a5ce692db35679 Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Fri, 7 Mar 2025 09:17:57 -0500
-Subject: [PATCH 08/12] ASAHI: hk: advertise
+Subject: [PATCH 08/14] ASAHI: hk: advertise
  bufferDeviceAddressCaptureReplayEXT
 
 Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>

--- a/runtime-optenv32/mesa+32/autobuild/patches/0009-ASAHI-asahi-fix-depth-buffer-feedback-loops.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0009-ASAHI-asahi-fix-depth-buffer-feedback-loops.patch
@@ -1,7 +1,7 @@
-From 9ff19043d310819976c34feda07b3fd4c4930fb0 Mon Sep 17 00:00:00 2001
+From 5a3b15da3a8d9d3371589985c4bb0ea865e44a4c Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Tue, 11 Mar 2025 15:26:48 -0400
-Subject: [PATCH 09/13] ASAHI: asahi: fix depth buffer feedback loops
+Subject: [PATCH 09/14] ASAHI: asahi: fix depth buffer feedback loops
 
 fixes supertuxkart without the old hack.
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0010-BACKPORT-frontends-va-Support-A8R8G8B8-format-for-pr.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0010-BACKPORT-frontends-va-Support-A8R8G8B8-format-for-pr.patch
@@ -1,7 +1,7 @@
-From 6e2d2914f67ffbcc6fdd3a04a536215024d96d46 Mon Sep 17 00:00:00 2001
+From 7fb92b5b30193fa2377e3606b71a7f5068478a5b Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:41:30 +0100
-Subject: [PATCH 10/12] BACKPORT: frontends/va: Support A8R8G8B8 format for
+Subject: [PATCH 10/14] BACKPORT: frontends/va: Support A8R8G8B8 format for
  processing
 
 Reviewed-by: Ruijing Dong <ruijing.dong@amd.com>

--- a/runtime-optenv32/mesa+32/autobuild/patches/0011-BACKPORT-frontends-va-Use-ARGB-as-default-fourcc-for.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0011-BACKPORT-frontends-va-Use-ARGB-as-default-fourcc-for.patch
@@ -1,7 +1,7 @@
-From 78d0fdc094f18294c8c25ed5efa712ab9a8d6d54 Mon Sep 17 00:00:00 2001
+From dc6bf1fafc76640787b9c208e55b65a724658478 Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:41:54 +0100
-Subject: [PATCH 11/12] BACKPORT: frontends/va: Use ARGB as default fourcc for
+Subject: [PATCH 11/14] BACKPORT: frontends/va: Use ARGB as default fourcc for
  RGB32 RT format
 
 This matches Intel driver and is what Chromium expects.

--- a/runtime-optenv32/mesa+32/autobuild/patches/0012-BACKPORT-frontends-va-Don-t-filter-supported-formats.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0012-BACKPORT-frontends-va-Don-t-filter-supported-formats.patch
@@ -1,7 +1,7 @@
-From 05485b3056039ab8b9e6051fa888e1a77e952f3b Mon Sep 17 00:00:00 2001
+From faf8d66fdc9e27e8682b4e7ebb313c25f2eda05b Mon Sep 17 00:00:00 2001
 From: David Rosca <david.rosca@amd.com>
 Date: Tue, 11 Mar 2025 13:58:48 +0100
-Subject: [PATCH 12/12] BACKPORT: frontends/va: Don't filter supported formats
+Subject: [PATCH 12/14] BACKPORT: frontends/va: Don't filter supported formats
  according to config RT format
 
 This matches Intel driver. Chromium always sets RT format to YUV420

--- a/runtime-optenv32/mesa+32/autobuild/patches/0013-BACKPORT-libcl-vk-add-common-query-copy-write-routin.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0013-BACKPORT-libcl-vk-add-common-query-copy-write-routin.patch
@@ -1,7 +1,7 @@
-From b38d1a59137d1a21c2ecb144c10c8a84f4a5bb91 Mon Sep 17 00:00:00 2001
+From b17737355b1462183b7d5f7b45311ba12e2fe99a Mon Sep 17 00:00:00 2001
 From: Alyssa Rosenzweig <alyssa@rosenzweig.io>
 Date: Mon, 3 Feb 2025 14:52:00 -0500
-Subject: [PATCH 13/13] BACKPORT: libcl/vk: add common query copy write routine
+Subject: [PATCH 13/14] BACKPORT: libcl/vk: add common query copy write routine
 
 every VK driver ends up wanting this.
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0014-FROMLIST-radv-only-enable-DCC-for-invisible-VRAM-on-.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0014-FROMLIST-radv-only-enable-DCC-for-invisible-VRAM-on-.patch
@@ -1,0 +1,53 @@
+From de918e02f7709f16f7ee38ece32883e982010aff Mon Sep 17 00:00:00 2001
+From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Date: Wed, 2 Apr 2025 14:21:11 +0200
+Subject: [PATCH 14/14] FROMLIST: radv: only enable DCC for invisible VRAM on
+ GFX12
+
+DCC should only be allowed on invisible VRAM, otherwise the CPU could
+read the data and it will read garbage if it's compressed.
+
+This also caused GPU hangs after suspend/resume probably because
+some buffers were compressed when moved back from GTT to VRAM.
+
+Fixes: 9af11bf306c ("radv: add initial DCC support on GFX12")
+Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+
+Link: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34347
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/amd/vulkan/radv_device_memory.c           | 3 ++-
+ src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/amd/vulkan/radv_device_memory.c b/src/amd/vulkan/radv_device_memory.c
+index dc43dcfc5af..855979edf68 100644
+--- a/src/amd/vulkan/radv_device_memory.c
++++ b/src/amd/vulkan/radv_device_memory.c
+@@ -224,7 +224,8 @@ radv_alloc_memory(struct radv_device *device, const VkMemoryAllocateInfo *pAlloc
+        * (see DCC tiling flags).
+        */
+       if (pdev->info.gfx_level >= GFX12 && pdev->info.gfx12_supports_dcc_write_compress_disable &&
+-          domain == RADEON_DOMAIN_VRAM && !(instance->debug_flags & RADV_DEBUG_NO_DCC)) {
++          domain == RADEON_DOMAIN_VRAM && (flags & RADEON_FLAG_NO_CPU_ACCESS) &&
++          !(instance->debug_flags & RADV_DEBUG_NO_DCC)) {
+          flags |= RADEON_FLAG_GFX12_ALLOW_DCC;
+       }
+ 
+diff --git a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
+index c2546fcc0c5..da8b155eaa6 100644
+--- a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
++++ b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c
+@@ -513,7 +513,8 @@ radv_amdgpu_winsys_bo_create(struct radeon_winsys *_ws, uint64_t size, unsigned
+       request.flags |= AMDGPU_GEM_CREATE_DISCARDABLE;
+ 
+    if (flags & RADEON_FLAG_GFX12_ALLOW_DCC && ws->info.drm_minor >= 58) {
+-      assert(ws->info.gfx_level >= GFX12 && (initial_domain & RADEON_DOMAIN_VRAM));
++      assert(ws->info.gfx_level >= GFX12 && (initial_domain & RADEON_DOMAIN_VRAM) &&
++             (flags & RADEON_FLAG_NO_CPU_ACCESS));
+       bo->base.gfx12_allow_dcc = true;
+       request.flags |= AMDGPU_GEM_CREATE_GFX12_DCC;
+    }
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/spec
+++ b/runtime-optenv32/mesa+32/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=25.0.2
+UPSTREAM_VER=25.0.3
 DXHEADERS_VER=1.615.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::adf904d083b308df95898600ffed435f4b5c600d95fb6ec6d4c45638627fdc97 \
+CHKSUMS="sha256::5ff426ed6ce0588fd96d18975bdff451ae2ab2fe98b5d1528842ee71ec66711b \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/topics/mesa-25.0.3.toml
+++ b/topics/mesa-25.0.3.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "Mesa 3D Graphics Library 25.0.3"
+zh_CN = "Mesa 3D 图形库，版本 25.0.3"
+
+[caution]
+default = "Fixes occasional instability on resume ACPI suspend (S3) with AMD Radeon RX 9000 Series Graphics and crashes/hangs while playing \"Octopath Traveler II\" and other titles with AMD Radeon 780M"
+zh_CN = "修复 AMD Radeon RX 9000 系列显卡从 ACPI 睡眠 (S3) 唤醒后的偶发稳定性问题及 AMD Radeon 780M 运行《歧路旅人 II》等游戏时的崩溃或画面锁死问题"
+
+[packages]
+mesa = "1:25.0.3+dxheaders1.615.0"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.0.3+dxheaders1.615.0
    - Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.0.3
    \(HEAD: de918e02f7709f16f7ee38ece32883e982010aff\).
    - Backport a fix for suspend resume with AMD Radeon RX 9070 series.
- mesa: update to 25.0.3+dxheaders1.615.0
    - Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.0.3
    \(HEAD: de918e02f7709f16f7ee38ece32883e982010aff\).
    - Backport a fix for suspend resume with AMD Radeon RX 9070 series.

Package(s) Affected
-------------------

- mesa: 1:25.0.3+dxheaders1.615.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
