### PR TITLE
iosevka-fonts: update to 33.2.2

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.1
+VER=33.2.2
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::37dd247a0cea2f73e7651be38f311792c872a5b8297440c5ee48839157cbd9cc \
-         sha256::ff04a5adfbc3dab7f27a6814099090f651eb468af5aef6e660b79248f8f87a6c \
-         sha256::ce25b0078e2fac9c66a9888a8d15323ebd9fbd6a608f5d6c0ec822a5e38561ea \
-         sha256::3c55da9cbb2b383b5e7a1ab5444e5717fb2e85b88325e9987549f0c9a2dc67d6 \
-         sha256::a184c4dfd482d4999713c7df29ddd826aa08fbb7a932aa5201b7a6f5288d6148 \
-         sha256::fa6e7b54f5576ee61362638f0ef219c2d59462d08c413006367b26c42931836d \
-         sha256::d515468735d0cf8ed840b139f367157246304d4442e3b34d6153324964ed276c \
-         sha256::948dff2618356ac0d03345579b27af5f33c2818bd7e4ac59982f5fb6e03a2edd \
-         sha256::7d20c3bbc83e2bdd8a7135ce5cb2612530ce24074f0f16718042fd57064d3b59 \
-         sha256::88646e3b066390de675b6e54fec9b9ec615af25acbbb42edc5fca192c61c687c \
-         sha256::28f5e7909717474cdaa4481e2411c86b570c7a5abeaaa756317d432fe7b6b2a5 \
-         sha256::31ff3603d2b7b9028463b0f4736cbce55d4f8b85c0804ad72b53ed82db64bec2 \
-         sha256::e32f03b4efd6ee0a97537210356169107b37ba94199cdd0fb96c42c42c22be9a \
-         sha256::0e25dc4dcf14db5278b919afa5aca87bff655b765c934404b241c7c33322b1b9 \
-         sha256::bce01150f81b8d322eaa9de00dfc793d47d85b8a4e6ef6f5ca1d4ee5bd824163 \
-         sha256::45bb313bc352534a9be21d7409a0e0b65e0351326ecbae54d76bff0d0365d0c3 \
-         sha256::1e5af11bafae58baa2e9193bb5d69810e12b4d4c149d4bf1c84015fc59a13202 \
-         sha256::9a231a85b75e4ff42121f1c5048aa5ac9f1c7d9970323d4aa562d95650e8b343 \
-         sha256::66d71aa50e03c2640ed1bd0510b770e78011fe6b6a26e8da2e453e7e80c28901 \
-         sha256::2c2a770a58feb02ee944e056cf358c379cc9675bb26a2e48faf8074258587492 \
-         sha256::288d010e5fd0f1b4a975f13d5e19ffa26608630b5b36ee26e08d6d42d1ee4962 \
-         sha256::9db8b73fdefa09265285ec2c78c2ae4bea2df413caa41d567cc33e95194f202a \
-         sha256::b9c546f1e2a4319efb954f877acce6c3504334e7f408dc90e19577f7672b7526 \
-         sha256::96bc6f57bb6608320ad282603e701c3bbff321db78b3e15d18880a62a5bc6223 \
+CHKSUMS="sha256::ae0aed2bb9d4068beccc472961d943d165bb89f51a1425fca1324c5b32684736 \
+         sha256::0af50ed9541a3d173d02d565b7747a2291c2af4a8713a8130ad4cbf94430cc76 \
+         sha256::bfc57957ca969587e1e9b90c66878eb0a6be9f1bbc3067beca170ab35451f3bf \
+         sha256::330d41f47aa6173922177c3b64f1b0a42473811314ec3a1961088b7ac774b74e \
+         sha256::377eb05fbaff7111f0a36cee3c292368a89c01fd93af1606496289a6adec7d63 \
+         sha256::8f7e57b2ea44c0b4d69e995815d3b5560276e673dc626a097bf66bfcd6e84619 \
+         sha256::b2a4338a156d21dd896dd2c4f8b34bbb04136ac4d7c136c002673aed93ef6971 \
+         sha256::f87f72b238036315babe72cf6150dda64ce9986523c20a37bfa63d2afeb8d49d \
+         sha256::229b1ac12c523875e5c274c6bbc0d2926acd948dfb086d8a744ff07d7a93b5d3 \
+         sha256::649f0fc91dace1b99b86904c0fe0b34177c0a2e5219f670e790a85c2fa0fedec \
+         sha256::dcaab8c04496980f93afe6c7a93c1c471cff88699d06a59e12951874cbf02c11 \
+         sha256::4dfcd9f22982d1d6d1b1a48377216066e765a4974b77c067d404b3e6895d66a7 \
+         sha256::619baf8eb5d8a0d04683ad82c5b917a04e1bf972b829a864124b6b04d9162b94 \
+         sha256::9b9792c9a0fa84158539ea5651c356538f86a5566b855c97ccc99c2d6b1c1958 \
+         sha256::13dee9751b848eac8b315817fc0a3b91077136de5334944133aedf305a91f57a \
+         sha256::02fb2762f61706b0f5ee1a3259ff66822f93e454f326b80cd7271a84e33d1429 \
+         sha256::17ba47f7c9397eb3893a03b3275ab699c6ea59e11690b2d7d84f01314f2c568a \
+         sha256::f51c3c45bce9b7fdd64467e6526828fa647853e166c4b1b27dbc4a80e6d0fa12 \
+         sha256::bf870681cc82a9fc0614d58320c753632795871a66443cc349dd351178dd0fd4 \
+         sha256::f03b8e6cf83566c20c9737f2f89e5cb29178aff20657ac7c275ca98c467825b2 \
+         sha256::90a1e32b5367b2521e89eda7831debb7c961f73e424783b1c4bf58282957f28c \
+         sha256::d7a01bc0ba522ee7c5ba92e5d1b12bf35036638c6f1ce61538a6a17a7de0ab1c \
+         sha256::f0f962eb35738240bdebae121b384e95f3532ef35ff2fa2d2342bf18e23bead6 \
+         sha256::84935a2d37acaa11f18a0160def0d2d4b2e598ff81d910aeec82c9ce42c59d42 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
