### PR TITLE
libwapcaplet: fix build issue ABTYPE missing

### DIFF
--- a/runtime-web/libwapcaplet/autobuild/build
+++ b/runtime-web/libwapcaplet/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing libwapcaplet..."
+make install ${MAKE_AFTER} CFLAGS="-g -O2" STRIP="false"

--- a/runtime-web/libwapcaplet/autobuild/defines
+++ b/runtime-web/libwapcaplet/autobuild/defines
@@ -5,5 +5,6 @@ BUILDDEP="netsurf-buildsystem"
 PKGDES="A C library for string internment"
 
 MAKE_AFTER="PREFIX=/usr \
+            DESTDIR=$PKGDIR \
             LIBDIR=lib \
             COMPONENT_TYPE=lib-shared"

--- a/runtime-web/libwapcaplet/spec
+++ b/runtime-web/libwapcaplet/spec
@@ -1,5 +1,5 @@
 VER=0.4.3
-REL=1
+REL=2
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libwapcaplet-$VER-src.tar.gz"
 CHKSUMS="sha256::9b2aa1dd6d6645f8e992b3697fdbd87f0c0e1da5721fa54ed29b484d13160c5c"
 CHKUPDATE="anitya::id=1759"


### PR DESCRIPTION
Topic Description
-----------------

- libwapcaplet: fix build issue abtype missing

Package(s) Affected
-------------------

- libwapcaplet: 0.4.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libwapcaplet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
