### PR TITLE
systemd: add patch basic-linux-update-kernel-headers-from-v6.14-rc1

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
-From 1a778557f0c2970b01349989ad43c0190543174b Mon Sep 17 00:00:00 2001
+From 73132324300a50f6017a3316fbc15dc1892925c5 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 1/3] AOSCOS: sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 1/5] AOSCOS: sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
@@ -22,5 +22,5 @@ index 153f747342..5e409a8256 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.47.1
+2.43.0
 

--- a/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
@@ -1,7 +1,7 @@
-From a42ad01a43b82cd93473a97c2f58277b8933b706 Mon Sep 17 00:00:00 2001
+From 5722b12044e1491346677884979311af3d1ca056 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 12 Aug 2024 22:19:25 +0800
-Subject: [PATCH 2/3] AOSCOS: fix: do not tint terminal by default
+Subject: [PATCH 2/5] AOSCOS: fix: do not tint terminal by default
 
 Let's face it, it's weird and we have much better ways to notify the user
 about a system running in a container. Change the default behavior (tint by
@@ -26,5 +26,5 @@ index 4e38e60775..adb2f06617 100644
                  log_debug_errno(cache, "Failed to parse $SYSTEMD_TINT_BACKGROUND, leaving background tinting enabled: %m");
  
 -- 
-2.47.1
+2.43.0
 

--- a/app-admin/systemd/autobuild/patches/0003-AOSCOS-mount-setup.c-do-not-sleep-during-boot.patch
+++ b/app-admin/systemd/autobuild/patches/0003-AOSCOS-mount-setup.c-do-not-sleep-during-boot.patch
@@ -1,7 +1,7 @@
-From a0182794aa90a545866b1d0022913299aa8dc1c1 Mon Sep 17 00:00:00 2001
+From 0cf9b8ebccc3992988630711d4af9f3d5c51e000 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 10 Nov 2024 13:38:51 +0800
-Subject: [PATCH 3/3] AOSCOS: mount-setup.c: do not sleep during boot
+Subject: [PATCH 3/5] AOSCOS: mount-setup.c: do not sleep during boot
 
 To make the user happy.
 
@@ -28,5 +28,5 @@ index d5009fb59e..9e20aa7b7c 100644
                          return 0;
                  }
 -- 
-2.47.1
+2.43.0
 

--- a/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
+++ b/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
@@ -1,7 +1,7 @@
-From 12aeedaeea35223fb3c9684ae84576ed476f7979 Mon Sep 17 00:00:00 2001
+From 4ae6604db259779134f0d53a77876426db712f70 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 28 Dec 2024 16:06:22 +0800
-Subject: [PATCH 4/4] exec-credential: try forking again without CLONE_NEWNS
+Subject: [PATCH 4/5] exec-credential: try forking again without CLONE_NEWNS
 
 QEMU user emulation currently does not support CLONE_NEWS, fork()ing
 with it will result in an EINVAL, rendering the system unbootable with
@@ -11,10 +11,10 @@ systemd-nspawn.
  1 file changed, 7 insertions(+)
 
 diff --git a/src/core/exec-credential.c b/src/core/exec-credential.c
-index 6157ac4255..636092e9dc 100644
+index bce0ee7968..10e734f07b 100644
 --- a/src/core/exec-credential.c
 +++ b/src/core/exec-credential.c
-@@ -976,6 +976,13 @@ int exec_setup_credentials(
+@@ -1059,6 +1059,13 @@ int exec_setup_credentials(
                  return r;
  
          r = safe_fork("(sd-mkdcreds)", FORK_DEATHSIG_SIGTERM|FORK_WAIT|FORK_NEW_MOUNTNS, NULL);
@@ -29,5 +29,5 @@ index 6157ac4255..636092e9dc 100644
                  _cleanup_(rmdir_and_freep) char *u = NULL; /* remove the temporary workspace if we can */
                  _cleanup_free_ char *t = NULL;
 -- 
-2.47.1
+2.43.0
 

--- a/app-admin/systemd/autobuild/patches/0005-basic-linux-update-kernel-headers-from-v6.14-rc1.patch
+++ b/app-admin/systemd/autobuild/patches/0005-basic-linux-update-kernel-headers-from-v6.14-rc1.patch
@@ -1,0 +1,282 @@
+From 03008f1a054b8753282f5c5b6a1f940b8e165ef0 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Thu, 6 Feb 2025 19:41:27 +0900
+Subject: [PATCH 5/5] basic/linux: update kernel headers from v6.14-rc1
+
+Co-authored-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ src/basic/linux/bpf.h               | 10 +++++++++
+ src/basic/linux/dm-ioctl.h          |  2 +-
+ src/basic/linux/ethtool.h           |  2 ++
+ src/basic/linux/fib_rules.h         |  2 ++
+ src/basic/linux/if_link.h           |  5 +++++
+ src/basic/linux/in.h                |  2 ++
+ src/basic/linux/input-event-codes.h |  1 +
+ src/basic/linux/ip.h                | 16 ++++++++++++++
+ src/basic/linux/nl80211.h           | 33 +++++++++++++++++++++++++++++
+ src/basic/linux/rtnetlink.h         | 19 +++++++++++++++--
+ 10 files changed, 89 insertions(+), 3 deletions(-)
+
+diff --git a/src/basic/linux/bpf.h b/src/basic/linux/bpf.h
+index aa381a3d98..5d65d119a6 100644
+--- a/src/basic/linux/bpf.h
++++ b/src/basic/linux/bpf.h
+@@ -1572,6 +1572,16 @@ union bpf_attr {
+ 		 * If provided, prog_flags should have BPF_F_TOKEN_FD flag set.
+ 		 */
+ 		__s32		prog_token_fd;
++		/* The fd_array_cnt can be used to pass the length of the
++		 * fd_array array. In this case all the [map] file descriptors
++		 * passed in this array will be bound to the program, even if
++		 * the maps are not referenced directly. The functionality is
++		 * similar to the BPF_PROG_BIND_MAP syscall, but maps can be
++		 * used by the verifier during the program load. If provided,
++		 * then the fd_array[0,...,fd_array_cnt-1] is expected to be
++		 * continuous.
++		 */
++		__u32		fd_array_cnt;
+ 	};
+ 
+ 	struct { /* anonymous struct used by BPF_OBJ_* commands */
+diff --git a/src/basic/linux/dm-ioctl.h b/src/basic/linux/dm-ioctl.h
+index 9910b5eb1c..a110605794 100644
+--- a/src/basic/linux/dm-ioctl.h
++++ b/src/basic/linux/dm-ioctl.h
+@@ -288,7 +288,7 @@ enum {
+ #define DM_VERSION_MAJOR	4
+ #define DM_VERSION_MINOR	27
+ #define DM_VERSION_PATCHLEVEL	0
+-#define DM_VERSION_EXTRA	"-ioctl (2023-03-01)"
++#define DM_VERSION_EXTRA	"-ioctl (2025-01-17)"
+ 
+ /* Status bits */
+ #define DM_READONLY_FLAG	(1 << 0) /* In/Out */
+diff --git a/src/basic/linux/ethtool.h b/src/basic/linux/ethtool.h
+index a32293ba20..36806183c9 100644
+--- a/src/basic/linux/ethtool.h
++++ b/src/basic/linux/ethtool.h
+@@ -679,6 +679,7 @@ enum ethtool_link_ext_substate_module {
+  * @ETH_SS_STATS_ETH_MAC: names of IEEE 802.3 MAC statistics
+  * @ETH_SS_STATS_ETH_CTRL: names of IEEE 802.3 MAC Control statistics
+  * @ETH_SS_STATS_RMON: names of RMON statistics
++ * @ETH_SS_STATS_PHY: names of PHY(dev) statistics
+  *
+  * @ETH_SS_COUNT: number of defined string sets
+  */
+@@ -704,6 +705,7 @@ enum ethtool_stringset {
+ 	ETH_SS_STATS_ETH_MAC,
+ 	ETH_SS_STATS_ETH_CTRL,
+ 	ETH_SS_STATS_RMON,
++	ETH_SS_STATS_PHY,
+ 
+ 	/* add new constants above here */
+ 	ETH_SS_COUNT
+diff --git a/src/basic/linux/fib_rules.h b/src/basic/linux/fib_rules.h
+index a6924dd3af..00e9890ca3 100644
+--- a/src/basic/linux/fib_rules.h
++++ b/src/basic/linux/fib_rules.h
+@@ -68,6 +68,8 @@ enum {
+ 	FRA_SPORT_RANGE, /* sport */
+ 	FRA_DPORT_RANGE, /* dport */
+ 	FRA_DSCP,	/* dscp */
++	FRA_FLOWLABEL,	/* flowlabel */
++	FRA_FLOWLABEL_MASK,	/* flowlabel mask */
+ 	__FRA_MAX
+ };
+ 
+diff --git a/src/basic/linux/if_link.h b/src/basic/linux/if_link.h
+index 987efeddc3..70bec74009 100644
+--- a/src/basic/linux/if_link.h
++++ b/src/basic/linux/if_link.h
+@@ -1297,6 +1297,10 @@ enum {
+ 	IFLA_NETKIT_POLICY,
+ 	IFLA_NETKIT_PEER_POLICY,
+ 	IFLA_NETKIT_MODE,
++	IFLA_NETKIT_SCRUB,
++	IFLA_NETKIT_PEER_SCRUB,
++	IFLA_NETKIT_HEADROOM,
++	IFLA_NETKIT_TAILROOM,
+ 	__IFLA_NETKIT_MAX,
+ };
+ #define IFLA_NETKIT_MAX	(__IFLA_NETKIT_MAX - 1)
+@@ -1376,6 +1380,7 @@ enum {
+ 	IFLA_VXLAN_VNIFILTER, /* only applicable with COLLECT_METADATA mode */
+ 	IFLA_VXLAN_LOCALBYPASS,
+ 	IFLA_VXLAN_LABEL_POLICY, /* IPv6 flow label policy; ifla_vxlan_label_policy */
++	IFLA_VXLAN_RESERVED_BITS,
+ 	__IFLA_VXLAN_MAX
+ };
+ #define IFLA_VXLAN_MAX	(__IFLA_VXLAN_MAX - 1)
+diff --git a/src/basic/linux/in.h b/src/basic/linux/in.h
+index a7d41bb6c6..d59654e908 100644
+--- a/src/basic/linux/in.h
++++ b/src/basic/linux/in.h
+@@ -79,6 +79,8 @@ enum {
+ #define IPPROTO_MPLS		IPPROTO_MPLS
+   IPPROTO_ETHERNET = 143,	/* Ethernet-within-IPv6 Encapsulation	*/
+ #define IPPROTO_ETHERNET	IPPROTO_ETHERNET
++  IPPROTO_AGGFRAG = 144,	/* AGGFRAG in ESP (RFC 9347)		*/
++#define IPPROTO_AGGFRAG		IPPROTO_AGGFRAG
+   IPPROTO_RAW = 255,		/* Raw IP packets			*/
+ #define IPPROTO_RAW		IPPROTO_RAW
+   IPPROTO_SMC = 256,		/* Shared Memory Communications		*/
+diff --git a/src/basic/linux/input-event-codes.h b/src/basic/linux/input-event-codes.h
+index de4647601e..7cd934c799 100644
+--- a/src/basic/linux/input-event-codes.h
++++ b/src/basic/linux/input-event-codes.h
+@@ -519,6 +519,7 @@
+ #define KEY_NOTIFICATION_CENTER	0x1bc	/* Show/hide the notification center */
+ #define KEY_PICKUP_PHONE	0x1bd	/* Answer incoming call */
+ #define KEY_HANGUP_PHONE	0x1be	/* Decline incoming call */
++#define KEY_LINK_PHONE		0x1bf   /* AL Phone Syncing */
+ 
+ #define KEY_DEL_EOL		0x1c0
+ #define KEY_DEL_EOS		0x1c1
+diff --git a/src/basic/linux/ip.h b/src/basic/linux/ip.h
+index 9b4dd89ebe..83e53bc18a 100644
+--- a/src/basic/linux/ip.h
++++ b/src/basic/linux/ip.h
+@@ -137,6 +137,22 @@ struct ip_beet_phdr {
+ 	__u8 reserved;
+ };
+ 
++struct ip_iptfs_hdr {
++	__u8 subtype;		/* 0*: basic, 1: CC */
++	__u8 flags;
++	__be16 block_offset;
++};
++
++struct ip_iptfs_cc_hdr {
++	__u8 subtype;		/* 0: basic, 1*: CC */
++	__u8 flags;
++	__be16 block_offset;
++	__be32 loss_rate;
++	__be64 rtt_adelay_xdelay;
++	__be32 tval;
++	__be32 techo;
++};
++
+ /* index values for the variables in ipv4_devconf */
+ enum
+ {
+diff --git a/src/basic/linux/nl80211.h b/src/basic/linux/nl80211.h
+index f97f5adc8d..be5d6c8812 100644
+--- a/src/basic/linux/nl80211.h
++++ b/src/basic/linux/nl80211.h
+@@ -1329,6 +1329,13 @@
+  *      %NL80211_ATTR_MLO_TTLM_ULINK attributes are used to specify the
+  *      TID to Link mapping for downlink/uplink traffic.
+  *
++ * @NL80211_CMD_ASSOC_MLO_RECONF: For a non-AP MLD station, request to
++ *      add/remove links to/from the association.
++ *
++ * @NL80211_CMD_EPCS_CFG: EPCS configuration for a station. Used by userland to
++ *	control EPCS configuration. Used to notify userland on the current state
++ *	of EPCS.
++ *
+  * @NL80211_CMD_MAX: highest used command number
+  * @__NL80211_CMD_AFTER_LAST: internal use
+  */
+@@ -1586,6 +1593,9 @@ enum nl80211_commands {
+ 
+ 	NL80211_CMD_SET_TID_TO_LINK_MAPPING,
+ 
++	NL80211_CMD_ASSOC_MLO_RECONF,
++	NL80211_CMD_EPCS_CFG,
++
+ 	/* add new commands above here */
+ 
+ 	/* used to define NL80211_CMD_MAX below */
+@@ -2868,6 +2878,21 @@ enum nl80211_commands {
+  *	nested item, it contains attributes defined in
+  *	&enum nl80211_if_combination_attrs.
+  *
++ * @NL80211_ATTR_VIF_RADIO_MASK: Bitmask of allowed radios (u32).
++ *	A value of 0 means all radios.
++ *
++ * @NL80211_ATTR_SUPPORTED_SELECTORS: supported selectors, array of
++ *	supported selectors as defined by IEEE 802.11 7.3.2.2 but without the
++ *	length restriction (at most %NL80211_MAX_SUPP_SELECTORS).
++ *	This can be used to provide a list of selectors that are implemented
++ *	by the supplicant. If not given, support for SAE_H2E is assumed.
++ *
++ * @NL80211_ATTR_MLO_RECONF_REM_LINKS: (u16) A bitmask of the links requested
++ *      to be removed from the MLO association.
++ *
++ * @NL80211_ATTR_EPCS: Flag attribute indicating that EPCS is enabled for a
++ *	station interface.
++ *
+  * @NUM_NL80211_ATTR: total number of nl80211_attrs available
+  * @NL80211_ATTR_MAX: highest attribute number currently defined
+  * @__NL80211_ATTR_AFTER_LAST: internal use
+@@ -3416,6 +3441,13 @@ enum nl80211_attrs {
+ 	NL80211_ATTR_WIPHY_RADIOS,
+ 	NL80211_ATTR_WIPHY_INTERFACE_COMBINATIONS,
+ 
++	NL80211_ATTR_VIF_RADIO_MASK,
++
++	NL80211_ATTR_SUPPORTED_SELECTORS,
++
++	NL80211_ATTR_MLO_RECONF_REM_LINKS,
++	NL80211_ATTR_EPCS,
++
+ 	/* add attributes here, update the policy in nl80211.c */
+ 
+ 	__NL80211_ATTR_AFTER_LAST,
+@@ -3460,6 +3492,7 @@ enum nl80211_attrs {
+ #define NL80211_WIPHY_NAME_MAXLEN		64
+ 
+ #define NL80211_MAX_SUPP_RATES			32
++#define NL80211_MAX_SUPP_SELECTORS		128
+ #define NL80211_MAX_SUPP_HT_RATES		77
+ #define NL80211_MAX_SUPP_REG_RULES		128
+ #define NL80211_TKIP_DATA_OFFSET_ENCR_KEY	0
+diff --git a/src/basic/linux/rtnetlink.h b/src/basic/linux/rtnetlink.h
+index 4e6c8e14cc..31763b8acb 100644
+--- a/src/basic/linux/rtnetlink.h
++++ b/src/basic/linux/rtnetlink.h
+@@ -93,10 +93,18 @@ enum {
+ 	RTM_NEWPREFIX	= 52,
+ #define RTM_NEWPREFIX	RTM_NEWPREFIX
+ 
+-	RTM_GETMULTICAST = 58,
++	RTM_NEWMULTICAST = 56,
++#define RTM_NEWMULTICAST RTM_NEWMULTICAST
++	RTM_DELMULTICAST,
++#define RTM_DELMULTICAST RTM_DELMULTICAST
++	RTM_GETMULTICAST,
+ #define RTM_GETMULTICAST RTM_GETMULTICAST
+ 
+-	RTM_GETANYCAST	= 62,
++	RTM_NEWANYCAST	= 60,
++#define RTM_NEWANYCAST RTM_NEWANYCAST
++	RTM_DELANYCAST,
++#define RTM_DELANYCAST RTM_DELANYCAST
++	RTM_GETANYCAST,
+ #define RTM_GETANYCAST	RTM_GETANYCAST
+ 
+ 	RTM_NEWNEIGHTBL	= 64,
+@@ -389,6 +397,7 @@ enum rtattr_type_t {
+ 	RTA_SPORT,
+ 	RTA_DPORT,
+ 	RTA_NH_ID,
++	RTA_FLOWLABEL,
+ 	__RTA_MAX
+ };
+ 
+@@ -772,6 +781,12 @@ enum rtnetlink_groups {
+ #define RTNLGRP_TUNNEL		RTNLGRP_TUNNEL
+ 	RTNLGRP_STATS,
+ #define RTNLGRP_STATS		RTNLGRP_STATS
++	RTNLGRP_IPV4_MCADDR,
++#define RTNLGRP_IPV4_MCADDR	RTNLGRP_IPV4_MCADDR
++	RTNLGRP_IPV6_MCADDR,
++#define RTNLGRP_IPV6_MCADDR	RTNLGRP_IPV6_MCADDR
++	RTNLGRP_IPV6_ACADDR,
++#define RTNLGRP_IPV6_ACADDR	RTNLGRP_IPV6_ACADDR
+ 	__RTNLGRP_MAX
+ };
+ #define RTNLGRP_MAX	(__RTNLGRP_MAX - 1)
+-- 
+2.43.0
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=257.2
 
 # Use this for stable releases.
-REL=1
+REL=2
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 


### PR DESCRIPTION
Topic Description
-----------------

- systemd: fix build with Linux API headers >= 6.12.14
    Since Linux 6.12.14, commit 33a4a9f54ae9 \("Input: allocate keycode for phone linking"\) introduced a new event code \`KEY_LINK_PHONE', which resulted build failure from code generated from src/udev/keyboard-keys-from-name.gperf.
    Backport a change to address this build failure by adding a definition for this key code - as systemd synchronizes a local copy of kernel headers.
    Link: https://github.com/systemd/systemd/commit/0d879453acdc86b0d742c5854420c116d0f23ba4
    Link: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=33a4a9f54ae9b612605214e3bfa1772a439ca2d7
    Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1098631

Package(s) Affected
-------------------

- systemd: 1:257.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
