### PR TITLE
kmod: update to 34.2

### DIFF
--- a/app-admin/kmod/autobuild/beyond
+++ b/app-admin/kmod/autobuild/beyond
@@ -1,7 +1,2 @@
 abinfo "Installing standard depmod and modprobe configuration directories ..."
 install -dvm755 "$PKGDIR"/{etc,usr/lib}/{depmod,modprobe}.d
-
-abinfo "Symlinking various tools to kmod ..."
-for tool in {ins,ls,rm,dep}mod mod{probe,info}; do
-  ln -sv kmod "$PKGDIR"/usr/bin/$tool
-done

--- a/app-admin/kmod/autobuild/defines
+++ b/app-admin/kmod/autobuild/defines
@@ -1,16 +1,7 @@
 PKGNAME=kmod
 PKGSEC=admin
-PKGDEP="glibc openssl python-3 xz zlib zstd"
-PKGDEP__RETRO="glibc openssl xz zlib zstd"
-PKGDEP__ARMV4="$PKGDEP__RETRO"
-PKGDEP__ARMV6HF="$PKGDEP__RETRO"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="$PKGDEP__RETRO"
-PKGDEP__PPC64="$PKGDEP__RETRO"
-BUILDDEP="docbook-xsl gtk-doc"
+PKGDEP="glibc openssl xz zlib zstd"
+BUILDDEP="scdoc gtk-doc"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -22,29 +13,23 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Tools for managing kernel modules"
 
-# FIXME: Disabling gtk-doc-pdf as it has broken dblatex detection.
-AUTOTOOLS_AFTER=(
-    '--disable-experimental'
-    '--enable-tools'
-    '--enable-manpages'
-    '--enable-logging'
-    '--disable-debug'
-    '--enable-python'
-    '--disable-coverage'
-    '--enable-gtk-doc'
-    '--enable-gtk-doc-html'
-    '--disable-gtk-doc-pdf'
-    '--with-zstd'
-    '--with-xz'
-    '--with-zlib'
-    '--with-openssl'
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dtools=true'
+    '-Dmanpages=true'
+    '-Dlogging=true'
+    '-Ddebug=false'
+    '-Dzstd=enabled'
+    '-Dxz=enabled'
+    '-Dzlib=enabled'
+    '-Dopenssl=enabled'
+    '-Ddocs=true'
 )
-AUTOTOOLS_AFTER__RETRO=(
-    "${AUTOTOOLS_AFTER[@]}"
-    '--disable-python'
-    '--disable-gtk-doc'
-    '--disable-gtk-doc-html'
-    '--disable-gtk-doc-pdf'
+MESON_AFTER__RETRO=(
+    "${MESON_AFTER[@]}"
+    '-Ddocs=false'
 )
 
 PKGESS=1
+
+PKGBREAK="bash-completion<=1:2.14.0"

--- a/app-admin/kmod/autobuild/defines.stage2
+++ b/app-admin/kmod/autobuild/defines.stage2
@@ -1,44 +1,25 @@
 PKGNAME=kmod
 PKGSEC=admin
-PKGDEP="glibc openssl python-3 xz zlib zstd"
-PKGDEP__RETRO="glibc openssl xz zlib zstd"
-PKGDEP__ARMV4="$PKGDEP__RETRO"
-PKGDEP__ARMV6HF="$PKGDEP__RETRO"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="$PKGDEP__RETRO"
-PKGDEP__PPC64="$PKGDEP__RETRO"
+PKGDEP="glibc openssl xz zlib zstd"
 BUILDDEP=""
 PKGDES="Tools for managing kernel modules"
 
-# FIXME: Disabling gtk-doc-pdf as it has broken dblatex detection.
-AUTOTOOLS_AFTER=(
-    '--disable-experimental'
-    '--enable-tools'
-    '--enable-manpages'
-    '--enable-logging'
-    '--disable-debug'
-    '--enable-python'
-    '--disable-coverage'
-    '--enable-gtk-doc'
-    '--enable-gtk-doc-html'
-    '--disable-gtk-doc-pdf'
-    '--with-zstd'
-    '--with-xz'
-    '--with-zlib'
-    '--with-openssl'
-)
-AUTOTOOLS_AFTER__RETRO=(
-    "${AUTOTOOLS_AFTER[@]}"
-    '--disable-python'
-    '--disable-gtk-doc'
-    '--disable-gtk-doc-html'
-    '--disable-gtk-doc-pdf'
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dtools=true'
+    '-Dmanpages=false'
+    '-Dlogging=true'
+    '-Ddebug=false'
+    '-Dzstd=enabled'
+    '-Dxz=enabled'
+    '-Dzlib=enabled'
+    '-Dopenssl=enabled'
+    '-Ddocs=false'
 )
 
 # Note: Saves gtk-doc.
 RECONF=0
 
 PKGESS=1
+
+PKGBREAK="bash-completion<=1:2.14.0"

--- a/app-admin/kmod/spec
+++ b/app-admin/kmod/spec
@@ -1,5 +1,4 @@
-VER=31
-REL=3
+VER=34.2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-$VER.tar.xz"
-CHKSUMS="sha256::f5a6949043cc72c001b728d8c218609c5a15f3c33d75614b78c79418fcf00d80"
+CHKSUMS="sha256::5a5d5073070cc7e0c7a7a3c6ec2a0e1780850c8b47b3e3892226b93ffcb9cb54"
 CHKUPDATE="anitya::id=1517"

--- a/app-shells/bash-completion/spec
+++ b/app-shells/bash-completion/spec
@@ -1,4 +1,4 @@
-VER=2.14.0
+VER=2.16.0
 SRCS="git::commit=tags/$VER::https://github.com/scop/bash-completion"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5667"


### PR DESCRIPTION
Topic Description
-----------------

- kmod: update to 34.2
    - Experimental tools and Python binding has been dropped
    by the upstream in version 32.
    - Upstream moved manpages from xsltproc to scdoc in version 33.
- bash-completion: update to 2.16.0

Package(s) Affected
-------------------

- bash-completion: 1:2.16.0
- kmod: 34.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-completion kmod
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
