### PR TITLE
xfsprogs: update to 6.13.0

### DIFF
--- a/app-admin/xfsprogs/spec
+++ b/app-admin/xfsprogs/spec
@@ -1,4 +1,4 @@
-VER=6.12.0
+VER=6.13.0
 SRCS="https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-$VER.tar.xz"
-CHKSUMS="sha256::0832407247db791cc70def96e7e254bd6edf043dc84a80a62f3ccd6e3dffd329"
+CHKSUMS="sha256::0459933f93d94c82bc2789e7bd63742273d9d74207cdae67dc3032038da08337"
 CHKUPDATE="anitya::id=5188"


### PR DESCRIPTION
Topic Description
-----------------

- xfsprogs: update to 6.13.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- xfsprogs: 6.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
