### PR TITLE
nvm: update to 0.40.3

### DIFF
--- a/lang-js/nvm/autobuild/patches/0001-nvm.sh-drop-hash-r.patch
+++ b/lang-js/nvm/autobuild/patches/0001-nvm.sh-drop-hash-r.patch
@@ -1,4 +1,4 @@
-From a7185ed2ae440717e29cde5d923b62d621be03f9 Mon Sep 17 00:00:00 2001
+From 2bfd55e852ebfaed9a06caa62482d6d43e1f42a5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Sat, 6 Jan 2024 22:53:21 -0800
 Subject: [PATCH] nvm.sh: drop hash -r
@@ -8,10 +8,10 @@ Subject: [PATCH] nvm.sh: drop hash -r
  1 file changed, 2 deletions(-)
 
 diff --git a/nvm.sh b/nvm.sh
-index 2e4378f..cb4dda5 100644
+index d943896..89d69d9 100755
 --- a/nvm.sh
 +++ b/nvm.sh
-@@ -3565,7 +3565,6 @@ nvm() {
+@@ -3761,7 +3761,6 @@ nvm() {
          fi
        else
          export PATH="${NEWPATH}"
@@ -19,7 +19,7 @@ index 2e4378f..cb4dda5 100644
          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
            nvm_echo "${NVM_DIR}/*/bin removed from \${PATH}"
          fi
-@@ -3697,7 +3696,6 @@ nvm() {
+@@ -3906,7 +3905,6 @@ nvm() {
          export MANPATH
        fi
        export PATH
@@ -28,5 +28,5 @@ index 2e4378f..cb4dda5 100644
        export NVM_INC="${NVM_VERSION_DIR}/include/node"
        if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
 -- 
-2.39.1
+2.49.0
 

--- a/lang-js/nvm/spec
+++ b/lang-js/nvm/spec
@@ -1,4 +1,4 @@
-VER=0.39.7
-SRCS="git::commit=tags/v$VER::https://github.com/creationix/nvm"
+VER=0.40.3
+SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/creationix/nvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229016"


### PR DESCRIPTION
Topic Description
-----------------

- nvm: update to 0.40.3

Package(s) Affected
-------------------

- nvm: 0.40.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvm
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
