### PR TITLE
atuin: update to 18.5.0

### DIFF
--- a/app-utils/atuin/spec
+++ b/app-utils/atuin/spec
@@ -1,5 +1,4 @@
-VER=18.4.0
+VER=18.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/atuinsh/atuin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243615"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- atuin: update to 18.5.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- atuin: 18.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit atuin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
