### PR TITLE
opentofu: new, 1.9.1


### DIFF
--- a/app-admin/opentofu/autobuild/defines
+++ b/app-admin/opentofu/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=opentofu
+PKGSEC=admin
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="A declarative cloud infrastructure management tool"
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
+ABSPLITDBG=0
+
+GO_PACKAGES=('cmd/tofu')
+GO_LDFLAGS=("-X main.version=$PKGVER" "-X github.com/opentofu/opentofu/version.dev=no")

--- a/app-admin/opentofu/spec
+++ b/app-admin/opentofu/spec
@@ -1,0 +1,4 @@
+VER=1.9.1
+SRCS="git::commit=tags/v${VER}::https://github.com/opentofu/opentofu.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371292"


### PR DESCRIPTION
Topic Description
-----------------

- opentofu: new, 1.9.1

Package(s) Affected
-------------------

- opentofu: 1.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentofu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
