### PR TITLE
syncthing: update to 1.29.5

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,6 +1,5 @@
-VER=1.29.4
+VER=1.29.5
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::d17699e3233127dd7f1315b41bec3926fdac42b6beeca4fcb6f05b1e25ed9941"
+CHKSUMS="sha256::17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 1.29.5
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- syncthing: 1.29.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
