### PR TITLE
gitoxide: update to 0.42.0

### DIFF
--- a/app-vcs/gitoxide/spec
+++ b/app-vcs/gitoxide/spec
@@ -1,4 +1,4 @@
-VER=0.41.0
+VER=0.42.0
 SRCS="git::commit=tags/v$VER::https://github.com/GitoxideLabs/gitoxide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236380"


### PR DESCRIPTION
Topic Description
-----------------

- gitoxide: update to 0.42.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- gitoxide: 0.42.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitoxide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
