### PR TITLE
topics: match metapackages for linux-kernel*.toml

### DIFF
--- a/topics/linux-kernel-6.14.4.toml
+++ b/topics/linux-kernel-6.14.4.toml
@@ -10,3 +10,4 @@ zh_CN = "修复机械革命无界 14X 笔记本 S0ix 睡眠失败的问题"
 
 [packages]
 "linux-kernel-6.14.4" = "6.14.4-1"
+"linux+kernel" = "3:6.14.4"

--- a/topics/linux-kernel-6.14.toml
+++ b/topics/linux-kernel-6.14.toml
@@ -10,3 +10,4 @@ zh_CN = "包含对新设备支持的改进，尤其是 AMD Radeon RX 9000 系列
 
 [packages]
 "linux-kernel-6.14.0" = "6.14.0-2"
+"linux+kernel" = "3:6.14.0"

--- a/topics/linux-kernel-lts-6.12.25.toml
+++ b/topics/linux-kernel-lts-6.12.25.toml
@@ -10,3 +10,4 @@ zh_CN = "包含对新设备支持的改进，尤其是 AMD Radeon RX 9000 系列
 
 [packages]
 "linux-kernel-lts-6.12.25" = "6.12.25-1"
+"linux+kernel+lts" = "2:6.12.25"


### PR DESCRIPTION
Topic Description
-----------------

- topics: match metapackages for linux-kernel\*.toml
    All versioned kernel packages are installed upon updating
    linux+kernel{,+lts} and will not match any TUM conditions.
    List the metapackages to make sure they get matched.

Package(s) Affected
-------------------

- linux+kernel: 3:6.14.4
- linux+kernel+lts: 2:6.12.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux+kernel linux+kernel+lts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
