### PR TITLE
feishin: update to 0.12.5

### DIFF
--- a/app-multimedia/feishin/spec
+++ b/app-multimedia/feishin/spec
@@ -1,4 +1,4 @@
-VER=0.12.3
+VER=0.12.5
 SRCS="git::commit=tags/v${VER}::https://github.com/jeffvli/feishin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368971"


### PR DESCRIPTION
Topic Description
-----------------

- feishin: update to 0.12.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- feishin: 0.12.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit feishin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
