### PR TITLE
niri: adjust dependencies

### DIFF
--- a/desktop-wm/niri/autobuild/beyond
+++ b/desktop-wm/niri/autobuild/beyond
@@ -1,7 +1,7 @@
 abinfo "Installing niri resources"
-install -Dvm755 resources/niri-session -t "${PKGDIR}"/usr/bin/
-install -Dvm644 resources/niri.desktop -t "${PKGDIR}"/usr/share/wayland-sessions/
-install -Dvm644 resources/niri-portals.conf -t "${PKGDIR}"/usr/share/xdg-desktop-portal/
-install -Dvm644 resources/niri.service -t "${PKGDIR}"/usr/lib/systemd/user/
-install -Dvm644 resources/niri-shutdown.target -t "${PKGDIR}"/usr/lib/systemd/user/
-install -Dvm644 resources/default-config.kdl -t "${PKGDIR}"/usr/share/doc/niri/
+install -Dvm755 "${SRCDIR}"/resources/niri-session -t "${PKGDIR}"/usr/bin/
+install -Dvm644 "${SRCDIR}"/resources/niri.desktop -t "${PKGDIR}"/usr/share/wayland-sessions/
+install -Dvm644 "${SRCDIR}"/resources/niri-portals.conf -t "${PKGDIR}"/usr/share/xdg-desktop-portal/
+install -Dvm644 "${SRCDIR}"/resources/niri.service -t "${PKGDIR}"/usr/lib/systemd/user/
+install -Dvm644 "${SRCDIR}"/resources/niri-shutdown.target -t "${PKGDIR}"/usr/lib/systemd/user/
+install -Dvm644 "${SRCDIR}"/resources/default-config.kdl -t "${PKGDIR}"/usr/share/doc/niri/

--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -2,11 +2,13 @@ PKGNAME=niri
 PKGSEC=x11
 PKGDEP="bash cairo gcc-runtime glib glibc gnome-keyring libdisplay-info \
         libinput libxkbcommon mesa pango pipewire pixman seatd systemd \
-        wayland xdg-desktop-portal-gtk"
-PKGRECOM="alacritty xdg-desktop-portal-gnome xwayland-satellite"
+        wayland xdg-desktop-portal-gtk xdg-desktop-portal-gnome"
+PKGRECOM="alacritty fuzzel swaylock xwayland-satellite"
+PKGSUG="mako swaybg swayidle"
 BUILDDEP="rustc llvm"
-PKGDES="A scrollable-tiling Wayland compositor"
+PKGDES="Scrollable-tiling Wayland compositor"
 USECLANG=1
+ABTYPE=rust
 
 # FIXME: ld.lld is not yet available for loongson3.
 # ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -2,3 +2,4 @@ VER=25.02
 SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"
+REL=1

--- a/runtime-display/xwayland-satellite/autobuild/beyond
+++ b/runtime-display/xwayland-satellite/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Installing xwayland-satellite systemd service ..."
-install -Dvm644 resources/xwayland-satellite.service -t "${PKGDIR}"/usr/lib/systemd/user/
+install -Dvm644 "${SRCDIR}"/resources/xwayland-satellite.service -t "${PKGDIR}"/usr/lib/systemd/user/

--- a/runtime-display/xwayland-satellite/autobuild/defines
+++ b/runtime-display/xwayland-satellite/autobuild/defines
@@ -5,6 +5,7 @@ BUILDDEP="rustc llvm"
 PKGDES="Rootless Xwayland integration for compositors supporting xdg_wm_base"
 USECLANG=1
 CARGO_AFTER="--features systemd"
+ABTYPE=rust
 
 # FIXME: ld.lld is not yet available for loongson3.
 # ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 

--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -2,3 +2,4 @@ VER=0.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: use absolute path when installing
- niri: adjust dependencies

Package(s) Affected
-------------------

- niri: 25.02-1
- xwayland-satellite: 0.5.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
