### PR TITLE
linux-firmware: update to 20250425+debian20241210+1~bpo12+1

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=20250220
-DEBIANVER=20241210-1
+UPSTREAM_VER=20250425
+DEBIANVER=20241210-1~bpo12+1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 #SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=6cf959daab2a38d074b059f73c24aab9d4dbcbc3::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=8d82acd29b5c115f0b75b17907ebce712c6f2e22::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
@@ -14,6 +14,6 @@ CHKSUMS="SKIP \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::b37bfaff703166f41612420fa19a425c66c32cab32c144c737882e25163b9e69"
+         sha256::22187c54c6259e768e32c9ec97df2eb0121b75a4243b9e819c87fa07272f03f6"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"

--- a/topics/linux-firmware-20250425.toml
+++ b/topics/linux-firmware-20250425.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "Linux Firmware Update (April 25, 2025)"
+zh_CN = "Linux 固件更新（2025 年 4 月 25 日）"
+
+[caution]
+default = "With enhancements for various audio, graphics, networking, and SoC devices and platforms, and a fix for unusable Wi-Fi on REDMI Book Pro 14 2025"
+zh_CN = "包含对数款音频、图形和网络设备，以及 SoC 平台的支持增强，并修复 REDMI Book Pro 14 2025 上无线网络不可用的问题"
+
+[packages]
+"firmware-nonfree" = "20250425+debian20241210+1~bpo12+1"


### PR DESCRIPTION
Topic Description
-----------------

```
linux-firmware: update to 20250425+debian20241210+1~bpo12+1

AI (ooh):

- Intel...
  - Add firmware for NPUs found on Meteor Lake, Arrow Lake and Lunar Lake
    (version: ci_tag_ud202512_vpu_rc_20250306_1130)

Audio:

- Cirrus...
  - CS35L41...
    - Tweaks for Steam Deck
    - Add support for...
      - ASUSTek commercial/consumer laptops
      - HP Cadet, Clipper OmniBook, Turbine OmniBook, Trekker, Enstrom
        Onmibook, Piston Omnibook
  - CS35L56...
    - Fix amplifier issue with ASUSTek UM5606KA
    - Correct filenames of SSID (subsystem ID?) 103c:8e1b and 103c:8e1c
      - "These laptops use a cs35l56 part rather than the cs35l54 used in
        many of the other devices in that product family."
- Intel...
  - AVS topology file updates for...
    - Analog Devices 4567 (I2S)
    - Dialog 7219 (I2S)
    - Maxim 98357a (I2S)
    - Maxim 98373 (I2S)
    - Maxim 98927 (I2S)
    - Nuvoton 8825 (I2S)
    - Realtek 274 (I2S)
    - Realtek 286 (I2S)
    - Realtek 298 (I2S)
    - Realtek 5514 (I2S)
    - Realtek 5640 (I2S)
    - Realtek 5663 (I2S)
    - HD Audio codecs
    - HDMI codecs
    - Digital Microphone Arrays
- MediaTek...
  - Add firmware for MT8188/8195
- Texas Instruments...
  - tas2781...
    - DSP firmware update for Gemtree project
    - Swap channel for SPI projects
- Qualcomm...
  - Lenovo ThinkPad T14s (Qualcomm X1E80100): Add ASoC topology firmware
  - Lenovo Yoga Slim 7x (Qualcomm X1E80100): Add ASoC topology firmware

Cryptographic Accelerators:

- Intel...
  - Intel QAT 420xx crypto/compression accelerators...
    - Update firmware to 0.9.0
    - For changelogs and errata, see:
      https://intel.github.io/quickassist/RN/In-Tree/index.html

Graphics:

- AMDGPU...
  - Firmware updates...
    - Aldebaran, Beige Goby, Dimgrey Cavefish, Navi 10, Navi 12, Navi 14,
      Navy Flounder, Picasso, Sienna Cichlid, Vangogh, Vega 10, Vega 12,
      Vega 20, Yellow Carp
    - GC 9.4.3/9.4.4/10.3.6/10.3.7/11.0.0/11.0.1/11.0.2/11.0.3/11.0.4/
      11.5.0/11.5.1/11.5.2/12.0.0/12.0.1/14.0.3
    - PSP 13.0.6/13.0.0/13.0.4/13.0.7/13.0.10/13.0.14/14.0.0/14.0.1/14.0.2
    - SDMA 7.0.1
    - SMU 14.0.2/14.0.3
    - VCN 3.1.2/4.0.0/4.0.2/4.0.4/5.0.0
  - DCMUB - DCN 3.5/3.5.1/4.0.1: Update firmware to 0.1.6.0, to quote...
    - Fix initialization logic
    - Revise Replay residency calculation
    - Fix USB4 issues
    - Implement HDMI Read request
    - RMCM and MCM 3DLUT support
    - Enable urgent latency adjustment on DCN35
    - Enable phy-ssc reduction by default
  - DCMUB - DCN 3.1.4/4.0.1: Update firmware to 0.1.1.0, to quote...
    - Fix coverity overflow error
    - Fix problem with replay
  - DCMUB - DCN 3.5/3.5.1: Update firmware to 0.1.0.0, to quote...
    - Fix transition problem with dpg
    - Add new support in OTG
    - Fix problem suring suspend
    - Fix problem with replay + vrr
  - DCN 3.1.4: Update firmware to 8.0.78.0, to quote...
    - Fix missing ALPM init when transit state 2A to 4 ditectly
  - DCN 3.1.5/4.0.1: Update firmware to 0.0.255.0, allegedly fixing
    "DCN4X init" and "HPS after GPU reset"
  - DCN 3.5: Update firmware to 0.1.0.0
    - "Fixes a Replay/VRR interop issue."
  - DCN 3.5/3.5.1: Update firmware (???) to 9.0.27.0, to quote...
    - Fix dpia not bypass lttpr aux to tbt3 device
    - refine vupdate for PSR SU deadline missing
  - DCN 4.0.1: Update firmware to 0.1.3.0, to quote...
    - Updated DCCG programming sequence
    - Add read histogram
    - Fix 24/30FPS full screen video low residency
    - AUX channel default to I2C
- Intel...
  - Battlemage and Lunar Lake: Update GuC firmware to v70.44.1
  - DG1/DG2/TGL/ADL/MTL: Update GuC firmware to v70.44.1
  - Update Xe3LPD DMC to v2.23
    - Skip SW early wake when FlipQ is disabled or preempted
- Qualcomm...
  - QCS8300 chipset...
    - Add GMU and ZAP firmware, update a650_sqe.fw
    - qcom/a650_sqe.fw: v1.12
    - qcom/a623_gmu.bin: v3.06.00
    - qcom/qcs8300/a623_zap.mbn: v0.1
    - qcm6490: Add Host Firmware Interface (HFI) gen2 based video firmware
    - SA8775p: Add the binary with higher firmware size to support 32
      concurrency sessions in SA8775p
    - SM8250: VIDEO.VPU.1.0-00119-PROD-1

Industrial I/O:

- Bosch...
  - Add firmware for the BMI260 IMU

Multimedia:

- MediaTek...
  - MT8188: Add SCP firmware
    - "System Control Processor is an RISC-V processor in MediaTek MT8188
      SoC. It supports vedio encode/decode, MDP and CrOS EC host command."

Networking (Wired):

- Aeonsemi...
  - Add firmware for AS21x1x 1G/2.5G/5G/10G Ethernet PHY
- Mellanox...
  - Add NVIDIA Spectrum-family switch firmware for Spectrum
    (13.2014.4012), Spectrum-2 (29.2014.4012), Spectrum-3 (30.2014.4012)
    and Spectrum-4 (34.2014.4012)

SoC Platforms:

- Qualcomm...
  - Add firmware files for Lenovo Yoga Slim 7 (Snapdragon X1 Elite)
  - Add Iris support for Lenovo ThinkPad T14s G6 (Snapdragon X1 Elite)
  - Add QUPv3 firmware for Qualcomm QCS9100 platforms

Wi-Fi and Bluetooth:

- Intel...
  - BlazarI: Update firmware to Release Version: 23.120.0.4,
    FSEQ: 0x0.0.4.195, affecting...
    - Garfield Peak2 (AX211)
    - Filmore Peak2 (BE201)
  - BlazarU: Update firmware to Release Version: 23.120.0.4,
    FSEQ: 0x0.0.4.195, affecting...
    - Harrison Peak2 (AX201)
    - Harrison Peak1 (AX101)
  - Bz/gl: Update firmware for core95-82 release
  - Bz-hr: Add Bz-hr FW for core93-123 release
    - This should enable Wi-Fi functionality on REDMI Book Pro 2025 (14'')
  - cc/Qu/QuZ: Update firmware for core95-82 release
  - ty/So/Ma: Update firmware for core95-82 release
- MediaTek...
  - MT7920: Update bluetooth firmware to 20250210151502
  - MT7925...
    - Update Wi-Fi firmware, MCU version 20250305132908a,
      RAM code 20250305132802
    - Update bluetooth firmware to 20250305133215
- Qualcomm...
  - IPQ5018 hw1.0: Update to
    WLAN.HK.2.6.0.1-01300-QCAHKSWPL_SILICONZ-1
  - QCA2066...
    - Update bluetooth firmware to 2.1.0-00653
    - Add 2 additional non-volatile memory images...
      - qca/hpnv21.30a  : NVM dump
      - qca/hpnv21g.30a : NVM dump
    - Add USB transport support
      - qca/QCA2066/rampatch_usb_00130201.bin     : RAMPATCH
      - qca/QCA2066/nvm_usb_00130201_030a.bin     : NVM
      - qca/QCA2066/nvm_usb_00130201_gf_030a.bin  : NVM
  - QCA6698AQ hw2.1: Update board-2.bin
  - QCA6698AQ hw2.1: Update to
    WLAN.HSP.1.1-04604-QCAHSPSWPL_V1_V2_SILICONZ_IOE-1
  - QCN9074 hw1.0: Update to WLAN.HK.2.9.0.1-02175-QCAHKSWPL_SILICONZ-2
  - QCN9274 hw2.0: Update board-2.bin
  - WCN6855 hw2.0: Update board-2.bin
  - WCN685x hw2.1: Update bluetooth firmware to 2.1.0-00653
  - WCN7850 hw2.0: Update to
    WLAN.HMT.1.1.c5-00284-QCAHMTSWPL_V1.0_V2.0_SILICONZ-3
  - WCN785x (USB): Update bluetooth firmware to 2.0.0-00790-3
- Realtek...
  - RTL8814AE/RTL8814AU: Add firmware v33.6.0
    - "... from the vendor driver v5.8.5.1_35583.20191029 from
      https://github.com/morrownr/8814au"
  - RTL8852B: Update bluetooth USB firmware to 0x098B_154B
  - RTL8852BT: Update firmware to v0.29.122.0, BB parameter to 07,
    allegedly fixing occasional beacon loss
  - RTL8852BT/RTL8852BE-VT: Update bluetooth USB firmware to 0x1881_BA06
  - RTL8852C: Update firmware to v0.27.125.0, allegedly adding "[s]upport
    secure boot [sic.] with anti-rollback"
    - Update element RF TXPWR to R78
  - RTL8922A: Update firmware to v0.35.64.0, allegedly adding support for
    different TX power between RF path
    - Update element RF TXPWR to R40
  - RTL8922AE/8922AE-VS: Update firmware to v0.35.63.0, allegedly adding
    Secure Boot support
```

Package(s) Affected
-------------------

- firmware-free: 20250425+debian20241210+1~bpo12+1
- firmware-nonfree: 20250425+debian20241210+1~bpo12+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
