### PR TITLE
adw-gtk3: update to 6.1

### DIFF
--- a/desktop-themes/adw-gtk3/autobuild/build
+++ b/desktop-themes/adw-gtk3/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Installing adw-gtk3 and adw-gtk3-dark ..."
+install -d ${PKGDIR}/usr/share/themes
+cp -r ${SRCDIR}/adw-gtk3 ${PKGDIR}/usr/share/themes/
+cp -r ${SRCDIR}/adw-gtk3-dark ${PKGDIR}/usr/share/themes/

--- a/desktop-themes/adw-gtk3/autobuild/defines
+++ b/desktop-themes/adw-gtk3/autobuild/defines
@@ -1,6 +1,5 @@
 PKGNAME=adw-gtk3
 PKGSEC=x11
-BUILDDEP="sassc"
 PKGDES="GTK 3 port of the theme from libadwaita"
-
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-themes/adw-gtk3/spec
+++ b/desktop-themes/adw-gtk3/spec
@@ -1,4 +1,5 @@
-VER=5.10
-SRCS="git::commit=tags/v${VER}::https://github.com/lassekongo83/adw-gtk3"
-CHKSUMS="SKIP"
+VER=6.1
+SRCS="tbl::https://github.com/lassekongo83/adw-gtk3/releases/download/v${VER}/adw-gtk3v${VER}.tar.xz"
+CHKSUMS="sha256::e7e1d15f6b46f050f95608fdfc5f643105e9948ecc2653dc463d197b4da3fd9f"
 CHKUPDATE="anitya::id=301867"
+SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- adw-gtk3: update to 6.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- adw-gtk3: 6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit adw-gtk3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
