### PR TITLE
grep: update to 3.12

### DIFF
--- a/app-utils/grep/autobuild/defines
+++ b/app-utils/grep/autobuild/defines
@@ -4,6 +4,21 @@ PKGDES="A pattern-based string searcher"
 PKGDEP="glibc libsigsegv pcre2"
 BUILDDEP="texinfo gperf"
 
+# FIXME: Possibly mis-packaged gnulib.
+#
+# configure:9031: error: possibly undefined macro: gl_ANYTHREADLIB_EARLY
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+# configure:17568: error: possibly undefined macro: gl_PTHREADLIB
+# configure:17681: error: possibly undefined macro: gl_WEAK_SYMBOLS
+# configure:19621: error: possibly undefined macro: gl_TYPE_WINT_T_PREREQ
+#
+# Similar issues linked below.
+#
+# Link: https://www.openembedded.org/pipermail/openembedded-commits/2017-July/209707.html
+# Link: https://lists.nongnu.org/archive/html/nano-devel/2024-05/msg00012.html
+RECONF=0
+
 AUTOTOOLS_AFTER="--enable-largefile \
                  --enable-year2038 \
                  --enable-threads=posix \

--- a/app-utils/grep/spec
+++ b/app-utils/grep/spec
@@ -1,5 +1,4 @@
-VER=3.11
+VER=3.12
 SRCS="https://ftp.gnu.org/gnu/grep/grep-$VER.tar.xz"
-CHKSUMS="sha256::1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab"
+CHKSUMS="sha256::2649b27c0e90e632eadcd757be06c6e9a4f48d941de51e7c0f83ff76408a07b9"
 CHKUPDATE="anitya::id=1251"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- grep: update to 3.12
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- grep: 3.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
