### PR TITLE
mkvtoolnix: update to 91.0

### DIFF
--- a/app-multimedia/mkvtoolnix/autobuild/build
+++ b/app-multimedia/mkvtoolnix/autobuild/build
@@ -1,9 +1,8 @@
-abinfo "Configuring MKVToolNix ..."
-"$SRCDIR"/configure \
-    --prefix=/usr \
-    --with-boost-libdir=/usr/lib \
-    --enable-qt \
-    --without-curl
+# Use the functions within the autotools template
+# to complete the autotools configuration.
+build_autotools_update_base
+build_autotools_regenerate
+build_autotools_configure
 
 abinfo "Building MKVToolNix ..."
 rake \

--- a/app-multimedia/mkvtoolnix/autobuild/defines
+++ b/app-multimedia/mkvtoolnix/autobuild/defines
@@ -7,3 +7,14 @@ PKGDES="Set of tools to create, edit and inspect Matroska files"
 
 AB_FLAGS_O3=1
 AB_FLAGS_SPECS=0
+ABSHADOW=0
+
+# FIXME: If set ABTYPE=autotools, will return error `make: *** No targets
+# specified and no makefile found.`
+#
+# It contains Autotools source with a full configuration file, but it
+# does not generate a Makefile for building.
+ABTYPE=self
+AUTOTOOLS_AFTER=(
+    "--disable-update-check"
+)

--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,4 +1,4 @@
-VER=87.0
+VER=91.0
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
-CHKSUMS="sha256::01cdfcbe01d9a771da4d475ed44d882a97695d08b6939684cebf56231bdee820"
+CHKSUMS="sha256::451320ee90a041cf85b42dbb4683316bf288d2382c54cdd8cd33b1e0258a3bb3"
 CHKUPDATE="anitya::id=1991"


### PR DESCRIPTION
Topic Description
-----------------

- mkvtoolnix: update to 91.0

Package(s) Affected
-------------------

- mkvtoolnix: 91.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mkvtoolnix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
