### PR TITLE
gcc-15: new, 15.1.0

### DIFF
--- a/app-devel/gcc-15/autobuild/beyond
+++ b/app-devel/gcc-15/autobuild/beyond
@@ -1,0 +1,45 @@
+# WARNING!
+# Installing GCC runtime libraries to libdir/gcc/$HOST_TRIPLE/$PKGVER.
+abinfo "Determining the path to the installed shared libraries ..."
+SHLIBDIR=$(find $PKGDIR -maxdepth 3 -name libgcc_s.so.1 -printf '%h')
+
+abinfo "Setting executable bit for libgcc_s.so.1 ..."
+chmod -v +x "$SHLIBDIR"/libgcc_s.so.1
+
+abinfo "Removing libtool archives ..."
+find "$SHLIBDIR" -maxdepth 1 -name '*.la' -exec rm -v {} \;
+
+GCC_LIBDIR="$LIBDIR"/gcc/"${ARCH_TARGET[$ABHOST]}"/"$PKGVER"
+# Make sure the directory is what we wanted to install the libraries.
+if ! [ -e "$PKGDIR"/"$GCC_LIBDIR"/crtbegin.o ] ; then
+	abdie "Unable to find the initialization routine object files!"
+fi
+
+abinfo "Installing runtime files to GCC version-specific libdir ..."
+find "$SHLIBDIR" -maxdepth 1 -name '*.so' \
+	-exec cp -av {} "$PKGDIR"/"$GCC_LIBDIR"/ \;
+find "$SHLIBDIR" -maxdepth 1 -name '*.so.*' \
+	-exec cp -av {} "$PKGDIR"/"$GCC_LIBDIR"/ \;
+find "$SHLIBDIR" -maxdepth 1 -name '*.a' \
+	-exec cp -av {} "$PKGDIR"/"$GCC_LIBDIR"/ \;
+
+abinfo "Removing libraries from libdir ..."
+find "$SHLIBDIR" -maxdepth 1 -type f -exec rm -v {} \;
+find "$SHLIBDIR" -maxdepth 1 -type l -exec unlink {} \;
+
+if [ -d "$(dirname $SHLIBDIR)/lib64" ] ; then
+	abinfo "Moving everything to lib ..."
+	# GCC Go libraries resides in lib64.
+	# NOTE: -mindepth 1 to exclude self.
+	find "$(dirname $SHLIBDIR)/lib64" -mindepth 1 -maxdepth 1 \
+		-exec mv -v {} "$PKGDIR"/"$GCC_LIBDIR"/ \;
+	abinfo "Removing lib64 ..."
+	rm -rv "$(dirname $SHLIBDIR)/lib64"
+fi
+
+abinfo "Removing manual and textinfo pages ..."
+rm -rv "$PKGDIR/usr/share/info"
+rm -rv "$PKGDIR/usr/share/man"
+
+abinfo "Removing localization files ..."
+rm -rv "$PKGDIR/usr/share/locale"

--- a/app-devel/gcc-15/autobuild/defines
+++ b/app-devel/gcc-15/autobuild/defines
@@ -1,0 +1,97 @@
+PKGNAME=gcc-15
+PKGSEC=devel
+PKGDES="GNU Compiler Collection (Version 15)"
+# CAUTION: Native build depends on existing GCC runtime.
+PKGDEP="glibc gcc-runtime gmp mpc mpfr isl texinfo"
+
+# NOTE: taken from the main GCC defines file.
+# NOTE: libiberty will not be installed.
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER=(
+	"--prefix=/usr"
+	"--libdir=/usr/lib"
+	"--libexecdir=/usr/lib"
+	"--mandir=/usr/share/man"
+	"--infodir=/usr/share/info"
+	"--with-bugurl=https://github.com/AOSC-Dev/aosc-os-abbs/issues"
+	"--enable-shared"
+	"--enable-threads=posix"
+	"--with-system-zlib"
+	"--enable-gnu-indirect-function"
+	"--enable-__cxa_atexit"
+	"--disable-libunwind-exceptions"
+	"--enable-clocale=gnu"
+	"--disable-libstdcxx-pch"
+	"--disable-libssp"
+	"--enable-gnu-unique-object"
+	"--enable-linker-build-id"
+	"--with-isl=/usr"
+	"--enable-lto"
+	"--enable-plugin"
+	"--disable-install-libiberty"
+	"--disable-multilib"
+	"--disable-werror"
+	"--enable-pie"
+	"--enable-checking=release"
+	"--enable-libstdcxx-dual-abi"
+	"--with-default-libstdcxx-abi=new"
+	"--enable-default-pie"
+	"--enable-default-ssp"
+	"--enable-bootstrap"
+	"--program-suffix=-15"
+)
+
+AUTOTOOLS_AFTER__WITHGO="--enable-languages=c,c++,cobol,fortran,lto,go,objc,obj-c++,m2,d,ada"
+AUTOTOOLS_AFTER__WITHOUTGO="--enable-languages=c,c++,cobol,fortran,lto,objc,obj-c++,m2,d,ada"
+AUTOTOOLS_AFTER__AMD64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"${AUTOTOOLS_AFTER__WITHGO[@]}"
+)
+AUTOTOOLS_AFTER__ARM64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"${AUTOTOOLS_AFTER__WITHGO}"
+	"-with-arch=armv8-a"
+	"--enable-fix-cortex-a53-835769"
+	"--enable-fix-cortex-a53-843419"
+)
+AUTOTOOLS_AFTER__LOONGARCH64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"${AUTOTOOLS_AFTER__WITHOUTGO/,ada/}"
+	"--with-abi=lp64d"
+	"--with-arch=loongarch64"
+	"--with-tune=la464"
+)
+AUTOTOOLS_AFTER__LOONGSON3=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"${AUTOTOOLS_AFTER__WITHOUTGO/,ada/}"
+	"--enable-languages=c,c++,fortran,lto,objc,obj-c++,m2,d"
+	"--with-abi=64"
+	"--with-arch=gs464"
+	"--with-tune=gs464e"
+	"--with-mips-fix-loongson3-llsc"
+)
+AUTOTOOLS_AFTER__PPC64EL=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"${AUTOTOOLS_AFTER_WITHGO}"
+	"--with-libphobos-druntime-only=no"
+	"--with-cpu=power8"
+	"--with-tune=power9"
+	"--with-long-double-128"
+	"--with-long-double-format=ieee"
+	"--enable-secureplt"
+	"--enable-targets=powerpcle-linux"
+)
+AUTOTOOLS_AFTER__RISCV64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"--with-arch=rv64gc"
+	"--with-abi=lp64d"
+	"--with-isa-spec=2.2"
+)
+
+AB_FLAGS_SPECS=0
+AB_FLAGS_O3=1
+
+# static runtime files must be kept.
+NOSTATIC=0
+NOLTO=1
+RECONF=0

--- a/app-devel/gcc-15/autobuild/patches/0001-libiberty-also-generate-a-PIC-version-of-libiberty.a.patch
+++ b/app-devel/gcc-15/autobuild/patches/0001-libiberty-also-generate-a-PIC-version-of-libiberty.a.patch
@@ -1,0 +1,27 @@
+From b3f87d3c16f312d7111b4b3fa5f09f6517326ff5 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Mon, 25 Nov 2024 15:09:30 +0800
+Subject: [PATCH 1/2] libiberty: also generate a PIC version of libiberty.a
+
+---
+ libiberty/configure | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index 02fbaabe89e..21ba89fcde3 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -5409,10 +5409,6 @@ if [ "${enable_host_shared}" = "yes" ] || [ "${enable_host_pie}" = "yes" ]; then
+   shared=yes
+ fi
+ 
+-if [ "${shared}" != "yes" ]; then
+-  PICFLAG=
+-fi
+-
+ 
+ NOASANFLAG=
+ case " ${CFLAGS} " in
+-- 
+2.49.0
+

--- a/app-devel/gcc-15/autobuild/patches/0002-NFU-mips-disable-ext-dce-by-default.patch
+++ b/app-devel/gcc-15/autobuild/patches/0002-NFU-mips-disable-ext-dce-by-default.patch
@@ -1,0 +1,28 @@
+From 0fcbb90436ecbfcb4001006ae5de5bb0e82dff56 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 2 May 2025 22:50:42 +0800
+Subject: [PATCH 2/2] NFU: mips: disable ext-dce by default
+
+Temporary work around for PR120050.
+---
+ gcc/config/mips/mips.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gcc/config/mips/mips.cc b/gcc/config/mips/mips.cc
+index 24a28dcf817..cf4784c48bb 100644
+--- a/gcc/config/mips/mips.cc
++++ b/gcc/config/mips/mips.cc
+@@ -20993,6 +20993,10 @@ mips_option_override (void)
+     REAL_MODE_FORMAT (SFmode) = &spu_single_format;
+ 
+   mips_register_frame_header_opt ();
++
++  /* FIXME: PR120050 */
++  if (!OPTION_SET_P (flag_ext_dce))
++    flag_ext_dce = 0;
+ }
+ 
+ /* Swap the register information for registers I and I + 1, which
+-- 
+2.49.0
+

--- a/app-devel/gcc-15/autobuild/prepare
+++ b/app-devel/gcc-15/autobuild/prepare
@@ -1,0 +1,8 @@
+# You will see this in "gcc -v" output.
+# BASE-VER identifies the GCC version, please DO NOT EDIT.
+# * DEV-PHASE are used as branding identification, you may alter the line.
+abinfo "Appending AOSC versions to gcc -v ..."
+echo 'AOSC OS' > "$SRCDIR"/gcc/DEV-PHASE
+
+abinfo 'GCC only passes CPPFLAGS in some stages, appending other flags to $CPPFLAGS ...'
+export CPPFLAGS="${CPPFLAGS} -O3 ${CFLAGS_COMMON_ARCH}"

--- a/app-devel/gcc-15/spec
+++ b/app-devel/gcc-15/spec
@@ -1,0 +1,6 @@
+VER=15.1.0
+SRCS="https://sourceware.org/pub/gcc/releases/gcc-${VER}/gcc-${VER}.tar.xz"
+CHKSUMS="sha256::e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea"
+# NOTE: Pinning the major version number to 15. The non-capturing group
+#       is meant to strictly match the GCC release tags.
+CHKUPDATE="git::url=https://gcc.gnu.org/git/gcc.git;pattern=(?:releases/gcc-)(15\\.\\d+\\.\\d+)"


### PR DESCRIPTION
Topic Description
-----------------

- gcc-15: new, 15.1.0
    - Enable COBOL language backend.
    - Track patches at AOSC-Tracking/gcc @ aosc/releases/15.1.0
    \(HEAD: b3f87d3c16f312d7111b4b3fa5f09f6517326ff5\).

Package(s) Affected
-------------------

- gcc-15: 15.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc-15
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
