### PR TITLE
gtk-doc: remove dependency rarian

### DIFF
--- a/app-doc/gtk-doc/autobuild/defines
+++ b/app-doc/gtk-doc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gtk-doc
 PKGDES="API documentation generation tool for GTK+ and GNOME"
 PKGSEC=devel
-PKGDEP="docbook-xsl rarian perl itstool pygments"
+PKGDEP="docbook-xsl perl itstool pygments"
 BUILDDEP="which"
 
 AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3"

--- a/app-doc/gtk-doc/spec
+++ b/app-doc/gtk-doc/spec
@@ -1,4 +1,5 @@
 VER=1.34.0
+REL=1
 SRCS="https://download.gnome.org/sources/gtk-doc/${VER:0:4}/gtk-doc-$VER.tar.xz"
 CHKSUMS="sha256::b20b72b32a80bc18c7f975c9d4c16460c2276566a0b50f87d6852dff3aa7861c"
 CHKUPDATE="anitya::id=13140"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-doc: remove unused dependency rarian

Package(s) Affected
-------------------

- gtk-doc: 1.34.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-doc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
