### PR TITLE
wbg: new, 1.2.0

### DIFF
--- a/app-utils/wbg/autobuild/defines
+++ b/app-utils/wbg/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=wbg
+PKGSEC=utils
+PKGDEP="glibc libjpeg-turbo libpng libwebp pixman wayland"
+BUILDDEP="wayland-protocols meson ninja tllist"
+PKGDES="Wallpaper application for layer-shell Wayland compositors"
+
+ABTYPE=meson

--- a/app-utils/wbg/spec
+++ b/app-utils/wbg/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/wbg"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375605"


### PR DESCRIPTION
Topic Description
-----------------

- wbg: new, 1.2.0

Package(s) Affected
-------------------

- wbg: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wbg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
