### PR TITLE
clash-verge-rev: improve packaging for distribution

### DIFF
--- a/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,7 +1,7 @@
 From 0d41b69d1d10e1b0f2ac1b95b984114830cba809 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
-Subject: [PATCH 01/19] feat(src/assets): add XDG .desktop entry
+Subject: [PATCH 01/22] feat(src/assets): add XDG .desktop entry
 
 ---
  src/assets/xdg/io.github.clash-verge-rev.desktop | 14 ++++++++++++++

--- a/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,7 +1,7 @@
 From fcd2d7bf7e57b427fbf844252adfe07fc2a71772 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
-Subject: [PATCH 02/19] fix(tauri.conf.json): disable bundle distribution
+Subject: [PATCH 02/22] fix(tauri.conf.json): disable bundle distribution
 
 ---
  src-tauri/tauri.conf.json | 2 +-

--- a/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,7 +1,7 @@
 From 7a223062462803f59493a61dcf2b05991b953766 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
-Subject: [PATCH 03/19] fix(scripts): use ABI2 (New-World) Mihomo binary for
+Subject: [PATCH 03/22] fix(scripts): use ABI2 (New-World) Mihomo binary for
  loongarch64
 
 Currently, only the alpha Mihomo binary distinguishes between abi1 (old-world)

--- a/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
@@ -1,7 +1,7 @@
 From e2223c38aafb04982ec54f514086a841af84a3b7 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
-Subject: [PATCH 04/19] feat: drop clash-meta-alpha support
+Subject: [PATCH 04/22] feat: drop clash-meta-alpha support
 
 ---
  src/components/setting/mods/clash-core-viewer.tsx | 1 -

--- a/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,7 +1,7 @@
 From 9f7437c5eec14dbcbbc10c87e494e140d27ff6da Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
-Subject: [PATCH 05/19] fix(check.mjs): do not fetch Mihomo (Clash Meta)
+Subject: [PATCH 05/22] fix(check.mjs): do not fetch Mihomo (Clash Meta)
  binaries
 
 We use a system copy for this purpose.

--- a/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,7 +1,7 @@
 From 80336752686c414d459598a0066a18426a998112 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
-Subject: [PATCH 06/19] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
+Subject: [PATCH 06/22] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  Meta) bundling
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,7 +1,7 @@
 From 28749306cc657af118d33c5939aee5bb833ab903 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:36:28 +0800
-Subject: [PATCH 07/19] fix(check.mjs): do not check Mihomo (Clash Meta)
+Subject: [PATCH 07/22] fix(check.mjs): do not check Mihomo (Clash Meta)
  platform support
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
@@ -1,7 +1,7 @@
 From 418bdf5b15ea4f4a782d9fd4ab6a54036c92707e Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:49:46 +0800
-Subject: [PATCH 08/19] Do not create any bundle package
+Subject: [PATCH 08/22] Do not create any bundle package
 
 ---
  src-tauri/tauri.linux.conf.json | 32 +-------------------------------

--- a/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
@@ -1,7 +1,7 @@
 From e8cf9952891afd505008891bbdacbb74a31c1c04 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
-Subject: [PATCH 09/19] Drop check update feature
+Subject: [PATCH 09/22] Drop check update feature
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
@@ -1,7 +1,7 @@
 From 7ac3ec7044dea9a6eb38aec43d80b0f7e94f3e0b Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
-Subject: [PATCH 10/19] Set core binary name as mihomo
+Subject: [PATCH 10/22] Set core binary name as mihomo
 
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
@@ -1,7 +1,7 @@
 From ab72eee9e2c034a052fda6cb9879d652eadd2673 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
-Subject: [PATCH 11/19] feat: always not portable
+Subject: [PATCH 11/22] feat: always not portable
 
 ---
  src-tauri/src/utils/dirs.rs | 10 ----------

--- a/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0012-find-mihomo-from-PATH.patch
@@ -1,7 +1,7 @@
 From 5cdb534d1529fce2b9aff8c1ffe3a08c9ebb2081 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:02:52 +0800
-Subject: [PATCH 12/19] find `mihomo` from `$PATH`
+Subject: [PATCH 12/22] find `mihomo` from `$PATH`
 
 ---
  src-tauri/Cargo.lock          | 520 +++++++++++++++-------------------

--- a/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0013-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,7 +1,7 @@
 From 77ef5e609644546a0b13558ca61fc5657b33bce5 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
-Subject: [PATCH 13/19] Set service install/uninstall script path to
+Subject: [PATCH 13/22] Set service install/uninstall script path to
  /usr/libexec
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0014-Unset-all-release-profile.patch
@@ -1,7 +1,7 @@
 From e4093dcd4e78bfcd4813a8338b0a7462f9f8bf75 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:52:29 +0800
-Subject: [PATCH 14/19] Unset all release profile
+Subject: [PATCH 14/22] Unset all release profile
 
 ---
  src-tauri/Cargo.toml | 7 -------

--- a/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0015-Do-not-use-gcc.patch
@@ -1,7 +1,7 @@
 From 6578ef19962319a913ec10250de9b5bf9620797b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
-Subject: [PATCH 15/19] Do not use gcc
+Subject: [PATCH 15/22] Do not use gcc
 
 ---
  .cargo/config.toml | 5 -----

--- a/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0016-Drop-Upgrade-core-button.patch
@@ -1,7 +1,7 @@
 From 197ea231b7992cf8582773f2e60e622ddb2ed954 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
-Subject: [PATCH 16/19] Drop "Upgrade core" button
+Subject: [PATCH 16/22] Drop "Upgrade core" button
 
 ---
  .../setting/mods/clash-core-viewer.tsx        | 25 +------------------

--- a/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0017-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
@@ -1,7 +1,7 @@
 From c8e1c12e81991f520011422cdec3e342e060df44 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 12:09:38 +0800
-Subject: [PATCH 17/19] (ppc64el) Use `@rollup/wasm-node` to fix build on
+Subject: [PATCH 17/22] (ppc64el) Use `@rollup/wasm-node` to fix build on
  POWER8
 
 ---

--- a/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0018-Do-not-sidecar-mihomo-program.patch
@@ -1,7 +1,7 @@
 From aa8238cc8da7bcda1d841fed0aaf6ba4ef60eb47 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
-Subject: [PATCH 18/19] Do not sidecar mihomo program
+Subject: [PATCH 18/22] Do not sidecar mihomo program
 
 ---
  src-tauri/src/core/core.rs | 4 ++--

--- a/app-network/clash-verge-rev/autobuild/patches/0019-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0019-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
@@ -1,7 +1,7 @@
 From db13c229353f7ad4a39d7ea2d1ee9934fe4adc64 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 8 Apr 2025 12:32:41 +0800
-Subject: [PATCH 19/19] Fix if mihomo geoip file `src_path` is symlink
+Subject: [PATCH 19/22] Fix if mihomo geoip file `src_path` is symlink
 
 ---
  src-tauri/src/utils/init.rs | 30 +++++++++++++++++-------------

--- a/app-network/clash-verge-rev/autobuild/patches/0020-fix-components-drop-update-checker.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0020-fix-components-drop-update-checker.patch
@@ -1,0 +1,253 @@
+From fbc9a84fefb22c971b3551bf3b59c0a6ed76d2e6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 12 Apr 2025 10:43:15 +0800
+Subject: [PATCH 20/22] fix(components): drop update checker
+
+---
+ src/components/home/system-info-card.tsx      |  63 --------
+ src/components/setting/mods/update-viewer.tsx | 145 ------------------
+ 2 files changed, 208 deletions(-)
+ delete mode 100644 src/components/setting/mods/update-viewer.tsx
+
+diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
+index f3d6a8b5..f8076268 100644
+--- a/src/components/home/system-info-card.tsx
++++ b/src/components/home/system-info-card.tsx
+@@ -48,36 +48,6 @@ export const SystemInfoCard = () => {
+         }
+       })
+       .catch(console.error);
+-
+-    // 获取最后检查更新时间
+-    const lastCheck = localStorage.getItem("last_check_update");
+-    if (lastCheck) {
+-      try {
+-        const timestamp = parseInt(lastCheck, 10);
+-        if (!isNaN(timestamp)) {
+-          setSystemState((prev) => ({
+-            ...prev,
+-            lastCheckUpdate: new Date(timestamp).toLocaleString(),
+-          }));
+-        }
+-      } catch (e) {
+-        console.error("Error parsing last check update time", e);
+-      }
+-    } else if (verge?.auto_check_update) {
+-      // 如果启用了自动检查更新但没有记录，设置当前时间并延迟检查
+-      const now = Date.now();
+-      localStorage.setItem("last_check_update", now.toString());
+-      setSystemState((prev) => ({
+-        ...prev,
+-        lastCheckUpdate: new Date(now).toLocaleString(),
+-      }));
+-
+-      setTimeout(() => {
+-        if (verge?.auto_check_update) {
+-          checkUpdate().catch(console.error);
+-        }
+-      }, 5000);
+-    }
+   }, [verge?.auto_check_update]);
+ 
+   // 自动检查更新逻辑
+@@ -135,21 +105,6 @@ export const SystemInfoCard = () => {
+     }
+   }, [isSidecarMode, isAdminMode, onInstallService]);
+ 
+-  // 检查更新
+-  const onCheckUpdate = useLockFn(async () => {
+-    try {
+-      const info = await checkUpdate();
+-      if (!info?.available) {
+-        Notice.success(t("Currently on the Latest Version"));
+-      } else {
+-        Notice.info(t("Update Available"), 2000);
+-        goToSettings();
+-      }
+-    } catch (err: any) {
+-      Notice.error(err.message || err.toString());
+-    }
+-  });
+-
+   // 是否启用自启动
+   const autoLaunchEnabled = useMemo(
+     () => verge?.enable_auto_launch || false,
+@@ -289,24 +244,6 @@ export const SystemInfoCard = () => {
+           </Typography>
+         </Stack>
+         <Divider />
+-        <Stack direction="row" justifyContent="space-between">
+-          <Typography variant="body2" color="text.secondary">
+-            {t("Last Check Update")}
+-          </Typography>
+-          <Typography
+-            variant="body2"
+-            fontWeight="medium"
+-            onClick={onCheckUpdate}
+-            sx={{
+-              cursor: "pointer",
+-              textDecoration: "underline",
+-              "&:hover": { opacity: 0.7 },
+-            }}
+-          >
+-            {systemState.lastCheckUpdate}
+-          </Typography>
+-        </Stack>
+-        <Divider />
+         <Stack direction="row" justifyContent="space-between">
+           <Typography variant="body2" color="text.secondary">
+             {t("Verge Version")}
+diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
+deleted file mode 100644
+index 6eb8ef64..00000000
+--- a/src/components/setting/mods/update-viewer.tsx
++++ /dev/null
+@@ -1,145 +0,0 @@
+-import useSWR from "swr";
+-import { forwardRef, useImperativeHandle, useState, useMemo } from "react";
+-import { useLockFn } from "ahooks";
+-import { Box, LinearProgress, Button } from "@mui/material";
+-import { useTranslation } from "react-i18next";
+-import { relaunch } from "@tauri-apps/plugin-process";
+-import { check as checkUpdate } from "@tauri-apps/plugin-updater";
+-import { BaseDialog, DialogRef, Notice } from "@/components/base";
+-import { useUpdateState, useSetUpdateState } from "@/services/states";
+-import { Event, UnlistenFn } from "@tauri-apps/api/event";
+-import { portableFlag } from "@/pages/_layout";
+-import { open as openUrl } from "@tauri-apps/plugin-shell";
+-import ReactMarkdown from "react-markdown";
+-import { useListen } from "@/hooks/use-listen";
+-
+-let eventListener: UnlistenFn | null = null;
+-
+-export const UpdateViewer = forwardRef<DialogRef>((props, ref) => {
+-  const { t } = useTranslation();
+-
+-  const [open, setOpen] = useState(false);
+-
+-  const updateState = useUpdateState();
+-  const setUpdateState = useSetUpdateState();
+-  const { addListener } = useListen();
+-
+-  const { data: updateInfo } = useSWR("checkUpdate", checkUpdate, {
+-    errorRetryCount: 2,
+-    revalidateIfStale: false,
+-    focusThrottleInterval: 36e5, // 1 hour
+-  });
+-
+-  const [downloaded, setDownloaded] = useState(0);
+-  const [buffer, setBuffer] = useState(0);
+-  const [total, setTotal] = useState(0);
+-
+-  useImperativeHandle(ref, () => ({
+-    open: () => setOpen(true),
+-    close: () => setOpen(false),
+-  }));
+-
+-  const markdownContent = useMemo(() => {
+-    if (!updateInfo?.body) {
+-      return "New Version is available";
+-    }
+-    return updateInfo?.body;
+-  }, [updateInfo]);
+-
+-  const breakChangeFlag = useMemo(() => {
+-    if (!updateInfo?.body) {
+-      return false;
+-    }
+-    return updateInfo?.body.toLowerCase().includes("break change");
+-  }, [updateInfo]);
+-
+-  const onUpdate = useLockFn(async () => {
+-    if (portableFlag) {
+-      Notice.error(t("Portable Updater Error"));
+-      return;
+-    }
+-    if (!updateInfo?.body) return;
+-    if (breakChangeFlag) {
+-      Notice.error(t("Break Change Update Error"));
+-      return;
+-    }
+-    if (updateState) return;
+-    setUpdateState(true);
+-    if (eventListener !== null) {
+-      eventListener();
+-    }
+-    eventListener = await addListener(
+-      "tauri://update-download-progress",
+-      (e: Event<any>) => {
+-        setTotal(e.payload.contentLength);
+-        setBuffer(e.payload.chunkLength);
+-        setDownloaded((a) => {
+-          return a + e.payload.chunkLength;
+-        });
+-      },
+-    );
+-    try {
+-      await updateInfo.downloadAndInstall();
+-      await relaunch();
+-    } catch (err: any) {
+-      Notice.error(err?.message || err.toString());
+-    } finally {
+-      setUpdateState(false);
+-    }
+-  });
+-
+-  return (
+-    <BaseDialog
+-      open={open}
+-      title={
+-        <Box display="flex" justifyContent="space-between">
+-          {`New Version v${updateInfo?.version}`}
+-          <Box>
+-            <Button
+-              variant="contained"
+-              size="small"
+-              onClick={() => {
+-                openUrl(
+-                  `https://github.com/clash-verge-rev/clash-verge-rev/releases/tag/v${updateInfo?.version}`,
+-                );
+-              }}
+-            >
+-              {t("Go to Release Page")}
+-            </Button>
+-          </Box>
+-        </Box>
+-      }
+-      contentSx={{ minWidth: 360, maxWidth: 400, height: "50vh" }}
+-      okBtn={t("Update")}
+-      cancelBtn={t("Cancel")}
+-      onClose={() => setOpen(false)}
+-      onCancel={() => setOpen(false)}
+-      onOk={onUpdate}
+-    >
+-      <Box sx={{ height: "calc(100% - 10px)", overflow: "auto" }}>
+-        <ReactMarkdown
+-          components={{
+-            a: ({ node, ...props }) => {
+-              const { children } = props;
+-              return (
+-                <a {...props} target="_blank">
+-                  {children}
+-                </a>
+-              );
+-            },
+-          }}
+-        >
+-          {markdownContent}
+-        </ReactMarkdown>
+-      </Box>
+-      {updateState && (
+-        <LinearProgress
+-          variant="buffer"
+-          value={(downloaded / total) * 100}
+-          valueBuffer={buffer}
+-          sx={{ marginTop: "5px" }}
+-        />
+-      )}
+-    </BaseDialog>
+-  );
+-});
+-- 
+2.49.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0021-fix-drop-Open-Core-Dir-function.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0021-fix-drop-Open-Core-Dir-function.patch
@@ -1,0 +1,123 @@
+From 549c99d3fa1dbeda9465031c8f8943f2d2de589d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 12 Apr 2025 10:46:10 +0800
+Subject: [PATCH 21/22] fix: drop Open Core Dir function
+
+This is useless for our users as it would just open /usr/bin.
+---
+ src-tauri/src/cmd/app.rs                          |  8 --------
+ src-tauri/src/core/tray/mod.rs                    | 12 +-----------
+ src-tauri/src/lib.rs                              |  1 -
+ src/components/setting/setting-verge-advanced.tsx |  3 ---
+ src/services/cmds.ts                              |  6 ------
+ 5 files changed, 1 insertion(+), 29 deletions(-)
+
+diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
+index f428069f..ecd2ddfb 100644
+--- a/src-tauri/src/cmd/app.rs
++++ b/src-tauri/src/cmd/app.rs
+@@ -13,14 +13,6 @@ pub fn open_app_dir() -> CmdResult<()> {
+     wrap_err!(open::that(app_dir))
+ }
+ 
+-/// 打开核心所在目录
+-#[tauri::command]
+-pub fn open_core_dir() -> CmdResult<()> {
+-    let core_dir = wrap_err!(tauri::utils::platform::current_exe())?;
+-    let core_dir = core_dir.parent().ok_or("failed to get core dir")?;
+-    wrap_err!(open::that(core_dir))
+-}
+-
+ /// 打开日志目录
+ #[tauri::command]
+ pub fn open_logs_dir() -> CmdResult<()> {
+diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
+index 5f18905e..7f196911 100644
+--- a/src-tauri/src/core/tray/mod.rs
++++ b/src-tauri/src/core/tray/mod.rs
+@@ -575,15 +575,6 @@ fn create_tray_menu(
+     )
+     .unwrap();
+ 
+-    let open_core_dir = &MenuItem::with_id(
+-        app_handle,
+-        "open_core_dir",
+-        t("Core Dir"),
+-        true,
+-        None::<&str>,
+-    )
+-    .unwrap();
+-
+     let open_logs_dir = &MenuItem::with_id(
+         app_handle,
+         "open_logs_dir",
+@@ -598,7 +589,7 @@ fn create_tray_menu(
+         "open_dir",
+         t("Open Dir"),
+         true,
+-        &[open_app_dir, open_core_dir, open_logs_dir],
++        &[open_app_dir, open_logs_dir],
+     )
+     .unwrap();
+ 
+@@ -680,7 +671,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+         "tun_mode" => feat::toggle_tun_mode(None),
+         "copy_env" => feat::copy_clash_env(),
+         "open_app_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_app_dir()),
+-        "open_core_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_core_dir()),
+         "open_logs_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_logs_dir()),
+         "restart_clash" => feat::restart_clash_core(),
+         "restart_app" => feat::restart_app(),
+diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
+index a02caaa8..a72992af 100644
+--- a/src-tauri/src/lib.rs
++++ b/src-tauri/src/lib.rs
+@@ -145,7 +145,6 @@ pub fn run() {
+             cmd::open_app_dir,
+             cmd::open_logs_dir,
+             cmd::open_web_url,
+-            cmd::open_core_dir,
+             cmd::get_portable_flag,
+             cmd::get_network_interfaces,
+             cmd::restart_core,
+diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
+index 0e5d03f8..3a0d083d 100644
+--- a/src/components/setting/setting-verge-advanced.tsx
++++ b/src/components/setting/setting-verge-advanced.tsx
+@@ -4,7 +4,6 @@ import { Typography } from "@mui/material";
+ import {
+   exitApp,
+   openAppDir,
+-  openCoreDir,
+   openLogsDir,
+   openDevTools,
+   exportDiagnosticInfo,
+@@ -82,8 +81,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+         }
+       />
+ 
+-      <SettingItem onClick={openCoreDir} label={t("Open Core Dir")} />
+-
+       <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
+ 
+       <SettingItem onClick={openDevTools} label={t("Open Dev Tools")} />
+diff --git a/src/services/cmds.ts b/src/services/cmds.ts
+index 454315aa..8a7a0c5f 100644
+--- a/src/services/cmds.ts
++++ b/src/services/cmds.ts
+@@ -149,12 +149,6 @@ export async function openAppDir() {
+   );
+ }
+ 
+-export async function openCoreDir() {
+-  return invoke<void>("open_core_dir").catch((err) =>
+-    Notice.error(err?.message || err.toString(), 1500),
+-  );
+-}
+-
+ export async function openLogsDir() {
+   return invoke<void>("open_logs_dir").catch((err) =>
+     Notice.error(err?.message || err.toString(), 1500),
+-- 
+2.49.0
+

--- a/app-network/clash-verge-rev/autobuild/patches/0022-fix-disable-GeoData-update.patch
+++ b/app-network/clash-verge-rev/autobuild/patches/0022-fix-disable-GeoData-update.patch
@@ -1,0 +1,66 @@
+From 72e11697720681a99ad3c80b96f2101c772d18a2 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 12 Apr 2025 10:56:35 +0800
+Subject: [PATCH 22/22] fix: disable GeoData update
+
+We handle this via mihomo-rules-dat.
+---
+ src/components/setting/setting-clash.tsx | 10 ----------
+ src/services/api.ts                      |  6 ------
+ 2 files changed, 16 deletions(-)
+
+diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
+index 8de71ec1..84032a88 100644
+--- a/src/components/setting/setting-clash.tsx
++++ b/src/components/setting/setting-clash.tsx
+@@ -17,7 +17,6 @@ import { ClashCoreViewer } from "./mods/clash-core-viewer";
+ import { invoke_uwp_tool } from "@/services/cmds";
+ import getSystem from "@/utils/get-system";
+ import { useVerge } from "@/hooks/use-verge";
+-import { updateGeoData } from "@/services/api";
+ import { TooltipIcon } from "@/components/base/base-tooltip-icon";
+ import { NetworkInterfaceViewer } from "./mods/network-interface-viewer";
+ import { DnsViewer } from "./mods/dns-viewer";
+@@ -74,14 +73,6 @@ const SettingClash = ({ onError }: Props) => {
+   const onChangeVerge = (patch: Partial<IVergeConfig>) => {
+     mutateVerge({ ...verge, ...patch }, false);
+   };
+-  const onUpdateGeo = async () => {
+-    try {
+-      await updateGeoData();
+-      Notice.success(t("GeoData Updated"));
+-    } catch (err: any) {
+-      Notice.error(err?.response.data.message || err.toString());
+-    }
+-  };
+ 
+   // 实现DNS设置开关处理函数
+   const handleDnsToggle = useLockFn(async (enable: boolean) => {
+@@ -279,7 +270,6 @@ const SettingClash = ({ onError }: Props) => {
+         />
+       )}
+ 
+-      <SettingItem onClick={onUpdateGeo} label={t("Update GeoData")} />
+     </SettingList>
+   );
+ };
+diff --git a/src/services/api.ts b/src/services/api.ts
+index 34900239..2c7d4cd8 100644
+--- a/src/services/api.ts
++++ b/src/services/api.ts
+@@ -56,12 +56,6 @@ export const getClashConfig = async () => {
+   return instance.get("/configs") as Promise<IConfigData>;
+ };
+ 
+-/// Update geo data
+-export const updateGeoData = async () => {
+-  const instance = await getAxios();
+-  return instance.post("/configs/geo");
+-};
+-
+ /// Get current rules
+ export const getRules = async () => {
+   const instance = await getAxios();
+-- 
+2.49.0
+

--- a/app-network/clash-verge-rev/spec
+++ b/app-network/clash-verge-rev/spec
@@ -1,4 +1,5 @@
 VER=2.2.3
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: improve packaging for distribution
    - Disable self-update.
    - Remove options for GeoData update \(we ship them in mihomo-rules-dat\).
    - Remove "Open Core Dir" entry \(it's basically /usr/bin so why bother?\).

Package(s) Affected
-------------------

- clash-verge-rev: 2.2.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
