### PR TITLE
libcava: update to 0.10.4

### DIFF
--- a/app-utils/waybar/autobuild/patches/0001-fix-support-libcava-0.10.4.patch
+++ b/app-utils/waybar/autobuild/patches/0001-fix-support-libcava-0.10.4.patch
@@ -1,0 +1,34 @@
+From 252e4f78bfb18d515c99c55afbe47a3987deb2d7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sun, 13 Apr 2025 22:11:41 -0700
+Subject: [PATCH] fix: support libcava 0.10.4
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ include/modules/cava.hpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/include/modules/cava.hpp b/include/modules/cava.hpp
+index b4d2325b..1a88c7b7 100644
+--- a/include/modules/cava.hpp
++++ b/include/modules/cava.hpp
+@@ -5,7 +5,16 @@
+ 
+ namespace cava {
+ extern "C" {
++// Need sdl_glsl output feature to be enabled on libcava
++#ifndef SDL_GLSL
++#define SDL_GLSL
++#endif
++
+ #include <cava/common.h>
++
++#ifdef SDL_GLSL
++#undef SDL_GLSL
++#endif
+ }
+ }  // namespace cava
+ 
+-- 
+2.49.0
+

--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,5 +1,5 @@
 VER=0.12.0
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"
-REL=1

--- a/runtime-multimedia/libcava/autobuild/defines
+++ b/runtime-multimedia/libcava/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=libcava
 PKGSEC=sound
-PKGDEP="fftw iniparser ncurses sndio pulseaudio pipewire portaudio jack"
-BUILDDEP="alsa-lib"
+PKGDEP="fftw iniparser ncurses alsa-lib sndio pulseaudio pipewire portaudio jack sdl2"
 PKGDES="Console-based Audio Visualizer for Alsa (MPD and Pulseaudio) as a shared library"
 
 ABTYPE=meson
@@ -9,11 +8,17 @@ ABTYPE=meson
 # FIXME: FTBFS with LTO enabled
 NOLTO=1
 
-MESON_AFTER="-Dbuild_target=lib \
-        -Dcava_font=false \
-        -Dinput_alsa=enabled \
-        -Dinput_pulse=enabled \
-        -Dinput_pipewire=enabled \
-        -Dinput_portaudio=enabled \
-        -Dinput_sndio=enabled \
-        -Dinput_jack=enabled"
+MESON_AFTER=(
+    '-Dbuild_target=lib'
+    '-Dcava_font=false'
+    '-Dinput_alsa=enabled'
+    '-Dinput_pulse=enabled'
+    '-Dinput_pipewire=enabled'
+    '-Dinput_portaudio=enabled'
+    '-Dinput_sndio=enabled'
+    '-Doutput_sdl=enabled'
+    '-Doutput_ncurses=enabled'
+    '-Doutput_sdl_glsl=enabled'
+)
+
+PKGBREAK="waybar<=0.12.0-1"

--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,5 +1,4 @@
-VER=0.10.3
-REL=1
+VER=0.10.4
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 0.10.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libcava: 0.10.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava:-pkgbreak waybar libcava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
