### PR TITLE
dhcpc: set ABTYPE to autotools

### DIFF
--- a/app-network/dhcpcd/autobuild/defines
+++ b/app-network/dhcpcd/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=net
 PKGDES="RFC2131 compliant DHCP client daemon"
 PKGDEP=glibc
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER="--rundir=/run \
                  --dbdir=/var/lib/dhcpcd"
 ABSHADOW=0

--- a/app-network/dhcpcd/spec
+++ b/app-network/dhcpcd/spec
@@ -1,4 +1,5 @@
 VER=10.0.8
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/NetworkConfiguration/dhcpcd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11429"


### PR DESCRIPTION
Topic Description
-----------------

- dhcpc: set ABTYPE to autotools

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dhcpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
