### PR TITLE
dhcpcd: set ABTYPE to autotools

### DIFF
--- a/app-network/dhcpcd/autobuild/defines
+++ b/app-network/dhcpcd/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=net
 PKGDES="RFC2131 compliant DHCP client daemon"
 PKGDEP=glibc
 
+# This package has an available configure script in source root,
+# indicating it uses the GNU autotools-based build system.
+ABTYPE=autotools
 AUTOTOOLS_AFTER="--rundir=/run \
                  --dbdir=/var/lib/dhcpcd"
 ABSHADOW=0

--- a/app-network/dhcpcd/spec
+++ b/app-network/dhcpcd/spec
@@ -1,4 +1,5 @@
 VER=10.0.8
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/NetworkConfiguration/dhcpcd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11429"


### PR DESCRIPTION
Topic Description
-----------------

- dhcpcd: set ABTYPE to autotools
    This package has an available configure script in source root, indicating
    it uses the GNU autotools-based build system.
    link: https://wiki.aosc.io/developer/packaging/autobuild3-manual/
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- dhcpcd: 10.0.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dhcpcd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
