### PR TITLE
libpwquality: update to 1.4.5

### DIFF
--- a/runtime-cryptography/libpwquality/autobuild/defines
+++ b/runtime-cryptography/libpwquality/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=libpwquality
 PKGSEC=libs
-PKGDEP="cracklib python-2"
+PKGDEP="cracklib python-3"
 PKGDES="Library for password quality checking and generating random passwords"
 
 ABSHADOW=no
+AUTOTOOLS_AFTER=(
+    "--with-python-binary=python3"
+)

--- a/runtime-cryptography/libpwquality/spec
+++ b/runtime-cryptography/libpwquality/spec
@@ -1,4 +1,4 @@
-VER=1.4.2
+VER=1.4.5
 SRCS="tbl::https://github.com/libpwquality/libpwquality/releases/download/libpwquality-$VER/libpwquality-$VER.tar.bz2"
-CHKSUMS="sha256::5263e09ee62269c092f790ac159112aed3e66826a795e3afec85fdeac4281c8e"
+CHKSUMS="sha256::6fcf18b75d305d99d04d2e42982ed5b787a081af2842220ed63287a2d6a10988"
 CHKUPDATE="anitya::id=15580"


### PR DESCRIPTION
Topic Description
-----------------

- libpwquality: update to 1.4.5

Package(s) Affected
-------------------

- libpwquality: 1.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpwquality
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
