### PR TITLE
gnuplot: update to 6.0.2

### DIFF
--- a/app-utils/gnuplot/spec
+++ b/app-utils/gnuplot/spec
@@ -1,4 +1,4 @@
-VER=6.0.1
+VER=6.0.2
 SRCS="tbl::https://sourceforge.net/projects/gnuplot/files/gnuplot/$VER/gnuplot-$VER.tar.gz"
-CHKSUMS="sha256::e85a660c1a2a1808ff24f7e69981ffcbac66a45c9dcf711b65610b26ea71379a"
+CHKSUMS="sha256::f68a3b0bbb7bbbb437649674106d94522c00bf2f285cce0c19c3180b1ee7e738"
 CHKUPDATE="anitya::id=1216"


### PR DESCRIPTION
Topic Description
-----------------

- gnuplot: update to 6.0.2
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- gnuplot: 6.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnuplot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
