### PR TITLE
pyudev: update to 0.24.3

### DIFF
--- a/lang-python/pyudev/autobuild/defines
+++ b/lang-python/pyudev/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pyudev
 PKGSEC=python
-PKGDEP="six systemd"
+PKGDEP="systemd"
 BUILDDEP="setuptools"
 PKGDES="A pure Python binding for libudev"
 

--- a/lang-python/pyudev/spec
+++ b/lang-python/pyudev/spec
@@ -1,5 +1,4 @@
-VER=0.24.1
-REL=1
+VER=0.24.3
 SRCS="git::commit=tags/v$VER::https://github.com/pyudev/pyudev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8485"


### PR DESCRIPTION
Topic Description
-----------------

- pyudev: update to 0.24.3

Package(s) Affected
-------------------

- pyudev: 0.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyudev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
