### PR TITLE
tinty: new, 0.27.0

### DIFF
--- a/app-utils/tinty/autobuild/beyond
+++ b/app-utils/tinty/autobuild/beyond
@@ -1,0 +1,9 @@
+abinfo "Installing shell completions"
+install -Dvm644 "${SRCDIR}"/contrib/completion/tinty.bash "${PKGDIR}"/usr/share/bash-completion/completions/tinty
+install -Dvm644 "${SRCDIR}"/contrib/completion/tinty.fish "${PKGDIR}"/usr/share/fish/vendor_completions.d/tinty.fish
+install -Dvm644 "${SRCDIR}"/contrib/completion/tinty.zsh "${PKGDIR}"/usr/share/zsh/site-functions/_tinty
+install -Dvm644 "${SRCDIR}"/contrib/completion/tinty.elvish "${PKGDIR}"/usr/share/elvish/lib/tinty.elv
+
+abinfo "Installing docs"
+install -Dvm644 "${SRCDIR}"/USAGE.md "${PKGDIR}"/usr/share/doc/tinty/USAGE.md
+install -Dvm644 "${SRCDIR}"/example.toml "${PKGDIR}"/usr/share/doc/tinty/config.toml.example

--- a/app-utils/tinty/autobuild/defines
+++ b/app-utils/tinty/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=tinty
+PKGSEC=utils
+PKGDES="A base16 and base24 color scheme manager"
+BUILDDEP="rustc llvm"
+PKGDEP="gcc-runtime git glibc"
+
+ABTYPE=rust
+
+# FIXME: ld.lld is not yet available for loongson3.
+# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
+# recompile with -fPIC
+NOLTO__LOONGSON3=1

--- a/app-utils/tinty/spec
+++ b/app-utils/tinty/spec
@@ -1,0 +1,4 @@
+VER=0.27.0
+SRCS="git::commit=tags/v${VER}::https://github.com/tinted-theming/tinty"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377749"


### PR DESCRIPTION
Topic Description
-----------------

- tinty: new, 0.27.0

Package(s) Affected
-------------------

- tinty: 0.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tinty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
