### PR TITLE
highway: update to 1.2.0

### DIFF
--- a/app-devel/gtest/autobuild/defines
+++ b/app-devel/gtest/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=gtest
 PKGSEC=utils
-PKGDEP="bash"
-BUILDDEP="cmake"
+PKGDEP="gcc-runtime glibc"
 PKGDES="Google Test - C++ testing utility based on the xUnit framework (like JUnit)"
 
-NOSTATIC=0
-NOLTO=1
-ABSPLITDBG=0
+CMAKE_AFTER=(
+    "-DBUILD_SHARED_LIBS=ON"
+    "-Dgtest_build_tests=ON"
+)

--- a/app-devel/gtest/spec
+++ b/app-devel/gtest/spec
@@ -1,4 +1,4 @@
-VER=1.10.0+git20210513
-SRCS="git::commit=662fe38e44900c007eccb65a5d2ea19df7bd520e::https://github.com/google/googletest"
+VER=1.16.0
+SRCS="git::commit=tags/v$VER::https://github.com/google/googletest"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18290"

--- a/runtime-common/highway/autobuild/defines
+++ b/runtime-common/highway/autobuild/defines
@@ -1,22 +1,32 @@
 PKGNAME=highway
 PKGSEC=libs
 PKGDEP="gcc-runtime"
+BUILDDEP="gtest"
 PKGDES="A C++ library that provides portable SIMD/vector intrinsics"
 
 ABTYPE=cmakeninja
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
-             -DBUILD_TESTING=OFF \
-             -DHWY_ENABLE_CONTRIB=ON \
-             -DHWY_ENABLE_EXAMPLES=ON \
-             -DHWY_ENABLE_INSTALL=ON \
-             -DHWY_ENABLE_TESTS=OFF \
-             -DHWY_SYSTEM_GTEST=OFF \
-             -DHWY_WARNINGS_ARE_ERRORS=OFF"
-CMAKE_AFTER__ARMV7HF=" \
-             ${CMAKE_AFTER} \
-             -DHWY_CMAKE_ARM7=ON"
+# NOTE: Set HWY_ENABLE_TESTS=ON to generate hwy_gtest.h for libjxl.
+CMAKE_AFTER=(
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_TESTING=OFF"
+    "-DHWY_ENABLE_TESTS=ON"
+    "-DHWY_SYSTEM_GTEST=ON"
+)
 
-#FIXME: lto1: fatal error: target specific builtin not available
+# FIXME: Public Clang <= 18 still appears to require compiler flags for RVV.
+#
+# See: https://github.com/google/highway/issues/2227
+#
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER[@]}"
+    "-DHWY_CMAKE_RVV=OFF"
+)
+CMAKE_AFTER__ARMV7HF=(
+    "${CMAKE_AFTER[@]}"
+    "-DHWY_CMAKE_ARM7=ON"
+)
+
+# FIXME: lto1: fatal error: target specific builtin not available.
 NOLTO__RISCV64=1
 
 PKGBREAK="libjxl<=0.7.0"

--- a/runtime-common/highway/autobuild/patches/0001-disable-RVV-runtime-dispatch.patch
+++ b/runtime-common/highway/autobuild/patches/0001-disable-RVV-runtime-dispatch.patch
@@ -1,0 +1,91 @@
+From c95cc0237d2f7a0f5ca5dc3fb4b5961b2b1dcdfc Mon Sep 17 00:00:00 2001
+From: Jan Wassenberg <janwas@google.com>
+Date: Mon, 3 Jun 2024 02:51:20 -0700
+Subject: [PATCH] Disable RVV runtime dispatch. Fixes #2227
+
+Public Clang <= 18 still appears to require compiler flags for RVV.
+GCC 13 also has an #error and 14 is missing mulh/mulhu.
+
+Also split HWY_HAVE_RUNTIME_DISPATCH into multiple macros to enable
+overriding parts of the logic.
+
+PiperOrigin-RevId: 639709709
+---
+ hwy/detect_targets.h | 51 ++++++++++++++++++++++++++++++++------------
+ 1 file changed, 37 insertions(+), 14 deletions(-)
+
+diff --git a/hwy/detect_targets.h b/hwy/detect_targets.h
+index db4c786489..8914638e67 100644
+--- a/hwy/detect_targets.h
++++ b/hwy/detect_targets.h
+@@ -596,23 +596,46 @@
+ #endif
+ #endif  // HWY_HAVE_AUXV
+ 
++#ifndef HWY_HAVE_RUNTIME_DISPATCH_RVV  // allow override
++// The riscv_vector.h in (at least) Clang 16-18 requires compiler flags, see
++// https://github.com/llvm/llvm-project/issues/56592. GCC 13.3 also has an
++// #error check, whereas 14.1 fails with "argument type 'vuint16m8_t' requires
++// the V ISA extension": https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115325.
++// Hence disable runtime dispatch for now.
++#if HWY_ARCH_RISCV && 0
++#define HWY_HAVE_RUNTIME_DISPATCH_RVV 1
++#else
++#define HWY_HAVE_RUNTIME_DISPATCH_RVV 0
++#endif
++#endif  // HWY_HAVE_RUNTIME_DISPATCH_RVV
++
++#ifndef HWY_HAVE_RUNTIME_DISPATCH_APPLE  // allow override
++#if HWY_ARCH_ARM_A64 && HWY_OS_APPLE && \
++    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1700)
++#define HWY_HAVE_RUNTIME_DISPATCH_APPLE 1
++#else
++#define HWY_HAVE_RUNTIME_DISPATCH_APPLE 0
++#endif
++#endif  // HWY_HAVE_RUNTIME_DISPATCH_APPLE
++
++#ifndef HWY_HAVE_RUNTIME_DISPATCH_LINUX  // allow override
++#if (HWY_ARCH_ARM || HWY_ARCH_PPC || HWY_ARCH_S390X) && HWY_OS_LINUX && \
++    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1700) && HWY_HAVE_AUXV
++#define HWY_HAVE_RUNTIME_DISPATCH_LINUX 1
++#else
++#define HWY_HAVE_RUNTIME_DISPATCH_LINUX 0
++#endif
++#endif  // HWY_HAVE_RUNTIME_DISPATCH_LINUX
++
+ // Allow opting out, and without a guarantee of success, opting-in.
+ #ifndef HWY_HAVE_RUNTIME_DISPATCH
+-// Clang, GCC and MSVC allow runtime dispatch on x86.
+-#if HWY_ARCH_X86
+-#define HWY_HAVE_RUNTIME_DISPATCH 1
+-// On Arm, PPC, S390X, and RISC-V: GCC and Clang 17+ do, and we require Linux
+-// to detect CPU capabilities.
+-#elif (HWY_ARCH_ARM || HWY_ARCH_PPC || HWY_ARCH_S390X || HWY_ARCH_RISCV) &&    \
+-    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1700) && HWY_OS_LINUX && \
+-    HWY_HAVE_AUXV
+-#define HWY_HAVE_RUNTIME_DISPATCH 1
+-#elif HWY_ARCH_ARM_A64 && HWY_OS_APPLE && \
+-    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1700)
++// Clang, GCC and MSVC allow OS-independent runtime dispatch on x86.
++#if HWY_ARCH_X86 || HWY_HAVE_RUNTIME_DISPATCH_RVV || \
++    HWY_HAVE_RUNTIME_DISPATCH_APPLE || HWY_HAVE_RUNTIME_DISPATCH_LINUX
+ #define HWY_HAVE_RUNTIME_DISPATCH 1
+ #else
+ #define HWY_HAVE_RUNTIME_DISPATCH 0
+-#endif  // HWY_ARCH_*
++#endif
+ #endif  // HWY_HAVE_RUNTIME_DISPATCH
+ 
+ // AVX3_DL is not widely available yet. To reduce code size and compile time,
+@@ -675,9 +698,9 @@
+ #endif
+ 
+ #if HWY_ARCH_RISCV && HWY_HAVE_RUNTIME_DISPATCH
+-#define HWY_ATTAINABLE_RISCV (HWY_RVV)
++#define HWY_ATTAINABLE_RISCV HWY_RVV
+ #else
+-#define HWY_ATTAINABLE_RISCV 0
++#define HWY_ATTAINABLE_RISCV HWY_BASELINE_RVV
+ #endif
+ 
+ // Attainable means enabled and the compiler allows intrinsics (even when not

--- a/runtime-common/highway/spec
+++ b/runtime-common/highway/spec
@@ -1,4 +1,4 @@
-VER=1.1.0
+VER=1.2.0
 SRCS="git::commit=tags/$VER::https://github.com/google/highway"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205809"


### PR DESCRIPTION
Topic Description
-----------------

- highway: update to 1.2.0
    - Add gtest as BUILDDEP
    - Use system gtest to build
    - Clean up cmake parameters
    - Disable RVV runtime dispatch
- gtest: update to 1.16.0
    - Build as dynamic runtimes
    - Remove outdated parameters
    - Adjust PKGDEP

Package(s) Affected
-------------------

- gtest: 1.16.0
- highway: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtest highway
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
