### PR TITLE
kcoreaddons: rebuild for gamin dep change

### DIFF
--- a/desktop-kde/kcoreaddons/spec
+++ b/desktop-kde/kcoreaddons/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/kcoreaddons-$VER.tar.xz"
 CHKSUMS="sha256::8cd0e1d3e3e9da8de9519ac6fb70dac660cb9286c2deb1f695212edd2c8e99c9"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- kcoreaddons: rebuild for gamin dep change

Package(s) Affected
-------------------

- kcoreaddons: 5.115.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kcoreaddons
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
