### PR TITLE
octave: rework to remove restricted syntaxes in defines file


### DIFF
--- a/app-scientific/octave/autobuild/defines
+++ b/app-scientific/octave/autobuild/defines
@@ -5,15 +5,6 @@ PKGDEP="arpack-ng curl fftw fltk ghostscript glpk glu gnuplot graphicsmagick \
         openblas gl2ps"
 PKGDES="A high-level language intended for numerical computations"
 
-JAVA_HOME="/usr/lib/java"
-if [ -d "$JAVA_HOME/lib/server" ]; then
-    JAVA_LIBDIR="$JAVA_HOME/lib/server"
-elif [ -d "$JAVA_HOME/lib/zero" ]; then
-    JAVA_LIBDIR="$JAVA_HOME/lib/zero"
-elif [ -d "$JAVA_HOME/lib/client" ]; then
-    JAVA_LIBDIR="$JAVA_HOME/lib/client"
-fi
-
 ABTYPE=autotools
 AUTOTOOLS_AFTER=(
 	--libexecdir=/usr/lib
@@ -28,8 +19,6 @@ AUTOTOOLS_AFTER=(
 	--with-cxsparse
 	--with-blas=openblas
 	--disable-docs
-        --with-java-homedir=${JAVA_HOME}
-        --with-java-libdir=${JAVA_LIBDIR}
 )
 
 AB_FLAGS_O3=1

--- a/app-scientific/octave/autobuild/patches/0001-AOSCOS-Find-OpenJDK-of-zero-variant.patch
+++ b/app-scientific/octave/autobuild/patches/0001-AOSCOS-Find-OpenJDK-of-zero-variant.patch
@@ -1,0 +1,35 @@
+From 99129c683774adcea035efc0600eb58a1460cf65 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Thu, 1 May 2025 10:56:07 +0800
+Subject: [PATCH] AOSCOS: Find OpenJDK of zero variant
+X-Developer-Signature: v=1; a=openpgp-sha256; l=818; i=xtexchooser@duck.com;
+ h=from:subject; bh=/H7k7cpSjmf7qoMgKb+BiJSNXL36zVb/2MJ581DYLcg=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBlCjx491F7m8ONw+YJLq5/1VrI94a1jzuTfx2p/yHDT3
+ BecKdy1HaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIl8YmD4H3MzbWokD+Nr593M
+ EeXNOZO5qwu3Jy+0VlQqdbddwqf3jpFh/eq3mwVOH1D6MP1F4MWwx9XRKQLLNx3TOdEu/mn3T6c
+ +XgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3ad88a555d88..1adcd29cb1ba 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2624,7 +2624,7 @@ do
+     if test -z "$JAVA_LDPATH"; then
+       ## Nothing found.  Try Java again using bootpath argument.
+       JAVA_TMP_LDPATH=`$JAVA -classpath ${srcdir}/build-aux OctJavaQry JAVA_BOOTPATH`
+-      JAVA_TMP_LDPATH="${JAVA_TMP_LDPATH} ${JAVA_TMP_LDPATH}/client ${JAVA_TMP_LDPATH}/server"
++      JAVA_TMP_LDPATH="${JAVA_TMP_LDPATH} ${JAVA_TMP_LDPATH}/client ${JAVA_TMP_LDPATH}/server ${JAVA_TMP_LDPATH}/zero"
+       for dir in $JAVA_TMP_LDPATH; do
+         if test -f "$dir/$jvmlib"; then
+           JAVA_LDPATH=$dir
+
+base-commit: 341d14a59fe15d5d180ef777523665141982e091
+-- 
+2.49.0
+

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -1,5 +1,5 @@
 VER=9.2.0
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
 CHKSUMS="sha256::dcb2c098701cfcbc083f07e90e146261d15cdbf5e89c031032422112c89b47da"
 CHKUPDATE="anitya::id=2528"


### PR DESCRIPTION
Topic Description
-----------------

- octave: rework to remove restricted syntaxes in defines file

Package(s) Affected
-------------------

- octave: 9.2.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit octave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
