### PR TITLE
picard: update to 2.13.3

### DIFF
--- a/app-multimedia/picard/spec
+++ b/app-multimedia/picard/spec
@@ -1,4 +1,4 @@
-VER=2.12.3
+VER=2.13.3
 SRCS="git::commit=tags/release-$VER::https://github.com/metabrainz/picard"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3633"


### PR DESCRIPTION
Topic Description
-----------------

- picard: update to 2.13.3
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- picard: 2.13.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit picard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
