### PR TITLE
libproxy: update to 0.5.9

### DIFF
--- a/runtime-network/libproxy/autobuild/defines
+++ b/runtime-network/libproxy/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=libproxy
 PKGSEC=libs
-PKGDEP="gcc-runtime"
+PKGDEP="curl duktape gcc-runtime glib glibc"
 BUILDDEP="gsettings-desktop-schemas gi-docgen gobject-introspection vala"
 PKGDES="A library that provides automatic proxy configuration management"
 
-MESON_AFTER="-D release=true"
+ABTYPE=meson
+MESON_AFTER=(
+    "-Drelease=true"
+    "-Dtests=false"
+)

--- a/runtime-network/libproxy/autobuild/prepare
+++ b/runtime-network/libproxy/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Setting C++14 in CXXFLAGS ..."
-export CXXFLAGS="$CXXFLAGS -std=gnu++14"

--- a/runtime-network/libproxy/spec
+++ b/runtime-network/libproxy/spec
@@ -1,4 +1,4 @@
-VER=0.5.6
+VER=0.5.9
 SRCS="git::commit=tags/$VER::https://github.com/libproxy/libproxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12742"


### PR DESCRIPTION
Topic Description
-----------------

- libproxy: update to 0.5.9
    - Add missing dependencies.
    - Drop unused prepare script.
    - Improve defines script.

Package(s) Affected
-------------------

- libproxy: 0.5.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit libproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
