### PR TITLE
kernel-base: add broadcom-wl as recommended dependency

### DIFF
--- a/meta-bases/kernel-base/autobuild/build
+++ b/meta-bases/kernel-base/autobuild/build
@@ -1,1 +1,0 @@
-mkdir "$PKGDIR"

--- a/meta-bases/kernel-base/autobuild/defines
+++ b/meta-bases/kernel-base/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=kernel-base
 PKGSEC=Bases
 PKGRECOM="dracut-ng firmware-free firmware-nonfree linux+kernel kmod openfwwf \
           wireless-regdb"
+PKGRECOM__AMD64="${PKGRECOM} broadcom-wl"
 PKGRECOM__LOONGARCH64="${PKGRECOM} loonggpu-kernel-dkms"
 PKGRECOM__RETRO="kmod linux+kernel+retro"
 PKGRECOM__I486="${PKGRECOM__RETRO}"
@@ -13,4 +14,5 @@ PKGDES="Meta package for AOSC OS Linux Kernel support"
 
 VER_NONE=1
 
+ABTYPE=dummy
 ABSPLITDBG=0

--- a/meta-bases/kernel-base/spec
+++ b/meta-bases/kernel-base/spec
@@ -1,2 +1,2 @@
-VER=6
+VER=7
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- kernel-base: \(amd64\) add broadcom-wl as RECOM

Package(s) Affected
-------------------

- kernel-base: 7

Security Update?
----------------

No

Build Order
-----------

```
#buildit kernel-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
