### PR TITLE
idnkit: fix build with GCC >= 14

### DIFF
--- a/app-network/idnkit/autobuild/patches/0001-AOSCOS-fix-build-with-GCC-14.patch
+++ b/app-network/idnkit/autobuild/patches/0001-AOSCOS-fix-build-with-GCC-14.patch
@@ -1,0 +1,46 @@
+From c43fea8ee11359dd85b8e601dc3c53d6ea55e46e Mon Sep 17 00:00:00 2001
+From: ilikara <3435193369@qq.com>
+Date: Wed, 7 May 2025 13:18:00 +0800
+Subject: [PATCH] AOSCOS: fix build with GCC >= 14
+
+GCC 14 enforces stricter type checks and rejects `(const char **)NULL`
+when `iconv()` expects `char **`. Fix by passiing `(char **)NULL`.
+
+This avoids `-Wincompatible-pointer-types` errors in GCC >= 14.
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ lib/localconverter.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/localconverter.c b/lib/localconverter.c
+index 12312c6..b07c7f8 100755
+--- a/lib/localconverter.c
++++ b/lib/localconverter.c
+@@ -599,12 +599,12 @@ localconverter_iconv_conv(idn__localconverter_t ctx, void *privdata,
+ 	inleft = 0;
+ 	outbuf = NULL;
+ 	outleft = 0;
+-	iconv(ictx, (const char **)NULL, &inleft, &outbuf, &outleft);
++	iconv(ictx, (char **)NULL, &inleft, &outbuf, &outleft);
+ 
+ 	inleft = strlen(from);
+ 	inbuf = from;
+ 	outleft = tolen - 1;	/* reserve space for terminating NUL */
+-	sz = iconv(ictx, (const char **)&inbuf, &inleft, &to, &outleft);
++	sz = iconv(ictx, (char **)&inbuf, &inleft, &to, &outleft);
+ 
+ 	if (sz == (size_t)(-1) || inleft > 0) {
+ 		switch (errno) {
+@@ -630,7 +630,7 @@ localconverter_iconv_conv(idn__localconverter_t ctx, void *privdata,
+ 	 * Append a sequence of state reset.
+ 	 */
+ 	inleft = 0;
+-	sz = iconv(ictx, (const char **)NULL, &inleft, &to, &outleft);
++	sz = iconv(ictx, (char **)NULL, &inleft, &to, &outleft);
+ 	if (sz == (size_t)(-1)) {
+ 		switch (errno) {
+ 		case EILSEQ:
+-- 
+2.49.0
+

--- a/app-network/idnkit/spec
+++ b/app-network/idnkit/spec
@@ -1,4 +1,5 @@
 VER=2.3
+REL=1
 SRCS="tbl::http://jprs.co.jp/idn/idnkit-$VER.tar.bz2"
 CHKSUMS="sha256::26d07117650042ab4693f0e00960275d58a1be773e6d13c503ba384710f3e97e"
 CHKUPDATE="anitya::id=16111"


### PR DESCRIPTION
Topic Description
-----------------

- idnkit: fix build with GCC >= 14
    GCC 14 enforces stricter type checks and rejects \`\(const char \*\*\)NULL\`
    when \`iconv\(\)\` expects \`char \*\*\`. Fix by passiing \`\(char \*\*\)NULL\`.
    This avoids \`-Wincompatible-pointer-types\` errors in GCC >= 14.
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- idnkit: 2.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit idnkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
