### PR TITLE
fcft: use system nanosvg

### DIFF
--- a/runtime-display/fcft/autobuild/defines
+++ b/runtime-display/fcft/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=fcft
 PKGSEC=libs
-PKGDEP="fontconfig freetype pixman harfbuzz"
-BUILDDEP="meson ninja scdoc tllist"
+PKGDEP="fontconfig freetype glibc harfbuzz libutf8proc pixman"
+BUILDDEP="meson nanosvg ninja scdoc tllist"
 PKGDES="A small font loading and glyph rasterization library"
 
+ABTYPE=meson
 MESON_AFTER="-Dgrapheme-shaping=enabled \
-	-Drun-shaping=enabled"
+	     -Drun-shaping=enabled \
+             -Dsystem-nanosvg=enabled"

--- a/runtime-display/fcft/spec
+++ b/runtime-display/fcft/spec
@@ -2,3 +2,4 @@ VER=3.3.1
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fcft"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143240"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- fcft: use system nanosvg

Package(s) Affected
-------------------

- fcft: 3.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcft
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
