### PR TITLE
jh7110-pvr-blobs: add multiple libVK_IMG's

### DIFF
--- a/runtime-display/jh7110-pvr-blobs/autobuild/alternatives
+++ b/runtime-display/jh7110-pvr-blobs/autobuild/alternatives
@@ -1,0 +1,3 @@
+alternative /usr/lib/libVK_IMG.so /usr/lib/libVK_IMG.so.headless 30
+alternative /usr/lib/libVK_IMG.so /usr/lib/libVK_IMG.so.wayland 40
+alternative /usr/lib/libVK_IMG.so /usr/lib/libVK_IMG.so.xorg 50

--- a/runtime-display/jh7110-pvr-blobs/autobuild/build
+++ b/runtime-display/jh7110-pvr-blobs/autobuild/build
@@ -6,6 +6,15 @@ install -Dvm755 \
     "$SRCDIR"/target/usr/lib/{libGLESv1_CM_PVR_MESA,libGLESv2_PVR_MESA,libglslcompiler,libpvr_dri_support,libPVROCL,libPVRScopeServices,libsrv_um,libsutu_display,libufwriter,libusc,libVK_IMG}.so \
     -t "$PKGDIR"/usr/lib/
 
+abinfo "Renaming libVK_IMG.so (the headless variant)..."
+mv -v "$PKGDIR"/usr/lib/libVK_IMG.so{,.headless}
+
+abinfo "Copying extra libVK_IMG.so variants ..."
+for i in xorg wayland; do
+    cp -v "$SRCDIR"/../IMG_GPU-$i/usr/lib/libVK_IMG.so "$PKGDIR"/usr/lib/libVK_IMG.so.$i
+    chmod -v 755 "$PKGDIR"/usr/lib/libVK_IMG.so.$i
+done
+
 abinfo "Copying auxiliary files ..."
 cp -rv "$SRCDIR"/target/lib/firmware/ "$PKGDIR"/usr/lib/
 cp -rv "$SRCDIR"/target/etc/vulkan/ "$PKGDIR"/usr/share/

--- a/runtime-display/jh7110-pvr-blobs/spec
+++ b/runtime-display/jh7110-pvr-blobs/spec
@@ -1,3 +1,8 @@
-VER=1.19.6345021+git20231018
-SRCS="tbl::https://github.com/starfive-tech/soft_3rdpart/raw/1612caa97dd2ade2d51f37f10d314a7a2ac4755d/IMG_GPU/out/img-gpu-powervr-bin-1.19.6345021.tar.gz"
-CHKSUMS="sha256::9dcaf2084b13e59c4e50a4a288f5de56f8e9ee631627a3e818591675bf61311a"
+VER=1.19.6345021+git20231018+debian0.14.0
+SRCS="tbl::https://github.com/starfive-tech/soft_3rdpart/raw/1612caa97dd2ade2d51f37f10d314a7a2ac4755d/IMG_GPU/out/img-gpu-powervr-bin-1.19.6345021.tar.gz \
+      tbl::https://github.com/starfive-tech/Debian/raw/refs/tags/v0.14.0-engineering-release-wayland/gpu/DDK1.19-binary-xorg/IMG_GPU-xorg.tar.gz \
+      tbl::https://github.com/starfive-tech/Debian/raw/refs/tags/v0.14.0-engineering-release-wayland/gpu/DDK1.19-binary-wayland/IMG_GPU-wayland.tar.gz"
+SUBDIR="img-gpu-powervr-bin-1.19.6345021"
+CHKSUMS="sha256::9dcaf2084b13e59c4e50a4a288f5de56f8e9ee631627a3e818591675bf61311a \
+         sha256::fc3cf284bd78c858237abae64379141e4fd112f977d9e4266d89b8f3daf9800e \
+         sha256::6b570a4a922dbfa262118a51b61a6184db4f616fe0c1e571c7416c9a725c747d"


### PR DESCRIPTION
Topic Description
-----------------

- jh7110-pvr-blobs: add multiple libVK_IMG's
    Unfortunately the default libVK_IMG provided by StarFive in the
    soft_3rdpart repository isn't capable of displaying anything \(lacks
    VH_KHR_swapchain extension\). Alternative libVK_IMG files are available
    from the "Debian" repository on their GitHub\(although different files
    are still needed for different window systems\), but these libraries
    looks a little older than the default soft_3rdpart one.
    Install these all libVK_IMG variants and provide alternatives
    configuration. As the default desktop setup of AOSC OS uses X11, default
    to the xorg variant.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- jh7110-pvr-blobs: 1.19.6345021+git20231018+debian0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit jh7110-pvr-blobs
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
