### PR TITLE
CHKUPDATE Fixes (May 3rd, 2025) (Python Survey 2025)

### DIFF
--- a/lang-python/async-timeout/spec
+++ b/lang-python/async-timeout/spec
@@ -1,4 +1,4 @@
 VER=4.0.2
 SRCS="tbl::https://github.com/aio-libs/async-timeout/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::1eb41fc35a0a24461b00f3479553972c99300e194eb212ff8b816c90c084d1d4"
-CcHKUPDATE="anitya::id=37104"
+CHKUPDATE="anitya::id=37104"

--- a/lang-python/jsonschema/spec
+++ b/lang-python/jsonschema/spec
@@ -1,5 +1,5 @@
 VER=3.2.0
 SRCS="tbl::https://pypi.io/packages/source/j/jsonschema/jsonschema-$VER.tar.gz"
 CHKSUMS="sha256::c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
-CHKUPDATE="anitya::id=223202"
+CHKUPDATE="anitya::id=3898"
 REL=1

--- a/lang-python/lxml/spec
+++ b/lang-python/lxml/spec
@@ -1,4 +1,4 @@
 VER=4.7.1
 SRCS="tbl::https://github.com/lxml/lxml/archive/refs/tags/lxml-$VER.tar.gz"
 CHKSUMS="sha256::c495545191397b26ce33a2749e13a64bc2b44894e39fd92c4243922e36f7d5a9"
-CHKUPDATE="anitya::id=48378"
+CHKUPDATE="anitya::id=3914"

--- a/lang-python/multidict/spec
+++ b/lang-python/multidict/spec
@@ -1,5 +1,5 @@
 VER=5.1.0
 SRCS="tbl::https://github.com/aio-libs/multidict/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::1798708288851b808d2d03ea6046ca51bc44c228aaea12c9643a0a481ee41d8c"
-CHKUPDATE="anitya::id=45924"
+CHKUPDATE="anitya::id=11132"
 REL=1

--- a/lang-python/packaging/spec
+++ b/lang-python/packaging/spec
@@ -1,4 +1,4 @@
 VER=24.2
 SRCS="git::commit=tags/${VER}::https://github.com/pypa/packaging"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=11718"
+CHKUPDATE="anitya::id=60461"

--- a/lang-python/prompt-toolkit/spec
+++ b/lang-python/prompt-toolkit/spec
@@ -1,4 +1,4 @@
 VER=3.0.48
 SRCS="tbl::https://files.pythonhosted.org/packages/source/p/prompt-toolkit/prompt_toolkit-$VER.tar.gz"
 CHKSUMS="sha256::d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90"
-CHKUPDATE="anitya::id=48975"
+CHKUPDATE="anitya::id=8742"

--- a/lang-python/pybluez/spec
+++ b/lang-python/pybluez/spec
@@ -2,4 +2,4 @@ VER=0.22
 REL=4
 SRCS="tbl::https://github.com/karulis/pybluez/archive/$VER.tar.gz"
 CHKSUMS="sha256::53db881a2668791062985e1ff7afbe6527cdd9af3676a3160420a235bee3c768"
-CHKUPDATE="anitya::id=10020"
+CHKUPDATE="anitya::id=231532"

--- a/lang-python/pyjwt/spec
+++ b/lang-python/pyjwt/spec
@@ -1,4 +1,4 @@
 VER=2.3.0
 SRCS="tbl::https://pypi.io/packages/source/P/PyJWT/PyJWT-$VER.tar.gz"
 CHKSUMS="sha256::b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"
-CHKUPDATE="anitya::id=anitya::id=5653"
+CHKUPDATE="anitya::id=5653"

--- a/lang-python/python-crc/spec
+++ b/lang-python/python-crc/spec
@@ -1,3 +1,4 @@
 VER=7.0.0
 SRCS="tbl::https://github.com/Nicoretti/crc/releases/download/7.0.0/crc-7.0.0.tar.gz"
 CHKSUMS="sha256::b9fc521042167f2b59d9183ce27acc0897e4a17748421e8b304ccdf7ebf4280a"
+CHKUPDATE="anitya::id=86881"

--- a/lang-python/python-discid/spec
+++ b/lang-python/python-discid/spec
@@ -2,3 +2,4 @@ VER=1.2.0
 REL=1
 SRCS="https://files.pythonhosted.org/packages/source/d/discid/discid-${VER}.tar.gz"
 CHKSUMS="sha256::cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
+CHKUPDATE="anitya::id=309145"

--- a/lang-python/scipy/spec
+++ b/lang-python/scipy/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
 SRCS="tbl::https://github.com/scipy/scipy/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::6cdb9d3aabe46c1602d9fd2f34812700068eddfe3ffd1dafcbd7e7960a874e1c"
-CHKUPDATE="anitya::id=41104"
+CHKUPDATE="anitya::id=4768"
 REL=1

--- a/lang-python/typing-extensions/spec
+++ b/lang-python/typing-extensions/spec
@@ -1,4 +1,4 @@
 VER=4.12.2
 SRCS="tbl::https://files.pythonhosted.org/packages/source/t/typing-extensions/typing_extensions-$VER.tar.gz"
 CHKSUMS="sha256::1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-CHKUPDATE="anitya::id=33844"
+CHKUPDATE="anitya::id=19755"

--- a/lang-python/wcwidth/spec
+++ b/lang-python/wcwidth/spec
@@ -2,4 +2,4 @@ VER=0.1.8
 SRCS="tbl::https://pypi.io/packages/source/w/wcwidth/wcwidth-$VER.tar.gz"
 CHKSUMS="sha256::f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
 REL=2
-CHKUPDATE="anitya::id=88052"
+CHKUPDATE="anitya::id=8743"


### PR DESCRIPTION
Topic Description
-----------------

- pybluez: fix CHKUPDATE
- lxml: fix CHKUPDATE
- jsonschema: fix CHKUPDATE
- wcwidth: add CHKUPDATE
- typing-extensions: add CHKUPDATE
- scipy: add CHKUPDATE
- python-discid: add CHKUPDATE
- python-crc: add CHKUPDATE
- pyjwt: add CHKUPDATE
- prompt-toolkit: add CHKUPDATE

... and 3 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Test Build(s) Done
------------------

No need to rebuild any packages.