### PR TITLE
niri: new, 25.02

### DIFF
--- a/desktop-wm/niri/autobuild/beyond
+++ b/desktop-wm/niri/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing niri resources"
+install -Dvm755 resources/niri-session -t "${PKGDIR}"/usr/bin/
+install -Dvm644 resources/niri.desktop -t "${PKGDIR}"/usr/share/wayland-sessions/
+install -Dvm644 resources/niri-portals.conf -t "${PKGDIR}"/usr/share/xdg-desktop-portal/
+install -Dvm644 resources/niri.service -t "${PKGDIR}"/usr/lib/systemd/user/
+install -Dvm644 resources/niri-shutdown.target -t "${PKGDIR}"/usr/lib/systemd/user/
+install -Dvm644 resources/default-config.kdl -t "${PKGDIR}"/usr/share/doc/niri/

--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=niri
+PKGSEC=x11
+PKGDEP="bash cairo gcc-runtime glib glibc gnome-keyring libdisplay-info \
+        libinput libxkbcommon mesa pango pipewire pixman seatd systemd \
+        wayland xdg-desktop-portal-gtk"
+PKGRECOM="alacritty xdg-desktop-portal-gnome xwayland-satellite"
+BUILDDEP="rustc llvm"
+PKGDES="A scrollable-tiling Wayland compositor"
+USECLANG=1
+
+# FIXME: ld.lld is not yet available for loongson3.
+# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
+# recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/desktop-wm/niri/autobuild/patches/0001-use-gtk-portal-for-file-chooser.patch
+++ b/desktop-wm/niri/autobuild/patches/0001-use-gtk-portal-for-file-chooser.patch
@@ -1,0 +1,20 @@
+From 3beb66b96f89396316ed2ee08efe16c13abccbed Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=93=BA=E7=9B=96=E5=B4=BD?= <i@pugai.life>
+Date: Tue, 8 Apr 2025 09:00:44 +0800
+Subject: [PATCH] use gtk portal for file chooser dialogues
+
+---
+ resources/niri-portals.conf | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/resources/niri-portals.conf b/resources/niri-portals.conf
+index 3f13d669a..a79c5aa58 100644
+--- a/resources/niri-portals.conf
++++ b/resources/niri-portals.conf
+@@ -1,5 +1,6 @@
+ [preferred]
+ default=gnome;gtk;
+ org.freedesktop.impl.portal.Access=gtk;
++org.freedesktop.impl.portal.FileChooser=gtk;
+ org.freedesktop.impl.portal.Notification=gtk;
+ org.freedesktop.impl.portal.Secret=gnome-keyring;

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,0 +1,4 @@
+VER=25.02
+SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372826"

--- a/runtime-display/xwayland-satellite/autobuild/beyond
+++ b/runtime-display/xwayland-satellite/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Installing xwayland-satellite systemd service ..."
+install -Dvm644 resources/xwayland-satellite.service -t "${PKGDIR}"/usr/lib/systemd/user/

--- a/runtime-display/xwayland-satellite/autobuild/defines
+++ b/runtime-display/xwayland-satellite/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=xwayland-satellite
+PKGSEC=x11
+PKGDEP="systemd gcc-runtime glibc libxcb xcb-util-cursor xwayland"
+BUILDDEP="rustc llvm"
+PKGDES="Rootless Xwayland integration for compositors supporting xdg_wm_base"
+USECLANG=1
+CARGO_AFTER="--features systemd"
+
+# FIXME: ld.lld is not yet available for loongson3.
+# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
+# recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/runtime-display/xwayland-satellite/autobuild/patches/0001-fix-exec-path.patch
+++ b/runtime-display/xwayland-satellite/autobuild/patches/0001-fix-exec-path.patch
@@ -1,0 +1,22 @@
+From 59b09307d4e1657792f4a5690f045603cd89b077 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=93=BA=E7=9B=96=E5=B4=BD?= <i@pugai.life>
+Date: Tue, 8 Apr 2025 09:42:08 +0800
+Subject: [PATCH] fix-exec-path
+
+---
+ resources/xwayland-satellite.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/resources/xwayland-satellite.service b/resources/xwayland-satellite.service
+index 060ab6b..f68cefd 100644
+--- a/resources/xwayland-satellite.service
++++ b/resources/xwayland-satellite.service
+@@ -8,7 +8,7 @@ Requisite=graphical-session.target
+ [Service]
+ Type=notify
+ NotifyAccess=all
+-ExecStart=/usr/local/bin/xwayland-satellite
++ExecStart=/usr/bin/xwayland-satellite
+ StandardOutput=journal
+ 
+ [Install]

--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,0 +1,4 @@
+VER=0.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377600"


### PR DESCRIPTION
Topic Description
-----------------

- niri: new, 25.02
- xwayland-satellite: new, 0.5.1

Package(s) Affected
-------------------

- niri: 25.02
- xwayland-satellite: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
