### PR TITLE
lfortran: update to 0.51.0

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -1,26 +1,32 @@
 PKGNAME=lfortran
 PKGSEC=devel
-PKGDEP="gcc-runtime glibc libunwind llvm ncurses python-3"
-BUILDDEP="fmt libunwind llvm python-3 re2c zlib-static zstd-static"
+# Note: LLVM 20 is required since lfortran built with LLVM 18 crashes on loongarch64.
+# ...
+# >>> real :: a = 10
+# >>> a + 10
+# Program received signal SIGSEGV, Segmentation fault.
+# 0x00005555571d4ac4 in llvm::RuntimeDyldELF::computePlaceholderAddress(unsigned int, unsigned long) const ()
+PKGDEP="gcc-runtime glibc libunwind llvm-20 ncurses python-3"
+BUILDDEP="fmt libunwind llvm-20 python-3 re2c zlib-static zstd-static"
 PKGDES="Interactive LLVM-based Fortran compiler"
 
 ABTYPE=cmakeninja
+
 CMAKE_AFTER=" \
-    -DLLVM_DIR=$(llvm-config --cmakedir) \
     -DWITH_FMT=yes \
     -DWITH_LLVM=yes \
     -DWITH_RUNTIME_LIBRARY=yes \
-    -DWITH_RUNTIME_STACKTRACE=yes
+    -DWITH_RUNTIME_STACKTRACE=yes \
     -DWITH_STACKTRACE=yes \
     -DWITH_TARGET_WASM=no \
     -DWITH_UNWIND=yes \
     -DWITH_WHEREAMI=yes \
-    -DWITH_ZLIB=yes \
 "
-
-# FIXME: operations on real data type may cause segfault or incorrect results on loongarch64.
-# GitHub issue link: https://github.com/lfortran/lfortran/issues/5405
-FAIL_ARCH="loongarch64"
+# FIXME: enabling zlib requires LTO.
+CMAKE_AFTER__LOONGSON3=" \
+    ${CMAKE_AFTER} \
+    -DWITH_ZLIB=no \
+"
 
 # Note: prevent OOM errors.
 NOLTO__LOONGSON3=1

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.49.0
+VER=0.51.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::a9225fd33d34ce786f72a964a1179579caff62dd176a6a1477d2594fecdc7cd6"
+CHKSUMS="sha256::d7f81c13825e2d22fb10a8c8f2a37e10f0df2509f31132b4f6d51d8f6475b127"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.51.0
    - Enable loongarch64 support now that builds and execution produce correct results.

Package(s) Affected
-------------------

- lfortran: 0.51.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
