### PR TITLE
pysmbc: update to 1.0.25.1

### DIFF
--- a/lang-python/pysmbc/autobuild/defines
+++ b/lang-python/pysmbc/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="samba"
 BUILDDEP="setuptools"
 PKGDES="Python bindings for Samba client"
 
+NOPYTHON2=1
 ABTYPE=python

--- a/lang-python/pysmbc/spec
+++ b/lang-python/pysmbc/spec
@@ -1,5 +1,4 @@
-VER=1.0.22
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/p/pysmbc/pysmbc-$VER.tar.gz"
-CHKSUMS="sha256::f9ce6f8cf17a2e7867b3cd87b2a47eca04ed955f37937b617088698c06177eba"
+VER=1.0.25.1
+SRCS="pypi::version=$VER::pysmbc"
+CHKSUMS="sha256::22f1715df82589fd9cc4253feab390b4ef0babf14f64513cd8d07b3789963226"
 CHKUPDATE="anitya::id=86642"


### PR DESCRIPTION
Topic Description
-----------------

- pysmbc: update to 1.0.25.1
    - Drop python2 support.

Package(s) Affected
-------------------

- pysmbc: 1.0.25.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pysmbc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
