### PR TITLE
edk2-test: new, stable202406

### DIFF
--- a/app-benchmarks/edk2-test/autobuild/build
+++ b/app-benchmarks/edk2-test/autobuild/build
@@ -1,0 +1,18 @@
+if ab_match_arch amd64; then
+    _EDK2_TARGET="X64"
+elif ab_match_arch arm64; then
+    _EDK2_TARGET="AARCH64"
+elif ab_match_arch loongarch64; then
+    _EDK2_TARGET="LOONGARCH64"
+fi
+
+abinfo "Building EFI executable ($ARCH, ${_EDK2_TARGET} ..."
+ln -s "$SRCDIR"/../edk2-test_temp/uefi-sct/SctPkg "$SRCDIR"/../SctPkg
+cd "$SRCDIR"/../
+# Note: Build system requires SctPkg to be on the same level as EDK2 sources.
+SctPkg/build.sh ${_EDK2_TARGET} GCC5 RELEASE
+
+abinfo "Installing EFI executable $ARCH ${_EDK2_TARGET} ..."
+mkdir -pv "$PKGDIR"/usr/share/SctPackage/
+cp -av Build/UefiSct/RELEASE_GCC5/SctPackage${_EDK2_TARGET}/* \
+    "$PKGDIR"/usr/share/SctPackage

--- a/app-benchmarks/edk2-test/autobuild/defines
+++ b/app-benchmarks/edk2-test/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=edk2-test
+PKGSEC=utils
+PKGDES="Tester tools for UEFI platforms"
+PKGPROV="uefi-sct"
+BUILDDEP="nasm acpica-unix"
+
+# Note: This package is architecture-specific but has no ELF binary.
+ABSPLITDBG=0
+
+# FIXME: Limited by upstream support.
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/app-benchmarks/edk2-test/autobuild/postinst
+++ b/app-benchmarks/edk2-test/autobuild/postinst
@@ -1,0 +1,42 @@
+# We don't want to install SCT during release tarball generation and while in
+# chroot or containers.
+if systemd-detect-virt -qrc ; then
+    echo $"-- Running in container or chroot; Skipping the installation."
+    exit 0
+fi
+
+if [ ! -e /sys/firmware/efi ] ; then
+    echo "The system is not booted with EFI, skipping."
+    exit 0
+fi
+
+# Define the source and target paths for the program
+PROGRAM_SOURCE="/usr/share/SctPackage"
+PROGRAM_TARGET_DIR="EFI/"
+PROGRAM_TARGET=""
+
+# List all mounted vfat partitions and check for /efi or /boot/efi
+MOUNT_POINTS=$(findmnt -rno TARGET -t vfat)
+
+for MOUNT_POINT in $MOUNT_POINTS; do
+    if [[ "$MOUNT_POINT" == "/efi" || "$MOUNT_POINT" == "/boot/efi" ]]; then
+        PROGRAM_TARGET="$MOUNT_POINT/$PROGRAM_TARGET_DIR"
+        break
+    fi
+done
+
+# If no suitable mount point is found, output an error and exit
+if [ -z "$PROGRAM_TARGET" ]; then
+    echo "Warning: Could not find a mounted EFI System Partition."
+    exit 0
+fi
+
+# Create the target directory if it doesn't exist
+ mkdir -pv $(dirname "$PROGRAM_TARGET")
+
+# Copy the program files to the target directory
+echo "Copying SctPackage to $PROGRAM_TARGET..."
+cp -rf "$PROGRAM_SOURCE" "$PROGRAM_TARGET"
+
+# Success message
+echo "Program successfully installed to $PROGRAM_TARGET/SctPackage"

--- a/app-benchmarks/edk2-test/autobuild/prepare
+++ b/app-benchmarks/edk2-test/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Unsetting all preset compiler/linker flags for EFI applications ..."
+unset CPPFLAGS CFLAGS LDFLAGS

--- a/app-benchmarks/edk2-test/spec
+++ b/app-benchmarks/edk2-test/spec
@@ -1,0 +1,11 @@
+UPSTREAM_VER=202406
+EDK2_VER=202405
+VER=${UPSTREAM_VER}+edk2${EDK2_VER}
+# Note: The source repositories can be cached, including the submodules.
+# Letting ACBS to handle them will save time and network traffic, as these two contain a lot of submodules.
+SRCS="git::commit=aosc/edk2-test-stable${UPSTREAM_VER};rename=edk2-test_temp;copy-repo=true;submodule=recursive::https://github.com/AOSC-Tracking/edk2-test \
+      git::commit=aosc/edk2-stable${EDK2_VER};rename=edk2;copy-repo=true;submodule=recursive::https://github.com/AOSC-Tracking/edk2"
+CHKSUMS="SKIP \
+         SKIP"
+SUBDIR=edk2
+CHKUPDATE="anitya::id=377865"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
Tester Tools for UEFI platforms:
https://github.com/tianocore/edk2-test/releases

Ops:

1. Enter /efi/EFI
2. SctPackage/InstallXXX64.efi -> install SCT to Space Zone
3. Enter fsx:SCT
4. Usage:

  SCT [-a | -c | -s <seq> | -u | -p <MNP | IP4 | SERIAL>] [-r] [-g <report>][-v]
     -a    Executes all test cases.
     -c    Continues execute the test cases.
     -g    Generates test report.
     -p    Passive Mode with specified communication layer
     -r    Resets all test results.
     -s    Executes the test cases in the test sequence file.
     -u    Turns into user-friendly interface.
     -f    Force the operation execution, no confirmation from user.
     -v    Verbose function to disable screen output.

Result: Generate Report log

Re: https://github.com/AOSC-Dev/aosc-os-abbs/pull/10587


Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
