### PR TITLE
greetd-regreet: add default config for sway and niri

### DIFF
--- a/desktop-displaymanagers/greetd-regreet/autobuild/overrides/etc/greetd/regreet-niri.kdl
+++ b/desktop-displaymanagers/greetd-regreet/autobuild/overrides/etc/greetd/regreet-niri.kdl
@@ -1,0 +1,8 @@
+spawn-at-startup "regreet"
+hotkey-overlay {
+    skip-at-startup
+}
+
+// Add the following code to /etc/greetd/config.toml
+// [default_session]
+// command = "niri --config /etc/greetd/regreet-niri.kdl"

--- a/desktop-displaymanagers/greetd-regreet/autobuild/overrides/etc/greetd/regreet-sway
+++ b/desktop-displaymanagers/greetd-regreet/autobuild/overrides/etc/greetd/regreet-sway
@@ -1,0 +1,6 @@
+exec "regreet; swaymsg exit"
+include /etc/sway/config.d/*
+
+# Add the following code to /etc/greetd/config.toml
+# [default_session]
+# command = "sway --config /etc/greetd/regreet-sway"

--- a/desktop-displaymanagers/greetd-regreet/spec
+++ b/desktop-displaymanagers/greetd-regreet/spec
@@ -2,3 +2,4 @@ VER=0.2.0
 SRCS="git::commit=tags/${VER}::https://github.com/rharish101/ReGreet"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377619"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- greetd-regreet: add default config for sway and niri

Package(s) Affected
-------------------

- greetd-regreet: 0.2.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit greetd-regreet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
