### PR TITLE
nodejs-22: update to 22.15.0

### DIFF
--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,7 +1,6 @@
-VER=22.14.0
-REL=1
+VER=22.15.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::c609946bf793b55c7954c26582760808d54c16185d79cb2fb88065e52de21914"
+CHKSUMS="sha256::e7c4226d1d92f33ad854d6da4f7e519e77690b8e73f93496881f8c539174d9df"
 CHKUPDATE="anitya::id=374342"
 # Note: Node.js currently requires large memory to build. 
 #       Prefer 3C5000 (or faster) build hosts.


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: update to 22.15.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- nodejs-22: 22.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
