### PR TITLE
llvm-20: update to 20.1.4


### DIFF
--- a/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,4 +1,4 @@
-From ee2e8b1f88574d20db354fbb204dbc10106cc47a Mon Sep 17 00:00:00 2001
+From f02f326aae606d7c6953abeb3921b27787afb5e3 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:48:08 -0800
 Subject: [PATCH 1/9] Fix fuzzer objects building when LTO is enabled
@@ -21,7 +21,7 @@ index 6db24610df1f..201b880cfbb1 100644
        COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>"
        COMMAND ${CMAKE_AR} qcs "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" ${name}.o
 
-base-commit: 58df0ef89dd64126512e4ee27b4ac3fd8ddf6247
+base-commit: ec28b8f9cc7f2ac187d8a617a6d08d5e56f9120e
 -- 
 2.49.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
@@ -1,4 +1,4 @@
-From b78de9913040a295a6c3bb0defcf033a00fa2f0e Mon Sep 17 00:00:00 2001
+From 6fca9ab942e05353b8a7e90070cf64ca70b78887 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:47 -0800
 Subject: [PATCH 2/9] Fix MSVC detection

--- a/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,4 +1,4 @@
-From 3cc1ee0fe8375be08f4e769afdefeec077a7d040 Mon Sep 17 00:00:00 2001
+From 90c529dc0a409e16c4ac499750d3ba311bd679bf Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:26 -0800
 Subject: [PATCH 3/9] Add stub for mips64 LLDB impl

--- a/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,4 +1,4 @@
-From 427f4e990f0adbbf73f1d1d9d7feb4d949dbd0da Mon Sep 17 00:00:00 2001
+From 6545c2ada3a67d74fa7dd0e391c09d840595e700 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:52:51 -0800
 Subject: [PATCH 4/9] Add stub for lldb arch functions on loongson3

--- a/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
@@ -1,4 +1,4 @@
-From f52f3f1d5d936c4206429fc6974630606fdac965 Mon Sep 17 00:00:00 2001
+From ca57b2ca20ddd41b9a2e06a179222dcbaaba261b Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:53:18 -0800
 Subject: [PATCH 5/9] HACK: force enable cacheflush function

--- a/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
@@ -1,4 +1,4 @@
-From 9b0d4baa29956fc88a81b6b1d4ce741d503f8fe5 Mon Sep 17 00:00:00 2001
+From 98864a1761e2e2b7017b5d1db155573f295a3dcd Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 31 Jan 2024 14:37:12 +0800
 Subject: [PATCH 6/9] Fix build of LinuxSignals on Mips

--- a/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
@@ -1,4 +1,4 @@
-From 92a83a024f078d11df391cd7f4ef8e822cd679b3 Mon Sep 17 00:00:00 2001
+From 083de4a20fbe5d30b718a1d5a5b9ee615ad2f22d Mon Sep 17 00:00:00 2001
 From: Alex Crichton <alex@alexcrichton.com>
 Date: Sat, 10 Feb 2018 17:21:38 -0800
 Subject: [PATCH 7/9] Compile with /MT on MSVC

--- a/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,4 +1,4 @@
-From e8a9f449e355e30b10dce56f5c93e61ce390f404 Mon Sep 17 00:00:00 2001
+From 7ba2dae6079b1f2e067559928aea620d3d083516 Mon Sep 17 00:00:00 2001
 From: Adrian Cruceru <cruceruadrian@gmail.com>
 Date: Mon, 25 May 2020 20:58:30 +0200
 Subject: [PATCH 8/9] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'

--- a/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
@@ -1,4 +1,4 @@
-From 5228272c013ad39a04e7198766ff4cbcece2d257 Mon Sep 17 00:00:00 2001
+From afeba19447eb9e358a42254106af04621759d4c1 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 12 Apr 2025 15:25:26 +0800
 Subject: [PATCH 9/9] [compiler-rt] Disable installing of custom libcxx

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,6 +1,6 @@
-VER=20.1.3
-SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
-SUBDIR="llvm-project-$VER.src/llvm"
+VER=20.1.4
+SRCS="git::commit=tags/llvmorg-${VER}::https://github.com/llvm/llvm-project.git"
+SUBDIR="llvm-20/llvm"
 CHKSUMS="sha256::b6183c41281ee3f23da7fda790c6d4f5877aed103d1e759763b1008bdd0e2c50"
 CHKUPDATE="anitya::id=1830"
 # Note: Prefer larger RAM.


### PR DESCRIPTION
Topic Description
-----------------

- llvm-20: update to 20.1.4

Package(s) Affected
-------------------

- llvm-20: 20.1.4
- llvm-runtime-20: 20.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
