### PR TITLE
llvm-18, llvm-19: enable OpenMP offloading

### DIFF
--- a/app-devel/llvm-18/01-runtime/defines
+++ b/app-devel/llvm-18/01-runtime/defines
@@ -55,7 +55,6 @@ _LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang;libclc" # for main-T1 arch (e.
 _LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
 _LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;openmp"
 _LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET};pstl"
-_LLVM_BASE_RUNTIME_SET__LOONGARCH64="libcxx;libcxxabi"
 # FIXME: Runtime libraries does not build without lld.
 _LLVM_BASE_RUNTIME_SET__LOONGSON3=""
 
@@ -74,16 +73,22 @@ CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
 # Mainline
 CMAKE_AFTER__BASE=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__FULL=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__AMD64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__ARM64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__LOONGARCH64=" \
-              ${CMAKE_AFTER__FULL/;polly/} \
+             ${CMAKE_AFTER__FULL/;polly/} \
              -DLLVM_USE_LINKER=bfd \
              -DLLVM_PARALLEL_LINK_JOBS=2"
 CMAKE_AFTER__LOONGSON3=" \

--- a/app-devel/llvm-18/spec
+++ b/app-devel/llvm-18/spec
@@ -1,5 +1,5 @@
 VER=18.1.8
-REL=8
+REL=9
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"

--- a/app-devel/llvm-19/01-runtime/defines
+++ b/app-devel/llvm-19/01-runtime/defines
@@ -53,9 +53,8 @@ _LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2
 _LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang;libclc" # for main-T1 arch (e.g. amd64, arm64 ...)
 
 _LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
-_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;openmp"
+_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;offload;openmp"
 _LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET};pstl"
-_LLVM_BASE_RUNTIME_SET__LOONGARCH64="libcxx;libcxxabi"
 # FIXME: Runtime libraries does not build without lld.
 _LLVM_BASE_RUNTIME_SET__LOONGSON3=""
 
@@ -74,25 +73,37 @@ CMAKE_AFTER="-DLLVM_BUILD_LLVM_DYLIB=ON \
 # Mainline
 CMAKE_AFTER__BASE=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__FULL=" \
              ${CMAKE_AFTER} \
+             -DLIBOMPTARGET_ENABLE_DEBUG=ON \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET} \
-             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+             -DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET} \
+             -DOPENMP_ENABLE_LIBOMP_PROFILING=ON \
+             "
 CMAKE_AFTER__AMD64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__ARM64="${CMAKE_AFTER__FULL}"
 CMAKE_AFTER__LOONGARCH64=" \
-              ${CMAKE_AFTER__FULL/;polly/} \
+             ${CMAKE_AFTER__FULL/;polly/} \
+             -DLIBOMPTARGET_PLUGINS_TO_BUILD='amdgpu;cuda' \
              -DLLVM_USE_LINKER=bfd \
-             -DLLVM_PARALLEL_LINK_JOBS=2"
+             -DLLVM_PARALLEL_LINK_JOBS=2 \
+             "
 CMAKE_AFTER__LOONGSON3=" \
              ${CMAKE_AFTER} \
              -DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET} \
              -DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3} \
              -DLLVM_PARALLEL_LINK_JOBS=2 \
              -DLLVM_USE_LINKER="
-CMAKE_AFTER__RISCV64="${CMAKE_AFTER__BASE} -DLLVM_PARALLEL_LINK_JOBS=2"
+CMAKE_AFTER__RISCV64=" \
+             ${CMAKE_AFTER__BASE} \
+             -DLIBOMPTARGET_PLUGINS_TO_BUILD='amdgpu;cuda' \
+             -DLLVM_PARALLEL_LINK_JOBS=2 \
+             "
 CMAKE_AFTER__PPC64EL="${CMAKE_AFTER__BASE} -DLLVM_PARALLEL_LINK_JOBS=2"
 
 # Retro

--- a/app-devel/llvm-19/spec
+++ b/app-devel/llvm-19/spec
@@ -1,5 +1,5 @@
 VER=19.1.6
-REL=4
+REL=5
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
 CHKSUMS="sha256::e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-19: enable offload runtime
    Signed-off-by: ouankou <anjia@ouankou.com>
- llvm-18: enable libomptarget debugging
    Signed-off-by: ouankou <anjia@ouankou.com>

Package(s) Affected
-------------------

- llvm-18: 18.1.8-9
- llvm-19: 19.1.6-5
- llvm-runtime-18: 18.1.8-9
- llvm-runtime-19: 19.1.6-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-18 llvm-19
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
