### PR TITLE
Alternatives Fix Survey (Apr. 2025)

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -22,7 +22,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=6
+REL=7
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/02-compiler/beyond
+++ b/app-devel/llvm-19/02-compiler/beyond
@@ -22,7 +22,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,5 +1,5 @@
 VER=19.1.6
-REL=3
+REL=4
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"

--- a/app-devel/llvm-20/02-compiler/beyond
+++ b/app-devel/llvm-20/02-compiler/beyond
@@ -29,7 +29,7 @@ done
 
 cat << EOF > "$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all llvm || true
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
 fi
 EOF
 

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,5 +1,5 @@
 VER=20.1.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::f0a4a240aabc9b056142d14d5478bb6d962aeac549cbd75b809f5499240a8b38"

--- a/lang-java/openjdk-11/autobuild/beyond
+++ b/lang-java/openjdk-11/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=11.0.25-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"

--- a/lang-java/openjdk-17/autobuild/beyond
+++ b/lang-java/openjdk-17/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=17.0.14-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-21/autobuild/beyond
+++ b/lang-java/openjdk-21/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=21.0.6-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-22/autobuild/beyond
+++ b/lang-java/openjdk-22/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-22/spec
+++ b/lang-java/openjdk-22/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=22.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=2
+REL=3
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373785"

--- a/lang-java/openjdk-23/autobuild/beyond
+++ b/lang-java/openjdk-23/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,6 +1,7 @@
 MAJOR_VER=23
 UPSTREAM_VER=23.0.2-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374464"

--- a/lang-java/openjdk-24/autobuild/beyond
+++ b/lang-java/openjdk-24/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-24/spec
+++ b/lang-java/openjdk-24/spec
@@ -1,6 +1,7 @@
 MAJOR_VER=24
 UPSTREAM_VER=24-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376246"

--- a/lang-java/openjdk-8/autobuild/beyond
+++ b/lang-java/openjdk-8/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=8u442-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"

--- a/lang-js/nodejs-20/autobuild/beyond
+++ b/lang-js/nodejs-20/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node || true
+    update-alternatives --remove node /usr/lib/node${NODE_SUFFIX}/bin/node || true
 fi
 EOF
 

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,4 +1,5 @@
 VER=20.18.3
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::0674f16f3bc284c11724cd3f7c2a43f7c2c13d2eb7a872dd0db198f3d588c5f2"
 CHKUPDATE="anitya::id=369796"

--- a/lang-js/nodejs-22/autobuild/beyond
+++ b/lang-js/nodejs-22/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node || true
+    update-alternatives --remove node /usr/lib/node${NODE_SUFFIX}/bin/node || true
 fi
 EOF
 

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.14.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::c609946bf793b55c7954c26582760808d54c16185d79cb2fb88065e52de21914"
 CHKUPDATE="anitya::id=374342"


### PR DESCRIPTION
Topic Description
-----------------

Fix alternatives removal

Package(s) Affected
-------------------

`openjdk-8 openjdk-17 openjdk-21 openjdk-22 openjdk-23 openjdk-24 nodejs-20 nodejs-22 llvm-18 llvm-19 llvm-20`

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjdk-8 openjdk-17 openjdk-21 openjdk-22 openjdk-23 openjdk-24 nodejs-20 nodejs-22 llvm-18 llvm-19 llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
