### PR TITLE
libglibutil: update to 1.0.80

### DIFF
--- a/runtime-common/libglibutil/spec
+++ b/runtime-common/libglibutil/spec
@@ -1,4 +1,4 @@
-VER=1.0.79
+VER=1.0.80
 SRCS="git::commit=tags/$VER::https://github.com/sailfishos/libglibutil"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279493"


### PR DESCRIPTION
Topic Description
-----------------

- libglibutil: update to 1.0.80
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libglibutil: 1.0.80

Security Update?
----------------

No

Build Order
-----------

```
#buildit libglibutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
