### PR TITLE
breeze-icons: backport to fix telegram-desktop icon names

### DIFF
--- a/desktop-kde/breeze-icons/autobuild/patches/0002-Add-symbolic-links-for-telegram-desktop-new-icon-names.patch
+++ b/desktop-kde/breeze-icons/autobuild/patches/0002-Add-symbolic-links-for-telegram-desktop-new-icon-names.patch
@@ -1,0 +1,85 @@
+From d436c2fd8324c6a5d63f855f40115dc6397709e3 Mon Sep 17 00:00:00 2001
+From: Rocket Aaron <i@rocka.me>
+Date: Fri, 4 Apr 2025 12:48:30 +0000
+Subject: [PATCH] Add symbolic links for telegram-desktop new icon names
+
+Telegram Desktop changed their tray icon name since 5.12.4[^1], from
+`telegram{,-attention,-mute}-panel`
+to
+`org.telegram.desktop{,{,-attention,-mute}-symbolic}`.
+
+There is a `org.telegram.desktop` icon in Breeze Icons for colorful
+application icon, so all the tray icons just fell back to that one.
+
+This commit adds symlinks for all the new icon names.
+
+[^1]: https://github.com/telegramdesktop/tdesktop/commit/99a1c98ae07df9d383f120cdd26ddb2a31ad8a07
+
+CCBUG: 502049
+
+Patch from: https://invent.kde.org/frameworks/breeze-icons/-/commit/ca3edf98d1444b9988e0bf6b57fb5433a7347199
+---
+ icons/status/22/org.telegram.desktop-attention-symbolic.svg | 1 +
+ icons/status/22/org.telegram.desktop-attention.svg          | 1 +
+ icons/status/22/org.telegram.desktop-mute-symbolic.svg      | 1 +
+ icons/status/22/org.telegram.desktop-mute.svg               | 1 +
+ icons/status/22/org.telegram.desktop-symbolic.svg           | 1 +
+ icons/status/22/org.telegram.desktop.svg                    | 1 +
+ 6 files changed, 6 insertions(+)
+ create mode 120000 icons/status/22/org.telegram.desktop-attention-symbolic.svg
+ create mode 120000 icons/status/22/org.telegram.desktop-attention.svg
+ create mode 120000 icons/status/22/org.telegram.desktop-mute-symbolic.svg
+ create mode 120000 icons/status/22/org.telegram.desktop-mute.svg
+ create mode 120000 icons/status/22/org.telegram.desktop-symbolic.svg
+ create mode 120000 icons/status/22/org.telegram.desktop.svg
+
+diff --git a/icons/status/22/org.telegram.desktop-attention-symbolic.svg b/icons/status/22/org.telegram.desktop-attention-symbolic.svg
+new file mode 120000
+index 0000000..0ab50a8
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop-attention-symbolic.svg
+@@ -0,0 +1 @@
++telegram-attention-panel.svg
+\ No newline at end of file
+diff --git a/icons/status/22/org.telegram.desktop-attention.svg b/icons/status/22/org.telegram.desktop-attention.svg
+new file mode 120000
+index 0000000..0ab50a8
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop-attention.svg
+@@ -0,0 +1 @@
++telegram-attention-panel.svg
+\ No newline at end of file
+diff --git a/icons/status/22/org.telegram.desktop-mute-symbolic.svg b/icons/status/22/org.telegram.desktop-mute-symbolic.svg
+new file mode 120000
+index 0000000..7c081af
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop-mute-symbolic.svg
+@@ -0,0 +1 @@
++telegram-mute-panel.svg
+\ No newline at end of file
+diff --git a/icons/status/22/org.telegram.desktop-mute.svg b/icons/status/22/org.telegram.desktop-mute.svg
+new file mode 120000
+index 0000000..7c081af
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop-mute.svg
+@@ -0,0 +1 @@
++telegram-mute-panel.svg
+\ No newline at end of file
+diff --git a/icons/status/22/org.telegram.desktop-symbolic.svg b/icons/status/22/org.telegram.desktop-symbolic.svg
+new file mode 120000
+index 0000000..494fd29
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop-symbolic.svg
+@@ -0,0 +1 @@
++telegram-panel.svg
+\ No newline at end of file
+diff --git a/icons/status/22/org.telegram.desktop.svg b/icons/status/22/org.telegram.desktop.svg
+new file mode 120000
+index 0000000..494fd29
+--- /dev/null
++++ b/icons/status/22/org.telegram.desktop.svg
+@@ -0,0 +1 @@
++telegram-panel.svg
+\ No newline at end of file
+--
+2.49.0

--- a/desktop-kde/breeze-icons/spec
+++ b/desktop-kde/breeze-icons/spec
@@ -1,4 +1,5 @@
 VER=5.115.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/breeze-icons-$VER.tar.xz"
 CHKSUMS="sha256::c4fc87a0ea961dc849e1feac97b3c53ce0af79df76a9dd508eb4ba5a006f09b9"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- breeze-icons: backport to fix telegram-desktop icon names

Package(s) Affected
-------------------

- breeze-icons: 5.115.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit breeze-icons
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
