### PR TITLE
openmpt: update to 0.7.13

### DIFF
--- a/app-multimedia/audacious/spec
+++ b/app-multimedia/audacious/spec
@@ -1,4 +1,5 @@
 VER=4.4.2
+REL=1
 SRCS="tbl::https://distfiles.audacious-media-player.org/audacious-$VER.tar.bz2 \
       git::rename=audacious-plugins-$VER;commit=tags/audacious-plugins-$VER::https://github.com/audacious-media-player/audacious-plugins"
 CHKSUMS="sha256::34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,5 @@
 VER=0.24.2
+REL=1
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
 CHKSUMS="sha256::d69251fdd15bbd8fbcd1c486dd4dc6a4e008e045975b2408cb2f37461c10f1e4"
 CHKUPDATE="anitya::id=14864"

--- a/app-multimedia/openmpt/autobuild/defines
+++ b/app-multimedia/openmpt/autobuild/defines
@@ -12,4 +12,5 @@ PKGDES="A multi-format tracker music player"
 #
 # Declaring AB_FLAGS_O3=1 to keep in sync with the OPTIMIZE= flag.
 AB_FLAGS_O3=1
-FAIL_ARCH="((loongson3))"
+
+PKGBREAK="audacious<=4.4.2 gstreamer<=1.24.12-1 mpd<=0.24.2"

--- a/app-multimedia/openmpt/spec
+++ b/app-multimedia/openmpt/spec
@@ -1,5 +1,4 @@
-VER=0.6.4
-REL=1
+VER=0.7.13
 SRCS="git::commit=tags/libopenmpt-$VER::https://github.com/OpenMPT/openmpt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=275563"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: bump REL due to openmpt update to 0.7.13
- audacious: bump REL due to openmpt update to 0.7.13
- openmpt: update to 0.7.13
    - Now support for loongson3

Package(s) Affected
-------------------

- audacious: 4.4.2-1
- mpd: 0.24.2-1
- openmpt: 0.7.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit openmpt:-pkgbreak audacious mpd openmpt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
