### PR TITLE
e2fsprogs: Provide compatibility names for Ubuntu

### DIFF
--- a/app-admin/e2fsprogs/autobuild/defines
+++ b/app-admin/e2fsprogs/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=e2fsprogs
 PKGSEC=utils
 PKGDEP="glibc"
 PKGDES="Ext2/3/4 filesystem utilities"
+PKGPROV="libcom-err2_spiral comerr-dev_spiral libcomerr2_spiral"
 
 ABSHADOW=0
 NOSTATIC=0

--- a/app-admin/e2fsprogs/spec
+++ b/app-admin/e2fsprogs/spec
@@ -2,3 +2,4 @@ VER=1.47.2
 SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=646"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

In Ubuntu >= 18, the libcom-err2 and libcomerr-dev packages are separated from e2fsprogs.

In Ubuntu <= 16, it's named libcomerr2 (without "-") instead, and in Ubuntu 18 it's a dummy package depending on libcom-err2.

Provide those compatibility names as an attempt to satisfy Ubuntu packages.

Package(s) Affected
-------------------

- e2fsprogs: 1.47.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit e2fsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
