### PR TITLE
gnuchess: update to 6.2.11

### DIFF
--- a/app-games/gnuchess/autobuild/defines
+++ b/app-games/gnuchess/autobuild/defines
@@ -2,3 +2,7 @@ PKGNAME=gnuchess
 PKGSEC=games
 PKGDEP="glibc"
 PKGDES="Play chess against the computer on a terminal and an engine for graphical chess frontends"
+
+# FIXME: Hard-coded script paths.
+# make[1]: *** No rule to make target '/config.status', needed by 'Makefile'. Stop. 
+ABSHADOW=0

--- a/app-games/gnuchess/spec
+++ b/app-games/gnuchess/spec
@@ -1,4 +1,4 @@
-VER=6.2.9
+VER=6.2.11
 SRCS="tbl::https://ftp.gnu.org/gnu/chess/gnuchess-$VER.tar.gz"
-CHKSUMS="sha256::ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890"
+CHKSUMS="sha256::d81140eea5c69d14b0cfb63816d4b4c9e18fba51f5267de5b1539f468939e9bd"
 CHKUPDATE="anitya::id=1206"


### PR DESCRIPTION
Topic Description
-----------------

- gnuchess: update to 6.2.11
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gnuchess: 6.2.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnuchess
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
