### PR TITLE
qt-6: change include directory to /usr/include/qt6

### DIFF
--- a/runtime-desktop/qt-6/01-runtime/defines
+++ b/runtime-desktop/qt-6/01-runtime/defines
@@ -44,7 +44,7 @@ ABTYPE=cmakeninja
 # It's also helpful to refer to build options used by other distributions.
 CMAKE_AFTER="-DINSTALL_BINDIR=lib/qt6/bin \
              -DINSTALL_DOCDIR=share/doc/qt-6 \
-             -DINSTALL_HEADERDIR=include/qt6 \
+             -DINSTALL_INCLUDEDIR=include/qt6 \
              -DINSTALL_ARCHDATADIR=lib/qt6 \
              -DINSTALL_MKSPECSDIR=lib/qt6/mkspecs \
              -DINSTALL_DATADIR=share/qt6 \

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=1
+REL=2
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::659d8bb5931afac9ed5d89a78e868e6bd00465a58ab566e2123db02d674be559"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: change include directory to /usr/include/qt6

Package(s) Affected
-------------------

- qt-6: 6.8.2-2
- qt-6-doc: 6.8.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
