### PR TITLE
git: fix perl modules install path

### DIFF
--- a/app-vcs/git/01-git-core/beyond
+++ b/app-vcs/git/01-git-core/beyond
@@ -3,3 +3,9 @@ install -Dvm644 "$SRCDIR"/contrib/completion/git-completion.bash \
     "$PKGDIR"/usr/share/bash-completion/completions/git
 install -Dvm644 "$SRCDIR"/contrib/completion/git-completion.zsh \
     "$PKGDIR"/usr/share/zsh/site-functions/_git
+
+abinfo "Fixing Perl modules location ..."
+mkdir -vp "$PKGDIR"/usr/share/perl5/vendor_perl
+mv -v "$PKGDIR"/usr/share/perl5/Git "$PKGDIR"/usr/share/perl5/vendor_perl/Git
+mv -v "$PKGDIR"/usr/share/perl5/FromCPAN "$PKGDIR"/usr/share/perl5/vendor_perl/FromCPAN
+mv -v "$PKGDIR"/usr/share/perl5/Git.pm "$PKGDIR"/usr/share/perl5/vendor_perl/Git.pm

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,7 +1,7 @@
 VER=2.49.0
 
 # Use this for stable releases.
-REL=2
+REL=3
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- git: fix perl modules install path
    Signed-off-by: xtex <xtexchooser@duck.com>

Package(s) Affected
-------------------

- git: 2.49.0-3
- git-gui: 2.49.0-3
- gitk: 2.49.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
