### PR TITLE
broadcom-wl: update to 6.30.223.271-8

### DIFF
--- a/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
+++ b/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
@@ -25,7 +25,9 @@ PATCH[17]="019-linux614.patch"
 # Debian patches
 # https://packages.debian.org/sid/broadcom-sta-dkms
 PATCH[18]="05-remove-time-and-date-macros.patch"
+PATCH[19]="33-wl-Add-explanation-for-IBT-warnings-in-newer-kernels.patch"
+PATCH[20]="37-wl-Fix-memcpy-field-spanning-write-warning.patch"
 # AOSC OS patches
-PATCH[19]="aosc-1-wlan-ifname.patch"
-PATCH[20]="aosc-2-blob-path.patch"
+PATCH[21]="aosc-1-wlan-ifname.patch"
+PATCH[22]="aosc-2-blob-path.patch"
 AUTOINSTALL="yes"

--- a/runtime-kernel/broadcom-wl/autobuild/patches/33-wl-Add-explanation-for-IBT-warnings-in-newer-kernels.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/33-wl-Add-explanation-for-IBT-warnings-in-newer-kernels.patch
@@ -1,0 +1,36 @@
+From: Diego Escalante Urrelo <diegoe@gnome.org>
+Date: Thu, 13 Feb 2025 00:19:36 -0500
+Subject: wl: Add explanation for IBT warnings in newer kernels
+
+Because of the binary blob the driver will trigger the kernel's
+"Unpatched return thunk in use" warning. We can not fix without
+recompiling the blob.
+
+Considering that this driver handles wifi cards that are mostly
+attached/locked to pre-2020 CPUs, this patch adds a non-critical warning
+message explaining the scary kernel traces and suggesting `ibt=off`.
+
+Based on Andreas Beckmann <anbe@debian.org> patch and suggestion.
+
+See: https://salsa.debian.org/nvidia-team/nvidia-graphics-drivers/-/blob/470/debian/module/debian/patches/0033-refuse-to-load-legacy-module-if-IBT-is-enabled.patch?ref_type=heads
+See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1084853#10
+Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1084853
+---
+ amd64/src/wl/sys/wl_linux.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/amd64/src/wl/sys/wl_linux.c b/amd64/src/wl/sys/wl_linux.c
+index 4d618b7..d56bf2c 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -930,6 +930,10 @@ wl_module_init(void)
+ {
+ 	int error = -ENODEV;
+ 
++#ifdef CONFIG_X86_KERNEL_IBT
++	printk(KERN_WARNING "wl: This driver includes a binary blob incompatible with IBT protection, available since Intel Core Tiger Lake (11th gen, 2020). If your CPU is older you can ignore the 'Unpatched return thunk in use' warnings caused by this driver. You can disable IBT by adding `ibt=off` to your kernel boot options.");
++#endif
++
+ #ifdef BCMDBG
+ 	if (msglevel != 0xdeadbeef)
+ 		wl_msg_level = msglevel;

--- a/runtime-kernel/broadcom-wl/autobuild/patches/37-wl-Fix-memcpy-field-spanning-write-warning.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/37-wl-Fix-memcpy-field-spanning-write-warning.patch
@@ -1,0 +1,26 @@
+From: Diego Escalante Urrelo <diegoe@gnome.org>
+Date: Fri, 14 Feb 2025 00:06:29 -0500
+Subject: wl: Fix memcpy() field-spanning write warning
+
+Handle the following warning:
+  kernel: memcpy: detected field-spanning write (size 160) of single
+  field "dst" at .../src/wl/sys/wl_cfg80211_hybrid.c:3086 (size 0)
+
+See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1084853
+---
+ amd64/src/wl/sys/wl_cfg80211_hybrid.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/amd64/src/wl/sys/wl_cfg80211_hybrid.h b/amd64/src/wl/sys/wl_cfg80211_hybrid.h
+index bc6f3ad..014c399 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.h
++++ b/src/wl/sys/wl_cfg80211_hybrid.h
+@@ -103,7 +103,7 @@ struct beacon_proberesp {
+ 	__le64 timestamp;
+ 	__le16 beacon_int;
+ 	__le16 capab_info;
+-	u8 variable[0];
++	u8 variable[];
+ } __attribute__ ((packed));
+ 
+ struct wl_cfg80211_conf {

--- a/runtime-kernel/broadcom-wl/spec
+++ b/runtime-kernel/broadcom-wl/spec
@@ -1,5 +1,5 @@
 VER=6.30.223.271
-REL=7
+REL=8
 SRCS="tbl::https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/hybrid-v35_64-nodebug-pcoem-${VER//./_}.tar.gz"
 CHKSUMS="sha256::5f79774d5beec8f7636b59c0fb07a03108eef1e3fd3245638b20858c714144be"
 SUBDIR=.


### PR DESCRIPTION
Bring in some patches from Debian to explain and fix kernel log warnings.
Note, setting `ibt=off` does not suppress the _thunk_ warning.

Topic Description
-----------------

broadcom-wl-6.30.223.271-8
Proprietary Broadcom WiFi driver updated for better UX.

Package(s) Affected
-------------------

runtime-kernel/broadcom-wl

Security Update?
----------------

No

Build Order
----------------

```
#buildit broadcom-wl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
