### PR TITLE
gtk-4: update to 4.19.0

### DIFF
--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,4 @@
-VER=4.16.12
+VER=4.19.0
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
-CHKSUMS="sha256::ef31bdbd6f082c4401634a20c850b0050c9bf252ef1e079764ee95a2a0c4c95a"
+CHKSUMS="sha256::6473af432f5d73c876603b810d55a440d1e6153f00c52af3498f5a7642569ed6"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-4: update to 4.19.0
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- gtk-4: 1:4.19.0
- gtk-update-icon-cache: 4.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
