### PR TITLE
clash-verge-service: fix stop mihomo process

### DIFF
--- a/app-network/clash-verge-service/autobuild/patches/0001-Read-clash-verge-service-path-from-env.patch
+++ b/app-network/clash-verge-service/autobuild/patches/0001-Read-clash-verge-service-path-from-env.patch
@@ -1,7 +1,7 @@
 From 783e7a3a50cc26bba7ac912a5ad4f45e17904350 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 08:55:51 +0800
-Subject: [PATCH 1/2] Read `clash-verge-service` path from env
+Subject: [PATCH 1/3] Read `clash-verge-service` path from env
 
 ---
  Cargo.lock     | 82 ++++++++++++++++++++++++++++++++++++++++++++++++--

--- a/app-network/clash-verge-service/autobuild/patches/0002-Remove-unnecessary-nix-and-libc-dependency.patch
+++ b/app-network/clash-verge-service/autobuild/patches/0002-Remove-unnecessary-nix-and-libc-dependency.patch
@@ -1,7 +1,7 @@
 From 9e49c0a2902e96a1f524a9963ceee2caad20a06b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 4 Apr 2025 13:32:15 +0800
-Subject: [PATCH 2/2] Remove unnecessary `nix` and `libc` dependency
+Subject: [PATCH 2/3] Remove unnecessary `nix` and `libc` dependency
 
 ---
  Cargo.lock | 29 ++---------------------------

--- a/app-network/clash-verge-service/autobuild/patches/0003-Find-mihomo-process-not-verge-mihomo.patch
+++ b/app-network/clash-verge-service/autobuild/patches/0003-Find-mihomo-process-not-verge-mihomo.patch
@@ -1,0 +1,81 @@
+From b5c0811cd0507e166120b105e70aa25d57d8237a Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Sat, 12 Apr 2025 13:57:13 +0800
+Subject: [PATCH 3/3] Find `mihomo` process, not `verge-mihomo`
+
+---
+ src/service/core.rs | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/service/core.rs b/src/service/core.rs
+index 84407a5..4817674 100644
+--- a/src/service/core.rs
++++ b/src/service/core.rs
+@@ -121,7 +121,7 @@ impl CoreManager {
+             }
+         }
+ 
+-        // 检测并停止系统中其他可能运行的verge-mihomo进程
++        // 检测并停止系统中其他可能运行的mihomo进程
+         self.stop_other_mihomo_processes()?;
+ 
+         {
+@@ -216,7 +216,7 @@ impl CoreManager {
+         Ok(())
+     }
+ 
+-    // 检测并停止其他verge-mihomo进程
++    // 检测并停止其他mihomo进程
+     pub fn stop_other_mihomo_processes(&self) -> Result<()> {
+         // 获取当前进程的PID
+         let current_pid = std::process::id();
+@@ -228,20 +228,20 @@ impl CoreManager {
+             .running_pid
+             .load(Ordering::Relaxed) as u32;
+         
+-        match process::find_processes("verge-mihomo") {
++        match process::find_processes("mihomo") {
+             Ok(pids) => {
+                 // 直接在迭代过程中过滤和终止
+                 let kill_count = pids.into_iter()
+                     .filter(|&pid| pid != current_pid && (tracked_mihomo_pid <= 0 || pid != tracked_mihomo_pid))
+                     .map(|pid| {
+-                        println!("Found other verge-mihomo process with PID: {}, stopping it", pid);
++                        println!("Found other mihomo process with PID: {}, stopping it", pid);
+                         match process::kill_process(pid) {
+                             Ok(_) => {
+-                                println!("Successfully stopped verge-mihomo process {}", pid);
++                                println!("Successfully stopped mihomo process {}", pid);
+                                 true
+                             }
+                             Err(e) => {
+-                                eprintln!("Failed to kill verge-mihomo process {}: {}", pid, e);
++                                eprintln!("Failed to kill mihomo process {}: {}", pid, e);
+                                 false
+                             }
+                         }
+@@ -249,10 +249,10 @@ impl CoreManager {
+                     .filter(|&success| success)
+                     .count();
+                     
+-                println!("Successfully stopped {} verge-mihomo processes", kill_count);
++                println!("Successfully stopped {} mihomo processes", kill_count);
+             }
+             Err(e) => {
+-                eprintln!("Error finding verge-mihomo processes: {}", e);
++                eprintln!("Error finding mihomo processes: {}", e);
+             }
+         }
+         
+@@ -360,7 +360,7 @@ impl CoreManager {
+             eprintln!("Error killing clash process: {}", e);
+         }
+ 
+-        // 同时停止mihomo进程和其他verge-mihomo进程
++        // 同时停止mihomo进程和其他mihomo进程
+         let _ = self.stop_mihomo();
+         let _ = self.stop_other_mihomo_processes();
+ 
+-- 
+2.49.0
+

--- a/app-network/clash-verge-service/spec
+++ b/app-network/clash-verge-service/spec
@@ -1,3 +1,4 @@
 VER=0+git20250324
+REL=1
 SRCS="git::commit=ffcccc6095e052534980230f9e0ca97db2675062::https://github.com/clash-verge-rev/clash-verge-service"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-servie: fix stop mihomo process

Package(s) Affected
-------------------

- clash-verge-service: 0+git20250324-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
