### PR TITLE
mesa: support Zink for IMG Rogue GPUs

### DIFF
--- a/runtime-display/mesa/autobuild/patches/1001-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/1001-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,7 +1,7 @@
-From dd47ecb753711bed2206f4ae6d21e8628cf57dbb Mon Sep 17 00:00:00 2001
+From ed2e3846d5f727c7db536a2d293a5b63d81aed1e Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
-Subject: [PATCH 3/8] FROMLIST: zink: Do not use demote on IMG blobs
+Subject: [PATCH 1/6] zink: Do not use demote on IMG blobs
 
 The implementation of demote in IMG blobs seems to be a piece of hack,
 and the current use of it in Zink leads to assertion failure with
@@ -10,13 +10,7 @@ shader".
 
 Disable usage of demote for IMG blobs.
 
-[Mingcong Bai: Resolved minor merge conflict in
-src/gallium/drivers/zink/zink_screen.c, as
-PIPE_CAP_DEMOTE_TO_HELPER_INVOCATION in zink_get_param() was refactored
-as src->demote_to_helper_invocation in zink_init_screen_caps().]
-
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  src/gallium/drivers/zink/zink_compiler.c |  3 ++-
  src/gallium/drivers/zink/zink_screen.c   | 15 +++++++++++++--

--- a/runtime-display/mesa/autobuild/patches/1002-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-proprietary.patch
+++ b/runtime-display/mesa/autobuild/patches/1002-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-proprietary.patch
@@ -1,0 +1,36 @@
+From 646d403ec1d1192fa37948b611a7024726e9b63d Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 30 Nov 2024 17:11:09 +0800
+Subject: [PATCH 2/6] zink: don't assert geometryShader for IMG proprietary
+ driver
+
+The proprietary driver for Imagination Rogue-architecture GPUs does not
+come with geometryShader support.
+
+Change the assert for it to another if condition.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 3eddd1f7efd..8ce1e7b0995 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2902,10 +2902,9 @@ init_driver_workarounds(struct zink_screen *screen)
+    }
+ 
+    if (zink_driverid(screen) ==
+-       VK_DRIVER_ID_IMAGINATION_PROPRIETARY) {
+-      assert(screen->info.feats.features.geometryShader);
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+-   }
+ 
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/1003-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submitting.patch
+++ b/runtime-display/mesa/autobuild/patches/1003-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submitting.patch
@@ -1,0 +1,34 @@
+From bb467b9ac52fab4ba484e90c79014c86f5c131bc Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 09:00:21 +0800
+Subject: [PATCH 3/6] zink: skip empty VkSubmitInfo when submitting
+
+The closed blob from Imagination for their Rogue GPUs cannot accept
+empty VkSubmitInfo, skip them.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index 4000b5cbb4d..2ed0866d88b 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -667,6 +667,13 @@ submit_queue(void *data, void *gdata, int thread_index)
+       }
+    }
+ 
++   if (si[ZINK_SUBMIT_WAIT_ACQUIRE].waitSemaphoreCount != 0 &&
++       si[ZINK_SUBMIT_WAIT_FD].waitSemaphoreCount == 0) {
++      si[ZINK_SUBMIT_WAIT_FD] = si[ZINK_SUBMIT_WAIT_ACQUIRE];
++      num_si--;
++      submit++;
++   }
++
+    /* then the real submit */
+    si[ZINK_SUBMIT_CMDBUF].waitSemaphoreCount = util_dynarray_num_elements(&bs->wait_semaphores, VkSemaphore);
+    si[ZINK_SUBMIT_CMDBUF].pWaitSemaphores = bs->wait_semaphores.data;
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/1004-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Imagination.patch
+++ b/runtime-display/mesa/autobuild/patches/1004-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Imagination.patch
@@ -1,0 +1,73 @@
+From 2aed8456eb34a8db12a7f8a77777da0e01b55576 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 20:49:58 +0800
+Subject: [PATCH 4/6] zink: try to merge two VkSubmitInfo's for Imagination
+ Rogue
+
+The proprietary Vulkan driver for Imagination Rogue architecture GPUs
+has a broken VkQueueSubmit which cannot handle semaphore signaling w/o
+command buffers.
+
+Try to merge semaphores signaling submit to command processing one in
+this case.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c  | 9 ++++++++-
+ src/gallium/drivers/zink/zink_screen.c | 6 ++++++
+ src/gallium/drivers/zink/zink_types.h  | 1 +
+ 3 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index 2ed0866d88b..f845a814d5a 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -756,8 +756,15 @@ submit_queue(void *data, void *gdata, int thread_index)
+       );
+    }
+ 
+-   if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount)
++   if (!si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount &&
++       screen->driver_workarounds.broken_submit) {
++      si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount = si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount;
++      si[ZINK_SUBMIT_CMDBUF].pSignalSemaphores = si[ZINK_SUBMIT_SIGNAL].pSignalSemaphores;
++      si[ZINK_SUBMIT_CMDBUF].pNext = si[ZINK_SUBMIT_SIGNAL].pNext;
+       num_si--;
++   } else if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount) {
++      num_si--;
++   }
+ 
+    simple_mtx_lock(&screen->queue_lock);
+    VRAM_ALLOC_LOOP(result,
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 8ce1e7b0995..30301a058c7 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2906,6 +2906,12 @@ init_driver_workarounds(struct zink_screen *screen)
+        screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+ 
++   /* Assume Rogue when no geometryShader is available */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       !screen->info.feats.features.geometryShader)
++      screen->driver_workarounds.broken_submit = true;
++
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+     * proprietary driver.
+diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
+index 38a37fca724..9b90127aed7 100644
+--- a/src/gallium/drivers/zink/zink_types.h
++++ b/src/gallium/drivers/zink/zink_types.h
+@@ -1558,6 +1558,7 @@ struct zink_screen {
+       bool inconsistent_interpolation;
+       bool can_2d_view_sparse;
+       bool general_depth_layout;
++      bool broken_submit;
+       unsigned z16_unscaled_bias;
+       unsigned z24_unscaled_bias;
+    } driver_workarounds;
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/1005-FROMLIST-Revert-zink-reject-Imagination-proprietary-driver-w-.patch
+++ b/runtime-display/mesa/autobuild/patches/1005-FROMLIST-Revert-zink-reject-Imagination-proprietary-driver-w-.patch
@@ -1,0 +1,36 @@
+From 78721257d7fbc4bfa16ddce4e0c1f0515360a7b1 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 29 Nov 2024 16:10:29 +0800
+Subject: [PATCH 5/6] Revert "zink: reject Imagination proprietary driver w/o
+ geometryShader"
+
+This reverts commit ca087e202766872085d6d02363fd7f4961feba48.
+
+As running Zink on Rogue proprietary driver is somehow fixed now, revert
+this commit to reallow it.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 30301a058c7..175746db6d7 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3470,12 +3470,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
+-   if (zink_driverid(screen) == VK_DRIVER_ID_IMAGINATION_PROPRIETARY && !screen->info.feats.features.geometryShader) {
+-      if (!screen->driver_name_is_inferred)
+-         mesa_loge("zink: Imagination proprietary driver w/o geometryShader is unsupported");
+-      goto fail;
+-   }
+-
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/1006-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-enforced.patch
+++ b/runtime-display/mesa/autobuild/patches/1006-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-enforced.patch
@@ -1,0 +1,38 @@
+From fc3ce0d6e272b6506cc5618eb110cd2cdfadbb15 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 26 Apr 2025 22:13:35 +0800
+Subject: [PATCH 6/6] zink: reject IMG blob <= 1.17@6210866 unless enforced
+
+Imagination closed driver 1.17@6210866 is known to be very glitchy with
+Zink.
+
+Reject it unless zink is enforced.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 175746db6d7..9c5f86a3891 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3470,6 +3470,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
++   /* Reject IMG blobs with DDK below 1.17@6210866 if not forced */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.props.driverVersion <= 6210866) {
++      debug_printf("zink: Imagination proprietary driver is too old to be supported\n");
++      if (screen->driver_name_is_inferred)
++         goto fail;
++   }
++
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=25.0.4
 DXHEADERS_VER=1.615.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
+REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
 CHKSUMS="sha256::76293cf4372ca4e4e73fd6c36c567b917b608a4db9d11bd2e33068199a7df04d \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: add patches for supporting Zink on Imagination Rogue Vulkan driver
    Many embedded devices use GPUs of the Imagination Rogue architecture.
    Add patches for supporting Zink on the Rogue closed source Vulkan
    driver.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:25.0.4+dxheaders1.615.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
