### PR TITLE
chromium: update to 135.0.7049.114

### DIFF
--- a/app-web/chromium/autobuild/patches/0001-FEDORA-Set-intial-prefs-path-to-etc-chromium.patch
+++ b/app-web/chromium/autobuild/patches/0001-FEDORA-Set-intial-prefs-path-to-etc-chromium.patch
@@ -1,7 +1,7 @@
-From 0c065b9663086186153c1ef36e82c3762c1a7db3 Mon Sep 17 00:00:00 2001
+From ad76686e19239b762be8306b42510fe8cb7546ce Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:02:40 +0800
-Subject: [PATCH 01/14] FEDORA: Set intial prefs path to /etc/chromium
+Subject: [PATCH 01/15] FEDORA: Set intial prefs path to /etc/chromium
 
 Link: https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-115-initial_prefs-etc-path.patch
 Co-authored-by: Than Ngo <than@redhat.com>

--- a/app-web/chromium/autobuild/patches/0002-FEDORA-third_party-zlib-Drop-dependency-to-chromecon.patch
+++ b/app-web/chromium/autobuild/patches/0002-FEDORA-third_party-zlib-Drop-dependency-to-chromecon.patch
@@ -1,7 +1,7 @@
-From 8dbf5343dcf4f9954c51ecac3bdf2e36f0bb6d9d Mon Sep 17 00:00:00 2001
+From 8cc6dc91ad4b58e082b9ecc211dc963ecd7644b2 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 26 Jul 2024 05:04:35 +0800
-Subject: [PATCH 02/14] FEDORA: third_party/zlib: Drop dependency to
+Subject: [PATCH 02/15] FEDORA: third_party/zlib: Drop dependency to
  chromeconf.h
 
 Link: https://src.fedoraproject.org/rpms/chromium/blob/5b27efc518c86b93dd2f30e877536599ed07beac/f/chromium-77.0.3865.75-no-zlib-mangle.patch

--- a/app-web/chromium/autobuild/patches/0003-FEDORA-Hard-code-std-hardware_destructive_interferen.patch
+++ b/app-web/chromium/autobuild/patches/0003-FEDORA-Hard-code-std-hardware_destructive_interferen.patch
@@ -1,7 +1,7 @@
-From 3fa141f714b08ce476640ce10735927b66cedd50 Mon Sep 17 00:00:00 2001
+From 33ff7c601d0cc4f570032de5157527668a21f5bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 24 Dec 2024 07:25:22 -0800
-Subject: [PATCH 03/14] FEDORA: Hard-code
+Subject: [PATCH 03/15] FEDORA: Hard-code
  std::hardware_destructive_interference_size as 64
 
 Align the data on a cache line boundary.

--- a/app-web/chromium/autobuild/patches/0004-AOSCOS-media-enable-VA-API-decoding-encoding-by-defa.patch
+++ b/app-web/chromium/autobuild/patches/0004-AOSCOS-media-enable-VA-API-decoding-encoding-by-defa.patch
@@ -1,7 +1,7 @@
-From a33e31e73cc13e189222510c064b5fa85e8e6aae Mon Sep 17 00:00:00 2001
+From 5d5a2e9ebe6b776b8e31bd7a2da4702d56b54884 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:29:50 +0800
-Subject: [PATCH 04/14] AOSCOS: media: enable VA-API decoding/encoding by
+Subject: [PATCH 04/15] AOSCOS: media: enable VA-API decoding/encoding by
  default
 
 Enable the following features by default:

--- a/app-web/chromium/autobuild/patches/0005-AOSCOS-build-fix-invalid-flag-substitutions.patch
+++ b/app-web/chromium/autobuild/patches/0005-AOSCOS-build-fix-invalid-flag-substitutions.patch
@@ -1,7 +1,7 @@
-From 254ccc8047611648093b5b834da81e73d4677a43 Mon Sep 17 00:00:00 2001
+From db0cfd5625619c5d7611931f886629c1d7fdb989 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 21:55:40 +0800
-Subject: [PATCH 05/14] AOSCOS: build: fix invalid flag substitutions
+Subject: [PATCH 05/15] AOSCOS: build: fix invalid flag substitutions
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.3003-fix-invalid-substition-type.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0006-AOSCOS-build-correct-Clang-builtins-path.patch
+++ b/app-web/chromium/autobuild/patches/0006-AOSCOS-build-correct-Clang-builtins-path.patch
@@ -1,7 +1,7 @@
-From 45b43315b6aac17c214096aef824a35136576161 Mon Sep 17 00:00:00 2001
+From bf01f2f306e29ce34806a1a3fd964ad2ae61b3e0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 9 Apr 2025 11:07:13 +0800
-Subject: [PATCH 06/14] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 06/15] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 

--- a/app-web/chromium/autobuild/patches/0007-AOSCOS-blink-fix-build-with-gperf-3.2.patch
+++ b/app-web/chromium/autobuild/patches/0007-AOSCOS-blink-fix-build-with-gperf-3.2.patch
@@ -1,7 +1,7 @@
-From 4d73e1c25d9c9a7b546a40b4c98e35d454c8be5d Mon Sep 17 00:00:00 2001
+From 7db65c9d60471af53e6c6cc64386227bd8e0f56f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 8 Apr 2025 14:54:04 +0800
-Subject: [PATCH 07/14] AOSCOS: blink: fix build with gperf 3.2
+Subject: [PATCH 07/15] AOSCOS: blink: fix build with gperf 3.2
 
 gperf >= 3.2 fixes an issue where explicit fallthrough statements
 (`[[fallthrough]];') were not generated even if -std=c++17 was specified.

--- a/app-web/chromium/autobuild/patches/0008-AOSCOS-third_party-swiftshader-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0008-AOSCOS-third_party-swiftshader-add-LoongArch-support.patch
@@ -1,7 +1,7 @@
-From 84422e8afa2aebdcba7c09c3b7b8406b45785d19 Mon Sep 17 00:00:00 2001
+From 227ac0488026107e10a93b2206fb9d9640656e5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 23:29:42 +0800
-Subject: [PATCH 08/14] AOSCOS: third_party/swiftshader: add LoongArch support
+Subject: [PATCH 08/15] AOSCOS: third_party/swiftshader: add LoongArch support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4001-loongarch64-swiftshader.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0009-AOSCOS-sandbox-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0009-AOSCOS-sandbox-add-LoongArch-support.patch
@@ -1,7 +1,7 @@
-From 9589d1036dd1bd9c4ac695e80ee10f408dc98b7e Mon Sep 17 00:00:00 2001
+From da99046df49f07048f43fcdf12773f9323e31b07 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:22:01 +0800
-Subject: [PATCH 09/14] AOSCOS: sandbox: add LoongArch support
+Subject: [PATCH 09/15] AOSCOS: sandbox: add LoongArch support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4002-loongarch64-sandbox.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0010-AOSCOS-third_party-crashpad-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0010-AOSCOS-third_party-crashpad-add-LoongArch-support.patch
@@ -1,7 +1,7 @@
-From 350c27390c4866abf01e4e9e69f88baf02f305ec Mon Sep 17 00:00:00 2001
+From 41ee6d87816f718da810ef9a3f8f50f12ea860f6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:23:21 +0800
-Subject: [PATCH 10/14] AOSCOS: third_party/crashpad: add LoongArch support
+Subject: [PATCH 10/15] AOSCOS: third_party/crashpad: add LoongArch support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4003-loongarch64-crashpad.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0011-AOSCOS-third_party-dav1d-add-LoongArch-architecture-.patch
+++ b/app-web/chromium/autobuild/patches/0011-AOSCOS-third_party-dav1d-add-LoongArch-architecture-.patch
@@ -1,7 +1,7 @@
-From e94015773de9ea66a01d00942c5ce67f5bd7c03b Mon Sep 17 00:00:00 2001
+From f97d0817e4804bc8fffaf079e4c34cb842c46c00 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:24:31 +0800
-Subject: [PATCH 11/14] AOSCOS: third_party/dav1d: add LoongArch architecture
+Subject: [PATCH 11/15] AOSCOS: third_party/dav1d: add LoongArch architecture
  definitions
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4004-loongarch64-dav1d.diff

--- a/app-web/chromium/autobuild/patches/0012-AOSCOS-third_party-ffmpeg-add-LoongArch-support.patch
+++ b/app-web/chromium/autobuild/patches/0012-AOSCOS-third_party-ffmpeg-add-LoongArch-support.patch
@@ -1,7 +1,7 @@
-From 5e197273a81c3b0a515d4219046efcefbfcb727e Mon Sep 17 00:00:00 2001
+From 5d9477407e7e3f8befd5f6cce35b44eba5524479 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:25:02 +0800
-Subject: [PATCH 12/14] AOSCOS: third_party/ffmpeg: add LoongArch support
+Subject: [PATCH 12/15] AOSCOS: third_party/ffmpeg: add LoongArch support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.38-1/chromium/chromium-135.0.7049.38.4005-loongarch64-ffmpeg.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0013-AOSCOS-build-use-medium-code-model-for-LoongArch.patch
+++ b/app-web/chromium/autobuild/patches/0013-AOSCOS-build-use-medium-code-model-for-LoongArch.patch
@@ -1,7 +1,7 @@
-From 7e1b18fd39ac302a1df8ea272d2f9eaf337c1da9 Mon Sep 17 00:00:00 2001
+From f74b95c18a2df5d1031b9d4b71e07b674f3c4227 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:25:55 +0800
-Subject: [PATCH 13/14] AOSCOS: build: use medium code model for LoongArch
+Subject: [PATCH 13/15] AOSCOS: build: use medium code model for LoongArch
 
 This is needed to fix relaxation failure during linkage.
 

--- a/app-web/chromium/autobuild/patches/0014-AOSCOS-feat-introduce-miscellaneous-LoongArch-suppor.patch
+++ b/app-web/chromium/autobuild/patches/0014-AOSCOS-feat-introduce-miscellaneous-LoongArch-suppor.patch
@@ -1,7 +1,7 @@
-From 2b9cdb3136c576bcd3e69da626f0c35ff70f98e6 Mon Sep 17 00:00:00 2001
+From 75b6780e6885bbde65fd65ce31083619bb22d89f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 7 Apr 2025 22:26:39 +0800
-Subject: [PATCH 14/14] AOSCOS: feat: introduce miscellaneous LoongArch support
+Subject: [PATCH 14/15] AOSCOS: feat: introduce miscellaneous LoongArch support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.95-3/chromium/chromium-135.0.7049.38.4007-loongarch64.diff
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/app-web/chromium/autobuild/patches/0015-AOSCOS-fix-disable-2D-canvas-acceleration-on-Loongso.patch
+++ b/app-web/chromium/autobuild/patches/0015-AOSCOS-fix-disable-2D-canvas-acceleration-on-Loongso.patch
@@ -1,0 +1,42 @@
+From f529b8effe692d843141974cb2b3d8ba65d2df24 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 23 Apr 2025 11:35:57 +0800
+Subject: [PATCH 15/15] AOSCOS: fix: disable 2D canvas acceleration on Loongson
+ LG100/110 graphics
+
+2D-accelerated canvas causes corrupted webpage rendering on Loongson
+LG100/110 graphics. Disabling (using software rendering) as a workaround.
+
+Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.114-2/chromium/chromium-135.0.7049.114.4007-loongarch64-gpu.diff
+Co-authored-by: Jiajie Chen <c@jia.je>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ gpu/config/software_rendering_list.json | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+index 3f09ff3119..611bf3b6d8 100644
+--- a/gpu/config/software_rendering_list.json
++++ b/gpu/config/software_rendering_list.json
+@@ -1447,6 +1447,18 @@
+       "features": [
+         "accelerated_2d_canvas"
+       ]
++    },
++    {
++      "id": 184,
++      "description": "Corrupted webpage rendering on Loongson LG100/110 graphics with 2D acceleration enabled",
++      "os": {
++        "type" : "linux"
++      },
++      "vendor_id": "0x1014",
++      "device_id": [ "0x7a36" ],
++      "features": [
++        "accelerated_2d_canvas"
++      ]
+     }
+   ]
+ }
+-- 
+2.49.0
+

--- a/app-web/chromium/spec
+++ b/app-web/chromium/spec
@@ -1,11 +1,11 @@
-VER=135.0.7049.95
+VER=135.0.7049.114
 LAUNCHERVER=8
 SRCS="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$VER.tar.xz \
       https://github.com/foutrelis/chromium-launcher/archive/v$LAUNCHERVER.tar.gz \
       file::rename=chromium-$VER.txt::https://chromium.googlesource.com/chromium/src/+/$VER?format=TEXT"
-CHKSUMS="sha256::1dfd87fe48fa6d5a9d465363f7c85302c75851b9c6afd45e1e02b191413c20ca \
+CHKSUMS="sha256::aa85ce2bf36ed71261109fd7e700fac596a28b7be035a40a518c6a6fcf973c22 \
          sha256::213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a \
-         sha256::e4e5e4f36e1a8b9f03e95f6241fe5fedbc361c1ab08d348f2075d9b69744c103"
+         sha256::79b73d252778eb0b3a8bd61bcdb696707b43dad11147e94fd3fed10680ade79e"
 SUBDIR="chromium-$VER"
 CHKUPDATE="anitya::id=13344"
 ENVREQ__AMD64="core=96"


### PR DESCRIPTION
Topic Description
-----------------

- chromium: update to 135.0.7049.114
    Add a patch to disable 2D canvas acceleration on Loongson LG100/110
    graphics to workaround rendering issues.
    Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/chromium-135.0.7049.114-1/chromium/chromium-135.0.7049.114.4007-loongarch64-gpu.diff

Package(s) Affected
-------------------

- chromium: 135.0.7049.114

Security Update?
----------------

No

Build Order
-----------

```
#buildit chromium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
