### PR TITLE
virtualbox: update to 7.1.8

### DIFF
--- a/app-virtualization/virtualbox/01-host/patches/0001-FROM-ARCHLINUX-fix-Frontends-VirtualBox-disable-upda.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0001-FROM-ARCHLINUX-fix-Frontends-VirtualBox-disable-upda.patch
@@ -1,4 +1,4 @@
-From f83359a8ea3ec385467e71af0a9b361b999e03f1 Mon Sep 17 00:00:00 2001
+From 55b5774fc64e60b0b9e4d32a051550410c4ab054 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:26:00 +0800
 Subject: [PATCH 01/10] FROM ARCHLINUX: fix(Frontends/VirtualBox): disable
@@ -22,5 +22,5 @@ index cf81c1b50..44dd62c00 100644
  
  QString UIExtraDataManager::applicationUpdateData()
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0002-FROM-ARCHLINUX-properly-handle-i3wm.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0002-FROM-ARCHLINUX-properly-handle-i3wm.patch
@@ -1,4 +1,4 @@
-From 50cbf17b0b46940b3163fbe8296d660fc93fa242 Mon Sep 17 00:00:00 2001
+From 9c23d0e2d02cdd091ac4031d77d52aca83f86a60 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Tue, 17 Jan 2023 22:04:08 +0100
 Subject: [PATCH 02/10] FROM ARCHLINUX: properly handle i3wm
@@ -11,7 +11,7 @@ Subject: [PATCH 02/10] FROM ARCHLINUX: properly handle i3wm
  4 files changed, 11 insertions(+), 3 deletions(-)
 
 diff --git a/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp b/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
-index 0e0332b7a..ef9875ee0 100644
+index 62ab34103..03fd75f09 100644
 --- a/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
 +++ b/src/VBox/Frontends/VirtualBox/src/globals/UIDesktopWidgetWatchdog.cpp
 @@ -380,7 +380,8 @@ QRect UIDesktopWidgetWatchdog::availableGeometry(QScreen *pScreen) const
@@ -77,5 +77,5 @@ index e77a25ef5..9359d3d0b 100644
  
      /* Make sure we have no focus: */
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0003-FROM-ARCHLINUX-support-building-from-dkms.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0003-FROM-ARCHLINUX-support-building-from-dkms.patch
@@ -1,4 +1,4 @@
-From 5ea21621575e848fdce6ae2585df8492aa547600 Mon Sep 17 00:00:00 2001
+From 5ff54226e48929aded23a379950b15c9d055afad Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:30:32 +0200
 Subject: [PATCH 03/10] FROM ARCHLINUX: support building from dkms
@@ -53,5 +53,5 @@ index 295fc49eb..f33fb3633 100644
 +endif # ! KBUILD_EXTMOD
  
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0004-FROM-ARCHLINUX-upate-xclient-script.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0004-FROM-ARCHLINUX-upate-xclient-script.patch
@@ -1,4 +1,4 @@
-From 9e58b57a886693ccc9bb443cf5a010ba9db300ab Mon Sep 17 00:00:00 2001
+From 1c53050613fe4d02c7738d84df92d2922dab8051 Mon Sep 17 00:00:00 2001
 From: Christian Hesse <mail@eworm.de>
 Date: Mon, 17 Oct 2022 16:40:29 +0200
 Subject: [PATCH 04/10] FROM ARCHLINUX: upate xclient script
@@ -34,5 +34,5 @@ index 1e38d05c7..699dbdbb5 100755
 -    /usr/bin/VBoxClient --vmsvga-session # In case VMSVGA emulation is enabled
  fi
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0005-FROM-AOSC-fix-libs-dxvk-fix-build-with-GCC-13.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0005-FROM-AOSC-fix-libs-dxvk-fix-build-with-GCC-13.patch
@@ -1,4 +1,4 @@
-From 3420ccce741252679890ecc77e3cd5ae6b99fe6f Mon Sep 17 00:00:00 2001
+From a406004d4984b6552fe8f4370800d52ebce326a7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:38:50 +0800
 Subject: [PATCH 05/10] FROM AOSC: fix(libs/dxvk): fix build with GCC >= 13
@@ -20,5 +20,5 @@ index 08fea02f2..2f431be5c 100644
  #include "util_bit.h"
  #include "util_math.h"
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0006-FROM-AOSC-chore-use-the-wheel-group-for-hardware-acc.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0006-FROM-AOSC-chore-use-the-wheel-group-for-hardware-acc.patch
@@ -1,4 +1,4 @@
-From 965e62fc71290d2b1fe5cbea424726f4e4457080 Mon Sep 17 00:00:00 2001
+From 1e4e6e10f3a18561a280e0ff402ff55d963aeac3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 12:37:48 +0800
 Subject: [PATCH 06/10] FROM AOSC: chore: use the wheel group for hardware
@@ -1021,10 +1021,10 @@ index 2e39db5b3..e22cd6a9b 100755
  LICENSE_ACCEPTED=""
  PREV_INSTALLATION=""
 diff --git a/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec b/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
-index 07d015311..7812a6e0c 100644
+index 635d9c7db..eec6bb3b3 100644
 --- a/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
 +++ b/src/VBox/Installer/linux/rpm/VirtualBox.tmpl.spec
-@@ -291,9 +291,9 @@ rm -f /etc/vbox/module_not_compiled
+@@ -296,9 +296,9 @@ rm -f /etc/vbox/module_not_compiled
  # create users groups (disable with INSTALL_NO_GROUP=1 in /etc/default/virtualbox)
  if [ "$INSTALL_NO_GROUP" != "1" ]; then
    echo
@@ -1124,10 +1124,10 @@ index b8352e5f0..a66e58d94 100644
      </message>
      <message>
 diff --git a/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp b/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
-index 5baff1cfb..6cfc55936 100644
+index 234007e54..bacae3a6f 100644
 --- a/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
 +++ b/src/VBox/Main/src-client/ConsoleImplConfigCommon.cpp
-@@ -2624,7 +2624,7 @@ int Console::i_configNetwork(const char *pszDevice,
+@@ -2635,7 +2635,7 @@ int Console::i_configNetwork(const char *pszDevice,
                                                               "Failed to open '/dev/%s' for read/write access.  Please check the "
                                                               "permissions of that node, and that the net.link.tap.user_open "
                                                               "sysctl is set.  Either run 'chmod 0666 /dev/%s' or change the "
@@ -1150,5 +1150,5 @@ index 0440ae781..515e73fa5 100644
                  return setWarning(E_FAIL,
                                    tr("VirtualBox is not currently allowed to access USB devices.  You can change this by allowing your user to access the 'usbfs' folder and files.  Please see the user manual for a more detailed explanation"));
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0007-FROM-ARCHLINUX-fix-python-3.12-compatibility.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0007-FROM-ARCHLINUX-fix-python-3.12-compatibility.patch
@@ -1,4 +1,4 @@
-From eb7bcdc5479f4f7ffa00b1de094422d3a0e9d847 Mon Sep 17 00:00:00 2001
+From 9ed37b9bc7033ae2111e1cf634c399e6d6b76c61 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sun, 15 Sep 2024 21:24:25 +0800
 Subject: [PATCH 07/10] FROM ARCHLINUX: fix: python 3.12 compatibility
@@ -21,5 +21,5 @@ index 693e01e08..35a7c9528 100755
  if encoding:
      reload(sys)
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0008-FROM-AOSC-Link-against-vorbisenc.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0008-FROM-AOSC-Link-against-vorbisenc.patch
@@ -1,4 +1,4 @@
-From eecaacb52949eeebb9a2ba34702a5f00fc7ed03c Mon Sep 17 00:00:00 2001
+From e8f0fcdd316628e36acfbf4579f583cc31d282e7 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 16 Sep 2024 20:28:29 +0800
 Subject: [PATCH 08/10] FROM AOSC: Link against vorbisenc
@@ -9,7 +9,7 @@ vorbis_encode_setup_init symbol cannot be found when vorbisenc.so is not linked 
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index 65791d554..6c7669005 100755
+index 658c17404..f2769e20c 100755
 --- a/configure
 +++ b/configure
 @@ -1875,9 +1875,9 @@ check_libvorbis()
@@ -25,5 +25,5 @@ index 65791d554..6c7669005 100755
      cat > $ODIR.tmp_src.cc << EOF
  #include <cstdio>
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0009-FROM-AOSC-Add-gitignore.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0009-FROM-AOSC-Add-gitignore.patch
@@ -1,4 +1,4 @@
-From 72632f408c3f8bda337bc11f57267f9ee813b659 Mon Sep 17 00:00:00 2001
+From 976b0126b316fe15ad2a0dc86b795bb3ac311419 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 30 Sep 2024 21:48:02 +0800
 Subject: [PATCH 09/10] FROM AOSC: Add gitignore
@@ -20,5 +20,5 @@ index 000000000..8610ed868
 +/env.sh
 +/out
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/01-host/patches/0010-FROM-AOSC-Add-localinst.sh.patch
+++ b/app-virtualization/virtualbox/01-host/patches/0010-FROM-AOSC-Add-localinst.sh.patch
@@ -1,4 +1,4 @@
-From c4601380b0aa4cbc16b5b75370837e72ab787ee1 Mon Sep 17 00:00:00 2001
+From 420a7c7a2d76b09a44ff4259310f3dc079ea064e Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Mon, 30 Sep 2024 21:48:13 +0800
 Subject: [PATCH 10/10] FROM AOSC: Add localinst.sh
@@ -64,5 +64,5 @@ index 000000000..2073fcb25
 +install -vdm755 "$PKGDIR"/usr/lib/virtualbox/components
 +install -vm755 "$OUTPUTDIR"/components/* -t "$PKGDIR"/usr/lib/virtualbox/components
 -- 
-2.48.1
+2.49.0
 

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,10 +1,10 @@
-VER=7.1.6a
+VER=7.1.8
 # Note: Sometimes Oracle seems to release fix-up tarballs.
-UBUNTU_VBOX_VER="167084~Ubuntu~noble"
+UBUNTU_VBOX_VER="168469~Ubuntu~oracular"
 SRCS="tbl::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/VirtualBox-${VER}.tar.bz2 \
       file::rename=virtualbox.deb::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/virtualbox-${VER%.*}_${VER%%[a-z]*}-${UBUNTU_VBOX_VER}_amd64.deb \
       file::rename=VBoxGuestAdditions.iso::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/VBoxGuestAdditions_${VER%%[a-z]*}.iso"
-CHKSUMS="sha256::5a7b13066ec71990af0cc00a5eea9c7ec3c71ca5ed99bb549c85494ce2ea395d \
-         sha256::b1e8406c141ff40221cebe5a99224ec74f1960d1491986d3bb1300a99c4790a1 \
-         sha256::dbbda1645bc05c9260adfe9efc4949cb590ec5ec02680aff936375670cffcafc"
+CHKSUMS="sha256::3f7132c55ac6c5f50585bfaa115d29e30b47ccf535cb0a12ff50214ddae2f63d \
+         sha256::845386dfd1fde3f63947e966760ac28c52ef38e25e4fc9e6804a76b1be3bc01a \
+         sha256::0001ed19cc389f04723c9b911338559b9b74bea0d24edf794d8d2ce5b5cb14e0"
 CHKUPDATE="anitya::id=14449"


### PR DESCRIPTION
Topic Description
-----------------

- virtualbox: update to 7.1.8
    - Use Ubuntu "Oracular" package for documentation.
    - Track patches at AOSC-Tracking/virtualbox @ aosc/v7.1.8
    \(HEAD: 420a7c7a2d76b09a44ff4259310f3dc079ea064e\).

Package(s) Affected
-------------------

- virtualbox: 7.1.8
- virtualbox-guest: 7.1.8

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/10544

Build Order
-----------

```
#buildit virtualbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
