### PR TITLE
acme.sh: update to 3.1.1

### DIFF
--- a/app-utils/acme.sh/spec
+++ b/app-utils/acme.sh/spec
@@ -1,4 +1,4 @@
-VER=3.1.0
+VER=3.1.1
 SRCS="git::commit=tags/$VER::https://github.com/acmesh-official/acme.sh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=125711"


### PR DESCRIPTION
Topic Description
-----------------

- acme.sh: update to 3.1.1
    Co-authored-by: Billy Yang \(@handsomexdd1024\) <me@venti.love>

Package(s) Affected
-------------------

- acme.sh: 3.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit acme.sh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
