### PR TITLE
libapt-pkg-perl: update to 0.1.42

### DIFF
--- a/lang-perl/libapt-pkg-perl/spec
+++ b/lang-perl/libapt-pkg-perl/spec
@@ -1,4 +1,4 @@
-VER=0.1.41
+VER=0.1.42
 SRCS="tbl::http://deb.debian.org/debian/pool/main/liba/libapt-pkg-perl/libapt-pkg-perl_${VER}.tar.xz"
-CHKSUMS="sha256::53e140fb3d8a5685d9190ee0dec9c7f02cd051112a9e3b75347b22be5441cf0a"
+CHKSUMS="sha256::fb2deda595d8394807ace656a3a6568ed03a379b75a096d9669dc7568bcaa8e5"
 CHKUPDATE="anitya::id=231063"


### PR DESCRIPTION
Topic Description
-----------------

- libapt-pkg-perl: update to 0.1.42
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libapt-pkg-perl: 0.1.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit libapt-pkg-perl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
