### PR TITLE
opentabletdriver: new, 0.6.5.1

### DIFF
--- a/runtime-devices/opentabletdriver/autobuild/build
+++ b/runtime-devices/opentabletdriver/autobuild/build
@@ -1,0 +1,8 @@
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+abinfo "Building OpenTabletDriver..."
+"$SRCDIR"/eng/linux/package.sh --package Generic --output "$PKGDIR"
+
+# Note: Setting PKGDIR to $PKGDIR/files so that Autobuild can pick it up and
+# package binaries from there.
+PKGDIR="$PKGDIR"/files

--- a/runtime-devices/opentabletdriver/autobuild/config
+++ b/runtime-devices/opentabletdriver/autobuild/config
@@ -1,0 +1,4 @@
+. /usr/share/debconf/confmodule
+
+db_input high opentabletdriver/services_config_info || true
+db_go

--- a/runtime-devices/opentabletdriver/autobuild/defines
+++ b/runtime-devices/opentabletdriver/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=opentabletdriver
+PKGSEC=libs
+BUILDDEP="x11-lib libev dotnet-sdk-8.0 jq"
+PKGDEP="debconf libevdev gtk-3 dotnet-runtime-8.0 glibc gcc-runtime"
+PKGDES="A user-mode graphics tablet driver"
+FAIL_ARCH="!(arm64|amd64|armv7hf)" 
+
+# .NET binary releases break when stripped
+# See https://github.com/dotnet/runtime/issues/37334
+ABSTRIP=0

--- a/runtime-devices/opentabletdriver/autobuild/postinst
+++ b/runtime-devices/opentabletdriver/autobuild/postinst
@@ -1,0 +1,1 @@
+. /usr/share/debconf/confmodule

--- a/runtime-devices/opentabletdriver/autobuild/postrm
+++ b/runtime-devices/opentabletdriver/autobuild/postrm
@@ -1,0 +1,4 @@
+if [ "$1" = "purge" -a -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/runtime-devices/opentabletdriver/autobuild/templates
+++ b/runtime-devices/opentabletdriver/autobuild/templates
@@ -1,0 +1,18 @@
+Template: opentabletdriver/services_config_info
+Type: note
+Description: Extra configuration required for opentabletdriver service
+ To make OpenTabletDriver work correctly, please use the following command to enable the opentabletdriver service:
+ .
+ systemctl --user start opentabletdriver
+ .
+ If you want to enable the opentabletdriver service by default upon login, please enter the following command:
+ .
+ systemctl --user enable opentabletdriver --now
+Description-zh_CN.UTF-8: opentabletdriver 服务需要额外设置
+ 要使 OpenTabletDriver 正确工作，请使用如下命令启用 opentabletdriver 服务：
+ .
+ systemctl --user start opentabletdriver
+ .
+ 如果您希望在登录时默认启用 opentabletdriver 服务，请输入如下命令：
+ .
+ systemctl --user enable opentabletdriver --now

--- a/runtime-devices/opentabletdriver/spec
+++ b/runtime-devices/opentabletdriver/spec
@@ -1,0 +1,4 @@
+VER=0.6.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/OpenTabletDriver/OpenTabletDriver"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::241822"


### PR DESCRIPTION
Topic Description
-----------------

- opentabletdriver: new, 0.6.5.1

Package(s) Affected
-------------------

- opentabletdriver: 0.6.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentabletdriver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
