### PR TITLE
mihomo-party: add loongarch64 support

### DIFF
--- a/app-network/mihomo-party/autobuild/build
+++ b/app-network/mihomo-party/autobuild/build
@@ -1,5 +1,20 @@
 abinfo "Fetching dependencies and prepare ..."
-pnpm install
+if ab_match_arch amd64; then
+    pnpm remove @mihomo-party/sysproxy-darwin-arm64 
+    pnpm install
+elif ab_match_arch arm64; then
+    pnpm remove @mihomo-party/sysproxy-darwin-arm64 
+    pnpm install
+elif ab_match_arch loongarch64; then
+    export ELECTRON_MIRROR="https://github.com/darkyzhou/electron-loong64/releases/download/"
+    export electron_use_remote_checksums=1
+    # Note: mihomo-party specified Electron v34.0.2 in package.json, but loongarch64 ABI2.0 doesn't have this version, so I chose a version similar to Electron v34.0.2.
+    pnpm install electron@34.2.0 @darkyzhou-powered/electron-builder@25.1.8 -D
+    pnpm install @mihomo-party-loongarch64/sysproxy
+    pnpm remove electron-builder @mihomo-party/sysproxy @mihomo-party/sysproxy-darwin-arm64
+    pnpm install
+fi
+
 
 abinfo "Building Mihomo-Party ..."
 pnpm build:linux --dir

--- a/app-network/mihomo-party/autobuild/defines
+++ b/app-network/mihomo-party/autobuild/defines
@@ -5,4 +5,4 @@ BUILDDEP="nodejs"
 PKGDES="Graphical interface for managing Mihomo subscriptions, profiles, and settings"
 
 # FIXME: Electron is only (officially) supported on amd64, arm64.
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
+++ b/app-network/mihomo-party/autobuild/patches/0001-Keep-old-productName-on-linux.patch
@@ -1,7 +1,7 @@
 From d529e94a3e88a624b8ac313bfc15fa71d8ef9457 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 24 Nov 2024 17:58:46 +0800
-Subject: [PATCH 1/6] Keep old productName on linux
+Subject: [PATCH 1/7] Keep old productName on linux
 
 ---
  electron-builder.yml | 2 +-
@@ -19,5 +19,5 @@ index 0e136c0..d1fa1b5 100644
    buildResources: build
  files:
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0002-Drop-clash-meta-alpha-support.patch
+++ b/app-network/mihomo-party/autobuild/patches/0002-Drop-clash-meta-alpha-support.patch
@@ -1,7 +1,7 @@
 From 2ae8d184d5e191604c76c64920c6c2c188e2a10a Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:01:33 +0800
-Subject: [PATCH 2/6] Drop clash-meta-alpha support
+Subject: [PATCH 2/7] Drop clash-meta-alpha support
 
 ---
  src/renderer/src/pages/mihomo.tsx | 4 +---
@@ -35,5 +35,5 @@ index 3435e03..613bf0d 100644
            </SettingItem>
            <SettingItem title={t('mihomo.mixedPort')} divider>
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0003-Remove-upgrade-mihomo-UI.patch
+++ b/app-network/mihomo-party/autobuild/patches/0003-Remove-upgrade-mihomo-UI.patch
@@ -1,7 +1,7 @@
 From e0182c0a9c11796db8c1d0773a3306df8f14a3ba Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:04:04 +0800
-Subject: [PATCH 3/6] Remove upgrade mihomo UI
+Subject: [PATCH 3/7] Remove upgrade mihomo UI
 
 ---
  src/renderer/src/pages/mihomo.tsx | 33 -------------------------------
@@ -52,5 +52,5 @@ index 613bf0d..d128eeb 100644
            >
              <Select
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0004-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
+++ b/app-network/mihomo-party/autobuild/patches/0004-Do-not-fetch-Mihomo-Clash-Meta-binaries.patch
@@ -1,7 +1,7 @@
 From 5ff890cbf4edf04899df70fab1f16fff1d8e01b5 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:10:02 +0800
-Subject: [PATCH 4/6] Do not fetch Mihomo (Clash Meta) binaries We use a system
+Subject: [PATCH 4/7] Do not fetch Mihomo (Clash Meta) binaries We use a system
  copy for this purpose.
 
 ---
@@ -30,5 +30,5 @@ index e159b8d..7351460 100644
    { name: 'metadb', func: resolveMetadb, retry: 5 },
    { name: 'geosite', func: resolveGeosite, retry: 5 },
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0005-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
+++ b/app-network/mihomo-party/autobuild/patches/0005-Do-not-find-Mihomo-Clash-Meta-binary-in-sidecar-dir.patch
@@ -1,7 +1,7 @@
 From 94b63cf75c0f2414ef7245458f8d5c96c4384152 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Tue, 17 Dec 2024 00:54:50 +0800
-Subject: [PATCH 5/6] Do not find Mihomo(Clash Meta) binary in sidecar dir
+Subject: [PATCH 5/7] Do not find Mihomo(Clash Meta) binary in sidecar dir
 
 ---
  src/main/utils/dirs.ts | 3 ++-
@@ -22,5 +22,5 @@ index 0ea3566..8ba99d4 100644
  
  export function mihomoCorePath(core: string): string {
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0006-Remove-check-update-feature.patch
+++ b/app-network/mihomo-party/autobuild/patches/0006-Remove-check-update-feature.patch
@@ -1,7 +1,7 @@
 From 93cf61662b1778206e2f7c4374075cd2e72280ff Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Mon, 3 Mar 2025 18:49:33 +0800
-Subject: [PATCH 6/6] Remove check update feature
+Subject: [PATCH 6/7] Remove check update feature
 
 ---
  src/main/resolve/autoUpdater.ts               | 116 ------------------
@@ -517,5 +517,5 @@ index b7b2ef3..a4a92e3 100644
    autoCloseConnection: boolean
    sysProxy: ISysProxyConfig
 -- 
-2.48.1
+2.49.0
 

--- a/app-network/mihomo-party/autobuild/patches/0007-Add-loong64-support.patch.loongarch64
+++ b/app-network/mihomo-party/autobuild/patches/0007-Add-loong64-support.patch.loongarch64
@@ -1,0 +1,47 @@
+From 263d08ee138e1a1d651a4f83acaf0176116ee472 Mon Sep 17 00:00:00 2001
+From: miwu04 <mail@alanlin.icu>
+Date: Sat, 12 Apr 2025 00:26:33 +0800
+Subject: [PATCH 7/7] Add loong64 support
+
+---
+ scripts/prepare.mjs      | 6 ++++--
+ src/main/sys/sysproxy.ts | 2 +-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/prepare.mjs b/scripts/prepare.mjs
+index 7351460..111b03e 100644
+--- a/scripts/prepare.mjs
++++ b/scripts/prepare.mjs
+@@ -27,7 +27,8 @@ const MIHOMO_ALPHA_MAP = {
+   'darwin-x64': 'mihomo-darwin-amd64-compatible',
+   'darwin-arm64': 'mihomo-darwin-arm64',
+   'linux-x64': 'mihomo-linux-amd64-compatible',
+-  'linux-arm64': 'mihomo-linux-arm64'
++  'linux-arm64': 'mihomo-linux-arm64',
++  'linux-loong64':'mihomo-linux-loong64'
+ }
+ 
+ // Fetch the latest alpha release version from the version.txt file
+@@ -58,7 +59,8 @@ const MIHOMO_MAP = {
+   'darwin-x64': 'mihomo-darwin-amd64-compatible',
+   'darwin-arm64': 'mihomo-darwin-arm64',
+   'linux-x64': 'mihomo-linux-amd64-compatible',
+-  'linux-arm64': 'mihomo-linux-arm64'
++  'linux-arm64': 'mihomo-linux-arm64',
++  'linux-loong64':'mihomo-linux-loong64'
+ }
+ 
+ // Fetch the latest release version from the version.txt file
+diff --git a/src/main/sys/sysproxy.ts b/src/main/sys/sysproxy.ts
+index e8ac1dc..0b1ce14 100644
+--- a/src/main/sys/sysproxy.ts
++++ b/src/main/sys/sysproxy.ts
+@@ -1,4 +1,4 @@
+-import { triggerAutoProxy, triggerManualProxy } from '@mihomo-party/sysproxy'
++import { triggerAutoProxy, triggerManualProxy } from '@mihomo-party-loongarch64/sysproxy'
+ import { getAppConfig, getControledMihomoConfig } from '../config'
+ import { pacPort, startPacServer, stopPacServer } from '../resolve/server'
+ import { promisify } from 'util'
+-- 
+2.49.0
+

--- a/app-network/mihomo-party/spec
+++ b/app-network/mihomo-party/spec
@@ -1,4 +1,5 @@
 VER=1.7.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mihomo-party-org/mihomo-party.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375292"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo-party: add loongarch64 support

Package(s) Affected
-------------------

- mihomo-party: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo-party
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
