### PR TITLE
valgrind: update to 3.25.0

### DIFF
--- a/app-devel/valgrind/autobuild/defines
+++ b/app-devel/valgrind/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=valgrind
 PKGSEC=devel
 PKGDEP="glibc-dbg openmpi perl"
-PKGDEP__RISCV64="${PKGDEP/openmpi/}"
 PKGDES="A tool to help find memory management problems in programs"
 
 # Filter out some flags that cause lots of valgrind test failures.
@@ -17,10 +16,9 @@ AB_FLAGS_SSP=0
 AB_FLAGS_FTF=0
 NOLTO=1
 
-AUTOTOOLS_AFTER="--with-mpicc=mpicc"
-AUTOTOOLS_AFTER__RISCV64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-mpicc"
+AUTOTOOLS_AFTER=(
+    '--with-mpicc=mpicc'
+)
 
 PKGDEP__RETRO="glibc-dbg perl"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
@@ -32,14 +30,6 @@ PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 AUTOTOOLS_AFTER__RETRO="--without-mpicc"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
 
 # configure: error: Unsupported host architecture. Sorry
-FAIL_ARCH="(loongarch64|riscv64)"
+FAIL_ARCH="(loongarch64)"

--- a/app-devel/valgrind/spec
+++ b/app-devel/valgrind/spec
@@ -1,4 +1,4 @@
-VER=3.24.0
+VER=3.25.0
 SRCS="tbl::https://sourceware.org/pub/valgrind/valgrind-$VER.tar.bz2"
-CHKSUMS="sha256::71aee202bdef1ae73898ccf7e9c315134fa7db6c246063afc503aef702ec03bd"
+CHKSUMS="sha256::295f60291d6b64c0d90c1ce645634bdc5361d39b0c50ecf9de6385ee77586ecc"
 CHKUPDATE="anitya::id=13639"


### PR DESCRIPTION
Topic Description
-----------------

- valgrind: update to 3.25.0
    Enable building on RISC-V.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- valgrind: 3.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit valgrind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
