### PR TITLE
libadwaita: update to 1.7.2

### DIFF
--- a/desktop-gnome/libadwaita/spec
+++ b/desktop-gnome/libadwaita/spec
@@ -1,4 +1,4 @@
-VER=1.6.4
+VER=1.7.2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libadwaita/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234898"


### PR DESCRIPTION
Topic Description
-----------------

- libadwaita: update to 1.7.2
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- libadwaita: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libadwaita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
