### PR TITLE
starship: update to 1.23.0

### DIFF
--- a/app-utils/starship/autobuild/defines
+++ b/app-utils/starship/autobuild/defines
@@ -6,18 +6,6 @@ BUILDDEP="rustc llvm"
 
 ABTYPE=rust
 USECLANG=1
-ABSPLITDBG=0
-
-# FIXME: libz-ng does not support loongson3 and mips64r6el
-CARGO_AFTER__LOONGSON3="--no-default-features --features gix-faster"
-CARGO_AFTER__MIPS64R6EL="--no-default-features --features gix-faster"
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1
-NOLTO__MIPS64R6EL=1
-USECLANG__LOONGSON3=0
-
-# FIXME: libz-ng FTBFS on arm64
-# See: https://github.com/zlib-ng/zlib-ng/issues/1616
-CARGO_AFTER__ARM64="--no-default-features --features gix-faster"

--- a/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
+++ b/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
@@ -1,4 +1,4 @@
-From b33929647dd5b9030056d6784a9194872ef34a9a Mon Sep 17 00:00:00 2001
+From 0afe2aaad6c8424738fc1a9e4a11223642ab52e7 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 17 Sep 2023 18:30:43 +0800
 Subject: [PATCH 1/2] feat(status): add `success_symbol_rootuser` option
@@ -12,10 +12,10 @@ This commit will allow user to set a different success symbol for root users tha
  4 files changed, 43 insertions(+)
 
 diff --git a/.github/config-schema.json b/.github/config-schema.json
-index 6ec2c4b0..a0b73b02 100644
+index b5dcb83d..cac5d9b8 100644
 --- a/.github/config-schema.json
 +++ b/.github/config-schema.json
-@@ -1729,6 +1729,7 @@
+@@ -1606,6 +1606,7 @@
          "signal_symbol": "⚡",
          "style": "bold red",
          "success_symbol": "",
@@ -23,7 +23,7 @@ index 6ec2c4b0..a0b73b02 100644
          "symbol": "❌"
        },
        "allOf": [
-@@ -5989,6 +5990,10 @@
+@@ -5815,6 +5816,10 @@
            "default": "",
            "type": "string"
          },
@@ -35,10 +35,10 @@ index 6ec2c4b0..a0b73b02 100644
            "default": "🚫",
            "type": "string"
 diff --git a/docs/config/README.md b/docs/config/README.md
-index d481f84d..7cda892e 100644
+index 4ac9b238..d7e197ea 100644
 --- a/docs/config/README.md
 +++ b/docs/config/README.md
-@@ -4282,6 +4282,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+@@ -4437,6 +4437,7 @@ To enable it, set `disabled` to `false` in your configuration file.
  | `format`                    | `'[$symbol$status]($style) '`                                                  | The format of the module                                              |
  | `symbol`                    | `'❌'`                                                                         | The symbol displayed on program error                                 |
  | `success_symbol`            | `''`                                                                           | The symbol displayed on program success                               |
@@ -46,7 +46,7 @@ index d481f84d..7cda892e 100644
  | `not_executable_symbol`     | `'🚫'`                                                                         | The symbol displayed when file isn't executable                       |
  | `not_found_symbol`          | `'🔍'`                                                                         | The symbol displayed when the command can't be found                  |
  | `sigint_symbol`             | `'🧱'`                                                                         | The symbol displayed on SIGINT (Ctrl + c)                             |
-@@ -4323,6 +4324,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+@@ -4478,6 +4479,7 @@ To enable it, set `disabled` to `false` in your configuration file.
  style = 'bg:blue'
  symbol = '🔴 '
  success_symbol = '🟢 SUCCESS'
@@ -55,7 +55,7 @@ index d481f84d..7cda892e 100644
  map_symbol = true
  disabled = false
 diff --git a/src/configs/status.rs b/src/configs/status.rs
-index c4e4ed8d..c795e2e7 100644
+index adc42e48..b7c3c522 100644
 --- a/src/configs/status.rs
 +++ b/src/configs/status.rs
 @@ -11,6 +11,7 @@ pub struct StatusConfig<'a> {
@@ -75,7 +75,7 @@ index c4e4ed8d..c795e2e7 100644
              not_found_symbol: "🔍",
              sigint_symbol: "🧱",
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index d9276f2e..0f9e03d6 100644
+index acc11a53..d73b8371 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
 @@ -46,6 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -134,5 +134,5 @@ index d9276f2e..0f9e03d6 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 -- 
-2.47.1
+2.49.0
 

--- a/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
+++ b/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
@@ -1,4 +1,4 @@
-From dd25fe463af9365096cdd259a43e560eacd84abd Mon Sep 17 00:00:00 2001
+From 61a0255e1ba2b75d319fb29408372864bc88964d Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 21 Sep 2023 18:11:16 +0800
 Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
@@ -13,7 +13,7 @@ Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
  create mode 100644 src/modules/utils/is_root_user.rs
 
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index 0f9e03d6..6821a483 100644
+index d73b8371..26dd24d3 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
 @@ -1,5 +1,6 @@
@@ -63,7 +63,7 @@ index 0f9e03d6..6821a483 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 diff --git a/src/modules/username.rs b/src/modules/username.rs
-index c25a5bd2..97ef9824 100644
+index 9ce73ac0..0ab45d8d 100644
 --- a/src/modules/username.rs
 +++ b/src/modules/username.rs
 @@ -1,3 +1,4 @@
@@ -72,7 +72,7 @@ index c25a5bd2..97ef9824 100644
  
  use crate::configs::username::UsernameConfig;
 @@ -87,38 +88,6 @@ fn is_login_user(context: &Context, username: &str) -> bool {
-         .map_or(true, |logname| logname == username)
+         .is_none_or(|logname| logname == username)
  }
  
 -#[cfg(all(target_os = "windows", not(test)))]
@@ -158,5 +158,5 @@ index 209da8ed..445898b0 100644
 +
 +pub mod is_root_user;
 -- 
-2.47.1
+2.49.0
 

--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.22.1
+VER=1.23.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- starship: update to 1.23.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- starship: 1.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit starship
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
