### PR TITLE
oma: update to 1.16.0

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.15.2
+VER=1.16.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.16.0.toml
+++ b/topics/oma-1.16.0.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.16.0"
+zh_CN = "小熊猫包管理 (oma) 1.16.0"
+
+[caution]
+default = "With improved interface and instructions for fixing/reporting package manager errors, topic-aware undo functionality, and enhancements to various interfaces."
+zh_CN = "修缮了软件包管理报错及修复操作的用户界面、为撤销功能 (oma undo) 新增了对安同 OS 测试源 (topics) 设置的状态操作支持，并对一部分界面设计进行了优化"
+
+[packages]
+oma = "1.16.0"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.16.0

Package(s) Affected
-------------------

- oma: 1.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



