### PR TITLE
zed: update to 0.183.10

### DIFF
--- a/app-editors/zed/autobuild/defines
+++ b/app-editors/zed/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME="zed"
 PKGDES="A general-purpose, multiplayer code editor"
 PKGSEC=devel
-PKGDEP="gcc-runtime alsa-lib zstd openssl zlib libxcb libxkbcommon curl \
-        glibc libxau libxdmcp nghttp3 nghttp2 libidn2 rtmpdump libssh2 \
-        libpsl krb5 brotli icu libunistring keyutils e2fsprogs"
+PKGDEP="alsa-lib gcc-runtime glibc libxcb libxkbcommon x11-lib zlib"
 BUILDDEP="rustc llvm"
 
 # FIXME: Limited by wasmtime support.

--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.182.11
+VER=0.183.10
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.183.10
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- zed: 0.183.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
