### PR TITLE
wmenu: update to 0.2.0

### DIFF
--- a/app-utils/wmenu/spec
+++ b/app-utils/wmenu/spec
@@ -1,4 +1,4 @@
-VER=0.1.9
+VER=0.2.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/adnano/wmenu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371633"


### PR DESCRIPTION
Topic Description
-----------------

- wmenu: update to 0.2.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wmenu: 0.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wmenu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
