### PR TITLE
newt: update to 0.52.23, drop python 2 binding

### DIFF
--- a/runtime-common/newt/autobuild/defines
+++ b/runtime-common/newt/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=newt
 PKGSEC=libs
-PKGDEP="gpm popt slang python-2 python-3 tcl"
+PKGDEP="gpm popt slang python-3 tcl"
 PKGDEP__RETRO="gpm popt slang"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -17,12 +17,13 @@ PKGPROV="whiptail"
 # FIXME: Makefile reads hard-coded "$SRCDIR"/configure.ac (in relative path)
 # for some reason.
 ABSHADOW=0
+NOPYTHON2=1
+
 AUTOTOOLS_AFTER="--enable-largefile \
                  --enable-nls \
                  --with-python \
                  --with-tcl \
-                 --with-gpm-support \
-                 PYTHON=/usr/bin/python3"
+                 --with-gpm-support"
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \
                  --without-python \

--- a/runtime-common/newt/autobuild/patch
+++ b/runtime-common/newt/autobuild/patch
@@ -1,2 +1,0 @@
-sed -i "s:tcl8.4:tcl8.6:" Makefile.in
-echo '#define USE_INTERP_RESULT 1' >> config.h

--- a/runtime-common/newt/spec
+++ b/runtime-common/newt/spec
@@ -1,4 +1,4 @@
-VER=0.52.23
+VER=0.52.25
 SRCS="tbl::https://pagure.io/releases/newt/newt-$VER.tar.gz"
-CHKSUMS="sha256::caa372907b14ececfe298f0d512a62f41d33b290610244a58aed07bbc5ada12a"
+CHKSUMS="sha256::ef0ca9ee27850d1a5c863bb7ff9aa08096c9ed312ece9087b30f3a426828de82"
 CHKUPDATE="anitya::id=15129"


### PR DESCRIPTION
Topic Description
-----------------

- newt: update to 0.52.23, drop python 2 binding

Package(s) Affected
-------------------

- newt: 0.52.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit newt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
