### PR TITLE
gnuplot: switch off parallel build

### DIFF
--- a/app-utils/gnuplot/autobuild/defines
+++ b/app-utils/gnuplot/autobuild/defines
@@ -28,3 +28,15 @@ AUTOTOOLS_AFTER="--with-gihdir=/usr/share/gnuplot \
                  --libexecdir=/usr/bin \
                  --with-texdir=/usr/share/texmf"
 MAKE_AFTER="pkglibexecdir=/usr/bin"
+# FIXME: Somehow unable to build when compiling on lots of platform,
+# related to failing testing.
+#
+# On some platform (arm64), it calls:
+#
+#   test "/var/cache/acbs/build/acbs.2l73owzc/gnuplot-6.0.2" = ".." || rm -f ./dodecahedron.dat
+#   Making all in plugin
+#   Could not open polygon input file
+#   make[2]: *** [Makefile:726: binary3] Error 1
+#   make[2]: *** Waiting for unfinished jobs.... 
+#
+NOPARALLEL=1

--- a/app-utils/gnuplot/spec
+++ b/app-utils/gnuplot/spec
@@ -1,4 +1,5 @@
 VER=6.0.2
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/gnuplot/files/gnuplot/$VER/gnuplot-$VER.tar.gz"
 CHKSUMS="sha256::f68a3b0bbb7bbbb437649674106d94522c00bf2f285cce0c19c3180b1ee7e738"
 CHKUPDATE="anitya::id=1216"


### PR DESCRIPTION
Topic Description
-----------------

- gnuplot: switch off parallel build

Package(s) Affected
-------------------

- gnuplot: 6.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnuplot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
