### PR TITLE
photils-cli: new, 0.4.1

### DIFF
--- a/app-creativity/darktable/autobuild/beyond
+++ b/app-creativity/darktable/autobuild/beyond
@@ -1,9 +1,12 @@
-cd "$SRCDIR"/tools/basecurve
+abinfo "Creating symbolic links for curve tools"
+for PROGRAM in darktable-curve-tool darktable-curve-tool-helper; do
+	ln -sv "../libexec/darktable/tools/${PROGRAM}" \
+		"${PKGDIR}"/usr/bin/${PROGRAM}
+done
 
-cmake .
-make
-
-install -Dm0755 darktable-curve-tool "$PKGDIR"/usr/bin/darktable-curve-tool
-install -Dm0755 darktable-curve-tool-helper "$PKGDIR"/usr/bin/darktable-curve-tool-helper
-
-cd "$SRCDIR"
+abinfo "Installing lua-scripts"
+_LUA_SCRIPTS="${SRCDIR}/src/external/lua-scripts"
+_LUA_INSTALL="${PKGDIR}/usr/share/darktable/lua"
+for i in "${_LUA_SCRIPTS}/"*; do
+	cp -Rv "$i" "${_LUA_INSTALL}"/
+done

--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -6,12 +6,12 @@ PKGDEP="colord-gtk dbus-glib exiv2 flickcurl graphicsmagick gtk-3 \
         libxslt openexr openjpeg pugixml sdl sqlite libosmgpsmap \
         libcl jasper gmic lua-5.4 libheif libavif portmidi \
         libcamera libjxl"
-BUILDDEP="cmake intltool po4a llvm sphinx doxygen"
+BUILDDEP="cmake intltool po4a llvm-21 sphinx doxygen"
 PKGDES="Utility to organize and develop raw images"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
-	-DPROJECT_VERSION=$PKGVER
+	-DPROJECT_VERSION=${PKGVER}
 	-DBINARY_PACKAGE_BUILD=ON
 	-DBUILD_BATTERY_INDICATOR=ON
 	-DBUILD_CURVE_TOOLS=ON
@@ -23,6 +23,10 @@ CMAKE_AFTER=(
 	-DBUILD_SSE2_CODEPATHS=OFF
 	-DBUILD_TOOLS=ON
 	-DDONT_USE_INTERNAL_LUA=ON
+	-DENABLE_JASPER=ON
+	-DENABLE_LCMS=ON
+	-DENABLE_RAWSPEED=ON
+	-DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
 	-DUSE_AVIF=ON
 	-DUSE_CAMERA_SUPPORT=ON
 	-DUSE_COLORD=ON

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,6 @@
 VER=5.4.1
 EPOCH=1
+REL=1
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"

--- a/app-creativity/photils-cli/autobuild/defines
+++ b/app-creativity/photils-cli/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=photils-cli
+PKGSEC=graphics
+PKGDES="Offline neural network image classifier"
+PKGDEP="jsoncpp opencv"
+# FIXME: transitive dependency libgdal requires libavif (but is not marked as a depended package)
+BUILDDEP="cxxopts libavif"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+	-DBUILD_TESTS=OFF
+	-DUSE_CONAN=OFF
+)

--- a/app-creativity/photils-cli/autobuild/patches/0001-cmake-allow-using-system-libraries-without-conan.patch
+++ b/app-creativity/photils-cli/autobuild/patches/0001-cmake-allow-using-system-libraries-without-conan.patch
@@ -1,0 +1,128 @@
+From 8b6a0d32c2ed27193a403ed0e36313b2d291d14a Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Tue, 25 Mar 2025 00:21:35 -0400
+Subject: [PATCH] cmake: allow using system libraries without conan
+
+---
+ CMakeLists.txt       | 41 ++++++++++++++++++++++++++++++++++++-----
+ src/main.cpp         |  4 ++++
+ tests/CMakeLists.txt | 27 +++++++++++++++++++--------
+ 3 files changed, 59 insertions(+), 13 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed691c5..ac1d760 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,9 +7,33 @@ project(photils-cli)
+ project(${PROJECT_NAME} VERSION "0.4.1")
+ 
+ OPTION(BUILD_TESTS "Build test" ON)
++OPTION(USE_CONAN "Build with conan package manager" OFF)
++if(NOT UNIX)
++  set(USE_CONAN ON)
++endif()
+ 
+-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+-conan_basic_setup(NO_OUTPUT_DIRS)
++if(USE_CONAN)
++  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
++  conan_basic_setup(NO_OUTPUT_DIRS)
++else()
++  # Not using conan, find dependencies as required
++  find_package(OpenCV REQUIRED COMPONENTS opencv_core opencv_highgui opencv_dnn)
++  find_package(jsoncpp REQUIRED)
++  find_package(cxxopts REQUIRED)
++  if(cxxopts_VERSION VERSION_GREATER_EQUAL 3)
++    add_compile_definitions("CXXOPTS_3")
++  endif()
++  # Download ghc-filesystem
++  include(FetchContent)
++  FetchContent_Declare(
++          ghc_filesystem
++          GIT_REPOSITORY https://github.com/gulrak/filesystem.git
++          GIT_TAG 8a2edd6d92ed820521d42c94d179462bf06b5ed3 # v1.5.14
++          OVERRIDE_FIND_PACKAGE
++  )
++  FetchContent_MakeAvailable(ghc_filesystem)
++  find_package(ghc_filesystem)
++endif()
+ 
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+@@ -54,9 +78,16 @@ get_target_property( RESOURCE_FOLDER ${PROJECT_NAME} RUNTIME_OUTPUT_DIRECTORY)
+ get_filename_component(RESOURCE_FOLDER ${RESOURCE_FOLDER} DIRECTORY)
+ 
+ 
+-
+-message("conan: ${CONAN_LIBS}")
+-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
++if(USE_CONAN)
++  message("conan: ${CONAN_LIBS}")
++  target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
++else()
++  # TODO: Link system libraries
++  target_include_directories(${PROJECT_NAME} PRIVATE ${OpenCV_INCLUDE_DIR})
++  target_link_libraries(${PROJECT_NAME} PRIVATE ${OpenCV_LIBS})
++  target_include_directories(${PROJECT_NAME} PRIVATE ${jsoncpp_INCLUDE_DIR})
++  target_link_libraries(${PROJECT_NAME} PRIVATE JsonCpp::JsonCpp)
++endif()
+ 
+ message("COPY Target: ${RESOURCE_FOLDER}")
+ 
+diff --git a/src/main.cpp b/src/main.cpp
+index 75de511..12f7d4a 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -76,7 +76,11 @@ int main(int argc, char* argv[]) {
+ 
+       std::exit(predictions.size() > 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+     }
++#ifdef CXXOPTS_3
++  } catch (const cxxopts::exceptions::exception& ex) {
++#else
+   } catch (const cxxopts::OptionException& ex) {
++#endif
+     std::cerr << ex.what() << '\n';
+     std::exit(EXIT_FAILURE);
+   }
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 9522002..b763ead 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -33,14 +33,25 @@ set_target_properties( ${PROJECT_NAME}_test
+     RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin
+ )
+ 
+-target_include_directories(${PROJECT_NAME}_test PUBLIC ${PROJECT_SOURCE_DIR}/include)
+-
+-target_link_libraries(
+-  ${PROJECT_NAME}_test
+-  ${CONAN_LIBS}
+-  gtest_main
+-  gtest
+-)
++if(USE_CONAN)
++    target_include_directories(${PROJECT_NAME}_test PUBLIC ${PROJECT_SOURCE_DIR}/include)
++    target_link_libraries(
++      ${PROJECT_NAME}_test
++      ${CONAN_LIBS}
++      gtest_main
++      gtest
++    )
++else()
++    target_include_directories(${PROJECT_NAME}_test PRIVATE ${OpenCV_INCLUDE_DIR})
++    target_include_directories(${PROJECT_NAME}_test PRIVATE ${ghc_filesystem_SOURCE_DIR}/include)
++    target_link_libraries(
++      ${PROJECT_NAME}_test
++      ${OpenCV_LIBS}
++      JsonCpp::JsonCpp
++      gtest_main
++      gtest
++    )
++endif()
+ 
+ include(GoogleTest)
+ 
+-- 
+2.49.0
+

--- a/app-creativity/photils-cli/spec
+++ b/app-creativity/photils-cli/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="git::commit=tags/v${VER}::https://github.com/scheckmedia/photils-cli.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377317"

--- a/app-utils/graphicsmagick/spec
+++ b/app-utils/graphicsmagick/spec
@@ -1,5 +1,5 @@
 VER=1.3.46
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/$VER/GraphicsMagick-$VER.tar.xz/download"
 CHKSUMS="sha256::c7c706a505e9c6c3764156bb94a0c9644d79131785df15a89c9f8721d1abd061"
 CHKUPDATE="anitya::id=1248"

--- a/runtime-common/cxxopts/spec
+++ b/runtime-common/cxxopts/spec
@@ -1,4 +1,4 @@
-VER=3.2.0
+VER=3.3.1
 SRCS="git::commit=tags/v${VER}::https://github.com/jarro2783/cxxopts.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112688"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: rebuild to include lua scripts
- graphicsmagick: rebuild for liblcms2_fast_float.so.2
- photils-cli: new, 0.4.1
- cxxopts: upgrade to 3.3.1

Package(s) Affected
-------------------

- darktable: 1:5.0.1-3
- cxxopts: 3.3.1
- graphicsmagick: 1.3.46-2
- photils-cli: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cxxopts photils-cli graphicsmagick darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
