### PR TITLE
ostree: move ostree.conf to /usr/lib/dracut/dracut.conf.d/

### DIFF
--- a/app-admin/ostree/autobuild/beyond
+++ b/app-admin/ostree/autobuild/beyond
@@ -1,1 +1,2 @@
-rm -r "$PKGDIR"/etc/grub.d
+abinfo "Moving /etc/dracut.conf.d => /usr/lib/dracut/dracut.conf.d ..."
+mv -v "$PKGDIR"/{etc,usr/lib/dracut}/dracut.conf.d

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,5 @@
 VER=2025.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ostreedev/ostree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: move ostree.conf to /usr/lib/dracut
    - Restore /etc/grub.d
    - Add empty conffiles
    - move ostree.conf to /usr/lib/dracut

Package(s) Affected
-------------------

- ostree: 2025.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
