### PR TITLE
llvm-18: adjust the priority from 50 to 80

### DIFF
--- a/app-devel/llvm-18/02-compiler/beyond
+++ b/app-devel/llvm-18/02-compiler/beyond
@@ -2,7 +2,7 @@
 LLVM_SUFFIX="-${PKGVER%%.*}"
 
 abinfo "Generating postinst scripts ..."
-printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/bin/llvm-config 50' \
+printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/bin/llvm-config 80' \
     "$LLVM_SUFFIX" \
     >> "$SRCDIR/autobuild/postinst"
 for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=7
+REL=8
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-18 : adjust the priority from 50 to 80
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- llvm-18: 18.1.8-8
- llvm-runtime-18: 18.1.8-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
