### PR TITLE
openblas: Add another power8 fix patch

### DIFF
--- a/app-scientific/openblas/autobuild/patches/0002-Restore-the-non-vectorized-code-from-before-PR4880-f.patch
+++ b/app-scientific/openblas/autobuild/patches/0002-Restore-the-non-vectorized-code-from-before-PR4880-f.patch
@@ -1,24 +1,24 @@
-From 0d513a9bfe1c083a6702b3f8984b64ef54592ab7 Mon Sep 17 00:00:00 2001
+From 7c9ec7dab26bb24626af58d2d34cd0d999e26f38 Mon Sep 17 00:00:00 2001
 From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
-Date: Wed, 12 Feb 2025 09:07:20 +0100
-Subject: [PATCH 1/2] Restore the non-vectorized code from before PR4880 for
+Date: Wed, 12 Feb 2025 09:04:22 +0100
+Subject: [PATCH 2/2] Restore the non-vectorized code from before PR4880 for
  POWER8
 
-(cherry picked from commit 81eed868b68c72ea1868663902f0904dc1b22326)
+(cherry picked from commit 98b5ef929cfc98f2f3c236966830276c255118d2)
 ---
- kernel/power/sgemv_t_8.c | 24 ++++++++++++++++++++----
- 1 file changed, 20 insertions(+), 4 deletions(-)
+ kernel/power/sgemv_t.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
 
-diff --git a/kernel/power/sgemv_t_8.c b/kernel/power/sgemv_t_8.c
-index f21f6eb7d..b30bb1137 100644
---- a/kernel/power/sgemv_t_8.c
-+++ b/kernel/power/sgemv_t_8.c
-@@ -99,7 +99,17 @@ static void sgemv_kernel_8x8(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
-             temp7 += vx1* va7_1 + vx2 * va7_2;  
+diff --git a/kernel/power/sgemv_t.c b/kernel/power/sgemv_t.c
+index e133c815c..ed0a24230 100644
+--- a/kernel/power/sgemv_t.c
++++ b/kernel/power/sgemv_t.c
+@@ -78,7 +78,17 @@ static void sgemv_kernel_4x8(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
+             temp7 += v_x[i] * va7[i]; 
          }
      
 -  
-+  #if defined(POWER8)
++ #if defined(POWER8)
 +    y[0] += alpha * (temp0[0] + temp0[1]+temp0[2] + temp0[3]);
 +    y[1] += alpha * (temp1[0] + temp1[1]+temp1[2] + temp1[3]);
 +    y[2] += alpha * (temp2[0] + temp2[1]+temp2[2] + temp2[3]);
@@ -32,7 +32,7 @@ index f21f6eb7d..b30bb1137 100644
      register __vector float t0, t1, t2, t3;
      register __vector float a = { alpha, alpha, alpha, alpha };
       __vector float *v_y = (__vector float*) y;
-@@ -126,7 +136,7 @@ static void sgemv_kernel_8x8(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
+@@ -105,7 +115,7 @@ static void sgemv_kernel_4x8(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
  
      v_y[0] += a * temp0;
      v_y[1] += a * temp4;
@@ -41,12 +41,11 @@ index f21f6eb7d..b30bb1137 100644
  }
   
  
-@@ -153,7 +163,13 @@ static void sgemv_kernel_8x4(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
-         temp2 += v_x[i] * va2[i] + v_x[i+1] * va2[i+1];
-         temp3 += v_x[i] * va3[i] + v_x[i+1] * va3[i+1]; 
+@@ -132,7 +142,12 @@ static void sgemv_kernel_4x4(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
+         temp2 += v_x[i] * va2[i];
+         temp3 += v_x[i] * va3[i]; 
      }
 - 
-+
 + #if defined(POWER8)
 +    y[0] += alpha * (temp0[0] + temp0[1]+temp0[2] + temp0[3]);
 +    y[1] += alpha * (temp1[0] + temp1[1]+temp1[2] + temp1[3]);
@@ -56,7 +55,7 @@ index f21f6eb7d..b30bb1137 100644
      register __vector float t0, t1, t2, t3;
      register __vector float a = { alpha, alpha, alpha, alpha };
       __vector float *v_y = (__vector float*) y;
-@@ -169,7 +185,7 @@ static void sgemv_kernel_8x4(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
+@@ -148,7 +163,7 @@ static void sgemv_kernel_4x4(BLASLONG n, BLASLONG lda, FLOAT *ap, FLOAT *x, FLOA
      temp0 += temp1 + temp2 + temp3;
  
      v_y[0] += a * temp0;

--- a/app-scientific/openblas/spec
+++ b/app-scientific/openblas/spec
@@ -2,3 +2,4 @@ VER=0.3.29
 SRCS="git::commit=tags/v$VER::https://github.com/xianyi/OpenBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2540"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

The upstream has two power8 fix commits with the same subject (?!) but I only picked one in #9281.  Add another one.

Manually tested on power8.

Package(s) Affected
-------------------

- openblas: 0.3.29-1

Security Update?
----------------

No

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

Build Order

```
#buildit openblas
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
