### PR TITLE
breeze-icons: rework to fix telegram-desktop icon

### DIFF
--- a/desktop-kde/breeze-icons/autobuild/patches/0003-remove-org.telegram.desktop.svg-symlink.patch
+++ b/desktop-kde/breeze-icons/autobuild/patches/0003-remove-org.telegram.desktop.svg-symlink.patch
@@ -1,0 +1,21 @@
+From f631a90eb4cce158c348af9870408a53df5cc3dd Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Tue, 8 Apr 2025 15:33:46 +0800
+Subject: [PATCH] remove org.telegram.desktop.svg symlink
+
+---
+ icons/status/22/org.telegram.desktop.svg | 1 -
+ 1 file changed, 1 deletion(-)
+ delete mode 120000 icons/status/22/org.telegram.desktop.svg
+
+diff --git a/icons/status/22/org.telegram.desktop.svg b/icons/status/22/org.telegram.desktop.svg
+deleted file mode 120000
+index 494fd29..0000000
+--- a/icons/status/22/org.telegram.desktop.svg
++++ /dev/null
+@@ -1 +0,0 @@
+-telegram-panel.svg
+\ No newline at end of file
+-- 
+2.49.0
+

--- a/desktop-kde/breeze-icons/spec
+++ b/desktop-kde/breeze-icons/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/breeze-icons-$VER.tar.xz"
 CHKSUMS="sha256::c4fc87a0ea961dc849e1feac97b3c53ce0af79df76a9dd508eb4ba5a006f09b9"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- breeze-icons: rework to fix telegram-desktop icon

Package(s) Affected
-------------------

- breeze-icons: 5.115.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit breeze-icons
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
