### PR TITLE
httpx-go: new,1.7.0

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.8.0
+VER=4.9.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-utils/httpx-go/autobuild/beyond
+++ b/app-utils/httpx-go/autobuild/beyond
@@ -1,0 +1,6 @@
+# FIXME: The binary name conflicts with the existing 
+# python-httpx package, so it is necessary to 
+# modify the file name to avoid conflicts
+
+abinfo "Modify binary file name....."
+mv "$PKGDIR"/usr/bin/httpx "$PKGDIR"/usr/bin/httpx-go

--- a/app-utils/httpx-go/autobuild/defines
+++ b/app-utils/httpx-go/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=httpx-go
+PKGDES="Multi-purpose HTTP probing toolkit"
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="go"
+
+GO_PACKAGES=('cmd/httpx')

--- a/app-utils/httpx-go/autobuild/patches/0001-feat-disable-auto-update-and-version-check.patch
+++ b/app-utils/httpx-go/autobuild/patches/0001-feat-disable-auto-update-and-version-check.patch
@@ -1,0 +1,33 @@
+From 4c2bbd5d7c5beb962117994c6c0d81660df5bf3b Mon Sep 17 00:00:00 2001
+From: Neko205 <neko200553@gmail.com>
+Date: Sun, 27 Apr 2025 19:06:43 +0800
+Subject: [PATCH] feat: disable auto-update and version check
+
+---
+ runner/options.go | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/runner/options.go b/runner/options.go
+index bbadb40..7864fd1 100644
+--- a/runner/options.go
++++ b/runner/options.go
+@@ -453,10 +453,12 @@ func ParseOptions() *Options {
+ 		flagSet.BoolVarP(&options.ListDSLVariable, "list-dsl-variables", "ldv", false, "list json output field keys name that support dsl matcher/filter"),
+ 	)
+ 
+-	flagSet.CreateGroup("update", "Update",
+-		flagSet.CallbackVarP(GetUpdateCallback(), "update", "up", "update httpx to latest version"),
+-		flagSet.BoolVarP(&options.DisableUpdateCheck, "disable-update-check", "duc", false, "disable automatic httpx update check"),
+-	)
++	//Disable auto-update and version detection
++	//flagSet.CreateGroup("update", "Update",
++	//	flagSet.CallbackVarP(GetUpdateCallback(), "update", "up", "update httpx to latest version"),
++	//	flagSet.BoolVarP(&options.DisableUpdateCheck, "disable-update-check", "duc", false, "disable automatic httpx update check"),
++	//)
++	options.DisableUpdateCheck = true
+ 
+ 	flagSet.CreateGroup("output", "Output",
+ 		flagSet.StringVarP(&options.Output, "output", "o", "", "file to write output results"),
+-- 
+2.49.0
+

--- a/app-utils/httpx-go/spec
+++ b/app-utils/httpx-go/spec
@@ -1,0 +1,4 @@
+VER=1.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/httpx.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328160"


### PR DESCRIPTION
Topic Description
-----------------

httpx-go: new,1.7.0

Package(s) Affected
-------------------

- httpx-go: 1.7.0
- autobuild4 : 4.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4,httpx-go
```


Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
