### PR TITLE
pkgsite-tools: update to 0.7.2

### DIFF
--- a/app-utils/pkgsite-tools/autobuild/defines
+++ b/app-utils/pkgsite-tools/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=pkgsite-tools
 PKGSEC=utils
+PKGDEP="curl"
 BUILDDEP="rustc llvm"
 PKGDES="AOSC Packages Site utilities"
 
@@ -8,3 +9,23 @@ USECLANG=1
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
+
+# NOTE: Minimising the binary size, using `nyquest,compio,clap` instead of the
+# default `reqwest,tokio,clap` backends. `minimal` feature set enables `argh` to
+# replace `clap` resulting in even smaller binary size but less user-friendly
+# CLI frontend, thus we do not use `minimal` here.
+#
+# NOTE: `nyquest` requires curl.
+CARGO_AFTER="--no-default-features --features nyquest,compio,clap"
+
+# FIXME: Enabling `io-uring-bindgen` feature to generate architecture-dependent
+# `sys.rs` for io-uring, working around the missing `sys.rs` for some
+# architectures.
+# 
+# Ref: https://github.com/tokio-rs/io-uring/pull/327 (ppc64el)
+# Ref: https://github.com/tokio-rs/io-uring/pull/328 (loongarch64)
+# Ref: https://github.com/tokio-rs/io-uring/pull/330 (loongson3)
+CARGO_AFTER__BINDGEN="--no-default-features --features nyquest,compio,clap,io-uring-bindgen"
+CARGO_AFTER__PPC64EL="${CARGO_AFTER__BINDGEN}"
+CARGO_AFTER__LOONGARCH64="${CARGO_AFTER__BINDGEN}"
+CARGO_AFTER__LOONGSON3="${CARGO_AFTER__BINDGEN}"

--- a/app-utils/pkgsite-tools/spec
+++ b/app-utils/pkgsite-tools/spec
@@ -1,4 +1,4 @@
-VER=0.3.4
+VER=0.7.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/pkgsite-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377917"


### PR DESCRIPTION
Topic Description
-----------------

- pkgsite-tools: update to 0.7.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- pkgsite-tools: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgsite-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
