### PR TITLE
showmethekey: update to 1.18.1

### DIFF
--- a/app-utils/showmethekey/autobuild/defines
+++ b/app-utils/showmethekey/autobuild/defines
@@ -4,3 +4,5 @@ PKGDES="Show keys you typed on screen"
 PKGDEP="systemd libadwaita libevdev libinput gtk-4 glib json-glib cairo pango \
         libxkbcommon polkit"
 BUILDDEP="gtk-update-icon-cache"
+
+ABTYPE=meson

--- a/app-utils/showmethekey/spec
+++ b/app-utils/showmethekey/spec
@@ -1,4 +1,4 @@
-VER=1.14.0
+VER=1.18.1
 SRCS="git::commit=tags/v$VER::https://github.com/AlynxZhou/showmethekey"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236314"


### PR DESCRIPTION
Topic Description
-----------------

- showmethekey: update to 1.18.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- showmethekey: 1.18.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit showmethekey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
