### PR TITLE
lact: disable nvidia in loongarch64 and loongson3 to fix build

### DIFF
--- a/app-admin/lact/autobuild/defines
+++ b/app-admin/lact/autobuild/defines
@@ -4,6 +4,10 @@ PKGDES="Linux AMDGPU Control Application"
 PKGDEP="libdrm hwdata gtk-4"
 BUILDDEP="rustc gtk-4 llvm blueprint-compiler"
 
+# FIXME: no nvidia support yet
+CARGO_AFTER__LOONGSON3="--no-default-features --features lact-gui"
+CARGO_AFTER__LOONGARCH64="--no-default-features --features lact-gui"
+
 USECLANG=1
 
 # FIXME: ld.lld is not yet available for these architectures.

--- a/app-admin/lact/autobuild/patches/0001-chore-lact-daemon-make-nvidia-bindgen-feature-as-opt.patch
+++ b/app-admin/lact/autobuild/patches/0001-chore-lact-daemon-make-nvidia-bindgen-feature-as-opt.patch
@@ -1,0 +1,125 @@
+From c2da885b082a8cee687585d9754bdd4210cfa58f Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Tue, 8 Apr 2025 14:34:39 +0800
+Subject: [PATCH] chore(lact-daemon): make nvidia bindgen feature as optional
+ ...
+
+... to fix loongson3 and loongarch64 architecture build
+---
+ lact-daemon/Cargo.toml                   | 3 ++-
+ lact-daemon/build.rs                     | 4 ++++
+ lact-daemon/src/bindings.rs              | 1 +
+ lact-daemon/src/server/gpu_controller.rs | 8 ++++++++
+ lact/Cargo.toml                          | 5 +++--
+ 5 files changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/lact-daemon/Cargo.toml b/lact-daemon/Cargo.toml
+index 3376286..0b47e88 100644
+--- a/lact-daemon/Cargo.toml
++++ b/lact-daemon/Cargo.toml
+@@ -4,8 +4,9 @@ version = "0.7.3"
+ edition = "2021"
+ 
+ [features]
+-default = []
++default = ["nvidia"]
+ bench = ["dep:divan"]
++nvidia = []
+ 
+ [dependencies]
+ lact-schema = { path = "../lact-schema" }
+diff --git a/lact-daemon/build.rs b/lact-daemon/build.rs
+index 566f12a..f27e6d2 100644
+--- a/lact-daemon/build.rs
++++ b/lact-daemon/build.rs
+@@ -8,7 +8,10 @@ fn main() {
+     println!("cargo::rerun-if-changed=include/");
+ 
+     gen_intel_bindings();
++
++    #[cfg(feature = "nvidia")]
+     gen_nvidia_bindings();
++
+     gen_vulkan_constants();
+ }
+ 
+@@ -26,6 +29,7 @@ fn gen_intel_bindings() {
+         .expect("Couldn't write bindings!");
+ }
+ 
++#[cfg(feature = "nvidia")]
+ fn gen_nvidia_bindings() {
+     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+ 
+diff --git a/lact-daemon/src/bindings.rs b/lact-daemon/src/bindings.rs
+index 758d3be..8171987 100644
+--- a/lact-daemon/src/bindings.rs
++++ b/lact-daemon/src/bindings.rs
+@@ -12,6 +12,7 @@ pub mod intel {
+     include!(concat!(env!("OUT_DIR"), "/intel_bindings.rs"));
+ }
+ 
++#[cfg(feature = "nvidia")]
+ pub mod nvidia {
+     include!(concat!(env!("OUT_DIR"), "/nvidia_bindings.rs"));
+ }
+diff --git a/lact-daemon/src/server/gpu_controller.rs b/lact-daemon/src/server/gpu_controller.rs
+index f9fbb74..14b47c0 100644
+--- a/lact-daemon/src/server/gpu_controller.rs
++++ b/lact-daemon/src/server/gpu_controller.rs
+@@ -2,10 +2,14 @@
+ mod amd;
+ pub mod fan_control;
+ mod intel;
++
++#[cfg(feature = "nvidia")]
+ mod nvidia;
+ 
+ use amd::AmdGpuController;
+ use intel::IntelGpuController;
++
++#[cfg(feature = "nvidia")]
+ use nvidia::NvidiaGpuController;
+ 
+ pub const VENDOR_AMD: &str = "1002";
+@@ -90,6 +94,9 @@ pub(crate) fn init_controller(
+     amd_drm: &LazyCell<Option<LibDrmAmdgpu>>,
+     intel_drm: &LazyCell<Option<Rc<IntelDrm>>>,
+ ) -> anyhow::Result<Box<dyn GpuController>> {
++    #[cfg(not(feature = "nvidia"))]
++    let _ = nvml;
++
+     let uevent_path = path.join("uevent");
+     let uevent = fs::read_to_string(uevent_path).context("Could not read 'uevent'")?;
+     let mut uevent_map = parse_uevent(&uevent);
+@@ -175,6 +182,7 @@ pub(crate) fn init_controller(
+                 error!("Intel DRM library missing, Intel controls will not be available");
+             }
+         }
++        #[cfg(feature = "nvidia")]
+         "nvidia" => {
+             if let Some(nvml) = nvml.as_ref().cloned() {
+                 match NvidiaGpuController::new(common.clone(), nvml) {
+diff --git a/lact/Cargo.toml b/lact/Cargo.toml
+index 227ff3f..2a9c61f 100644
+--- a/lact/Cargo.toml
++++ b/lact/Cargo.toml
+@@ -4,12 +4,13 @@ version = "0.7.3"
+ edition = "2021"
+ 
+ [features]
+-default = ["lact-gui"]
++default = ["lact-gui", "nvidia"]
+ adw = ["lact-gui/adw"]
+ flatpak = ["dep:configparser"]
++nvidia = ["lact-daemon/nvidia"]
+ 
+ [dependencies]
+-lact-daemon = { path = "../lact-daemon" }
++lact-daemon = { path = "../lact-daemon", default-features = false }
+ lact-schema = { path = "../lact-schema", features = ["args"] }
+ lact-cli = { path = "../lact-cli" }
+ lact-gui = { path = "../lact-gui", optional = true }
+-- 
+2.49.0
+

--- a/app-admin/lact/spec
+++ b/app-admin/lact/spec
@@ -1,4 +1,5 @@
 VER=0.7.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ilya-zlobintsev/LACT"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372202"


### PR DESCRIPTION
Topic Description
-----------------

- lact: disable nvidia in loongarch64 and loongson3 to fix build

Package(s) Affected
-------------------

- lact: 0.7.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lact
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
