### PR TITLE
broadcom-wl: update to 6.30.223.271-7

### DIFF
--- a/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
+++ b/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
@@ -21,10 +21,11 @@ PATCH[13]="015-linux600.patch"
 PATCH[14]="016-linux601.patch"
 PATCH[15]="017-linux612.patch"
 PATCH[16]="018-linux613.patch"
+PATCH[17]="019-linux614.patch"
 # Debian patches
 # https://packages.debian.org/sid/broadcom-sta-dkms
-PATCH[17]="05-remove-time-and-date-macros.patch"
+PATCH[18]="05-remove-time-and-date-macros.patch"
 # AOSC OS patches
-PATCH[18]="aosc-1-wlan-ifname.patch"
-PATCH[19]="aosc-2-blob-path.patch"
+PATCH[19]="aosc-1-wlan-ifname.patch"
+PATCH[20]="aosc-2-blob-path.patch"
 AUTOINSTALL="yes"

--- a/runtime-kernel/broadcom-wl/autobuild/patches/019-linux614.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/019-linux614.patch
@@ -1,0 +1,34 @@
+From: Eduard Bloch <blade@debian.org>
+Date: Sun, 16 Mar 2025 16:13:08 +0100
+Subject: Prepare for 6.14.0-rc6
+
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 2c865c1..e23ef83 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -98,7 +98,9 @@ static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy,
+            enum tx_power_setting type, s32 mbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm);
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm);
+@@ -1159,7 +1161,9 @@ wl_cfg80211_set_tx_power(struct wiphy *wiphy, enum tx_power_setting type, s32 mb
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm)
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm)

--- a/runtime-kernel/broadcom-wl/spec
+++ b/runtime-kernel/broadcom-wl/spec
@@ -1,5 +1,5 @@
 VER=6.30.223.271
-REL=6
+REL=7
 SRCS="tbl::https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/hybrid-v35_64-nodebug-pcoem-${VER//./_}.tar.gz"
 CHKSUMS="sha256::5f79774d5beec8f7636b59c0fb07a03108eef1e3fd3245638b20858c714144be"
 SUBDIR=.


### PR DESCRIPTION
Bring in latest patch from Arch Linux for Linux 6.14

Topic Description
-----------------

broadcom-wl-6.30.223.271-7
Proprietary Broadcom WiFi driver updated for Linux v6.14

Package(s) Affected
-------------------

runtime-kernel/broadcom-wl

Security Update?
----------------

No

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`

Build Order
------------------

```
#buildit broadcom-wl
```