### PR TITLE
osdlyrics: fix Python version used

### DIFF
--- a/app-multimedia/osdlyrics/autobuild/defines
+++ b/app-multimedia/osdlyrics/autobuild/defines
@@ -5,3 +5,6 @@ BUILDDEP="intltool"
 PKGDES="Standalone lyrics fetcher/displayer"
 PKGEPOCH=1
 ABSHADOW=0
+
+ABTYPE=autotools
+AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"

--- a/app-multimedia/osdlyrics/spec
+++ b/app-multimedia/osdlyrics/spec
@@ -1,4 +1,5 @@
 VER=0.5.15
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/osdlyrics/osdlyrics"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230945"


### PR DESCRIPTION
Topic Description
-----------------

- osdlyrics: manually specify PYTHON to python3
    We didn't have dbus-python for Python 2 any longer and OSD Lyrics
    upstream dropped support for Python 2 in 0.5.15.
    However, our system still default to Python 2, which leads to a
    non-working osdlyrics-daemon \(running with /usr/bin/python2\).
    Explicitly specify PYTHON=/usr/bin/python3 as AUTOTOOLS_AFTER to force
    the use of Python 3.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- osdlyrics: 1:0.5.15-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit osdlyrics
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
