### PR TITLE
intel-gmmlib: remove compiler options exceeding baseline

### DIFF
--- a/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
@@ -1,0 +1,86 @@
+From a01861e7b566a03ae5f9b07beb9ef23041cca982 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Thu, 24 Apr 2025 10:20:33 +0800
+Subject: [PATCH] AOSCOS: remove compiler options exceeding baseline
+
+Signed-off-by: Qing Yun <kf@aosc.io>
+---
+ Source/GmmLib/CMakeLists.txt                        |  6 ------
+ Source/GmmLib/Linux.cmake                           | 13 -------------
+ Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c |  5 -----
+ 3 files changed, 24 deletions(-)
+
+diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
+index 48d054c..f6e8386 100644
+--- a/Source/GmmLib/CMakeLists.txt
++++ b/Source/GmmLib/CMakeLists.txt
+@@ -165,12 +165,6 @@ else()
+     set (GMMLIB_ARCH "32")
+ endif()
+ 
+-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
+-    set(GMMLIB_MARCH "armv8-a+fp+simd")
+-elseif("${GMMLIB_MARCH}" STREQUAL "")
+-    set(GMMLIB_MARCH "corei7")
+-endif()
+-
+ MESSAGE("platform: ${CMAKE_HOST_SYSTEM_NAME}")
+ MESSAGE("source_dir: ${BS_DIR_GMMLIB}")
+ MESSAGE("arch: ${GMMLIB_ARCH}")
+diff --git a/Source/GmmLib/Linux.cmake b/Source/GmmLib/Linux.cmake
+index 87b74d8..cfef475 100644
+--- a/Source/GmmLib/Linux.cmake
++++ b/Source/GmmLib/Linux.cmake
+@@ -39,7 +39,6 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
+     -Werror=return-type
+ 
+     # General optimization options
+-    -march=${GMMLIB_MARCH}
+     -finline-functions
+     -fno-short-enums
+     -Wa,--noexecstack
+@@ -76,16 +75,6 @@ else()
+     -Werror=return-type
+ 
+     # General optimization options
+-    -march=${GMMLIB_MARCH}
+-    -mpopcnt
+-    -msse
+-    -msse2
+-    -msse3
+-    -mssse3
+-    -msse4
+-    -msse4.1
+-    -msse4.2
+-    -mfpmath=sse
+     -finline-functions
+     -fno-short-enums
+     -Wa,--noexecstack
+@@ -94,8 +83,6 @@ else()
+     -DUSE_MMX
+     -DUSE_SSE
+     -DUSE_SSE2
+-    -DUSE_SSE3
+-    -DUSE_SSSE3
+     # Other common flags
+     -fstack-protector
+     -fdata-sections
+diff --git a/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c b/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
+index e090fd6..c412853 100644
+--- a/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
++++ b/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
+@@ -749,11 +749,6 @@ void CpuSwizzleBlt( // #########################################################
+                 #elif(defined(__ARM_ARCH))
+                     #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
+                     StreamingLoadSupported = 0;
+-                #elif((defined __clang__) || (__GNUC__ > 4) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 5))
+-                    #define MOVNTDQA_R(Reg, Src) ((Reg) = _mm_stream_load_si128((__m128i *)(Src)))
+-                    unsigned int eax, ebx, ecx, edx;
+-                    __cpuid(1, eax, ebx, ecx, edx);
+-                    StreamingLoadSupported = ((ecx & (1 << 19)) != 0); // ECX[19] = SSE4.1
+                 #else
+                     #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
+                     StreamingLoadSupported = 0;
+-- 
+2.49.0
+

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
@@ -1,4 +1,4 @@
-From 75799dad3f2f49debb1ce034ad69da8698da57fb Mon Sep 17 00:00:00 2001
+From 9b1d60246eab77779e200bc74dede0734e99a474 Mon Sep 17 00:00:00 2001
 From: Vihang Mehta <vihang@gimletlabs.ai>
 Date: Wed, 26 Feb 2025 09:59:15 -0800
 Subject: [PATCH] ARM64: FROMEXT: Disable AuxTable test on aarch64

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0003-HACK-add-experimental-support-for-LoongArch.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0003-HACK-add-experimental-support-for-LoongArch.am.loongarch64
@@ -1,16 +1,16 @@
-From 56f9a4ca8e2230c57784e8c786d8e33d7a142423 Mon Sep 17 00:00:00 2001
+From 8b12cee8d780a9d370c24b4a0eba2376d975694b Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:03:47 +0800
 Subject: [PATCH] HACK: add experimental support for LoongArch
 
 Ref: https://github.com/FanFansfan/gmmlib/commit/5b95524c513b00f93bbcf0f23b4d7226facf773d
 ---
- .gitmodules                                   |  3 +++
- Source/GmmLib/CMakeLists.txt                  |  4 +++-
- Source/GmmLib/Linux.cmake                     | 20 ++-----------------
- .../Utility/CpuSwizzleBlt/CpuSwizzleBlt.c     |  9 ++++++++-
- third_party/simde                             |  1 +
- 5 files changed, 17 insertions(+), 20 deletions(-)
+ .gitmodules                                         | 3 +++
+ Source/GmmLib/CMakeLists.txt                        | 2 ++
+ Source/GmmLib/Linux.cmake                           | 9 ++-------
+ Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c | 9 ++++++++-
+ third_party/simde                                   | 1 +
+ 5 files changed, 16 insertions(+), 8 deletions(-)
  create mode 100644 .gitmodules
  create mode 160000 third_party/simde
 
@@ -24,19 +24,10 @@ index 0000000..e5233a0
 +	path = third_party/simde
 +	url = https://github.com/simd-everywhere/simde
 diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
-index 48d054c..882f2ba 100644
+index f6e8386..d67c56b 100644
 --- a/Source/GmmLib/CMakeLists.txt
 +++ b/Source/GmmLib/CMakeLists.txt
-@@ -168,7 +168,7 @@ endif()
- if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
-     set(GMMLIB_MARCH "armv8-a+fp+simd")
- elseif("${GMMLIB_MARCH}" STREQUAL "")
--    set(GMMLIB_MARCH "corei7")
-+    set(GMMLIB_MARCH "native")
- endif()
- 
- MESSAGE("platform: ${CMAKE_HOST_SYSTEM_NAME}")
-@@ -443,6 +443,8 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR})
+@@ -437,6 +437,8 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR})
  
  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
      include_directories(${GFX_DEVELOPMENT_DIR}/third_party/sse2neon)
@@ -46,36 +37,20 @@ index 48d054c..882f2ba 100644
  
  set(headers
 diff --git a/Source/GmmLib/Linux.cmake b/Source/GmmLib/Linux.cmake
-index 87b74d8..09783e6 100644
+index cfef475..af05c8e 100644
 --- a/Source/GmmLib/Linux.cmake
 +++ b/Source/GmmLib/Linux.cmake
-@@ -77,25 +77,11 @@ else()
- 
-     # General optimization options
-     -march=${GMMLIB_MARCH}
--    -mpopcnt
--    -msse
--    -msse2
--    -msse3
--    -mssse3
--    -msse4
--    -msse4.1
--    -msse4.2
--    -mfpmath=sse
-     -finline-functions
-     -fno-short-enums
+@@ -80,9 +80,6 @@ else()
      -Wa,--noexecstack
      -fno-strict-aliasing
      # Common defines
 -    -DUSE_MMX
 -    -DUSE_SSE
 -    -DUSE_SSE2
--    -DUSE_SSE3
--    -DUSE_SSSE3
      # Other common flags
      -fstack-protector
      -fdata-sections
-@@ -104,8 +90,6 @@ else()
+@@ -91,8 +88,6 @@ else()
      -fvisibility=hidden
      -fPIC
      -g
@@ -84,7 +59,7 @@ index 87b74d8..09783e6 100644
      )
  endif()
  
-@@ -178,6 +162,6 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
+@@ -165,6 +160,6 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
      SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
      SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
  else()
@@ -94,7 +69,7 @@ index 87b74d8..09783e6 100644
 +    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
  endif()
 diff --git a/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c b/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
-index e090fd6..327f809 100644
+index c412853..73b2bb6 100644
 --- a/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
 +++ b/Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c
 @@ -375,6 +375,9 @@ extern void CpuSwizzleBlt(CPU_SWIZZLE_BLT_SURFACE *pDest, CPU_SWIZZLE_BLT_SURFAC
@@ -107,17 +82,17 @@ index e090fd6..327f809 100644
  #elif((defined __clang__) ||(__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)))
      #include <cpuid.h>
      #include <x86intrin.h>
-@@ -749,6 +752,9 @@ void CpuSwizzleBlt( // #########################################################
+@@ -748,6 +751,9 @@ void CpuSwizzleBlt( // #########################################################
+                     StreamingLoadSupported = ((CpuInfo[2] & (1 << 19)) != 0); // ECX[19] = SSE4.1
                  #elif(defined(__ARM_ARCH))
                      #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
-                     StreamingLoadSupported = 0;
-+		#elif(defined(__loongarch64))
-+                    #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
 +                    StreamingLoadSupported = 0;
-                 #elif((defined __clang__) || (__GNUC__ > 4) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 5))
-                     #define MOVNTDQA_R(Reg, Src) ((Reg) = _mm_stream_load_si128((__m128i *)(Src)))
-                     unsigned int eax, ebx, ecx, edx;
-@@ -1148,7 +1154,8 @@ void CpuSwizzleBlt( // #########################################################
++		        #elif(defined(__loongarch64))
++                    #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
+                     StreamingLoadSupported = 0;
+                 #else
+                     #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
+@@ -1143,7 +1149,8 @@ void CpuSwizzleBlt( // #########################################################
  
              } // foreach(y)
  

--- a/runtime-devices/intel-gmmlib/autobuild/prepare
+++ b/runtime-devices/intel-gmmlib/autobuild/prepare
@@ -1,7 +1,17 @@
+# FIXME:
+# Applying LoongArch support patch causes:
+# error: Source/GmmLib/CMakeLists.txt: does not match index
+# error: Source/GmmLib/Linux.cmake: does not match index
+# error: Source/GmmLib/Utility/CpuSwizzleBlt/CpuSwizzleBlt.c: does not match index
+#
+# Apply patches manully 
+abinfo "Applying patches ..."
+git config --local user.name "AOSC Maintainers"
+git config --local user.email "maintainers@aosc.io"
+git am "$SRCDIR"/autobuild/patches/*.am
+
 if ab_match_arch loongarch64; then
     abinfo "Applying LoongArch support patch ..."
-    git config --local user.name "AOSC Maintainers"
-    git config --local user.email "maintainers@aosc.io"
     git am "$SRCDIR"/autobuild/patches/*.am.loongarch64
     git submodule update --init --recursive
 

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,5 @@
 VER=22.7.1
+REL=1
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"


### PR DESCRIPTION
Topic Description
-----------------

- intel-gmmlib: remove compiler options exceeding baseline
    - Track patches at AOSC-Tracking/gmmlib @ aosc/intel-gmmlib-22.7.1
    - \(HEAD: 8b12cee8d780a9d370c24b4a0eba2376d975694b\).
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- intel-gmmlib: 22.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
