### PR TITLE
vscode: update to 1.99.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.99.0
+VER=1.99.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::5ae2bd49869f6dee91d996d39c9aa7de69a8b039a5d62f299dc8bf4c6638228c"
-CHKSUMS__ARM64="sha256::23a4a4a2012f2c4b4609a04765584e8f13f47c41c42a76b815bf2206e9aa01f6"
+CHKSUMS__AMD64="sha256::8f6b53f866c1afb35e61b52d99bc83f2e5959eee41d80bb69996a31169957f90"
+CHKSUMS__ARM64="sha256::20e7ef599021a6ae187b5393806dcdbf697e870494c7b0f445d26fe7162449df"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.99.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.99.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
