### PR TITLE
renderdoc: add support for LoongArch64

### DIFF
--- a/app-devel/renderdoc/autobuild/defines
+++ b/app-devel/renderdoc/autobuild/defines
@@ -6,6 +6,6 @@ PKGDES="Stand-alone graphics API debugging tool for Vulkan and OpenGL"
 
 CMAKE_AFTER="-DBUILD_VERSION_STABLE=ON \
              -DPYSIDE2_PACKAGE_INIT_PY=/usr/lib/python${ABPY3VER}/site-packages/PySide2/__init__.py"
-FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|riscv64)"
 # FIXME: LTO breaks binary
 NOLTO=1

--- a/app-devel/renderdoc/autobuild/defines
+++ b/app-devel/renderdoc/autobuild/defines
@@ -6,6 +6,6 @@ PKGDES="Stand-alone graphics API debugging tool for Vulkan and OpenGL"
 
 CMAKE_AFTER="-DBUILD_VERSION_STABLE=ON \
              -DPYSIDE2_PACKAGE_INIT_PY=/usr/lib/python${ABPY3VER}/site-packages/PySide2/__init__.py"
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"
 # FIXME: LTO breaks binary
 NOLTO=1

--- a/app-devel/renderdoc/autobuild/patches/0002-Add-loongarch64-support.patch
+++ b/app-devel/renderdoc/autobuild/patches/0002-Add-loongarch64-support.patch
@@ -1,3 +1,13 @@
+From 1705f743e58db1d4b1e27e71ad2005ce7551e07a Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sat, 12 Apr 2025 12:28:55 +0800
+Subject: [PATCH 2/2] renderdoc: add support for LoongArch64
+
+---
+ renderdoc/3rdparty/plthook/plthook_elf.c   | 3 +++
+ renderdoc/os/posix/linux/linux_process.cpp | 8 ++++++++
+ 2 files changed, 11 insertions(+)
+
 diff --git a/renderdoc/3rdparty/plthook/plthook_elf.c b/renderdoc/3rdparty/plthook/plthook_elf.c
 index 6fc2ac6e3..04fc602b1 100644
 --- a/renderdoc/3rdparty/plthook/plthook_elf.c
@@ -13,23 +23,13 @@ index 6fc2ac6e3..04fc602b1 100644
  #error unsupported OS
  #endif
 diff --git a/renderdoc/os/posix/linux/linux_process.cpp b/renderdoc/os/posix/linux/linux_process.cpp
-index aa9c7393c..ec612910e 100644
+index 446fe9ad6..f86659958 100644
 --- a/renderdoc/os/posix/linux/linux_process.cpp
 +++ b/renderdoc/os/posix/linux/linux_process.cpp
-@@ -236,6 +236,24 @@ static uint64_t get_nanotime()
+@@ -246,6 +246,14 @@ static uint64_t get_nanotime()
  #define BREAK_INST_BYTES_SIZE 4
  #define BREAK_INST_INST_PTR_ADJUST 4
  
-+#elif defined(__powerpc64__)
-+
-+#define user_regs_struct struct pt_regs
-+
-+#define INST_PTR_REG nip
-+
-+#define BREAK_INST 0x0800e07fULL
-+#define BREAK_INST_BYTES_SIZE 4
-+#define BREAK_INST_INST_PTR_ADJUST 4
-+
 +#elif defined(__loongarch64)
 +
 +#define INST_PTR_REG csr_era
@@ -41,3 +41,6 @@ index aa9c7393c..ec612910e 100644
  #else
  
  #define BREAK_INST 0xccULL
+-- 
+2.49.0
+

--- a/app-devel/renderdoc/autobuild/patches/0002-Add-loongarch64-support.patch
+++ b/app-devel/renderdoc/autobuild/patches/0002-Add-loongarch64-support.patch
@@ -1,0 +1,43 @@
+diff --git a/renderdoc/3rdparty/plthook/plthook_elf.c b/renderdoc/3rdparty/plthook/plthook_elf.c
+index 6fc2ac6e3..04fc602b1 100644
+--- a/renderdoc/3rdparty/plthook/plthook_elf.c
++++ b/renderdoc/3rdparty/plthook/plthook_elf.c
+@@ -107,6 +107,9 @@
+ #elif 0 /* disabled because not tested */ && (defined __ia64 || defined __ia64__)
+ #define R_JUMP_SLOT   R_IA64_IPLTMSB
+ #define Elf_Plt_Rel   Elf_Rela
++#elif defined __loongarch64
++#define R_JUMP_SLOT   R_LARCH_JUMP_SLOT
++#define Elf_Plt_Rel   Elf_Rela
+ #else
+ #error unsupported OS
+ #endif
+diff --git a/renderdoc/os/posix/linux/linux_process.cpp b/renderdoc/os/posix/linux/linux_process.cpp
+index aa9c7393c..ec612910e 100644
+--- a/renderdoc/os/posix/linux/linux_process.cpp
++++ b/renderdoc/os/posix/linux/linux_process.cpp
+@@ -236,6 +236,24 @@ static uint64_t get_nanotime()
+ #define BREAK_INST_BYTES_SIZE 4
+ #define BREAK_INST_INST_PTR_ADJUST 4
+ 
++#elif defined(__powerpc64__)
++
++#define user_regs_struct struct pt_regs
++
++#define INST_PTR_REG nip
++
++#define BREAK_INST 0x0800e07fULL
++#define BREAK_INST_BYTES_SIZE 4
++#define BREAK_INST_INST_PTR_ADJUST 4
++
++#elif defined(__loongarch64)
++
++#define INST_PTR_REG csr_era
++
++#define BREAK_INST 0x002a0000ULL
++#define BREAK_INST_BYTES_SIZE 4
++#define BREAK_INST_INST_PTR_ADJUST 4
++
+ #else
+ 
+ #define BREAK_INST 0xccULL

--- a/app-devel/renderdoc/spec
+++ b/app-devel/renderdoc/spec
@@ -1,4 +1,5 @@
 VER=1.37
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/baldurk/renderdoc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14973"


### PR DESCRIPTION
Topic Description
-----------------

- renderdoc: add a patch to support loongarch64

Package(s) Affected
-------------------

- renderdoc: 1.37-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit renderdoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
