### PR TITLE
shh: new, 2025.4.12

### DIFF
--- a/app-utils/shh/autobuild/beyond
+++ b/app-utils/shh/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Building manpages ..."
+install -dvm755 "$SRCDIR"/target/man
+cargo run \
+    --locked \
+    --features gen-man-pages \
+    -- "$SRCDIR"/target/man/
+
+abinfo "Installing manpages ..."
+install -Dvm644 "$SRCDIR"/target/man/* \
+    -t "$PKGDIR"/usr/share/man/man1

--- a/app-utils/shh/autobuild/defines
+++ b/app-utils/shh/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=shh
+PKGSEC=utils
+PKGDES="Systemd service hardening helper"
+PKGDEP="gcc-runtime glibc strace"
+BUILDDEP="rustc llvm"
+
+USECLANG=1
+ABTYPE=rust
+
+# Because we sets '-Dseccomp=false' in systemd build parameters for loongson3,
+# calling 'systemd-analyze syscall-filter' will build error .
+#
+# > thread 'main' panicked at build.rs:32:5:
+# > assertion failed: output.status.success()
+#
+# See: https://github.com/desbma/shh/blob/1efed23a5fa90889669435b6fdd16086d72fd3b0/build.rs#L32
+FAIL_ARCH="loongson3"

--- a/app-utils/shh/spec
+++ b/app-utils/shh/spec
@@ -1,0 +1,4 @@
+VER=2025.4.12
+SRCS="git::commit=tags/v$VER::https://github.com/desbma/shh.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377910"


### PR DESCRIPTION
Topic Description
-----------------

- shh: new, 2025.4.12

Package(s) Affected
-------------------

- shh: 2025.4.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit shh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
