### PR TITLE
nanobind: new, 2.6.1

### DIFF
--- a/lang-python/nanobind/autobuild/defines
+++ b/lang-python/nanobind/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="nanobind"
+PKGSEC="python"
+PKGDEP="python-3 typing-extensions exceptiongroup robin-map"
+BUILDDEP="scikit-build-core setuptools"
+PKGDES="Binding library that exposes C++ types in Python and vice versa"
+
+ABTYPE=pep517
+
+ABHOST=noarch

--- a/lang-python/nanobind/spec
+++ b/lang-python/nanobind/spec
@@ -1,0 +1,4 @@
+VER=2.6.1
+SRCS="git::commit=tags/v$VER::https://github.com/wjakob/nanobind"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=297734"

--- a/lang-python/packaging/autobuild/defines
+++ b/lang-python/packaging/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=packaging
 PKGSEC=python
 PKGDEP="python-3 pyparsing"
-BUILDDEP="python-build python-installer"
+BUILDDEP="python-build python-installer flit-core"
 PKGDES="Core utilities for Python packaging"
 
+ABTYPE=pep517
 ABHOST=noarch
-NOPYTHON2=1

--- a/lang-python/packaging/spec
+++ b/lang-python/packaging/spec
@@ -1,4 +1,4 @@
-VER=23.0
-SRCS="tbl::https://github.com/pypa/packaging/archive/$VER.tar.gz"
-CHKSUMS="sha256::698f2c072c89a5eb7d9560b64401d52b2d5eaca412bc53f9bddfef214dca71aa"
+VER=24.2
+SRCS="git::commit=tags/${VER}::https://github.com/pypa/packaging"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11718"

--- a/lang-python/scikit-build-core/autobuild/defines
+++ b/lang-python/scikit-build-core/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=scikit-build-core
+PKGSEC=python
+PKGDEP="distro packaging tomli typing-extensions wheel hatchling hatch-vcs hatch-fancy-pypi-readme"
+BUILDDEP="python-build packaging python-installer setuptools-scm"
+PKGDES="Build backend for Python that uses CMake to build extension modules"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/scikit-build-core/spec
+++ b/lang-python/scikit-build-core/spec
@@ -1,0 +1,4 @@
+VER=0.11.1
+SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/scikit-build/scikit-build-core"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=302380"

--- a/lang-python/scikit-build/autobuild/defines
+++ b/lang-python/scikit-build/autobuild/defines
@@ -4,6 +4,5 @@ PKGSEC=python
 PKGDEP="distro packaging tomli typing-extensions wheel hatchling hatch-vcs hatch-fancy-pypi-readme"
 BUILDDEP="python-build packaging python-installer setuptools-scm"
 
-NOPYTHON2=1
+ABTYPE=pep517
 ABHOST=noarch
-ABSPLITDBG=0

--- a/lang-python/scikit-build/spec
+++ b/lang-python/scikit-build/spec
@@ -1,4 +1,4 @@
-VER=0.18.0
+VER=0.18.1
 SRCS="git::copy-repo=true;commit=tags/${VER}::https://github.com/scikit-build/scikit-build.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=97753"

--- a/runtime-games/robin-map/autobuild/defines
+++ b/runtime-games/robin-map/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME="robin-map"
+PKGSEC="libs"
+PKGDES="Header-only C++ hashmap/set library"
+ABHOST=noarch

--- a/runtime-games/robin-map/spec
+++ b/runtime-games/robin-map/spec
@@ -1,0 +1,4 @@
+VER=1.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/Tessil/robin-map"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=18602"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
nanobind 是一个小型C++/Python 绑定库

<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- robin-map: new,1.4.0
- packaging: update to 24.2
- scikit-build: update to 0.18.1
- scikit-build-core: new,0.11.1
- nanobind: new,2.6.1
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
NO
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->



Build Order
-----------


<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->


```
#buildit robin-map packaging scikit-build scikit-build-core nanobind 
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [x] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
