### PR TITLE
fuzzel: use system nanosvg

### DIFF
--- a/app-utils/fuzzel/autobuild/defines
+++ b/app-utils/fuzzel/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=fuzzel
 PKGSEC=x11
-PKGDEP="wayland libxkbcommon cairo libpng librsvg pixman fcft"
-BUILDDEP="wayland-protocols scdoc meson ninja tllist"
+PKGDEP="cairo fcft fontconfig glibc libpng libxkbcommon pixman wayland"
+BUILDDEP="wayland-protocols scdoc meson nanosvg ninja tllist"
 PKGDES="A Wayland-native application launcher"
 
-MESON_AFTER="-Denable-cairo=enabled \
-	-Dpng-backend=libpng \
-	-Dsvg-backend=librsvg"
+ABTYPE=meson
+MESON_AFTER="-Dsystem-nanosvg=enabled"

--- a/app-utils/fuzzel/spec
+++ b/app-utils/fuzzel/spec
@@ -2,3 +2,4 @@ VER=1.12.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fuzzel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=190841"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- fuzzel: use system nanosvg

Package(s) Affected
-------------------

- fuzzel: 1.12.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuzzel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
