### PR TITLE
fend: update to 1.5.6

### DIFF
--- a/app-utils/fend/spec
+++ b/app-utils/fend/spec
@@ -1,4 +1,4 @@
-VER=1.5.5
+VER=1.5.6
 SRCS="git::commit=tags/v$VER::https://github.com/printfn/fend"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328520"


### PR DESCRIPTION
Topic Description
-----------------

- fend: update to 1.5.6
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- fend: 1.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit fend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
