### PR TITLE
niri: fix wrong PKGSUG

### DIFF
--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="bash cairo gcc-runtime glib glibc gnome-keyring libdisplay-info \
         libinput libxkbcommon mesa pango pipewire pixman seatd systemd \
         wayland xdg-desktop-portal-gtk xdg-desktop-portal-gnome"
 PKGRECOM="alacritty fuzzel swaylock xwayland-satellite"
-PKGSUG="mako swaybg swayidle"
+PKGSUG="mako-notification-daemon swaybg swayidle"
 BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"
 USECLANG=1

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -2,4 +2,4 @@ VER=25.02
 SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- niri: fix wrong PKGSUG

I am sorry for my mistake.

Package(s) Affected
-------------------

- niri: 25.02-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
