### PR TITLE
php: update to 8.4.6

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,4 @@
-VER=8.4.5
+VER=8.4.6
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::0d3270bbce4d9ec617befce52458b763fd461d475f1fe2ed878bb8573faed327"
+CHKSUMS="sha256::089b08a5efef02313483325f3bacd8c4fe311cf1e1e56749d5cc7d059e225631"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.4.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- php: 1:8.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
