### PR TITLE
smartmontools: update to 7.5

### DIFF
--- a/app-admin/smartmontools/autobuild/defines
+++ b/app-admin/smartmontools/autobuild/defines
@@ -1,21 +1,21 @@
 PKGNAME=smartmontools
 PKGSEC=utils
-PKGDES="Control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
 PKGDEP="gcc-runtime bash libcap-ng"
+PKGDES="Control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
 
 # --enable-sample         Enables appending .sample to the installed smartd rc
 #                         script and configuration file
 #
 # Note: Disabling --with-update-smart-drivedb, and --with-gnupg=no is required.
-AUTOTOOLS_AFTER="--disable-sample \
-                 --enable-scsi-cdb-check \
-                 --enable-fast-lebe \
-                 --with-gnupg=no \
-                 --with-update-smart-drivedb=no \
-                 --with-selinux=no \
-                 --with-libcap-ng=yes \
-                 --with-libsystemd=yes \
-                 --with-systemdsystemunitdir=/usr/lib/systemd/system \
-                 --with-nvme-devicescan=yes \
-                 --with-solaris-sparc-ata=yes \
-                 --with-signal-func=sigaction"
+AUTOTOOLS_AFTER=(
+    '--disable-sample'
+    '--enable-scsi-cdb-check'
+    '--enable-fast-lebe'
+    '--with-gnupg=no'
+    '--with-update-smart-drivedb=no'
+    '--with-selinux=no'
+    '--with-libcap-ng=yes'
+    '--with-libsystemd=yes'
+    '--with-systemdsystemunitdir=/usr/lib/systemd/system'
+    '--with-nvme-devicescan=yes'
+)

--- a/app-admin/smartmontools/spec
+++ b/app-admin/smartmontools/spec
@@ -1,4 +1,4 @@
-VER=7.3
+VER=7.5
 SRCS="tbl::https://sourceforge.net/projects/smartmontools/files/smartmontools/$VER/smartmontools-$VER.tar.gz"
-CHKSUMS="sha256::a544f8808d0c58cfb0e7424ca1841cb858a974922b035d505d4e4c248be3a22b"
+CHKSUMS="sha256::690b83ca331378da9ea0d9d61008c4b22dde391387b9bbad7f29387f2595f76e"
 CHKUPDATE="anitya::id=4835"


### PR DESCRIPTION
Topic Description
-----------------

- smartmontools: update to 7.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- smartmontools: 7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit smartmontools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
