### PR TITLE
waybar: replace ppd with tuned

### DIFF
--- a/app-utils/waybar/autobuild/defines
+++ b/app-utils/waybar/autobuild/defines
@@ -3,8 +3,8 @@ PKGSEC=utils
 PKGDEP="gtkmm-3 jsoncpp libsigc++ fmt wayland spdlog gtk-3 \
     gobject-introspection pulseaudio libnl libappindicator libdbusmenu \
     libmpdclient sndio libevdev libxkbcommon upower pipewire jack \
-    wireplumber playerctl libinput gtk-layer-shell libcava \
-    power-profiles-daemon"
+    wireplumber playerctl libinput gtk-layer-shell libcava"
+PKGRECOM="tuned"
 BUILDDEP="meson ninja wayland-protocols scdoc catch2"
 PKGDES="A highly customizable Wayland bar for wlroots based compositors"
 

--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -2,3 +2,4 @@ VER=0.12.0
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- waybar: replace ppd with tuned

Package(s) Affected
-------------------

- waybar: 0.12.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit waybar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
