### PR TITLE
qtcreator: update to 16.0.0

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,4 +1,4 @@
-VER=15.0.1
+VER=16.0.0
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::743bad5bbe35ed7f5009f7ce161f1da2f26c17bb5131473e061ce65b3a7ae093"
+CHKSUMS="sha256::18b4353e68a31c062713008c05ce7f7ee88aaaf56d5ac0c6de579babfb2837da"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 16.0.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qtcreator: 16.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
