### PR TITLE
strace: update to 6.14

### DIFF
--- a/app-devel/strace/autobuild/defines
+++ b/app-devel/strace/autobuild/defines
@@ -1,20 +1,18 @@
 PKGNAME=strace
 PKGSEC=devel
 PKGDEP="libunwind perl"
-PKGDEP__RISCV64="${PKGDEP/libunwind/}"
 PKGDEP__M68K="${PKGDEP/libunwind/}"
 PKGDES="A useful diagnostic, instructional, and debugging tool"
 
-AUTOTOOLS_AFTER=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-mpers=no"
-AUTOTOOLS_AFTER__RISCV64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-libunwind"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-libunwind"
+    "--enable-mpers=check"
+)
 
-AUTOTOOLS_AFTER__M68K=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-libunwind \
-                 --enable-mpers=no"
+AUTOTOOLS_AFTER__M68K=(
+    "--without-libunwind"
+    "--enable-mpers=check"
+)
 
 RECONF=0

--- a/app-devel/strace/autobuild/prepare
+++ b/app-devel/strace/autobuild/prepare
@@ -1,3 +1,0 @@
-ln -sv /usr/bin/ld.bfd "$SRCDIR"/ld
-export PATH="$SRCDIR:$PATH"
-export CPPFLAGS="${CPPFLAGS} -O2"

--- a/app-devel/strace/spec
+++ b/app-devel/strace/spec
@@ -1,4 +1,4 @@
-VER=6.13
+VER=6.14
 SRCS="tbl::https://github.com/strace/strace/releases/download/v$VER/strace-$VER.tar.xz"
-CHKSUMS="sha256::e209daf0ee038ca5adcc4c277e9273b4d51f46a2ff86da575d36742ac3508a17"
+CHKSUMS="sha256::244f3b5c20a32854ca9b7ca7a3ee091dd3d4bd20933a171ecee8db486c77d3c9"
 CHKUPDATE="anitya::id=4897"


### PR DESCRIPTION
Topic Description
-----------------

- strace: update to 6.14
    - Drop unused prepare script.
    - Adjust Autotools parameters.

Package(s) Affected
-------------------

- strace: 6.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit strace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
