### PR TITLE
sing-box: update to 1.11.10

### DIFF
--- a/app-network/sing-box/autobuild/beyond
+++ b/app-network/sing-box/autobuild/beyond
@@ -8,8 +8,11 @@ install -Dvm644 "$SRCDIR"/release/config/config.json \
 
 abinfo "Installing completion files ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
-"$PKGDIR"/usr/bin/sing-box completion bash > "$PKGDIR"/usr/share/bash-completion/completions/sing-box
+"$PKGDIR"/usr/bin/sing-box completion bash \
+    > "$PKGDIR"/usr/share/bash-completion/completions/sing-box
 mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions
-"$PKGDIR"/usr/bin/sing-box completion zsh > "$PKGDIR"/usr/share/zsh/site-functions/_sing-box
+"$PKGDIR"/usr/bin/sing-box completion zsh \
+    > "$PKGDIR"/usr/share/zsh/site-functions/_sing-box
 mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d
-"$PKGDIR"/usr/bin/sing-box completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/sing-box.fish
+"$PKGDIR"/usr/bin/sing-box completion fish \
+    > "$PKGDIR"/usr/share/fish/vendor_completions.d/sing-box.fish

--- a/app-network/sing-box/autobuild/defines
+++ b/app-network/sing-box/autobuild/defines
@@ -4,8 +4,9 @@ PKGDES="A universal proxy platform"
 PKGDEP="glibc"
 BUILDDEP="go"
 
+# FIXME: Autobuild does not yet support splitting debug symbols
+# from Go executables.
 ABSPLITDBG=0
-GO_BUILD_AFTER=(
-    -tags "with_gvisor,with_quic,with_wireguard,with_grpc,with_ech,with_utls,with_reality_server,with_acme,with_dhcp,with_clash_api,with_v2ray_api"
-    "$SRCDIR"/cmd/sing-box
-)
+ABTYPE=gomod
+GO_LDFLAGS=("-X github.com/sagernet/sing-box/constant.Version=$PKGVER")
+GO_PACKAGES=("cmd/sing-box")

--- a/app-network/sing-box/autobuild/prepare
+++ b/app-network/sing-box/autobuild/prepare
@@ -1,2 +1,17 @@
-abinfo "Setting GO_LDFLAGS ..."
-GO_LDFLAGS+=("-X 'github.com/sagernet/sing-box/constant.Version=$PKGVER'")
+abinfo "Setting build tags ..."
+TAGS=(
+    "with_quic"
+    "with_grpc"
+    "with_dhcp"
+    "with_wireguard"
+    "with_utls"
+    "with_acme"
+    "with_ech"
+    "with_reality_server"
+    "with_clash_api"
+    "with_v2ray_api"
+    "with_gvisor"
+)
+GO_BUILD_AFTER=(
+    -tags "${TAGS[*]}"
+)

--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.11.9
-SRCS="git::commit=tags/v$VER::https://github.com/SagerNet/sing-box"
+VER=1.11.10
+SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.11.10
    - Disable submodule to save time pulling source, because we don't need to build Android and \`Apple\` apps.
    - Improve prepare and beyond scripts.

Package(s) Affected
-------------------

- sing-box: 1.11.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
