### PR TITLE
renpy: fix figure and bypass system path writing

### DIFF
--- a/runtime-games/renpy/autobuild/build
+++ b/runtime-games/renpy/autobuild/build
@@ -39,8 +39,12 @@ install -Dvm644 "$SRCDIR"/README.rst \
 
 install -dvm755 \
     "$PKGDIR"/usr/share/renpy/lib/py3-linux-$ARCH
-ln -sv ../../../../bin/renpy \
+ln -sv /bin/renpy \
     "$PKGDIR"/usr/share/renpy/lib/"py3-linux-$(uname -m)"
+# Use system font than provided to avoid CJK figure issue.
+# Font path is hardcoded so we link system font here.
+ln -sfv /usr/share/fonts/TTF/NotoSansCJK-Regular.ttc \
+    "$PKGDIR"/usr/share/renpy/sdk-fonts/SourceHanSansLite.ttf
 
 cd "$SRCDIR"/module
 python3 \

--- a/runtime-games/renpy/autobuild/defines
+++ b/runtime-games/renpy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=renpy
 PKGSEC=games
 PKGDEP="ffmpeg fribidi harfbuzz freetype libpng sdl2 sdl2-image pefile future \
-        sdl2-mixer sdl2-gfx sdl2-ttf assimp pygame-sdl2 ecdsa legacy-cgi"
+        sdl2-mixer sdl2-gfx sdl2-ttf assimp pygame-sdl2 ecdsa legacy-cgi noto-cjk-fonts"
 BUILDDEP="cython setuptools-scm sphinx-rtd-theme wheel python-build \
           python-installer sphinx-rtd-dark-mode"
 PKGDES="The Ren'Py Visual Novel Engine"

--- a/runtime-games/renpy/autobuild/patches/0002-system-dir-read-only-bypass.patch
+++ b/runtime-games/renpy/autobuild/patches/0002-system-dir-read-only-bypass.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -ruN a/renpy/script.py b/renpy/script.py
+--- a/renpy/script.py	2025-04-07 17:55:46.274898239 +0800
++++ b/renpy/script.py	2025-04-12 16:59:56.879717971 +0800
+@@ -810,7 +810,7 @@
+ 
+                 pickle_data_after_static_transforms = dumps((data, stmts))
+ 
+-                if not renpy.macapp:
++                if not renpy.macapp and not rpycfn.startswith("/usr/share/renpy"):
+                     try:
+                         with open(rpycfn, "wb") as f:
+                             self.write_rpyc_header(f)


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
This topic fixes CJK figure problem in renpy launcher and skips writing into /usr/share/renpy to avoid error.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
renpy
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order
-----------

```
#buildit renpy
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
