### PR TITLE
gzip: update to 1.14

### DIFF
--- a/app-utils/gzip/spec
+++ b/app-utils/gzip/spec
@@ -1,5 +1,4 @@
-VER=1.13
+VER=1.14
 SRCS="tbl::https://ftp.gnu.org/gnu/gzip/gzip-$VER.tar.xz"
-CHKSUMS="sha256::7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057"
+CHKSUMS="sha256::01a7b881bd220bfdf615f97b8718f80bdfd3f6add385b993dcf6efd14e8c0ac6"
 CHKUPDATE="anitya::id=1290"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gzip: update to 1.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gzip: 1:1.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit gzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
