### PR TITLE
git-absorb: update to 0.8.0

### DIFF
--- a/app-devel/git-absorb/spec
+++ b/app-devel/git-absorb/spec
@@ -1,4 +1,4 @@
-VER=0.7.0
+VER=0.8.0
 SRCS="git::commit=tags/$VER::https://github.com/tummychow/git-absorb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328525"


### PR DESCRIPTION
Topic Description
-----------------

- git-absorb: update to 0.8.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- git-absorb: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-absorb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
