### PR TITLE
NVIDIA Driver 570.133.07

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=12.6.3
-MIN_DRIVER_VER=560.35.05
+UPSTREAM_VER=12.8.1
+MIN_DRIVER_VER=570.124.06
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::81d60e48044796d7883aa8a049afe6501b843f2c45639b3703b2378de30d55d3"
+CHKSUMS__AMD64="sha256::228f6bcaf5b7618d032939f431914fc92d0e5ed39ebe37098a24502f26a19797"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::213ea63a6357020978a8b0a79a8c9d12a2a5941afa1cdc69d5a3f933fa8bed04"
+CHKSUMS__ARM64="sha256::353cbab1b57282a1001071796efd95c1e40ec27a3375e854d12637eaa1c6107c"

--- a/groups/nvidia
+++ b/groups/nvidia
@@ -1,0 +1,5 @@
+runtime-display/nvidia
+runtime-display/nvidia-open
+runtime-display/libxnvctrl
+runtime-optenv32/libxnvctrl+32
+app-devel/cuda

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,8 +1,7 @@
-_DRIVER_VER=570.124.04
+_DRIVER_VER=570.133.07
 # Note: sometimes utilities are not updated timely
-_UTILS_VERS=570.124.04
+_UTILS_VERS=570.133.07
 VER=${_DRIVER_VER}+utils${_UTILS_VERS}
-REL=1
 SRCS="git::rename=nvidia-driver;commit=tags/${_DRIVER_VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,9 +1,8 @@
-VER=570.124.04
-REL=1
+VER=570.133.07
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::1b786a4b7122d7c4216c58ae4007688a4f778c196c148d919163815ee10d53c4"
+CHKSUMS__AMD64="sha256::2d43e64c581be5ef554de9888b1aa90037ef6d45f54284d3d9dcedc08dc4dc26"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run"
-CHKSUMS__ARM64="sha256::1cde7c374d12344c0c40a48ab8e3005d55ba276548ff66320ee9503491ee55e3"
+CHKSUMS__ARM64="sha256::c93a2f527a3fd5391a91e99194da4d07dd54f95d380024ccc0f1210e893b8c8d"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 12.8.1+570.124.06
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 570.133.07
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 570.133.07
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- groups: add nvidia
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 12.8.1+570.124.06
- nvidia: 570.133.07
- nvidia-firmware: 570.133.07
- nvidia-open: 570.133.07+utils570.133.07
- nvidia-utils: 570.133.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
