### PR TITLE
latx: sync patches from the upstream (20250416)

### DIFF
--- a/app-emulation/latx/autobuild/patches/0001-AOSC-latx-epoll-pwait2.patch
+++ b/app-emulation/latx/autobuild/patches/0001-AOSC-latx-epoll-pwait2.patch
@@ -1,0 +1,96 @@
+diff --git a/linux-user/i386/syscall_32.tbl b/linux-user/i386/syscall_32.tbl
+index 9d11028736..52d3e157e4 100644
+--- a/linux-user/i386/syscall_32.tbl
++++ b/linux-user/i386/syscall_32.tbl
+@@ -444,3 +444,4 @@
+ 437	i386	openat2			sys_openat2
+ 438	i386	pidfd_getfd		sys_pidfd_getfd
+ 439	i386	faccessat2		sys_faccessat2
++441	i386	epoll_pwait2		sys_epoll_pwait2		compat_sys_epoll_pwait2
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 5284c1f2ed..5f8590ded9 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -810,6 +810,11 @@ safe_syscall5(int, ppoll, struct pollfd *, ufds, unsigned int, nfds,
+ safe_syscall6(int, epoll_pwait, int, epfd, struct epoll_event *, events,
+               int, maxevents, int, timeout, const sigset_t *, sigmask,
+               size_t, sigsetsize)
++#if defined(__NR_epoll_pwait2)
++safe_syscall6(int, epoll_pwait2, int, epfd, struct epoll_event *, events,
++              int, maxevents, struct timespec *, timeout, const sigset_t *, sigmask,
++              size_t, sigsetsize)
++#endif
+ #if defined(__NR_futex)
+ safe_syscall6(int,futex,int *,uaddr,int,op,int,val, \
+               const struct timespec *,timeout,int *,uaddr2,int,val3)
+@@ -16527,19 +16532,22 @@ defined(__loongarch__)
+     }
+ #endif
+ 
+-#if defined(TARGET_NR_epoll_wait) || defined(TARGET_NR_epoll_pwait)
++#if defined(TARGET_NR_epoll_wait) || defined(TARGET_NR_epoll_pwait) || defined(TARGET_NR_epoll_pwait2)
+ #if defined(TARGET_NR_epoll_wait)
+     case TARGET_NR_epoll_wait:
+ #endif
+ #if defined(TARGET_NR_epoll_pwait)
+     case TARGET_NR_epoll_pwait:
++#endif
++#if defined(TARGET_NR_epoll_pwait2)
++    case TARGET_NR_epoll_pwait2:
+ #endif
+     {
+         struct target_epoll_event *target_ep;
+         struct epoll_event *ep;
+         int epfd = arg1;
+         int maxevents = arg3;
+-        int timeout = arg4;
++        abi_long timeout = arg4;
+ 
+         if (maxevents <= 0 || maxevents > TARGET_EP_MAX_EVENTS) {
+             return -TARGET_EINVAL;
+@@ -16560,6 +16568,9 @@ defined(__loongarch__)
+         switch (num) {
+ #if defined(TARGET_NR_epoll_pwait)
+         case TARGET_NR_epoll_pwait:
++#if defined(TARGET_NR_epoll_pwait2)
++        case TARGET_NR_epoll_pwait2:
++#endif
+         {
+             target_sigset_t *target_set;
+             sigset_t _set, *set = &_set;
+@@ -16581,10 +16592,19 @@ defined(__loongarch__)
+             } else {
+                 set = NULL;
+             }
+-
+-            ret = get_errno(safe_epoll_pwait(epfd, ep, maxevents, timeout,
+-                                             set, SIGSET_T_SIZE));
+-            break;
++            if (num == TARGET_NR_epoll_pwait) {
++                ret = get_errno(safe_epoll_pwait(epfd, ep, maxevents, timeout,
++                                                 set, SIGSET_T_SIZE));
++            } else {
++                struct timespec hspec;
++                struct timespec *ts_arg = NULL;
++                if (timeout != 0) {
++                    target_to_host_timespec(&hspec, (abi_ulong)timeout);
++                    ts_arg = &hspec;
++                }
++                ret = get_errno(safe_epoll_pwait2(epfd, ep, maxevents, ts_arg, set, SIGSET_T_SIZE));
++            }
++                break;
+         }
+ #endif
+ #if defined(TARGET_NR_epoll_wait)
+diff --git a/linux-user/x86_64/syscall_64.tbl b/linux-user/x86_64/syscall_64.tbl
+index f30d6ae9a6..6e3f0cef07 100644
+--- a/linux-user/x86_64/syscall_64.tbl
++++ b/linux-user/x86_64/syscall_64.tbl
+@@ -361,6 +361,7 @@
+ 437	common	openat2			sys_openat2
+ 438	common	pidfd_getfd		sys_pidfd_getfd
+ 439	common	faccessat2		sys_faccessat2
++441	common	epoll_pwait2		sys_epoll_pwait2
+ 
+ #
+ # x32-specific system call numbers start at 512 to avoid cache impact

--- a/app-emulation/latx/autobuild/patches/1000-Add-a-check-for-the-existence-of-the-lsb_release-com.patch
+++ b/app-emulation/latx/autobuild/patches/1000-Add-a-check-for-the-existence-of-the-lsb_release-com.patch
@@ -1,7 +1,7 @@
 From 7cef838259c072ab3e94141f85f6ea7e1f28f50a Mon Sep 17 00:00:00 2001
 From: Sun Haiyong <sunhaiyong@zdbr.net>
 Date: Wed, 26 Mar 2025 08:33:38 +0000
-Subject: [PATCH 1000/1022] Add a check for the existence of the lsb_release
+Subject: [PATCH 1000/1058] Add a check for the existence of the lsb_release
  command.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-emulation/latx/autobuild/patches/1001-Fix-for-New-World-system-build.patch
+++ b/app-emulation/latx/autobuild/patches/1001-Fix-for-New-World-system-build.patch
@@ -1,7 +1,7 @@
 From 041a54d2b0b6c923708a4b7b629b4d9010839947 Mon Sep 17 00:00:00 2001
 From: Sun Haiyong <sunhaiyong@zdbr.net>
 Date: Wed, 26 Mar 2025 12:13:33 +0000
-Subject: [PATCH 1001/1022] Fix for New World system build.
+Subject: [PATCH 1001/1058] Fix for New World system build.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/app-emulation/latx/autobuild/patches/1002-add-VLDREPL.W-VLDREPL.D-VLDREPL.H-and-VLDREPL.B-inst.patch
+++ b/app-emulation/latx/autobuild/patches/1002-add-VLDREPL.W-VLDREPL.D-VLDREPL.H-and-VLDREPL.B-inst.patch
@@ -1,7 +1,7 @@
 From 10d8c8065c915e93788841d54ae7d0ed8d36747c Mon Sep 17 00:00:00 2001
 From: Sun Haiyong <sunhaiyong@zdbr.net>
 Date: Thu, 27 Mar 2025 02:52:34 +0000
-Subject: [PATCH 1002/1022] add VLDREPL.W, VLDREPL.D, VLDREPL.H, and VLDREPL.B
+Subject: [PATCH 1002/1058] add VLDREPL.W, VLDREPL.D, VLDREPL.H, and VLDREPL.B
  instructions for ABI 2.0.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-emulation/latx/autobuild/patches/1003-Merge-the-usage-of-the-lasxintrin.h-header-file-betw.patch
+++ b/app-emulation/latx/autobuild/patches/1003-Merge-the-usage-of-the-lasxintrin.h-header-file-betw.patch
@@ -1,7 +1,7 @@
 From f4f87f83c7e3b2964bc5e29db9900dc34bb2ad5d Mon Sep 17 00:00:00 2001
 From: Sun Haiyong <sunhaiyong@zdbr.net>
 Date: Thu, 27 Mar 2025 03:28:12 +0000
-Subject: [PATCH 1003/1022] Merge the usage of the lasxintrin.h header file
+Subject: [PATCH 1003/1058] Merge the usage of the lasxintrin.h header file
  between ABI 1.0 and 2.0.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-emulation/latx/autobuild/patches/1004-fix-submodule-error.patch
+++ b/app-emulation/latx/autobuild/patches/1004-fix-submodule-error.patch
@@ -1,7 +1,7 @@
 From 346fc0db5e7e5f8f3a303f5744918394c773803a Mon Sep 17 00:00:00 2001
 From: Xiaotian Wu <wuxiaotian@loongson.cn>
 Date: Thu, 27 Mar 2025 17:42:22 +0800
-Subject: [PATCH 1004/1022] fix submodule error
+Subject: [PATCH 1004/1058] fix submodule error
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/app-emulation/latx/autobuild/patches/1006-feat-optimize-several-vnor-vand-to-vandn.patch
+++ b/app-emulation/latx/autobuild/patches/1006-feat-optimize-several-vnor-vand-to-vandn.patch
@@ -1,7 +1,7 @@
 From 9db022f85f7869e54ca71921ccfc01498720903e Mon Sep 17 00:00:00 2001
 From: Yang Liu <numbksco@gmail.com>
 Date: Thu, 27 Mar 2025 21:17:31 +0800
-Subject: [PATCH 1006/1022] feat: optimize several vnor+vand to vandn
+Subject: [PATCH 1006/1058] feat: optimize several vnor+vand to vandn
 
 ---
  target/i386/latx/translator/tr-simd.c | 32 ++++++++++-----------------

--- a/app-emulation/latx/autobuild/patches/1007-LATX-fix-Fix-tcg_tb_lookup-error-when-AOT-is-enabled.patch
+++ b/app-emulation/latx/autobuild/patches/1007-LATX-fix-Fix-tcg_tb_lookup-error-when-AOT-is-enabled.patch
@@ -1,7 +1,7 @@
 From b4ba024c000eb0372b508e287d991f4856fa8a22 Mon Sep 17 00:00:00 2001
 From: Hanlu Li <heuleehanlu@gmail.com>
 Date: Thu, 27 Mar 2025 20:23:49 +0800
-Subject: [PATCH 1007/1022] LATX, fix: Fix tcg_tb_lookup() error when AOT is
+Subject: [PATCH 1007/1058] LATX, fix: Fix tcg_tb_lookup() error when AOT is
  enabled
 
 This patch updates the TBMini logic to be compatible with the TU design,

--- a/app-emulation/latx/autobuild/patches/1009-LATX-style-merge-multiple-ifdef-CONFIG_LOONGARCH_NEW.patch
+++ b/app-emulation/latx/autobuild/patches/1009-LATX-style-merge-multiple-ifdef-CONFIG_LOONGARCH_NEW.patch
@@ -1,7 +1,7 @@
 From 86ae3d0db86e9d909c913d2cf192f59fe4ff30f7 Mon Sep 17 00:00:00 2001
 From: Hanlu Li <heuleehanlu@gmail.com>
 Date: Fri, 28 Mar 2025 09:54:13 +0800
-Subject: [PATCH 1009/1022] LATX, style: merge multiple `#ifdef
+Subject: [PATCH 1009/1058] LATX, style: merge multiple `#ifdef
  CONFIG_LOONGARCH_NEW_WORLD` blocks
 
 Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>

--- a/app-emulation/latx/autobuild/patches/1010-LATX-fix-Fix-compile-error-caused-by-commit-041a54d2.patch
+++ b/app-emulation/latx/autobuild/patches/1010-LATX-fix-Fix-compile-error-caused-by-commit-041a54d2.patch
@@ -1,7 +1,7 @@
 From ca954a8e3886ea214febfb9eb5fe57502fce2864 Mon Sep 17 00:00:00 2001
 From: Hanlu Li <heuleehanlu@gmail.com>
 Date: Fri, 28 Mar 2025 10:08:37 +0800
-Subject: [PATCH 1010/1022] LATX, fix: Fix compile error caused by commit
+Subject: [PATCH 1010/1058] LATX, fix: Fix compile error caused by commit
  `041a54d2b0 Fix for New World system build`
 
 The correct definition for `uc_mcontext` is provided by `/usr/include/loongarch64-linux-gnu/sys/ucontext.h`.

--- a/app-emulation/latx/autobuild/patches/1011-LATX-fix-Fix-encode_search-for-TU.patch
+++ b/app-emulation/latx/autobuild/patches/1011-LATX-fix-Fix-encode_search-for-TU.patch
@@ -1,7 +1,7 @@
 From f3735d80abb17fc3bebc33d45034cf8282587c50 Mon Sep 17 00:00:00 2001
 From: Hanlu Li <heuleehanlu@gmail.com>
 Date: Fri, 28 Mar 2025 14:06:35 +0800
-Subject: [PATCH 1011/1022] LATX, fix: Fix encode_search() for TU
+Subject: [PATCH 1011/1058] LATX, fix: Fix encode_search() for TU
 
 Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
 ---

--- a/app-emulation/latx/autobuild/patches/1012-LATX-update-README.patch
+++ b/app-emulation/latx/autobuild/patches/1012-LATX-update-README.patch
@@ -1,7 +1,7 @@
 From b6b5d29b45b92be531ee11fff39567f07ebd2da6 Mon Sep 17 00:00:00 2001
 From: Hanlu Li <heuleehanlu@gmail.com>
 Date: Fri, 28 Mar 2025 14:20:10 +0800
-Subject: [PATCH 1012/1022] LATX: update README
+Subject: [PATCH 1012/1058] LATX: update README
 
 Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
 ---

--- a/app-emulation/latx/autobuild/patches/1013-LATX-feat-Add-new-world-detector.patch
+++ b/app-emulation/latx/autobuild/patches/1013-LATX-feat-Add-new-world-detector.patch
@@ -1,7 +1,7 @@
 From 1cc7757d197dd548b5961305b90fff7a1ea60b94 Mon Sep 17 00:00:00 2001
 From: Qi HU <github@spcsky.com>
 Date: Fri, 28 Mar 2025 14:39:15 +0800
-Subject: [PATCH 1013/1022] LATX, feat: Add new world detector
+Subject: [PATCH 1013/1058] LATX, feat: Add new world detector
 
 For new world, this patch adds a detector in the build process,
 which can ignore the compile parameter.

--- a/app-emulation/latx/autobuild/patches/1014-feat-add-issue-templates.patch
+++ b/app-emulation/latx/autobuild/patches/1014-feat-add-issue-templates.patch
@@ -1,7 +1,7 @@
 From 219d0a3da4b0a3e13b0e7628431c4217ddafb509 Mon Sep 17 00:00:00 2001
 From: Qi HU <github@spcsky.com>
 Date: Fri, 28 Mar 2025 21:52:01 +0800
-Subject: [PATCH 1014/1022] feat: add issue templates
+Subject: [PATCH 1014/1058] feat: add issue templates
 
 Signed-off-by: Qi HU <github@spcsky.com>
 ---

--- a/app-emulation/latx/autobuild/patches/1015-feat-optimize-MMX-shift-opcodes.patch
+++ b/app-emulation/latx/autobuild/patches/1015-feat-optimize-MMX-shift-opcodes.patch
@@ -1,7 +1,7 @@
 From 8a24ab7c487775e8a691d4ec5eeae4879d8a9edb Mon Sep 17 00:00:00 2001
 From: Yang Liu <numbksco@gmail.com>
 Date: Fri, 28 Mar 2025 21:22:25 +0800
-Subject: [PATCH 1015/1022] feat: optimize MMX shift opcodes
+Subject: [PATCH 1015/1058] feat: optimize MMX shift opcodes
 
 ---
  target/i386/latx/translator/tr-simd-shift.c | 81 +++++++--------------

--- a/app-emulation/latx/autobuild/patches/1016-improve-build-scripts.patch
+++ b/app-emulation/latx/autobuild/patches/1016-improve-build-scripts.patch
@@ -1,7 +1,7 @@
 From c8e8c90f90b1ce0dc8e5e0516101f9e2bb509350 Mon Sep 17 00:00:00 2001
 From: Xiaotian Wu <yetist@gmail.com>
 Date: Mon, 31 Mar 2025 11:24:57 +0800
-Subject: [PATCH 1016/1022] improve build scripts
+Subject: [PATCH 1016/1058] improve build scripts
 
 ---
  latxbuild/build-release.sh | 231 ++++++++++++++++---------------------

--- a/app-emulation/latx/autobuild/patches/1017-LATX-fix-Fixed-function-page_find_range_empty.patch
+++ b/app-emulation/latx/autobuild/patches/1017-LATX-fix-Fixed-function-page_find_range_empty.patch
@@ -1,7 +1,7 @@
 From 8ac3cd56a2f0dc601a2f8811a9ec9f8d472e2c48 Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 16:43:53 +0800
-Subject: [PATCH 1017/1022] LATX, fix: Fixed function page_find_range_empty().
+Subject: [PATCH 1017/1058] LATX, fix: Fixed function page_find_range_empty().
 
 The addresses are allocated from high to low, so when a new free space
 is found, mmap_next_start need to be equal to min, not min + len.

--- a/app-emulation/latx/autobuild/patches/1018-LATX-fix-When-ir1_opnd_num-1-rotate_need_of-need-ret.patch
+++ b/app-emulation/latx/autobuild/patches/1018-LATX-fix-When-ir1_opnd_num-1-rotate_need_of-need-ret.patch
@@ -1,7 +1,7 @@
 From 883f7d2074af964c201e77ddd26b51d811dcda4f Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 16:48:53 +0800
-Subject: [PATCH 1018/1022] LATX, fix: When ir1_opnd_num == 1 rotate_need_of()
+Subject: [PATCH 1018/1058] LATX, fix: When ir1_opnd_num == 1 rotate_need_of()
  need return false.
 
 Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>

--- a/app-emulation/latx/autobuild/patches/1019-LATX-opt-Use-xvpickve_w-translate-movss.patch
+++ b/app-emulation/latx/autobuild/patches/1019-LATX-opt-Use-xvpickve_w-translate-movss.patch
@@ -1,7 +1,7 @@
 From 1c55a28cfee5ea3d47b006a4dc4c250483e31742 Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 16:50:01 +0800
-Subject: [PATCH 1019/1022] LATX, opt: Use xvpickve_w translate movss.
+Subject: [PATCH 1019/1058] LATX, opt: Use xvpickve_w translate movss.
 
 Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 ---

--- a/app-emulation/latx/autobuild/patches/1020-LATX-fix-Fixed-the-error-of-mapping-misaligned-file-.patch
+++ b/app-emulation/latx/autobuild/patches/1020-LATX-fix-Fixed-the-error-of-mapping-misaligned-file-.patch
@@ -1,7 +1,7 @@
 From b2be1e731484d7642a4f5f4030479a05a0bb1a94 Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 16:51:24 +0800
-Subject: [PATCH 1020/1022] LATX, fix: Fixed the error of mapping misaligned
+Subject: [PATCH 1020/1058] LATX, fix: Fixed the error of mapping misaligned
  file on shadow page.
 
 When mapping offset misaligned files on the shadow page, the

--- a/app-emulation/latx/autobuild/patches/1021-LATX-fix-Adjustable-initial-address-for-guest-addres.patch
+++ b/app-emulation/latx/autobuild/patches/1021-LATX-fix-Adjustable-initial-address-for-guest-addres.patch
@@ -1,7 +1,7 @@
 From 4628add610e0556c68eb8132f96128a3b9e858a5 Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 16:52:43 +0800
-Subject: [PATCH 1021/1022] LATX, fix: Adjustable initial address for guest
+Subject: [PATCH 1021/1058] LATX, fix: Adjustable initial address for guest
  address.
 
 Wine will reserve some addresses for special applications, and it is

--- a/app-emulation/latx/autobuild/patches/1022-LATX-fix-clean-old-version-AOT.patch
+++ b/app-emulation/latx/autobuild/patches/1022-LATX-fix-clean-old-version-AOT.patch
@@ -1,7 +1,7 @@
 From 2aa4d71672b33e0d92fc85a8f137fd459813ec28 Mon Sep 17 00:00:00 2001
 From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 Date: Fri, 28 Mar 2025 17:16:18 +0800
-Subject: [PATCH 1022/1022] LATX,fix: clean old version AOT.
+Subject: [PATCH 1022/1058] LATX,fix: clean old version AOT.
 
 Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
 ---

--- a/app-emulation/latx/autobuild/patches/1023-LATX-fix-Adjust-mmap_min_addr-policy.patch
+++ b/app-emulation/latx/autobuild/patches/1023-LATX-fix-Adjust-mmap_min_addr-policy.patch
@@ -1,0 +1,81 @@
+From df09d6789fc4234e2328fbdebae13e5e299fb3f6 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 31 Mar 2025 11:35:29 +0800
+Subject: [PATCH 1023/1058] LATX, fix: Adjust mmap_min_addr policy
+
+Adjust mmap_min_addr policy to fix "requires virtual address space that is in use".
+
+close:#25
+
+Co-authored-by: Qi HU <github@spcsky.com>
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/main.c | 39 +++++++++++++++++++++++++--------------
+ 1 file changed, 25 insertions(+), 14 deletions(-)
+
+diff --git a/linux-user/main.c b/linux-user/main.c
+index 3e45394bb3..bf19b0d71e 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -1261,6 +1261,7 @@ int main(int argc, char **argv, char **envp)
+     target_environ = envlist_to_environ(envlist, NULL);
+     envlist_free(envlist);
+ 
++#define KERNEL_CONFIG_LSM_MMAP_MIN_ADDR 65536
+     /*
+      * Read in mmap_min_addr kernel parameter.  This value is used
+      * When loading the ELF image to determine whether guest_base
+@@ -1271,26 +1272,36 @@ int main(int argc, char **argv, char **envp)
+ 
+         if ((fp = fopen("/proc/sys/vm/mmap_min_addr", "r")) != NULL) {
+             unsigned long tmp;
+-            if (fscanf(fp, "%lu", &tmp) == 1 && tmp != 0) {
++            if (fscanf(fp, "%lu", &tmp) == 1) {
+                 mmap_min_addr = tmp;
+-                qemu_log_mask(CPU_LOG_PAGE, "host mmap_min_addr=0x%lx\n",
+-                              mmap_min_addr);
++                /*
++                 * We prefer to not make NULL pointers accessible to QEMU.
++                 * If we're in a chroot with no /proc, fall back to 1 page.
++                 */
++                if (mmap_min_addr < qemu_host_page_size) {
++                    mmap_min_addr = qemu_host_page_size;
++                }
++
++                /* get the mmap_min_addr from kernel */
++                void *addr = mmap(
++                    (void *)mmap_min_addr, qemu_host_page_size,
++                    PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
++                if (addr != MAP_FAILED) {
++                    munmap(addr, qemu_host_page_size);
++                    assert(!(addr > KERNEL_CONFIG_LSM_MMAP_MIN_ADDR &&
++                            addr > mmap_min_addr));
++                    mmap_min_addr = (unsigned long)addr;
++                    qemu_log_mask(CPU_LOG_PAGE, "host mmap_min_addr=0x%lx\n",
++                                  mmap_min_addr);
++                } else {
++                    /* error */
++                    qemu_log_mask(CPU_LOG_PAGE, "get mmap_min_addr error\n");
++                }
+             }
+             fclose(fp);
+         }
+     }
+ 
+-    /*
+-     * We prefer to not make NULL pointers accessible to QEMU.
+-     * If we're in a chroot with no /proc, fall back to 1 page.
+-     */
+-    if (mmap_min_addr == 0) {
+-        mmap_min_addr = qemu_host_page_size;
+-        qemu_log_mask(CPU_LOG_PAGE,
+-                      "host mmap_min_addr=0x%lx (fallback)\n",
+-                      mmap_min_addr);
+-    }
+-
+     /*
+      * Prepare copy of argv vector for target.
+      */
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1024-doc-Add-Compile-Tutorial.patch
+++ b/app-emulation/latx/autobuild/patches/1024-doc-Add-Compile-Tutorial.patch
@@ -1,0 +1,34 @@
+From 4fb58b98d412bb0c7ad2681ad2f730b8bd732992 Mon Sep 17 00:00:00 2001
+From: shenmo <jifengshenmo@outlook.com>
+Date: Wed, 2 Apr 2025 12:40:04 +0800
+Subject: [PATCH 1024/1058] (doc)Add: Compile Tutorial
+
+---
+ README.rst | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/README.rst b/README.rst
+index b16e52379e..5ab32e8a36 100644
+--- a/README.rst
++++ b/README.rst
+@@ -136,6 +136,17 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
+ 
+ 同时感谢在文档编写、社区管理、流程搭建、版本测试等方面做出贡献的所有伙伴。
+ 
++编译
++====
++
++.. code-block:: text
++# debian sid
++apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
++git clone --depth=1 --recursive https://github.com/lat-opensource/lat
++cd lat/latxbuild
++./build-release.sh
++
++
+ 未来规划（TODO）
+ ===============
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1025-LATX-fix-disable-KZT-by-default.patch
+++ b/app-emulation/latx/autobuild/patches/1025-LATX-fix-disable-KZT-by-default.patch
@@ -1,0 +1,26 @@
+From f81c45b3035d0d70da9e645a8a030182dc725f92 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Wed, 2 Apr 2025 14:28:26 +0800
+Subject: [PATCH 1025/1058] LATX, fix: disable KZT by default
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ target/i386/latx/latx-options.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/target/i386/latx/latx-options.c b/target/i386/latx/latx-options.c
+index caf75d37ba..4d59aaba17 100644
+--- a/target/i386/latx/latx-options.c
++++ b/target/i386/latx/latx-options.c
+@@ -5,7 +5,7 @@
+ #include "latx-debug.h"
+ 
+ #if defined(CONFIG_LATX_KZT)
+-int option_kzt = 1;
++int option_kzt = 0;
+ #endif
+ 
+ #ifdef CONFIG_LATX_FLAG_REDUCTION
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1026-doc-Fix-Render-error-caused-by-badly-formed-indent.patch
+++ b/app-emulation/latx/autobuild/patches/1026-doc-Fix-Render-error-caused-by-badly-formed-indent.patch
@@ -1,0 +1,38 @@
+From 3f51c02e570aa44f84afa778eefd0197fe55d0b7 Mon Sep 17 00:00:00 2001
+From: shenmo <47873776+shenmo7192@users.noreply.github.com>
+Date: Thu, 3 Apr 2025 11:38:09 +0800
+Subject: [PATCH 1026/1058] (doc) Fix: Render error caused by badly formed
+ indent
+
+---
+ README.rst | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/README.rst b/README.rst
+index 5ab32e8a36..4a720b71e5 100644
+--- a/README.rst
++++ b/README.rst
+@@ -139,12 +139,14 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
+ 编译
+ ====
+ 
+-.. code-block:: text
+-# debian sid
+-apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
+-git clone --depth=1 --recursive https://github.com/lat-opensource/lat
+-cd lat/latxbuild
+-./build-release.sh
++.. code-block:: bash
++
++    # debian sid
++    apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
++    git clone --depth=1 --recursive https://github.com/lat-opensource/lat
++    cd lat/latxbuild
++    ./build-release.sh
++
+ 
+ 
+ 未来规划（TODO）
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1027-feat-Add-help-wanted-issue-template.patch
+++ b/app-emulation/latx/autobuild/patches/1027-feat-Add-help-wanted-issue-template.patch
@@ -1,0 +1,123 @@
+From dca410e4c535f3f1361d61468d2666d5da47f646 Mon Sep 17 00:00:00 2001
+From: Qi HU <github@spcsky.com>
+Date: Thu, 3 Apr 2025 13:53:48 +0800
+Subject: [PATCH 1027/1058] feat: Add help wanted issue template
+
+Signed-off-by: Qi HU <github@spcsky.com>
+---
+ .github/ISSUE_TEMPLATE/1-bug-report.yml      |  5 +-
+ .github/ISSUE_TEMPLATE/2-feature-request.yml |  3 +
+ .github/ISSUE_TEMPLATE/3-help-wanted.yml     | 64 ++++++++++++++++++++
+ 3 files changed, 71 insertions(+), 1 deletion(-)
+ create mode 100644 .github/ISSUE_TEMPLATE/3-help-wanted.yml
+
+diff --git a/.github/ISSUE_TEMPLATE/1-bug-report.yml b/.github/ISSUE_TEMPLATE/1-bug-report.yml
+index 353a8ad3f5..38bdc12ee5 100644
+--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
++++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
+@@ -2,6 +2,9 @@ name: Bug Report / 错误报告
+ description: Report a bug to help us improve / 报告一个错误以帮助我们改进
+ title: "[Bug]: "
+ labels: ["bug"]
++assignees:
++  - deuso
++  - LaurenIsACoder
+ body:
+   - type: markdown
+     attributes:
+@@ -21,7 +24,7 @@ body:
+   - type: textarea
+     id: environment
+     attributes:
+-      label: Environment / 环境
++      label: Environment Information / 环境信息
+       description: Specify the environment where the bug occurred (e.g., OS, version, or commit hash). / 指定错误发生的环境（例如：操作系统、版本或提交哈希号）。
+       placeholder: Enter environment details (e.g., OS, version, commit hash) / 输入环境详细信息（例如：操作系统、版本、提交哈希号）
+       value: |
+diff --git a/.github/ISSUE_TEMPLATE/2-feature-request.yml b/.github/ISSUE_TEMPLATE/2-feature-request.yml
+index 1146c2652e..4d12119503 100644
+--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
++++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
+@@ -2,6 +2,9 @@ name: "Feature Request / 功能请求"
+ description: "Suggest a new feature or enhancement / 提议新功能或改进"
+ title: "[Feature Request]: "
+ labels: ["enhancement"]
++assignees:
++  - deuso
++  - LaurenIsACoder
+ body:
+   - type: markdown
+     attributes:
+diff --git a/.github/ISSUE_TEMPLATE/3-help-wanted.yml b/.github/ISSUE_TEMPLATE/3-help-wanted.yml
+new file mode 100644
+index 0000000000..4797a475ca
+--- /dev/null
++++ b/.github/ISSUE_TEMPLATE/3-help-wanted.yml
+@@ -0,0 +1,64 @@
++name: "Help Wanted / 问题请求"
++description: Submitting question inquiries / 提交问题请求
++title: "[Help Wanted]: "
++labels: ["question", "help wanted"]
++assignees:
++  - deuso
++  - LaurenIsACoder
++
++body:
++  - type: markdown
++    attributes:
++      value: |
++        Thank you for submitting your question! Please fill out the template below so we can better assist you.  
++        感谢您提交问题！请按照以下模板填写，以便我们更好地帮助您。
++
++  - type: input
++    id: summary
++    attributes:
++      label: Summary / 问题概述
++      description: Please briefly describe your question. / 请简要描述您的问题。
++      placeholder: Enter a summary of your question here / 在这里输入问题概述
++    validations:
++      required: true
++
++  - type: textarea
++    id: details
++    attributes:
++      label: Detailed Description / 详细描述
++      description: Please provide a detailed description of your question, including background information and attempted solutions.  
++                   / 请详细描述您的问题，包括背景信息、尝试过的解决方法等。
++      placeholder: Enter a detailed description here / 在这里输入详细描述
++    validations:
++      required: true
++
++  - type: textarea
++    id: environment
++    attributes:
++      label: Environment Information / 环境信息
++      description: Specify the environment where the bug occurred (e.g., OS, version, or commit hash). / 指定错误发生的环境（例如：操作系统、版本或提交哈希号）。
++      placeholder: Enter environment details (e.g., OS, version, commit hash) / 输入环境详细信息（例如：操作系统、版本、提交哈希号）
++      value: |
++        **OS**: [e.g., Loongnix, etc.]
++        **操作系统**: [例如：龙芯操作系统等]
++
++        **Kernel Version**: [e.g., 5.4.0, etc.]
++        **Linux 内核版本**: [例如：5.4.0等]
++
++        **GCC Version**: [e.g., 9.3.0, etc.]
++        **GCC 版本**: [例如：9.3.0等]
++
++        **GLIBC Version**: [e.g., 2.31, etc.]
++        **GLIBC 版本**: [例如：2.31等]
++
++        **LAT Version / Commit Hash**: [e.g., 1.6.0, abc1234, etc.]
++        **LAT 版本号 / 提交 Hash**: [例如：1.6.0, abc1234等]
++
++
++  - type: textarea
++    id: additional
++    attributes:
++      label: Additional Information / 补充信息
++      description: If there is any additional information, please provide it here.  
++                   / 如果有其他需要补充的信息，请在这里填写。
++      placeholder: Enter additional information here (optional) / 在这里输入补充信息（可选）
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1028-feat-optimize-MINPD-MINPS-MAXPD-MAXPS.patch
+++ b/app-emulation/latx/autobuild/patches/1028-feat-optimize-MINPD-MINPS-MAXPD-MAXPS.patch
@@ -1,0 +1,113 @@
+From 5bff601b5db2adc07ef5b2599c916a13a7e09e4f Mon Sep 17 00:00:00 2001
+From: phorcys <phorcys02@126.com>
+Date: Thu, 3 Apr 2025 13:33:44 +0800
+Subject: [PATCH 1028/1058] feat: optimize MINPD/MINPS/MAXPD/MAXPS Optimize
+ MINPD/MINPS 3x 1 cycle insts => 1 x 1cycle inst, should be faster. unittest
+ src: https://gist.github.com/phorcys/25ac9ed3479446462a26cc77ff8ee8ed
+
+---
+ target/i386/latx/translator/tr-simd.c | 67 +++++++++------------------
+ 1 file changed, 23 insertions(+), 44 deletions(-)
+
+diff --git a/target/i386/latx/translator/tr-simd.c b/target/i386/latx/translator/tr-simd.c
+index 22e36a2e92..717f8eeb55 100644
+--- a/target/i386/latx/translator/tr-simd.c
++++ b/target/i386/latx/translator/tr-simd.c
+@@ -800,17 +800,8 @@ bool translate_maxpd(IR1_INST *pir1)
+     IR2_OPND dest = load_freg128_from_ir1(opnd0);
+     IR2_OPND src = load_freg128_from_ir1(opnd1);
+     IR2_OPND mask = ra_alloc_ftemp();
+-    /* 1.if dest[i] > src[i]  (0 <= i < 2)
+-     *     mask[i] = 0xffffffffffffffff
+-     * else
+-     *     mask[i] = 0 */
+-    la_vfcmp_cond_d(mask, src, dest, 0x3);
+-    /* 2. when dest[i] > src[i] is true, dest[i] = dest[i] */
+-    la_vand_v(dest, dest, mask);
+-    /* 3. when dest[i] > src[i] is false, dest[i] = src[i] */
+-    la_vandn_v(mask, mask, src);
+-    /* 4. get final result */
+-    la_vor_v(dest, dest, mask);
++    la_vfcmp_cond_d(mask, dest, src, 0xF); // equal, unorder and dest < src, use src
++    la_vbitsel_v(dest, dest, src, mask);
+     return true;
+ }
+ 
+@@ -827,17 +818,8 @@ bool translate_maxps(IR1_INST *pir1)
+     IR2_OPND dest = load_freg128_from_ir1(opnd0);
+     IR2_OPND src = load_freg128_from_ir1(opnd1);
+     IR2_OPND mask = ra_alloc_ftemp();
+-    /* 1.if dest[i] > src[i]  (0 <= i < 4)
+-     *     mask[i] = 0xffffffffffffffff
+-     * else
+-     *     mask[i] = 0 */
+-    la_vfcmp_cond_s(mask, src, dest, 0x3);
+-    /* 2. when dest[i] > src[i] is true, dest[i] = dest[i] */
+-    la_vand_v(dest, dest, mask);
+-    /* 3. when dest[i] > src[i] is false, dest[i] = src[i] */
+-    la_vandn_v(mask, mask, src);
+-    /* 4. get final result */
+-    la_vor_v(dest, dest, mask);
++    la_vfcmp_cond_s(mask, dest, src, 0xF); // equal, unorder and dest < src, use src
++    la_vbitsel_v(dest, dest, src, mask);
+     return true;
+ }
+ 
+@@ -912,17 +894,22 @@ bool translate_minpd(IR1_INST *pir1)
+     IR2_OPND dest = load_freg128_from_ir1(opnd0);
+     IR2_OPND src = load_freg128_from_ir1(opnd1);
+     IR2_OPND mask = ra_alloc_ftemp();
+-    /* 1.if dest[i] > src[i]  (0 <= i < 2)
+-     *     mask[i] = 0xffffffffffffffff
+-     * else
+-     *     mask[i] = 0 */
+-    la_vfcmp_cond_d(mask, dest, src, 0x3);
+-    /* 2. when dest[i] > src[i] is true, dest[i] = dest[i] */
+-    la_vand_v(dest, dest, mask);
+-    /* 3. when dest[i] > src[i] is false, dest[i] = src[i] */
+-    la_vandn_v(mask, mask, src);
+-    /* 4. get final result */
+-    la_vor_v(dest, dest, mask);
++    // sse minpd:
++    //  * MIN(SRC1, SRC2)
++    // {
++    //     IF ((SRC1 = 0.0) and (SRC2 = 0.0)) THEN DEST := SRC2;
++    //         ELSE IF (SRC1 = NaN) THEN DEST := SRC2; FI;
++    //         ELSE IF (SRC2 = NaN) THEN DEST := SRC2; FI;
++    //         ELSE IF (SRC1 < SRC2) THEN DEST := SRC1;
++    //         ELSE DEST := SRC2;
++    //     FI;
++    // }
++    //  SULE = 0xF = un lt eq
++    //  un: either operand 1 or 2 is Nan, choose second operand
++    //  eq: +0.0 == -0.0 , choose second operand. not zero, either operand 1 or 2 is ok
++    //  lt: choose second operand
++    la_vfcmp_cond_d(mask, src, dest, 0xF);
++    la_vbitsel_v(dest, dest, src, mask);
+     return true;
+ }
+ 
+@@ -939,17 +926,9 @@ bool translate_minps(IR1_INST *pir1)
+     IR2_OPND dest = load_freg128_from_ir1(opnd0);
+     IR2_OPND src = load_freg128_from_ir1(opnd1);
+     IR2_OPND mask = ra_alloc_ftemp();
+-    /* 1.if dest[i] > src[i]  (0 <= i < 4)
+-     *     mask[i] = 0xffffffffffffffff
+-     * else
+-     *     mask[i] = 0 */
+-    la_vfcmp_cond_s(mask, dest, src, 0x3);
+-    /* 2. when dest[i] > src[i] is true, dest[i] = dest[i] */
+-    la_vand_v(dest, dest, mask);
+-    /* 3. when dest[i] > src[i] is false, dest[i] = src[i] */
+-    la_vandn_v(mask, mask, src);
+-    /* 4. get final result */
+-    la_vor_v(dest, dest, mask);
++    // as MINPD
++    la_vfcmp_cond_s(mask, src, dest, 0xF);
++    la_vbitsel_v(dest, dest, src, mask);
+     return true;
+ }
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1029-LATX-doc-update-README-with-Arch-package-requirement.patch
+++ b/app-emulation/latx/autobuild/patches/1029-LATX-doc-update-README-with-Arch-package-requirement.patch
@@ -1,0 +1,56 @@
+From 3f0e4d78f347d9bb8ebe0fc7d49bcfeb1f84384e Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 7 Apr 2025 10:10:00 +0800
+Subject: [PATCH 1029/1058] LATX, doc: update README with Arch package
+ requirements
+
+Add required packages for building on Arch Linux to the README
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ README.en.rst | 14 ++++++++++++++
+ README.rst    |  3 +++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/README.en.rst b/README.en.rst
+index e98450f340..5cf4f0e3c9 100644
+--- a/README.en.rst
++++ b/README.en.rst
+@@ -153,6 +153,20 @@ automation, and testing:
+ 
+     - Contributor for adaptation to new-world support
+ 
++Build
++=====
++
++.. code-block:: text
++# debian sid
++apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
++git clone --depth=1 --recursive https://github.com/lat-opensource/lat
++cd lat/latxbuild
++./build-release.sh
++
++.. code-block:: text
++# Arch Linux
++pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
++
+ Future Plans (TODO)
+ ===============
+ 
+diff --git a/README.rst b/README.rst
+index 4a720b71e5..db85b74aac 100644
+--- a/README.rst
++++ b/README.rst
+@@ -148,6 +148,9 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
+     ./build-release.sh
+ 
+ 
++.. code-block:: text
++# Arch Linux
++pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
+ 
+ 未来规划（TODO）
+ ===============
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1030-LATX-fix-Fix-an-build-error.patch
+++ b/app-emulation/latx/autobuild/patches/1030-LATX-fix-Fix-an-build-error.patch
@@ -1,0 +1,31 @@
+From fe0d49ff6277201dd549a236b67beed9f6831dd6 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Thu, 3 Apr 2025 15:02:26 +0800
+Subject: [PATCH 1030/1058] LATX, fix: Fix an build error
+
+This patch to fix failure with build64-dbg.sh.
+Build now works.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/linux-user/main.c b/linux-user/main.c
+index bf19b0d71e..4c0fc1e02f 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -1288,8 +1288,8 @@ int main(int argc, char **argv, char **envp)
+                     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                 if (addr != MAP_FAILED) {
+                     munmap(addr, qemu_host_page_size);
+-                    assert(!(addr > KERNEL_CONFIG_LSM_MMAP_MIN_ADDR &&
+-                            addr > mmap_min_addr));
++                    assert(!((unsigned long)addr > KERNEL_CONFIG_LSM_MMAP_MIN_ADDR &&
++                            (unsigned long)addr > mmap_min_addr));
+                     mmap_min_addr = (unsigned long)addr;
+                     qemu_log_mask(CPU_LOG_PAGE, "host mmap_min_addr=0x%lx\n",
+                                   mmap_min_addr);
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1031-LATX-fix-Fix-Assertion-rj-11-rj-20-failed.patch
+++ b/app-emulation/latx/autobuild/patches/1031-LATX-fix-Fix-Assertion-rj-11-rj-20-failed.patch
@@ -1,0 +1,200 @@
+From bca9ff0e309f98d9f3885e94fb54268b5c639dd9 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Thu, 10 Apr 2025 14:20:18 +0800
+Subject: [PATCH 1031/1058] LATX, fix: Fix Assertion `(rj >= 11 && rj <= 20)'
+ failed
+
+In the function shared_private_interpret(), the base register of the faulting
+instruction was overwriting with the shadow page address. If the base
+register was not a itemp reg, this could corrupt its value and break
+subsequent instructions.
+
+CLOSES #39
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ accel/tcg/translate-all.c               | 51 ++++++++++++++++++-------
+ include/qemu/osdep.h                    |  1 +
+ target/i386/latx/include/latx-config.h  |  2 +
+ target/i386/latx/latx-config.c          | 10 +++++
+ target/i386/latx/translator/translate.c |  1 +
+ tcg/loongarch/tcg-target.c.inc          |  1 +
+ 6 files changed, 53 insertions(+), 13 deletions(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 268cc0c379..e67b97e4f6 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -4308,6 +4308,27 @@ static bool no_right(int64_t addr, int bit_count,
+     return false;
+ }
+ 
++static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
++{
++    int cpu_index = current_cpu->cpu_index;
++    uint32_t *glue = cpu_index * 4 + interpret_glue;
++
++    /* save guest addr to scr0 */
++    UC_SCR(uc)[0] = UC_GR(uc)[rj];
++    /* save epc to scr1 */
++    UC_SCR(uc)[1] = UC_PC(uc) + 4;
++    /*
++     * glue:
++     *     inst
++     *     movscr2gr rj,0
++     *     jiscr1 0
++     */
++    glue[0] = inst;
++    glue[1] = ((0x18 << 7) | rj);
++    glue[2] = 0x48000300;
++    UC_PC(uc) = (unsigned long)glue;
++}
++
+ int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
+ {
+     /* fd: fd/vd/xd */
+@@ -4507,40 +4528,43 @@ int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
+             return 1;
+         }
+         assert(siaddr == real_guest_addr);
+-        assert((rj >= 11 && rj <= 20));
++        if (reg_itemp_reverse_map[rj] == INVALID_TEMP) {
++            set_interpret_glue_code(uc, inst, rj);
++        }
+         UC_GR(uc)[rj] += shadow_pd->access_off;
+-        UC_PC(uc) -= 4;
+-        goto end;
++        goto ret;
+     case 0xad: /* FST.S */
+         if (no_right(real_guest_addr, 4, PAGE_WRITE, &siaddr)) {
+             info->si_addr = (void *)siaddr;
+             return 1;
+         }
+-        assert((rj >= 11 && rj <= 20));
+         assert(siaddr == real_guest_addr);
++        if (reg_itemp_reverse_map[rj] == INVALID_TEMP) {
++            set_interpret_glue_code(uc, inst, rj);
++        }
+         UC_GR(uc)[rj] += shadow_pd->access_off;
+-        UC_PC(uc) -= 4;
+-        goto end;
++        goto ret;
+     case 0xae: /* FLD.D */
+         if (no_right(real_guest_addr, 8, PAGE_READ, &siaddr)) {
+             info->si_addr = (void *)siaddr;
+             return 1;
+         }
+-        assert(siaddr == real_guest_addr);
+-        assert((rj >= 11 && rj <= 20));
++        if (reg_itemp_reverse_map[rj] == INVALID_TEMP) {
++            set_interpret_glue_code(uc, inst, rj);
++        }
+         UC_GR(uc)[rj] += shadow_pd->access_off;
+-        UC_PC(uc) -= 4;
+-        goto end;
++        goto ret;
+     case 0xaf: /* FST.D */
+         if (no_right(real_guest_addr, 8, PAGE_WRITE, &siaddr)) {
+             info->si_addr = (void *)siaddr;
+             return 1;
+         }
+         assert(siaddr == real_guest_addr);
+-        assert((rj >= 11 && rj <= 20));
++        if (reg_itemp_reverse_map[rj] == INVALID_TEMP) {
++            set_interpret_glue_code(uc, inst, rj);
++        }
+         UC_GR(uc)[rj] += shadow_pd->access_off;
+-        UC_PC(uc) -= 4;
+-        goto end;
++        goto ret;
+     case 0xb0: /* VLD */
+         if (no_right(real_guest_addr, 16, PAGE_READ, &siaddr)) {
+             info->si_addr = (void *)siaddr;
+@@ -4900,6 +4924,7 @@ int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
+     }
+ end:
+     UC_PC(uc) += 4;
++ret:
+     return 0;
+ }
+ 
+diff --git a/include/qemu/osdep.h b/include/qemu/osdep.h
+index a15e744f1b..93ee65b2f1 100644
+--- a/include/qemu/osdep.h
++++ b/include/qemu/osdep.h
+@@ -37,6 +37,7 @@
+ #define UC_GR(uc) ((uc)->uc_mcontext.__gregs)
+ #define UC_PC(uc) ((uc)->uc_mcontext.__pc)
+ #ifndef CONFIG_LOONGARCH_NEW_WORLD
++ #define UC_SCR(uc) ((uc)->uc_mcontext.__fpregs->__val64)
+  #define UC_FREG(uc) ((uc)->uc_mcontext.__fpregs)
+  #define UC_FCSR(uc) ((uc)->uc_mcontext.__fcsr)
+ #endif
+diff --git a/target/i386/latx/include/latx-config.h b/target/i386/latx/include/latx-config.h
+index 9ec6fb2701..9c5c2ca9b4 100644
+--- a/target/i386/latx/include/latx-config.h
++++ b/target/i386/latx/include/latx-config.h
+@@ -6,6 +6,7 @@
+ #include "exec/exec-all.h"
+ #include "latx-disassemble-trace.h"
+ 
++extern void *interpret_glue;
+ extern ADDR context_switch_bt_to_native;
+ #if defined(CONFIG_LATX_KZT)
+ int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86State *));
+@@ -13,6 +14,7 @@ int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86S
+ 
+ int target_latx_host(CPUArchState *env, struct TranslationBlock *tb, int max_insns);
+ int target_latx_prologue(void *code_buf_addr);
++void latx_interpret_glue_init(void);
+ int target_latx_epilogue(void *code_buf_addr);
+ int target_latx_fpu_rotate(void *code_buf_addr);
+ void latx_tb_set_jmp_target(struct TranslationBlock *, int, struct TranslationBlock *);
+diff --git a/target/i386/latx/latx-config.c b/target/i386/latx/latx-config.c
+index dfea416031..83a06eeaea 100644
+--- a/target/i386/latx/latx-config.c
++++ b/target/i386/latx/latx-config.c
+@@ -215,6 +215,16 @@ int target_latx_ld_callback(void *code_buf_addr, void (*kzt_tb_callback)(CPUX86S
+ }
+ #endif
+ 
++void latx_interpret_glue_init(void)
++{
++    interpret_glue = mmap(NULL, qemu_host_page_size,
++                            PROT_EXEC | PROT_READ | PROT_WRITE,
++                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
++    if (interpret_glue == MAP_FAILED) {
++        fprintf(stderr, "[LATX-LOG] alloc interpret_glue error!\n");
++    }
++}
++
+ /*
+  * prologue <=> bt to native
+  */
+diff --git a/target/i386/latx/translator/translate.c b/target/i386/latx/translator/translate.c
+index e639f119c1..3ca66e2ae7 100644
+--- a/target/i386/latx/translator/translate.c
++++ b/target/i386/latx/translator/translate.c
+@@ -57,6 +57,7 @@ ADDR context_switch_bt_to_native;
+ ADDR context_switch_native_to_bt_ret_0;
+ ADDR context_switch_native_to_bt;
+ ADDR ss_match_fail_native;
++void *interpret_glue;
+ 
+ ADDR native_rotate_fpu_by; /* native_rotate_fpu_by(step, return_address) */
+ ADDR indirect_jmp_glue;
+diff --git a/tcg/loongarch/tcg-target.c.inc b/tcg/loongarch/tcg-target.c.inc
+index 7625808cd4..aeb9cea884 100644
+--- a/tcg/loongarch/tcg-target.c.inc
++++ b/tcg/loongarch/tcg-target.c.inc
+@@ -1782,6 +1782,7 @@ static void tcg_target_qemu_prologue(TCGContext *s)
+ 
+     int inst_nr = 0;
+ 
++    latx_interpret_glue_init();
+ // --------------------------------- prologue ------------------------------- //
+     inst_nr = target_latx_prologue(s->code_ptr);
+     if (option_dump)
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1032-LATX-fix-Fixed-capstone-cannot-disassembly-dc-d8.patch
+++ b/app-emulation/latx/autobuild/patches/1032-LATX-fix-Fixed-capstone-cannot-disassembly-dc-d8.patch
@@ -1,0 +1,27 @@
+From a07952d624ba1680b32740f56a3f50d84d213967 Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Tue, 8 Apr 2025 16:40:49 +0800
+Subject: [PATCH 1032/1058] LATX, fix: Fixed capstone cannot disassembly 'dc
+ d8'.
+
+Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+---
+ .../latx/capstone_git/arch/X86/X86GenDisassemblerTables.inc     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/target/i386/latx/capstone_git/arch/X86/X86GenDisassemblerTables.inc b/target/i386/latx/capstone_git/arch/X86/X86GenDisassemblerTables.inc
+index 163cf0ee94..835121dbc4 100644
+--- a/target/i386/latx/capstone_git/arch/X86/X86GenDisassemblerTables.inc
++++ b/target/i386/latx/capstone_git/arch/X86/X86GenDisassemblerTables.inc
+@@ -85877,7 +85877,7 @@ static const InstrUID modRMTable[] = {
+   0x10a, /* ADD_FrST0 */
+   0x6f9, /* MUL_FrST0 */
+   0x0, /*  */
+-  0x0, /*  */
++  0x2d1, /* COMP_FST0r */
+   0xad6, /* SUBR_FrST0 */
+   0xaf3, /* SUB_FrST0 */
+   0x351, /* DIVR_FrST0 */
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1033-LATX-fix-SHBR-src-maybe-not-XMM.patch
+++ b/app-emulation/latx/autobuild/patches/1033-LATX-fix-SHBR-src-maybe-not-XMM.patch
@@ -1,0 +1,26 @@
+From f54ef63f86a3fde47d9ad77f2dac719999f053df Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Tue, 8 Apr 2025 15:13:13 +0800
+Subject: [PATCH 1033/1058] LATX, fix: SHBR src maybe not XMM.
+
+---
+ target/i386/latx/optimization/hbr.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/target/i386/latx/optimization/hbr.c b/target/i386/latx/optimization/hbr.c
+index 2f34476a72..7eb57a7faa 100644
+--- a/target/i386/latx/optimization/hbr.c
++++ b/target/i386/latx/optimization/hbr.c
+@@ -858,8 +858,7 @@ static void over_tb_shbr_opt(TranslationBlock **tb_list, int tb_num_in_tu,
+                         if ((ir1->xmm_def & SHBR_UPDATE_DES) && !(ir1->xmm_use & SHBR_NEED_DES)) {
+                             no_opt_xmm &= ~(1 << dest_num);
+                         }
+-                        if (ir1->xmm_use & SHBR_NEED_SRC) {
+-                            assert(ir1_opnd_is_xmm(opnd1));
++                        if ((ir1->xmm_use & SHBR_NEED_SRC) && ir1_opnd_is_xmm(opnd1)) {
+                             src_num = ir1_opnd_base_reg_num(opnd1);
+                             no_opt_xmm |= (1 << src_num);
+                         }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1034-LATX-fix-Set-the-handler-for-SIGCHLD-to-the-default-.patch
+++ b/app-emulation/latx/autobuild/patches/1034-LATX-fix-Set-the-handler-for-SIGCHLD-to-the-default-.patch
@@ -1,0 +1,36 @@
+From 54d567043c9e297a0378d0de97aaf56958f33305 Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Tue, 8 Apr 2025 16:43:01 +0800
+Subject: [PATCH 1034/1058] LATX, fix: Set the handler for SIGCHLD to the
+ default before fork.
+
+Signed-off-by: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+---
+ target/i386/latx/sbt/aot.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/target/i386/latx/sbt/aot.c b/target/i386/latx/sbt/aot.c
+index 1c9d119d4b..12df6f6f85 100644
+--- a/target/i386/latx/sbt/aot.c
++++ b/target/i386/latx/sbt/aot.c
+@@ -1525,7 +1525,7 @@ void aot_exit_entry(CPUState *cpu, int is_end)
+         goto parent_exit;
+     }
+ 
+-    if (old_sa.sa_handler == SIG_IGN) {
++    if (old_sa.sa_handler != SIG_DFL) {
+         struct sigaction new_sa;
+         new_sa.sa_handler = SIG_DFL;
+         sigemptyset(&new_sa.sa_mask);
+@@ -1550,7 +1550,7 @@ void aot_exit_entry(CPUState *cpu, int is_end)
+     if (pid) {
+         if (pid > 0) {
+             wait(NULL);
+-            if (old_sa.sa_handler == SIG_IGN) {
++            if (old_sa.sa_handler != SIG_DFL) {
+                 sigaction(signum, &old_sa, NULL);
+             }
+             if (sigismember(&sigset, signum)) {
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1035-LATX-fix-The-warning-of-AOT-only-appears-in-debug-mo.patch
+++ b/app-emulation/latx/autobuild/patches/1035-LATX-fix-The-warning-of-AOT-only-appears-in-debug-mo.patch
@@ -1,0 +1,27 @@
+From b0f9d467b4a1accd10a068034dd8ea6f427d4b4d Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Tue, 8 Apr 2025 11:32:20 +0800
+Subject: [PATCH 1035/1058] LATX, fix: The warning of AOT only appears in debug
+ mode.
+
+---
+ accel/tcg/translate-all.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index e67b97e4f6..445050b625 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -2404,7 +2404,9 @@ void aot_tb_register(TranslationBlock *tb)
+     existing_tb = tb_link_page(tb, phys_pc, phys_page2);
+     /* if the TB already exists, discard what we just translated */
+     if (existing_tb != tb) {
++#ifdef CONFIG_LATX_DEBUG
+         fprintf(stderr, "aot_register_tb failed due to tb_link page\n");
++#endif
+     }
+     tcg_tb_insert(tb);
+ }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1036-LATX-fix-The-instruction-with-lock-prefix-does-not-r.patch
+++ b/app-emulation/latx/autobuild/patches/1036-LATX-fix-The-instruction-with-lock-prefix-does-not-r.patch
@@ -1,0 +1,153 @@
+From 27a4c3af97832d950d92751ed67201e2acecb9a7 Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Thu, 10 Apr 2025 10:25:21 +0800
+Subject: [PATCH 1036/1058] LATX, fix: The instruction with lock prefix does
+ not require GHBR.
+
+---
+ target/i386/latx/translator/tr-lock.c | 52 +++++++--------------------
+ 1 file changed, 12 insertions(+), 40 deletions(-)
+
+diff --git a/target/i386/latx/translator/tr-lock.c b/target/i386/latx/translator/tr-lock.c
+index 01f00292d2..87c5ce4669 100644
+--- a/target/i386/latx/translator/tr-lock.c
++++ b/target/i386/latx/translator/tr-lock.c
+@@ -136,9 +136,7 @@ bool translate_lock_sbb(IR1_INST *pir1)
+     generate_eflag_calculation(dest, src0, src1, pir1, true);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -273,9 +271,7 @@ bool translate_lock_add(IR1_INST *pir1)
+     la_add_w(dest, src0, src1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -412,9 +408,7 @@ bool translate_lock_adc(IR1_INST *pir1)
+     la_adc_w(dest, src0, src1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -548,9 +542,7 @@ bool translate_lock_and(IR1_INST *pir1)
+     la_and(dest, src0, src1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -683,9 +675,7 @@ bool translate_lock_inc(IR1_INST *pir1)
+     la_addi_w(dest, src0, 1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -819,9 +809,7 @@ bool translate_lock_dec(IR1_INST *pir1)
+     la_addi_w(dest, src0, -1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -957,9 +945,7 @@ bool translate_lock_sub(IR1_INST *pir1)
+     la_sub_w(dest, src0, src1);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -1099,9 +1085,7 @@ bool translate_lock_neg(IR1_INST *pir1)
+     la_sub_w(dest, zero_ir2_opnd, src0);
+ 
+     /* rebuild dest */
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -1237,10 +1221,7 @@ bool translate_lock_or(IR1_INST *pir1)
+     la_or(dest, src0, src1);
+ 
+     /* rebuild dest */
+-
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -1372,10 +1353,7 @@ bool translate_lock_not(IR1_INST *pir1)
+     la_nor(dest, zero_ir2_opnd, src0);
+ 
+     /* rebuild dest */
+-
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -1510,10 +1488,7 @@ bool translate_lock_xor(IR1_INST *pir1)
+     la_xor(dest, src0, src1);
+ 
+     /* rebuild dest */
+-
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+@@ -1651,10 +1626,7 @@ bool translate_lock_xadd(IR1_INST *pir1)
+     la_add_w(dest, src0, src1);
+ 
+     /* rebuild dest */
+-
+-    if (!GHBR_ON(pir1)) {
+-        la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+-    }
++    la_bstrpick_d(dest, dest, opnd0_size - 1, 0);
+     la_sll_d(dest, dest, tmp);
+     la_or(src0_cpy, src0_cpy, dest);
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1037-LATX-fix-GHBR-has-added-analysis-for-ins-with-hidden.patch
+++ b/app-emulation/latx/autobuild/patches/1037-LATX-fix-GHBR-has-added-analysis-for-ins-with-hidden.patch
@@ -1,0 +1,249 @@
+From cf1640c1ab82585ad316e2beaaa21646acc9efbb Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Thu, 10 Apr 2025 10:28:18 +0800
+Subject: [PATCH 1037/1058] LATX, fix: GHBR has added analysis for ins with
+ hidden operands.
+
+---
+ target/i386/latx/optimization/hbr.c | 157 ++++++++++++++++++++++++----
+ 1 file changed, 138 insertions(+), 19 deletions(-)
+
+diff --git a/target/i386/latx/optimization/hbr.c b/target/i386/latx/optimization/hbr.c
+index 7eb57a7faa..6d80028a6f 100644
+--- a/target/i386/latx/optimization/hbr.c
++++ b/target/i386/latx/optimization/hbr.c
+@@ -563,7 +563,6 @@ static bool xmm_analyse_32(TranslationBlock *tb,
+     return false;
+ }
+ 
+-/* FIXME! */
+ static bool deal_dest_not_xmm_64(TranslationBlock *tb,
+         IR1_INST *ir1, uint32_t xmm[XMM_NUM])
+ {
+@@ -571,7 +570,6 @@ static bool deal_dest_not_xmm_64(TranslationBlock *tb,
+     return false;
+ }
+ 
+-/* FIX ME! */
+ static bool deal_src_not_xmm_64(TranslationBlock *tb,
+         IR1_INST *ir1, uint32_t xmm[XMM_NUM])
+ {
+@@ -580,6 +578,7 @@ static bool deal_src_not_xmm_64(TranslationBlock *tb,
+ }
+ 
+ /* analyse 64 ~ 127 bit. */
++/* TODO: analyze more instructions. */
+ static bool xmm_analyse_64(TranslationBlock *tb,
+         IR1_INST *ir1, uint32_t xmm[XMM_NUM])
+ {
+@@ -1010,14 +1009,31 @@ static void des_def_gpr(TranslationBlock *tb, IR1_INST *ir1)
+     tb->s_data->gpr_def |= 1 << dest_num;
+ }
+ 
+-static bool cover_des_gpr(TranslationBlock *tb, IR1_INST *ir1)
++static void deal_hide_opnd_def(TranslationBlock *tb, IR1_INST *ir1)
+ {
+-    /* return true; */
+-    if (ir1_opcode(ir1) == WRAP(CWDE)) {
++    switch (ir1_opcode(ir1)) {
++    case WRAP(CWDE):
+         ir1->gpr_def |= 1 << eax_index;
+         tb->s_data->gpr_def |= 1 << eax_index;
+-        return true;
++        break;
++    case WRAP(CQO):
++        ir1->gpr_def |= 1 << edx_index;
++        tb->s_data->gpr_def |= 1 << edx_index;
++        break;
++    case WRAP(POPAW):
++        ir1->gpr_def |= 0xff & ~esp_index;
++        tb->s_data->gpr_def |= 0xff & ~esp_index;
++        break;
++    default:
++        break;
+     }
++}
++
++/* Some ins can update the h32 bits of des opnd
++ * without using the h32 bits of des opnd. */
++static bool def_h32(TranslationBlock *tb, IR1_INST *ir1)
++{
++    deal_hide_opnd_def(tb, ir1);
+ 
+     if (!ir1_get_opnd_num(ir1)) {
+         return false;
+@@ -1095,16 +1111,123 @@ static void set_use_reg(TranslationBlock *tb, IR1_INST *ir1, int reg_num)
+ {
+     if (reg_num >= 0 && reg_num < 16) {
+         ir1->gpr_use |= 1 << reg_num;
+-        /* Use not def reg. */
++        /* Need pre tb provide if curr tb  not def this reg. */
+         if (!(tb->s_data->gpr_def & (1 << reg_num))) {
+             tb->s_data->gpr_use |= 1 << reg_num;
+         }
+     }
+ }
+ 
+-static void use_gpr(TranslationBlock *tb, IR1_INST *ir1)
++static void deal_hide_opnd_use(TranslationBlock *tb, IR1_INST *ir1)
++{
++    switch (ir1_opcode(ir1)) {
++    case WRAP(CMPXCHG):
++    case WRAP(SALC):
++    case WRAP(CWD):
++    case WRAP(CDQ):
++    case WRAP(CBW):
++    case WRAP(CWDE):
++    case WRAP(CDQE):
++        set_use_reg(tb, ir1, eax_index);
++        break;
++    case WRAP(XLATB):
++        set_use_reg(tb, ir1, ebx_index);
++        break;
++    case WRAP(JRCXZ):
++    case WRAP(JCXZ):
++    case WRAP(JECXZ):
++    case WRAP(LOOPE):
++    case WRAP(LOOPNE):
++    case WRAP(LOOP):
++        set_use_reg(tb, ir1, ecx_index);
++        break;
++    case WRAP(MASKMOVQ):
++    case WRAP(MASKMOVDQU):
++        set_use_reg(tb, ir1, edi_index);
++        break;
++    case WRAP(POPF):
++    case WRAP(POP):
++    case WRAP(PUSHF):
++    case WRAP(PUSH):
++    case WRAP(CALL):
++    case WRAP(RET):
++    case WRAP(RETF):
++    case WRAP(IRET):
++    case WRAP(IRETQ):
++        set_use_reg(tb, ir1, esp_index);
++        break;
++    case WRAP(LODSB):
++    case WRAP(LODSQ):
++    case WRAP(LODSW):
++    case WRAP(LODSD):
++        set_use_reg(tb, ir1, esi_index);
++        set_use_reg(tb, ir1, ecx_index);
++        break;
++    case WRAP(MUL):
++    case WRAP(DIV):
++    case WRAP(IDIV):
++    case WRAP(RDTSC):
++    case WRAP(CQO):
++        set_use_reg(tb, ir1, eax_index);
++        break;
++    case WRAP(IMUL):
++        if (ir1_opnd_num(ir1) == 1) {
++            set_use_reg(tb, ir1, eax_index);
++            set_use_reg(tb, ir1, edx_index);
++        }
++        break;
++    case WRAP(ENTER):
++    case WRAP(LEAVE):
++        set_use_reg(tb, ir1, esp_index);
++        set_use_reg(tb, ir1, ebp_index);
++        break;
++    case WRAP(MOVSD):
++    case WRAP(CMPSD):
++        set_use_reg(tb, ir1, esi_index);
++        set_use_reg(tb, ir1, edi_index);
++        set_use_reg(tb, ir1, ecx_index);
++        break;
++    case WRAP(STOSB):
++    case WRAP(STOSW):
++    case WRAP(STOSD):
++    case WRAP(STOSQ):
++    case WRAP(SCASB):
++    case WRAP(SCASW):
++    case WRAP(SCASD):
++    case WRAP(SCASQ):
++        set_use_reg(tb, ir1, eax_index);
++        set_use_reg(tb, ir1, edi_index);
++        set_use_reg(tb, ir1, ecx_index);
++        break;
++    case WRAP(RDTSCP):
++        set_use_reg(tb, ir1, eax_index);
++        set_use_reg(tb, ir1, ecx_index);
++        set_use_reg(tb, ir1, edx_index);
++        break;
++    case WRAP(CMPXCHG8B):
++    case WRAP(CMPXCHG16B):
++        set_use_reg(tb, ir1, eax_index);
++        set_use_reg(tb, ir1, ebx_index);
++        set_use_reg(tb, ir1, ecx_index);
++        set_use_reg(tb, ir1, edx_index);
++        break;
++    case WRAP(INT3):
++    case WRAP(PUSHAW):
++    case WRAP(PUSHAL):
++        ir1->gpr_use |= GHBR_GPR_ALL;
++        tb->s_data->gpr_use |= ~tb->s_data->gpr_def;
++        break;
++    default:
++        break;
++    }
++}
++
++static void use_h32(TranslationBlock *tb, IR1_INST *ir1)
+ {
++    deal_hide_opnd_use(tb, ir1);
+     int opnd_num = ir1_get_opnd_num(ir1);
++    /* We roughly assume that the high 32 bit of all gpr in curr ins will be used,
++     * except for updating their own h32 des opnd without using their own h32 bit. */
+     int i = 0;
+     if (ir1->gpr_def) {
+         i = 1;
+@@ -1126,6 +1249,10 @@ static void use_gpr(TranslationBlock *tb, IR1_INST *ir1)
+     }
+ }
+ 
++/* The current strategy used is relatively conservative, */
++/* only including analysis of a small number of instructions.
++ * If the strategy is changed to analyze more instructions,
++ * better results may be achieved. */
+ static void get_gpr_use_def(TranslationBlock *tb)
+ {
+     tb->s_data->gpr_use = 0;
+@@ -1137,8 +1264,8 @@ static void get_gpr_use_def(TranslationBlock *tb)
+         ir1 = tb_ir1_inst(tb, i);
+         ir1->gpr_def = 0;
+         ir1->gpr_use = 0;
+-        cover_des_gpr(tb, ir1);
+-        use_gpr(tb, ir1);
++        def_h32(tb, ir1);
++        use_h32(tb, ir1);
+     }
+ }
+ 
+@@ -1157,9 +1284,7 @@ void hbr_opt(TranslationBlock **tb_list, int tb_num_in_tu)
+     do_shbr_opt32(tb_list, tb_num_in_tu);
+     do_shbr_opt64(tb_list, tb_num_in_tu);
+ #ifdef TARGET_X86_64
+-    if (1) {
+-        do_gpr_opt(tb_list, tb_num_in_tu);
+-    }
++    do_gpr_opt(tb_list, tb_num_in_tu);
+ #endif
+ }
+ 
+@@ -1192,12 +1317,6 @@ bool can_ghbr_opt(IR1_INST *ir1)
+     if (!in_pre_translate) {
+         return false;
+     }
+-    IR1_OPND *opnd0 = ir1_get_opnd(ir1, 0);
+-    int opnd0_size = ir1_opnd_size(opnd0);
+-    if (!(ir1_opnd_is_gpr(opnd0) && opnd0_size == 32)) {
+-        return false;
+-    }
+-
+     if (ir1->hbr_flag & GHBR_CAN_OPT) {
+         return true;
+     }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1038-LATX-fix-add-TCGETS2-and-HIDRAW-ioctls.patch
+++ b/app-emulation/latx/autobuild/patches/1038-LATX-fix-add-TCGETS2-and-HIDRAW-ioctls.patch
@@ -1,0 +1,179 @@
+From 0033e7fc6631ca26dca19949cade141888dfcb83 Mon Sep 17 00:00:00 2001
+From: Lu Zeng <luzeng87@gmail.com>
+Date: Thu, 10 Apr 2025 14:25:46 +0800
+Subject: [PATCH 1038/1058] LATX, fix: add TCGETS2 and HIDRAW* ioctls
+
+Signed-off-by: Lu Zeng <luzeng87@gmail.com>
+---
+ linux-user/ioctls.h        |  5 +++++
+ linux-user/main.c          |  1 +
+ linux-user/syscall.c       | 37 ++++++++++++++++++++++++++++++++++++-
+ linux-user/syscall_defs.h  | 19 +++++++++++++++++++
+ linux-user/syscall_types.h | 16 ++++++++++++++++
+ 5 files changed, 77 insertions(+), 1 deletion(-)
+
+diff --git a/linux-user/ioctls.h b/linux-user/ioctls.h
+index 0d8cf2e3ea..fb7151e936 100644
+--- a/linux-user/ioctls.h
++++ b/linux-user/ioctls.h
+@@ -1,5 +1,6 @@
+      /* emulated ioctl list */
+ 
++     IOCTL(TCGETS2, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios2)))
+      IOCTL(TCGETS, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios)))
+      IOCTL(TCSETS, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
+      IOCTL(TCSETSF, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
+@@ -1316,3 +1317,7 @@
+   IOCTL(UI_SET_RELBIT, IOC_W, TYPE_INT)
+   IOCTL(UI_DEV_CREATE, 0)
+   IOCTL(UI_DEV_DESTROY, 0)
++
++  IOCTL(HIDIOCGRDESCSIZE, IOC_R, TYPE_INT)
++  IOCTL(HIDIOCGRDESC, IOC_R, MK_PTR(MK_STRUCT(STRUCT_hidraw_report_descriptor)))
++  IOCTL(HIDIOCGRAWINFO, IOC_R, MK_PTR(MK_STRUCT(STRUCT_hidraw_devinfo)))
+diff --git a/linux-user/main.c b/linux-user/main.c
+index 4c0fc1e02f..ff0b40bcf9 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -49,6 +49,7 @@
+ #include "target_elf.h"
+ #include "cpu_loop-common.h"
+ #include "crypto/init.h"
++int mydebug = 1;
+ 
+ #ifdef CONFIG_LATX
+ #include "latx-config.h"
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 5af9df1045..bc67c9cfd9 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -5433,7 +5433,7 @@ STRUCT_MAX
+ #undef STRUCT
+ #undef STRUCT_SPECIAL
+ 
+-#define MAX_STRUCT_SIZE 4096
++#define MAX_STRUCT_SIZE 16384
+ 
+ #ifdef CONFIG_FIEMAP
+ /* So fiemap access checks don't overflow on 32 bit systems.
+@@ -8102,8 +8102,25 @@ static abi_long do_ioctl_mpt3(const IOCTLEntry *ie,
+     }
+     return -TARGET_ENOSYS;
+ }
++static abi_long handle_hidfeature(int fd, abi_ulong cmd, abi_ulong arg,
++                                  int len, bool is_read)
++{
++    void *host_buf;
++
++    host_buf = lock_user(is_read ? VERIFY_WRITE : VERIFY_READ, arg, len, 1);
++    if (!host_buf) {
++        return -TARGET_EFAULT;
++    }
++
++    int ret = get_errno(safe_ioctl(fd, cmd, host_buf));
++
++    unlock_user(host_buf, arg, len);
++
++    return ret;
++}
+ 
+ #include "ioctl/ioctl_syscall/syscall_amdgpu_drm.c"
++#include <linux/hidraw.h>
+ 
+ typedef __u32 u32;
+ typedef __u64 u64;
+@@ -8148,6 +8165,19 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
+ #endif
+     /* slow path to iterate the ioctl_entries */
+     if (ie->target_cmd != cmd) {
++        switch(TARGET_IOC_NR(cmd)) {
++            case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGRAWNAME(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGRAWPHYS(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGRAWUNIQ(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCSINPUT(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGINPUT(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCSOUTPUT(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCGOUTPUT(0)):
++            case TARGET_IOC_NR(TARGET_HIDIOCREVOKE):
++                return handle_hidfeature(fd, cmd, arg, TARGET_IOC_SIZE(cmd), 1);
++        } 
+         ie = ioctl_entries;
+         for (i = 0; ; i++) {
+             if (ie->target_cmd == 0) {
+@@ -8195,6 +8225,11 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
+         target_size = thunk_type_size(arg_type, 0);
+         switch(ie->access) {
+         case IOC_R:
++            if (ie->host_cmd == HIDIOCGRDESC) {
++                /* kernel use the size, should pass it */
++                argptr = lock_user(VERIFY_WRITE, arg, 4, 0);
++                *(uint32_t*)buf_temp = *(uint32_t *)argptr;
++            }
+             ret = get_errno(safe_ioctl(fd, ie->host_cmd, buf_temp));
+             if (!is_error(ret)) {
+                 argptr = lock_user(VERIFY_WRITE, arg, target_size, 0);
+diff --git a/linux-user/syscall_defs.h b/linux-user/syscall_defs.h
+index 76ae0b50fe..d747c96727 100644
+--- a/linux-user/syscall_defs.h
++++ b/linux-user/syscall_defs.h
+@@ -130,6 +130,9 @@
+     ((nr)   << TARGET_IOC_NRSHIFT) | \
+     ((size) << TARGET_IOC_SIZESHIFT))
+ 
++#define TARGET_IOC_NR(nr)		(((nr) >> TARGET_IOC_NRSHIFT) & TARGET_IOC_NRMASK)
++#define TARGET_IOC_SIZE(nr)		(((nr) >> TARGET_IOC_SIZESHIFT) & TARGET_IOC_SIZEMASK)
++
+ /* used to create numbers */
+ #define TARGET_IO(type,nr)		TARGET_IOC(TARGET_IOC_NONE,(type),(nr),0)
+ #define TARGET_IOR(type,nr,size)	TARGET_IOC(TARGET_IOC_READ,(type),(nr),sizeof(size))
+@@ -3833,4 +3836,20 @@ struct target_snd_xferi {
+ #define TARGET_UI_SET_RELBIT	TARGET_IOW('U', 102, int)
+ #define TARGET_UI_DEV_CREATE    TARGET_IO('U', 1)
+ #define TARGET_UI_DEV_DESTROY   TARGET_IO('U', 2)
++
++/* ioctl interface */
++#define TARGET_HIDIOCGRDESCSIZE	TARGET_IOR('H', 0x01, int)
++#define TARGET_HIDIOCGRDESC		TARGET_IOR('H', 0x02, struct hidraw_report_descriptor)
++#define TARGET_HIDIOCGRAWINFO		TARGET_IOR('H', 0x03, struct hidraw_devinfo)
++#define TARGET_HIDIOCGRAWNAME(len)     TARGET_IOC(TARGET_IOC_READ, 'H', 0x04, len)
++#define TARGET_HIDIOCGRAWPHYS(len)     TARGET_IOC(TARGET_IOC_READ, 'H', 0x05, len)
++/* The first byte of SFEATURE and GFEATURE is the report number */
++#define TARGET_HIDIOCSFEATURE(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x06, len)
++#define TARGET_HIDIOCGFEATURE(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x07, len)
++#define TARGET_HIDIOCGRAWUNIQ(len)     TARGET_IOC(TARGET_IOC_READ, 'H', 0x08, len)
++#define TARGET_HIDIOCSINPUT(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x09, len)
++#define TARGET_HIDIOCGINPUT(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x0A, len)
++#define TARGET_HIDIOCSOUTPUT(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x0B, len)
++#define TARGET_HIDIOCGOUTPUT(len)    TARGET_IOC(TARGET_IOC_WRITE|TARGET_IOC_READ, 'H', 0x0C, len)
++#define TARGET_HIDIOCREVOKE    TARGET_IOW('H', 0x0D, int)
+ #endif
+diff --git a/linux-user/syscall_types.h b/linux-user/syscall_types.h
+index 07f5545578..8a205856be 100644
+--- a/linux-user/syscall_types.h
++++ b/linux-user/syscall_types.h
+@@ -1929,4 +1929,20 @@ STRUCT(sg_io_hdr,
+         TYPE_INT,
+         TYPE_INT,
+         TYPE_INT)
++STRUCT(termios2,
++         TYPE_INT,
++         TYPE_INT,
++         TYPE_INT,
++         TYPE_INT,
++         TYPE_CHAR,
++         MK_ARRAY(TYPE_CHAR, 19),
++         TYPE_INT,
++         TYPE_INT)
++STRUCT(hidraw_devinfo,
++         TYPE_INT,
++         TYPE_SHORT,
++         TYPE_SHORT)
++STRUCT(hidraw_report_descriptor,
++         TYPE_INT,
++         MK_ARRAY(TYPE_CHAR, 4096))
+ #include "ioctl/ioctl_type/type_amdgpu_drm.h"
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1039-LATX-fix-Invalidate-checksum_fail_tb.patch
+++ b/app-emulation/latx/autobuild/patches/1039-LATX-fix-Invalidate-checksum_fail_tb.patch
@@ -1,0 +1,59 @@
+From 5c1af90bf501b6eea29e8775445e694fc7599114 Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Thu, 10 Apr 2025 20:19:06 +0800
+Subject: [PATCH 1039/1058] LATX, fix: Invalidate checksum_fail_tb.
+
+If the shared memory where TB is located is modified, we should
+retranslate it.
+---
+ accel/tcg/cpu-exec.c      | 10 ++++++++++
+ accel/tcg/translate-all.c |  5 +----
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
+index 17eab7505f..e8203fc5e0 100644
+--- a/accel/tcg/cpu-exec.c
++++ b/accel/tcg/cpu-exec.c
+@@ -261,6 +261,16 @@ cpu_tb_exec(CPUState *cpu, TranslationBlock *itb, int *tb_exit)
+     env->fpu_clobber = false;
+     ret = tcg_qemu_tb_exec(env, tb_ptr);
+ 
++    if (env->checksum_fail_tb) {
++        TranslationBlock * tb_fail = (TranslationBlock *)env->checksum_fail_tb;
++        lsassert(tb_fail->checksum && tb_fail->pc == env->eip);
++        mmap_lock();
++        tb_phys_invalidate(tb_fail, tb_page_addr0(tb_fail));
++        mmap_unlock();
++        env->checksum_fail_tb = NULL;
++        /*qemu_log("latx checksum fail, retranslate pc=%lx\n", tb_fail->pc);*/
++    }
++
+     if (env->insn_save[0]) {
+         link_indirect_jmp(env);
+     }
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 445050b625..0a5aaf4270 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -3523,9 +3523,6 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
+          len != 0;
+          len -= TARGET_PAGE_SIZE, addr += TARGET_PAGE_SIZE) {
+         PageFlagsNode *p = pageflags_find(addr, addr);
+-        if (p && p->flags & PAGE_MEMSHARE) {
+-            p->flags |= PAGE_MEMSHARE;
+-        }
+ #ifdef CONFIG_LATX_AOT
+         if (option_aot && (flags & PAGE_WRITE) && p && !(p->flags & PAGE_WRITE)) {
+             if (foreach_tb_first(addr, addr + TARGET_PAGE_SIZE)) {
+@@ -3542,7 +3539,7 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
+ 
+     if (flags) {
+         inval_tb |= pageflags_set_clear(start, last, flags,
+-            ~(reset ? 0 : PAGE_ANON | PAGE_OVERFLOW));
++            ~(reset ? 0 : PAGE_ANON | PAGE_OVERFLOW | PAGE_MEMSHARE));
+     }
+ 
+     if (inval_tb) {
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1040-LATX-fix-Add-option_monitor_shared_mem.patch
+++ b/app-emulation/latx/autobuild/patches/1040-LATX-fix-Add-option_monitor_shared_mem.patch
@@ -1,0 +1,144 @@
+From bad35962b443a9b26296c6441fea460fc52e8931 Mon Sep 17 00:00:00 2001
+From: Wenqiang Wei <weiwenqiang@mail.ustc.edu.cn>
+Date: Thu, 10 Apr 2025 20:52:25 +0800
+Subject: [PATCH 1040/1058] LATX, fix: Add option_monitor_shared_mem.
+
+This option is used to control whether shared memory monitoring is
+enabled.
+
+Usage: export LATX_MONITOR_SHARED_MEM=1
+---
+ accel/tcg/cpu-exec.c                    | 2 +-
+ accel/tcg/translate-all.c               | 4 +++-
+ linux-user/main.c                       | 7 +++++++
+ linux-user/mmap.c                       | 6 ++++--
+ target/i386/latx/include/latx-options.h | 1 +
+ target/i386/latx/latx-options.c         | 2 ++
+ target/i386/latx/translator/translate.c | 2 +-
+ 7 files changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
+index e8203fc5e0..364b392079 100644
+--- a/accel/tcg/cpu-exec.c
++++ b/accel/tcg/cpu-exec.c
+@@ -261,7 +261,7 @@ cpu_tb_exec(CPUState *cpu, TranslationBlock *itb, int *tb_exit)
+     env->fpu_clobber = false;
+     ret = tcg_qemu_tb_exec(env, tb_ptr);
+ 
+-    if (env->checksum_fail_tb) {
++    if (option_monitor_shared_mem && env->checksum_fail_tb) {
+         TranslationBlock * tb_fail = (TranslationBlock *)env->checksum_fail_tb;
+         lsassert(tb_fail->checksum && tb_fail->pc == env->eip);
+         mmap_lock();
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 0a5aaf4270..8920e4a002 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -2240,7 +2240,9 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
+         mprotect((void*)(pc & qemu_host_page_mask), qemu_host_page_size, PROT_READ);
+     }
+ 
+-    tb->checksum = p_flags & PAGE_MEMSHARE;
++    if (option_monitor_shared_mem) {
++        tb->checksum = p_flags & PAGE_MEMSHARE;
++    }
+     gen_code_size = target_latx_host(env, tb, max_insns);
+     if (unlikely(gen_code_size < 0)) {
+         /*
+diff --git a/linux-user/main.c b/linux-user/main.c
+index ff0b40bcf9..e525886367 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -702,6 +702,11 @@ static void handle_arg_latx_real_maps(const char *arg)
+     }
+ }
+ 
++static void handle_arg_latx_monitor_shared_mem(const char *arg)
++{
++    option_monitor_shared_mem = strtol(arg, NULL, 0);
++}
++
+ #ifdef CONFIG_LATX_AOT
+ static void handle_arg_latx_aot(const char *arg)
+ {
+@@ -795,6 +800,8 @@ static const struct qemu_argument arg_table[] = {
+     "",           "test memory right when memory access"},
+     {"latx-real-maps",    "LATX_REAL_MAPS",     true,  handle_arg_latx_real_maps,
+     "",           "enable get real self maps"},
++    {"latx-monitor-shared-mem",    "LATX_MONITOR_SHARED_MEM",     true,  handle_arg_latx_monitor_shared_mem,
++    "",           "monitor shared memory, retranslate self modifying page"},
+ #ifdef CONFIG_LATX_AOT
+     {"latx-aot",    "LATX_AOT",     true,  handle_arg_latx_aot,
+     "",           "enable aot"},
+diff --git a/linux-user/mmap.c b/linux-user/mmap.c
+index fc5b77a5f2..fbad1f8c69 100644
+--- a/linux-user/mmap.c
++++ b/linux-user/mmap.c
+@@ -680,7 +680,9 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int target_prot,
+      * be atomic with respect to an external process.
+      */
+     if (flags & MAP_SHARED) {
+-        page_flags |= PAGE_MEMSHARE;
++        if (option_monitor_shared_mem) {
++            page_flags |= PAGE_MEMSHARE;
++        }
+         CPUState *cpu = thread_cpu;
+         if (!(cpu->tcg_cflags & CF_PARALLEL)) {
+             cpu->tcg_cflags |= CF_PARALLEL;
+@@ -1254,7 +1256,7 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
+         new_addr = h2g(host_addr);
+         prot = page_get_flags(old_addr);
+         page_set_flags(old_addr, old_addr + old_size, 0);
+-        if ((flags & MAP_TYPE) == MAP_SHARED) {
++        if (option_monitor_shared_mem && (flags & MAP_TYPE) == MAP_SHARED) {
+             prot |= PAGE_MEMSHARE;
+         }
+         page_set_flags(new_addr, new_addr + new_size,
+diff --git a/target/i386/latx/include/latx-options.h b/target/i386/latx/include/latx-options.h
+index 52a431e951..cca8719110 100644
+--- a/target/i386/latx/include/latx-options.h
++++ b/target/i386/latx/include/latx-options.h
+@@ -68,6 +68,7 @@ extern int option_debug_imm_reg;
+ extern uint64_t imm_skip_pc;
+ extern int option_mem_test;
+ extern int option_real_maps;
++extern int option_monitor_shared_mem;
+ 
+ extern unsigned long long counter_tb_exec;
+ extern unsigned long long counter_tb_tr;
+diff --git a/target/i386/latx/latx-options.c b/target/i386/latx/latx-options.c
+index 4d59aaba17..0d51a17008 100644
+--- a/target/i386/latx/latx-options.c
++++ b/target/i386/latx/latx-options.c
+@@ -82,6 +82,7 @@ int option_split_tb;
+ int option_anonym;
+ int option_mem_test;
+ int option_real_maps;
++int option_monitor_shared_mem;
+ 
+ unsigned long long counter_tb_exec;
+ unsigned long long counter_tb_tr;
+@@ -131,6 +132,7 @@ void options_init(void)
+     option_anonym = 0;
+     option_mem_test = 0;
+     option_real_maps = 0;
++    option_monitor_shared_mem = 0;
+ }
+ 
+ #define OPTIONS_IMM_REG 0
+diff --git a/target/i386/latx/translator/translate.c b/target/i386/latx/translator/translate.c
+index 3ca66e2ae7..aa75dc6eae 100644
+--- a/target/i386/latx/translator/translate.c
++++ b/target/i386/latx/translator/translate.c
+@@ -1557,7 +1557,7 @@ int tr_ir2_generate(struct TranslationBlock *tb)
+     bool reduce_proepo = false;
+     int tr_func_idx;
+ 
+-    if (tb->checksum) {
++    if (option_monitor_shared_mem && tb->checksum) {
+         tr_check_x86ins_change(tb);
+     }
+ #ifdef CONFIG_LATX_IMM_REG
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1041-LATX-fix-SIGSEGV-handling-support-for-new-world.patch
+++ b/app-emulation/latx/autobuild/patches/1041-LATX-fix-SIGSEGV-handling-support-for-new-world.patch
@@ -1,0 +1,82 @@
+From bed881cf5493108b0ed2115b51f0749222ca41a6 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Fri, 11 Apr 2025 10:44:54 +0800
+Subject: [PATCH 1041/1058] LATX, fix: SIGSEGV handling support for new world
+
+This patch adds support for SIGSEGV handling in the new world of LATX.
+As `UC_SCR` is not supported in the new world, we need to use extcontext
+to modify the `SCR` in signal context.
+
+CLOSE #41
+
+Co-authored-by: Qi HU <github@spcsky.com>
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ accel/tcg/translate-all.c      |  2 ++
+ linux-user/signal.c            | 16 ++++++++--------
+ target/i386/latx/latx-signal.c |  2 +-
+ 3 files changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 8920e4a002..82ea28cc57 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -4309,6 +4309,7 @@ static bool no_right(int64_t addr, int bit_count,
+     return false;
+ }
+ 
++#ifndef CONFIG_LOONGARCH_NEW_WORLD
+ static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
+ {
+     int cpu_index = current_cpu->cpu_index;
+@@ -4329,6 +4330,7 @@ static void set_interpret_glue_code(ucontext_t *uc, unsigned int inst, int rj)
+     glue[2] = 0x48000300;
+     UC_PC(uc) = (unsigned long)glue;
+ }
++#endif
+ 
+ int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
+ {
+diff --git a/linux-user/signal.c b/linux-user/signal.c
+index 579d7ffca5..6181b05c26 100644
+--- a/linux-user/signal.c
++++ b/linux-user/signal.c
+@@ -1030,14 +1030,14 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
+         TranslationBlock *current_tb = tcg_tb_lookup(UC_PC(uc));
+         if (current_tb) {
+             /* clear scr0 */
+-#ifndef CONFIG_LOONGARCH_NEW_WORLD
+-            UC_FREG(uc)[0].__val64[0] = 0;
+-#else
+-	    struct extctx_layout extctx;
+-	    memset(&extctx, 0, sizeof(extctx));
+-	    parse_extcontext(uc, &extctx);
+-	    UC_LBT(&extctx)->regs[0] = 0;
+-#endif
++ #ifndef CONFIG_LOONGARCH_NEW_WORLD
++            UC_SCR(uc)[0] = 0;
++ #else
++	        struct extctx_layout extctx;
++	        memset(&extctx, 0, sizeof(extctx));
++	        parse_extcontext(uc, &extctx);
++	        UC_LBT(&extctx)->regs[0] = 0;
++ #endif
+             /* set the next TB and point the epc to the epilogue */
+             UC_GR(uc)[reg_statics_map[S_UD1]] = current_tb->pc;
+             UC_PC(uc) = context_switch_native_to_bt_ret_0;
+diff --git a/target/i386/latx/latx-signal.c b/target/i386/latx/latx-signal.c
+index 1812f7b4b3..f7c5be5402 100644
+--- a/target/i386/latx/latx-signal.c
++++ b/target/i386/latx/latx-signal.c
+@@ -59,7 +59,7 @@ void unlink_indirect_jmp(CPUArchState *env, TranslationBlock *tb, ucontext_t *uc
+ 
+ #ifndef CONFIG_LOONGARCH_NEW_WORLD
+     /* clear scr0 */
+-    UC_FREG(uc)[0].__val64[0] = 0;
++    UC_SCR(uc)[0] = 0;
+ #else
+     struct extctx_layout extctx;
+     memset(&extctx, 0, sizeof(extctx));
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1042-feat-Optimize-PACKSSWB.patch
+++ b/app-emulation/latx/autobuild/patches/1042-feat-Optimize-PACKSSWB.patch
@@ -1,0 +1,65 @@
+From 4dc3b558a304c9d17d29e86d197715e98092d3f1 Mon Sep 17 00:00:00 2001
+From: phorcys <phorcys02@126.com>
+Date: Thu, 10 Apr 2025 23:14:14 +0800
+Subject: [PATCH 1042/1058] feat: Optimize PACKSSWB copied from box64 , author
+ @ksco
+ https://github.com/ptitSeb/box64/blob/0bb41a73c27df807ba8fcaa205612be7b3a1ac95/src/dynarec/la64/dynarec_la64_660f.c#L1420
+
+from https://jia.je/unofficial-loongarch-intrinsics-guide/
+on 3A6000
+vssrani.b.h  latency 4 IPC 2
+vsat.h      latency 2 IPC 2
+vpickev.b   latency 1 IPC 4
+replace vssrani.b.h  with vsat.h +vpickev.b should be a little faster.
+
+please review this opt.
+---
+ target/i386/latx/translator/tr-simd.c | 23 ++++++++++++++++++-----
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/target/i386/latx/translator/tr-simd.c b/target/i386/latx/translator/tr-simd.c
+index 717f8eeb55..1866bac18f 100644
+--- a/target/i386/latx/translator/tr-simd.c
++++ b/target/i386/latx/translator/tr-simd.c
+@@ -60,12 +60,23 @@ bool translate_packsswb(IR1_INST *pir1)
+         if (ir1_opnd_is_xmm(ir1_get_opnd(pir1, 1)) &&
+             (ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 0)) ==
+              ir1_opnd_base_reg_num(ir1_get_opnd(pir1, 1)))) {
+-            la_vssrani_b_h(dest, dest, 0);
++            //la_vssrani_b_h(dest, dest, 0);
++            // on 3A6000
++            // vsrani.b.h  latency 4 IPC 2 
++            // vsat.h      latency 2 IPC 2
++            // vpickev.b   latency 1 IPC 4
++            // latency&IPC from https://jia.je/unofficial-loongarch-intrinsics-guide/
++            la_vsat_h(dest, dest, 7);
++            la_vpickev_b(dest, dest, dest);
+         } else {
+-            la_vssrani_b_h(dest, dest, 0);
++            // la_vssrani_b_h(dest, dest, 0);
++            // IR2_OPND temp = ra_alloc_ftemp();
++            // la_vssrani_b_h(temp, src, 0);
++            // la_vextrins_d(dest, temp, VEXTRINS_IMM_4_0(1, 0));
+             IR2_OPND temp = ra_alloc_ftemp();
+-            la_vssrani_b_h(temp, src, 0);
+-            la_vextrins_d(dest, temp, VEXTRINS_IMM_4_0(1, 0));
++            la_vsat_h(dest, dest, 7);
++            la_vsat_h(temp, src, 7);
++            la_vpickev_b(dest, temp, dest);
+         }
+     } else { //mmx
+         /* transfer_to_mmx_mode */
+@@ -76,7 +87,9 @@ bool translate_packsswb(IR1_INST *pir1)
+         IR2_OPND src =
+             load_freg_from_ir1_1(ir1_get_opnd(pir1, 1), false, IS_INTEGER);
+         la_vpackev_d(dest, src, dest);
+-        la_vssrani_b_h(dest, dest, 0);
++        //la_vssrani_b_h(dest, dest, 0);
++        la_vsat_h(dest, dest, 7);
++        la_vpickev_b(dest, dest, dest);
+     }
+     return true;
+ }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1043-LATX-doc-Fix-a-formatting-issue-in-README-for-better.patch
+++ b/app-emulation/latx/autobuild/patches/1043-LATX-doc-Fix-a-formatting-issue-in-README-for-better.patch
@@ -1,0 +1,112 @@
+From da63dde59d35fe3ff7fb144cb9cf06135fe430ec Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 14 Apr 2025 10:09:35 +0800
+Subject: [PATCH 1043/1058] LATX, doc: Fix a formatting issue in README for
+ better readability
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ README.en.rst | 38 +++++++++++++++++++++++++++++---------
+ README.rst    | 30 ++++++++++++++++++++++++------
+ 2 files changed, 53 insertions(+), 15 deletions(-)
+
+diff --git a/README.en.rst b/README.en.rst
+index 5cf4f0e3c9..1a8201e029 100644
+--- a/README.en.rst
++++ b/README.en.rst
+@@ -156,16 +156,36 @@ automation, and testing:
+ Build
+ =====
+ 
+-.. code-block:: text
+-# debian sid
+-apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
+-git clone --depth=1 --recursive https://github.com/lat-opensource/lat
+-cd lat/latxbuild
+-./build-release.sh
++STEP1:
++
++
++.. code-block:: bash
++
++    git clone --depth=1 --recursive https://github.com/lat-opensource/lat
++    cd lat/latxbuild
++
++
++STEP2:
++
++- debian
++
++.. code-block:: bash
++
++    apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
++
++- Arch Linux
++
++.. code-block:: bash
++
++    pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
++
++
++STEP3:
++
++.. code-block:: bash
++
++    ./build-release.sh
+ 
+-.. code-block:: text
+-# Arch Linux
+-pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
+ 
+ Future Plans (TODO)
+ ===============
+diff --git a/README.rst b/README.rst
+index db85b74aac..f086257ff9 100644
+--- a/README.rst
++++ b/README.rst
+@@ -139,18 +139,36 @@ LATX 基于 QEMU 6 版本开发并进行了深度优化，性能相比原生 QEM
+ 编译
+ ====
+ 
++STEP1:
++
++
+ .. code-block:: bash
+ 
+-    # debian sid
+-    apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
+     git clone --depth=1 --recursive https://github.com/lat-opensource/lat
+     cd lat/latxbuild
+-    ./build-release.sh
+ 
+ 
+-.. code-block:: text
+-# Arch Linux
+-pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
++STEP2:
++
++- debian
++
++.. code-block:: bash
++
++    apt install -y git ninja-build libssl-dev libc6 gcc g++ pkg-config libglib2.0-dev libdrm-dev lsb-release make python3-setuptools
++
++- Arch Linux
++
++.. code-block:: bash
++
++    pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
++
++
++STEP3:
++
++.. code-block:: bash
++
++    ./build-release.sh
++
+ 
+ 未来规划（TODO）
+ ===============
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1044-LATX-fix-Fix-struct-target_stat64.patch
+++ b/app-emulation/latx/autobuild/patches/1044-LATX-fix-Fix-struct-target_stat64.patch
@@ -1,0 +1,55 @@
+From ad896981132280dd2246adbdf4777f258cc919d2 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Tue, 15 Apr 2025 17:31:14 +0800
+Subject: [PATCH 1044/1058] LATX, fix: Fix struct target_stat64
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+之前对 fstat 的 st_dev 按照 32 位的系统调用进行了截断，是为了解决 deepin-wine6
+运行失败的问题。该 wine 使用 64 位的 server 和 32 位的 client，两端通信依赖使用
+st_dev 建立的目录，如"/tmp/.wine-1000/server-305-166a42"。server 使用的 st_dev
+为 10305 client 使用的为 305，无法建立通信，因此在 fstat 的模拟中将 10305 截断。
+
+上述方法并未从根本上解决问题，其根因为翻译器中 target_stat64 结构中 st_dev 定义
+不恰当，本补丁进行了修复。
+
+CLOSE: 27
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/syscall.c      | 2 --
+ linux-user/syscall_defs.h | 4 ++--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index bc67c9cfd9..5284c1f2ed 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -13609,8 +13609,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 __put_user(st.st_ctim.tv_nsec,
+                            &target_st->target_st_ctime_nsec);
+ #endif
+-                /* workaround for wineserver64 + wine32 */
+-                target_st->st_dev = target_st->st_dev & 0xffff;
+                 unlock_user_struct(target_st, arg2, 1);
+             }
+         }
+diff --git a/linux-user/syscall_defs.h b/linux-user/syscall_defs.h
+index d747c96727..6fe3080d38 100644
+--- a/linux-user/syscall_defs.h
++++ b/linux-user/syscall_defs.h
+@@ -1680,8 +1680,8 @@ struct target_stat {
+  */
+ #define TARGET_HAS_STRUCT_STAT64
+ struct target_stat64 {
+-	unsigned short	st_dev;
+-	unsigned char	__pad0[10];
++    unsigned long long st_dev;
++    unsigned int    __pad1;
+ 
+ #define TARGET_STAT64_HAS_BROKEN_ST_INO	1
+ 	abi_ulong	__st_ino;
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1045-LATX-fix-Fix-segmentation-fault-caused-by-incorrect-.patch
+++ b/app-emulation/latx/autobuild/patches/1045-LATX-fix-Fix-segmentation-fault-caused-by-incorrect-.patch
@@ -1,0 +1,99 @@
+From f97847151dc757251ca92e9a40798c63fd0a4a5f Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Tue, 8 Apr 2025 17:51:16 +0800
+Subject: [PATCH 1045/1058] LATX, fix: Fix segmentation fault caused by
+ incorrect mprotect in shadow page scenario
+
+This patch fixes a segmentation fault introduced by a previous patch that
+addressed the correctness of self-modifying code under multithreaded race
+conditions (see issue #36).
+
+The earlier patch introduced logic to mprotect the target page to PROT_READ
+before translation. Here is the original commit message for reference:
+
+  There is a time window that a PROT_WRITE page will be translated(t1)
+  and a patcher thread(t2) is modifying the code.
+
+  1. t1 translate version 1 and remove PROT_WRITE of the page.
+  2. t2 mod to version 2 but failed due to PROT_WRITE removed, v1 is
+     thus invalidated.
+  3.1 t1 found v1 is invalid and re-translate, but read the code before
+      t2 finish the code modification.
+  3.2 t2 is modifying the code in parallel when t1 translating,
+      no SEGV can be triggered.
+  3.3 t1 finish the translation and remove PROT_WRITE of the page.
+  4. t1 still translate to version 1 but there is no chance for t2 to
+     re-trigger the smc flow.
+
+  To fix this problem, we should serialize (3.2) and (3.1,3.3), a viable
+  solution is mprotect the page to PROT_READ in 3.1 before the translation.
+  Remove PROT_WRITE will cause 3.2 to trigger SEGV and blocked in signal
+  handler due to mmap_lock held by t1 in 3.1, and the lock is released in
+  3.2. The time window can be removed.
+
+However, in shadow page scenarios, this approach causes an issue:
+mprotect a shadow page to PROT_READ, which leads to data corruption or
+segmentation faults.
+
+This patch adds proper handling to avoid changing protection of PROT_NONE
+shadow pages, thus preserving their semantics and fixing the crash.
+
+CLOSES #36
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ accel/tcg/translate-all.c | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 82ea28cc57..fbad49bcfb 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -452,6 +452,11 @@ static void page_init(void)
+ 
+ }
+ 
++static bool is_shadow_page(target_ulong address)
++{
++    return page_get_target_data(address);
++}
++
+ #ifndef CONFIG_USER_ONLY
+ PageDesc *page_find_alloc(tb_page_addr_t index, int alloc)
+ {
+@@ -2236,7 +2241,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
+      * but the paired page cross 16K boundary is still not protected.
+      */
+     int p_flags = page_get_flags(pc);
+-    if (p_flags & PAGE_WRITE) {
++    if ((p_flags & PAGE_WRITE) && !is_shadow_page(pc)) {
+         mprotect((void*)(pc & qemu_host_page_mask), qemu_host_page_size, PROT_READ);
+     }
+ 
+@@ -3803,8 +3808,10 @@ void page_protect(tb_page_addr_t address)
+         }
+ 
+         pageflags_set_clear(start, last, 0, PAGE_WRITE);
+-        mprotect(g2h_untagged(start), qemu_host_page_size,
+-                (prot & PAGE_BITS) & ~PAGE_WRITE);
++        if (!is_shadow_page(address)) {
++            mprotect(g2h_untagged(start), qemu_host_page_size,
++                    (prot & PAGE_BITS) & ~PAGE_WRITE);
++        }
+     }
+ }
+ 
+@@ -3892,7 +3899,9 @@ int page_unprotect(target_ulong address, uintptr_t pc)
+         if (prot & PAGE_EXEC) {
+             prot = (prot & ~PAGE_EXEC) | PAGE_READ;
+         }
+-        mprotect((void *)g2h_untagged(start), len, prot & PAGE_BITS);
++        if (!is_shadow_page(address)) {
++            mprotect((void *)g2h_untagged(start), len, prot & PAGE_BITS);
++        }
+     }
+     mmap_unlock();
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1046-LATX-fix-Add-fallback-for-vector-initialization-usin.patch
+++ b/app-emulation/latx/autobuild/patches/1046-LATX-fix-Add-fallback-for-vector-initialization-usin.patch
@@ -1,0 +1,181 @@
+From a2d1076f7348930a7c0dc1278f36275bce235032 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Thu, 17 Apr 2025 11:21:08 +0800
+Subject: [PATCH 1046/1058] LATX, fix: Add fallback for vector initialization
+ using raw instruction encoding
+
+Some system use GCC versions that do not support LoongArch vector extensions such
+as LSX or LASX. To improve compatibility, replace vector register initialization
+with equivalent raw instruction encoding using inline assembly.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/i386/signal.c       |   1 -
+ target/i386/latx/latx-config.c | 131 +++++++++++++++++----------------
+ 2 files changed, 66 insertions(+), 66 deletions(-)
+
+diff --git a/linux-user/i386/signal.c b/linux-user/i386/signal.c
+index cdec4ccf07..280ee084ba 100644
+--- a/linux-user/i386/signal.c
++++ b/linux-user/i386/signal.c
+@@ -23,7 +23,6 @@
+ #ifdef CONFIG_LATX
+ #include "latx-options.h"
+ #include "reg-map.h"
+-#include <lasxintrin.h>
+ #endif
+ 
+ /* from the Linux kernel - /arch/x86/include/uapi/asm/sigcontext.h */
+diff --git a/target/i386/latx/latx-config.c b/target/i386/latx/latx-config.c
+index 83a06eeaea..eca0f6114a 100644
+--- a/target/i386/latx/latx-config.c
++++ b/target/i386/latx/latx-config.c
+@@ -502,79 +502,80 @@ void latx_dt_init(void)
+ #endif
+ }
+ 
+-#include <lasxintrin.h>
+ void latx_init_fpu_regs(CPUArchState *env)
+ {
+     if (option_enable_lasx) {
++        /* vldi $vr0,0 */
+         asm volatile (
+-            "xvldi $xr0,0\r\n"
+-            "xvldi $xr1,0\r\n"
+-            "xvldi $xr2,0\r\n"
+-            "xvldi $xr3,0\r\n"
+-            "xvldi $xr4,0\r\n"
+-            "xvldi $xr5,0\r\n"
+-            "xvldi $xr6,0\r\n"
+-            "xvldi $xr7,0\r\n"
+-            "xvldi $xr8,0\r\n"
+-            "xvldi $xr9,0\r\n"
+-            "xvldi $xr10,0\r\n"
+-            "xvldi $xr11,0\r\n"
+-            "xvldi $xr12,0\r\n"
+-            "xvldi $xr13,0\r\n"
+-            "xvldi $xr14,0\r\n"
+-            "xvldi $xr15,0\r\n"
+-            "xvldi $xr16,0\r\n"
+-            "xvldi $xr17,0\r\n"
+-            "xvldi $xr18,0\r\n"
+-            "xvldi $xr19,0\r\n"
+-            "xvldi $xr20,0\r\n"
+-            "xvldi $xr21,0\r\n"
+-            "xvldi $xr22,0\r\n"
+-            "xvldi $xr23,0\r\n"
+-            "xvldi $xr24,0\r\n"
+-            "xvldi $xr25,0\r\n"
+-            "xvldi $xr26,0\r\n"
+-            "xvldi $xr27,0\r\n"
+-            "xvldi $xr28,0\r\n"
+-            "xvldi $xr29,0\r\n"
+-            "xvldi $xr30,0\r\n"
+-            "xvldi $xr31,0\r\n"
++            ".word (0x77e00000 | (0 << 5) | (0)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (1)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (2)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (3)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (4)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (5)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (6)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (7)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (8)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (9)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (10)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (11)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (12)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (13)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (14)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (15)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (16)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (17)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (18)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (19)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (20)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (21)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (22)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (23)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (24)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (25)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (26)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (27)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (28)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (29)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (30)) \r\n"
++            ".word (0x77e00000 | (0 << 5) | (31)) \r\n"
+             : : :
+         );
+     } else {
++        /* vldi $vr0,0 */
+         asm volatile (
+-            "vldi $vr0,0\r\n"
+-            "vldi $vr1,0\r\n"
+-            "vldi $vr2,0\r\n"
+-            "vldi $vr3,0\r\n"
+-            "vldi $vr4,0\r\n"
+-            "vldi $vr5,0\r\n"
+-            "vldi $vr6,0\r\n"
+-            "vldi $vr7,0\r\n"
+-            "vldi $vr8,0\r\n"
+-            "vldi $vr9,0\r\n"
+-            "vldi $vr10,0\r\n"
+-            "vldi $vr11,0\r\n"
+-            "vldi $vr12,0\r\n"
+-            "vldi $vr13,0\r\n"
+-            "vldi $vr14,0\r\n"
+-            "vldi $vr15,0\r\n"
+-            "vldi $vr16,0\r\n"
+-            "vldi $vr17,0\r\n"
+-            "vldi $vr18,0\r\n"
+-            "vldi $vr19,0\r\n"
+-            "vldi $vr20,0\r\n"
+-            "vldi $vr21,0\r\n"
+-            "vldi $vr22,0\r\n"
+-            "vldi $vr23,0\r\n"
+-            "vldi $vr24,0\r\n"
+-            "vldi $vr25,0\r\n"
+-            "vldi $vr26,0\r\n"
+-            "vldi $vr27,0\r\n"
+-            "vldi $vr28,0\r\n"
+-            "vldi $vr29,0\r\n"
+-            "vldi $vr30,0\r\n"
+-            "vldi $vr31,0\r\n"
++            ".word (0x73e00000 | (0 << 5) | (0)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (1)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (2)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (3)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (4)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (5)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (6)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (7)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (8)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (9)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (10)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (11)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (12)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (13)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (14)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (15)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (16)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (17)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (18)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (19)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (20)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (21)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (22)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (23)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (24)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (25)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (26)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (27)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (28)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (29)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (30)) \r\n"
++            ".word (0x73e00000 | (0 << 5) | (31)) \r\n"
+             : : :
+         );
+     }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1047-LATX-doc-update-README-with-AOSC-package-requirement.patch
+++ b/app-emulation/latx/autobuild/patches/1047-LATX-doc-update-README-with-AOSC-package-requirement.patch
@@ -1,0 +1,49 @@
+From 4f57ed76075a8a67e6a88166ec9593b9f327b424 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Wed, 16 Apr 2025 17:46:08 +0800
+Subject: [PATCH 1047/1058] LATX, doc: update README with AOSC package
+ requirements
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ README.en.rst | 6 ++++++
+ README.rst    | 6 ++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/README.en.rst b/README.en.rst
+index 1a8201e029..32461cb2cb 100644
+--- a/README.en.rst
++++ b/README.en.rst
+@@ -179,6 +179,12 @@ STEP2:
+ 
+     pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
+ 
++- AOSC OS
++
++.. code-block:: bash
++
++    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
++
+ 
+ STEP3:
+ 
+diff --git a/README.rst b/README.rst
+index f086257ff9..2e0b884f9e 100644
+--- a/README.rst
++++ b/README.rst
+@@ -162,6 +162,12 @@ STEP2:
+ 
+     pacman -S --noconfirm ninja gcc pkgconf python3 python-setuptools openssl-static openssl
+ 
++- 安同 OS (AOSC OS)
++
++.. code-block:: bash
++
++    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
++
+ 
+ STEP3:
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1048-LATX-doc-recommend-oma-for-AOSC-OS.patch
+++ b/app-emulation/latx/autobuild/patches/1048-LATX-doc-recommend-oma-for-AOSC-OS.patch
@@ -1,0 +1,44 @@
+From e65777cf6e6588a8887d449cfb03e293cc269b1d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 17 Apr 2025 11:44:32 +0800
+Subject: [PATCH 1048/1058] LATX, doc: recommend oma for AOSC OS
+
+AOSC OS uses oma as its default package manager (apt is supplied as a fallback).
+
+See: https://aosc.io/oma
+See: https://github.com/AOSC-Dev/oma
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ README.en.rst | 2 +-
+ README.rst    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/README.en.rst b/README.en.rst
+index 32461cb2cb..a9f0b0b27f 100644
+--- a/README.en.rst
++++ b/README.en.rst
+@@ -183,7 +183,7 @@ STEP2:
+ 
+ .. code-block:: bash
+ 
+-    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
++    oma install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
+ 
+ 
+ STEP3:
+diff --git a/README.rst b/README.rst
+index 2e0b884f9e..9466eb73f6 100644
+--- a/README.rst
++++ b/README.rst
+@@ -166,7 +166,7 @@ STEP2:
+ 
+ .. code-block:: bash
+ 
+-    apt install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
++    oma install -y gcc nettle pcre2 libffi gnutls glib zlib glib-static libgcrypt-static libgpg-error-static libnfs-static pcre-static zlib-static zstd-static openssl-static
+ 
+ 
+ STEP3:
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1049-fix-build-error-in-anolis.patch
+++ b/app-emulation/latx/autobuild/patches/1049-fix-build-error-in-anolis.patch
@@ -1,0 +1,70 @@
+From abdd60fcda99df4a166f8d1eb797bab4b032705c Mon Sep 17 00:00:00 2001
+From: Wenlong Zhang <zhangwenlong@loongson.cn>
+Date: Mon, 21 Apr 2025 15:10:04 +0800
+Subject: [PATCH 1049/1058] fix build error in anolis
+
+---
+ README.en.rst              | 4 ++--
+ README.rst                 | 4 ++--
+ latxbuild/build-release.sh | 1 -
+ 3 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/README.en.rst b/README.en.rst
+index a9f0b0b27f..3a1303594c 100644
+--- a/README.en.rst
++++ b/README.en.rst
+@@ -162,7 +162,7 @@ STEP1:
+ .. code-block:: bash
+ 
+     git clone --depth=1 --recursive https://github.com/lat-opensource/lat
+-    cd lat/latxbuild
++    cd lat
+ 
+ 
+ STEP2:
+@@ -190,7 +190,7 @@ STEP3:
+ 
+ .. code-block:: bash
+ 
+-    ./build-release.sh
++    ./latxbuild/build-release.sh
+ 
+ 
+ Future Plans (TODO)
+diff --git a/README.rst b/README.rst
+index 9466eb73f6..bfba7ad3e6 100644
+--- a/README.rst
++++ b/README.rst
+@@ -145,7 +145,7 @@ STEP1:
+ .. code-block:: bash
+ 
+     git clone --depth=1 --recursive https://github.com/lat-opensource/lat
+-    cd lat/latxbuild
++    cd lat
+ 
+ 
+ STEP2:
+@@ -173,7 +173,7 @@ STEP3:
+ 
+ .. code-block:: bash
+ 
+-    ./build-release.sh
++    ./latxbuild/build-release.sh
+ 
+ 
+ 未来规划（TODO）
+diff --git a/latxbuild/build-release.sh b/latxbuild/build-release.sh
+index 13d3bc54a0..b1165d5c36 100755
+--- a/latxbuild/build-release.sh
++++ b/latxbuild/build-release.sh
+@@ -55,7 +55,6 @@ build() {
+         --disable-docs
+         --disable-werror
+         --disable-pie
+-        --static
+         --disable-linux-io-uring
+     )
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1050-LAT-fix-Fix-compilation-error-caused-by-duplicate-ma.patch
+++ b/app-emulation/latx/autobuild/patches/1050-LAT-fix-Fix-compilation-error-caused-by-duplicate-ma.patch
@@ -1,0 +1,53 @@
+From cd749ac80f5d41f74c9de5a60f01ac4b065566dd Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Fri, 18 Apr 2025 10:18:20 +0800
+Subject: [PATCH 1050/1058] LAT, fix: Fix compilation error caused by duplicate
+ macro definition
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes the following compilation failure on AOSC OS:
+
+../linux-user/syscall_defs.h:1533:9: 错误：“MAP_HUGE_2MB”重定义 [-Werror]
+ 1533 | #define MAP_HUGE_2MB     (21 << HUGETLB_FLAG_ENCODE_SHIFT)
+      |         ^~~~~~~~~~~~
+In file included from /usr/include/bits/mman.h:32,
+                 from /usr/include/sys/mman.h:41,
+                 from /home/lauren/lat/include/sysemu/os-posix.h:29,
+                 from /home/lauren/lat/include/qemu/osdep.h:161,
+                 from ../linux-user/i386/signal.c:19:
+/usr/include/bits/mman-linux.h:70:9: 附注：这是先前定义的位置
+   70 | #define MAP_HUGE_2MB    (21 << MAP_HUGE_SHIFT)
+      |         ^~~~~~~~~~~~
+../linux-user/syscall_defs.h:1534:9: 错误：“MAP_HUGE_1GB”重定义 [-Werror]
+ 1534 | #define MAP_HUGE_1GB     (30 << HUGETLB_FLAG_ENCODE_SHIFT)
+      |         ^~~~~~~~~~~~
+/usr/include/bits/mman-linux.h:76:9: 附注：这是先前定义的位置
+   76 | #define MAP_HUGE_1GB    (30 << MAP_HUGE_SHIFT)
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/syscall_defs.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/linux-user/syscall_defs.h b/linux-user/syscall_defs.h
+index 6fe3080d38..4e42eec516 100644
+--- a/linux-user/syscall_defs.h
++++ b/linux-user/syscall_defs.h
+@@ -1530,8 +1530,12 @@ struct target_winsize {
+ #include "termbits.h"
+ 
+ #define HUGETLB_FLAG_ENCODE_SHIFT   26
++#ifndef MAP_HUGE_2MB
+ #define MAP_HUGE_2MB     (21 << HUGETLB_FLAG_ENCODE_SHIFT)
++#endif
++#ifndef MAP_HUGE_1GB
+ #define MAP_HUGE_1GB     (30 << HUGETLB_FLAG_ENCODE_SHIFT)
++#endif
+ #define LEGACY_MAP_MASK (TARGET_MAP_SHARED \
+         | TARGET_MAP_PRIVATE \
+         | TARGET_MAP_FIXED \
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1051-LATX-fix-Replace-deprecated-SHA_-API-with-EVP-API.patch
+++ b/app-emulation/latx/autobuild/patches/1051-LATX-fix-Replace-deprecated-SHA_-API-with-EVP-API.patch
@@ -1,0 +1,97 @@
+From 5af564592209acdab4d981389abd925e9b6d167b Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Fri, 18 Apr 2025 11:39:55 +0800
+Subject: [PATCH 1051/1058] LATX, fix: Replace deprecated SHA_* API with EVP
+ API
+
+The SHA_Init(), SHA_Update() and SHA_Final() functions have been deprecated in
+OpenSSL 3.0. This patch replaces them with the recommended EVP API to eliminate
+build warnings and ensure compatibility with OpenSSL 3.x.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ configure                |  2 +-
+ latxbuild/build32-dbg.sh |  2 +-
+ linux-user/main.c        | 18 ++++++++++--------
+ 3 files changed, 12 insertions(+), 10 deletions(-)
+
+diff --git a/configure b/configure
+index d3e30c8f25..91767e1b8e 100755
+--- a/configure
++++ b/configure
+@@ -1711,7 +1711,7 @@ if test "$latx" = "yes" ; then
+   else
+     QEMU_LDFLAGS="-export-dynamic $QEMU_LDFLAGS"
+   fi
+-  QEMU_LDFLAGS="-lcrypto $QEMU_LDFLAGS"
++  QEMU_LDFLAGS="-lcrypto -lz $QEMU_LDFLAGS"
+ else
+   echo "build for target $target_list"
+   if test "$target_list" = "x86_64-linux-user" ; then
+diff --git a/latxbuild/build32-dbg.sh b/latxbuild/build32-dbg.sh
+index f2b45e94b0..8b4f2adae0 100755
+--- a/latxbuild/build32-dbg.sh
++++ b/latxbuild/build32-dbg.sh
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ set -e
+-export CFLAGS="-Wno-error=unused-but-set-variable -Wno-error=unused-function  -Wformat -Werror=format-y2k"
++export CFLAGS="-Wno-error=unused-but-set-variable -Wno-error=unused-function -Wformat -Werror=format-y2k"
+ make_configure=0
+ opt_level=1
+ 
+diff --git a/linux-user/main.c b/linux-user/main.c
+index e525886367..6bffe74f71 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -56,7 +56,7 @@ int mydebug = 1;
+ #include "latx-options.h"
+ #include "aot.h"
+ #include "latx-version.h"
+-#include <openssl/sha.h>
++#include <openssl/evp.h>
+ #endif
+ #ifdef CONFIG_LATX_PERF
+ #include "latx-perf.h"
+@@ -1330,8 +1330,9 @@ int main(int argc, char **argv, char **envp)
+     }
+ 
+ #ifdef CONFIG_LATX_AOT
+-    SHA_CTX ctx;
+-    unsigned char hash[SHA_DIGEST_LENGTH];
++    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
++    unsigned char hash[EVP_MAX_MD_SIZE];
++    unsigned int hash_len;
+     char *buf;
+     char real[PATH_MAX], *temp;
+     char *aot_dir;
+@@ -1357,8 +1358,8 @@ int main(int argc, char **argv, char **envp)
+     if (temp == NULL) {
+         lsassertm(0, "%s error!", __func__);
+     }
+-    SHA1_Init(&ctx);
+-    SHA1_Update(&ctx, real, strlen(real));
++    EVP_DigestInit_ex(ctx, EVP_sha1(), NULL);
++    EVP_DigestUpdate(ctx, real, strlen(real));
+     int aotac = 4;
+     for (; i < target_argc; i++) {
+         target_argv[i] = strdup(argv[optind + i]);
+@@ -1374,11 +1375,12 @@ int main(int argc, char **argv, char **envp)
+                 aotac = 2;
+                 continue;
+             }
+-            SHA1_Update(&ctx, target_argv[i], arglen);
++            EVP_DigestUpdate(ctx, target_argv[i], arglen);
+         }
+     }
+-    SHA1_Final(hash, &ctx);
+-    for (i = 0; i < SHA_DIGEST_LENGTH; i++) {
++    EVP_DigestFinal_ex(ctx, hash, &hash_len);
++    EVP_MD_CTX_free(ctx);
++    for (i = 0; i < hash_len; i++) {
+         sprintf(buf, "%02x", hash[i] & 0xff);
+         buf += 2;
+     }
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1052-LATX-fix-Add-support-for-AOSC-OS-in-syscall-and-meso.patch
+++ b/app-emulation/latx/autobuild/patches/1052-LATX-fix-Add-support-for-AOSC-OS-in-syscall-and-meso.patch
@@ -1,0 +1,131 @@
+From 65a72dbc9934bfa5affe6392e995e8b8d3c63f61 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Sat, 19 Apr 2025 15:12:44 +0800
+Subject: [PATCH 1052/1058] LATX, fix: Add support for AOSC OS in syscall and
+ meson configuration
+
+Handling of 'reserved' fields in struct v4l2_ext_controls differently.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/syscall.c | 36 +++++++++++++-----------------------
+ meson.build          | 24 ++----------------------
+ 2 files changed, 15 insertions(+), 45 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 5284c1f2ed..fd16948b05 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -121,19 +121,17 @@
+ #ifdef HAVE_BTRFS_H
+ #include <linux/btrfs.h>
+ #endif
+-#ifdef HAVE_DRM_H
+-#if defined(IS_LOONGNIX) || defined(IS_ARCH)
++#if defined(HAVE_LIBDRM_H)
+ #include <libdrm/drm.h>
+ #include <libdrm/i915_drm.h>
+ #include <libdrm/radeon_drm.h>
+ #include <libdrm/amdgpu_drm.h>
+-#else
++#elif defined(HAVE_DRM_H)
+ #include <drm/drm.h>
+ #include <drm/i915_drm.h>
+ #include <drm/radeon_drm.h>
+ #include <drm/amdgpu_drm.h>
+ #endif
+-#endif
+ #include <linux/can/raw.h>
+ #include <linux/videodev2.h>
+ #include <sound/asequencer.h>
+@@ -6487,20 +6485,16 @@ static inline abi_long target_to_host_ext_ctrls(struct v4l2_ext_controls *host_v
+ {
+     memset(host_ver, 0, sizeof(*host_ver));
+     uint64_t controls;
++    size_t error_idx_offset = offsetof(struct v4l2_ext_controls, error_idx);
++    size_t request_fd_offset = error_idx_offset + sizeof(uint32_t);
++    size_t reserved_offset = request_fd_offset + sizeof(uint32_t);
+     __get_user(host_ver->ctrl_class, &target_ver->ctrl_class);
+     __get_user(host_ver->count, &target_ver->count);
+     __get_user(host_ver->error_idx, &target_ver->error_idx);
+-#if defined(IS_KYLIN) || defined(IS_NFS)
+-    __get_user(host_ver->request_fd,
+-                                    &target_ver->reserved[0]);
+-    __get_user(host_ver->reserved[0],
+-                                    &target_ver->reserved[1]);
+-#else
+-    __get_user(host_ver->reserved[0],
+-                                    &target_ver->reserved[0]);
+-    __get_user(host_ver->reserved[1],
++    __get_user(*(int32_t *)((uint64_t)host_ver + request_fd_offset),
++                &target_ver->reserved[0]);
++    __get_user(*(uint32_t *)((uint64_t)host_ver + reserved_offset),
+                                     &target_ver->reserved[1]);
+-#endif
+     __get_user(controls, &target_ver->controls);
+     host_ver->controls = (struct v4l2_ext_control *)controls;
+     return 0;
+@@ -6511,20 +6505,16 @@ static inline void host_to_target_ext_ctrls(
+                   struct v4l2_ext_controls *host_ver)
+ {
+     uint64_t controls = (uint64_t)host_ver->controls;
++    size_t error_idx_offset = offsetof(struct v4l2_ext_controls, error_idx);
++    size_t request_fd_offset = error_idx_offset + sizeof(uint32_t);
++    size_t reserved_offset = request_fd_offset + sizeof(uint32_t);
+     __put_user(host_ver->ctrl_class, &target_ver->ctrl_class);
+     __put_user(host_ver->count, &target_ver->count);
+     __put_user(host_ver->error_idx, &target_ver->error_idx);
+-#if defined(IS_KYLIN) || defined(IS_NFS)
+-    __put_user(host_ver->request_fd,
+-                                    &target_ver->reserved[0]);
+-    __put_user(host_ver->reserved[0],
+-                                    &target_ver->reserved[1]);
+-#else
+-    __put_user(host_ver->reserved[0],
++    __put_user(*(int32_t *)((uint64_t)host_ver + request_fd_offset),
+                                     &target_ver->reserved[0]);
+-    __put_user(host_ver->reserved[1],
++    __put_user(*(uint32_t *)((uint64_t)host_ver + reserved_offset),
+                                     &target_ver->reserved[1]);
+-#endif
+     __put_user(controls, &target_ver->controls);
+ }
+ 
+diff --git a/meson.build b/meson.build
+index a30002f0ec..6e212407ca 100644
+--- a/meson.build
++++ b/meson.build
+@@ -203,28 +203,8 @@ config_host_data.set('CONFIG_LIBATTR', have_old_libattr)
+ config_host_data.set('CONFIG_GETTID', has_gettid)
+ config_host_data.set('CONFIG_MALLOC_TRIM', has_malloc_trim)
+ 
+-lsb_release = find_program('lsb_release', required: false)
+-if lsb_release.found()
+-  lsb_release_output = run_command('lsb_release', '-si').stdout().strip()
+-  if lsb_release_output == 'Loongnix'
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('libdrm/drm.h'))
+-    config_host_data.set('IS_LOONGNIX', 'true')
+-  elif lsb_release_output == 'Arch'
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('libdrm/drm.h'))
+-    config_host_data.set('IS_ARCH', 'true')
+-  elif lsb_release_output == 'Kylin'
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('drm/drm.h'))
+-    config_host_data.set('IS_KYLIN', 'true')
+-  elif lsb_release_output == 'Nfsdesktop'
+-    #方德
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('drm/drm.h'))
+-    config_host_data.set('IS_NFS', 'true')
+-  else
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('drm/drm.h'))
+-  endif
+-else
+-    config_host_data.set('HAVE_DRM_H', cc.has_header('drm/drm.h'))
+-endif
++config_host_data.set('HAVE_LIBDRM_H', cc.has_header('libdrm/drm.h'))
++config_host_data.set('HAVE_DRM_H', cc.has_header('drm/drm.h'))
+ 
+ config_host_data.set('CONFIG_PREADV', cc.has_function('preadv', prefix: '#include <sys/uio.h>'))
+ 
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1053-LATX-fix-Fix-invalid-NULL-usage-in-epoll_wait-call.patch
+++ b/app-emulation/latx/autobuild/patches/1053-LATX-fix-Fix-invalid-NULL-usage-in-epoll_wait-call.patch
@@ -1,0 +1,48 @@
+From 7b5ba6187fe16d2ceae773ea8e5d0b4139ffb630 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Sat, 19 Apr 2025 16:23:28 +0800
+Subject: [PATCH 1053/1058] LATX, fix: Fix invalid NULL usage in epoll_wait
+ call
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ target/i386/latx/context/wrappedlibc.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/target/i386/latx/context/wrappedlibc.c b/target/i386/latx/context/wrappedlibc.c
+index fa5b70c644..f104feeb80 100644
+--- a/target/i386/latx/context/wrappedlibc.c
++++ b/target/i386/latx/context/wrappedlibc.c
+@@ -1877,8 +1877,13 @@ EXPORT int32_t my_epoll_ctl(int32_t epfd, int32_t op, int32_t fd, void* event)
+ EXPORT int32_t my_epoll_wait(int32_t epfd, void* events, int32_t maxevents, int32_t timeout)
+ {
+     struct epoll_event _events[maxevents];
++    int32_t ret = 0;
+     //AlignEpollEvent(_events, events, maxevents);
+-    int32_t ret = epoll_wait(epfd, events?_events:NULL, maxevents, timeout);
++    if (events) {
++        ret = epoll_wait(epfd, _events, maxevents, timeout);
++    } else {
++        ret = -1;
++    }
+     if(ret>0)
+         UnalignEpollEvent(events, _events, ret);
+     return ret;
+@@ -1886,8 +1891,13 @@ EXPORT int32_t my_epoll_wait(int32_t epfd, void* events, int32_t maxevents, int3
+ EXPORT int32_t my_epoll_pwait(int32_t epfd, void* events, int32_t maxevents, int32_t timeout, const sigset_t *sigmask)
+ {
+     struct epoll_event _events[maxevents];
++    int32_t ret = 0;
+     //AlignEpollEvent(_events, events, maxevents);
+-    int32_t ret = epoll_pwait(epfd, events?_events:NULL, maxevents, timeout, sigmask);
++    if (events) {
++        ret = epoll_pwait(epfd, _events, maxevents, timeout, sigmask);
++    } else {
++        ret = -1;
++    }
+     if(ret>0)
+         UnalignEpollEvent(events, _events, ret);
+     return ret;
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1054-LATX-fix-Fix-various-compiler-warnings.patch
+++ b/app-emulation/latx/autobuild/patches/1054-LATX-fix-Fix-various-compiler-warnings.patch
@@ -1,0 +1,232 @@
+From ae4b93cfa58ab2ed5bbc211349691879d470f16a Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Fri, 18 Apr 2025 17:53:27 +0800
+Subject: [PATCH 1054/1058] LATX, fix: Fix various compiler warnings
+
+This patch resolves multiple compiler warning triggered by recent toolchain
+updates and stricter build flags. These include:
+
+- Fixing buffer size issues reported by __builtin_strncpy.
+- Avoiding out-of-bounds array access in fixed-size _u32 arrays.
+- Moving struct declarations out of function parameter lists to ensure
+  visibility and compatibility.
+- Cleaning up misplaced typedefs and invalid declarations.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ accel/tcg/translate-all.c                          |  2 ++
+ configure                                          |  2 +-
+ include/loongarch-extcontext.h                     | 14 ++++++++------
+ linux-user/ioctl/amdgpu_drm.h                      |  2 +-
+ .../ioctl/ioctl_syscall/syscall_amdgpu_drm.c       |  2 ++
+ linux-user/syscall.c                               |  6 ++++++
+ target/i386/latx/context/myalign.c                 |  1 +
+ target/i386/latx/context/wrappedlibc.c             |  1 -
+ target/i386/latx/latx-special-args.c               |  2 +-
+ target/i386/latx/sbt/aot.c                         |  3 ++-
+ target/i386/latx/sbt/file_ctx.c                    |  3 ++-
+ 11 files changed, 26 insertions(+), 12 deletions(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index fbad49bcfb..d6f5bd4000 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -4936,7 +4936,9 @@ int shared_private_interpret(siginfo_t *info, ucontext_t *uc)
+     }
+ end:
+     UC_PC(uc) += 4;
++#ifndef CONFIG_LOONGARCH_NEW_WORLD
+ ret:
++#endif
+     return 0;
+ }
+ 
+diff --git a/configure b/configure
+index 91767e1b8e..243c8debe6 100755
+--- a/configure
++++ b/configure
+@@ -455,7 +455,7 @@ tls_priority="NORMAL"
+ gnutls="$default_feature"
+ nettle="$default_feature"
+ nettle_xts="no"
+-gcrypt="$default_feature"
++gcrypt="no"
+ gcrypt_hmac="no"
+ gcrypt_xts="no"
+ qemu_private_xts="yes"
+diff --git a/include/loongarch-extcontext.h b/include/loongarch-extcontext.h
+index 3a6ae916b7..1feb2cd5b0 100644
+--- a/include/loongarch-extcontext.h
++++ b/include/loongarch-extcontext.h
+@@ -60,29 +60,31 @@ static void *get_ctx_through_ctxinfo(struct sctx_info *info)
+ 
+ #define UC_SET_FPR(_uc, _fp, _val, _type) \
+     if (UC_FPU(_uc)) \
+-        (*(_type *)(&(UC_FPU(_uc)->regs[_fp])) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_FPU(_uc)->regs[_fp])) = *(_type *)(unsigned long)(_val)); \
+     else \
+         UC_SET_LSX(_uc, _fp, 0, _val, _type);
+ 
+ #define UC_SET_FCSR(_uc, _val, _type) \
+     if (UC_LASX(_uc)) \
+-        (*(_type *)(&(UC_LASX(_uc)->fcsr)) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_LASX(_uc)->fcsr)) = *(_type *)(unsigned long)(_val)); \
+     else if (UC_LSX(_uc)) \
+-        (*(_type *)(&(UC_LSX(_uc)->fcsr)) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_LSX(_uc)->fcsr)) = *(_type *)(unsigned long)(_val)); \
+     else if (UC_FPU(_uc)) \
+-        (*(_type *)(&(UC_FPU(_uc)->fcsr)) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_FPU(_uc)->fcsr)) = *(_type *)(unsigned long)(_val)); \
+     else \
+         g_assert_not_reached();
+ 
+ #define UC_SET_LSX(_uc, _fp, _bias, _val, _type) \
+     if (UC_LSX(_uc)) \
+-        (*(_type *)(&(UC_LSX(_uc)->regs[_fp * 2 + _bias])) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_LSX(_uc)->regs[_fp * 2 + _bias])) = \
++            *(_type *)(unsigned long)(_val)); \
+     else \
+         UC_SET_LASX(_uc, _fp, _bias, _val, _type);
+ 
+ #define UC_SET_LASX(_uc, _fp, _bias, _val, _type) \
+     if (UC_LASX(_uc)) \
+-        (*(_type *)(&(UC_LASX(_uc)->regs[_fp * 4 + _bias])) = *(_type *)(_val)); \
++        (*(_type *)(&(UC_LASX(_uc)->regs[_fp * 4 + _bias])) = \
++            *(_type *)(unsigned long)(_val)); \
+     else \
+         g_assert_not_reached();
+ 
+diff --git a/linux-user/ioctl/amdgpu_drm.h b/linux-user/ioctl/amdgpu_drm.h
+index 34a2c3af05..cfcc60aebf 100644
+--- a/linux-user/ioctl/amdgpu_drm.h
++++ b/linux-user/ioctl/amdgpu_drm.h
+@@ -84,7 +84,7 @@ extern "C" {
+ #define DRM_IOCTL_AMDGPU_VM    \
+     DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_VM, union drm_amdgpu_vm)
+ #define DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE,
++    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE, \
+              union drm_amdgpu_fence_to_handle)
+ #define DRM_IOCTL_AMDGPU_SCHED    \
+     DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_SCHED, union drm_amdgpu_sched)
+diff --git a/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c b/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
+index d006b4fd0c..ef220e1ffa 100644
+--- a/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
++++ b/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
+@@ -1,3 +1,5 @@
++#include "linux-user/ioctl/amdgpu_drm.h"
++
+ static inline abi_long target_to_host_drm_amdgpu_info
+                         (struct drm_amdgpu_info *host_ver,
+          struct target_drm_amdgpu_info *target_ver)
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index fd16948b05..73c68ed933 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -126,11 +126,13 @@
+ #include <libdrm/i915_drm.h>
+ #include <libdrm/radeon_drm.h>
+ #include <libdrm/amdgpu_drm.h>
++#include <libdrm/drm_mode.h>
+ #elif defined(HAVE_DRM_H)
+ #include <drm/drm.h>
+ #include <drm/i915_drm.h>
+ #include <drm/radeon_drm.h>
+ #include <drm/amdgpu_drm.h>
++#include <drm/drm_mode.h>
+ #endif
+ #include <linux/can/raw.h>
+ #include <linux/videodev2.h>
+@@ -847,10 +849,12 @@ safe_syscall6(ssize_t, recvfrom, int, fd, void *, buf, size_t, len,
+               int, flags, struct sockaddr *, addr, socklen_t *, addrlen)
+ safe_syscall3(ssize_t, sendmsg, int, fd, const struct msghdr *, msg, int, flags)
+ safe_syscall3(ssize_t, recvmsg, int, fd, struct msghdr *, msg, int, flags)
++#ifdef TARGET_X86_64
+ safe_syscall4(ssize_t, sendmmsg, int, fd, struct msghdr *, msgvec, unsigned int, vlen,
+               int, flags)
+ safe_syscall5(ssize_t, recvmmsg, int, fd, struct msghdr *, msgvec, unsigned int, vlen,
+               int, flags, struct timespec *, timeout)
++#endif
+ safe_syscall2(int, flock, int, fd, int, operation)
+ #if defined(TARGET_NR_rt_sigtimedwait) || defined(TARGET_NR_rt_sigtimedwait_time64)
+ safe_syscall4(int, rt_sigtimedwait, const sigset_t *, these, siginfo_t *, uinfo,
+@@ -904,9 +908,11 @@ safe_syscall6(ssize_t, copy_file_range, int, infd, loff_t *, pinoff,
+               unsigned int, flags)
+ #endif
+ #ifdef __NR_quotactl
++#ifdef TARGET_X86_64
+ safe_syscall4(int, quotactl, int, cmd, const char *, special,
+               int, id, caddr_t, addr)
+ #endif
++#endif
+ 
+ /* We do ioctl like this rather than via safe_syscall3 to preserve the
+  * "third argument might be integer or pointer or not present" behaviour of
+diff --git a/target/i386/latx/context/myalign.c b/target/i386/latx/context/myalign.c
+index 3695113b7e..1e2796368e 100644
+--- a/target/i386/latx/context/myalign.c
++++ b/target/i386/latx/context/myalign.c
+@@ -1255,6 +1255,7 @@ const char* getCpuName(void)
+                 while(strchr(tmp, '\n'))
+                     *strchr(tmp,'\n') = ' ';
+                 strncpy(name, tmp, 199);
++                name[199] = '\0';
+             }
+             return name;
+         }
+diff --git a/target/i386/latx/context/wrappedlibc.c b/target/i386/latx/context/wrappedlibc.c
+index f104feeb80..d87399df0f 100644
+--- a/target/i386/latx/context/wrappedlibc.c
++++ b/target/i386/latx/context/wrappedlibc.c
+@@ -3523,7 +3523,6 @@ static void Push64(CPUX86State *cpu, uint64_t v)
+     *((uint64_t*)cpu->regs[R_ESP]) = v;
+ }
+ 
+-extern const char *interp_prefix;
+ void kzt_wine_init_x86(void);
+ int init_x86dlfun(void);
+ int init_x86dlfun(void)
+diff --git a/target/i386/latx/latx-special-args.c b/target/i386/latx/latx-special-args.c
+index 238d29d338..e1b36a5fd8 100644
+--- a/target/i386/latx/latx-special-args.c
++++ b/target/i386/latx/latx-special-args.c
+@@ -26,7 +26,7 @@ static void extract_filename(char* filename, char* buffer,
+     } else {
+         filename_only = filename;
+     }
+-    strncpy(buffer, filename_only, buffer_size);
++    strncpy(buffer, filename_only, buffer_size - 1);
+     char* extension = strchr(buffer, '.');
+     if (extension != NULL) {
+         *extension = '\0';
+diff --git a/target/i386/latx/sbt/aot.c b/target/i386/latx/sbt/aot.c
+index 12df6f6f85..b05043c5ca 100644
+--- a/target/i386/latx/sbt/aot.c
++++ b/target/i386/latx/sbt/aot.c
+@@ -950,7 +950,8 @@ int aot_get_file_init(char *aot_file)
+     int count = 0;
+     char pathtmp[PATH_MAX] = {0};
+     if (access(aot_file, 0) >= 0) {
+-        strncpy(pathtmp, aot_file, PATH_MAX);
++        strncpy(pathtmp, aot_file, PATH_MAX - 1);
++        pathtmp[PATH_MAX - 1] = '\0';
+         strcat(pathtmp, "A");
+         for (int jj = 1; jj < 100; jj++) {
+             if (access(pathtmp, 0) < 0) {
+diff --git a/target/i386/latx/sbt/file_ctx.c b/target/i386/latx/sbt/file_ctx.c
+index 517cccd60a..8e05532a2e 100644
+--- a/target/i386/latx/sbt/file_ctx.c
++++ b/target/i386/latx/sbt/file_ctx.c
+@@ -228,7 +228,8 @@ int aot_file_ctx(uint64_t maxSize, uint64_t leftMinSize)
+         }
+         aot_total_size += statbuf.st_size;
+         struct aot_info *my_info = malloc(sizeof(struct aot_info));
+-        strncpy(my_info->d_name, subdir, PATH_MAX);
++        strncpy(my_info->d_name, subdir, PATH_MAX - 1);
++        my_info->d_name[PATH_MAX - 1] = '\0';
+         my_info->st_actime = statbuf.st_atime;
+         if (i_count >= max_aot_file_count) {
+             max_aot_file_count += 1000;
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1055-LATX-fix-Fix-build-scripts.patch
+++ b/app-emulation/latx/autobuild/patches/1055-LATX-fix-Fix-build-scripts.patch
@@ -1,0 +1,74 @@
+From 08c22bb00159f33a049318150b7a5c15d86ea5c7 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 21 Apr 2025 10:06:17 +0800
+Subject: [PATCH 1055/1058] LATX, fix: Fix build scripts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[393/393] Linking target latx-i386
+./latxbuild/build32-dbg.sh: 第 83 行：cd: ./latxbuild/../: 没有那个文件或目录
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ latxbuild/build32-dbg.sh | 2 --
+ latxbuild/build32.sh     | 2 --
+ latxbuild/build64-dbg.sh | 2 --
+ latxbuild/build64.sh     | 2 --
+ 4 files changed, 8 deletions(-)
+
+diff --git a/latxbuild/build32-dbg.sh b/latxbuild/build32-dbg.sh
+index 8b4f2adae0..b64e318bc1 100755
+--- a/latxbuild/build32-dbg.sh
++++ b/latxbuild/build32-dbg.sh
+@@ -79,8 +79,6 @@ make_cmd() {
+     else
+         ninja
+     fi
+-
+-    cd `dirname $0`/../
+ }
+ 
+ parseArgs "$@"
+diff --git a/latxbuild/build32.sh b/latxbuild/build32.sh
+index 8a1bc04b7b..f34fa9921e 100755
+--- a/latxbuild/build32.sh
++++ b/latxbuild/build32.sh
+@@ -78,8 +78,6 @@ make_cmd() {
+     else
+         ninja
+     fi
+-
+-    cd $(dirname $0)/../
+ }
+ 
+ parseArgs "$@"
+diff --git a/latxbuild/build64-dbg.sh b/latxbuild/build64-dbg.sh
+index 99f895b764..7ec59f4e2d 100755
+--- a/latxbuild/build64-dbg.sh
++++ b/latxbuild/build64-dbg.sh
+@@ -78,8 +78,6 @@ make_cmd() {
+     else
+         ninja
+     fi
+-
+-    cd $(dirname $0)/../
+ }
+ 
+ parseArgs "$@"
+diff --git a/latxbuild/build64.sh b/latxbuild/build64.sh
+index cd3af3cec2..48b882a0d6 100755
+--- a/latxbuild/build64.sh
++++ b/latxbuild/build64.sh
+@@ -78,8 +78,6 @@ make_cmd() {
+     else
+         ninja
+     fi
+-
+-    cd $(dirname $0)/../
+ }
+ 
+ parseArgs "$@"
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1056-LATX-linux-user-add-support-for-epoll_pwait2-syscall.patch
+++ b/app-emulation/latx/autobuild/patches/1056-LATX-linux-user-add-support-for-epoll_pwait2-syscall.patch
@@ -1,3 +1,16 @@
+From c181abc7dec1b99f930507a8cca9c9ec5f0286f5 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu@aosc.io>
+Date: Tue, 22 Apr 2025 10:33:27 +0800
+Subject: [PATCH 1056/1058] LATX, linux-user: add support for epoll_pwait2
+ syscall
+
+Signed-off-by: liushuyu <liushuyu@aosc.io>
+---
+ linux-user/i386/syscall_32.tbl   |  1 +
+ linux-user/syscall.c             | 36 ++++++++++++++++++++++++++------
+ linux-user/x86_64/syscall_64.tbl |  1 +
+ 3 files changed, 32 insertions(+), 6 deletions(-)
+
 diff --git a/linux-user/i386/syscall_32.tbl b/linux-user/i386/syscall_32.tbl
 index 9d11028736..52d3e157e4 100644
 --- a/linux-user/i386/syscall_32.tbl
@@ -8,7 +21,7 @@ index 9d11028736..52d3e157e4 100644
  439	i386	faccessat2		sys_faccessat2
 +441	i386	epoll_pwait2		sys_epoll_pwait2		compat_sys_epoll_pwait2
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index 5284c1f2ed..5f8590ded9 100644
+index 73c68ed933..9008e7adad 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
 @@ -810,6 +810,11 @@ safe_syscall5(int, ppoll, struct pollfd *, ufds, unsigned int, nfds,
@@ -23,7 +36,7 @@ index 5284c1f2ed..5f8590ded9 100644
  #if defined(__NR_futex)
  safe_syscall6(int,futex,int *,uaddr,int,op,int,val, \
                const struct timespec *,timeout,int *,uaddr2,int,val3)
-@@ -16527,19 +16532,22 @@ defined(__loongarch__)
+@@ -16523,19 +16528,22 @@ defined(__loongarch__)
      }
  #endif
  
@@ -48,7 +61,7 @@ index 5284c1f2ed..5f8590ded9 100644
  
          if (maxevents <= 0 || maxevents > TARGET_EP_MAX_EVENTS) {
              return -TARGET_EINVAL;
-@@ -16560,6 +16568,9 @@ defined(__loongarch__)
+@@ -16556,6 +16564,9 @@ defined(__loongarch__)
          switch (num) {
  #if defined(TARGET_NR_epoll_pwait)
          case TARGET_NR_epoll_pwait:
@@ -58,7 +71,7 @@ index 5284c1f2ed..5f8590ded9 100644
          {
              target_sigset_t *target_set;
              sigset_t _set, *set = &_set;
-@@ -16581,10 +16592,19 @@ defined(__loongarch__)
+@@ -16577,10 +16588,23 @@ defined(__loongarch__)
              } else {
                  set = NULL;
              }
@@ -70,6 +83,7 @@ index 5284c1f2ed..5f8590ded9 100644
 +                ret = get_errno(safe_epoll_pwait(epfd, ep, maxevents, timeout,
 +                                                 set, SIGSET_T_SIZE));
 +            } else {
++#if defined(TARGET_NR_epoll_pwait2)
 +                struct timespec hspec;
 +                struct timespec *ts_arg = NULL;
 +                if (timeout != 0) {
@@ -77,6 +91,9 @@ index 5284c1f2ed..5f8590ded9 100644
 +                    ts_arg = &hspec;
 +                }
 +                ret = get_errno(safe_epoll_pwait2(epfd, ep, maxevents, ts_arg, set, SIGSET_T_SIZE));
++#else
++                return -TARGET_ENOSYS;
++#endif
 +            }
 +                break;
          }
@@ -94,3 +111,6 @@ index f30d6ae9a6..6e3f0cef07 100644
  
  #
  # x32-specific system call numbers start at 512 to avoid cache impact
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1057-LATX-fix-Remove-linux-user-ioctl-amdgpu_drm.h.patch
+++ b/app-emulation/latx/autobuild/patches/1057-LATX-fix-Remove-linux-user-ioctl-amdgpu_drm.h.patch
@@ -1,0 +1,1050 @@
+From 6e88854e464748437cbb69c528fc10a0e43e0fe9 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 21 Apr 2025 17:24:44 +0800
+Subject: [PATCH 1057/1058] LATX, fix: Remove linux-user/ioctl/amdgpu_drm.h
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/ioctl/amdgpu_drm.h                 | 1019 -----------------
+ .../ioctl/ioctl_syscall/syscall_amdgpu_drm.c  |    2 -
+ 2 files changed, 1021 deletions(-)
+ delete mode 100644 linux-user/ioctl/amdgpu_drm.h
+
+diff --git a/linux-user/ioctl/amdgpu_drm.h b/linux-user/ioctl/amdgpu_drm.h
+deleted file mode 100644
+index cfcc60aebf..0000000000
+--- a/linux-user/ioctl/amdgpu_drm.h
++++ /dev/null
+@@ -1,1019 +0,0 @@
+-/* amdgpu_drm.h -- Public header for the amdgpu driver -*- linux-c -*-
+- *
+- * Copyright 2000 Precision Insight, Inc., Cedar Park, Texas.
+- * Copyright 2000 VA Linux Systems, Inc., Fremont, California.
+- * Copyright 2002 Tungsten Graphics, Inc., Cedar Park, Texas.
+- * Copyright 2014 Advanced Micro Devices, Inc.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be included in
+- * all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+- * OTHER DEALINGS IN THE SOFTWARE.
+- *
+- * Authors:
+- *    Kevin E. Martin <martin@valinux.com>
+- *    Gareth Hughes <gareth@valinux.com>
+- *    Keith Whitwell <keith@tungstengraphics.com>
+- */
+-
+-#ifndef __AMDGPU_DRM_H__
+-#define __AMDGPU_DRM_H__
+-
+-#include <libdrm/drm.h>
+-
+-#if defined(__cplusplus)
+-extern "C" {
+-#endif
+-
+-#define DRM_AMDGPU_GEM_CREATE    0x00
+-#define DRM_AMDGPU_GEM_MMAP    0x01
+-#define DRM_AMDGPU_CTX      0x02
+-#define DRM_AMDGPU_BO_LIST    0x03
+-#define DRM_AMDGPU_CS      0x04
+-#define DRM_AMDGPU_INFO      0x05
+-#define DRM_AMDGPU_GEM_METADATA    0x06
+-#define DRM_AMDGPU_GEM_WAIT_IDLE  0x07
+-#define DRM_AMDGPU_GEM_VA    0x08
+-#define DRM_AMDGPU_WAIT_CS    0x09
+-#define DRM_AMDGPU_GEM_OP    0x10
+-#define DRM_AMDGPU_GEM_USERPTR    0x11
+-#define DRM_AMDGPU_WAIT_FENCES    0x12
+-#define DRM_AMDGPU_VM      0x13
+-#define DRM_AMDGPU_FENCE_TO_HANDLE  0x14
+-#define DRM_AMDGPU_SCHED    0x15
+-
+-#define DRM_IOCTL_AMDGPU_GEM_CREATE  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_CREATE, union drm_amdgpu_gem_create)
+-#define DRM_IOCTL_AMDGPU_GEM_MMAP  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_MMAP, union drm_amdgpu_gem_mmap)
+-#define DRM_IOCTL_AMDGPU_CTX    \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_CTX, union drm_amdgpu_ctx)
+-#define DRM_IOCTL_AMDGPU_BO_LIST  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_BO_LIST, union drm_amdgpu_bo_list)
+-#define DRM_IOCTL_AMDGPU_CS    \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_CS, union drm_amdgpu_cs)
+-#define DRM_IOCTL_AMDGPU_INFO    \
+-    DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_INFO, struct drm_amdgpu_info)
+-#define DRM_IOCTL_AMDGPU_GEM_METADATA  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_METADATA, struct drm_amdgpu_gem_metadata)
+-#define DRM_IOCTL_AMDGPU_GEM_WAIT_IDLE  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_WAIT_IDLE, union drm_amdgpu_gem_wait_idle)
+-#define DRM_IOCTL_AMDGPU_GEM_VA    \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA, struct drm_amdgpu_gem_va)
+-#define DRM_IOCTL_AMDGPU_WAIT_CS  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_WAIT_CS, union drm_amdgpu_wait_cs)
+-#define DRM_IOCTL_AMDGPU_GEM_OP    \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_OP, struct drm_amdgpu_gem_op)
+-#define DRM_IOCTL_AMDGPU_GEM_USERPTR  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_USERPTR, struct drm_amdgpu_gem_userptr)
+-#define DRM_IOCTL_AMDGPU_WAIT_FENCES  \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_WAIT_FENCES, union drm_amdgpu_wait_fences)
+-#define DRM_IOCTL_AMDGPU_VM    \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_VM, union drm_amdgpu_vm)
+-#define DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE \
+-    DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE, \
+-             union drm_amdgpu_fence_to_handle)
+-#define DRM_IOCTL_AMDGPU_SCHED    \
+-    DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_SCHED, union drm_amdgpu_sched)
+-
+-/**
+- * DOC: memory domains
+- *
+- * %AMDGPU_GEM_DOMAIN_CPU  System memory that is not GPU accessible.
+- * Memory in this pool could be swapped out to disk if there is pressure.
+- *
+- * %AMDGPU_GEM_DOMAIN_GTT  GPU accessible system memory, mapped into the
+- * GPU's virtual address space via gart. Gart memory linearizes non-contiguous
+- * pages of system memory, allows GPU access system memory in a linezrized
+- * fashion.
+- *
+- * %AMDGPU_GEM_DOMAIN_VRAM  Local video memory. For APUs, it is memory
+- * carved out by the BIOS.
+- *
+- * %AMDGPU_GEM_DOMAIN_GDS  Global on-chip data storage used to share data
+- * across shader threads.
+- *
+- * %AMDGPU_GEM_DOMAIN_GWS  Global wave sync, used to synchronize the
+- * execution of all the waves on a device.
+- *
+- * %AMDGPU_GEM_DOMAIN_OA  Ordered append, used by 3D or Compute engines
+- * for appending data.
+- */
+-#define AMDGPU_GEM_DOMAIN_CPU    0x1
+-#define AMDGPU_GEM_DOMAIN_GTT    0x2
+-#define AMDGPU_GEM_DOMAIN_VRAM    0x4
+-#define AMDGPU_GEM_DOMAIN_GDS    0x8
+-#define AMDGPU_GEM_DOMAIN_GWS    0x10
+-#define AMDGPU_GEM_DOMAIN_OA    0x20
+-#define AMDGPU_GEM_DOMAIN_MASK    (AMDGPU_GEM_DOMAIN_CPU | \
+-           AMDGPU_GEM_DOMAIN_GTT | \
+-           AMDGPU_GEM_DOMAIN_VRAM | \
+-           AMDGPU_GEM_DOMAIN_GDS | \
+-           AMDGPU_GEM_DOMAIN_GWS | \
+-           AMDGPU_GEM_DOMAIN_OA)
+-
+-/* Flag that CPU access will be required for the case of VRAM domain */
+-#define AMDGPU_GEM_CREATE_CPU_ACCESS_REQUIRED  (1 << 0)
+-/* Flag that CPU access will not work, this VRAM domain is invisible */
+-#define AMDGPU_GEM_CREATE_NO_CPU_ACCESS    (1 << 1)
+-/* Flag that USWC attributes should be used for GTT */
+-#define AMDGPU_GEM_CREATE_CPU_GTT_USWC    (1 << 2)
+-/* Flag that the memory should be in VRAM and cleared */
+-#define AMDGPU_GEM_CREATE_VRAM_CLEARED    (1 << 3)
+-/* Flag that create shadow bo(GTT) while allocating vram bo */
+-#define AMDGPU_GEM_CREATE_SHADOW    (1 << 4)
+-/* Flag that allocating the BO should use linear VRAM */
+-#define AMDGPU_GEM_CREATE_VRAM_CONTIGUOUS  (1 << 5)
+-/* Flag that BO is always valid in this VM */
+-#define AMDGPU_GEM_CREATE_VM_ALWAYS_VALID  (1 << 6)
+-/* Flag that BO sharing will be explicitly synchronized */
+-#define AMDGPU_GEM_CREATE_EXPLICIT_SYNC    (1 << 7)
+-/* Flag that indicates allocating MQD gart on GFX9, where the mtype
+- * for the second page onward should be set to NC.
+- */
+-#define AMDGPU_GEM_CREATE_MQD_GFX9    (1 << 8)
+-
+-struct drm_amdgpu_gem_create_in  {
+-  /** the requested memory size */
+-  __u64 bo_size;
+-  /** physical start_addr alignment in bytes for some HW requirements */
+-  __u64 alignment;
+-  /** the requested memory domains */
+-  __u64 domains;
+-  /** allocation flags */
+-  __u64 domain_flags;
+-};
+-
+-struct drm_amdgpu_gem_create_out  {
+-  /** returned GEM object handle */
+-  __u32 handle;
+-  __u32 _pad;
+-};
+-
+-union drm_amdgpu_gem_create {
+-  struct drm_amdgpu_gem_create_in    in;
+-  struct drm_amdgpu_gem_create_out  out;
+-};
+-
+-/** Opcode to create new residency list.  */
+-#define AMDGPU_BO_LIST_OP_CREATE  0
+-/** Opcode to destroy previously created residency list */
+-#define AMDGPU_BO_LIST_OP_DESTROY  1
+-/** Opcode to update resource information in the list */
+-#define AMDGPU_BO_LIST_OP_UPDATE  2
+-
+-struct drm_amdgpu_bo_list_in {
+-  /** Type of operation */
+-  __u32 operation;
+-  /** Handle of list or 0 if we want to create one */
+-  __u32 list_handle;
+-  /** Number of BOs in list  */
+-  __u32 bo_number;
+-  /** Size of each element describing BO */
+-  __u32 bo_info_size;
+-  /** Pointer to array describing BOs */
+-  __u64 bo_info_ptr;
+-};
+-
+-struct drm_amdgpu_bo_list_entry {
+-  /** Handle of BO */
+-  __u32 bo_handle;
+-  /** New (if specified) BO priority to be used during migration */
+-  __u32 bo_priority;
+-};
+-
+-struct drm_amdgpu_bo_list_out {
+-  /** Handle of resource list  */
+-  __u32 list_handle;
+-  __u32 _pad;
+-};
+-
+-union drm_amdgpu_bo_list {
+-  struct drm_amdgpu_bo_list_in in;
+-  struct drm_amdgpu_bo_list_out out;
+-};
+-
+-/* context related */
+-#define AMDGPU_CTX_OP_ALLOC_CTX  1
+-#define AMDGPU_CTX_OP_FREE_CTX  2
+-#define AMDGPU_CTX_OP_QUERY_STATE  3
+-#define AMDGPU_CTX_OP_QUERY_STATE2  4
+-
+-/* GPU reset status */
+-#define AMDGPU_CTX_NO_RESET    0
+-/* this the context caused it */
+-#define AMDGPU_CTX_GUILTY_RESET    1
+-/* some other context caused it */
+-#define AMDGPU_CTX_INNOCENT_RESET  2
+-/* unknown cause */
+-#define AMDGPU_CTX_UNKNOWN_RESET  3
+-
+-/* indicate gpu reset occured after ctx created */
+-#define AMDGPU_CTX_QUERY2_FLAGS_RESET    (1 << 0)
+-/* indicate vram lost occured after ctx created */
+-#define AMDGPU_CTX_QUERY2_FLAGS_VRAMLOST (1 << 1)
+-/* indicate some job from this context once cause gpu hang */
+-#define AMDGPU_CTX_QUERY2_FLAGS_GUILTY   (1 << 2)
+-
+-/* Context priority level */
+-#define AMDGPU_CTX_PRIORITY_UNSET       -2048
+-#define AMDGPU_CTX_PRIORITY_VERY_LOW    -1023
+-#define AMDGPU_CTX_PRIORITY_LOW         -512
+-#define AMDGPU_CTX_PRIORITY_NORMAL      0
+-/* Selecting a priority above NORMAL requires CAP_SYS_NICE or DRM_MASTER */
+-#define AMDGPU_CTX_PRIORITY_HIGH        512
+-#define AMDGPU_CTX_PRIORITY_VERY_HIGH   1023
+-
+-struct drm_amdgpu_ctx_in {
+-  /** AMDGPU_CTX_OP_* */
+-  __u32  op;
+-  /** For future use, no flags defined so far */
+-  __u32  flags;
+-  __u32  ctx_id;
+-  __s32  priority;
+-};
+-
+-union drm_amdgpu_ctx_out {
+-    struct {
+-      __u32  ctx_id;
+-      __u32  _pad;
+-    } alloc;
+-
+-    struct {
+-      /** For future use, no flags defined so far */
+-      __u64  flags;
+-      /** Number of resets caused by this context so far. */
+-      __u32  hangs;
+-      /** Reset status since the last call of the ioctl. */
+-      __u32  reset_status;
+-    } state;
+-};
+-
+-union drm_amdgpu_ctx {
+-  struct drm_amdgpu_ctx_in in;
+-  union drm_amdgpu_ctx_out out;
+-};
+-
+-/* vm ioctl */
+-#define AMDGPU_VM_OP_RESERVE_VMID  1
+-#define AMDGPU_VM_OP_UNRESERVE_VMID  2
+-
+-struct drm_amdgpu_vm_in {
+-  /** AMDGPU_VM_OP_* */
+-  __u32  op;
+-  __u32  flags;
+-};
+-
+-struct drm_amdgpu_vm_out {
+-  /** For future use, no flags defined so far */
+-  __u64  flags;
+-};
+-
+-union drm_amdgpu_vm {
+-  struct drm_amdgpu_vm_in in;
+-  struct drm_amdgpu_vm_out out;
+-};
+-
+-/* sched ioctl */
+-#define AMDGPU_SCHED_OP_PROCESS_PRIORITY_OVERRIDE  1
+-
+-struct drm_amdgpu_sched_in {
+-  /* AMDGPU_SCHED_OP_* */
+-  __u32  op;
+-  __u32  fd;
+-  __s32  priority;
+-  __u32  flags;
+-};
+-
+-union drm_amdgpu_sched {
+-  struct drm_amdgpu_sched_in in;
+-};
+-
+-/*
+- * This is not a reliable API and you should expect it to fail for any
+- * number of reasons and have fallback path that do not use userptr to
+- * perform any operation.
+- */
+-#define AMDGPU_GEM_USERPTR_READONLY  (1 << 0)
+-#define AMDGPU_GEM_USERPTR_ANONONLY  (1 << 1)
+-#define AMDGPU_GEM_USERPTR_VALIDATE  (1 << 2)
+-#define AMDGPU_GEM_USERPTR_REGISTER  (1 << 3)
+-
+-struct drm_amdgpu_gem_userptr {
+-  __u64    addr;
+-  __u64    size;
+-  /* AMDGPU_GEM_USERPTR_* */
+-  __u32    flags;
+-  /* Resulting GEM handle */
+-  __u32    handle;
+-};
+-
+-/* SI-CI-VI: */
+-/* same meaning as the GB_TILE_MODE and GL_MACRO_TILE_MODE fields */
+-#define AMDGPU_TILING_ARRAY_MODE_SHIFT      0
+-#define AMDGPU_TILING_ARRAY_MODE_MASK      0xf
+-#define AMDGPU_TILING_PIPE_CONFIG_SHIFT      4
+-#define AMDGPU_TILING_PIPE_CONFIG_MASK      0x1f
+-#define AMDGPU_TILING_TILE_SPLIT_SHIFT      9
+-#define AMDGPU_TILING_TILE_SPLIT_MASK      0x7
+-#define AMDGPU_TILING_MICRO_TILE_MODE_SHIFT    12
+-#define AMDGPU_TILING_MICRO_TILE_MODE_MASK    0x7
+-#define AMDGPU_TILING_BANK_WIDTH_SHIFT      15
+-#define AMDGPU_TILING_BANK_WIDTH_MASK      0x3
+-#define AMDGPU_TILING_BANK_HEIGHT_SHIFT      17
+-#define AMDGPU_TILING_BANK_HEIGHT_MASK      0x3
+-#define AMDGPU_TILING_MACRO_TILE_ASPECT_SHIFT    19
+-#define AMDGPU_TILING_MACRO_TILE_ASPECT_MASK    0x3
+-#define AMDGPU_TILING_NUM_BANKS_SHIFT      21
+-#define AMDGPU_TILING_NUM_BANKS_MASK      0x3
+-
+-/* GFX9 and later: */
+-#define AMDGPU_TILING_SWIZZLE_MODE_SHIFT    0
+-#define AMDGPU_TILING_SWIZZLE_MODE_MASK      0x1f
+-#define AMDGPU_TILING_DCC_OFFSET_256B_SHIFT    5
+-#define AMDGPU_TILING_DCC_OFFSET_256B_MASK    0xFFFFFF
+-#define AMDGPU_TILING_DCC_PITCH_MAX_SHIFT    29
+-#define AMDGPU_TILING_DCC_PITCH_MAX_MASK    0x3FFF
+-#define AMDGPU_TILING_DCC_INDEPENDENT_64B_SHIFT    43
+-#define AMDGPU_TILING_DCC_INDEPENDENT_64B_MASK    0x1
+-
+-/* Set/Get helpers for tiling flags. */
+-#define AMDGPU_TILING_SET(field, value) \
+-  (((__u64)(value) & AMDGPU_TILING_##field##_MASK) << AMDGPU_TILING_##field##_SHIFT)
+-#define AMDGPU_TILING_GET(value, field) \
+-  (((__u64)(value) >> AMDGPU_TILING_##field##_SHIFT) & AMDGPU_TILING_##field##_MASK)
+-
+-#define AMDGPU_GEM_METADATA_OP_SET_METADATA                  1
+-#define AMDGPU_GEM_METADATA_OP_GET_METADATA                  2
+-
+-/** The same structure is shared for input/output */
+-struct drm_amdgpu_gem_metadata {
+-  /** GEM Object handle */
+-  __u32  handle;
+-  /** Do we want get or set metadata */
+-  __u32  op;
+-  struct {
+-    /** For future use, no flags defined so far */
+-    __u64  flags;
+-    /** family specific tiling info */
+-    __u64  tiling_info;
+-    __u32  data_size_bytes;
+-    __u32  data[64];
+-  } data;
+-};
+-
+-struct drm_amdgpu_gem_mmap_in {
+-  /** the GEM object handle */
+-  __u32 handle;
+-  __u32 _pad;
+-};
+-
+-struct drm_amdgpu_gem_mmap_out {
+-  /** mmap offset from the vma offset manager */
+-  __u64 addr_ptr;
+-};
+-
+-union drm_amdgpu_gem_mmap {
+-  struct drm_amdgpu_gem_mmap_in   in;
+-  struct drm_amdgpu_gem_mmap_out out;
+-};
+-
+-struct drm_amdgpu_gem_wait_idle_in {
+-  /** GEM object handle */
+-  __u32 handle;
+-  /** For future use, no flags defined so far */
+-  __u32 flags;
+-  /** Absolute timeout to wait */
+-  __u64 timeout;
+-};
+-
+-struct drm_amdgpu_gem_wait_idle_out {
+-  /** BO status:  0 - BO is idle, 1 - BO is busy */
+-  __u32 status;
+-  /** Returned current memory domain */
+-  __u32 domain;
+-};
+-
+-union drm_amdgpu_gem_wait_idle {
+-  struct drm_amdgpu_gem_wait_idle_in  in;
+-  struct drm_amdgpu_gem_wait_idle_out out;
+-};
+-
+-struct drm_amdgpu_wait_cs_in {
+-  /* Command submission handle
+-         * handle equals 0 means none to wait for
+-         * handle equals ~0ull means wait for the latest sequence number
+-         */
+-  __u64 handle;
+-  /** Absolute timeout to wait */
+-  __u64 timeout;
+-  __u32 ip_type;
+-  __u32 ip_instance;
+-  __u32 ring;
+-  __u32 ctx_id;
+-};
+-
+-struct drm_amdgpu_wait_cs_out {
+-  /** CS status:  0 - CS completed, 1 - CS still busy */
+-  __u64 status;
+-};
+-
+-union drm_amdgpu_wait_cs {
+-  struct drm_amdgpu_wait_cs_in in;
+-  struct drm_amdgpu_wait_cs_out out;
+-};
+-
+-struct drm_amdgpu_fence {
+-  __u32 ctx_id;
+-  __u32 ip_type;
+-  __u32 ip_instance;
+-  __u32 ring;
+-  __u64 seq_no;
+-};
+-
+-struct drm_amdgpu_wait_fences_in {
+-  /** This points to uint64_t * which points to fences */
+-  __u64 fences;
+-  __u32 fence_count;
+-  __u32 wait_all;
+-  __u64 timeout_ns;
+-};
+-
+-struct drm_amdgpu_wait_fences_out {
+-  __u32 status;
+-  __u32 first_signaled;
+-};
+-
+-union drm_amdgpu_wait_fences {
+-  struct drm_amdgpu_wait_fences_in in;
+-  struct drm_amdgpu_wait_fences_out out;
+-};
+-
+-#define AMDGPU_GEM_OP_GET_GEM_CREATE_INFO  0
+-#define AMDGPU_GEM_OP_SET_PLACEMENT    1
+-
+-/* Sets or returns a value associated with a buffer. */
+-struct drm_amdgpu_gem_op {
+-  /** GEM object handle */
+-  __u32  handle;
+-  /** AMDGPU_GEM_OP_* */
+-  __u32  op;
+-  /** Input or return value */
+-  __u64  value;
+-};
+-
+-#define AMDGPU_VA_OP_MAP      1
+-#define AMDGPU_VA_OP_UNMAP      2
+-#define AMDGPU_VA_OP_CLEAR      3
+-#define AMDGPU_VA_OP_REPLACE      4
+-
+-/* Delay the page table update till the next CS */
+-#define AMDGPU_VM_DELAY_UPDATE    (1 << 0)
+-
+-/* Mapping flags */
+-/* readable mapping */
+-#define AMDGPU_VM_PAGE_READABLE    (1 << 1)
+-/* writable mapping */
+-#define AMDGPU_VM_PAGE_WRITEABLE  (1 << 2)
+-/* executable mapping, new for VI */
+-#define AMDGPU_VM_PAGE_EXECUTABLE  (1 << 3)
+-/* partially resident texture */
+-#define AMDGPU_VM_PAGE_PRT    (1 << 4)
+-/* MTYPE flags use bit 5 to 8 */
+-#define AMDGPU_VM_MTYPE_MASK    (0xf << 5)
+-/* Default MTYPE. Pre-AI must use this.  Recommended for newer ASICs. */
+-#define AMDGPU_VM_MTYPE_DEFAULT    (0 << 5)
+-/* Use NC MTYPE instead of default MTYPE */
+-#define AMDGPU_VM_MTYPE_NC    (1 << 5)
+-/* Use WC MTYPE instead of default MTYPE */
+-#define AMDGPU_VM_MTYPE_WC    (2 << 5)
+-/* Use CC MTYPE instead of default MTYPE */
+-#define AMDGPU_VM_MTYPE_CC    (3 << 5)
+-/* Use UC MTYPE instead of default MTYPE */
+-#define AMDGPU_VM_MTYPE_UC    (4 << 5)
+-
+-struct drm_amdgpu_gem_va {
+-  /** GEM object handle */
+-  __u32 handle;
+-  __u32 _pad;
+-  /** AMDGPU_VA_OP_* */
+-  __u32 operation;
+-  /** AMDGPU_VM_PAGE_* */
+-  __u32 flags;
+-  /** va address to assign . Must be correctly aligned.*/
+-  __u64 va_address;
+-  /** Specify offset inside of BO to assign. Must be correctly aligned.*/
+-  __u64 offset_in_bo;
+-  /** Specify mapping size. Must be correctly aligned. */
+-  __u64 map_size;
+-};
+-
+-#define AMDGPU_HW_IP_GFX          0
+-#define AMDGPU_HW_IP_COMPUTE      1
+-#define AMDGPU_HW_IP_DMA          2
+-#define AMDGPU_HW_IP_UVD          3
+-#define AMDGPU_HW_IP_VCE          4
+-#define AMDGPU_HW_IP_UVD_ENC      5
+-#define AMDGPU_HW_IP_VCN_DEC      6
+-#define AMDGPU_HW_IP_VCN_ENC      7
+-#define AMDGPU_HW_IP_VCN_JPEG     8
+-#define AMDGPU_HW_IP_NUM          9
+-
+-#define AMDGPU_HW_IP_INSTANCE_MAX_COUNT 1
+-
+-#define AMDGPU_CHUNK_ID_IB    0x01
+-#define AMDGPU_CHUNK_ID_FENCE    0x02
+-#define AMDGPU_CHUNK_ID_DEPENDENCIES  0x03
+-#define AMDGPU_CHUNK_ID_SYNCOBJ_IN      0x04
+-#define AMDGPU_CHUNK_ID_SYNCOBJ_OUT     0x05
+-#define AMDGPU_CHUNK_ID_BO_HANDLES      0x06
+-
+-struct drm_amdgpu_cs_chunk {
+-  __u32    chunk_id;
+-  __u32    length_dw;
+-  __u64    chunk_data;
+-};
+-
+-struct drm_amdgpu_cs_in {
+-  /** Rendering context id */
+-  __u32    ctx_id;
+-  /**  Handle of resource list associated with CS */
+-  __u32    bo_list_handle;
+-  __u32    num_chunks;
+-  __u32    _pad;
+-  /** this points to __u64 * which point to cs chunks */
+-  __u64    chunks;
+-};
+-
+-struct drm_amdgpu_cs_out {
+-  __u64 handle;
+-};
+-
+-union drm_amdgpu_cs {
+-  struct drm_amdgpu_cs_in in;
+-  struct drm_amdgpu_cs_out out;
+-};
+-
+-/* Specify flags to be used for IB */
+-
+-/* This IB should be submitted to CE */
+-#define AMDGPU_IB_FLAG_CE  (1 << 0)
+-
+-/* Preamble flag, which means the IB could be dropped if no context switch */
+-#define AMDGPU_IB_FLAG_PREAMBLE (1 << 1)
+-
+-/* Preempt flag, IB should set Pre_enb bit if PREEMPT flag detected */
+-#define AMDGPU_IB_FLAG_PREEMPT (1 << 2)
+-
+-/* The IB fence should do the L2 writeback but not invalidate any shader
+- * caches (L2/vL1/sL1/I$). */
+-#define AMDGPU_IB_FLAG_TC_WB_NOT_INVALIDATE (1 << 3)
+-
+-struct drm_amdgpu_cs_chunk_ib {
+-  __u32 _pad;
+-  /** AMDGPU_IB_FLAG_* */
+-  __u32 flags;
+-  /** Virtual address to begin IB execution */
+-  __u64 va_start;
+-  /** Size of submission */
+-  __u32 ib_bytes;
+-  /** HW IP to submit to */
+-  __u32 ip_type;
+-  /** HW IP index of the same type to submit to  */
+-  __u32 ip_instance;
+-  /** Ring index to submit to */
+-  __u32 ring;
+-};
+-
+-struct drm_amdgpu_cs_chunk_dep {
+-  __u32 ip_type;
+-  __u32 ip_instance;
+-  __u32 ring;
+-  __u32 ctx_id;
+-  __u64 handle;
+-};
+-
+-struct drm_amdgpu_cs_chunk_fence {
+-  __u32 handle;
+-  __u32 offset;
+-};
+-
+-struct drm_amdgpu_cs_chunk_sem {
+-  __u32 handle;
+-};
+-
+-#define AMDGPU_FENCE_TO_HANDLE_GET_SYNCOBJ  0
+-#define AMDGPU_FENCE_TO_HANDLE_GET_SYNCOBJ_FD  1
+-#define AMDGPU_FENCE_TO_HANDLE_GET_SYNC_FILE_FD  2
+-
+-union drm_amdgpu_fence_to_handle {
+-  struct {
+-    struct drm_amdgpu_fence fence;
+-    __u32 what;
+-    __u32 pad;
+-  } in;
+-  struct {
+-    __u32 handle;
+-  } out;
+-};
+-
+-struct drm_amdgpu_cs_chunk_data {
+-  union {
+-    struct drm_amdgpu_cs_chunk_ib    ib_data;
+-    struct drm_amdgpu_cs_chunk_fence  fence_data;
+-  };
+-};
+-
+-/**
+- *  Query h/w info: Flag that this is integrated (a.h.a. fusion) GPU
+- *
+- */
+-#define AMDGPU_IDS_FLAGS_FUSION         0x1
+-#define AMDGPU_IDS_FLAGS_PREEMPTION     0x2
+-
+-/* indicate if acceleration can be working */
+-#define AMDGPU_INFO_ACCEL_WORKING    0x00
+-/* get the crtc_id from the mode object id? */
+-#define AMDGPU_INFO_CRTC_FROM_ID    0x01
+-/* query hw IP info */
+-#define AMDGPU_INFO_HW_IP_INFO      0x02
+-/* query hw IP instance count for the specified type */
+-#define AMDGPU_INFO_HW_IP_COUNT      0x03
+-/* timestamp for GL_ARB_timer_query */
+-#define AMDGPU_INFO_TIMESTAMP      0x05
+-/* Query the firmware version */
+-#define AMDGPU_INFO_FW_VERSION      0x0e
+-  /* Subquery id: Query VCE firmware version */
+-  #define AMDGPU_INFO_FW_VCE    0x1
+-  /* Subquery id: Query UVD firmware version */
+-  #define AMDGPU_INFO_FW_UVD    0x2
+-  /* Subquery id: Query GMC firmware version */
+-  #define AMDGPU_INFO_FW_GMC    0x03
+-  /* Subquery id: Query GFX ME firmware version */
+-  #define AMDGPU_INFO_FW_GFX_ME    0x04
+-  /* Subquery id: Query GFX PFP firmware version */
+-  #define AMDGPU_INFO_FW_GFX_PFP    0x05
+-  /* Subquery id: Query GFX CE firmware version */
+-  #define AMDGPU_INFO_FW_GFX_CE    0x06
+-  /* Subquery id: Query GFX RLC firmware version */
+-  #define AMDGPU_INFO_FW_GFX_RLC    0x07
+-  /* Subquery id: Query GFX MEC firmware version */
+-  #define AMDGPU_INFO_FW_GFX_MEC    0x08
+-  /* Subquery id: Query SMC firmware version */
+-  #define AMDGPU_INFO_FW_SMC    0x0a
+-  /* Subquery id: Query SDMA firmware version */
+-  #define AMDGPU_INFO_FW_SDMA    0x0b
+-  /* Subquery id: Query PSP SOS firmware version */
+-  #define AMDGPU_INFO_FW_SOS    0x0c
+-  /* Subquery id: Query PSP ASD firmware version */
+-  #define AMDGPU_INFO_FW_ASD    0x0d
+-  /* Subquery id: Query VCN firmware version */
+-  #define AMDGPU_INFO_FW_VCN    0x0e
+-  /* Subquery id: Query GFX RLC SRLC firmware version */
+-  #define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_CNTL 0x0f
+-  /* Subquery id: Query GFX RLC SRLG firmware version */
+-  #define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_GPM_MEM 0x10
+-  /* Subquery id: Query GFX RLC SRLS firmware version */
+-  #define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_SRM_MEM 0x11
+-  /* Subquery id: Query DMCU firmware version */
+-  #define AMDGPU_INFO_FW_DMCU    0x12
+-/* number of bytes moved for TTM migration */
+-#define AMDGPU_INFO_NUM_BYTES_MOVED    0x0f
+-/* the used VRAM size */
+-#define AMDGPU_INFO_VRAM_USAGE      0x10
+-/* the used GTT size */
+-#define AMDGPU_INFO_GTT_USAGE      0x11
+-/* Information about GDS, etc. resource configuration */
+-#define AMDGPU_INFO_GDS_CONFIG      0x13
+-/* Query information about VRAM and GTT domains */
+-#define AMDGPU_INFO_VRAM_GTT      0x14
+-/* Query information about register in MMR address space*/
+-#define AMDGPU_INFO_READ_MMR_REG    0x15
+-/* Query information about device: rev id, family, etc. */
+-#define AMDGPU_INFO_DEV_INFO      0x16
+-/* visible vram usage */
+-#define AMDGPU_INFO_VIS_VRAM_USAGE    0x17
+-/* number of TTM buffer evictions */
+-#define AMDGPU_INFO_NUM_EVICTIONS    0x18
+-/* Query memory about VRAM and GTT domains */
+-#define AMDGPU_INFO_MEMORY      0x19
+-/* Query vce clock table */
+-#define AMDGPU_INFO_VCE_CLOCK_TABLE    0x1A
+-/* Query vbios related information */
+-#define AMDGPU_INFO_VBIOS      0x1B
+-  /* Subquery id: Query vbios size */
+-  #define AMDGPU_INFO_VBIOS_SIZE    0x1
+-  /* Subquery id: Query vbios image */
+-  #define AMDGPU_INFO_VBIOS_IMAGE    0x2
+-/* Query UVD handles */
+-#define AMDGPU_INFO_NUM_HANDLES      0x1C
+-/* Query sensor related information */
+-#define AMDGPU_INFO_SENSOR      0x1D
+-  /* Subquery id: Query GPU shader clock */
+-  #define AMDGPU_INFO_SENSOR_GFX_SCLK    0x1
+-  /* Subquery id: Query GPU memory clock */
+-  #define AMDGPU_INFO_SENSOR_GFX_MCLK    0x2
+-  /* Subquery id: Query GPU temperature */
+-  #define AMDGPU_INFO_SENSOR_GPU_TEMP    0x3
+-  /* Subquery id: Query GPU load */
+-  #define AMDGPU_INFO_SENSOR_GPU_LOAD    0x4
+-  /* Subquery id: Query average GPU power  */
+-  #define AMDGPU_INFO_SENSOR_GPU_AVG_POWER  0x5
+-  /* Subquery id: Query northbridge voltage */
+-  #define AMDGPU_INFO_SENSOR_VDDNB    0x6
+-  /* Subquery id: Query graphics voltage */
+-  #define AMDGPU_INFO_SENSOR_VDDGFX    0x7
+-  /* Subquery id: Query GPU stable pstate shader clock */
+-  #define AMDGPU_INFO_SENSOR_STABLE_PSTATE_GFX_SCLK    0x8
+-  /* Subquery id: Query GPU stable pstate memory clock */
+-  #define AMDGPU_INFO_SENSOR_STABLE_PSTATE_GFX_MCLK    0x9
+-/* Number of VRAM page faults on CPU access. */
+-#define AMDGPU_INFO_NUM_VRAM_CPU_PAGE_FAULTS  0x1E
+-#define AMDGPU_INFO_VRAM_LOST_COUNTER    0x1F
+-
+-#define AMDGPU_INFO_MMR_SE_INDEX_SHIFT  0
+-#define AMDGPU_INFO_MMR_SE_INDEX_MASK  0xff
+-#define AMDGPU_INFO_MMR_SH_INDEX_SHIFT  8
+-#define AMDGPU_INFO_MMR_SH_INDEX_MASK  0xff
+-
+-struct drm_amdgpu_query_fw {
+-  /** AMDGPU_INFO_FW_* */
+-  __u32 fw_type;
+-  /**
+-   * Index of the IP if there are more IPs of
+-   * the same type.
+-   */
+-  __u32 ip_instance;
+-  /**
+-   * Index of the engine. Whether this is used depends
+-   * on the firmware type. (e.g. MEC, SDMA)
+-   */
+-  __u32 index;
+-  __u32 _pad;
+-};
+-
+-/* Input structure for the INFO ioctl */
+-struct drm_amdgpu_info {
+-  /* Where the return value will be stored */
+-  __u64 return_pointer;
+-  /* The size of the return value. Just like "size" in "snprintf",
+-   * it limits how many bytes the kernel can write. */
+-  __u32 return_size;
+-  /* The query request id. */
+-  __u32 query;
+-
+-  union {
+-    struct {
+-      __u32 id;
+-      __u32 _pad;
+-    } mode_crtc;
+-
+-    struct {
+-      /** AMDGPU_HW_IP_* */
+-      __u32 type;
+-      /**
+-       * Index of the IP if there are more IPs of the same
+-       * type. Ignored by AMDGPU_INFO_HW_IP_COUNT.
+-       */
+-      __u32 ip_instance;
+-    } query_hw_ip;
+-
+-    struct {
+-      __u32 dword_offset;
+-      /** number of registers to read */
+-      __u32 count;
+-      __u32 instance;
+-      /** For future use, no flags defined so far */
+-      __u32 flags;
+-    } read_mmr_reg;
+-
+-    struct drm_amdgpu_query_fw query_fw;
+-
+-    struct {
+-      __u32 type;
+-      __u32 offset;
+-    } vbios_info;
+-
+-    struct {
+-      __u32 type;
+-    } sensor_info;
+-  };
+-};
+-
+-struct drm_amdgpu_info_gds {
+-  /** GDS GFX partition size */
+-  __u32 gds_gfx_partition_size;
+-  /** GDS compute partition size */
+-  __u32 compute_partition_size;
+-  /** total GDS memory size */
+-  __u32 gds_total_size;
+-  /** GWS size per GFX partition */
+-  __u32 gws_per_gfx_partition;
+-  /** GSW size per compute partition */
+-  __u32 gws_per_compute_partition;
+-  /** OA size per GFX partition */
+-  __u32 oa_per_gfx_partition;
+-  /** OA size per compute partition */
+-  __u32 oa_per_compute_partition;
+-  __u32 _pad;
+-};
+-
+-struct drm_amdgpu_info_vram_gtt {
+-  __u64 vram_size;
+-  __u64 vram_cpu_accessible_size;
+-  __u64 gtt_size;
+-};
+-
+-struct drm_amdgpu_heap_info {
+-  /** max. physical memory */
+-  __u64 total_heap_size;
+-
+-  /** Theoretical max. available memory in the given heap */
+-  __u64 usable_heap_size;
+-
+-  /**
+-   * Number of bytes allocated in the heap. This includes all processes
+-   * and private allocations in the kernel. It changes when new buffers
+-   * are allocated, freed, and moved. It cannot be larger than
+-   * heap_size.
+-   */
+-  __u64 heap_usage;
+-
+-  /**
+-   * Theoretical possible max. size of buffer which
+-   * could be allocated in the given heap
+-   */
+-  __u64 max_allocation;
+-};
+-
+-struct drm_amdgpu_memory_info {
+-  struct drm_amdgpu_heap_info vram;
+-  struct drm_amdgpu_heap_info cpu_accessible_vram;
+-  struct drm_amdgpu_heap_info gtt;
+-};
+-
+-struct drm_amdgpu_info_firmware {
+-  __u32 ver;
+-  __u32 feature;
+-};
+-
+-#define AMDGPU_VRAM_TYPE_UNKNOWN 0
+-#define AMDGPU_VRAM_TYPE_GDDR1 1
+-#define AMDGPU_VRAM_TYPE_DDR2  2
+-#define AMDGPU_VRAM_TYPE_GDDR3 3
+-#define AMDGPU_VRAM_TYPE_GDDR4 4
+-#define AMDGPU_VRAM_TYPE_GDDR5 5
+-#define AMDGPU_VRAM_TYPE_HBM   6
+-#define AMDGPU_VRAM_TYPE_DDR3  7
+-#define AMDGPU_VRAM_TYPE_DDR4  8
+-
+-struct drm_amdgpu_info_device {
+-  /** PCI Device ID */
+-  __u32 device_id;
+-  /** Internal chip revision: A0, A1, etc.) */
+-  __u32 chip_rev;
+-  __u32 external_rev;
+-  /** Revision id in PCI Config space */
+-  __u32 pci_rev;
+-  __u32 family;
+-  __u32 num_shader_engines;
+-  __u32 num_shader_arrays_per_engine;
+-  /* in KHz */
+-  __u32 gpu_counter_freq;
+-  __u64 max_engine_clock;
+-  __u64 max_memory_clock;
+-  /* cu information */
+-  __u32 cu_active_number;
+-  /* NOTE: cu_ao_mask is INVALID, DON'T use it */
+-  __u32 cu_ao_mask;
+-  __u32 cu_bitmap[4][4];
+-  /** Render backend pipe mask. One render backend is CB+DB. */
+-  __u32 enabled_rb_pipes_mask;
+-  __u32 num_rb_pipes;
+-  __u32 num_hw_gfx_contexts;
+-  __u32 _pad;
+-  __u64 ids_flags;
+-  /** Starting virtual address for UMDs. */
+-  __u64 virtual_address_offset;
+-  /** The maximum virtual address */
+-  __u64 virtual_address_max;
+-  /** Required alignment of virtual addresses. */
+-  __u32 virtual_address_alignment;
+-  /** Page table entry - fragment size */
+-  __u32 pte_fragment_size;
+-  __u32 gart_page_size;
+-  /** constant engine ram size*/
+-  __u32 ce_ram_size;
+-  /** video memory type info*/
+-  __u32 vram_type;
+-  /** video memory bit width*/
+-  __u32 vram_bit_width;
+-  /* vce harvesting instance */
+-  __u32 vce_harvest_config;
+-  /* gfx double offchip LDS buffers */
+-  __u32 gc_double_offchip_lds_buf;
+-  /* NGG Primitive Buffer */
+-  __u64 prim_buf_gpu_addr;
+-  /* NGG Position Buffer */
+-  __u64 pos_buf_gpu_addr;
+-  /* NGG Control Sideband */
+-  __u64 cntl_sb_buf_gpu_addr;
+-  /* NGG Parameter Cache */
+-  __u64 param_buf_gpu_addr;
+-  __u32 prim_buf_size;
+-  __u32 pos_buf_size;
+-  __u32 cntl_sb_buf_size;
+-  __u32 param_buf_size;
+-  /* wavefront size*/
+-  __u32 wave_front_size;
+-  /* shader visible vgprs*/
+-  __u32 num_shader_visible_vgprs;
+-  /* CU per shader array*/
+-  __u32 num_cu_per_sh;
+-  /* number of tcc blocks*/
+-  __u32 num_tcc_blocks;
+-  /* gs vgt table depth*/
+-  __u32 gs_vgt_table_depth;
+-  /* gs primitive buffer depth*/
+-  __u32 gs_prim_buffer_depth;
+-  /* max gs wavefront per vgt*/
+-  __u32 max_gs_waves_per_vgt;
+-  __u32 _pad1;
+-  /* always on cu bitmap */
+-  __u32 cu_ao_bitmap[4][4];
+-  /** Starting high virtual address for UMDs. */
+-  __u64 high_va_offset;
+-  /** The maximum high virtual address */
+-  __u64 high_va_max;
+-};
+-
+-struct drm_amdgpu_info_hw_ip {
+-  /** Version of h/w IP */
+-  __u32  hw_ip_version_major;
+-  __u32  hw_ip_version_minor;
+-  /** Capabilities */
+-  __u64  capabilities_flags;
+-  /** command buffer address start alignment*/
+-  __u32  ib_start_alignment;
+-  /** command buffer size alignment*/
+-  __u32  ib_size_alignment;
+-  /** Bitmask of available rings. Bit 0 means ring 0, etc. */
+-  __u32  available_rings;
+-  __u32  _pad;
+-};
+-
+-struct drm_amdgpu_info_num_handles {
+-  /** Max handles as supported by firmware for UVD */
+-  __u32  uvd_max_handles;
+-  /** Handles currently in use for UVD */
+-  __u32  uvd_used_handles;
+-};
+-
+-#define AMDGPU_VCE_CLOCK_TABLE_ENTRIES    6
+-
+-struct drm_amdgpu_info_vce_clock_table_entry {
+-  /** System clock */
+-  __u32 sclk;
+-  /** Memory clock */
+-  __u32 mclk;
+-  /** VCE clock */
+-  __u32 eclk;
+-  __u32 pad;
+-};
+-
+-struct drm_amdgpu_info_vce_clock_table {
+-  struct drm_amdgpu_info_vce_clock_table_entry entries[AMDGPU_VCE_CLOCK_TABLE_ENTRIES];
+-  __u32 num_valid_entries;
+-  __u32 pad;
+-};
+-
+-/*
+- * Supported GPU families
+- */
+-#define AMDGPU_FAMILY_UNKNOWN      0
+-#define AMDGPU_FAMILY_SI      110 /* Hainan, Oland, Verde, Pitcairn, Tahiti */
+-#define AMDGPU_FAMILY_CI      120 /* Bonaire, Hawaii */
+-#define AMDGPU_FAMILY_KV      125 /* Kaveri, Kabini, Mullins */
+-#define AMDGPU_FAMILY_VI      130 /* Iceland, Tonga */
+-#define AMDGPU_FAMILY_CZ      135 /* Carrizo, Stoney */
+-#define AMDGPU_FAMILY_AI      141 /* Vega10 */
+-#define AMDGPU_FAMILY_RV      142 /* Raven */
+-
+-#if defined(__cplusplus)
+-}
+-#endif
+-
+-#endif
+diff --git a/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c b/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
+index ef220e1ffa..d006b4fd0c 100644
+--- a/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
++++ b/linux-user/ioctl/ioctl_syscall/syscall_amdgpu_drm.c
+@@ -1,5 +1,3 @@
+-#include "linux-user/ioctl/amdgpu_drm.h"
+-
+ static inline abi_long target_to_host_drm_amdgpu_info
+                         (struct drm_amdgpu_info *host_ver,
+          struct target_drm_amdgpu_info *target_ver)
+-- 
+2.49.0
+

--- a/app-emulation/latx/autobuild/patches/1058-LATX-fix-Fix-ioctl-command-mismatch-due-to-high-16-b.patch
+++ b/app-emulation/latx/autobuild/patches/1058-LATX-fix-Fix-ioctl-command-mismatch-due-to-high-16-b.patch
@@ -1,0 +1,55 @@
+From 7892d979813c550df04ed84c537df2b5864eb6d5 Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Mon, 21 Apr 2025 17:31:34 +0800
+Subject: [PATCH 1058/1058] LATX, fix: Fix ioctl command mismatch due to high
+ 16 bits
+
+This patch changes the behavior to log a warning when a mismatch is detected,
+but still proceeds with handing the ioctl. This improves compatibility with
+headers that use different high bits, such as amdgpu_drm.h.
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+---
+ linux-user/syscall.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 9008e7adad..3e1fa78218 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -8159,13 +8159,21 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
+     ie += ioctl_cache_val;
+ 
+ #ifdef TARGET_X86_64
+-    if (ioctl_cache_unsupported_cmd[hash] == cmd) {
++    if ((uint16_t)ioctl_cache_unsupported_cmd[hash] == (uint16_t)cmd) {
+         ret = get_errno(safe_ioctl(fd, cmd, arg));
+         return ret;
+     }
+ #endif
+     /* slow path to iterate the ioctl_entries */
+-    if (ie->target_cmd != cmd) {
++    if ((uint16_t)ie->target_cmd != (uint16_t)cmd) {
++#ifdef CONFIG_LATX_DEBUG
++        if (ie->target_cmd != cmd) {
++            qemu_log_mask(LAT_LOG_SYSCALL,
++                    "[LATX_SYSCALL] do_ioctl fd " TARGET_FMT_ld
++                    " cmd 0x" TARGET_FMT_lx " ie->target_cmd != cmd\n",
++                    arg1, arg2);
++        }
++#endif
+         switch(TARGET_IOC_NR(cmd)) {
+             case TARGET_IOC_NR(TARGET_HIDIOCSFEATURE(0)):
+             case TARGET_IOC_NR(TARGET_HIDIOCGFEATURE(0)):
+@@ -8190,7 +8198,7 @@ static abi_long do_ioctl(int fd, int cmd, abi_ulong arg)
+                 return -TARGET_ENOSYS;
+ #endif
+             }
+-            if (ie->target_cmd == cmd) {
++            if ((uint16_t)ie->target_cmd == (uint16_t)cmd) {
+                 ioctl_cache[hash] = i;
+ #ifdef TARGET_X86_64
+                 ioctl_cache_unsupported_cmd[hash] = 0;
+-- 
+2.49.0
+

--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=1.6.0
 # Note: 1.5.3-rc1 => 1.5.3~rc1
 VER=${UPSTREAM_VER/-/~}
+REL=1
 # Note: The last source is for installing documentation.
 SRCS="git::commit=tags/${UPSTREAM_VER};copy-repo=true;submodule=false::https://github.com/lat-opensource/lat"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- latx: add a home-grown patch in an attempt to fix Wine 10.x

Package(s) Affected
-------------------

- latx: 1.6.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit latx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
