### PR TITLE
clash-verge-rev: fix copy geoip data to home dir

### DIFF
--- a/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,7 +1,7 @@
 From fad532395485d803e6860685aba5549f8f00a8d1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
-Subject: [PATCH 01/19] feat(src/assets): add XDG .desktop entry
+Subject: [PATCH 01/20] feat(src/assets): add XDG .desktop entry
 
 ---
  src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++

--- a/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,7 +1,7 @@
 From c4f98ea7a48d4900fbd93eb35a87a739f859ca4f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
-Subject: [PATCH 02/19] fix(tauri.conf.json): disable bundle distribution
+Subject: [PATCH 02/20] fix(tauri.conf.json): disable bundle distribution
 
 ---
  src-tauri/tauri.conf.json | 2 +-

--- a/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,7 +1,7 @@
 From fcc633af9e9a328a342fe40a5085b954b58ad6c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
-Subject: [PATCH 03/19] fix(scripts): use ABI2 (New-World) Mihomo binary for
+Subject: [PATCH 03/20] fix(scripts): use ABI2 (New-World) Mihomo binary for
  loongarch64
 
 Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)

--- a/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
@@ -1,7 +1,7 @@
 From cde8d6652957e09904c006ff85aa6b920e712f12 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
-Subject: [PATCH 04/19] feat: drop clash-meta-alpha support
+Subject: [PATCH 04/20] feat: drop clash-meta-alpha support
 
 ---
  src/components/setting/mods/clash-core-viewer.tsx | 1 -

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,7 +1,7 @@
 From ccb9aa39c7787d69183d7cb76485523fb31ca3fd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
-Subject: [PATCH 05/19] fix(check.mjs): do not fetch Mihomo (Clash Meta)
+Subject: [PATCH 05/20] fix(check.mjs): do not fetch Mihomo (Clash Meta)
  binaries
 
 We use a system copy for this purpose.

--- a/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,7 +1,7 @@
 From 6ded251c51f7c13eab79eed1df5a84b92257f186 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
-Subject: [PATCH 06/19] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+Subject: [PATCH 06/20] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  Meta) bundling
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,7 +1,7 @@
 From 11745233f000a348cb12efc6be3cd53aada268be Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:36:28 +0800
-Subject: [PATCH 07/19] fix(check.mjs): do not check Mihomo (Clash Meta)
+Subject: [PATCH 07/20] fix(check.mjs): do not check Mihomo (Clash Meta)
  platform support
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
@@ -1,7 +1,7 @@
 From 21f1f05411356fbc712660f580910ea181a2fdf2 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:49:46 +0800
-Subject: [PATCH 08/19] Do not create any bundle package
+Subject: [PATCH 08/20] Do not create any bundle package
 
 ---
  src-tauri/tauri.linux.conf.json | 32 +-------------------------------

--- a/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
@@ -1,7 +1,7 @@
 From 8c65bc67cf7e1bb5566394d899b506e568d526da Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
-Subject: [PATCH 09/19] Drop check update feature
+Subject: [PATCH 09/20] Drop check update feature
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
@@ -1,7 +1,7 @@
 From 57d5401d2baad2acf717f2d006a8a1a2e55a94d6 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
-Subject: [PATCH 10/19] Set core binary name as mihomo
+Subject: [PATCH 10/20] Set core binary name as mihomo
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
@@ -1,7 +1,7 @@
 From 44245d632b166c15329e8172d06f1b426b2166b3 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
-Subject: [PATCH 11/19] feat: always not portable
+Subject: [PATCH 11/20] feat: always not portable
 
 ---
  src-tauri/src/utils/dirs.rs | 10 ----------

--- a/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
@@ -1,7 +1,7 @@
 From 5edbe7cd7dbc1b0559c8f979eb365476500af24f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:02:52 +0800
-Subject: [PATCH 12/19] find `mihomo` from `$PATH`
+Subject: [PATCH 12/20] find `mihomo` from `$PATH`
 
 ---
  src-tauri/Cargo.lock          | 27 ++++++++++++++++++++++++++-

--- a/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,7 +1,7 @@
 From e9b7fb4be7c9a456f92542c774bc30e7ec9a7ad7 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
-Subject: [PATCH 13/19] Set service install/uninstall script path to
+Subject: [PATCH 13/20] Set service install/uninstall script path to
  /usr/libexec
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
@@ -1,7 +1,7 @@
 From 835e19b0d842eaa7e2cbcddfe4e4ec65da6add9c Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:52:29 +0800
-Subject: [PATCH 14/19] Unset all release profile
+Subject: [PATCH 14/20] Unset all release profile
 
 ---
  src-tauri/Cargo.toml | 7 -------

--- a/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
@@ -1,7 +1,7 @@
 From 1d50141cbcd38b747a8511db2675ff9a4c197ef8 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
-Subject: [PATCH 15/19] Do not use gcc
+Subject: [PATCH 15/20] Do not use gcc
 
 ---
  .cargo/config.toml | 5 -----

--- a/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
@@ -1,7 +1,7 @@
 From a7e8b203786f3c90e82e387beb4e9979516e5792 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
-Subject: [PATCH 16/19] Drop "Upgrade core" button
+Subject: [PATCH 16/20] Drop "Upgrade core" button
 
 ---
  .../setting/mods/clash-core-viewer.tsx        | 25 +------------------

--- a/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch.ppc64el
+++ b/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch.ppc64el
@@ -1,7 +1,7 @@
 From fec3b97cd65a7148b0c5976dec76e4c1d7a58ec7 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 12:09:38 +0800
-Subject: [PATCH 17/19] (ppc64el) Use `@rollup/wasm-node` to fix build on
+Subject: [PATCH 17/20] (ppc64el) Use `@rollup/wasm-node` to fix build on
  POWER8
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
@@ -1,7 +1,7 @@
 From deddf317f739580925e7198ef09995420fe42cca Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
-Subject: [PATCH 18/19] Do not sidecar mihomo program
+Subject: [PATCH 18/20] Do not sidecar mihomo program
 
 ---
  src-tauri/src/core/core.rs | 2 +-

--- a/app-network/clash-verge-rev/autobuild/patches/0019-Remove-check-config-step-from-init_config.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0019-Remove-check-config-step-from-init_config.patch
@@ -1,7 +1,7 @@
 From 0e5a11fde3ab531b9529da8c88a983251323a343 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 17 Mar 2025 10:55:23 +0800
-Subject: [PATCH 19/19] Remove check config step from `init_config`
+Subject: [PATCH 19/20] Remove check config step from `init_config`
 
 ---
  src-tauri/src/config/config.rs |  46 +-----

--- a/app-network/clash-verge-rev/autobuild/patches/0020-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0020-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
@@ -1,0 +1,90 @@
+From f1a0b1abd3b1efb981bcc04e2259802b20fdccca Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Tue, 8 Apr 2025 12:32:41 +0800
+Subject: [PATCH 20/20] Fix if mihomo geoip file `src_path` is symlink
+
+---
+ src-tauri/src/utils/init.rs | 32 ++++++++++++++++++--------------
+ 1 file changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/src-tauri/src/utils/init.rs b/src-tauri/src/utils/init.rs
+index 06593572..79f49894 100644
+--- a/src-tauri/src/utils/init.rs
++++ b/src-tauri/src/utils/init.rs
+@@ -13,7 +13,7 @@ use log4rs::{
+ };
+ use std::{
+     fs::{self, DirEntry},
+-    path::PathBuf,
++    path::{Path, PathBuf},
+     str::FromStr,
+ };
+ use tauri_plugin_shell::ShellExt;
+@@ -318,25 +318,20 @@ pub fn init_resources() -> Result<()> {
+     // copy the resource file
+     // if the source file is newer than the destination file, copy it over
+     for file in file_list.iter() {
+-        let src_path = res_dir.join(file);
++        let mut src_path = res_dir.join(file);
+         let dest_path = app_dir.join(file);
+         let test_dest_path = test_dir.join(file);
+         log::debug!(target: "app", "src_path: {src_path:?}, dest_path: {dest_path:?}");
+ 
+-        let handle_copy = |dest: &PathBuf| {
+-            match fs::copy(&src_path, dest) {
+-                Ok(_) => log::debug!(target: "app", "resources copied '{file}'"),
+-                Err(err) => {
+-                    log::error!(target: "app", "failed to copy resources '{file}' to '{dest:?}', {err}")
+-                }
+-            };
+-        };
++        if src_path.is_symlink() {
++            src_path = src_path.read_link()?;
++        }
+ 
+         if src_path.exists() && !test_dest_path.exists() {
+-            handle_copy(&test_dest_path);
++            copy(&src_path, &test_dest_path, &file);
+         }
+         if src_path.exists() && !dest_path.exists() {
+-            handle_copy(&dest_path);
++            copy(&src_path, &dest_path, &file);
+             continue;
+         }
+ 
+@@ -346,14 +341,14 @@ pub fn init_resources() -> Result<()> {
+         match (src_modified, dest_modified) {
+             (Ok(src_modified), Ok(dest_modified)) => {
+                 if src_modified > dest_modified {
+-                    handle_copy(&dest_path);
++                    copy(&src_path, &dest_path, &file);
+                 } else {
+                     log::debug!(target: "app", "skipping resource copy '{file}'");
+                 }
+             }
+             _ => {
+                 log::debug!(target: "app", "failed to get modified '{file}'");
+-                handle_copy(&dest_path);
++                copy(&src_path, &dest_path, &file);
+             }
+         };
+     }
+@@ -361,6 +356,15 @@ pub fn init_resources() -> Result<()> {
+     Ok(())
+ }
+ 
++fn copy(src_path: &Path, dest: &Path, file: &str) {
++    match fs::copy(src_path, dest) {
++        Ok(_) => log::debug!(target: "app", "resources copied '{file}'"),
++        Err(err) => {
++            log::error!(target: "app", "failed to copy resources '{file}' to '{dest:?}', {err}")
++        }
++    };
++}
++
+ /// initialize url scheme
+ #[cfg(target_os = "windows")]
+ pub fn init_scheme() -> Result<()> {
+-- 
+2.49.0
+

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,4 +1,5 @@
 VER=2.2.2
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: fix copt geoip data to home dir

Package(s) Affected
-------------------

- clash-verge-rev: 2.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
