### PR TITLE
yambar: add xcb-util-errors support

### DIFF
--- a/app-utils/yambar/autobuild/defines
+++ b/app-utils/yambar/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=yambar
 PKGSEC=utils
 PKGDEP="alsa-lib fcft glibc json-c libmpdclient libxcb pipewire pixman \
-        pulseaudio systemd wayland xcb-util xcb-util-cursor \
+        pulseaudio systemd wayland xcb-util xcb-util-cursor xcb-util-errors \
         xcb-util-renderutil xcb-util-wm yaml"
 PKGRECOM="font-awesome"
 BUILDDEP="meson ninja scdoc tllist"

--- a/app-utils/yambar/spec
+++ b/app-utils/yambar/spec
@@ -2,3 +2,4 @@ VER=1.11.0
 SRCS="git::commit=tags/${VER}::https://codeberg.org/dnkl/yambar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=284436"
+REL=1

--- a/runtime-display/xcb-util-errors/autobuild/defines
+++ b/runtime-display/xcb-util-errors/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=xcb-util-errors
+PKGDEP="xcb-util xcb-proto"
+PKGSEC=x11
+PKGDES="X11 Client Side Utilities - Error Display Libraries"
+
+RECONF=0

--- a/runtime-display/xcb-util-errors/spec
+++ b/runtime-display/xcb-util-errors/spec
@@ -1,0 +1,4 @@
+VER=1.0.1
+SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-errors-$VER.tar.xz"
+CHKSUMS="sha256::5628c87b984259ad927bacd8a42958319c36bdf4b065887803c9d820fb80f357"
+CHKUPDATE="anitya::id=371158"


### PR DESCRIPTION
Topic Description
-----------------

- yambar: add xcb-util-errors support

Package(s) Affected
-------------------

- xcb-util-errors: 1.0.1
- yambar: 1.11.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcb-util-errors yambar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
