### PR TITLE
cyrus-sasl: add patch Fix-time.h-check

### DIFF
--- a/app-network/cyrus-sasl/autobuild/patches/0001-Fix-time.h-check.patch
+++ b/app-network/cyrus-sasl/autobuild/patches/0001-Fix-time.h-check.patch
@@ -1,0 +1,60 @@
+From 4e1b017745b5ff054ad486d853abe415254f5434 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Wed, 23 Feb 2022 00:45:15 +0000
+Subject: [PATCH 1/3] Fix <time.h> check
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We're conditionally including based on HAVE_TIME_H in a bunch of places,
+but we're not actually checking for time.h, so that's never going to be defined.
+
+While at it, add in a missing include in the cram plugin.
+
+This fixes a bunch of implicit declaration warnings:
+```
+ * cyrus-sasl-2.1.28/lib/saslutil.c:280:3: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:364:41: warning: implicit declaration of function ‘clock’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/plugins/cram.c:132:7: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:280:3: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/lib/saslutil.c:364:41: warning: implicit declaration of function ‘clock’ [-Wimplicit-function-declaration]
+ * cyrus-sasl-2.1.28/plugins/cram.c:132:7: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ configure.ac   | 2 +-
+ plugins/cram.c | 4 ++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2d89fdaa..2e1e697d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1231,7 +1231,7 @@ AC_CHECK_HEADERS_ONCE([sys/time.h])
+ 
+ AC_HEADER_DIRENT
+ AC_HEADER_SYS_WAIT
+-AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
++AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h time.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
+ 
+ IPv6_CHECK_SS_FAMILY()
+ IPv6_CHECK_SA_LEN()
+diff --git a/plugins/cram.c b/plugins/cram.c
+index d02e9baa..695aaa91 100644
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -53,6 +53,10 @@
+ #endif
+ #include <fcntl.h>
+ 
++#ifdef HAVE_TIME_H
++#include <time.h>
++#endif
++
+ #include <sasl.h>
+ #include <saslplug.h>
+ #include <saslutil.h>
+-- 
+2.43.0
+

--- a/app-network/cyrus-sasl/autobuild/patches/0002-Fix-build-with-Wl-as-needed.patch
+++ b/app-network/cyrus-sasl/autobuild/patches/0002-Fix-build-with-Wl-as-needed.patch
@@ -1,11 +1,13 @@
-From ffb8a2038d81ab1fe5c6d2626f658f2a8dcfd70f Mon Sep 17 00:00:00 2001
+From 78edbbd91a7f3ffe8710c97bc85520c55993061c Mon Sep 17 00:00:00 2001
 From: Heiko Becker <heirecka@exherbo.org>
 Date: Fri, 23 Nov 2018 18:11:12 +0100
-Subject: [PATCH 1/2] Fix build with -Wl,--as-needed
+Subject: [PATCH 2/3] Fix build with -Wl,--as-needed
 
 Fails with "x86_64-pc-linux-gnu-ld: ../sasldb/.libs/libsasldb.a(db_gdbm.o):
 in function `_sasldb_getdata': db_gdbm.c:(.text+0xcf): undefined
 reference to `gdbm_open'..." otherwise.
+
+Signed-off-by: Heiko Becker <heirecka@exherbo.org>
 ---
  sasldb/Makefile.am | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -23,5 +25,5 @@ index 97f4a5be..067f0ac8 100644
  libsasldb_la_LIBADD = $(SASL_DB_BACKEND) $(SASL_DB_LIB)
  libsasldb_la_LDFLAGS = -no-undefined
 -- 
-2.45.1
+2.43.0
 

--- a/app-network/cyrus-sasl/autobuild/patches/0003-Make-the-libsasl2-symbols-versioned.patch
+++ b/app-network/cyrus-sasl/autobuild/patches/0003-Make-the-libsasl2-symbols-versioned.patch
@@ -1,8 +1,10 @@
-From 44cb16d94a1c514542fa6df0602b49d3e12ea67f Mon Sep 17 00:00:00 2001
-From: Jiajie Chen <c@jia.je>
-Date: Thu, 4 Apr 2024 09:47:08 -0700
-Subject: [PATCH 2/2] Make the libsasl2 symbols versioned
+From 4f761e0f21adb00cd15207bd89dfd3a4005c28fd Mon Sep 17 00:00:00 2001
+From: Debian Cyrus SASL Team
+ <pkg-cyrus-sasl2-debian-devel@lists.alioth.debian.org>
+Date: Thu, 24 Mar 2016 11:35:02 +0100
+Subject: [PATCH 3/3] Make the libsasl2 symbols versioned
 
+Gbp-Pq: Name 0001-Make-the-libsasl2-symbols-versioned.patch
 ---
  Versions        | 7 +++++++
  lib/Makefile.am | 3 ++-
@@ -37,5 +39,5 @@ index 9a43ae0d..7852c2b0 100644
  libsasl2_la_LIBADD = $(SASL_DL_LIB) $(SASL_STATIC_LIBS) $(LIB_SOCKET) $(LIB_DOOR) $(PLUGIN_COMMON_OBJS)
  if BUILD_LIBOBJ
 -- 
-2.45.1
+2.43.0
 

--- a/app-network/cyrus-sasl/spec
+++ b/app-network/cyrus-sasl/spec
@@ -1,4 +1,5 @@
 VER=2.1.28
+REL=1
 SRCS="git::commit=tags/cyrus-sasl-$VER::https://github.com/cyrusimap/cyrus-sasl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13280"


### PR DESCRIPTION
Topic Description
-----------------

- cyrus-sasl: add patch Fix-time.h-check

Package(s) Affected
-------------------

- cyrus-sasl: 2.1.28-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cyrus-sasl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
