### PR TITLE
fnott: new, 1.7.1

### DIFF
--- a/app-utils/fnott/autobuild/defines
+++ b/app-utils/fnott/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=fnott
+PKGSEC=utils
+PKGDEP="dbus fcft fontconfig glibc libpng pixman wayland"
+BUILDDEP="meson scdoc tllist wayland-protocols"
+PKGDES="Keyboard-driven Wayland notification daemon"
+
+ABTYPE=meson

--- a/app-utils/fnott/spec
+++ b/app-utils/fnott/spec
@@ -1,0 +1,4 @@
+VER=1.7.1
+SRCS="git::commit=tags/${VER}::https://codeberg.org/dnkl/fnott"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375603"


### PR DESCRIPTION
Topic Description
-----------------

- fnott: new, 1.7.1

Package(s) Affected
-------------------

- fnott: 1.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fnott
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
