### PR TITLE
libarchive: update to 3.7.8

### DIFF
--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,4 @@
-VER=3.7.7
+VER=3.7.8
 SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
-CHKSUMS="sha256::4cc540a3e9a1eebdefa1045d2e4184831100667e6d7d5b315bb1cbc951f8ddff"
+CHKSUMS="sha256::a123d87b1bd8adb19e8c187da17ae2d957c7f9596e741b929e6b9ceefea5ad0f"
 CHKUPDATE="anitya::id=1558"

--- a/topics/libarchive-3.7.8.toml
+++ b/topics/libarchive-3.7.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libarchive 3.7.8"
+
+[caution]
+default = "Fixes multiple security vulnerabilities (3 of medium severity)"
+zh_CN = "修复三个安全漏洞（含 3 个中危漏洞）"
+
+[packages]
+libarchive = "1:3.7.8"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add libarchive-3.7.8.toml
- libarchive: update to 3.7.8

Package(s) Affected
-------------------

- libarchive: 1:3.7.8

Security Update?
----------------

Yes, #10789

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
