### PR TITLE
libvpl: update to 2023.4.0

### DIFF
--- a/runtime-multimedia/libvpl/spec
+++ b/runtime-multimedia/libvpl/spec
@@ -1,4 +1,4 @@
-VER=2.14.0
+VER=2023.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242664"


### PR DESCRIPTION
Topic Description
-----------------

- libvpl: update to 2023.4.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libvpl: 2023.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvpl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
