### PR TITLE
celluloid: update to 0.28

### DIFF
--- a/app-multimedia/celluloid/spec
+++ b/app-multimedia/celluloid/spec
@@ -1,5 +1,4 @@
-VER=0.27
-REL=1
+VER=0.28
 SRCS="git::commit=tags/v$VER::https://github.com/celluloid-player/celluloid"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=193876"


### PR DESCRIPTION
Topic Description
-----------------

- celluloid: update to 0.28
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- celluloid: 0.28

Security Update?
----------------

No

Build Order
-----------

```
#buildit celluloid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
