### PR TITLE
acpica-unix: rework for 20250404

### DIFF
--- a/app-devel/acpica-unix/autobuild/build
+++ b/app-devel/acpica-unix/autobuild/build
@@ -1,10 +1,8 @@
 abinfo "Building acpica-unix ..."
 make \
-    V=1 \
-    VERBOSE=1 \
+    OPT_CFLAGS="${CPPFLAGS} ${CFLAGS}" \
+    OPT_LDFLAGS="${LDFLAGS}"
 
 abinfo "Installing acpica-unix ..."
 make install \
-    V=1 \
-    VERBOSE=1 \
     DESTDIR="$PKGDIR"

--- a/app-devel/acpica-unix/autobuild/defines
+++ b/app-devel/acpica-unix/autobuild/defines
@@ -3,5 +3,4 @@ PKGSEC=devel
 PKGDEP="glibc"
 PKGDES="Intel ACPI Source Language compiler"
 
-ABMK="OPT_CFLAGS=${CFLAGS} OPT_LDFLAGS=${LDFLAGS}"
 ABTYPE=self

--- a/app-devel/acpica-unix/spec
+++ b/app-devel/acpica-unix/spec
@@ -1,4 +1,5 @@
 VER=20250404
+REL=1
 __VER="${VER:0:4}_${VER:4:2}_${VER:6:2}"
 SRCS="tbl::https://github.com/acpica/acpica/releases/download/R${__VER}/acpica-unix-${VER}.tar.gz"
 CHKSUMS="sha256::c0895489e6cb2dc92e49dc60cdf94ac02b0d33602166354267b8f4b6586c2315"


### PR DESCRIPTION
Topic Description
-----------------

- acpica-unix: rework for 20250404
    - Add back an incorrectly removed reference to ABMK, which contains
    OPT_{C,LD}FLAGS.
    - Move said flags definitions to build for better readability.
    - Drop unused V= and VERBOSE= flags for make.

Package(s) Affected
-------------------

- acpica-unix: 20250404-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit acpica-unix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
