### PR TITLE
Vulkan SDK 1.4.309.0

### DIFF
--- a/app-utils/vulkan-tools/spec
+++ b/app-utils/vulkan-tools/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"

--- a/groups/vulkan
+++ b/groups/vulkan
@@ -1,8 +1,9 @@
+runtime-display/spirv-headers
+runtime-display/spirv-tools
 runtime-display/vulkan-headers
 runtime-display/vulkan-loader
 runtime-display/vulkan-utility-libraries
 runtime-display/vulkan-validationlayers
-runtime-display/spirv-headers
 runtime-display/volk-meta-loader
 app-utils/vulkan-tools
 runtime-display/vulkan-extensionlayer

--- a/runtime-display/spirv-headers/spec
+++ b/runtime-display/spirv-headers/spec
@@ -1,4 +1,4 @@
-VER=1.4.304.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230542"

--- a/runtime-display/spirv-tools/spec
+++ b/runtime-display/spirv-tools/spec
@@ -1,4 +1,4 @@
-VER=1.4.304.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,4 +1,4 @@
-VER=1.4.304
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.304
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-display/vulkan-extensionlayer/spec
+++ b/runtime-display/vulkan-extensionlayer/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,5 +1,4 @@
-VER=1.3.283.0
-REL=1
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-display/vulkan-utility-libraries/spec
+++ b/runtime-display/vulkan-utility-libraries/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370173"

--- a/runtime-display/vulkan-validationlayers/spec
+++ b/runtime-display/vulkan-validationlayers/spec
@@ -1,4 +1,4 @@
-VER=1.3.283.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ValidationLayers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-optenv32/spirv-tools+32/spec
+++ b/runtime-optenv32/spirv-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.304.0
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"

--- a/runtime-optenv32/volk-meta-loader+32/spec
+++ b/runtime-optenv32/volk-meta-loader+32/spec
@@ -1,5 +1,4 @@
-VER=1.3.283.0
-REL=1
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-optenv32/vulkan-headers+32/spec
+++ b/runtime-optenv32/vulkan-headers+32/spec
@@ -1,5 +1,4 @@
-VER=1.3.283.0
-REL=1
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-optenv32/vulkan-loader+32/spec
+++ b/runtime-optenv32/vulkan-loader+32/spec
@@ -1,5 +1,4 @@
-VER=1.3.283.0
-REL=1
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-optenv32/vulkan-tools+32/autobuild/defines
+++ b/runtime-optenv32/vulkan-tools+32/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=vulkan-tools+32
 PKGSEC=utils
 PKGDEP="aosc-aaa+32 libxkbcommon+32 x11-lib+32 vulkan-loader+32"
-BUILDDEP="devel-base+32 lxml glslang vulkan-headers+32 volk-meta-loader+32"
+# FIXME: vulkan-headers is used to provide the CMake modules needed during the
+# CMake configuration process.
+BUILDDEP="devel-base+32 lxml glslang vulkan-headers vulkan-headers+32 volk-meta-loader+32"
 PKGDES="Vulkan Tools and Utilities (32-bit x86 runtime)"
 
 # FIXME: WSL_WAYLAND requires waylandpp+32

--- a/runtime-optenv32/vulkan-tools+32/spec
+++ b/runtime-optenv32/vulkan-tools+32/spec
@@ -1,5 +1,4 @@
-VER=1.3.283.0
-REL=1
+VER=1.4.309.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"


### PR DESCRIPTION
Topic Description
-----------------

- vulkan-tools: update to 1.4.309.0
- volk-meta-loader: update to 1.4.304
- spirv-headers: update to 1.4.309.0
- vulkan-extensionlayer: update to 1.4.309.0
- vulkan-validationlayers: update to 1.4.309.0
- vulkan-utility-libraries: update to 1.4.309.0
- vulkan-loader: update to 1.4.309.0
- vulkan-headers: update to 1.4.309.0

Package(s) Affected
-------------------

- spirv-headers: 1:1.4.309.0
- volk-meta-loader: 1.4.304
- vulkan-extensionlayer: 1.4.309.0
- vulkan-headers: 1.4.309.0
- vulkan-loader: 1.4.309.0
- vulkan-tools: 1.4.309.0
- vulkan-utility-libraries: 1.4.309.0
- vulkan-validationlayers: 1.4.309.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-utility-libraries vulkan-validationlayers volk-meta-loader vulkan-tools vulkan-extensionlayer
```

For optenv32:

```
/build vulkan-sdk-1.4.309.0 vulkan-headers,spirv-headers,spirv-tools+32,vulkan-headers+32,vulkan-loader+32,vulkan-tools+32,volk-meta-loader+32 amd64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
