### PR TITLE
ostree: move ostree.conf to /usr/lib/dracut/dracut.conf.d/

### DIFF
--- a/app-admin/ostree/autobuild/beyond
+++ b/app-admin/ostree/autobuild/beyond
@@ -1,1 +1,1 @@
-rm -r "$PKGDIR"/etc/grub.d
+rm -r "$PKGDIR"/usr/lib/dracut/grub.d

--- a/app-admin/ostree/autobuild/defines
+++ b/app-admin/ostree/autobuild/defines
@@ -34,6 +34,7 @@ AUTOTOOLS_AFTER="--with-grub2-mkconfig-path=/usr/bin/grub-mkconfig \
                  --with-libsystemd \
                  --with-builtin-grub2-mkconfig=no \
                  --with-grub2-mkconfig-path \
-                 --without-static-compiler"
+                 --without-static-compiler \
+                 --sysconfdir=/usr/lib/dracut"
 
 ABSHADOW=0

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,5 @@
 VER=2025.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ostreedev/ostree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: move ostree.conf to /usr/lib/dracut/dracut.conf.d/
    - ostree.conf is not a configuration file

Package(s) Affected
-------------------

- ostree: 2025.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
