### PR TITLE
pkgsite-tools: new, 0.3.3

### DIFF
--- a/app-utils/pkgsite-tools/autobuild/beyond
+++ b/app-utils/pkgsite-tools/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Installing assets ..."
+PREFIX="$PKGDIR"/usr/ "$SRCDIR"/install-assets.sh

--- a/app-utils/pkgsite-tools/autobuild/defines
+++ b/app-utils/pkgsite-tools/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=pkgsite-tools
+PKGSEC=utils
+BUILDDEP="rustc llvm"
+PKGDES="AOSC Packages Site utilities"
+
+ABTYPE=rust
+USECLANG=1
+
+# FIXME: ld.lld is not yet available.
+NOLTO__LOONGSON3=1

--- a/app-utils/pkgsite-tools/spec
+++ b/app-utils/pkgsite-tools/spec
@@ -1,0 +1,4 @@
+VER=0.3.3
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/pkgsite-tools.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377917"


### PR DESCRIPTION
Topic Description
-----------------

- pkgsite-tools: new, 0.3.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- pkgsite-tools: 0.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgsite-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
