### PR TITLE
oma: update to 1.16.3

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,5 +1,4 @@
-VER=1.16.2
-REL=1
+VER=1.16.3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.16.3

Package(s) Affected
-------------------

- oma: 1.16.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



