### PR TITLE
vscodium: update to 1.99.22418

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -14,6 +14,7 @@ export CI_BUILD=yes
 export OS_NAME=linux
 export RELEASE_VERSION="$PKGVER"
 export DISABLE_UPDATE=yes
+export VSCODE_USE_SYSTEM_CARGO=yes
 
 if [[ "${CROSS:-$ARCH}" = "amd64" ]]; then
   export VSCODE_ARCH="x64"

--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
 PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-BUILDDEP="gcc make pkg-config jq nodejs-20"
+BUILDDEP="jq llvm make nodejs pkg-config rustc"
 PKGPROV="codium"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"

--- a/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
+++ b/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
@@ -1,0 +1,43 @@
+From da1c5d6ba67ea60a78b5243a77e433ab20b2101b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 12 Apr 2025 11:23:43 +0800
+Subject: [PATCH 1/2] fix(cli): add an option to use system Cargo/rustc
+
+Allow using the `cargo' and `rustc' executables installed in the system so
+that distribution packagers won't have to install rustup as part of their
+build environment.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ build_cli.sh | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build_cli.sh b/build_cli.sh
+index 6998735..ded94cf 100755
+--- a/build_cli.sh
++++ b/build_cli.sh
+@@ -48,7 +48,9 @@ elif [[ "${OS_NAME}" == "windows" ]]; then
+   export OPENSSL_LIB_DIR="$( pwd )/openssl/out/${VSCODE_ARCH}-windows-static/lib"
+   export OPENSSL_INCLUDE_DIR="$( pwd )/openssl/out/${VSCODE_ARCH}-windows-static/include"
+ 
+-  rustup target add "${VSCODE_CLI_TARGET}"
++  if [[ "${VSCODE_USE_SYSTEM_CARGO}" = "no" ]]; then
++    rustup target add "${VSCODE_CLI_TARGET}"
++  fi
+ 
+   cargo build --release --target "${VSCODE_CLI_TARGET}" --bin=code
+ 
+@@ -84,7 +86,9 @@ else
+   fi
+ 
+   if [[ -n "${VSCODE_CLI_TARGET}" ]]; then
+-    rustup target add "${VSCODE_CLI_TARGET}"
++    if [[ "${VSCODE_USE_SYSTEM_CARGO}" = "no" ]]; then
++      rustup target add "${VSCODE_CLI_TARGET}"
++    fi
+ 
+     cargo build --release --target "${VSCODE_CLI_TARGET}" --bin=code
+ 
+-- 
+2.49.0
+

--- a/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
+++ b/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
@@ -1,0 +1,30 @@
+From 60a98dcd878e14ab9220af4c70cb3cd3eeeb616c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 12 Apr 2025 12:49:44 +0800
+Subject: [PATCH 2/2] fix(build_cli.sh): drop hard-coded cross compiler setting
+
+ARM != cross compile.
+---
+ build_cli.sh | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/build_cli.sh b/build_cli.sh
+index ded94cf..9c2ae97 100755
+--- a/build_cli.sh
++++ b/build_cli.sh
+@@ -63,12 +63,6 @@ else
+   if [[ "${VSCODE_ARCH}" == "arm64" ]]; then
+     VSCODE_CLI_TARGET="aarch64-unknown-linux-gnu"
+ 
+-    if [[ "${CI_BUILD}" != "no" ]]; then
+-      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+-      export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+-      export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+-      export PKG_CONFIG_ALLOW_CROSS=1
+-    fi
+   elif [[ "${VSCODE_ARCH}" == "armhf" ]]; then
+     VSCODE_CLI_TARGET="armv7-unknown-linux-gnueabihf"
+ 
+-- 
+2.49.0
+

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.99.02277
+VER=1.99.22418
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.99.22418
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vscodium: 1.99.22418

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
