### PR TITLE
virt-manager: remove dependency rarian

### DIFF
--- a/app-virtualization/virt-manager/01-virt-install/defines
+++ b/app-virtualization/virt-manager/01-virt-install/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP="cpio libisoburn libosinfo libvirt-python pygobject-3 requests"
 BUILDDEP="docutils dbus-python graphite gtk-vnc gtk-4 gtksourceview-4 \
           intltool ipy librsvg libspice-gtk libuser libvirt-glib \
-          libxml2 netcat rarian vte-gtk3 yajl gtk-update-icon-cache"
+          libxml2 netcat vte-gtk3 yajl gtk-update-icon-cache"
 PKGDES="Command line tools for creating new KVM, Xen, or Linux container guests"
 
 ABTYPE=meson

--- a/app-virtualization/virt-manager/02-virt-manager/defines
+++ b/app-virtualization/virt-manager/02-virt-manager/defines
@@ -1,7 +1,7 @@
 PKGNAME=virt-manager
 PKGSEC=admin
 PKGDEP="dbus-python graphite gtk-vnc gtksourceview-4 ipy librsvg \
-        libspice-gtk libuser libvirt-glib libxml2 netcat rarian \
+        libspice-gtk libuser libvirt-glib libxml2 netcat \
         virt-install vte-gtk3 yajl"
 PKGDES="Desktop user interface for managing virtual machines"
 

--- a/app-virtualization/virt-manager/spec
+++ b/app-virtualization/virt-manager/spec
@@ -1,4 +1,5 @@
 VER=5.0.0
+REL=1
 SRCS="tbl::https://releases.pagure.org/virt-manager/virt-manager-$VER.tar.xz"
 CHKSUMS="sha256::bc89ae46e0c997bd754ed62a419ca39c6aadec27e3d8b850cea5282f0083f84a"
 CHKUPDATE="anitya::id=8183"


### PR DESCRIPTION
Topic Description
-----------------

- virt-manager: remove unused dependency rarian

Package(s) Affected
-------------------

- virt-install: 5.0.0-1
- virt-manager: 5.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit virt-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
