### PR TITLE
stress-ng: update to 0.18.12

### DIFF
--- a/app-benchmarks/stress-ng/spec
+++ b/app-benchmarks/stress-ng/spec
@@ -1,4 +1,4 @@
-VER=0.18.11
+VER=0.18.12
 SRCS="git::commit=tags/V${VER}::https://github.com/ColinIanKing/stress-ng.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12538"


### PR DESCRIPTION
Topic Description
-----------------

- stress-ng: update to 0.18.12
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- stress-ng: 0.18.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
