### PR TITLE
llvm-20: enable offload runtime

### DIFF
--- a/app-devel/llvm-20/01-runtime/defines
+++ b/app-devel/llvm-20/01-runtime/defines
@@ -53,9 +53,8 @@ _LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2
 _LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang;libclc" # for main-T1 arch (e.g. amd64, arm64 ...)
 
 _LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
-_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;openmp"
+_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;offload;openmp"
 _LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET};pstl"
-_LLVM_BASE_RUNTIME_SET__LOONGARCH64="libcxx;libcxxabi"
 # FIXME: Runtime libraries does not build without lld.
 _LLVM_BASE_RUNTIME_SET__LOONGSON3=""
 
@@ -74,12 +73,18 @@ CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
 # Mainline
 CMAKE_AFTER__BASE=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__FULL=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__AMD64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__ARM64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__LOONGARCH64=" \

--- a/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,7 +1,7 @@
-From 8956a86ad829d29c4661011522a9db2104cf7fac Mon Sep 17 00:00:00 2001
+From ee2e8b1f88574d20db354fbb204dbc10106cc47a Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:48:08 -0800
-Subject: [PATCH 1/8] Fix fuzzer objects building when LTO is enabled
+Subject: [PATCH 1/9] Fix fuzzer objects building when LTO is enabled
 
 ---
  compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-
@@ -21,7 +21,7 @@ index 6db24610df1f..201b880cfbb1 100644
        COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>"
        COMMAND ${CMAKE_AR} qcs "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" ${name}.o
 
-base-commit: 24a30daaa559829ad079f2ff7f73eb4e18095f88
+base-commit: 58df0ef89dd64126512e4ee27b4ac3fd8ddf6247
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
@@ -1,7 +1,7 @@
-From 5541aa3864cdac28b795c0f5d27876b676f7ae3f Mon Sep 17 00:00:00 2001
+From b78de9913040a295a6c3bb0defcf033a00fa2f0e Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:47 -0800
-Subject: [PATCH 2/8] Fix MSVC detection
+Subject: [PATCH 2/9] Fix MSVC detection
 
 ---
  llvm/cmake/modules/CheckProblematicConfigurations.cmake | 2 +-
@@ -21,5 +21,5 @@ index e133873d756c..71484172cfb6 100644
    if(_FLAGS MATCHES "/arch:avx[0-9]*")
      log_problematic("Compiling LLVM with MSVC and the /arch:AVX flag is known to cause issues with parts of LLVM.\nSee https://github.com/llvm/llvm-project/issues/54645 for details.\nUse clang-cl if you want to enable AVX instructions.")
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,7 +1,7 @@
-From 3bc8c5c7d09308e8563367a36697d956277a03b2 Mon Sep 17 00:00:00 2001
+From 3cc1ee0fe8375be08f4e769afdefeec077a7d040 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:26 -0800
-Subject: [PATCH 3/8] Add stub for mips64 LLDB impl
+Subject: [PATCH 3/9] Add stub for mips64 LLDB impl
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-
@@ -26,5 +26,5 @@ index 08f19d374e28..a042dd3dd677 100644
    // Determine the architecture of the thread given by its ID.
    static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,7 +1,7 @@
-From aad667568a7688c28f8f4c1c782a60ed84e8090d Mon Sep 17 00:00:00 2001
+From 427f4e990f0adbbf73f1d1d9d7feb4d949dbd0da Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:52:51 -0800
-Subject: [PATCH 4/8] Add stub for lldb arch functions on loongson3
+Subject: [PATCH 4/9] Add stub for lldb arch functions on loongson3
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++
@@ -28,5 +28,5 @@ index a042dd3dd677..ee4901aa7cd3 100644
    // Invalidates cached values in register context data structures
    virtual void InvalidateAllRegisters(){}
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
@@ -1,7 +1,7 @@
-From 852fffc97a562005272f4e27a8f0957d88aa13d3 Mon Sep 17 00:00:00 2001
+From f52f3f1d5d936c4206429fc6974630606fdac965 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:53:18 -0800
-Subject: [PATCH 5/8] HACK: force enable cacheflush function
+Subject: [PATCH 5/9] HACK: force enable cacheflush function
 
 ---
  compiler-rt/lib/builtins/clear_cache.c | 1 +
@@ -20,5 +20,5 @@ index 2ac99b25c243..f055d3fcee4d 100644
  #include <sys/syscall.h>
  #include <unistd.h>
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
@@ -1,7 +1,7 @@
-From c732b41e9a9a1fea8e3f7aae925385603a21ca1e Mon Sep 17 00:00:00 2001
+From 9b0d4baa29956fc88a81b6b1d4ce741d503f8fe5 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 31 Jan 2024 14:37:12 +0800
-Subject: [PATCH 6/8] Fix build of LinuxSignals on Mips
+Subject: [PATCH 6/9] Fix build of LinuxSignals on Mips
 
 But only the build, not the functionality because lldb won't work
 anyway.
@@ -89,5 +89,5 @@ index eaecc84df15d..a087eea6d145 100644
    AddSignal(33,     "SIG33",        false,    false,  false,  "threading library internal signal 2");
    AddSignal(34,     "SIGRTMIN",     false,    false,  false,  "real time signal 0");
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
@@ -1,7 +1,7 @@
-From 40591be13a2579175ea48d0a728e22ef73245917 Mon Sep 17 00:00:00 2001
+From 92a83a024f078d11df391cd7f4ef8e822cd679b3 Mon Sep 17 00:00:00 2001
 From: Alex Crichton <alex@alexcrichton.com>
 Date: Sat, 10 Feb 2018 17:21:38 -0800
-Subject: [PATCH 7/8] Compile with /MT on MSVC
+Subject: [PATCH 7/9] Compile with /MT on MSVC
 
 Can't seem to figure out how to do this without this patch...
 ---
@@ -33,5 +33,5 @@ index 64c9f2380550..10eace58caee 100644
  add_subdirectory(tools/lld)
  
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,7 +1,7 @@
-From 1047032a41b1682f18d298151f8445838f1bffdd Mon Sep 17 00:00:00 2001
+From e8a9f449e355e30b10dce56f5c93e61ce390f404 Mon Sep 17 00:00:00 2001
 From: Adrian Cruceru <cruceruadrian@gmail.com>
 Date: Mon, 25 May 2020 20:58:30 +0200
-Subject: [PATCH 8/8] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
+Subject: [PATCH 8/9] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
  nightly target.
 
 Code is guarded via defines to enable only if 'RUST_SGX' is present.
@@ -494,5 +494,5 @@ index deb5a4d4d73d..5337be4b3d50 100644
  #ifdef __APPLE__
    #if defined(FOR_DYLD)
 -- 
-2.49.0.rc2
+2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
@@ -1,0 +1,41 @@
+From 5228272c013ad39a04e7198766ff4cbcece2d257 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 12 Apr 2025 15:25:26 +0800
+Subject: [PATCH 9/9] [compiler-rt] Disable installing of custom libcxx
+
+e7bad34475e2 ([compiler-rt] Use installed libc++(abi) for tests
+instead of build tree, 2024-11-06) removed 'INSTALL_COMMAND ""' line.
+After that, CMake will install files to locations like
+$DESTDIR/var/cache/acbs/build/acbs.p8hoyk2z/llvm-project-20.1.2.src/llvm/
+build/runtimes/runtimes-bins/compiler-rt/lib/fuzzer/libcxx_fuzzer_x86_64.
+
+Link: https://github.com/llvm/llvm-project/issues/135476
+Fixes: e7bad34475e2 ("[compiler-rt] Use installed libc++(abi) for tests instead of build tree")
+Signed-off-by: xtex <xtex@aosc.io>
+---
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index c3e734f72392..858342bcc3a6 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -637,7 +637,6 @@ macro(add_custom_libcxx name prefix)
+     CMAKE_SHARED_LINKER_FLAGS
+     CMAKE_MODULE_LINKER_FLAGS
+     CMAKE_EXE_LINKER_FLAGS
+-    CMAKE_INSTALL_PREFIX
+     CMAKE_MAKE_PROGRAM
+     CMAKE_LINKER
+     CMAKE_AR
+@@ -707,6 +706,7 @@ macro(add_custom_libcxx name prefix)
+                -DLLVM_INCLUDE_TESTS=OFF
+                -DLLVM_INCLUDE_DOCS=OFF
+                ${LIBCXX_CMAKE_ARGS}
++    INSTALL_COMMAND ""
+     STEP_TARGETS configure build
+     BUILD_ALWAYS 1
+     USES_TERMINAL_CONFIGURE 1
+-- 
+2.49.0
+

--- a/app-devel/llvm-20/02-compiler/build
+++ b/app-devel/llvm-20/02-compiler/build
@@ -92,3 +92,12 @@ for i in ../lib/llvm-${PKGVER%%.*}/bin/*; do
 done
 # Note: Remove double-suffixed executables.
 rm -v "$PKGDIR"/usr/bin/*-${PKGVER%%.*}-${PKGVER%%.*}
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-20/02-compiler/build.stage2
+++ b/app-devel/llvm-20/02-compiler/build.stage2
@@ -40,3 +40,12 @@ strip \
     --remove-section=.comment \
     --remove-section=.note \
     "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,4 +1,5 @@
 VER=20.1.2
+REL=1
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::f0a4a240aabc9b056142d14d5478bb6d962aeac549cbd75b809f5499240a8b38"

--- a/runtime-common/libffi/autobuild/defines
+++ b/runtime-common/libffi/autobuild/defines
@@ -8,3 +8,7 @@ AUTOTOOLS_AFTER="--enable-pax_emutramp \
 
 NOSTATIC=0
 NOSTATIC__RETRO=1
+
+# FIXME: LLVM offload runtime requires libffi.a compiled with -fPIC.
+# Otherwise, linking fails due to undefined ffi symbols.
+NOLTO=1

--- a/runtime-common/libffi/spec
+++ b/runtime-common/libffi/spec
@@ -1,5 +1,4 @@
-VER=3.4.7
-REL=1
+VER=3.4.8
 SRCS="tbl::https://github.com/libffi/libffi/releases/download/v${VER}/libffi-${VER}.tar.gz"
-CHKSUMS="sha256::138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d"
+CHKSUMS="sha256::bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b"
 CHKUPDATE="anitya::id=1611"


### PR DESCRIPTION
Topic Description
-----------------

- libffi: update to 3.4.8
    - Disable LTO to resolve LLVM 20 offload linking error.
    Signed-off-by: ouankou <anjia@ouankou.com>
- llvm-20: enable offload runtime
    Signed-off-by: ouankou <anjia@ouankou.com>

Package(s) Affected
-------------------

- libffi: 3.4.8
- llvm-20: 20.1.2-1
- llvm-runtime-20: 20.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libffi llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
