### PR TITLE
mariadb: improve packaging

### DIFF
--- a/app-database/mariadb/autobuild/defines
+++ b/app-database/mariadb/autobuild/defines
@@ -4,59 +4,62 @@ PKGDEP="libaio perl-term-readkey libxml2 pcre inetutils zlib openssl \
         jemalloc snappy lz4"
 PKGREP="percona-server"
 PKGPROV="mysql percona-server"
-PKGDES="A drop-in replacement for Oracle MySQL"
+PKGDES="Drop-in replacement for Oracle MySQL"
 
-NOLTO=1
-NOSTATIC=no
+# FIXME: Failure during linkage.
+#
+# .../storage/innobase/log/log0sync.cc:273:(.text+0x1ccf10): relocation truncated to fit: R_MIPS_TLS_LDM against `__tls_guard'
+NOLTO__LOONGSON3=1
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
-        # Build options
-        -DBUILD_CONFIG=mysql_release 
-        -DCMAKE_AR=/usr/bin/gcc-ar 
-        -DCMAKE_RANLIB=/usr/bin/gcc-ranlib 
-        # Installation directories
-        -DCMAKE_INSTALL_PREFIX=/usr 
-        -DSYSCONFDIR=/etc/mysql 
-        -DINSTALL_INFODIR=share/mysql/docs 
-        -DINSTALL_MANDIR=share/man 
-        -DINSTALL_PLUGINDIR=lib/mysql/plugin 
-        -DINSTALL_SCRIPTDIR=bin 
-        -DINSTALL_INCLUDEDIR=include/mysql 
-        -DINSTALL_DOCREADMEDIR=share/mysql 
-        -DINSTALL_SUPPORTFILESDIR=share/mysql 
-        -DINSTALL_MYSQLSHAREDIR=share/mysql 
-        -DINSTALL_DOCDIR=share/mysql/docs 
-        -DINSTALL_SHAREDIR=share/mysql
-        -DMYSQL_DATADIR=/var/lib/mysql 
-        -DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock 
-        # Default configurations
-        -DDEFAULT_CHARSET=utf8 
-        -DDEFAULT_COLLATION=utf8_general_ci 
-        # Features
-        -DENABLED_LOCAL_INFILE=ON 
-        -DWITH_READLINE=ON 
-        -DWITH_ZLIB=system 
-        -DWITH_SSL=system 
-        -DWITH_PCRE=bundled 
-        -DWITH_LIBWRAP=OFF 
-        -DWITH_JEMALLOC=yes 
-        -DWITH_LIBARCHIVE=ON 
-        -DWITH_MARIABACKUP=ON 
-        -DWITH_EXTRA_CHARSETS=complex 
-        -DWITH_EMBEDDED_SERVER=ON 
-        -DWITH_ARCHIVE_STORAGE_ENGINE=1 
-        -DWITH_BLACKHOLE_STORAGE_ENGINE=1 
-        -DWITH_INNOBASE_STORAGE_ENGINE=1 
-        -DWITH_PARTITION_STORAGE_ENGINE=1 
-        -DWITH_TOKUDB=ON 
-        -DWITH_SYSTEMD=yes 
-        -DWITHOUT_EXAMPLE_STORAGE_ENGINE=1 
-        -DWITHOUT_FEDERATED_STORAGE_ENGINE=1 
-        -DWITHOUT_PBXT_STORAGE_ENGINE=1 
-        -DWITH_MYSQLD_LDFLAGS=${LD_MYSQLD} 
-        -DLZ4_LIBS:FILEPATH=/usr/lib
+    # Build options
+    '-DBUILD_CONFIG=mysql_release'
+    '-DCMAKE_AR=/usr/bin/gcc-ar'
+    '-DCMAKE_RANLIB=/usr/bin/gcc-ranlib'
+    # Installation directories
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+    '-DSYSCONFDIR=/etc/mysql'
+    '-DINSTALL_INFODIR=share/mysql/docs'
+    '-DINSTALL_MANDIR=share/man'
+    '-DINSTALL_PLUGINDIR=lib/mysql/plugin'
+    '-DINSTALL_SCRIPTDIR=bin'
+    '-DINSTALL_INCLUDEDIR=include/mysql'
+    '-DINSTALL_DOCREADMEDIR=share/mysql'
+    '-DINSTALL_SUPPORTFILESDIR=share/mysql'
+    '-DINSTALL_MYSQLSHAREDIR=share/mysql'
+    '-DINSTALL_DOCDIR=share/mysql/docs'
+    '-DINSTALL_SHAREDIR=share/mysql'
+    '-DMYSQL_DATADIR=/var/lib/mysql'
+    '-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock'
+    # Default configurations
+    '-DDEFAULT_CHARSET=utf8'
+    '-DDEFAULT_COLLATION=utf8_general_ci'
+    # Features
+    '-DENABLED_LOCAL_INFILE=ON'
+    '-DWITH_READLINE=ON'
+    '-DWITH_ZLIB=system'
+    '-DWITH_SSL=system'
+    '-DWITH_PCRE=bundled'
+    '-DWITH_LIBWRAP=OFF'
+    '-DWITH_JEMALLOC=yes'
+    '-DWITH_LIBARCHIVE=ON'
+    '-DWITH_MARIABACKUP=ON'
+    '-DWITH_EXTRA_CHARSETS=complex'
+    '-DWITH_EMBEDDED_SERVER=ON'
+    '-DWITH_ARCHIVE_STORAGE_ENGINE=1'
+    '-DWITH_BLACKHOLE_STORAGE_ENGINE=1'
+    '-DWITH_INNOBASE_STORAGE_ENGINE=1'
+    '-DWITH_PARTITION_STORAGE_ENGINE=1'
+    '-DWITH_TOKUDB=ON'
+    '-DWITH_SYSTEMD=yes'
+    '-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1'
+    '-DWITHOUT_FEDERATED_STORAGE_ENGINE=1'
+    '-DWITHOUT_PBXT_STORAGE_ENGINE=1'
+    '-DLZ4_LIBS:FILEPATH=/usr/lib'
 )
-CMAKE_AFTER__RISCV64=(${CMAKE_AFTER[@]} 
-             -DCMAKE_EXE_LINKER_FLAGS=-latomic 
-             -DCMAKE_SHARED_LINKER_FLAGS=-latomic)
-ABTYPE=cmake
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER[@]}"
+    '-DCMAKE_EXE_LINKER_FLAGS=-latomic'
+    '-DCMAKE_SHARED_LINKER_FLAGS=-latomic'
+)

--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,4 +1,5 @@
 VER=11.7.2
+REL=1
 SRCS="git::commit=tags/mariadb-$VER::https://github.com/MariaDB/server"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1887"


### PR DESCRIPTION
Topic Description
-----------------

- mariadb: improve packaging
    - Drop unused static libraries.
    - Clean up array syntax.
    - Drop an unreferenced option.

Package(s) Affected
-------------------

- mariadb: 11.7.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
