### PR TITLE
libjxl: rebuild rework

### DIFF
--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,5 @@
 VER=5.0.1
-REL=1
+REL=2
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,5 @@
 VER=2.10.38
-REL=2
+REL=3
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:4}/gimp-$VER.tar.bz2"
 CHKSUMS="sha256::50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e"
 CHKUPDATE="anitya::id=1161"

--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,5 +1,5 @@
 VER=5.2.9
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/krita/${VER:0:5}/krita-$VER.tar.xz"
 CHKSUMS="sha256::f74e710e6d93ddd593fa0b249a64006ed4121a64ce7f95ac29aaa332a7e6e53e"
 CHKUPDATE="anitya::id=10918"

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,5 +1,5 @@
 VER=4.5.0
-REL=5
+REL=6
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"

--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,5 +1,5 @@
 VER=1.14.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17542"

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,5 +1,5 @@
 VER=1.1.4
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369437"

--- a/desktop-kde/kimageformats/spec
+++ b/desktop-kde/kimageformats/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/kimageformats-$VER.tar.xz"
 CHKSUMS="sha256::9f61020d66f86b8b10bce14e42a39c5e8fd8e40ec9e6ca8b9e9b5ce3e1aa7283"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,5 @@
 VER=3.10.1
-REL=6
+REL=7
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
 CHKSUMS="sha256::9211eac72b53f5f85d23cf6d83ee20245c6d818733405024e71f2af41e5c5f91"
 CHKUPDATE="anitya::id=881"

--- a/runtime-imaging/libjxl/autobuild/defines
+++ b/runtime-imaging/libjxl/autobuild/defines
@@ -25,6 +25,6 @@ CMAKE_AFTER=(
     "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
 )
 
-PKGBREAK="chafa<=1.14.5 darktable<=1:5.0.1 gimp<=2.10.38-1 glycin<=1.1.4 \
-          imv<=4.5.0-4 kimageformats<=5.115.0-1 krita<=5.2.9 libvips<=8.16.1 \
-          webkit2gtk<=1:2.44.2-3"
+PKGBREAK="chafa<=1.14.5-1 darktable<=1:5.0.1-1 gdal<=3.10.1-6 gimp<=2.10.38-2 \
+          glycin<=1.1.4-1 imv<=4.5.0-5 kimageformats<=5.115.0-2 \
+          krita<=5.2.9-1 libvips<=8.16.1-1 webkit2gtk<=1:2.44.2-4"

--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,4 +1,5 @@
 VER=0.11.1
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,5 @@
 VER=8.16.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -4,4 +4,4 @@ CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=4
+REL=5


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: bump REL due to libjxl update to 0.11.1-1
- libvips: bump REL due to libjxl update to 0.11.1-1
- krita: bump REL due to libjxl update to 0.11.1-1
- kimageformats: bump REL due to libjxl update to 0.11.1-1
- imv: bump REL due to libjxl update to 0.11.1-1
- glycin: bump REL due to libjxl update to 0.11.1-1
- gimp: bump REL due to libjxl update to 0.11.1-1
- gdal: bump REL due to libjxl update to 0.11.1-1
- darktable: bump REL due to libjxl update to 0.11.1-1
- chafa: bump REL due to libjxl update to 0.11.1-1

... and 1 more commits

Package(s) Affected
-------------------

- chafa: 1.14.5-2
- darktable: 1:5.0.1-2
- gdal: 3.10.1-7
- gimp: 2.10.38-3
- glycin: 1.1.4-2
- imv: 4.5.0-6
- kimageformats: 5.115.0-3
- krita: 5.2.9-2
- libjxl: 0.11.1-1
- libvips: 8.16.1-2
- webkit2gtk: 1:2.44.2-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjxl:-pkgbreak gimp chafa darktable gdal glycin imv kimageformats krita libvips webkit2gtk libjxl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
