### PR TITLE
ada: debundle dependencies

### DIFF
--- a/runtime-common/cxxopts/autobuild/defines
+++ b/runtime-common/cxxopts/autobuild/defines
@@ -1,0 +1,18 @@
+PKGNAME=cxxopts
+PKGSEC=libs
+PKGDES="Lightweight C++ command line option parser"
+
+# Note: library is header only
+ABHOST="noarch"
+
+# Note: Disable unicode help to decouble libicu from header only library
+CMAKE_AFTER=(
+	-DCXXOPTS_BUILD_EXAMPLES=ON
+	-DCXXOPTS_BUILD_TESTS=OFF
+	-DCXXOPTS_ENABLE_INSTALL=ON
+	-DCXXOPTS_ENABLE_WARNINGS=ON
+	-DCXXOPTS_USE_UNICODE_HELP=OFF
+)
+
+# Note: ada <= 2.9.1 incorrectly bundles cxxopts
+PKGBREAK="ada<=2.9.1"

--- a/runtime-common/cxxopts/spec
+++ b/runtime-common/cxxopts/spec
@@ -1,0 +1,4 @@
+VER=3.2.0
+SRCS="git::commit=tags/v${VER}::https://github.com/jarro2783/cxxopts.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=112688"

--- a/runtime-web/ada/autobuild/defines
+++ b/runtime-web/ada/autobuild/defines
@@ -1,8 +1,11 @@
 PKGNAME=ada
 PKGSEC=libs
-PKGDEP="gcc-runtime"
+PKGDEP="gcc-runtime fmt"
+BUILDDEP="cxxopts"
 PKGDES="WHATWG-compliant URL parser library"
 
 CMAKE_AFTER="-DADA_BENCHMARKS=OFF \
              -DADA_TESTING=OFF \
+             -DCPM_LOCAL_PACKAGES_ONLY=ON \
+             -DCPM_USE_LOCAL_PACKAGES=ON \
              -DBUILD_SHARED_LIBS=ON"

--- a/runtime-web/ada/spec
+++ b/runtime-web/ada/spec
@@ -1,4 +1,5 @@
 VER=2.9.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ada-url/ada"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370270"


### PR DESCRIPTION
Topic Description
-----------------

- ada: debundle dependencies
- cxxopts: new, 3.2.0

Package(s) Affected
-------------------

- ada: 2.9.1-1
- cxxopts: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cxxopts ada
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
