### PR TITLE
fractal: fix missing gst-plugins

### DIFF
--- a/desktop-gnome/fractal/autobuild/defines
+++ b/desktop-gnome/fractal/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=fractal
 PKGSEC=gnome
 PKGDEP="glib gtk-4 libadwaita gstreamer gtksourceview-5 openssl libshumate \
-        sqlite pango graphene libseccomp lcms2 libwebp glycin gstreamer"
+        sqlite pango graphene libseccomp lcms2 libwebp glycin gstreamer \
+        gst-plugins-rs"
 BUILDDEP="meson ninja rustc llvm xdg-desktop-portal gtk-update-icon-cache \
           desktop-file-utils grass"
 PKGDES="A Matrix messaging client for GNOME"

--- a/desktop-gnome/fractal/spec
+++ b/desktop-gnome/fractal/spec
@@ -1,4 +1,5 @@
 VER=10.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/World/fractal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=197366"

--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -1,0 +1,18 @@
+PKGNAME=gst-plugins-rs
+PKGSEC=libs
+PKGDEP="glib gstreamer nasm gtk-4 libsodium pango openssl cairo dav1d \
+        libwebp"
+BUILDDEP="rustc llvm cargo-c hotdoc"
+PKGDES="GStreamer plugins and elements written in Rust"
+
+ABTYPE=meson
+USECLANG=1
+
+MESON_AFTER=(
+    '-Ddoc=enabled'
+    '-Dexamples=disabled'
+    '-Dtests=disabled'
+)
+
+# FIXME: ld.lld is not yet available on loongson3
+NOLTO__LOONGSON3=1

--- a/runtime-multimedia/gst-plugins-rs/spec
+++ b/runtime-multimedia/gst-plugins-rs/spec
@@ -1,0 +1,4 @@
+VER=0.13.5
+SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=328366"

--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -30,8 +30,8 @@ PKGREP="${PKGBREAK}"
 # Note: -Dlibnice=disabled, to use system dependency (enabled means using
 # libnice sources in the subproject, WTF).
 #
-# Note: -Drs=disabled, Rust bindings are used for development only (usually
-# bundled as a dependency in third-party projects).
+# Note: -Drs=disabled, Rust bindings are provided in `gst-plugins-rs` as
+# they are not simply submodules but subprojects not shipped with `gstreamer`.
 #
 # FIXME: -Ddoc=disabled
 # Downloading https://github.com/hotdoc/hotdoc_lumen_theme/releases/download/0.16/hotdoc_lumen_theme-0.16.tar.xz?sha256=b7d7dde51285d1c90836c44ae298754e4cfa957e9a6d14ee5844b8a2cac04b5a


### PR DESCRIPTION
Topic Description
-----------------

- fractal: fix missing gst-plugins
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- gst-plugins-rs: new, 0.13.5
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fractal: 10.1-1
- gst-plugins-rs: 0.13.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gst-plugins-rs fractal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
