### PR TITLE
[FLIGHT] linux-kernel: add 32x32 CJK font data

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
@@ -1,7 +1,7 @@
 From a68e84ac9f595d6a3c5accdccf7d08e867662eef Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:29 +0800
-Subject: [PATCH 001/334] FROMGIT: dt-bindings: display: rockchip: Fix label
+Subject: [PATCH 001/335] FROMGIT: dt-bindings: display: rockchip: Fix label
  name of hdptxphy for RK3588 HDMI TX Controller
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
@@ -1,7 +1,7 @@
 From 6ee3eb2a95b1330316e0f1c7fe35015923efb9ee Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:04 +0200
-Subject: [PATCH 002/334] FROMGIT: dt-bindings: display: vop2: Add optional PLL
+Subject: [PATCH 002/335] FROMGIT: dt-bindings: display: vop2: Add optional PLL
  clock properties
 
 On RK3588, HDMI PHY PLL can be used as an alternative and more accurate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
@@ -1,7 +1,7 @@
 From 597b04abb7aedef039fa4d25149314272df19fd8 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:05 +0200
-Subject: [PATCH 003/334] FROMGIT: drm/rockchip: vop2: Drop unnecessary
+Subject: [PATCH 003/335] FROMGIT: drm/rockchip: vop2: Drop unnecessary
  if_pixclk_rate computation
 
 The if_pixclk_rate variable is not being used outside of the if-block in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-drm-rockchip-vop2-Improve-display-modes-hand.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-drm-rockchip-vop2-Improve-display-modes-hand.patch
@@ -1,7 +1,7 @@
 From f03e897e8f2abc2e840950358d5bc5d536e93207 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:06 +0200
-Subject: [PATCH 004/334] FROMGIT: drm/rockchip: vop2: Improve display modes
+Subject: [PATCH 004/335] FROMGIT: drm/rockchip: vop2: Improve display modes
  handling on RK3588 HDMI0
 
 The RK3588 specific implementation is currently quite limited in terms

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
@@ -1,7 +1,7 @@
 From bdf167582a1beef0f4edbff6df9c4988523e4337 Mon Sep 17 00:00:00 2001
 From: Jianfeng Liu <liujianfeng1994@gmail.com>
 Date: Wed, 15 Jan 2025 10:33:21 +0800
-Subject: [PATCH 005/334] FROMGIT: arm64: dts: rockchip: Enable HDMI on
+Subject: [PATCH 005/335] FROMGIT: arm64: dts: rockchip: Enable HDMI on
  armsom-sige7
 
 Add the necessary DT changes to enable HDMI on ArmSoM Sige7.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
@@ -1,7 +1,7 @@
 From 1085e1d53491747a93982426e8771d4f78a7883e Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:07 +0200
-Subject: [PATCH 006/334] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
+Subject: [PATCH 006/335] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
  provider on RK3588
 
 Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
@@ -1,7 +1,7 @@
 From 135984f46cd0813152ea0df44ad48d64286a2ad4 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:08 +0200
-Subject: [PATCH 007/334] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
+Subject: [PATCH 007/335] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
  clock source to VOP2 on RK3588
 
 VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
@@ -1,7 +1,7 @@
 From ae3664a0ea159375e6491c698f85f1b22fa0ea83 Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:30 +0800
-Subject: [PATCH 008/334] FROMGIT: arm64: dts: rockchip: Fix label name of
+Subject: [PATCH 008/335] FROMGIT: arm64: dts: rockchip: Fix label name of
  hdptxphy for RK3588
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
@@ -1,7 +1,7 @@
 From ec0676d3b261a0a9147ee52539a461dc7171841e Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:15 +0200
-Subject: [PATCH 009/334] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
+Subject: [PATCH 009/335] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
  for HDMI1 TX port on RK3588
 
 In preparation to enable the second HDMI output port found on RK3588

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
@@ -1,7 +1,7 @@
 From 6b107d56c946cae556335c80295f45a94ecee87f Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:16 +0200
-Subject: [PATCH 010/334] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
+Subject: [PATCH 010/335] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
  RK3588
 
 Add support for the second HDMI TX port found on RK3588 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
@@ -1,7 +1,7 @@
 From d9e64c67a78f1a890c641f9c710dd036eed67eb7 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:17 +0200
-Subject: [PATCH 011/334] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
+Subject: [PATCH 011/335] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
  rock-5b
 
 Add the necessary DT changes to enable the second HDMI output port on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
@@ -1,7 +1,7 @@
 From 3be12e9ac001dfab3e4079f1203aa1287c36c0cb Mon Sep 17 00:00:00 2001
 From: Jagan Teki <jagan@edgeble.ai>
 Date: Fri, 27 Dec 2024 18:59:36 +0530
-Subject: [PATCH 012/334] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
+Subject: [PATCH 012/335] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
  Edgeble-6TOPS Modules
 
 Edgeble-6TOPS modules configure HDMI1 for HDMI Out from RK3588.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
@@ -1,7 +1,7 @@
 From dcf0afe5fb3d5017e010ae5de0f3b575bf9e1819 Mon Sep 17 00:00:00 2001
 From: Jimmy Hon <honyuenkwun@gmail.com>
 Date: Wed, 8 Jan 2025 23:16:18 -0600
-Subject: [PATCH 013/334] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
+Subject: [PATCH 013/335] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
  Pi 5 Max
 
 Enable the second HDMI output port on the Orange Pi 5 Max

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
@@ -1,7 +1,7 @@
 From eb297b3d7527f2c48e80a73e8dbce8c097171a5f Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko.stuebner@cherry.de>
 Date: Fri, 6 Dec 2024 11:34:00 +0100
-Subject: [PATCH 014/334] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
+Subject: [PATCH 014/335] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
  regmap register-callback
 
 The variant of the driver in the vendor-tree contained those handy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
@@ -1,7 +1,7 @@
 From 444c19c0dace8cfa809e3245c28f3ea60eefe6e1 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:40 -0800
-Subject: [PATCH 015/334] FROMGIT: perf trace: Allocate syscall stats only if
+Subject: [PATCH 015/335] FROMGIT: perf trace: Allocate syscall stats only if
  summary is on
 
 The syscall stats are used only when summary is requested.  Let's avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
@@ -1,7 +1,7 @@
 From 78e51114e61ac8f47c569340a2c2541b66e19a70 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:41 -0800
-Subject: [PATCH 016/334] FROMGIT: perf trace: Convert syscall_stats to hashmap
+Subject: [PATCH 016/335] FROMGIT: perf trace: Convert syscall_stats to hashmap
 
 It was using a RBtree-based int-list as a hash and a custom resort
 logic for that.  As we have hashmap, let's convert to it and add a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
@@ -1,7 +1,7 @@
 From 86d1adbcb51010ab132e0ceeeb939f698c50337f Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:42 -0800
-Subject: [PATCH 017/334] FROMGIT: perf tools: Get rid of now-unused
+Subject: [PATCH 017/335] FROMGIT: perf tools: Get rid of now-unused
  rb_resort.h
 
 It was only used in perf trace and it switched to use hashmap instead.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-trace-Add-summary-mode-option.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-trace-Add-summary-mode-option.patch
@@ -1,7 +1,7 @@
 From 53c83cd3f2df2f80cbb7df4c2b58324d8e6e6e66 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:43 -0800
-Subject: [PATCH 018/334] FROMGIT: perf trace: Add --summary-mode option
+Subject: [PATCH 018/335] FROMGIT: perf trace: Add --summary-mode option
 
 The --summary-mode option will select how to show the syscall summary at
 the end.  By default, it'll show the summary for each thread and it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
@@ -1,7 +1,7 @@
 From f34740ad8a28fc7eaec947d1a7de26573007f6c6 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:01 -0800
-Subject: [PATCH 019/334] FROMGIT: perf tools: Add dummy functions for
+Subject: [PATCH 019/335] FROMGIT: perf tools: Add dummy functions for
  !HAVE_LZMA_SUPPORT
 
 This allows us to use them without needing to ifdef the calling code.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
@@ -1,7 +1,7 @@
 From c8d07ef566b42f4f5a218a5b387edac55e03608e Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:02 -0800
-Subject: [PATCH 020/334] FROMGIT: perf tools: Add LZMA decompression from FILE
+Subject: [PATCH 020/335] FROMGIT: perf tools: Add LZMA decompression from FILE
 
 Internally lzma_decompress_to_file() creates a FILE from the filename.
 Add an API that takes an existing FILE directly. This allows

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
@@ -1,7 +1,7 @@
 From 796ce8ca77cafa99f719091b9e3cb7bdfce94b3f Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:03 -0800
-Subject: [PATCH 021/334] FROMGIT: perf symbol: Support .gnu_debugdata for
+Subject: [PATCH 021/335] FROMGIT: perf symbol: Support .gnu_debugdata for
  symbols
 
 Fedora introduced a "MiniDebuginfo" feature, in which an LZMA-compressed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
@@ -1,7 +1,7 @@
 From 9ef6d8ec6a72590a0b77f1e68bfd200762c7cc88 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:49 -0700
-Subject: [PATCH 022/334] FROMGIT: perf mutex: Add annotations for
+Subject: [PATCH 022/335] FROMGIT: perf mutex: Add annotations for
  LOCKS_EXCLUDED and LOCKS_RETURNED
 
 Used to annotate when locks shouldn't be held for a function or if a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
@@ -1,7 +1,7 @@
 From beee2827331c76a391cb023506c678952dc18d51 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:50 -0700
-Subject: [PATCH 023/334] FROMGIT: perf dso: Use lock annotations to fix asan
+Subject: [PATCH 023/335] FROMGIT: perf dso: Use lock annotations to fix asan
  deadlock
 
 dso__list_del with address sanitizer and/or reference count checking

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
@@ -1,7 +1,7 @@
 From 2c5fa5e7eb9fbf55670d1575efd672b43b925634 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:51 -0700
-Subject: [PATCH 024/334] FROMGIT: perf test dso-data: Correctly free test file
+Subject: [PATCH 024/335] FROMGIT: perf test dso-data: Correctly free test file
  in read test
 
 The DSO data read test opens a file but as dsos__exit is used the test

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
@@ -1,7 +1,7 @@
 From d9dea1daf3456c2ac25ad71a35df18a4f07bb739 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:28 -0700
-Subject: [PATCH 025/334] FROMGIT: perf dso: Move libunwind dso_data variables
+Subject: [PATCH 025/335] FROMGIT: perf dso: Move libunwind dso_data variables
  into ifdef
 
 The variables elf_base_addr, debug_frame_offset, eh_frame_hdr_addr and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
@@ -1,7 +1,7 @@
 From 76f8f62e6917b27aaed2bec90fad0a28d5f49109 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:29 -0700
-Subject: [PATCH 026/334] FROMGIT: perf dso: kernel-doc for enum
+Subject: [PATCH 026/335] FROMGIT: perf dso: kernel-doc for enum
  dso_binary_type
 
 There are many and non-obvious meanings to the dso_binary_type enum

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
@@ -1,7 +1,7 @@
 From f29c39ddab51224396cb052e6460ecb6395629ba Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:30 -0700
-Subject: [PATCH 027/334] FROMGIT: perf syscalltbl: Remove syscall_table.h
+Subject: [PATCH 027/335] FROMGIT: perf syscalltbl: Remove syscall_table.h
 
 The definition of "static const char *const syscalltbl[] = {" is done
 in a generated syscalls_32.h or syscalls_64.h that is architecture

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-trace-Reorganize-syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-trace-Reorganize-syscalls.patch
@@ -1,7 +1,7 @@
 From ae1c87b00978255883435c9e74f3b09269733806 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:31 -0700
-Subject: [PATCH 028/334] FROMGIT: perf trace: Reorganize syscalls
+Subject: [PATCH 028/335] FROMGIT: perf trace: Reorganize syscalls
 
 Identify struct syscall information in the syscalls table by a machine
 type and syscall number, not just system call number. Having the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
@@ -1,7 +1,7 @@
 From 00abfaea112e77dee517e3dd9bf48d3ec03d4053 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:32 -0700
-Subject: [PATCH 029/334] FROMGIT: perf syscalltbl: Remove struct syscalltbl
+Subject: [PATCH 029/335] FROMGIT: perf syscalltbl: Remove struct syscalltbl
 
 The syscalltbl held entries of system call name and number pairs,
 generated from a native syscalltbl at start up. As there are gaps in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
@@ -1,7 +1,7 @@
 From 718611fd903aec9dea286b4c383f0c5f47fb349b Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:33 -0700
-Subject: [PATCH 030/334] FROMGIT: perf dso: Add support for reading the
+Subject: [PATCH 030/335] FROMGIT: perf dso: Add support for reading the
  e_machine type for a dso
 
 For ELF file dsos read the e_machine from the ELF header. For kernel

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
@@ -1,7 +1,7 @@
 From cfeb67f8be6dfc8d1c2b6381135d61a069ec619f Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:34 -0700
-Subject: [PATCH 031/334] FROMGIT: perf thread: Add support for reading the
+Subject: [PATCH 031/335] FROMGIT: perf thread: Add support for reading the
  e_machine type for a thread
 
 First try to read the e_machine from the dsos associated with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
@@ -1,7 +1,7 @@
 From 3a211bd0ddc844a8899efb13043672ae35f81a93 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:35 -0700
-Subject: [PATCH 032/334] FROMGIT: perf trace beauty: Add syscalltbl.sh
+Subject: [PATCH 032/335] FROMGIT: perf trace beauty: Add syscalltbl.sh
  generating all system call tables
 
 Rather than generating individual syscall header files generate a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
@@ -1,7 +1,7 @@
 From 29a54d2439146504fe3de7b4a048196094ed1f6f Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:36 -0700
-Subject: [PATCH 033/334] FROMGIT: perf syscalltbl: Use lookup table containing
+Subject: [PATCH 033/335] FROMGIT: perf syscalltbl: Use lookup table containing
  multiple architectures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
@@ -1,7 +1,7 @@
 From 63a079c5ed0bfa7fe0e3bdf4b2cf97528e440270 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:37 -0700
-Subject: [PATCH 034/334] FROMGIT: perf build: Remove Makefile.syscalls
+Subject: [PATCH 034/335] FROMGIT: perf build: Remove Makefile.syscalls
 
 Now a single beauty file is generated and used by all architectures,
 remove the per-architecture Makefiles, Kbuild files and previous

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
@@ -1,7 +1,7 @@
 From 8dad02362d732abdca32f9405233148d2e45dbbf Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:38 -0700
-Subject: [PATCH 035/334] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
+Subject: [PATCH 035/335] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
  system calls
 
 Arnd Bergmann described that MIPS system calls don't necessarily start

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Make-syscall-table-stable.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Make-syscall-table-stable.patch
@@ -1,7 +1,7 @@
 From b58dbb41e11dde5f8c97e5b6cf0bb692b6bf5994 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:39 -0700
-Subject: [PATCH 036/334] FROMGIT: perf trace: Make syscall table stable
+Subject: [PATCH 036/335] FROMGIT: perf trace: Make syscall table stable
 
 Namhyung fixed the syscall table being reallocated and moving by
 reloading the system call pointer after a move:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
@@ -1,7 +1,7 @@
 From c217c368fbf18e4d20d7e3fb9464b53dccaf1836 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:40 -0700
-Subject: [PATCH 037/334] FROMGIT: perf trace: Fix BTF memory leak
+Subject: [PATCH 037/335] FROMGIT: perf trace: Fix BTF memory leak
 
 Add missing btf__free in trace__exit.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
@@ -1,7 +1,7 @@
 From 9cc1522493f3a3906d0261be1687883b8bf56a39 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:41 -0700
-Subject: [PATCH 038/334] FROMGIT: perf trace: Fix evlist memory leak
+Subject: [PATCH 038/335] FROMGIT: perf trace: Fix evlist memory leak
 
 Leak sanitizer was reporting a memory leak in the "perf record and
 replay" test. Add evlist__delete to trace__exit, also ensure

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-net-stmmac-dwmac-loongson-Set-correct-tx-rx-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-net-stmmac-dwmac-loongson-Set-correct-tx-rx-.patch
@@ -1,7 +1,7 @@
 From 84efb34c213c5113658c7c014514a2a60839bfb1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 10 Feb 2025 21:43:28 +0800
-Subject: [PATCH 039/334] FROMGIT: net: stmmac: dwmac-loongson: Set correct
+Subject: [PATCH 039/335] FROMGIT: net: stmmac: dwmac-loongson: Set correct
  {tx,rx}_fifo_size
 
 Now for dwmac-loongson {tx,rx}_fifo_size are uninitialised, which means

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
@@ -1,7 +1,7 @@
 From 04e9402ceaa2a25ea1f311e3577aa567300dd8a6 Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Sat, 22 Feb 2025 19:45:31 +0800
-Subject: [PATCH 040/334] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
+Subject: [PATCH 040/335] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
  Support for mic and audio mute LEDs
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
@@ -1,7 +1,7 @@
 From 765c60786773302f6f43596656907eb12b3447d3 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:51 +0800
-Subject: [PATCH 041/334] FROMGIT: dt-bindings: gpio: loongson: Add new
+Subject: [PATCH 041/335] FROMGIT: dt-bindings: gpio: loongson: Add new
  loongson gpio chip compatible
 
 Add the devicetree compatibles for Loongson-7A2000 and Loongson-3A6000

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
@@ -1,7 +1,7 @@
 From f9710ada08492162339ed509a6381bc35d9dba3c Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:52 +0800
-Subject: [PATCH 042/334] FROMGIT: gpio: loongson-64bit: Add more gpio chip
+Subject: [PATCH 042/335] FROMGIT: gpio: loongson-64bit: Add more gpio chip
  support
 
 The Loongson-7A2000 and Loongson-3A6000 share the same gpio chip model.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
@@ -1,7 +1,7 @@
 From b39a649b773baae9652ab9e90b25e6b6afba1c06 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 12 Mar 2025 21:39:54 +0800
-Subject: [PATCH 043/334] FROMGIT: ata: libata: Improve return value of
+Subject: [PATCH 043/335] FROMGIT: ata: libata: Improve return value of
  atapi_check_dma()
 
 atapi_check_dma() allows a LLD to filter ATAPI commands, returning a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
@@ -1,7 +1,7 @@
 From 622bb569d72ba99510e5a69c240122bb31f24177 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:13 +0800
-Subject: [PATCH 044/334] FROMGIT: objtool/LoongArch: Add support for switch
+Subject: [PATCH 044/335] FROMGIT: objtool/LoongArch: Add support for switch
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
@@ -1,7 +1,7 @@
 From bcd134363dab63b48dda35f1bde84315b8ad52b1 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:14 +0800
-Subject: [PATCH 045/334] FROMGIT: objtool/LoongArch: Add support for goto
+Subject: [PATCH 045/335] FROMGIT: objtool/LoongArch: Add support for goto
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
@@ -1,7 +1,7 @@
 From 49325014d1db00d0287c256e73b9e01af3aaffba Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 17 Dec 2024 09:09:03 +0800
-Subject: [PATCH 046/334] FROMGIT: LoongArch: Enable jump table for objtool
+Subject: [PATCH 046/335] FROMGIT: LoongArch: Enable jump table for objtool
 
 For now, it is time to remove -fno-jump-tables to enable jump table for
 objtool if the compiler has -mannotate-tablejump, otherwise it is better

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
@@ -1,7 +1,7 @@
 From b2a654f5b5133b5b565e066f902fc9dafe781ede Mon Sep 17 00:00:00 2001
 From: Masahiro Yamada <masahiroy@kernel.org>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 047/334] FROMGIT: LoongArch: KVM: Remove unnecessary header
+Subject: [PATCH 047/335] FROMGIT: LoongArch: KVM: Remove unnecessary header
  include path
 
 arch/loongarch/kvm/ includes local headers with the double-quote form

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
@@ -1,7 +1,7 @@
 From fb695baa7c68e6e1a0e655bafc5ca054bd43f928 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 048/334] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
+Subject: [PATCH 048/335] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
  context switch
 
 PGD table for primary mmu keeps unchanged once VM is created, it is not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
@@ -1,7 +1,7 @@
 From f6338cf58ecb44e854cdea6cea78b0b1a42bfa93 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 049/334] FROMGIT: LoongArch: KVM: Add stub for
+Subject: [PATCH 049/335] FROMGIT: LoongArch: KVM: Add stub for
  kvm_arch_vcpu_preempted_in_kernel()
 
 Pause-Loop Exiting is not supported by LoongArch hardware, nor is pv

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
@@ -1,7 +1,7 @@
 From 3d7646f69be5c8ff817ad33fc026529b1622573b Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 050/334] FROMGIT: LoongArch: KVM: Implement arch-specific
+Subject: [PATCH 050/335] FROMGIT: LoongArch: KVM: Implement arch-specific
  functions for guest perf
 
 Three architecture specific functions are added for the guest perf

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
@@ -1,7 +1,7 @@
 From 5079540f30ecf605ddd2c84da1c9920329647b85 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 051/334] FROMGIT: LoongArch: KVM: Register perf callbacks for
+Subject: [PATCH 051/335] FROMGIT: LoongArch: KVM: Register perf callbacks for
  guest
 
 Add selection for GUEST_PERF_EVENTS if KVM is enabled, also add perf

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 32ff32e269afc46f039a27ad09b8aa3add7c1339 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 052/334] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 052/335] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
@@ -1,7 +1,7 @@
 From e15c8c356f0a4f1f2d9892c2e7ff3067e6a72fde Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 053/334] FROMLIST: drm/Makefile: Move tiny drivers before
+Subject: [PATCH 053/335] FROMLIST: drm/Makefile: Move tiny drivers before
  native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From d47b514c8735027ce76aa597dc494926c2027596 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 054/334] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 054/335] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From a84b4b8656fee1eb5c9d9eabdf881dd315cde53e Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 055/334] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 055/335] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
@@ -1,7 +1,7 @@
 From 79ecd229ca504220a16a43f309a94ee64c709ada Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
-Subject: [PATCH 056/334] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
+Subject: [PATCH 056/335] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
  when selected cpu is offline
 
 Call work_on_cpu(cpu, fn, arg) in pci_call_probe() while the argument

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From f326ebf68a65b83cccc6e5b5eb05bc13e623fbe1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 4 Aug 2024 09:24:18 +0800
-Subject: [PATCH 057/334] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 057/335] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
 From 4c27874cee77797d0abfd78eafb3a489e4694b7d Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 058/334] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 058/335] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
 From 9c980e738381125a4b7ab9c0aedad23ff1024551 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 059/334] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 059/335] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
 From b817ee3c07a77ceaebc2af7d3b364c793fc0b81a Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 060/334] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 060/335] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From f9197b0ae219e7bccbf414ea98f65dc18eb0e748 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 061/334] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 061/335] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
@@ -1,7 +1,7 @@
 From 1377fbd12c34eec9574ed180dc44a2d38359ae91 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 11 Nov 2024 21:21:49 +0800
-Subject: [PATCH 062/334] FROMLIST: drm: Remove redundant statement in
+Subject: [PATCH 062/335] FROMLIST: drm: Remove redundant statement in
  drm_crtc_helper_set_mode()
 
 Commit dbbfaf5f2641a ("drm: Remove bridge support from legacy helpers")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From dc58c2dc846ae36b82da94a1cb4510d13c690510 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 063/334] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 063/335] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
 From 9f4eea3ffae61bfec8d4566e927909bf55554c54 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:08 +0800
-Subject: [PATCH 064/334] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 064/335] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC MFD Core driver
 
 The Loongson-2K Board Management Controller provides an PCIe

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
 From fef10ea6058cf3216cc669f7b05d3b31b958bdd7 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:09 +0800
-Subject: [PATCH 065/334] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 065/335] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
@@ -1,7 +1,7 @@
 From d4da8cf8c93557531a3fccd704234fd33c156b5d Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:10 +0800
-Subject: [PATCH 066/334] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
+Subject: [PATCH 066/335] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
  BMC display
 
 Adds a driver for the Loongson-2K BMC display as a sub-function of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
 From 5e961a7f2151efc1dadcc0f6763eb68aeb5beb82 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:36 +0800
-Subject: [PATCH 067/334] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 067/335] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 0906eee613de9206862286382ad1c55b8f23ce4e Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 068/334] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 068/335] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
@@ -1,7 +1,7 @@
 From 77def15b6eb01c6d37d1dd8946ffa81bfb3dc77b Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:29:56 +0800
-Subject: [PATCH 069/334] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
+Subject: [PATCH 069/335] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
@@ -1,7 +1,7 @@
 From a557a07b0941ed15cfdce5205bc5638533a5696d Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:15 +0800
-Subject: [PATCH 070/334] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
+Subject: [PATCH 070/335] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
@@ -1,7 +1,7 @@
 From bc5cbe036bc8feb7e2e8be8d2133f39c960df64c Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:35 +0800
-Subject: [PATCH 071/334] FROMLIST: drm/amd/display: Harden callers of division
+Subject: [PATCH 071/335] FROMLIST: drm/amd/display: Harden callers of division
  functions
 
 There are objtool warnings compiled with the latest mainline LLVM:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-FROMLIST-iommu-intel-apply-quirk_iommu_igfx-for-8086.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-FROMLIST-iommu-intel-apply-quirk_iommu_igfx-for-8086.patch
@@ -1,7 +1,7 @@
 From 2ce56be229f7ac2a79051ed42c1f289d1ea227e8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 17:35:39 +0800
-Subject: [PATCH 072/334] FROMLIST: iommu: intel: apply quirk_iommu_igfx for
+Subject: [PATCH 072/335] FROMLIST: iommu: intel: apply quirk_iommu_igfx for
  8086:0044 (QM57/QS57)
 
 (I'm not very confident about the approach of this patch but I failed to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
@@ -1,7 +1,7 @@
 From 6f6375fbddf31f2c99181b639572b2d6c18178f1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 21 Jan 2025 19:42:25 +0800
-Subject: [PATCH 073/334] FROMLIST: PCI: loongson: Add quirk for OHCI device
+Subject: [PATCH 073/335] FROMLIST: PCI: loongson: Add quirk for OHCI device
  rev 0x02
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From 07fe23bb7110dd1d73a93dd528bb68daf5b34f8c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 074/334] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 074/335] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
@@ -1,7 +1,7 @@
 From 1ad6fd91be3cb7e855419a1e7adec7450b255df4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:24 +0800
-Subject: [PATCH 075/334] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
+Subject: [PATCH 075/335] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
  PWM controller
 
 Add Loongson PWM controller binding with DT schema format using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,7 +1,7 @@
 From 5372d6d53a8ce7b579b0c098f3c40930f815ee15 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:25 +0800
-Subject: [PATCH 076/334] FROMLIST: pwm: Add Loongson PWM controller support
+Subject: [PATCH 076/335] FROMLIST: pwm: Add Loongson PWM controller support
 
 This commit adds a generic PWM framework driver for the PWM controller
 found on Loongson family chips.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
 From 5617af9b7973f72cd6c32c6aa17e5a306090350f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:40 +0800
-Subject: [PATCH 077/334] FROMLIST: riscv: vDSO: Remove --hash-style=both
+Subject: [PATCH 077/335] FROMLIST: riscv: vDSO: Remove --hash-style=both
 
 When RISC-V borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
 From 131f43029c49bc44f83cd7abe54eb9a727de49bc Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:41 +0800
-Subject: [PATCH 078/334] FROMLIST: csky: vDSO: Remove --hash-style=both
+Subject: [PATCH 078/335] FROMLIST: csky: vDSO: Remove --hash-style=both
 
 When CSKY borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
@@ -1,7 +1,7 @@
 From b2565f541d529d64d6099377a909665c461ae12a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:42 +0800
-Subject: [PATCH 079/334] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
+Subject: [PATCH 079/335] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
 
 glibc added support for .gnu.hash in 2006 and .hash has been obsoleted
 far before the first LoongArch CPU was taped.  Using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
@@ -1,7 +1,7 @@
 From f1cf96ee3ce9a1e2ea27c1ef95c4ae3b9bb9b130 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 080/334] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
+Subject: [PATCH 080/335] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
  page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From 32fedda8f5d0f9863c568ae84736b9a9590a102c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 081/334] FROMLIST: drm/xe/guc: use SZ_4K for alignment
+Subject: [PATCH 081/335] FROMLIST: drm/xe/guc: use SZ_4K for alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From 6c652a73e1c480711e02aff2657941537f47d0fa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 082/334] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 082/335] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From cef2207241c49431182cd71422c01029582b11fd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 083/334] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 083/335] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From 6bdbf7bca81f4664fcf332ee8958ffe4012bb3b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 084/334] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 084/335] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 0abb4736d266551a88ed3a7b2e09f1082c6f7fbe Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 4 Mar 2025 14:33:51 +0800
-Subject: [PATCH 085/334] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 085/335] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-USB-OHCI-Add-quirk-for-LS7A-OHCI-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-USB-OHCI-Add-quirk-for-LS7A-OHCI-controller.patch
@@ -1,7 +1,7 @@
 From 5d6a667838c935c33ce52633d47ab96e4a8c8022 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Mar 2025 12:00:59 +0800
-Subject: [PATCH 086/334] FROMLIST: USB: OHCI: Add quirk for LS7A OHCI
+Subject: [PATCH 086/335] FROMLIST: USB: OHCI: Add quirk for LS7A OHCI
  controller (rev 0x02)
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 4b393b2e4706fc1dd9ec121d91820c34687c089d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 087/334] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 087/335] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 042af59dc6d503c6fc3dbb6b7d8e735e1861a38c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 088/334] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 088/335] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From f1c173b9a74835c3a4a8d32bf43dc874807d83fb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 089/334] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 089/335] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From c752a9824cc7824cbb9cfb21bb3df8b350b18a94 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 090/334] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 090/335] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 17ac13d9e39663af07692260c6987b79f2efde66 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 091/334] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 091/335] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 4dae6a22720cb916c51b76e69f1122325ad125ce Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 092/334] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 092/335] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From c5892add37ed80e3e082adc0b8278749a20c1288 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 093/334] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 093/335] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From 106fbd6adc57137bb2ac4da85b069136b3bcc672 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 094/334] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 094/335] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 0179a93c60cc8fc28db4ca4fd250b3b466531e44 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 095/334] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 095/335] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From 47b410860ab34f9cb69a7039a9a8abce90b33897 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 096/334] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 096/335] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From c6549ede2e3b614dc5c08697fc757849bc24fe04 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 097/334] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 097/335] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From d4091a40413ca83f2c6a192026acc09383be346a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 098/334] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 098/335] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From 0ec1603b61cbe841089c23a627ff443cb1b14fbd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 099/334] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 099/335] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
@@ -1,7 +1,7 @@
 From 4fa0830daef246d372fc268af646938c406e01e4 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 25 Feb 2025 17:24:20 +0800
-Subject: [PATCH 100/334] LOONGSON: LoongArch: Always select
+Subject: [PATCH 100/335] LOONGSON: LoongArch: Always select
  HAVE_VIRT_CPU_ACCOUNTING_GEN
 
 Option HAVE_VIRT_CPU_ACCOUNTING_GEN is selected by default for 64bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
@@ -1,7 +1,7 @@
 From 034fca172d18469bbb61cfcaec42fa90f0a3ed58 Mon Sep 17 00:00:00 2001
 From: Yuli Wang <wangyuli@uniontech.com>
 Date: Thu, 6 Feb 2025 14:38:20 +0800
-Subject: [PATCH 101/334] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
+Subject: [PATCH 101/335] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
  Sanitizer)
 
 Select ARCH_HAS_UBSAN in order to allow the user to enable CONFIG_UBSAN

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
@@ -1,7 +1,7 @@
 From e0688920beab549e43fc098ef5818d5385aa0d4d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 21 Feb 2025 19:32:43 +0800
-Subject: [PATCH 102/334] LOONGSON: LoongArch: vDSO: Make use of the t8
+Subject: [PATCH 102/335] LOONGSON: LoongArch: vDSO: Make use of the t8
  register for vgetrandom-chacha
 
 Make use of the t8 register for vgetrandom-chacha, so we don't need to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From ffcb6c6723e6806b98ca677bc391e556eb15c3f0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 103/334] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 103/335] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From e65b7fe85e1712809fabd5eaf242a5f85d6e78ec Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 104/334] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 104/335] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 4bd27664e21b06fc5b130352e0382cac98e77de3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 105/334] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 105/335] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 4eea11961dddbdaf2bea6ae16c67f731133e64e0 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 106/334] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 106/335] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From 2fff0a7bf25a3b6a04e96c6763a94a5e9f0fdd8d Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 107/334] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 107/335] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From 21794ea60ca0940f3484566bf83ee34b7ddf05d9 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 108/334] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 108/335] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From da8f19d6b70250b7525c5bad9ae9240cce94cf6f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 109/334] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 109/335] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From b966e354cf4acbdea5ee908091b1bf98beca5678 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 110/334] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 110/335] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 9c5ae364bcd21692b997279b1d0f6d1e3b9476ab Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 111/334] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 111/335] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From 1513217857d1cfc55e0b70236508eff479767734 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 112/334] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 112/335] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From cb756eeb8fd2068e922552192b59af78e65092db Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 113/334] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 113/335] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From a4fb6be09afd424f7b082d97421779dc228aadb6 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 114/334] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 114/335] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 21356807ba0cf8d3266c0120a8436a4002365a14 Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 115/334] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 115/335] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From 6f3dbd575ae58f07a855562c45c6393b6cfa9ee4 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 116/334] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 116/335] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From 35bdd4673fa8e14c75e27b3729edf66a163f00f2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 117/334] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 117/335] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From 6e0da2a94d839e666e91f1222bae9194fff7689f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 118/334] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 118/335] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From e612f8c880ec26dc4f892b7e384c658993f6aecd Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 119/334] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 119/335] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 7a6ea78048714685f4f162bd0c6ccf62794f7ccb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 120/334] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 120/335] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From 623d0e7efee3ca108c42eb5a66b196f9b591aad6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 121/334] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 121/335] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From 4b25b4e569bfcbf2d69fd46f0096a119fa11d2f9 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 122/334] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 122/335] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From 7722a70662039984eaaa725d5b0b971b5adf2b37 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 123/334] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 123/335] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From 12995e16b231de76d324ce97e2cf91c2c4a2358f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 124/334] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 124/335] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From 0428b96bb9c8f9b54ab62b1a7563ac49483bf649 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 125/334] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 125/335] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From ab9d213aaef2b1aee512c81f5205a3e710d81439 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 126/334] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 126/335] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 144af2ef71b9232064d3ddff61f4e3b4a85c83e7 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 127/334] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 127/335] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From 0984d4928607f3d3abb671ba1e24c313098a8b1e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 128/334] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 128/335] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From cadc5ffbbe8f9bd41a49617fa52b78787b147e1a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 129/334] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 129/335] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 25d12198be36e1eb170bf09e52fa584c4b9f44e0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 130/334] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 130/335] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 1d923d6e25190b8fa7b278abab80de48f822aa2f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 131/334] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 131/335] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 9163367b2de442871c51718cdd2eab109ac7abd2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 132/334] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 132/335] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 86652a8e5aa3679df6cd257774efbfda0bd667d9 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 133/334] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 133/335] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 4d37a6ffc51dad776664c0e099060acd569dbb08 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 134/334] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 134/335] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From 4e2157be0937adfd6d91fa44252095e82fa0b7d4 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 135/334] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 135/335] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From a68e971a429d24f24f63c92cb7e29022b7219d33 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 136/334] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 136/335] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 63b3d489bc632cc26c5726cc9e3da6fc6c216ee5 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 137/334] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 137/335] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 61f1c834c910e6bd2a151362044bc157da3bec32 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 138/334] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 138/335] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From 4a68eccfbaaf036f29f138192fe8bb529b11b756 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 139/334] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 139/335] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From 4432fcd9ed70aeaf3885131b3b9770da375db297 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 140/334] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 140/335] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From ada4989bdb51b58a45b82ed6fc71083c05211f70 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 141/334] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 141/335] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
@@ -1,7 +1,7 @@
 From 7cf2aabd2376e41d4c5df1a95f98d3b2c54b2ea7 Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:31 +0800
-Subject: [PATCH 142/334] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
+Subject: [PATCH 142/335] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
  support for MPAM
 
 maillist inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
@@ -1,7 +1,7 @@
 From 8d0ad9197d11b601f73e75b15aafd975daf787b9 Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:32 +0800
-Subject: [PATCH 143/334] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
+Subject: [PATCH 143/335] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
  guest accesses to the MPAM registers
 
 maillist inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
@@ -1,7 +1,7 @@
 From cfb4e27b3cc1e766ab4a7649b113012dc297b5dd Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Sat, 1 Jun 2024 14:38:28 +0800
-Subject: [PATCH 144/334] BACKPORT: OPENEULER: arm64: cpufeature: Both the
+Subject: [PATCH 144/335] BACKPORT: OPENEULER: arm64: cpufeature: Both the
  major and the minor version numbers need to be checked
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
@@ -1,7 +1,7 @@
 From 62ad46c40614164f835d99073cfdf1f297497c65 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:52 +0800
-Subject: [PATCH 145/334] BACKPORT: OPENEULER: Revert "arm64: head.S:
+Subject: [PATCH 145/335] BACKPORT: OPENEULER: Revert "arm64: head.S:
  Initialise MPAM EL2 registers and disable traps"
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
@@ -1,7 +1,7 @@
 From e8376257743ab7c078665c3890e7191cc51455a2 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:53 +0800
-Subject: [PATCH 146/334] BACKPORT: OPENEULER: arm64/mpam: Check
+Subject: [PATCH 146/335] BACKPORT: OPENEULER: arm64/mpam: Check
  mpam_detect_is_enabled() before accessing MPAM registers
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
@@ -1,7 +1,7 @@
 From bf2feb3c7587abd229fc93ac651ea6256edc0eb6 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Thu, 26 Sep 2024 17:28:18 +0800
-Subject: [PATCH 147/334] OPENEULER: arm64/mpam: Fix redefined reference of
+Subject: [PATCH 147/335] OPENEULER: arm64/mpam: Fix redefined reference of
  'mpam_detect_is_enabled'
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From 532d0e51faab92e6491da7f403d3f6da1de70474 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 148/334] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 148/335] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From 8621883b08e1349e3226214a5a20e55b66d1130e Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 149/334] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 149/335] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 43ef0f1909928e8c3b427eb724a124b21671e6c5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 150/334] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 150/335] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
 From 3ccdc7984c05ed224f8a043924228a0724fdec62 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 151/334] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 151/335] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
@@ -1,7 +1,7 @@
 From 14adbbbbccce1e1303370b9c3287a7554a9a1215 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:51:08 +0800
-Subject: [PATCH 152/334] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
+Subject: [PATCH 152/335] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
  of the number of packages
 
 Signed-off-by: wanghongliang <wanghongliang@loongson.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
@@ -1,7 +1,7 @@
 From f5026af453831391f12446bc3ea89048ac6e6813 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 153/334] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
+Subject: [PATCH 153/335] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
  devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
 From 7c91028481b8ae01ae0570211be2a14a67d93c39 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 154/334] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 154/335] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From 6337e5f544a86eea631cd5e984bb5e03da271f6c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 155/334] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 155/335] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 351cc86e8d0c4b5924b78850fbaa77a97b1a93ca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 156/334] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 156/335] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From e04b063512db175cc2c5fd6ed1783e1d4a33c481 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 157/334] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 157/335] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From 6efcb5d127deb5aa2ed3b34bb5329b4bff12e406 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 158/334] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 158/335] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From 9df87377e02dfc214298b39ce526250235410301 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 159/334] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 159/335] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 5a5601920a6679f5328ab842021902e982f4d9e0 Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 160/334] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 160/335] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From c89f6a7c59ab552af327c121db11110cb8893769 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 161/334] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 161/335] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From cca649202c9ed09d11cf4eabe27b83db6f85649b Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 162/334] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 162/335] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
 From 9788098724de2a9479714b34bb1502088d824fab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 163/334] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 163/335] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 53c7e2a5315e7f04caecdfcca57b803fbb020ad6 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 164/334] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 164/335] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
@@ -1,7 +1,7 @@
 From 12a37bf56566b0fae3e7d4738ed0ab3fc2088f2d Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 165/334] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
+Subject: [PATCH 165/335] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
 Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
@@ -1,7 +1,7 @@
 From f0d900ca0aee981647829544a84885dffc2040e0 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 166/334] BACKPORT: SURFACE: hid: Add support for Intel Precise
+Subject: [PATCH 166/335] BACKPORT: SURFACE: hid: Add support for Intel Precise
  Touch and Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From f2c771f4c5bd461bd26904cb4787e5c870f3c13c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 167/334] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 167/335] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From f86038dd8cb05b51dfbaa65a09e1418b8f35b3d6 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 168/334] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 168/335] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From bd6a700af7ea597e2e6fcb88efec992623af7d0e Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 169/334] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 169/335] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
@@ -1,7 +1,7 @@
 From fea4344c3c08bffff42a02a88d60d761afd598a7 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 170/334] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
+Subject: [PATCH 170/335] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
  for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From becc5ea0e9074e3ed68baafe5083631c4da3b4b5 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 171/334] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 171/335] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 2710d5e99bee7be40cb1d2722a0d50b06186f376 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 172/334] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 172/335] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From e9da737c377652f6972857b62df4ca3fc4accf07 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 173/334] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 173/335] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From 25cbc1cde810fadbc24e32171604e05dbac9beb1 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 174/334] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 174/335] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From 7a0f7fd168bba45c150df65c486afdb2bc7193c4 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 175/334] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 175/335] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From ed8da4de7673c6876034866ff04ac031d2b66811 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 176/334] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 176/335] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From 92c7d8320217c767c87ed9079db1c0e431d9be1b Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 177/334] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 177/335] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
@@ -1,7 +1,7 @@
 From e4699f0ce090011ff07cc17e799ca9209f5d6aff Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Mon, 16 Sep 2024 05:55:58 -0400
-Subject: [PATCH 178/334] FROMEXT:
+Subject: [PATCH 178/335] FROMEXT:
  more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-FROMEXT-cjktty-6.9.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-FROMEXT-cjktty-6.9.patch.patch
@@ -1,7 +1,7 @@
 From 011193ecb7e0dbab33fa758e56e4c36185aa5b55 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 18 Dec 2024 12:31:33 +0800
-Subject: [PATCH 179/334] FROMEXT: cjktty-6.9.patch
+Subject: [PATCH 179/335] FROMEXT: cjktty-6.9.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
@@ -1,7 +1,7 @@
 From afbaa06b7820e12211a94f7b73949ea704182cc2 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 13 Sep 2024 17:30:35 +0300
-Subject: [PATCH 180/334] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
+Subject: [PATCH 180/335] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
  clock ratio and scrambling support
 
 Enable use of HDMI 2.0 display modes, e.g. 4K@60Hz, by permitting TMDS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From f1f9ab7ed1d8662ecfd71f7b953be0b99553f74e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 181/334] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 181/335] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 200e439f41ce6fe9b7ed8839ce6caa5ae1a5da02 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 182/334] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 182/335] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From 9e6a1dbe26f4205905f24cf7922e3779c7b455eb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 183/334] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 183/335] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 16137aa37b8efa64841c2cc8ced5ba9794bd28c9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 184/334] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 184/335] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From 9104450f5ad12559bdf776d487d3ddaed98627b3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 185/334] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 185/335] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 04fb9a95c2c8c40dccdd60e8d77f4829dc4ed24d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 186/334] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 186/335] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From ac4513192a94895855f7033e6f2b3a0d4f0f36ca Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 187/334] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 187/335] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 6aec67c4f1cdb473cf3fab3a8890eef9424ea771 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 188/334] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 188/335] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From da806afa16ac0ee3f6aa681eee93358761253b62 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 189/334] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 189/335] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 97483fe314678b0d210ab52c7f30002536fa6df3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 190/334] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 190/335] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From 28bc6faa6cad5dee571f1a8a4840960442dbc6fe Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 191/334] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 191/335] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From 8aa06c5cef832439a5831c5d29d12f3ef4d460f3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 192/334] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 192/335] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From 47fc4d10b4b8c82d6f9474ef89b8170a8d4fb4d9 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 193/334] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 193/335] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From 18cc1d549cbfbca0930c94e1871022008b693fe4 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 194/334] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 194/335] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From 77b792eb367ab0efa4a59dd694784d83d5f5e475 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 195/334] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 195/335] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 29c62a07b43fe8c45a99e5f1ac40fdc2f2bf3e72 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 196/334] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 196/335] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-platform-x86-ideapad-laptop-add-fixes-for-Thi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-platform-x86-ideapad-laptop-add-fixes-for-Thi.patch
@@ -1,7 +1,7 @@
 From 75eda8ff5c3c9d9c0b18f25bf59e256bb20b721c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sat, 17 Aug 2024 11:32:11 +0800
-Subject: [PATCH 197/334] AOSCOS: platform: x86: ideapad-laptop: add fixes for
+Subject: [PATCH 197/335] AOSCOS: platform: x86: ideapad-laptop: add fixes for
  ThinkBook 14+ (2024 G6+)
 
 This is a patch taken from ideapad-laptop-tb2024g6plus in an attempt to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 943277ac4eb17302cd7f570c7320a821e64253de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 198/334] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 198/335] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From d7bc2fbab3bf4ac8d61f117e1d908dbaca40e61d Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 199/334] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 199/335] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 42f215747d5d730bc16690988e89cae82ec7986b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 200/334] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 200/335] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 19b0d1283707d10a07e54405935322ebe49717f8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 201/334] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 201/335] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From b3a1d3ac39aaf033203f88de78fc20c83eb65ce1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 202/334] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 202/335] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From f20cf020658227e230289036d74ad1b32deee5ed Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 203/334] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 203/335] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From 23aab9dcdfbf2b6029c5494f991da16af89c96f5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 204/334] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 204/335] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-platform-ideapad-laptop-fix-if-branch-syntax.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-platform-ideapad-laptop-fix-if-branch-syntax.patch
@@ -1,7 +1,7 @@
 From 0d5ed9ebeab47b0e4df2a2d5c8834b9022d38a0e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 26 Dec 2024 10:13:42 +0800
-Subject: [PATCH 205/334] AOSCOS: platform: ideapad-laptop: fix if branch
+Subject: [PATCH 205/335] AOSCOS: platform: ideapad-laptop: fix if branch
  syntax
 
 With "AOSCOS: platform: x86: ideapad-laptop: add fixes for ThinkBook 14+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
@@ -1,7 +1,7 @@
 From eae334403667dea8051088d1dccb55890a0aa3de Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 31 Dec 2024 15:56:52 +0800
-Subject: [PATCH 206/334] AOSCOS: drm/ls2kbmc: Add id_table for
+Subject: [PATCH 206/335] AOSCOS: drm/ls2kbmc: Add id_table for
  ls2kbmc_platform_driver
 
 Try to fix device binding for the driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From ef8025dea7b842b3e7d486537b7ff70a6a8adf50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 207/334] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 207/335] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From e706601d60df3fda6b1263b144bd2d9b43f1bdce Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 208/334] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 208/335] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 8a8c54d42d92767344b2bf6ba4ee950dd7a0fc47 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 209/334] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 209/335] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From 0c46353c33feee31116a9df887352ca205572058 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 210/334] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 210/335] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
@@ -1,7 +1,7 @@
 From b4b5bb3cb8b1c7abe21fba00ba7ddbce78f7f808 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:06:44 +0800
-Subject: [PATCH 211/334] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
+Subject: [PATCH 211/335] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
 
 Following upstream name changes.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From bf7137ffac38d7c61149a5bf42a8be2f3f2e6cb6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:41:10 +0800
-Subject: [PATCH 212/334] AOSCOS: drm/ls2kbmc: remove driver date
+Subject: [PATCH 212/335] AOSCOS: drm/ls2kbmc: remove driver date
 
 Following upstream changes.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From 10338b230dd298cee7203beef2bfb2e018be1b5a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 213/334] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 213/335] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 1412bfaf34b8681faacc35a319d760a0da921f40 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 214/334] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 214/335] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From 6f99e855d74c91a7b0c033730023d82fed66c1bd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 215/334] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 215/335] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 7ed422a7af789baa97bdd9d30e1b68b8713ccffa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 216/334] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 216/335] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From c199ae3b6d8de4754de5a6a0156417a4f65af6da Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 217/334] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 217/335] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From a18850110c6d730ea05bcbe55455788cdced1d44 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 218/334] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 218/335] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From 5d9fef414d99c5867174ffff6936baac25dea3d6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 219/334] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 219/335] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From 1253b2c9fb79276ef43a5605080d61b2ade86a24 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 220/334] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 220/335] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 372f7e71e0eac9afb1518fa687f33af900796b50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 221/334] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 221/335] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From 1839c695cbe64d59e3aefaaef22c26709d6f06a3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 222/334] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 222/335] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 767e70ee7f49e11112d945967dc95a7db040f2eb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 223/334] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 223/335] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From 04e93423d0d0c4bd259b174f75d5efe1eb589dba Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 224/334] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 224/335] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From c7c754a6c7f0ff830e89fdcbb59324fb3007b2d8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 225/334] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 225/335] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 36be9fc2055fa80b0fe537ee2d3cc5fe4772af95 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 226/334] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 226/335] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 7478c1ac37000c0d7867cb0da6745552ba19f706 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 227/334] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 227/335] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From c8bc10781a364cc35902158a9a6b36c7be2fb0d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 228/334] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 228/335] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 8d050a9eb0c5ec804386c0af51eee89f58e27602 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 229/334] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 229/335] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From bc3eefdf951d2896d719f002dccf653aa4bf95d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 230/334] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 230/335] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From bfe4588917869a8675b038dc27a690d5f567dd5b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 231/334] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 231/335] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 347b98936245e91cd70eb6fdadf68d0e7dca3175 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 232/334] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 232/335] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 960bfaa0d15519ee3742153df62d662ece8d27bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 233/334] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 233/335] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From 01f78f0a51e35b0ffa5fcecd90387e53a2f27381 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 234/334] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 234/335] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 9af40831aaf23dabbe3b9031f5ca84c7dae60d3c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 235/334] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 235/335] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 54da15a43b3820269f849461de6ed098e040464a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 236/334] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 236/335] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From e4039335b02e18d358e967f536595680d7f5c6eb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 237/334] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 237/335] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From fc8dd2c484c79f628b4835ae30964be549c28cdd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 238/334] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 238/335] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From 146fd4d6d8323880475ccd9b3436e3502322159b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 239/334] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 239/335] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From ca03c43a001d7838dd5ca82f2cb1dcd850f504f7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 240/334] AOSCOS: input: atkbd: disable
+Subject: [PATCH 240/335] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 45c026b2e1dc9c24e21eb49f596f87e7f0a59e43 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 241/334] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 241/335] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From d59653fb00fbcdcdb0cbbc111127eba6ade84244 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 242/334] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 242/335] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 4f39fbef292d7f78dadd5eb4161593207d850f8b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 243/334] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 243/335] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 5a264e293d4946abfc964645b7245fea40d87d41 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 244/334] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 244/335] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 9655340dffeae8f1aa32ebfca451018eb334e4ac Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 245/334] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 245/335] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 5e133994353433b1c47ea41d469bf77ee2df1c8f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 246/334] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 246/335] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 5f087b1c85e2e465c729022b8e8812ff56ba589a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 247/334] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 247/335] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From e864111f09e0228afd02a4fc2b9ec6084db49109 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 248/334] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 248/335] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From c2d34c7ddc086d8372064b060b0ace86c7584317 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 249/334] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 249/335] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From 3541751fecc1fa993c2aa110da03194f954b6f3a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 250/334] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 250/335] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 4bb17379839c86660b2686d01934a29270cc4f9d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 251/334] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 251/335] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From a0dbec05e6681c2148214df0f3d52ecda44ff5b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 252/334] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 252/335] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 7f057f241ed4f4ecb862e5af2b7f9ad093c50c97 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 253/334] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 253/335] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From 3116c5732e1a0eb8c0f20b95246040f0b86b439d Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 254/334] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 254/335] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From 5addf48db5e51dbcb5b8332d0044e3d829d51f34 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 255/334] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 255/335] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From 967f33e97e0545f04283d07baaf7772eb4e84733 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 256/334] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 256/335] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 9b9d4b35dac1f8d7f5de15a7296362b5c9955f17 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 257/334] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 257/335] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 30136b22392eba229227d622ecc94d0d98c383a4 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 258/334] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 258/335] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From 141b29ed3eadad482cc9be900f02631b9a5c4046 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 259/334] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 259/335] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From 8369249536c43e383336b5d3f3c0979fd2d934c2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 260/334] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 260/335] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From eaba481a28f02da88d26a1c2765a2c0a5b0827ff Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 261/334] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 261/335] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From f2f96af6734cd7314bf2d4fa070f208684dcb1f3 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 262/334] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 262/335] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From a3c389978e7ae835e950a19e7f93f31f9bd0043d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 263/334] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 263/335] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 37148939cef42b34b4a0add85719240629f51cb9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 264/334] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 264/335] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From 97e7323fd03d9de78131a0dffc8386812c321b1b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 265/334] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 265/335] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From 60ebfa5d4f0e332096e526817433d748db8dde8a Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 266/334] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 266/335] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 6efae2a4715038abda94b3433b7e9cef9eeca2f1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 267/334] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 267/335] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From cf7cd364aa15a87d49de500851fd690de3dcb78c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 268/334] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 268/335] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From 4f7fdf4d1a490d0fbeb23704641baf1de5fabee3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 269/334] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 269/335] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 617cbe8f8668ca1ca7d688b0d89716845b0f642b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 270/334] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 270/335] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From 07ce156ad1eda2882c5fed9f9b1d0e3753c80dbb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 271/334] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 271/335] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 54977a2595197479513cbcdd33f80755363a4209 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 272/334] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 272/335] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 7e56ea931ce074e00a4cdf346578029516b1ea77 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 273/334] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 273/335] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 9c5b308a0bf94efc0597dd453f89a9931923c685 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 274/334] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 274/335] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From 8f56065b486d553a3f5f312d31f988f8fa54bf72 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 275/334] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 275/335] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 498db23b29b2d85eea51b2f407d1d5ce9d05fa98 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 276/334] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 276/335] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From 2e27b1bb5176f6c162973cd46cb0db5afe275c7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 277/334] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 277/335] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 59eca619d4f1d7720c63bf2a5ccb76175ac8be97 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 278/334] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 278/335] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 64a0176a25434b93a1e043a74ab42cf90688bcde Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 279/334] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 279/335] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From d96f8691a0696caf092008eb8216f3ec94865631 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 280/334] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 280/335] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From f0534af060eb9b60c165cde05e0a015a48560a3e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 281/334] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 281/335] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From ce6b47b1c97c2c652cd468fe12774e7836ff90d5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 282/334] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 282/335] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 384b60463eeb3e714b5ac2168e45a28fe6ac7373 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 283/334] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 283/335] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 3aeac15f159bdd3821b3ca188124c38086262b7c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 284/334] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 284/335] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 3c044902cd7e887f2f9bb16936fbaac9bcac6d5a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 285/334] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 285/335] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From fe401ac5b91343e09920a7905885e7a1e5c94094 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 286/334] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 286/335] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From 2c1364e0ea16575c8c0c3708fda5b5d40a642984 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 287/334] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 287/335] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From fe6bf758aa9646756e171630af5b9949b2c48b4a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 288/334] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 288/335] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From 727ceb5e677ecc7cfc61461712bb7ad454e2b646 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 289/334] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 289/335] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 67c45adfd60e1c376f69448d26671a05013b278a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 290/334] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 290/335] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From b531425e9e06412715e99fa313ec37a64a941a0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 291/334] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 291/335] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From 8b7122da147e64c100b1c8a3f18a2e39b9fbc328 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 292/334] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 292/335] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From a0df3603ccb9767c9836ed25fd723117ef477ac7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 293/334] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 293/335] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From cad75e8de3da6e6e86650506b23ac86242f809ec Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 294/334] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 294/335] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 6e5db1a48fc169fcb1059549537e4b41fa686141 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 295/334] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 295/335] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From b54e849e994194544ef50fde651aa045b4710dd7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 296/334] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 296/335] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 2d672f41fb6f10d54e9a0418fb0afa43525f5986 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 297/334] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 297/335] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From 1b564263b91a3dd1c22cc70b05f5378f99dd3cc7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 298/334] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 298/335] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 6ec0a678b6297ac126ccc88ff302ee4403704d36 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 299/334] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 299/335] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 02d490096c57ab4283469189a92edef58c771b65 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 300/334] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 300/335] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 77692f2677ed828a8afbaf36e376bdcd2809467a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 301/334] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 301/335] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 6e6d3ec1f8a9e8810a9bd8955efcc62b074ed9cb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 302/334] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 302/335] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From daa6fd33579ff267798ac68fc0d86a398f3c55bd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 303/334] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 303/335] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From be1230cb2bf64403facb8bd92456f28d2b24d159 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 304/334] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 304/335] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-USB-XHCI-Fix-device-lost-problems-on-ETRON-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-USB-XHCI-Fix-device-lost-problems-on-ETRON-co.patch
@@ -1,7 +1,7 @@
 From 43b72c7eb87ab9f000bec0fcd1c9d64e575047cc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 3 Jun 2019 10:16:02 +0800
-Subject: [PATCH 305/334] AOSCOS: USB: XHCI: Fix device lost problems on ETRON
+Subject: [PATCH 305/335] AOSCOS: USB: XHCI: Fix device lost problems on ETRON
  controller
 
 [Mingcong Bai: Resolved merge conflicts in drivers/usb/host/xhci-ring.c

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 37a213e2d6c3333790acc23fc94d02f8180b3d9d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 306/334] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 306/335] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 7ebf50f0b10ef479bda9cad81bcf714321455cd6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 307/334] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 307/335] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From e33a892c7b141dd7b7bfb8303912483b3328baea Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 308/334] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 308/335] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From ba5ec61365cdf01c4ae90fe88b59f7d15d940829 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 309/334] AOSCOS: Optimize clear_page
+Subject: [PATCH 309/335] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From b2cc9ee761fdd97d0ad92575b8e140c8b554de55 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 310/334] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 310/335] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 0f5dd9aa81b9ddd8fddd32090315bb21c6924e14 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 311/334] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 311/335] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 154fe6330b587f9c1779a856caf7613e5714e7f2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 312/334] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 312/335] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From c1e7c2c2023874a063236940de2e4b743a766b46 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 313/334] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 313/335] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 171bacafbca24a30a8953fb80abe7d485e67201e Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 314/334] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 314/335] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 716733ead49c9eeaf9b89bc484a90cbc0bbe1b96 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 315/334] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 315/335] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From b224e9ff6f4ea38f5ed147d6109dbc8564062205 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 316/334] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 316/335] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From 84d9d902532848ac81ae42186af3c482d49685d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 317/334] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 317/335] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 0ac91268057bc12134bdf5050a8dcfea430e2e83 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 318/334] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 318/335] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 6f043467b5174510704a517e2bda8c47a4fed29d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 319/334] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 319/335] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 974c3cfea521450c83d3c0f93f3b12e9d84f26c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 320/334] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 320/335] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From 11ed58f99f5ee6282268f1478c2ed4ec735fec64 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 321/334] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 321/335] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From 821de572ecd0f486e5953842160a6ed6e9a4158e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 322/334] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 322/335] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From d5f62f24483544b4bd31fa5f7b92da7a67082ff9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 323/334] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 323/335] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From ba6b4e3b1671360827ee65c34040344f0d339b00 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 324/334] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 324/335] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From ba623b0b25ee3709ac1d0ed933c3c8813da38634 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 325/334] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 325/335] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 4f985d67933fe25de3b52a4c9f43212e0e93ee02 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 326/334] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 326/335] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From 7e12002a764797c82b5b4adf9906e07797b2d122 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 327/334] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 327/335] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 0d2b984770de25cef9ba3ac13cd052486e2c4c87 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 328/334] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 328/335] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 9d15951f87d87bf0dd552e9076dba5f95a33f448 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 329/334] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 329/335] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-ACPI-EC-Set-ec_no_wakeup-for-MECHR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-ACPI-EC-Set-ec_no_wakeup-for-MECHR.patch
@@ -1,7 +1,7 @@
 From 493870c5f10a145410ead9aa898577c093d86204 Mon Sep 17 00:00:00 2001
 From: Runhua He <hua@aosc.io>
 Date: Fri, 18 Apr 2025 19:22:27 +0800
-Subject: [PATCH 330/334] BACKPORT: FROMLIST: ACPI: EC: Set ec_no_wakeup for
+Subject: [PATCH 330/335] BACKPORT: FROMLIST: ACPI: EC: Set ec_no_wakeup for
  MECHREVO Wujie 14XA (GX4HRXL)
 
 MECHREVO Wujie 14XA (GX4HRXL) wakes up immediately after s2idle entry.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
 From 4964679ec2a0ea5756d8f7b16627dd8c9c36c27e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 331/334] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 331/335] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
 From 685b18d98bd71449d800b31a9f9cc174e7b8d3e0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 332/334] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 332/335] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
@@ -1,7 +1,7 @@
 From 9fb28e7555059ce12775e5bad19d0ca1b57c5615 Mon Sep 17 00:00:00 2001
 From: Qunqin Zhao <zhaoqunqin@loongson.cn>
 Date: Tue, 1 Apr 2025 17:41:54 +0800
-Subject: [PATCH 333/334] LOONGSON: input: atkbd: do not init atkbd_reset
+Subject: [PATCH 333/335] LOONGSON: input: atkbd: do not init atkbd_reset
  variable to true on Loongson
 
 The keyboard will not be confused on Loongson platform, so do not need a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
@@ -1,7 +1,7 @@
 From 061ec6e2b5663fcebdbacb6bfd6aedec264db380 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 22 Apr 2025 14:17:54 +0800
-Subject: [PATCH 334/334] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
+Subject: [PATCH 334/335] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
  RTL8723BE with subsystem ID 11ad:1723
 
 RTL8723BE found on some ASUSTek laptops, such as F441U and X555UQ with

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.14.4
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=1.3
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel: add 32x32 CJK font data

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.14.4-1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
