### PR TITLE
zope-interface: update to 7.2

### DIFF
--- a/lang-python/zope-interface/autobuild/beyond
+++ b/lang-python/zope-interface/autobuild/beyond
@@ -1,1 +1,0 @@
-rm -rf "$PKGDIR"/dist

--- a/lang-python/zope-interface/autobuild/defines
+++ b/lang-python/zope-interface/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=zope-interface
-PKGDES="Zope Interface"
-PKGSEC=zope
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer setuptools wheel"
+PKGDES="An object interfaces implementation for Python"
+
+ABTYPE=pep517

--- a/lang-python/zope-interface/autobuild/patches/0001-AOSCOS-fix-pyproject.toml-relax-setuptools-version-r.patch
+++ b/lang-python/zope-interface/autobuild/patches/0001-AOSCOS-fix-pyproject.toml-relax-setuptools-version-r.patch
@@ -1,0 +1,30 @@
+From 0a36d58196038879d8be41c3412699deabe18b09 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 7 May 2025 17:28:12 +0800
+Subject: [PATCH] AOSCOS: fix(pyproject.toml): relax setuptools version
+ requirements
+
+There seems to be no reason to limit the highest supported version for
+setuptools at all.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index c787aa9..7906a37 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,7 @@
+ # https://github.com/zopefoundation/meta/tree/master/config/c-code
+ 
+ [build-system]
+-requires = ["setuptools < 74"]
++requires = ["setuptools"]
+ build-backend = "setuptools.build_meta"
+ 
+ [tool.coverage.run]
+-- 
+2.49.0
+

--- a/lang-python/zope-interface/spec
+++ b/lang-python/zope-interface/spec
@@ -1,5 +1,4 @@
-VER=5.4.0
+VER=7.2
 SRCS="tbl::https://pypi.io/packages/source/z/zope.interface/zope.interface-$VER.tar.gz"
-CHKSUMS="sha256::5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e"
+CHKSUMS="sha256::8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe"
 CHKUPDATE="anitya::id=4112"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- zope-interface: update to 7.2
    - Switch to pep517 ABTYPE and drop Python 2 bindings.
    - Drop unused beyond script.

Package(s) Affected
-------------------

- zope-interface: 7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zope-interface
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
