### PR TITLE
pkgsite-tools: update to 0.3.4

### DIFF
--- a/app-utils/pkgsite-tools/spec
+++ b/app-utils/pkgsite-tools/spec
@@ -1,4 +1,4 @@
-VER=0.3.3
+VER=0.3.4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/pkgsite-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377917"


### PR DESCRIPTION
Topic Description
-----------------

- pkgsite-tools: update to 0.3.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- pkgsite-tools: 0.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgsite-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
