### PR TITLE
EmuKit Update (Apr, 2025)

### DIFF
--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,8 +1,8 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.1.0
-WINE_VER=9.13
+__MONO_VER=10.0.0
+WINE_VER=10.6
 VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="file::rename=wine.deb::https://repo.aosc.io/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::ab7b87934e0891c081a1e4299e0dc14265bea99b41c1926de746c9b93cf63083"
+CHKSUMS="sha256::d523615cc431f4cbd3a384ef042b70998106333cc0c8ba67747f1f05adf2c4d2"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.

--- a/runtime-emulation/emukit/spec
+++ b/runtime-emulation/emukit/spec
@@ -1,8 +1,8 @@
-VER=20240730
+VER=20250424
 # Note: deepin-udis86 (closed source) is used by Loongapps's WeChat, which comes bundled with deepin-wine.
 SRCS="file::rename=amd64.squashfs::https://releases.aosc.io/os-amd64/emukit/aosc-os_emukit_${VER}_amd64.squashfs \
       file::rename=deepin-udis86.deb::https://community-packages.deepin.com/deepin/pool/non-free/u/udis86/udis86_1.72-4_i386.deb"
-CHKSUMS="sha256::ff5dfd869964223a55cf5df1eba843542ac2dfa7774240130228d98f12a6ec50 \
+CHKSUMS="sha256::42e7c8ab16318f3946d6cc20943e06896ac7f130809f548c96fe2aa100fb1073 \
          sha256::ec874ecdf12f95d634c038a4dd2915951aae09753f4baba50b2074d154e04374"
 # Note: We ship our own EmuKit in releases.aosc.io.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: update to 10.6+gecko2.47.4+mono10.0.0
- emukit: update to 20250424
    Add fuse, fuse-3 runtime libraries for AppImage support.

Package(s) Affected
-------------------

- emukit: 20250424
- wine: 2:10.6+gecko2.47.4+mono10.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit emukit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] LoongArch 64-bit `loongarch64`
