### PR TITLE
hdf5: fix path of HDF5_INSTALL_CMAKE_DIR

### DIFF
--- a/runtime-scientific/hdf5/autobuild/defines
+++ b/runtime-scientific/hdf5/autobuild/defines
@@ -8,7 +8,7 @@ CMAKE_AFTER=(
     '-DHDF5_BUILD_HL_LIB=ON'
     '-DBUILD_STATIC_LIBS=ON'
     '-DHDF5_INSTALL_DATA_DIR=share/doc/hdf5'
-    '-DHDF5_INSTALL_CMAKE_DIR=lib/cmake'
+    '-DHDF5_INSTALL_CMAKE_DIR=lib/cmake/hdf5'
 )
 
 PKGBREAK="alembic<=1.8.6 cgns<=4.2.0 flann<=1.9.2 gdal<=3.10.1-2 \

--- a/runtime-scientific/hdf5/spec
+++ b/runtime-scientific/hdf5/spec
@@ -1,5 +1,5 @@
 VER=1.14.6
-REL=1
+REL=2
 SRCS="git::commit=tags/hdf5_$VER::https://github.com/HDFGroup/hdf5"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1303"


### PR DESCRIPTION
Topic Description
-----------------

- hdf5: fix path of HDF5_INSTALL_CMAKE_DIR
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- hdf5: 1.14.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hdf5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
