### PR TITLE
zellij: update to 0.42.2

### DIFF
--- a/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
+++ b/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
@@ -1,17 +1,17 @@
-From 9a64c11c8551e88041a0d1d839eca1c5c6c4beb5 Mon Sep 17 00:00:00 2001
+From 1e52abcaa68d574ca7ff6dfadf6c29c12fdedfe6 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 21 Mar 2025 03:27:32 -0700
 Subject: [PATCH 1/2] chore: update wasmtime to 30.0.2
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- Cargo.lock                              | 267 +++++++++++-------------
+ Cargo.lock                              | 257 +++++++++++-------------
  zellij-server/Cargo.toml                |   6 +-
  zellij-server/src/plugins/plugin_map.rs |  15 +-
- 3 files changed, 129 insertions(+), 159 deletions(-)
+ 3 files changed, 129 insertions(+), 149 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 34be5fd0..cf380854 100644
+index 204fd5cc..ef55c939 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -34,18 +34,6 @@ version = "1.0.2"
@@ -175,7 +175,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "cranelift-codegen",
   "libc",
-@@ -1550,15 +1557,6 @@ version = "0.11.2"
+@@ -1514,15 +1521,6 @@ version = "0.11.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
  
@@ -191,7 +191,7 @@ index 34be5fd0..cf380854 100644
  [[package]]
  name = "hashbrown"
  version = "0.15.2"
-@@ -2863,13 +2861,12 @@ dependencies = [
+@@ -2795,13 +2793,12 @@ dependencies = [
  
  [[package]]
  name = "pulley-interpreter"
@@ -207,7 +207,7 @@ index 34be5fd0..cf380854 100644
   "wasmtime-math",
  ]
  
-@@ -2901,7 +2898,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+@@ -2833,7 +2830,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
  dependencies = [
   "rand_chacha 0.9.0",
   "rand_core 0.9.0",
@@ -216,7 +216,7 @@ index 34be5fd0..cf380854 100644
  ]
  
  [[package]]
-@@ -2940,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -2872,7 +2869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
  dependencies = [
   "getrandom 0.3.1",
@@ -225,24 +225,7 @@ index 34be5fd0..cf380854 100644
  ]
  
  [[package]]
-@@ -4183,16 +4180,6 @@ version = "0.2.87"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
- 
--[[package]]
--name = "wasm-encoder"
--version = "0.221.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
--dependencies = [
-- "leb128",
-- "wasmparser 0.221.2",
--]
--
- [[package]]
- name = "wasm-encoder"
- version = "0.224.0"
-@@ -4200,14 +4187,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -4094,14 +4091,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
  dependencies = [
   "leb128",
@@ -252,15 +235,15 @@ index 34be5fd0..cf380854 100644
  
  [[package]]
  name = "wasmparser"
--version = "0.221.2"
+-version = "0.221.3"
 +version = "0.224.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
+-checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 +checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
  dependencies = [
   "bitflags 2.5.0",
   "hashbrown 0.15.2",
-@@ -4216,33 +4203,22 @@ dependencies = [
+@@ -4110,33 +4107,22 @@ dependencies = [
   "serde",
  ]
  
@@ -285,7 +268,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "termcolor",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasmparser",
  ]
  
@@ -299,7 +282,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "addr2line 0.24.2",
   "anyhow",
-@@ -4254,7 +4230,7 @@ dependencies = [
+@@ -4148,7 +4134,7 @@ dependencies = [
   "encoding_rs",
   "fxprof-processed-profile",
   "gimli 0.31.1",
@@ -308,18 +291,18 @@ index 34be5fd0..cf380854 100644
   "indexmap 2.7.1",
   "ittapi",
   "libc",
-@@ -4277,8 +4253,8 @@ dependencies = [
+@@ -4171,8 +4157,8 @@ dependencies = [
   "sptr",
   "target-lexicon",
   "trait-variant",
 - "wasm-encoder 0.221.2",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasm-encoder",
 + "wasmparser",
   "wasmtime-asm-macros",
   "wasmtime-cache",
   "wasmtime-component-macro",
-@@ -4298,18 +4274,18 @@ dependencies = [
+@@ -4192,18 +4178,18 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-asm-macros"
@@ -342,7 +325,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "base64 0.21.0",
-@@ -4327,9 +4303,9 @@ dependencies = [
+@@ -4221,9 +4207,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-macro"
@@ -354,7 +337,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "proc-macro2",
-@@ -4342,15 +4318,15 @@ dependencies = [
+@@ -4236,15 +4222,15 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-util"
@@ -374,7 +357,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4363,19 +4339,20 @@ dependencies = [
+@@ -4257,19 +4243,20 @@ dependencies = [
   "itertools 0.12.1",
   "log",
   "object 0.36.7",
@@ -382,7 +365,7 @@ index 34be5fd0..cf380854 100644
   "smallvec",
   "target-lexicon",
   "thiserror 1.0.61",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasmparser",
   "wasmtime-environ",
   "wasmtime-versioned-export-macros",
@@ -398,12 +381,12 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "cpp_demangle",
-@@ -4392,17 +4369,17 @@ dependencies = [
+@@ -4286,17 +4273,17 @@ dependencies = [
   "serde_derive",
   "smallvec",
   "target-lexicon",
 - "wasm-encoder 0.221.2",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasm-encoder",
 + "wasmparser",
   "wasmprinter",
@@ -420,7 +403,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "cc",
-@@ -4415,10 +4392,11 @@ dependencies = [
+@@ -4309,10 +4296,11 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-debug"
@@ -434,7 +417,7 @@ index 34be5fd0..cf380854 100644
   "object 0.36.7",
   "rustix 0.38.44",
   "wasmtime-versioned-export-macros",
-@@ -4426,9 +4404,9 @@ dependencies = [
+@@ -4320,9 +4308,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-icache-coherence"
@@ -446,7 +429,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4438,24 +4416,24 @@ dependencies = [
+@@ -4332,24 +4320,24 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-math"
@@ -477,7 +460,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4464,9 +4442,9 @@ dependencies = [
+@@ -4358,9 +4346,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wasi"
@@ -489,7 +472,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4486,25 +4464,38 @@ dependencies = [
+@@ -4380,25 +4368,38 @@ dependencies = [
   "thiserror 1.0.61",
   "tokio",
   "tracing",
@@ -527,12 +510,12 @@ index 34be5fd0..cf380854 100644
   "gimli 0.31.1",
   "object 0.36.7",
   "target-lexicon",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasmparser",
   "wasmtime-cranelift",
   "wasmtime-environ",
   "winch-codegen",
-@@ -4512,9 +4503,9 @@ dependencies = [
+@@ -4406,9 +4407,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wit-bindgen"
@@ -544,7 +527,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4541,7 +4532,7 @@ dependencies = [
+@@ -4435,7 +4436,7 @@ dependencies = [
   "leb128",
   "memchr",
   "unicode-width 0.2.0",
@@ -553,7 +536,7 @@ index 34be5fd0..cf380854 100644
  ]
  
  [[package]]
-@@ -4657,9 +4648,9 @@ dependencies = [
+@@ -4551,9 +4552,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle"
@@ -565,7 +548,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4672,9 +4663,9 @@ dependencies = [
+@@ -4566,9 +4567,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-generate"
@@ -577,7 +560,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4687,9 +4678,9 @@ dependencies = [
+@@ -4581,9 +4582,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-macro"
@@ -589,7 +572,7 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4730,9 +4721,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+@@ -4624,9 +4625,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
  
  [[package]]
  name = "winch-codegen"
@@ -601,38 +584,38 @@ index 34be5fd0..cf380854 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -4741,7 +4732,7 @@ dependencies = [
+@@ -4635,7 +4636,7 @@ dependencies = [
   "smallvec",
   "target-lexicon",
   "thiserror 1.0.61",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasmparser",
   "wasmtime-cranelift",
   "wasmtime-environ",
  ]
-@@ -4999,9 +4990,9 @@ dependencies = [
+@@ -4893,9 +4894,9 @@ dependencies = [
  
  [[package]]
  name = "wit-parser"
--version = "0.221.2"
+-version = "0.221.3"
 +version = "0.224.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+-checksum = "896112579ed56b4a538b07a3d16e562d101ff6265c46b515ce0c701eef16b2ac"
 +checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
  dependencies = [
   "anyhow",
   "id-arena",
-@@ -5012,7 +5003,7 @@ dependencies = [
+@@ -4906,7 +4907,7 @@ dependencies = [
   "serde_derive",
   "serde_json",
   "unicode-xid",
-- "wasmparser 0.221.2",
+- "wasmparser 0.221.3",
 + "wasmparser",
  ]
  
  [[package]]
-@@ -5215,33 +5206,13 @@ dependencies = [
-  "vte 0.11.0",
+@@ -5132,33 +5133,13 @@ dependencies = [
+  "uuid",
  ]
  
 -[[package]]
@@ -667,28 +650,24 @@ index 34be5fd0..cf380854 100644
  
  [[package]]
 diff --git a/zellij-server/Cargo.toml b/zellij-server/Cargo.toml
-index ceaaf93f..f542cdc4 100644
+index c42ff874..9511ee7a 100644
 --- a/zellij-server/Cargo.toml
 +++ b/zellij-server/Cargo.toml
-@@ -19,7 +19,7 @@ daemonize = "0.5"
- serde_json = "1.0"
- unicode-width = "0.1.8"
- url = "2.2.2"
--wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
-+wasmtime-wasi = "30.0.2" # Keep in sync with wasmtime
- cassowary = "0.3.0"
- zellij-utils = { path = "../zellij-utils/", version = "0.42.1" }
- log = "0.4.17"
-@@ -34,7 +34,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
- semver = "0.11.0"
+@@ -45,11 +45,11 @@ unicode-width = { workspace = true }
+ url = { workspace = true }
+ uuid = { workspace = true }
+ vte = { workspace = true }
+-wasmtime-wasi = { version = "29.0.1", default-features = false, features = ["preview1"] } # Keep in sync with wasmtime
++wasmtime-wasi = { version = "30.0.2", default-features = false, features = ["preview1"] } # Keep in sync with wasmtime
+ zellij-utils = { workspace = true }
  
  [dependencies.wasmtime]
 -version = "29.0.1" # Keep in sync with wasmtime-wasi
 +version = "30.0.2" # Keep in sync with wasmtime-wasi
  default-features = false
  features = [
-   'async',
-@@ -54,7 +54,7 @@ features = [
+   'addr2line',
+@@ -65,7 +65,7 @@ features = [
  [dev-dependencies]
  insta = "1.6.0"
  tempfile = "3.2.0"
@@ -698,7 +677,7 @@ index ceaaf93f..f542cdc4 100644
  [features]
  singlepass = ["wasmtime/winch"]
 diff --git a/zellij-server/src/plugins/plugin_map.rs b/zellij-server/src/plugins/plugin_map.rs
-index 655aec50..bb2385fe 100644
+index 6716dffd..c923c778 100644
 --- a/zellij-server/src/plugins/plugin_map.rs
 +++ b/zellij-server/src/plugins/plugin_map.rs
 @@ -10,8 +10,7 @@ use std::{

--- a/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
+++ b/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
@@ -1,23 +1,23 @@
-From 4da340d708db28d42117bced036723b902f5c302 Mon Sep 17 00:00:00 2001
+From f9b12fbc26b9b5761d4795e478c4c7413d7fc979 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 21 Mar 2025 03:27:12 -0700
 Subject: [PATCH 2/2] chore: update nix to >=0.27 to support loongarch64
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- Cargo.lock                           | 19 ++--------
+ Cargo.lock                           | 35 ++++--------------
+ Cargo.toml                           |  2 +-
  zellij-client/src/lib.rs             | 17 ++++-----
  zellij-client/src/os_input_output.rs | 24 ++++++-------
  zellij-server/src/os_input_output.rs | 54 +++++++++++++++++-----------
  zellij-server/src/pty.rs             | 35 ++++++++++++++----
- zellij-utils/Cargo.toml              |  2 +-
- 6 files changed, 87 insertions(+), 64 deletions(-)
+ 6 files changed, 90 insertions(+), 77 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index cf380854..9d147bb1 100644
+index ef55c939..997790d1 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2136,7 +2136,7 @@ version = "1.1.8"
+@@ -2078,7 +2078,7 @@ version = "1.1.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
  dependencies = [
@@ -26,7 +26,7 @@ index cf380854..9d147bb1 100644
   "winapi",
  ]
  
-@@ -2296,19 +2296,6 @@ dependencies = [
+@@ -2238,19 +2238,6 @@ dependencies = [
   "rand 0.8.5",
  ]
  
@@ -46,7 +46,7 @@ index cf380854..9d147bb1 100644
  [[package]]
  name = "nix"
  version = "0.29.0"
-@@ -3654,7 +3641,7 @@ dependencies = [
+@@ -3566,7 +3553,7 @@ dependencies = [
   "libc",
   "log",
   "memmem",
@@ -54,18 +54,75 @@ index cf380854..9d147bb1 100644
 + "nix",
   "num-derive",
   "num-traits",
-  "ordered-float 4.2.0",
-@@ -5181,7 +5168,7 @@ dependencies = [
+  "ordered-float",
+@@ -4074,16 +4061,6 @@ version = "0.2.87"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+ 
+-[[package]]
+-name = "wasm-encoder"
+-version = "0.221.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+-dependencies = [
+- "leb128",
+- "wasmparser 0.221.3",
+-]
+-
+ [[package]]
+ name = "wasm-encoder"
+ version = "0.224.0"
+@@ -4986,7 +4963,7 @@ dependencies = [
+  "log",
+  "miette",
+  "names",
+- "nix 0.23.1",
++ "nix",
+  "rand 0.8.5",
+  "regex",
+  "ssh2",
+@@ -5009,7 +4986,7 @@ dependencies = [
+  "libc",
+  "log",
+  "mio 0.7.14",
+- "nix 0.23.1",
++ "nix",
+  "notify-debouncer-full",
+  "regex",
+  "serde",
+@@ -5046,7 +5023,7 @@ dependencies = [
+  "lazy_static",
+  "libc",
+  "log",
+- "nix 0.23.1",
++ "nix",
+  "notify-debouncer-full",
+  "prost",
+  "regex",
+@@ -5113,7 +5090,7 @@ dependencies = [
   "log",
   "log4rs",
   "miette",
 - "nix 0.23.1",
 + "nix",
-  "notify-debouncer-full",
-  "once_cell",
   "openssl-sys",
+  "percent-encoding",
+  "prost",
+diff --git a/Cargo.toml b/Cargo.toml
+index e48dfa2c..02394a61 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -67,7 +67,7 @@ lazy_static = { version = "1.4.0", default-features = false }
+ libc = { version = "0.2", default-features = false, features = ["std"] }
+ log = { version = "0.4.17", default-features = false }
+ miette = { version = "5.7.0", default-features = false, features = ["fancy"] }
+-nix = { version = "0.23.1", default-features = false }
++nix = { version = "0.29.0", default-features = false, features = ["fs", "process", "signal", "term", "user"]  }
+ notify-debouncer-full = { version = "0.1.0", default-features = false }
+ prost = { version = "0.11.9", default-features = false, features = ["std", "prost-derive"] }
+ regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
 diff --git a/zellij-client/src/lib.rs b/zellij-client/src/lib.rs
-index 725ed8cd..1dacff98 100644
+index 3256ada1..ebca605d 100644
 --- a/zellij-client/src/lib.rs
 +++ b/zellij-client/src/lib.rs
 @@ -11,6 +11,7 @@ mod stdin_handler;
@@ -149,10 +206,10 @@ index 725ed8cd..1dacff98 100644
          let exit_kitty_keyboard_mode = "\u{1b}[<1u";
          if !explicitly_disable_kitty_keyboard_protocol {
 diff --git a/zellij-client/src/os_input_output.rs b/zellij-client/src/os_input_output.rs
-index 41d03b0f..c3fcb601 100644
+index 8f7d8817..65f1dc6a 100644
 --- a/zellij-client/src/os_input_output.rs
 +++ b/zellij-client/src/os_input_output.rs
-@@ -9,7 +9,7 @@ use nix::sys::termios;
+@@ -12,7 +12,7 @@ use nix::sys::termios;
  use signal_hook::{consts::signal::*, iterator::Signals};
  use std::io::prelude::*;
  use std::io::IsTerminal;
@@ -161,7 +218,7 @@ index 41d03b0f..c3fcb601 100644
  use std::path::Path;
  use std::sync::{Arc, Mutex};
  use std::{io, thread, time};
-@@ -27,7 +27,7 @@ const ENABLE_MOUSE_SUPPORT: &str =
+@@ -30,7 +30,7 @@ const ENABLE_MOUSE_SUPPORT: &str =
  const DISABLE_MOUSE_SUPPORT: &str =
      "\u{1b}[?1006l\u{1b}[?1015l\u{1b}[?1003l\u{1b}[?1002l\u{1b}[?1000l";
  
@@ -170,7 +227,7 @@ index 41d03b0f..c3fcb601 100644
      let mut tio = termios::tcgetattr(pid).expect("could not get terminal attribute");
      termios::cfmakeraw(&mut tio);
      match termios::tcsetattr(pid, termios::SetArg::TCSANOW, &tio) {
-@@ -36,11 +36,11 @@ fn into_raw_mode(pid: RawFd) {
+@@ -39,11 +39,11 @@ fn into_raw_mode(pid: RawFd) {
      };
  }
  
@@ -184,7 +241,7 @@ index 41d03b0f..c3fcb601 100644
      // TODO: do this with the nix ioctl
      use libc::ioctl;
      use libc::TIOCGWINSZ;
-@@ -57,7 +57,7 @@ pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> Size {
+@@ -60,7 +60,7 @@ pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> Size {
      // useless conversion.
      #[allow(clippy::useless_conversion)]
      unsafe {
@@ -193,7 +250,7 @@ index 41d03b0f..c3fcb601 100644
      };
  
      // fallback to default values when rows/cols == 0: https://github.com/zellij-org/zellij/issues/1551
-@@ -89,13 +89,13 @@ pub struct ClientOsInputOutput {
+@@ -92,13 +92,13 @@ pub struct ClientOsInputOutput {
  /// Zellij client requires.
  pub trait ClientOsApi: Send + Sync {
      /// Returns the size of the terminal associated to file descriptor `fd`.
@@ -210,7 +267,7 @@ index 41d03b0f..c3fcb601 100644
      /// Returns the writer that allows writing to standard output.
      fn get_stdout_writer(&self) -> Box<dyn io::Write>;
      /// Returns a BufReader that allows to read from STDIN line by line, also locks STDIN
-@@ -130,13 +130,13 @@ pub trait ClientOsApi: Send + Sync {
+@@ -133,13 +133,13 @@ pub trait ClientOsApi: Send + Sync {
  }
  
  impl ClientOsApi for ClientOsInputOutput {
@@ -227,7 +284,7 @@ index 41d03b0f..c3fcb601 100644
          match &self.orig_termios {
              Some(orig_termios) => {
                  let orig_termios = orig_termios.lock().unwrap();
-@@ -319,7 +319,7 @@ impl Clone for Box<dyn ClientOsApi> {
+@@ -322,7 +322,7 @@ impl Clone for Box<dyn ClientOsApi> {
  }
  
  pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
@@ -237,7 +294,7 @@ index 41d03b0f..c3fcb601 100644
      let reading_from_stdin = Arc::new(Mutex::new(None));
      Ok(ClientOsInputOutput {
 diff --git a/zellij-server/src/os_input_output.rs b/zellij-server/src/os_input_output.rs
-index 59c63bd6..c8feb674 100644
+index c6e4de78..5f39005c 100644
 --- a/zellij-server/src/os_input_output.rs
 +++ b/zellij-server/src/os_input_output.rs
 @@ -1,6 +1,10 @@
@@ -252,7 +309,7 @@ index 59c63bd6..c8feb674 100644
  use interprocess::local_socket::LocalSocketStream;
  use nix::{
      pty::{openpty, OpenptyResult, Winsize},
-@@ -34,8 +38,12 @@ use std::{
+@@ -36,8 +40,12 @@ use std::{
      collections::{BTreeMap, BTreeSet, HashMap},
      env,
      fs::File,
@@ -266,7 +323,7 @@ index 59c63bd6..c8feb674 100644
      path::PathBuf,
      process::{Child, Command},
      sync::{Arc, Mutex},
-@@ -45,7 +53,7 @@ pub use async_trait::async_trait;
+@@ -47,7 +55,7 @@ pub use async_trait::async_trait;
  pub use nix::unistd::Pid;
  
  fn set_terminal_size_using_fd(
@@ -275,7 +332,7 @@ index 59c63bd6..c8feb674 100644
      columns: u16,
      rows: u16,
      width_in_pixels: Option<u16>,
-@@ -68,7 +76,7 @@ fn set_terminal_size_using_fd(
+@@ -70,7 +78,7 @@ fn set_terminal_size_using_fd(
      // useless conversion.
      #[allow(clippy::useless_conversion)]
      unsafe {
@@ -284,7 +341,7 @@ index 59c63bd6..c8feb674 100644
      };
  }
  
-@@ -155,7 +163,7 @@ fn handle_openpty(
+@@ -157,7 +165,7 @@ fn handle_openpty(
      cmd: RunCommand,
      quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
      terminal_id: u32,
@@ -293,7 +350,7 @@ index 59c63bd6..c8feb674 100644
      let err_context = |cmd: &RunCommand| {
          format!(
              "failed to open PTY for command '{}'",
-@@ -165,7 +173,7 @@ fn handle_openpty(
+@@ -167,7 +175,7 @@ fn handle_openpty(
  
      // primary side of pty and child fd
      let pid_primary = open_pty_res.master;
@@ -302,7 +359,7 @@ index 59c63bd6..c8feb674 100644
  
      if command_exists(&cmd) {
          let mut child = unsafe {
-@@ -224,7 +232,7 @@ fn handle_terminal(
+@@ -226,7 +234,7 @@ fn handle_terminal(
      orig_termios: Option<termios::Termios>,
      quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
      terminal_id: u32,
@@ -311,7 +368,7 @@ index 59c63bd6..c8feb674 100644
      let err_context = || "failed to spawn child terminal".to_string();
  
      // Create a pipe to allow the child the communicate the shell's pid to its
-@@ -236,7 +244,7 @@ fn handle_terminal(
+@@ -238,7 +246,7 @@ fn handle_terminal(
                  handle_terminal(failover_cmd, None, orig_termios, quit_cb, terminal_id)
                      .with_context(err_context)
              },
@@ -320,7 +377,7 @@ index 59c63bd6..c8feb674 100644
                  .context("failed to start pty")
                  .with_context(err_context)
                  .to_log(),
-@@ -283,7 +291,7 @@ fn spawn_terminal(
+@@ -285,7 +293,7 @@ fn spawn_terminal(
      quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit_status
      default_editor: Option<PathBuf>,
      terminal_id: u32,
@@ -329,7 +386,7 @@ index 59c63bd6..c8feb674 100644
      // returns the terminal_id, the primary fd and the
      // secondary fd
      let mut failover_cmd_args = None;
-@@ -421,7 +429,7 @@ impl ClientSender {
+@@ -423,7 +431,7 @@ impl ClientSender {
  pub struct ServerOsInputOutput {
      orig_termios: Arc<Mutex<Option<termios::Termios>>>,
      client_senders: Arc<Mutex<HashMap<ClientId, ClientSender>>>,
@@ -338,7 +395,7 @@ index 59c63bd6..c8feb674 100644
      // terminal_id exists but is
      // not connected to an fd (eg.
      // a command pane with a
-@@ -476,7 +484,7 @@ pub trait ServerOsApi: Send + Sync {
+@@ -478,7 +486,7 @@ pub trait ServerOsApi: Send + Sync {
          terminal_action: TerminalAction,
          quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
          default_editor: Option<PathBuf>,
@@ -347,7 +404,7 @@ index 59c63bd6..c8feb674 100644
      // reserves a terminal id without actually opening a terminal
      fn reserve_terminal_id(&self) -> Result<u32> {
          unimplemented!()
-@@ -521,7 +529,7 @@ pub trait ServerOsApi: Send + Sync {
+@@ -523,7 +531,7 @@ pub trait ServerOsApi: Send + Sync {
          terminal_id: u32,
          run_command: RunCommand,
          quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
@@ -356,7 +413,7 @@ index 59c63bd6..c8feb674 100644
      fn clear_terminal_id(&self, terminal_id: u32) -> Result<()>;
      fn cache_resizes(&mut self) {}
      fn apply_cached_resizes(&mut self) {}
-@@ -556,7 +564,13 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -558,7 +566,13 @@ impl ServerOsApi for ServerOsInputOutput {
          {
              Some(Some(fd)) => {
                  if cols > 0 && rows > 0 {
@@ -371,7 +428,7 @@ index 59c63bd6..c8feb674 100644
                  }
              },
              _ => {
-@@ -573,7 +587,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -575,7 +589,7 @@ impl ServerOsApi for ServerOsInputOutput {
          terminal_action: TerminalAction,
          quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
          default_editor: Option<PathBuf>,
@@ -380,7 +437,7 @@ index 59c63bd6..c8feb674 100644
          let err_context = || "failed to spawn terminal".to_string();
  
          let orig_termios = self
-@@ -610,7 +624,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -612,7 +626,7 @@ impl ServerOsApi for ServerOsInputOutput {
                      self.terminal_id_to_raw_fd
                          .lock()
                          .to_anyhow()?
@@ -389,7 +446,7 @@ index 59c63bd6..c8feb674 100644
                      Ok((terminal_id, pid_primary, pid_secondary))
                  })
                  .with_context(err_context)
-@@ -661,7 +675,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -663,7 +677,7 @@ impl ServerOsApi for ServerOsInputOutput {
              .with_context(err_context)?
              .get(&terminal_id)
          {
@@ -398,7 +455,7 @@ index 59c63bd6..c8feb674 100644
              _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
          }
      }
-@@ -675,7 +689,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -677,7 +691,7 @@ impl ServerOsApi for ServerOsInputOutput {
              .with_context(err_context)?
              .get(&terminal_id)
          {
@@ -407,7 +464,7 @@ index 59c63bd6..c8feb674 100644
              _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
          }
      }
-@@ -816,7 +830,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -818,7 +832,7 @@ impl ServerOsApi for ServerOsInputOutput {
          terminal_id: u32,
          run_command: RunCommand,
          quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
@@ -416,7 +473,7 @@ index 59c63bd6..c8feb674 100644
          let default_editor = None; // no need for a default editor when running an explicit command
          self.orig_termios
              .lock()
-@@ -834,7 +848,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -836,7 +850,7 @@ impl ServerOsApi for ServerOsInputOutput {
                  self.terminal_id_to_raw_fd
                      .lock()
                      .to_anyhow()?
@@ -425,7 +482,7 @@ index 59c63bd6..c8feb674 100644
                  Ok((pid_primary, pid_secondary))
              })
              .with_context(|| format!("failed to rerun command in terminal id {}", terminal_id))
-@@ -877,7 +891,7 @@ impl Clone for Box<dyn ServerOsApi> {
+@@ -879,7 +893,7 @@ impl Clone for Box<dyn ServerOsApi> {
  }
  
  pub fn get_server_os_input() -> Result<ServerOsInputOutput, nix::Error> {
@@ -435,12 +492,12 @@ index 59c63bd6..c8feb674 100644
          log::warn!("Starting a server without a controlling terminal, using the default termios configuration.");
      }
 diff --git a/zellij-server/src/pty.rs b/zellij-server/src/pty.rs
-index 3bb5f227..78822ee3 100644
+index 450f0b0b..ca16cad0 100644
 --- a/zellij-server/src/pty.rs
 +++ b/zellij-server/src/pty.rs
-@@ -10,7 +10,11 @@ use crate::{
+@@ -14,7 +14,11 @@ use async_std::{
  };
- use async_std::task::{self, JoinHandle};
+ use nix::unistd::Pid;
  use std::sync::Arc;
 -use std::{collections::HashMap, os::unix::io::RawFd, path::PathBuf};
 +use std::{
@@ -448,10 +505,10 @@ index 3bb5f227..78822ee3 100644
 +    os::unix::io::{IntoRawFd, OwnedFd, RawFd},
 +    path::PathBuf,
 +};
- use zellij_utils::nix::unistd::Pid;
  use zellij_utils::{
-     async_std,
-@@ -985,7 +989,7 @@ impl Pty {
+     data::{Event, FloatingPaneCoordinates, OriginatingPlugin},
+     errors::prelude::*,
+@@ -987,7 +991,7 @@ impl Pty {
                  }
              }
          });
@@ -460,7 +517,7 @@ index 3bb5f227..78822ee3 100644
              .bus
              .os_input
              .as_mut()
-@@ -994,6 +998,7 @@ impl Pty {
+@@ -996,6 +1000,7 @@ impl Pty {
                  os_input.spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())
              })
              .with_context(err_context)?;
@@ -468,7 +525,7 @@ index 3bb5f227..78822ee3 100644
          let terminal_bytes = task::spawn({
              let err_context =
                  |terminal_id: u32| format!("failed to run async task for terminal {terminal_id}");
-@@ -1233,7 +1238,7 @@ impl Pty {
+@@ -1235,7 +1240,7 @@ impl Pty {
                                  terminal_id,
                                  starts_held,
                                  Some(command.clone()),
@@ -477,7 +534,7 @@ index 3bb5f227..78822ee3 100644
                              )))
                          },
                          Err(err) => {
-@@ -1261,7 +1266,12 @@ impl Pty {
+@@ -1263,7 +1268,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -491,7 +548,7 @@ index 3bb5f227..78822ee3 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1292,7 +1302,12 @@ impl Pty {
+@@ -1294,7 +1304,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -505,7 +562,7 @@ index 3bb5f227..78822ee3 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1315,7 +1330,12 @@ impl Pty {
+@@ -1317,7 +1332,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -519,7 +576,7 @@ index 3bb5f227..78822ee3 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1420,7 +1440,7 @@ impl Pty {
+@@ -1422,7 +1442,7 @@ impl Pty {
                          }
                      }
                  });
@@ -528,7 +585,7 @@ index 3bb5f227..78822ee3 100644
                      .bus
                      .os_input
                      .as_mut()
-@@ -1429,6 +1449,7 @@ impl Pty {
+@@ -1431,6 +1451,7 @@ impl Pty {
                          os_input.re_run_command_in_terminal(id, run_command, quit_cb)
                      })
                      .with_context(err_context)?;
@@ -536,19 +593,6 @@ index 3bb5f227..78822ee3 100644
                  let terminal_bytes = task::spawn({
                      let err_context =
                          |pane_id| format!("failed to run async task for pane {pane_id:?}");
-diff --git a/zellij-utils/Cargo.toml b/zellij-utils/Cargo.toml
-index 14e50b51..f62a51cc 100644
---- a/zellij-utils/Cargo.toml
-+++ b/zellij-utils/Cargo.toml
-@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
- libc = "0.2"
- log = "0.4.17"
- miette = { version = "5.7.0", features = ["fancy"] }
--nix = "0.23.1"
-+nix = { version = "0.29.0", features = ["fs", "process", "signal", "term", "user"] }
- once_cell = "1.8.0"
- percent-encoding = "2.1.0"
- prost = "0.11.9"
 -- 
 2.49.0
 

--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.42.1
+VER=0.42.2
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.42.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.42.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
