### PR TITLE
gperf: update to 3.2

### DIFF
--- a/app-utils/gperf/spec
+++ b/app-utils/gperf/spec
@@ -1,5 +1,4 @@
-VER=3.1
-REL=3
+VER=3.2
 SRCS="tbl::https://ftp.gnu.org/gnu/gperf/gperf-$VER.tar.gz"
-CHKSUMS="sha256::588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
+CHKSUMS="sha256::e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62"
 CHKUPDATE="anitya::id=1237"


### PR DESCRIPTION
Topic Description
-----------------

- gperf: update to 3.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gperf: 3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gperf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
