### PR TITLE
scummvm: update to 2.9.0

### DIFF
--- a/app-games/scummvm/autobuild/beyond
+++ b/app-games/scummvm/autobuild/beyond
@@ -1,2 +1,0 @@
-install -Dm644 dists/org.scummvm.scummvm.desktop \
-    "$PKGDIR"/usr/share/applications/org.scummvm.scummvm.desktop

--- a/app-games/scummvm/autobuild/build
+++ b/app-games/scummvm/autobuild/build
@@ -1,3 +1,14 @@
-./configure --prefix=/usr "${AUTOTOOLS_AFTER}"
-make
-make install DESTDIR="$PKGDIR"
+abinfo "Configuring scummvm ..."
+"$SRCDIR"/configure \
+    "${AUTOTOOLS_DEF[@]}" \
+    "--enable-all-engines" \
+    "--enable-release" \
+    "--enable-debug" \
+    "--with-manual-version=${PKGVER}"
+
+abinfo "Building scummvm ..."
+make V=1 VERBOSE=1
+
+abinfo "Installing scummvm ..."
+make install V=1 VERBOSE=1 \
+    DESTDIR="$PKGDIR"

--- a/app-games/scummvm/autobuild/defines
+++ b/app-games/scummvm/autobuild/defines
@@ -1,11 +1,13 @@
 PKGNAME=scummvm
 PKGSEC=games
-PKGDEP="faad2 flac fluidsynth freetype glu libjpeg-turbo libmad libmpeg2 \
-        libpng libtheora libvorbis sdl2 readline zlib fribidi \
-        speech-dispatcher libvpx libmikmod nasm curl"
+PKGDEP="a52dec alsa-lib curl faad2 flac fluidsynth freetype fribidi gcc-runtime \
+        giflib glibc glu libjpeg-turbo libmad libmikmod libmpcdec libmpeg2 \
+        libogg libpng libtheora libvorbis libvpx openmpt sdl2 sonivox \
+        speech-dispatcher zlib"
 PKGDES="A software virtual machine for classic point-and-click adventure games"
 
-AUTOTOOLS_AFTER="--enable-all-engines \
-                 --enable-release \
-                 --enable-debug"
 ABSHADOW=0
+ABTYPE=self
+
+# FIXME: _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
+NOLTO=1

--- a/app-games/scummvm/autobuild/prepare
+++ b/app-games/scummvm/autobuild/prepare
@@ -1,2 +1,0 @@
-unset CPPFLAGS CXXFLAGS CFLAGS LDFLAGS
-export CXXFLAGS="${CXXFLAGS} -I/usr/include/SDL2 -I/usr/include/freetype2"

--- a/app-games/scummvm/spec
+++ b/app-games/scummvm/spec
@@ -1,4 +1,4 @@
-VER=2.8.1
+VER=2.9.0
 SRCS="tbl::https://www.scummvm.org/frs/scummvm/$VER/scummvm-$VER.tar.xz"
-CHKSUMS="sha256::7e97f4a13d22d570b70c9b357c941999be71deb9186039c87d82bbd9c20727b7"
+CHKSUMS="sha256::d5b33532bd70d247f09127719c670b4b935810f53ebb6b7b6eafacaa5da99452"
 CHKUPDATE="anitya::id=4775"


### PR DESCRIPTION
Topic Description
-----------------

- scummvm: update to 2.9.0
    - Adjust PKGDEP
    - Improve build files

Package(s) Affected
-------------------

- scummvm: 2.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scummvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
