### PR TITLE
kodi: update to 21.2

### DIFF
--- a/app-multimedia/kodi/autobuild/beyond
+++ b/app-multimedia/kodi/autobuild/beyond
@@ -24,7 +24,7 @@ for i in peripheral.joystick; do
 	        -G Ninja \
 	        -DCMAKE_INSTALL_PREFIX=/usr \
 	        -DCMAKE_INSTALL_LIBDIR=/usr/lib/kodi \
-	        -DCMAKE_BUILD_TYPE=Release \
+	        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	        -DBUILD_SHARED_LIBS=1 \
 	        -DADDONS_TO_BUILD="$i" \
 	        -DADDONS_SRC_PREFIX="$SRCDIR"/../"$i" \

--- a/app-multimedia/kodi/autobuild/defines
+++ b/app-multimedia/kodi/autobuild/defines
@@ -7,40 +7,42 @@ PKGDEP="afpfs-ng bluez dcadec fribidi glew hicolor-icon-theme \
         mesa-demos pillow pulseaudio samba shairplay simplejson sdl2 \
         taglib tinyxml udisks unrar unzip upower yajl rtmpdump \
         pybluez cwiid flatbuffers fmt fstrcmp rapidjson mariadb libxslt \
-        sndio spdlog waylandpp libinput libudfread dav1d ffmpeg tinyxml2"
+        sndio spdlog waylandpp libinput libudfread dav1d ffmpeg tinyxml2 \
+        giflib libpng"
 BUILDDEP="boost cmake curl doxygen gperf jasper openjdk swig zip"
 BUILDDEP__AMD64="${BUILDDEP} nasm yasm"
-BUILDDEP__MIPS64R6EL="${BUILDDEP/openjdk/}"
 PKGDES="A media center application for home theatres"
 
 # FIXME: cmakeninja ABTYPE breaks internal crossguid build.
 ABTYPE=cmake
-CMAKE_AFTER="-DMARIADBCLIENT_INCLUDE_DIR=/usr/include/ \
-             -DENABLE_AIRTUNES=ON \
-             -DENABLE_ALSA=ON \
-             -DENABLE_AVAHI=ON \
-             -DENABLE_BLURAY=ON \
-             -DENABLE_CEC=ON \
-             -DENABLE_DBUS=ON \
-             -DENABLE_DVDCSS=OFF \
-             -DENABLE_EVENTCLIENTS=ON \
-             -DENABLE_INTERNAL_FFMPEG=OFF \
-             -DENABLE_INTERNAL_CROSSGUID=ON \
-             -DENABLE_INTERNAL_FSTRCMP=OFF \
-             -DENABLE_INTERNAL_FLATBUFFERS=OFF \
-             -DENABLE_INTERNAL_UDFREAD=OFF \
-             -DCORE_PLATFORM_NAME=x11 \
-             -DENABLE_MICROHTTPD=ON \
-             -DENABLE_MYSQLCLIENT=ON \
-             -DENABLE_NFS=ON \
-             -DENABLE_OPTICAL=ON \
-             -DENABLE_PULSEAUDIO=ON \
-             -DENABLE_SMBCLIENT=ON \
-             -DENABLE_UDEV=ON \
-             -DENABLE_UPNP=ON \
-             -DENABLE_VAAPI=ON \
-             -DENABLE_XSLT=ON \
-             -DAPP_RENDER_SYSTEM=gl \
-             -DENABLE_TESTING=OFF"
+CMAKE_AFTER=(
+    "-DMARIADBCLIENT_INCLUDE_DIR=/usr/include/"
+    "-DENABLE_AIRTUNES=ON"
+    "-DENABLE_ALSA=ON"
+    "-DENABLE_AVAHI=ON"
+    "-DENABLE_BLURAY=ON"
+    "-DENABLE_CEC=ON"
+    "-DENABLE_DBUS=ON"
+    "-DENABLE_DVDCSS=OFF"
+    "-DENABLE_EVENTCLIENTS=ON"
+    "-DENABLE_INTERNAL_FFMPEG=OFF"
+    "-DENABLE_INTERNAL_CROSSGUID=ON"
+    "-DENABLE_INTERNAL_FSTRCMP=OFF"
+    "-DENABLE_INTERNAL_FLATBUFFERS=OFF"
+    "-DENABLE_INTERNAL_UDFREAD=OFF"
+    "-DCORE_PLATFORM_NAME=x11"
+    "-DENABLE_MICROHTTPD=ON"
+    "-DENABLE_MYSQLCLIENT=ON"
+    "-DENABLE_NFS=ON"
+    "-DENABLE_OPTICAL=ON"
+    "-DENABLE_PULSEAUDIO=ON"
+    "-DENABLE_SMBCLIENT=ON"
+    "-DENABLE_UDEV=ON"
+    "-DENABLE_UPNP=ON"
+    "-DENABLE_VAAPI=ON"
+    "-DENABLE_XSLT=ON"
+    "-DAPP_RENDER_SYSTEM=gl"
+    "-DENABLE_TESTING=OFF"
+)
 
 NOLTO=1

--- a/app-multimedia/kodi/spec
+++ b/app-multimedia/kodi/spec
@@ -1,8 +1,8 @@
-VER=21.1
+VER=21.2
 PERIPHERAL_JOYSTICK_VER=20.1.0-Nexus
 CODE=Omega
 # Note: Take commit from branch with the corresponding codename.
-RSRC_COMMIT="c451373742c0df37de392d66fa5274736bc0022e"
+RSRC_COMMIT="d0d7517e19472e42e6b8b964cc8fb17cc0561252"
 COPACETIC_FONT_COMMIT="e657c31500fb1ce7e4d7e3eacfb5440ce7aa088e"
 SRCS="git::rename=xbmc;commit=tags/${VER}-${CODE}::https://github.com/xbmc/xbmc.git \
       git::rename=kodi-res;commit=${RSRC_COMMIT}::https://github.com/xbmc/repo-resources.git \


### PR DESCRIPTION
Topic Description
-----------------

- kodi: update to 21.2

Package(s) Affected
-------------------

- kodi: 1:21.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kodi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
