### PR TITLE
erofs-utils: new, 1.8.6


### DIFF
--- a/app-admin/erofs-utils/autobuild/defines
+++ b/app-admin/erofs-utils/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=erofs-utils
+PKGSEC=admin
+PKGDES="Userspace tools for EROFS filesystem"
+PKGDEP="fuse-3 zlib libdeflate zstd xxhash lz4 util-linux-runtime glibc"
+
+AUTOTOOLS_AFTER=(
+    "--enable-multithreading"
+    "--enable-fuse"
+    "--enable-lz4"
+    "--enable-lzma"
+    "--with-libzstd"
+    "--with-libdeflate"
+    "--with-xxhash"
+    "--with-zlib"
+    "--with-uuid"
+)

--- a/app-admin/erofs-utils/spec
+++ b/app-admin/erofs-utils/spec
@@ -1,0 +1,4 @@
+VER=1.8.6
+SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=63188"


### PR DESCRIPTION
Topic Description
-----------------

- erofs-utils: new, 1.8.6

Package(s) Affected
-------------------

- erofs-utils: 1.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit erofs-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
