### PR TITLE
fnott: use system nanosvg

### DIFF
--- a/app-utils/fnott/autobuild/defines
+++ b/app-utils/fnott/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=fnott
 PKGSEC=utils
-PKGDEP="dbus fcft fontconfig glibc libpng pixman wayland"
+PKGDEP="dbus fcft fontconfig glibc libpng nanosvg pixman wayland"
 BUILDDEP="meson scdoc tllist wayland-protocols"
 PKGDES="Keyboard-driven Wayland notification daemon"
 
 ABTYPE=meson
+MESON_AFTER="-Dsystem-nanosvg=enabled"

--- a/app-utils/fnott/spec
+++ b/app-utils/fnott/spec
@@ -2,3 +2,4 @@ VER=1.7.1
 SRCS="git::commit=tags/${VER}::https://codeberg.org/dnkl/fnott"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375603"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- fnott: use system nanosvg

Package(s) Affected
-------------------

- fnott: 1.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fnott
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
