### PR TITLE
kose-font: update to 3.120

### DIFF
--- a/desktop-fonts/kose-font/spec
+++ b/desktop-fonts/kose-font/spec
@@ -1,8 +1,8 @@
-VER=3.113
+VER=3.120
 SRCS="git::commit=tags/v$VER::https://github.com/lxgw/kose-font \
       file::rename=XiaolaiMonoSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiMonoSC-Regular.ttf \
       file::rename=XiaolaiSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiSC-Regular.ttf"
 CHKSUMS="SKIP \
-         sha256::95ecac13c3f8c69e3e80fa73864102f13730b5fd87e7438c23b96766ef458e41 \
-         sha256::b04eec580794279f6178644f6d7af090bd9bcbd3fb3b6873f3c714e21fa514fb"
+         sha256::a1e0bbdf369bd8a49d02d95ef2fba9f7d75ea5b685e662a2513be566da96b2f3 \
+         sha256::65e0c689eb0aff0782cc5a2adba97127bf2843fc302bfbc92e3cdf21ed20207f"
 CHKUPDATE="anitya::id=374941"


### PR DESCRIPTION
Topic Description
-----------------

- kose-font: update to 3.120
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- kose-font: 3.120
- xiaolai-font: 3.120

Security Update?
----------------

No

Build Order
-----------

```
#buildit kose-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
