### PR TITLE
openssh: update to 10.0p1

### DIFF
--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,4 +1,4 @@
-VER=9.9p2
+VER=10.0p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673"
+CHKSUMS="sha256::021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
 CHKUPDATE="anitya::id=2565"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update to 10.0p1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openssh: 10.0p1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
