### PR TITLE
libfishsound: update to 1.0.1

### DIFF
--- a/runtime-multimedia/libfishsound/autobuild/defines
+++ b/runtime-multimedia/libfishsound/autobuild/defines
@@ -3,5 +3,5 @@ PKGSEC=sound
 PKGDEP="flac libvorbis speex"
 PKGDES="A simple programming interface that wraps Xiph.Org audio codecs"
 
-MAKE_AFTER="docdir=./docs"
+ABTYPE=autotools
 RECONF=0

--- a/runtime-multimedia/libfishsound/spec
+++ b/runtime-multimedia/libfishsound/spec
@@ -1,5 +1,4 @@
-VER=1.0.0
-REL=2
+VER=1.0.1
 SRCS="tbl::https://downloads.xiph.org/releases/libfishsound/libfishsound-$VER.tar.gz"
-CHKSUMS="sha256::2e0b57ce2fecc9375eef72938ed08ac8c8f6c5238e1cae24458f0b0e8dade7c7"
+CHKSUMS="sha256::03eb1601e2306adc88c776afdf212217c6547990d2d0f9ca544dad9a8a9dbb8f"
 CHKUPDATE="anitya::id=230926"


### PR DESCRIPTION
Topic Description
-----------------

- libfishsound: update to 1.0.1

Package(s) Affected
-------------------

- libfishsound: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfishsound
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
