### PR TITLE
onedrivegui: new, 1.1.1

### DIFF
--- a/app-web/onedrive/autobuild/defines
+++ b/app-web/onedrive/autobuild/defines
@@ -20,3 +20,6 @@ AUTOTOOLS_AFTER=(
     '--with-fish-completion-dir=/usr/share/fish/vendor_completions.d'
     '--with-zsh-completion-dir=/usr/share/zsh/site-functions'
 )
+
+# FIXME: LDC is not available on these architectures.
+FAIL_ARCH="(loongson3|mips64r6el|ppc64el)"

--- a/app-web/onedrive/autobuild/defines
+++ b/app-web/onedrive/autobuild/defines
@@ -1,0 +1,22 @@
+PKGNAME=onedrive
+PKGSEC=web
+PKGDEP="curl liblphobos libnotify sqlite"
+BUILDDEP="ldc"
+PKGDES="OneDrive client implementation for Linux"
+
+# FIXME: Fails to find source file with shadow build.
+#
+# ldmd2 -w -J. -O -version=NoPragma -version=NoGdk -version=Notifications -L-lcurl -L-lsqlite3 -L-lnotify -L-lgdk_pixbuf-2.0 -L-lgio-2.0 -L-lgobject-2.0 -L-lglib-2.0  -L-ldl src/main.d src/config.d src/log.d src/util.d src/qxor.d src/curlEngine.d src/onedrive.d src/webhook.d src/sync.d src/itemdb.d src/sqlite.d src/clientSideFiltering.d src/monitor.d src/arsd/cgi.d src/xattr.d src/notifications/notify.d src/notifications/dnotify.d -ofonedrive
+# Error: cannot find input file `src/main.d`
+# import path[0] = /usr/include/d
+# make: *** [Makefile:109: onedrive] Error 1
+ABSHADOW=0
+
+AUTOTOOLS_AFTER=(
+    '--enable-notifications'
+    '--enable-completions'
+    '--disable-debug'
+    '--with-bash-completion-dir=/usr/share/bash-completion/completions'
+    '--with-fish-completion-dir=/usr/share/fish/vendor_completions.d'
+    '--with-zsh-completion-dir=/usr/share/zsh/site-functions'
+)

--- a/app-web/onedrive/spec
+++ b/app-web/onedrive/spec
@@ -1,0 +1,4 @@
+VER=2.5.5
+SRCS="git::commit=tags/v$VER::https://github.com/abraunegg/onedrive"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=16974"

--- a/app-web/onedrivegui/autobuild/build
+++ b/app-web/onedrivegui/autobuild/build
@@ -1,0 +1,19 @@
+abinfo "Installing application data ..."
+mkdir -pv "$PKGDIR"/usr/share/onedrivegui
+cp -av "$SRCDIR"/src/{OneDriveGUI.py,resources,ui,version.py} \
+    "$PKGDIR"/usr/share/onedrivegui/
+
+abinfo "Setting executable bit on OneDriveGUI.py ..."
+chmod -v +x "$PKGDIR"/usr/share/onedrivegui/OneDriveGUI.py
+
+# Note: Upstream supplies only a 48x48 icon.
+# TODO: Submit a vectorized icon.
+abinfo "Installing icons ..."
+mkdir -pv "$PKGDIR"/usr/share/pixmaps
+ln -sv ../onedrivegui/resources/images/OneDriveGUI.svg \
+    "$PKGDIR"/usr/share/pixmaps/onedrivegui.svg
+
+abinfo "Installing a symlink for the main executable ..."
+mkdir -pv "$PKGDIR"/usr/bin
+ln -sv ../share/onedrivegui/OneDriveGUI.py \
+    "$PKGDIR"/usr/bin/onedrivegui

--- a/app-web/onedrivegui/autobuild/defines
+++ b/app-web/onedrivegui/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="onedrive pyside6 requests"
 PKGDES="Unofficial graphical interface for OneDrive"
 
 ABHOST=noarch
+
+# FIXME: LDC is not available on these architectures.
+FAIL_ARCH="(loongson3|mips64r6el|ppc64el)"

--- a/app-web/onedrivegui/autobuild/defines
+++ b/app-web/onedrivegui/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=onedrivegui
+PKGSEC=web
+PKGDEP="onedrive pyside6 requests"
+PKGDES="Unofficial graphical interface for OneDrive"
+
+ABHOST=noarch

--- a/app-web/onedrivegui/autobuild/overrides/usr/share/applications/onedrivegui.desktop
+++ b/app-web/onedrivegui/autobuild/overrides/usr/share/applications/onedrivegui.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+StartupNotify=true
+Name=OneDriveGUI
+Comment=Unofficial graphical interface for OneDrive
+Comment[zh_CN]=非官方 OneDrive 图形管理界面
+Exec=onedrivegui
+Icon=onedrivegui
+Categories=Network;

--- a/app-web/onedrivegui/autobuild/patches/0001-feat-resources-add-a-vectorised-main-icon.patch
+++ b/app-web/onedrivegui/autobuild/patches/0001-feat-resources-add-a-vectorised-main-icon.patch
@@ -1,0 +1,83 @@
+From 798987743b25d69a3ea081524375742cfa3345e1 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 4 May 2025 23:53:42 +0800
+Subject: [PATCH] feat(resources): add a vectorised main icon
+
+---
+ src/resources/images/OneDriveGUI.svg | 64 ++++++++++++++++++++++++++++
+ 1 file changed, 64 insertions(+)
+ create mode 100644 src/resources/images/OneDriveGUI.svg
+
+diff --git a/src/resources/images/OneDriveGUI.svg b/src/resources/images/OneDriveGUI.svg
+new file mode 100644
+index 0000000..8260730
+--- /dev/null
++++ b/src/resources/images/OneDriveGUI.svg
+@@ -0,0 +1,64 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<!-- Created with Inkscape (http://www.inkscape.org/) -->
++
++<svg
++   width="64"
++   height="64"
++   viewBox="0 0 16.933333 16.933333"
++   version="1.1"
++   id="svg1"
++   xml:space="preserve"
++   inkscape:version="1.4.1 (unknown)"
++   sodipodi:docname="OneDriveGUI.svg"
++   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
++   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
++   xmlns="http://www.w3.org/2000/svg"
++   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
++     id="namedview1"
++     pagecolor="#ffffff"
++     bordercolor="#000000"
++     borderopacity="0.25"
++     inkscape:showpageshadow="2"
++     inkscape:pageopacity="0.0"
++     inkscape:pagecheckerboard="0"
++     inkscape:deskcolor="#d1d1d1"
++     inkscape:document-units="mm"
++     inkscape:zoom="14.192585"
++     inkscape:cx="47.736194"
++     inkscape:cy="36.63885"
++     inkscape:window-width="1920"
++     inkscape:window-height="1111"
++     inkscape:window-x="0"
++     inkscape:window-y="0"
++     inkscape:window-maximized="1"
++     inkscape:current-layer="layer1" /><defs
++     id="defs1" /><g
++     inkscape:label="图层 1"
++     inkscape:groupmode="layer"
++     id="layer1"><circle
++       style="fill:#bbdefb;fill-opacity:1;stroke-width:11.1159;stroke-linecap:round;paint-order:stroke fill markers"
++       id="path1"
++       cx="3.7016394"
++       cy="10.349719"
++       r="2.4590819" /><circle
++       style="fill:#bbdefb;fill-opacity:1;stroke-width:11.1159;stroke-linecap:round;paint-order:stroke fill markers"
++       id="path1-9"
++       cx="6.200614"
++       cy="7.7482996"
++       r="2.4590819" /><circle
++       style="fill:#bbdefb;fill-opacity:1;stroke-width:13.3906;stroke-linecap:round;paint-order:stroke fill markers"
++       id="path1-3"
++       cx="10.511781"
++       cy="7.0868225"
++       r="2.9622917" /><circle
++       style="fill:#bbdefb;fill-opacity:1;stroke-width:11.9314;stroke-linecap:round;paint-order:stroke fill markers"
++       id="path1-3-9"
++       cx="13.051298"
++       cy="10.169324"
++       r="2.639478" /><rect
++       style="fill:#bbdefb;fill-opacity:1;stroke-width:9.59929;stroke-linecap:round;paint-order:stroke fill markers"
++       id="rect1"
++       width="9.3087673"
++       height="4.1775908"
++       x="3.708101"
++       y="8.6312113" /></g></svg>
+-- 
+2.49.0
+

--- a/app-web/onedrivegui/spec
+++ b/app-web/onedrivegui/spec
@@ -1,0 +1,4 @@
+VER=1.1.1
+SRCS="git::commit=tags/v$VER::https://github.com/bpozdena/OneDriveGUI"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=374597"


### PR DESCRIPTION
Topic Description
-----------------

- onedrivegui: update FAIL_ARCH
- onedrive: update FAIL_ARCH
- onedrivegui: new, 1.1.1
- onedrive: new, 2.5.5

Package(s) Affected
-------------------

- onedrive: 2.5.5
- onedrivegui: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit onedrive onedrivegui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
