### PR TITLE
apache-maven: update to 3.9.9

### DIFF
--- a/lang-java/apache-maven/spec
+++ b/lang-java/apache-maven/spec
@@ -1,5 +1,5 @@
-VER=3.9.8
+VER=3.9.9
 SRCS="tbl::https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$VER/apache-maven-${VER}-src.tar.gz"
-CHKSUMS="sha256::c035591b9238d6832c19ad6e56506631f6330ad5c53868a80fdd5eaea365a467"
+CHKSUMS="sha256::8a24c448d4ac397e6b0c019a4d7250068c02d1cdb553299e6bb71c3ccca78b2c"
 CHKUPDATE="anitya::id=1894"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- apache-maven: update to 3.9.9
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- apache-maven: 3.9.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit apache-maven
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
