### PR TITLE
OpenJDK Survey (Apr. 2025)

### DIFF
--- a/lang-java/openjdk-11/autobuild/beyond
+++ b/lang-java/openjdk-11/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=11.0.25-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"

--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=11.0.25-ga
-REL=1
+UPSTREAM_VER=11.0.27-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"

--- a/lang-java/openjdk-17/autobuild/beyond
+++ b/lang-java/openjdk-17/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=17.0.14-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=17.0.14-ga
-REL=1
+UPSTREAM_VER=17.0.15-ga
 VER=${UPSTREAM_VER/-/+}
-SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
+SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235001"

--- a/lang-java/openjdk-21/autobuild/beyond
+++ b/lang-java/openjdk-21/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=21.0.6-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=21.0.6-ga
-REL=1
+UPSTREAM_VER=21.0.7-ga
 VER=${UPSTREAM_VER/-/+}
-SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
+SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369281"

--- a/lang-java/openjdk-22/autobuild/beyond
+++ b/lang-java/openjdk-22/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-22/spec
+++ b/lang-java/openjdk-22/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=22.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=2
+REL=3
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373785"

--- a/lang-java/openjdk-22/spec
+++ b/lang-java/openjdk-22/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=22.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=3
-SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
+REL=4
+SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373785"

--- a/lang-java/openjdk-23/autobuild/beyond
+++ b/lang-java/openjdk-23/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,6 +1,7 @@
 MAJOR_VER=23
 UPSTREAM_VER=23.0.2-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374464"

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,7 +1,7 @@
 MAJOR_VER=23
 UPSTREAM_VER=23.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
-SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk"
+REL=2
+SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374464"

--- a/lang-java/openjdk-24/autobuild/beyond
+++ b/lang-java/openjdk-24/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-24/spec
+++ b/lang-java/openjdk-24/spec
@@ -1,6 +1,7 @@
 MAJOR_VER=24
 UPSTREAM_VER=24-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376246"

--- a/lang-java/openjdk-24/spec
+++ b/lang-java/openjdk-24/spec
@@ -1,7 +1,6 @@
 MAJOR_VER=24
-UPSTREAM_VER=24-ga
+UPSTREAM_VER=24.0.1-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376246"

--- a/lang-java/openjdk-8/autobuild/beyond
+++ b/lang-java/openjdk-8/autobuild/beyond
@@ -11,7 +11,8 @@ done
 
 cat <<EOF >"$SRCDIR/autobuild/postrm"
 if [ "\$1" != "upgrade" ]; then
-    update-alternatives --remove-all java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
 fi
 EOF
 

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=8u442-ga
+REL=1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=8u442-ga
-REL=1
+UPSTREAM_VER=8u452-ga
 VER=${UPSTREAM_VER/-/+}
-SRCS="git::commit=aosc/8/${UPSTREAM_VER}::https://github.com/AOSC-Tracking/jdk.git"
+SRCS="git::commit=aosc/8/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17307"

--- a/topics/openjdk-security-2025-apr.toml
+++ b/topics/openjdk-security-2025-apr.toml
@@ -7,7 +7,7 @@ zh_CN = "OpenJDK 安全更新（2025 年 4 月）"
 
 [caution]
 default = "Fixes over 20 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - April 2025 (multiple of high severity)"
-zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的逾 20 个安装漏洞（含多个高危漏洞）"
+zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的逾 20 个安全漏洞（含多个高危漏洞）"
 
 [packages]
 "openjdk-8" = "8u452+ga"

--- a/topics/openjdk-security-2025-apr.toml
+++ b/topics/openjdk-security-2025-apr.toml
@@ -1,0 +1,17 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenJDK Security Updates (April, 2025)"
+zh_CN = "OpenJDK 安全更新（2025 年 4 月）"
+
+[caution]
+default = "Fixes over 20 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - April 2025 (multiple of high severity)"
+zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的逾 20 个安装漏洞（含多个高危漏洞）"
+
+[packages]
+"openjdk-8" = "8u452+ga"
+"openjdk-11" = "11.0.27+ga"
+"openjdk-17" = "17.0.15+ga"
+"openjdk-21" = "21.0.7+ga"
+"openjdk-24" = "24.0.1+ga"

--- a/topics/virtualbox-7.1.8.toml
+++ b/topics/virtualbox-7.1.8.toml
@@ -5,7 +5,7 @@ default = "Oracle VM VirtualBox 7.1.8"
 
 [caution]
 default = "Fixes 3 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - April 2025 (1 of high severity)"
-zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的 3 个安装漏洞（含 1 个高危漏洞）"
+zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的 3 个安全漏洞（含 1 个高危漏洞）"
 
 [packages]
 "virtualbox" = "7.1.8"

--- a/topics/virtualbox-7.1.8.toml
+++ b/topics/virtualbox-7.1.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Oracle VM VirtualBox 7.1.8"
+
+[caution]
+default = "Fixes 3 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - April 2025 (1 of high severity)"
+zh_CN = "修复 Oracle 重要更新公告（2025 年 4 月）中披露的 3 个安装漏洞（含 1 个高危漏洞）"
+
+[packages]
+"virtualbox" = "7.1.8"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-8: update to 8u452+ga
    - Security update \(OpenJDK Security Advisory 2025/04/15\)
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/8/8u452-ga/0
    Tag: 55c7e096a52d3fddfc1d398ff077a7c029ceb2e7
    HEAD: 512acbcb121b42e8a7af78dc5fcd55e6db02691c
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-24: update to 24.0.1+ga
    - Security update \(OpenJDK Security Advisory 2025/04/15\)
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/24/24.0.1-ga/0
    Tag: 5cbe5ad1e8a0e407d677959c2aced7db9c424b62
    HEAD: 83087c2716834d9a3c16aa3da46d5290ffe24b9a
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-23: update to 23.0.2+ga
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/23/23.0.2-ga/2
    Tag: 243592cc5b3a25d3a8383d19625cde1e9420ec5f
    HEAD: 7ee849a5d928f9ba8fd9bfecb343a54b6427a41d
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-22: update to 22.0.2+ga
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/22/22.0.2-ga/4
    Tag: 59531a8ed7b374d5ae3fa8a9f8688310df4f30aa
    HEAD: 210e64af7f962872ee45039e4b7f2148c902914a
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-21: update to 21.0.7+ga
    - Security update \(OpenJDK Security Advisory 2025/04/15\)
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/21/21.0.7-ga/0
    Tag: 7021ebee95436e4e83afe8b5d6a4a537f82dd09b
    HEAD: 9fc517c211ddef475dd201ad62b9a68648c814f1
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-17: update to 17.0.15+ga
    - Security update \(OpenJDK Security Advisory 2025/04/15\)
    - Extend default thread stack size for zero variants
    - Track patches at AOSC-Tracking/jdk @ aosc/17/17.0.15-ga/0
    Tag: 19a599ddb82dd9a1fcc83bb9f14bc08d63ada790
    HEAD: 6d0f909392d369e203ed57ea1682562cc5640b60
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-11: update to 11.0.27+ga
    - Security update \(OpenJDK Security Advisory 2025/04/15\)
    - Extend default thread stack size for zero variants
- openjdk-24: fix alternatives removal
    - Track patches at AOSC-Tracking/jdk @ aosc/24/24-ga/1
    Tag: 6fb4116251fd579c7363a5248652c177a9eb1674
    HEAD: a233b420435fd9c6581549ef6884a36f5ef05396
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-23: fix alternatives removal
    - Track patches at AOSC-Tracking/jdk @ aosc/23/23.0.2-ga/1
    Tag: 6d50ec5c4bea0d2ed85401af711d1e2880c3fede
    HEAD: 97799214da298b5fb6bf31d74b46367c10561b41
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)
- openjdk-22: fix alternatives removal
    - Track patches at AOSC-Tracking/jdk @ aosc/22/22.0.2-ga/3
    Tag: 4a86f1f365eb1158e6bcd538566daaf03855c73c
    HEAD: a8c76b278265644dc5b0c9b16be452f923879710
    Signed by xtex <xtex@xtexx.eu.org> \(7231804B052C670F15A6771DB918086ED8045B91\)

... and 3 more commits

Package(s) Affected
-------------------

- openjdk-11: 3:11.0.27+ga
- openjdk-17: 3:17.0.15+ga
- openjdk-21: 3:21.0.7+ga
- openjdk-22: 3:22.0.2+ga-4
- openjdk-23: 3:23.0.2+ga-2
- openjdk-24: 24.0.1+ga
- openjdk-8: 3:8u452+ga

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/10544

Build Order
-----------

```
#buildit openjdk-8 openjdk-11 openjdk-17 openjdk-21 openjdk-22 openjdk-23 openjdk-24
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
