### PR TITLE
Alternatives Fixes (Apr. 2025)

### DIFF
--- a/lang-js/nodejs-20/autobuild/beyond
+++ b/lang-js/nodejs-20/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node || true
+    update-alternatives --remove node /usr/lib/node${NODE_SUFFIX}/bin/node || true
 fi
 EOF
 

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,4 +1,5 @@
 VER=20.18.3
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::0674f16f3bc284c11724cd3f7c2a43f7c2c13d2eb7a872dd0db198f3d588c5f2"
 CHKUPDATE="anitya::id=369796"

--- a/lang-js/nodejs-22/autobuild/beyond
+++ b/lang-js/nodejs-22/autobuild/beyond
@@ -10,7 +10,7 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all node || true
+    update-alternatives --remove node /usr/lib/node${NODE_SUFFIX}/bin/node || true
 fi
 EOF
 

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.14.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::c609946bf793b55c7954c26582760808d54c16185d79cb2fb88065e52de21914"
 CHKUPDATE="anitya::id=374342"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: fix alternatives removal
- nodejs-20: fix alternatives removal

Package(s) Affected
-------------------

- nodejs-20: 20.18.3-1
- nodejs-22: 22.14.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-20 nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
