### PR TITLE
geant4: update to 11.3.2

### DIFF
--- a/app-scientific/geant4/spec
+++ b/app-scientific/geant4/spec
@@ -1,4 +1,4 @@
-VER=11.3.1
+VER=11.3.2
 SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
-CHKSUMS="sha256::c93ca996f6f35aa43f948ffcaba9603468df01deeb62f61c33ba769227c319fe"
+CHKSUMS="sha256::892aedd7425262a50ac3d3c7117d81c0c0da4b408c6880dbaf5478b9301e488c"
 CHKUPDATE="anitya::id=375805"


### PR DESCRIPTION
Topic Description
-----------------

- geant4: update to 11.3.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- geant4: 11.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit geant4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
