### PR TITLE
expect: fix build with GCC >= 14

### DIFF
--- a/app-utils/expect/autobuild/patches/0001-fix-build-with-GCC-14.patch
+++ b/app-utils/expect/autobuild/patches/0001-fix-build-with-GCC-14.patch
@@ -1,0 +1,297 @@
+From 6f113f40aec8a3c930cd5b9b0beef4569fa0ede4 Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Tue, 6 May 2025 22:14:20 +0800
+Subject: [PATCH] fix build with GCC >= 14
+
+fix build failure caused by the pre-C99 syntax no longer allowed by GCC 14
+in the default C99 mode
+
+link: https://www.linuxfromscratch.org/patches/lfs/development/expect-5.45.4-gcc14-1.patch
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ configure      | 33 ++++++++++++++-------------------
+ exp_chan.c     |  5 ++++-
+ exp_clib.c     | 12 ++++++++++++
+ exp_log.c      |  5 ++++-
+ exp_main_sub.c |  1 +
+ pty_termios.c  |  2 ++
+ 6 files changed, 37 insertions(+), 21 deletions(-)
+
+diff --git a/configure b/configure
+index 8fc3396..758f031 100755
+--- a/configure
++++ b/configure
+@@ -7994,7 +7994,6 @@ main ()
+ {
+ extern long timezone;
+ 	    timezone += 1;
+-	    exit (0);
+   ;
+   return 0;
+ }
+@@ -8030,7 +8029,6 @@ main ()
+ {
+ extern time_t timezone;
+ 		timezone += 1;
+-		exit (0);
+   ;
+   return 0;
+ }
+@@ -8791,7 +8789,7 @@ fi
+ $as_echo_n "checking for memcpy... " >&6; }
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-
++#include <string.h>
+ int
+ main ()
+ {
+@@ -8831,7 +8829,7 @@ else
+ /* end confdefs.h.  */
+ 
+ #include <sys/wait.h>
+-main() {
++int main() {
+ #ifndef WNOHANG
+ 	return 0;
+ #else
+@@ -8867,7 +8865,7 @@ else
+ 
+ #include <stdio.h>
+ #include <sys/wait.h>
+-main() {
++int main() {
+ #ifdef WNOHANG
+ 	FILE *fp = fopen("wnohang","w");
+ 	fprintf(fp,"%d",WNOHANG);
+@@ -8935,7 +8933,9 @@ else
+ /* end confdefs.h.  */
+ 
+ #include <signal.h>
+-#define RETSIGTYPE $retsigtype
++#include <stdlib.h>
++#include <unistd.h>
++#include <sys/wait.h>
+ 
+ int signal_rearms = 0;
+ 
+@@ -8952,7 +8952,7 @@ int n;
+ signal_rearms++;
+ }
+ 
+-main()
++int main()
+ {
+ 	signal(SIGINT,parent_sigint_handler);
+ 
+@@ -9234,10 +9234,9 @@ else
+ /* end confdefs.h.  */
+ 
+ #include <sgtty.h>
+-main()
++int main()
+ {
+   struct sgttyb tmp;
+-  exit(0);
+ }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+@@ -9274,10 +9273,9 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <termio.h>
+-  main()
++  int main()
+   {
+     struct termio tmp;
+-    exit(0);
+   }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+@@ -9312,10 +9310,9 @@ else
+ #  include <inttypes.h>
+ #  endif
+ #  include <termios.h>
+-  main()
++  int main()
+   {
+     struct termios tmp;
+-    exit(0);
+   }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+@@ -9350,7 +9347,7 @@ else
+ #include <inttypes.h>
+ #endif
+ #include <termios.h>
+-main() {
++int main() {
+ #if defined(TCGETS) || defined(TCGETA)
+ 	return 0;
+ #else
+@@ -9388,7 +9385,7 @@ else
+ #include <inttypes.h>
+ #endif
+ #include <termios.h>
+-main() {
++int main() {
+ #ifdef TIOCGWINSZ
+ 	return 0;
+ #else
+@@ -9423,7 +9420,7 @@ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+-main(){
++int main(){
+ #ifdef CRAY
+ 	return 0;
+ #else
+@@ -9565,12 +9562,10 @@ else
+ 
+ extern char *tzname[2];
+ extern int daylight;
+-main()
++int main()
+ {
+   int *x = &daylight;
+   char **y = tzname;
+-
+-  exit(0);
+ }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+diff --git a/exp_chan.c b/exp_chan.c
+index 79f486c..944200a 100644
+--- a/exp_chan.c
++++ b/exp_chan.c
+@@ -51,6 +51,8 @@ static void		ExpWatchProc _ANSI_ARGS_((ClientData instanceData,
+ 		            int mask));
+ static int		ExpGetHandleProc _ANSI_ARGS_((ClientData instanceData,
+ 		            int direction, ClientData *handlePtr));
++void			exp_background_channelhandler _ANSI_ARGS_((ClientData,
++		            int));
+ 
+ /*
+  * This structure describes the channel type structure for Expect-based IO:
+@@ -58,7 +60,7 @@ static int		ExpGetHandleProc _ANSI_ARGS_((ClientData instanceData,
+ 
+ Tcl_ChannelType expChannelType = {
+     "exp",				/* Type name. */
+-    ExpBlockModeProc,			/* Set blocking/nonblocking mode.*/
++    TCL_CHANNEL_VERSION_2,
+     ExpCloseProc,			/* Close proc. */
+     ExpInputProc,			/* Input proc. */
+     ExpOutputProc,			/* Output proc. */
+@@ -68,6 +70,7 @@ Tcl_ChannelType expChannelType = {
+     ExpWatchProc,			/* Initialize notifier. */
+     ExpGetHandleProc,			/* Get OS handles out of channel. */
+     NULL,				/* Close2 proc */
++    ExpBlockModeProc,			/* Set blocking/nonblocking mode.*/
+ };
+ 
+ typedef struct ThreadSpecificData {
+diff --git a/exp_clib.c b/exp_clib.c
+index 1699775..55ca098 100644
+--- a/exp_clib.c
++++ b/exp_clib.c
+@@ -37,6 +37,14 @@ would appreciate credit if this program or parts of it are used.
+ # endif
+ #endif
+ 
++#ifdef HAVE_UNISTD_H
++# include <unistd.h>
++#endif
++
++//#ifdef HAVE_SYS_WAIT_H
++# include <sys/wait.h>
++//#endif
++
+ #ifdef HAVE_SYS_FCNTL_H
+ #  include <sys/fcntl.h>
+ #else
+@@ -1734,6 +1742,7 @@ int exp_getptyslave();
+ #define sysreturn(x)	return(errno = x, -1)
+ 
+ void exp_init_pty();
++void exp_init_tty();
+ 
+ /*
+    The following functions are linked from the Tcl library.  They
+@@ -2253,6 +2262,7 @@ exp_spawnl TCL_VARARGS_DEF(char *,arg1)
+ 		argv[i] = va_arg(args,char *);
+ 		if (!argv[i]) break;
+ 	}
++	va_end(args);
+ 	i = exp_spawnv(argv[0],argv+1);
+ 	free((char *)argv);
+ 	return(i);
+@@ -2726,6 +2736,7 @@ exp_expectl TCL_VARARGS_DEF(int,arg1)
+ 		/* Ultrix 4.2 compiler refuses enumerations comparison!? */
+ 		if ((int)type < 0 || (int)type >= (int)exp_bogus) {
+ 			fprintf(stderr,"bad type (set %d) in exp_expectl\n",i);
++			va_end(args);
+ 			sysreturn(EINVAL);
+ 		}
+ 
+@@ -2791,6 +2802,7 @@ exp_fexpectl TCL_VARARGS_DEF(FILE *,arg1)
+ 		/* Ultrix 4.2 compiler refuses enumerations comparison!? */
+ 		if ((int)type < 0 || (int)type >= (int)exp_bogus) {
+ 			fprintf(stderr,"bad type (set %d) in exp_expectl\n",i);
++			va_end(args);
+ 			sysreturn(EINVAL);
+ 		}
+ 
+diff --git a/exp_log.c b/exp_log.c
+index b378641..e3c6e25 100644
+--- a/exp_log.c
++++ b/exp_log.c
+@@ -174,7 +174,10 @@ expStdoutLog TCL_VARARGS_DEF(int,arg1)
+     force_stdout = TCL_VARARGS_START(int,arg1,args);
+     fmt = va_arg(args,char *);
+ 
+-    if ((!tsdPtr->logUser) && (!force_stdout) && (!tsdPtr->logAll)) return;
++    if ((!tsdPtr->logUser) && (!force_stdout) && (!tsdPtr->logAll)) {
++        va_end(args);
++        return;
++    }
+ 
+     (void) vsprintf(bigbuf,fmt,args);
+     expDiagWriteBytes(bigbuf,-1);
+diff --git a/exp_main_sub.c b/exp_main_sub.c
+index fcfaa6e..499c0ae 100644
+--- a/exp_main_sub.c
++++ b/exp_main_sub.c
+@@ -57,6 +57,7 @@ int exp_cmdlinecmds = FALSE;
+ int exp_interactive =  FALSE;
+ int exp_buffer_command_input = FALSE;/* read in entire cmdfile at once */
+ int exp_fgets();
++int exp_tty_cooked_echo(Tcl_Interp *interp, exp_tty *tty_old, int *was_raw, int *was_echo);
+ 
+ Tcl_Interp *exp_interp;	/* for use by signal handlers who can't figure out */
+ 			/* the interpreter directly */
+diff --git a/pty_termios.c b/pty_termios.c
+index c605b23..d78658a 100644
+--- a/pty_termios.c
++++ b/pty_termios.c
+@@ -105,6 +105,7 @@ with openpty which supports 4000 while ptmx supports 60. */
+ 
+ void expDiagLog();
+ void expDiagLogPtr();
++char *expErrnoMsg(int errorNo);
+ 
+ #include <errno.h>
+ /*extern char *sys_errlist[];*/
+@@ -189,6 +190,7 @@ static char slave_name[MAXPTYNAMELEN];
+ #endif /* HAVE_SCO_CLIST_PTYS */
+ 
+ #ifdef HAVE_OPENPTY
++#include <pty.h>
+ static char master_name[64];
+ static char slave_name[64];
+ #endif
+-- 
+2.49.0
+

--- a/app-utils/expect/spec
+++ b/app-utils/expect/spec
@@ -1,5 +1,5 @@
 VER=5.45.4
-REL=2
+REL=3
 SRCS="tbl::http://http.debian.net/debian/pool/main/e/expect/expect_$VER.orig.tar.gz"
 CHKSUMS="sha256::d082bf340fdb7a85b1e4e5df4d967d0140835db34a8a035c3102abb5eb62d450"
 CHKUPDATE="anitya::id=771"


### PR DESCRIPTION
Topic Description
-----------------

- expect: fix build with GCC >= 14
    Fix some build failure caused by the pre-C99 syntax no longer allowed by GCC 14
    in the default C99 mode.
    link: https://www.linuxfromscratch.org/patches/lfs/development/expect-5.45.4-gcc14-1.patch
    Signed-off-by: Xi Ruoyao <xry111@xry111.site>
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- expect: 5.45.4-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit expect
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
