### PR TITLE
uboot-tools: update to 2025.04

### DIFF
--- a/app-utils/uboot-tools/spec
+++ b/app-utils/uboot-tools/spec
@@ -1,4 +1,4 @@
-VER=2024.10
+VER=2025.04
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::b28daf4ac17e43156363078bf510297584137f6df50fced9b12df34f61a92fb0"
+CHKSUMS="sha256::439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718"
 CHKUPDATE="anitya::id=5022"

--- a/topics/uboot-tools-2025.04.toml
+++ b/topics/uboot-tools-2025.04.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "U-Boot Utilities 2025.04"
+zh_CN = "U-Boot 实用工具 2025.04"
+
+[caution]
+default = "Fixes multiple security vulnerabilities (5 of high severity, 1 low)"
+zh_CN = "修复多个安全漏洞（含 5 个高危漏洞，1 个低危漏洞）"
+
+[packages]
+uboot-tools = "2025.04"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add uboot-tools-2025.04.toml
- uboot-tools: update to 2025.04

Package(s) Affected
-------------------

- uboot-tools: 2025.04

Security Update?
----------------

Yes, #10787

Build Order
-----------

```
#buildit uboot-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
