### PR TITLE
ydcv-rs: switch upstream to ydcv-saki

### DIFF
--- a/app-i18n/ydcv-rs/autobuild/beyond
+++ b/app-i18n/ydcv-rs/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "symlink binary to ydcv ..."
-ln -sv ydcv-rs "$PKGDIR"/usr/bin/ydcv

--- a/app-i18n/ydcv-rs/autobuild/defines
+++ b/app-i18n/ydcv-rs/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ydcv-rs
 PKGDES="A command-line YouDao Dictionary client"
-PKGDEP="openssl dbus libxcb"
-BUILDDEP="git rustc python-3 llvm"
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="rustc llvm"
 PKGSEC=localization
 
 USECLANG=1
@@ -9,13 +9,6 @@ BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
 NOLTO__LOONGSON3=1
 USECLANG__LOONGSON3=0
 ABSPLITDBG=0
-
-CARGO_AFTER__PPC64EL="--no-default-features \
-                      --features notify,clipboard,native-tls"
-CARGO_AFTER__LOONGSON3="--no-default-features \
-                      --features notify,clipboard,native-tls"
-CARGO_AFTER__RISCV64="--no-default-features \
-                      --features notify,clipboard,native-tls"
 
 PKGBREAK="ydcv<=0.7-2"
 PKGREP="ydcv<=0.7-2"

--- a/app-i18n/ydcv-rs/spec
+++ b/app-i18n/ydcv-rs/spec
@@ -1,4 +1,4 @@
-VER=0.6.3
-SRCS="git::commit=tags/v$VER::https://github.com/farseerfc/ydcv-rs/"
+VER=0.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/eatradish/ydcv-saki/"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=228963"
+CHKUPDATE="anitya::id=377888"


### PR DESCRIPTION
Topic Description
-----------------

- ydcv-rs: update to 0.7.0 ...
    - Switch upstream to https://github.com/eatradish/ydcv-saki

Package(s) Affected
-------------------

- ydcv-rs: 0.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ydcv-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
