### PR TITLE
iotop: update to 1.28

### DIFF
--- a/app-utils/iotop/autobuild/patches/0001-install-binary-to-bin-instead-of-sbin.patch
+++ b/app-utils/iotop/autobuild/patches/0001-install-binary-to-bin-instead-of-sbin.patch
@@ -1,31 +1,25 @@
-From c4759c8bfcbdefbd9487a37aba9a2cf7bf8097a9 Mon Sep 17 00:00:00 2001
+From 1684ef249726ab9765c8ab8384cfbd51dd8a6a0d Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 25 Mar 2025 21:50:02 +0800
 Subject: [PATCH 1/2] install binary to bin instead of sbin
 
 ---
- Makefile | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index bffac53..7a47972 100644
+index 14d7f75..ac04685 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -145,12 +145,12 @@ install: $(TARGET)
- 	$(E) STRIP $(TARGET)
- 	$(Q)$(STRIP) $(TARGET)
- 	$(E) INSTALL $(TARGET)
--	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/sbin/$(TARGET)
-+	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/bin/$(TARGET)
- 	$(Q)$(INSTALL) -D -m 0644 iotop.8 $(PREFIX)/share/man/man8/iotop.8
+@@ -36,7 +36,7 @@ CFLAGS+=-fanalyzer
+ endif
  
- uninstall:
- 	$(E) UNINSTALL $(TARGET)
--	$(Q)rm -f $(PREFIX)/sbin/$(TARGET)
-+	$(Q)rm -f $(PREFIX)/bin/$(TARGET)
- 	$(Q)rm -f $(PREFIX)/share/man/man8/iotop.8
+ PREFIX?=$(DESTDIR)/usr
+-BINDIR?=$(PREFIX)/sbin
++BINDIR?=$(PREFIX)/bin
+ INSTALL?=install
+ STRIP?=strip
  
- bld/.mkdir:
 -- 
 2.49.0
 

--- a/app-utils/iotop/autobuild/patches/0002-do-not-strip-during-compilation.patch
+++ b/app-utils/iotop/autobuild/patches/0002-do-not-strip-during-compilation.patch
@@ -1,32 +1,24 @@
-From 53dc9022b54212b49e9e236de5bccb681b9221c1 Mon Sep 17 00:00:00 2001
+From 869061812a2e983c4a9ba8ff46b97cee961f6937 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 25 Mar 2025 21:50:14 +0800
 Subject: [PATCH 2/2] do not strip during compilation
 
 ---
- Makefile | 3 ---
- 1 file changed, 3 deletions(-)
+ Makefile | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 7a47972..89abe01 100644
+index ac04685..148f64d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -37,7 +37,6 @@ endif
- 
- PREFIX?=$(DESTDIR)/usr
- INSTALL?=install
--STRIP?=strip
- 
- PKG_CONFIG?=pkg-config
- NCCC?=$(shell $(PKG_CONFIG) --cflags ncursesw)
-@@ -142,8 +141,6 @@ clean:
+@@ -143,8 +143,6 @@ clean:
  	$(Q)rm -rf ./bld $(TARGET)
  
  install: $(TARGET)
 -	$(E) STRIP $(TARGET)
 -	$(Q)$(STRIP) $(TARGET)
  	$(E) INSTALL $(TARGET)
- 	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(PREFIX)/bin/$(TARGET)
+ 	$(Q)$(INSTALL) -D -m 0755 $(TARGET) $(BINDIR)/$(TARGET)
  	$(Q)$(INSTALL) -D -m 0644 iotop.8 $(PREFIX)/share/man/man8/iotop.8
 -- 
 2.49.0

--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,5 +1,4 @@
-VER=1.27
-REL=1
+VER=1.28
 SRCS="git::commit=tags/v$VER::https://github.com/Tomas-M/iotop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=259120"


### PR DESCRIPTION
Topic Description
-----------------

- iotop: update to 1.28
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iotop: 1.28

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
