### PR TITLE
cgdb: fix compilation with GCC >= 14

### DIFF
--- a/app-devel/cgdb/autobuild/defines
+++ b/app-devel/cgdb/autobuild/defines
@@ -3,5 +3,3 @@ PKGSEC=devel
 PKGDEP="ncurses gdb"
 BUILDDEP="help2man"
 PKGDES="Curses-based interface to GNU DeBugger"
-
-RECONF=0

--- a/app-devel/cgdb/autobuild/patches/0001-config-fix-compilation-with-GCC14.patch
+++ b/app-devel/cgdb/autobuild/patches/0001-config-fix-compilation-with-GCC14.patch
@@ -1,0 +1,30 @@
+From 7cdd0aaa534e72b6a8a3e0000cfbe666129c27b5 Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Mon, 30 Dec 2024 09:23:57 +0100
+Subject: [PATCH] config: fix compilation with GCC14
+
+The `main()` function we use in the readline config check does not have
+a return type declared. This became a hard error starting with GCC14 and
+thus causes `./configure` to fail.
+
+Fix the issue by declaring the return type.
+---
+ config/readline_check_version.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/readline_check_version.m4 b/config/readline_check_version.m4
+index 01e61c2..71fccf1 100644
+--- a/config/readline_check_version.m4
++++ b/config/readline_check_version.m4
+@@ -86,7 +86,7 @@ AC_CACHE_VAL(ac_cv_rl_version,
+ #include <stdlib.h>
+ #include <readline/readline.h>
+ 
+-main()
++int main()
+ {
+ 	FILE *fp;
+ 	fp = fopen("conftest.rlv", "w");
+-- 
+2.43.0
+

--- a/app-devel/cgdb/spec
+++ b/app-devel/cgdb/spec
@@ -1,5 +1,13 @@
 VER=0.8.0
-REL=1
-SRCS="tbl::https://cgdb.me/files/cgdb-$VER.tar.gz"
-CHKSUMS="sha256::0d38b524d377257b106bad6d856d8ae3304140e1ee24085343e6ddf1b65811f1"
+REL=2
+# FIXME: Do not use upstream tarball as it fails to generate a working
+# configure script via autogen.sh.
+#
+# configure: line 7258: RL_LIB_READLINE_VERSION: command not found
+# configure: error: CGDB requires GNU readline 5.1 or greater to link.
+#   If you used --with-readline instead of using the system readline library,
+#   make sure to set the correct readline library on the linker search path
+#   via LD_LIBRARY_PATH or some other facility.
+SRCS="git::commit=tags/v$VER::https://github.com/cgdb/cgdb"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13935"


### PR DESCRIPTION
Topic Description
-----------------

- cgdb: fix compilation with GCC >= 14
    Use Git source to workaround autogen.sh failure.
    Link: https://github.com/cgdb/cgdb/pull/368/commits/50f7f365a35762db761d172ad53d76a6082b259e

Package(s) Affected
-------------------

- cgdb: 0.8.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cgdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
