### PR TITLE
e2fsprogs: add libcomerr2 spiral alias

### DIFF
--- a/app-admin/e2fsprogs/autobuild/defines
+++ b/app-admin/e2fsprogs/autobuild/defines
@@ -59,3 +59,6 @@ AUTOTOOLS_AFTER__RETRO=" \
 MAKE_INSTALL_AFTER="-j1"
 
 RECONF=0
+
+# Note: Extra Provides for Spiral (Debian compatibility).
+PKGPROV="libcomerr2_spiral"

--- a/app-admin/e2fsprogs/spec
+++ b/app-admin/e2fsprogs/spec
@@ -1,4 +1,5 @@
 VER=1.47.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=646"


### PR DESCRIPTION
Topic Description
-----------------

- e2fsprogs: add libcomerr2 spiral alias

Package(s) Affected
-------------------

- e2fsprogs: 1.47.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit e2fsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
