### PR TITLE
yambar: new, 1.11.0

### DIFF
--- a/app-utils/yambar/autobuild/defines
+++ b/app-utils/yambar/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=yambar
+PKGSEC=utils
+PKGDEP="alsa-lib fcft glibc json-c libmpdclient libxcb pipewire pixman \
+        pulseaudio systemd wayland xcb-util xcb-util-cursor \
+        xcb-util-renderutil xcb-util-wm yaml"
+PKGRECOM="font-awesome"
+BUILDDEP="meson ninja scdoc tllist"
+PKGDES="Modular status panel for X11 and Wayland"
+
+ABTYPE=meson

--- a/app-utils/yambar/spec
+++ b/app-utils/yambar/spec
@@ -1,0 +1,4 @@
+VER=1.11.0
+SRCS="git::commit=tags/${VER}::https://codeberg.org/dnkl/yambar"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=284436"


### PR DESCRIPTION
Topic Description
-----------------

- yambar: new, 1.11.0

Package(s) Affected
-------------------

- yambar: 1.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit yambar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
