### PR TITLE
chromium: update to 135.0.7049.95

### DIFF
--- a/app-web/chromium/autobuild/patches/0001-FEDORA-Set-intial-prefs-path-to-etc-chromium.patch
+++ b/app-web/chromium/autobuild/patches/0001-FEDORA-Set-intial-prefs-path-to-etc-chromium.patch
@@ -1,4 +1,4 @@
-From 1d70d552a8b42629ce46772ca0bff2fb1195d2d3 Mon Sep 17 00:00:00 2001
+From 0c065b9663086186153c1ef36e82c3762c1a7db3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:02:40 +0800
 Subject: [PATCH 01/14] FEDORA: Set intial prefs path to /etc/chromium

--- a/app-web/chromium/autobuild/patches/0002-FEDORA-third_party-zlib-Drop-dependency-to-chromecon.patch
+++ b/app-web/chromium/autobuild/patches/0002-FEDORA-third_party-zlib-Drop-dependency-to-chromecon.patch
@@ -1,4 +1,4 @@
-From 026b61111c43d6368e02219ea8663bdd4c57fd86 Mon Sep 17 00:00:00 2001
+From 8dbf5343dcf4f9954c51ecac3bdf2e36f0bb6d9d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:04:35 +0800
 Subject: [PATCH 02/14] FEDORA: third_party/zlib: Drop dependency to

--- a/app-web/chromium/autobuild/patches/0003-FEDORA-Hard-code-std-hardware_destructive_interferen.patch
+++ b/app-web/chromium/autobuild/patches/0003-FEDORA-Hard-code-std-hardware_destructive_interferen.patch
@@ -1,4 +1,4 @@
-From 8214f63a935aec40f7b8ae66532063e2aa9a96cf Mon Sep 17 00:00:00 2001
+From 3fa141f714b08ce476640ce10735927b66cedd50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 24 Dec 2024 07:25:22 -0800
 Subject: [PATCH 03/14] FEDORA: Hard-code

--- a/app-web/chromium/autobuild/patches/0004-AOSCOS-media-enable-VA-API-decoding-encoding-by-defa.patch
+++ b/app-web/chromium/autobuild/patches/0004-AOSCOS-media-enable-VA-API-decoding-encoding-by-defa.patch
@@ -1,4 +1,4 @@
-From 4925d4c924e5f6ecd1c5175b744ecdefc64ab125 Mon Sep 17 00:00:00 2001
+From a33e31e73cc13e189222510c064b5fa85e8e6aae Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:29:50 +0800
 Subject: [PATCH 04/14] AOSCOS: media: enable VA-API decoding/encoding by

--- a/app-web/chromium/autobuild/patches/0005-AOSCOS-build-fix-invalid-flag-substitutions.patch
+++ b/app-web/chromium/autobuild/patches/0005-AOSCOS-build-fix-invalid-flag-substitutions.patch
@@ -1,4 +1,4 @@
-From 736174f933a4209c260a9b6265caa1831eb4f0a2 Mon Sep 17 00:00:00 2001
+From 254ccc8047611648093b5b834da81e73d4677a43 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 21:55:40 +0800
 Subject: [PATCH 05/14] AOSCOS: build: fix invalid flag substitutions

--- a/app-web/chromium/autobuild/patches/0006-AOSCOS-build-correct-Clang-builtins-path.patch
+++ b/app-web/chromium/autobuild/patches/0006-AOSCOS-build-correct-Clang-builtins-path.patch
@@ -1,4 +1,4 @@
-From ac8b809304441406d148eb3b0031b6853d4e6fdf Mon Sep 17 00:00:00 2001
+From 45b43315b6aac17c214096aef824a35136576161 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 9 Apr 2025 11:07:13 +0800
 Subject: [PATCH 06/14] AOSCOS: build: correct Clang builtins path

--- a/app-web/chromium/autobuild/patches/0007-AOSCOS-blink-fix-build-with-gperf-3.2.patch
+++ b/app-web/chromium/autobuild/patches/0007-AOSCOS-blink-fix-build-with-gperf-3.2.patch
@@ -1,4 +1,4 @@
-From 7e2c19062545e805c3bc10967fefe803f77aa87b Mon Sep 17 00:00:00 2001
+From 4d73e1c25d9c9a7b546a40b4c98e35d454c8be5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 8 Apr 2025 14:54:04 +0800
 Subject: [PATCH 07/14] AOSCOS: blink: fix build with gperf 3.2

--- a/app-web/chromium/autobuild/patches/0008-AOSCOS-third_party-swiftshader-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0008-AOSCOS-third_party-swiftshader-add-LoongArch-support.patch
@@ -1,4 +1,4 @@
-From 8a2f7f3be1e9597d8e0004198892dd72e37db0b1 Mon Sep 17 00:00:00 2001
+From 84422e8afa2aebdcba7c09c3b7b8406b45785d19 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 23:29:42 +0800
 Subject: [PATCH 08/14] AOSCOS: third_party/swiftshader: add LoongArch support

--- a/app-web/chromium/autobuild/patches/0009-AOSCOS-sandbox-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0009-AOSCOS-sandbox-add-LoongArch-support.patch
@@ -1,4 +1,4 @@
-From 312d59feaa5de0902de1029d11799cf472cf09a8 Mon Sep 17 00:00:00 2001
+From 9589d1036dd1bd9c4ac695e80ee10f408dc98b7e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:22:01 +0800
 Subject: [PATCH 09/14] AOSCOS: sandbox: add LoongArch support

--- a/app-web/chromium/autobuild/patches/0010-AOSCOS-third_party-crashpad-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0010-AOSCOS-third_party-crashpad-add-LoongArch-support.patch
@@ -1,4 +1,4 @@
-From b280c6c4ab49e49de718ffb449cccb247c7ade38 Mon Sep 17 00:00:00 2001
+From 350c27390c4866abf01e4e9e69f88baf02f305ec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:23:21 +0800
 Subject: [PATCH 10/14] AOSCOS: third_party/crashpad: add LoongArch support

--- a/app-web/chromium/autobuild/patches/0011-AOSCOS-third_party-dav1d-add-LoongArch-architecture-.patch
+++ b/app-web/chromium/autobuild/patches/0011-AOSCOS-third_party-dav1d-add-LoongArch-architecture-.patch
@@ -1,4 +1,4 @@
-From b2e6849ee861a6c604837b77cfbd6f31c56ca301 Mon Sep 17 00:00:00 2001
+From e94015773de9ea66a01d00942c5ce67f5bd7c03b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:24:31 +0800
 Subject: [PATCH 11/14] AOSCOS: third_party/dav1d: add LoongArch architecture

--- a/app-web/chromium/autobuild/patches/0012-AOSCOS-third_party-ffmpeg-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0012-AOSCOS-third_party-ffmpeg-add-LoongArch-support.patch
@@ -1,4 +1,4 @@
-From 5cd3381cfcafa504e08aa6bd1398d4c97e2a07e9 Mon Sep 17 00:00:00 2001
+From 5e197273a81c3b0a515d4219046efcefbfcb727e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:25:02 +0800
 Subject: [PATCH 12/14] AOSCOS: third_party/ffmpeg: add LoongArch support

--- a/app-web/chromium/autobuild/patches/0013-AOSCOS-build-use-medium-code-model-for-LoongArch.patch
+++ b/app-web/chromium/autobuild/patches/0013-AOSCOS-build-use-medium-code-model-for-LoongArch.patch
@@ -1,4 +1,4 @@
-From 1c9c8e50a138db47c6c429aa0ce4b597dafb5272 Mon Sep 17 00:00:00 2001
+From 7e1b18fd39ac302a1df8ea272d2f9eaf337c1da9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:25:55 +0800
 Subject: [PATCH 13/14] AOSCOS: build: use medium code model for LoongArch

--- a/app-web/chromium/autobuild/patches/0014-AOSCOS-feat-introduce-miscellaneous-LoongArch-suppor.patch
+++ b/app-web/chromium/autobuild/patches/0014-AOSCOS-feat-introduce-miscellaneous-LoongArch-suppor.patch
@@ -1,9 +1,9 @@
-From 039fd9025ea055e520d626db181826a9f263041e Mon Sep 17 00:00:00 2001
+From 2b9cdb3136c576bcd3e69da626f0c35ff70f98e6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:26:39 +0800
 Subject: [PATCH 14/14] AOSCOS: feat: introduce miscellaneous LoongArch support
 
-Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4007-loongarch64.diff
+Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.95-3/chromium/chromium-135.0.7049.38.4007-loongarch64.diff
 Co-authored-by: Jiajie Chen <c@jia.je>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
@@ -15,15 +15,17 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  build/config/compiler/BUILD.gn                |  2 +-
  build/config/loongarch64.gni                  |  2 +-
  build/config/rust.gni                         |  5 ++
+ .../runtime/chrome_runtime_api_delegate.cc    |  4 +
  .../metrics/debug/metrics_internals_utils.cc  |  2 +
  components/variations/proto/study.proto       |  2 +
  .../variations_field_trial_creator_base.cc    |  3 +
  content/common/user_agent.cc                  |  2 +
+ extensions/common/api/runtime.json            |  6 +-
  .../loongarch64/webgl_image_conversion_lsx.h  | 88 +++++++++----------
  .../boringssl/src/include/openssl/target.h    |  2 +
  .../src/scripts/build/rollup.config.mjs       |  2 +-
  third_party/skia/src/opts/SkOpts_SetTarget.h  |  3 +-
- 16 files changed, 121 insertions(+), 50 deletions(-)
+ 18 files changed, 129 insertions(+), 52 deletions(-)
  create mode 100644 base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc
 
 diff --git a/base/allocator/partition_allocator/partition_alloc.gni b/base/allocator/partition_allocator/partition_alloc.gni
@@ -183,6 +185,28 @@ index 5b9e3e1e65..e71e408394 100644
  }
  
  assert(!toolchain_has_rust || rust_target_arch != "")
+diff --git a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
+index 244313bdc9..9594ca3aa5 100644
+--- a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
++++ b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
+@@ -311,6 +311,8 @@ bool ChromeRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->arch = extensions::api::runtime::PlatformArch::kMips;
+   } else if (strcmp(arch, "mips64el") == 0) {
+     info->arch = extensions::api::runtime::PlatformArch::kMips64;
++  } else if (strcmp(arch, "loongarch64") == 0) {
++    info->arch = extensions::api::runtime::PlatformArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }
+@@ -326,6 +328,8 @@ bool ChromeRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kMips;
+   } else if (strcmp(nacl_arch, "mips64") == 0) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kMips64;
++  } else if (strcmp(nacl_arch, "loongarch64") == 0) {
++    info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }
 diff --git a/components/metrics/debug/metrics_internals_utils.cc b/components/metrics/debug/metrics_internals_utils.cc
 index 69d3709fcd..654f7ee0e3 100644
 --- a/components/metrics/debug/metrics_internals_utils.cc
@@ -236,6 +260,30 @@ index d930058bb0..a2a7c62c42 100644
    }
  #elif BUILDFLAG(IS_FUCHSIA)
    std::string cpu_arch = base::SysInfo::ProcessCPUArchitecture();
+diff --git a/extensions/common/api/runtime.json b/extensions/common/api/runtime.json
+index 723850ef9a..8ea579f6c6 100644
+--- a/extensions/common/api/runtime.json
++++ b/extensions/common/api/runtime.json
+@@ -98,7 +98,8 @@
+             {"name": "x86-32", "description": "Specifies the processer architecture as x86-32."},
+             {"name": "x86-64", "description": "Specifies the processer architecture as x86-64."},
+             {"name": "mips", "description": "Specifies the processer architecture as mips."},
+-            {"name": "mips64", "description": "Specifies the processer architecture as mips64."}
++            {"name": "mips64", "description": "Specifies the processer architecture as mips64."},
++            {"name": "loongarch64", "description": "Specifies the processer architecture as loongarch64."}
+          ],
+         "description": "The machine's processor architecture."
+       },
+@@ -111,7 +112,8 @@
+           {"name": "x86-32", "description": "Specifies the native client architecture as x86-32."},
+           {"name": "x86-64", "description": "Specifies the native client architecture as x86-64."},
+           {"name": "mips", "description": "Specifies the native client architecture as mips."},
+-          {"name": "mips64", "description": "Specifies the native client architecture as mips64."}
++          {"name": "mips64", "description": "Specifies the native client architecture as mips64."},
++          {"name": "loongarch64", "description": "Specifies the native client architecture as loongarch64."}
+         ]
+       },
+       {
 diff --git a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
 index 114f3c112e..1e2096f651 100644
 --- a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=135.0.7049.84
+VER=135.0.7049.95
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::43fafda47b177c4aa89ab2849bfb8e9bf035be5281f9bb0e0cae41eabd53832e \
+CHKSUMS="sha256::1dfd87fe48fa6d5a9d465363f7c85302c75851b9c6afd45e1e02b191413c20ca \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::7b0bfc540c8624737a2bd6f8bca8bdd559b3bc984ce8d07a97ce110545c026ca"
+         sha256::e4e5e4f36e1a8b9f03e95f6241fe5fedbc361c1ab08d348f2075d9b69744c103"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"

--- a/topics/chromium-135.0.7049.95.toml
+++ b/topics/chromium-135.0.7049.95.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Chromium 135.0.7049.95"
+
+[caution]
+default = "Fixes 2 security vulnerabilities (1 each of critical and high severities)"
+zh_CN = "修复 2 个安全漏洞（含 1 个严重漏洞，1 个高危漏洞）"
+
+[packages]
+"chromium" = "135.0.7049.95"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 135.0.7049.95
    Adopt a change from AOSC-Dev/chromium-loongarch64 @ tags/chromium-135.0.7049.95-3
    to fix crashes in extensions.

Package(s) Affected
-------------------

- chromium: 135.0.7049.95

Security Update?
----------------

Yes, #10576

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
