### PR TITLE
gperf: update to 3.3

### DIFF
--- a/app-utils/gperf/spec
+++ b/app-utils/gperf/spec
@@ -1,4 +1,4 @@
-VER=3.2
+VER=3.3
 SRCS="tbl::https://ftp.gnu.org/gnu/gperf/gperf-$VER.tar.gz"
-CHKSUMS="sha256::e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62"
+CHKSUMS="sha256::fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8"
 CHKUPDATE="anitya::id=1237"


### PR DESCRIPTION
Topic Description
-----------------

- gperf: update to 3.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gperf: 3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gperf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
