### PR TITLE
llvm: add alternatives for CMake modules and headers

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -13,6 +13,13 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
             >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
+    BIN="$(basename $i)"
+    printf " --slave /usr/lib/cmake/$BIN ${BIN}-cmake /usr/lib/llvm%s/lib/cmake/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
     OMP_LIB="$(basename $i)"
     printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \

--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -39,7 +39,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -20,6 +20,16 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
         >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/include/*; do
+    ! [[ "$i" =~ .*unwind.* ]] || continue
+    ! [[ "$i" =~ .*clc ]] || continue
+    ! [[ "$i" =~ .*c\+\+ ]] || continue
+    BIN="$(basename $i)"
+    printf " --slave /usr/include/$BIN ${BIN}-include /usr/lib/llvm%s/include/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
     OMP_LIB="$(basename $i)"
     printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=6
+REL=7
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -13,6 +13,13 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
             >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
+    BIN="$(basename $i)"
+    printf " --slave /usr/lib/cmake/$BIN ${BIN}-cmake /usr/lib/llvm%s/lib/cmake/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
     OMP_LIB="$(basename $i)"
     printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -39,7 +39,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -20,6 +20,16 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
         >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/include/*; do
+    ! [[ "$i" =~ .*unwind.* ]] || continue
+    ! [[ "$i" =~ .*clc ]] || continue
+    ! [[ "$i" =~ .*c\+\+ ]] || continue
+    BIN="$(basename $i)"
+    printf " --slave /usr/include/$BIN ${BIN}-include /usr/lib/llvm%s/include/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
     OMP_LIB="$(basename $i)"
     printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,5 +1,5 @@
 VER=19.1.6
-REL=3
+REL=4
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"

--- a/app-devel/llvm-20/02-compiler/beyond
+++ b/app-devel/llvm-20/02-compiler/beyond
@@ -39,7 +39,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-20/02-compiler/beyond
+++ b/app-devel/llvm-20/02-compiler/beyond
@@ -20,6 +20,16 @@ for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
         >> "$SRCDIR/autobuild/postinst"
 done
 
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/include/*; do
+    ! [[ "$i" =~ .*unwind.* ]] || continue
+    ! [[ "$i" =~ .*clc ]] || continue
+    ! [[ "$i" =~ .*c\+\+ ]] || continue
+    BIN="$(basename $i)"
+    printf " --slave /usr/include/$BIN ${BIN}-include /usr/lib/llvm%s/include/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
     OMP_LIB="$(basename $i)"
     printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,5 +1,5 @@
 VER=20.1.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::f0a4a240aabc9b056142d14d5478bb6d962aeac549cbd75b809f5499240a8b38"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-20: add alternatives for headers
- llvm-19: add alternatives for headers
- llvm-18: add alternatives for headers
- llvm-19: add alternatives for cmake modules
- llvm-18: add alternatives for cmake modules

Package(s) Affected
-------------------

- libffi: 3.4.8
- llvm-18: 18.1.8-7
- llvm-19: 19.1.6-4
- llvm-20: 20.1.2-2
- llvm-runtime-18: 18.1.8-7
- llvm-runtime-19: 19.1.6-4
- llvm-runtime-20: 20.1.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libffi llvm-18 llvm-19 llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
