### PR TITLE
qemu: update to 9.2.3

### DIFF
--- a/app-virtualization/qemu/01-shared/build
+++ b/app-virtualization/qemu/01-shared/build
@@ -141,6 +141,12 @@ popd
 
 mkdir -p "${SRCDIR}/src.user/build"
 pushd "${SRCDIR}/src.user/build"
+	if ab_match_arch loongson3 || \
+	   ab_match_arch riscv64; then
+		# FIXME: Relocation truncated to fit.
+		export CFLAGS="${CFLAGS} -mcode-model=medium"
+	fi
+
 	abinfo "Configuring user-mode binary build..."
 	../configure ${COMMON_CONFIGURE_FLAGS} ${USER_CONFIGURE_FLAGS} \
 		--extra-ldflags="${LDFLAGS}" \

--- a/app-virtualization/qemu/01-shared/defines
+++ b/app-virtualization/qemu/01-shared/defines
@@ -13,19 +13,6 @@ BUILDDEP="spice-protocol xmlto doxygen dtc sphinx jack glib-static \
 PKGDES="A KVM based virtualization client"
 
 AB_FLAGS_SPECS=0
-NOLTO__LOONGSON3=1
-
-# FIXME: /tcg/tcg-op-vec.c:244:(.text+0x3e6da8): relocation truncated to fit:
-# R_LARCH_PCREL20_S2 against `.LANCHOR21'
-# /usr/bin/ld: final link failed: bad value
-# collect2: error: ld returned 1 exit status
-NOLTO__LOONGARCH64=1
-
-# FIXME: relocation truncated to fit: R_RISCV_JAL against symbol
-# `safe_syscall_set_errno_tail' defined in .text section in
-# /tmp/cca5hLTf.ltrans0.ltrans.o
-ABSPLITDBG__RISCV64=0
-NOLTO__RISCV64=1
 
 # Note: Used to be debundled, now bundled.
 PKGBREAK="edk2<=2:202105 seabios<=1.14.0-1"

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=9.2.2
-REL=1
+VER=9.2.3
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
+CHKSUMS="sha256::baed494270c361bf69816acc84512e3efed71c7a23f76691642b80bc3de7693e"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 9.2.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qemu: 9.2.3
- qemu-aarch64-static: 9.2.3
- qemu-alpha-static: 9.2.3
- qemu-arm-static: 9.2.3
- qemu-armeb-static: 9.2.3
- qemu-guest-agent: 9.2.3
- qemu-i386-static: 9.2.3
- qemu-loongarch64-static: 9.2.3
- qemu-m68k-static: 9.2.3
- qemu-microblaze-static: 9.2.3
- qemu-microblazeel-static: 9.2.3
- qemu-mips-static: 9.2.3
- qemu-mips64-static: 9.2.3
- qemu-mips64el-static: 9.2.3
- qemu-mipsel-static: 9.2.3
- qemu-mipsn32-static: 9.2.3
- qemu-mipsn32el-static: 9.2.3
- qemu-or32-static: 9.2.3
- qemu-ppc-static: 9.2.3
- qemu-ppc64-static: 9.2.3
- qemu-ppc64le-static: 9.2.3
- qemu-riscv32-static: 9.2.3
- qemu-riscv64-static: 9.2.3
- qemu-s390x-static: 9.2.3
- qemu-sh4-static: 9.2.3
- qemu-sh4eb-static: 9.2.3
- qemu-sparc-static: 9.2.3
- qemu-sparc32plus-static: 9.2.3
- qemu-sparc64-static: 9.2.3
- qemu-user-static: 9.2.3
- qemu-x86-64-static: 9.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
