### PR TITLE
Revert "kernel-base: (amd64) add broadcom-wl as RECOM"

### DIFF
--- a/meta-bases/kernel-base/autobuild/defines
+++ b/meta-bases/kernel-base/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=kernel-base
 PKGSEC=Bases
 PKGRECOM="dracut-ng firmware-free firmware-nonfree linux+kernel kmod openfwwf \
           wireless-regdb"
-PKGRECOM__AMD64="${PKGRECOM} broadcom-wl"
 PKGRECOM__LOONGARCH64="${PKGRECOM} loonggpu-kernel-dkms"
 PKGRECOM__RETRO="kmod linux+kernel+retro"
 PKGRECOM__I486="${PKGRECOM__RETRO}"

--- a/meta-bases/kernel-base/spec
+++ b/meta-bases/kernel-base/spec
@@ -1,2 +1,2 @@
-VER=7
+VER=8
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- Revert "kernel-base: \(amd64\) add broadcom-wl as RECOM"
    For some reason, the wl module is always loaded, even if no such device
    was found on the device.
    This reverts commit 7d318142e89f3ad5c34f190bca58279b3d084ae7.

Package(s) Affected
-------------------

- kernel-base: 8

Security Update?
----------------

No

Build Order
-----------

```
#buildit kernel-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
