### PR TITLE
incus: update to 6.12.0

### DIFF
--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,4 @@
-VER=6.11.0
+VER=6.12.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"


### PR DESCRIPTION
Topic Description
-----------------

- incus: update to 6.12.0
    Co-authored-by: Billy Yang \(@handsomexdd1024\) <me@venti.love>

Package(s) Affected
-------------------

- incus: 6.12.0
- incus-agent: 6.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
