### PR TITLE
ffmpeg: rebuild for samba dep change

### DIFF
--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1
-REL=7
+REL=8
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: rebuild for samba dep change

Package(s) Affected
-------------------

- ffmpeg: 7.1-8
- ffmpeg-static-libs-for-sunshine: 7.1-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
