### PR TITLE
cargo-audit: update to 0.21.2

### DIFF
--- a/lang-rust/cargo-audit/spec
+++ b/lang-rust/cargo-audit/spec
@@ -1,4 +1,4 @@
-VER=0.21.0
+VER=0.21.2
 SRCS="git::commit=tags/cargo-audit/v$VER::https://github.com/RustSec/cargo-audit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231457"


### PR DESCRIPTION
Topic Description
-----------------

- cargo-audit: update to 0.21.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cargo-audit: 0.21.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-audit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
