### PR TITLE
pyside6: adapt to the new buildsystem

### DIFF
--- a/lang-python/pyside6/autobuild/beyond
+++ b/lang-python/pyside6/autobuild/beyond
@@ -1,9 +1,0 @@
-abinfo "Generating egg_info ..."
-python3 setup.py egg_info
-
-abinfo "Installing Python Egg-info files ..."
-for name in PySide6 shiboken6 shiboken6_generator; do
-  install -dv "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"
-  cp -pv $name.egg-info/{PKG-INFO,not-zip-safe,top_level.txt} \
-        "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"/
-done

--- a/lang-python/pyside6/autobuild/build
+++ b/lang-python/pyside6/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building Pyside6 and Shibiken6 ..."
+python3 "$SRCDIR"/setup.py install \
+    --root="$PKGDIR" \
+    --relwithdebinfo \
+    --verbose-build \
+    --qtpaths=/usr/bin/qtpaths6-qt6 \
+    --no-strip

--- a/lang-python/pyside6/autobuild/defines
+++ b/lang-python/pyside6/autobuild/defines
@@ -1,14 +1,11 @@
-PKGNAME=pyside2
+PKGNAME=pyside6
 PKGSEC=libs
 PKGDEP="qt-6 python-3 llvm"
-BUILDDEP="sphinx"
+BUILDDEP="sphinx patchelf wheel setuptools"
 PKGDES="Python bindings for the Qt 6 cross-platform application and UI framework"
 
 PKGPROV="shiboken6"
 
-# FIXME: race condition if ABTYPE=cmakeninja
-ABTYPE=cmake
-
-CMAKE_AFTER="-DUSE_PYTHON_VERSION=3 \
-             -DBUILD_TESTS=OFF \
-             -DNO_QT_TOOLS=yes"
+# Note: The setup.py script supplied by this package's source is really
+# a wrapper for a series of custom build procedures.
+ABTYPE=self


### PR DESCRIPTION
Topic Description
-----------------

- pyside6: use upstream setup.py script to build and install

Package(s) Affected
-------------------

- pyside6

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
