### PR TITLE
ouch: update to 0.6.1

### DIFF
--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -1,12 +1,13 @@
 PKGNAME="ouch"
 PKGDES="A command line (de)compression utility with support for multiple archive formats"
 PKGDEP="glibc zlib bzip2 xz gcc-runtime bzip3"
-BUILDDEP="rustc"
+BUILDDEP="rustc llvm"
 PKGSEC="util"
 
 # FIXME: ld.lld: error: undefined symbol: std::bad_alloc::bad_alloc()
 NOLTO=1
 
 ABSPLITDBG=0
+USECLANG=1
 
 CARGO_AFTER__I486="${CARGO_AFTER} --target=i486-unknown-linux-gnu"

--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="ouch"
 PKGDES="A command line (de)compression utility with support for multiple archive formats"
-PKGDEP="glibc zlib bzip2 xz gcc-runtime"
+PKGDEP="glibc zlib bzip2 xz gcc-runtime bzip3"
 BUILDDEP="rustc"
 PKGSEC="util"
 

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
+VER=0.6.1
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.6.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- ouch: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
