### PR TITLE
coreutils: update to 9.7

### DIFF
--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,4 +1,4 @@
-VER=9.6
+VER=9.7
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
-CHKSUMS="sha256::7a0124327b398fd9eb1a6abde583389821422c744ffa10734b24f557610d3283"
+CHKSUMS="sha256::e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf"
 CHKUPDATE="anitya::id=343"


### PR DESCRIPTION
Topic Description
-----------------

- coreutils: update to 9.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreutils: 9.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
