### PR TITLE
chezmoi: new, 2.62.2

### DIFF
--- a/app-utils/chezmoi/autobuild/beyond
+++ b/app-utils/chezmoi/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Installing completions ..."
+install -dvm755 "$PKGDIR"/usr/share/bash-completion/completions
+"$PKGDIR"/usr/bin/chezmoi completion bash \
+    > "$PKGDIR"/usr/share/bash-completion/completions/chezmoi
+install -dvm755 "$PKGDIR"/usr/share/zsh/site-functions
+"$PKGDIR"/usr/bin/chezmoi completion zsh \
+    > "$PKGDIR"/usr/share/zsh/site-functions/_chezmoi
+install -dvm755 "$PKGDIR"/usr/share/fish/vendor_completions.d
+"$PKGDIR"/usr/bin/chezmoi completion fish \
+    > "$PKGDIR"/usr/share/fish/vendor_completions.d/chezmoi.fish

--- a/app-utils/chezmoi/autobuild/defines
+++ b/app-utils/chezmoi/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=chezmoi
+PKGDES="Manage your dotfiles across multiple diverse machines"
+PKGSEC=utils
+PKGDEP="git glibc"
+BUILDDEP="go"
+
+# FIXME: Autobuild does not yet support splitting debug symbols
+# from Go executables.
+ABSPLITDBG=0
+ABTYPE=gomod
+GO_BUILD_AFTER=(-tags "noupgrade")

--- a/app-utils/chezmoi/autobuild/prepare
+++ b/app-utils/chezmoi/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Getting build information ..."
+COMMIT=$(git rev-parse --short HEAD)
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS=(
+    "-X main.version=$PKGVER"
+    "-X main.commit=$COMMIT"
+    "-X main.date=$DATE"
+    "-X main.builtBy=AOSC"
+)

--- a/app-utils/chezmoi/spec
+++ b/app-utils/chezmoi/spec
@@ -1,0 +1,4 @@
+VER=2.62.2
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/twpayne/chezmoi.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=232604"


### PR DESCRIPTION
Topic Description
-----------------

- chezmoi: new, 2.62.2

Package(s) Affected
-------------------

- chezmoi: 2.62.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit chezmoi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
