### PR TITLE
vscode: update to 1.99.3

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.99.2
+VER=1.99.3
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::8f6b53f866c1afb35e61b52d99bc83f2e5959eee41d80bb69996a31169957f90"
-CHKSUMS__ARM64="sha256::20e7ef599021a6ae187b5393806dcdbf697e870494c7b0f445d26fe7162449df"
+CHKSUMS__AMD64="sha256::2e2923bea718b4a059a323994eef53412efac3393b5456e91776efc89d8a354e"
+CHKSUMS__ARM64="sha256::7c241ee21b09356daf5ef696b260427e85bdfe0cc164c16f4460f3dd353b3dd5"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.99.3
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- vscode: 1.99.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
