### PR TITLE
topics: fix a typo in firefox-138.0.toml

### DIFF
--- a/topics/firefox-138.0.toml
+++ b/topics/firefox-138.0.toml
@@ -1,7 +1,7 @@
 security = true
 
 [name]
-default = "Firefox 139.0"
+default = "Firefox 138.0"
 
 [caution]
 default = "Fixes 11 security vulnerabilities disclosed in Mozilla Foundation Security Advisory 2025-28 (4 of high severity)"


### PR DESCRIPTION
Topic Description
-----------------

- topics: fix a typo in firefox-138.0.toml

Package(s) Affected
-------------------

- firefox: 138.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
