### PR TITLE
bat: workaround submodule failure

### DIFF
--- a/app-utils/bat/autobuild/patches/0001-remove-LiveScript-submodule.patch.deferred
+++ b/app-utils/bat/autobuild/patches/0001-remove-LiveScript-submodule.patch.deferred
@@ -1,0 +1,38 @@
+From 7868030fe6c994b021d52134173dafc37c991023 Mon Sep 17 00:00:00 2001
+From: Keith Hall <keith-hall@users.noreply.github.com>
+Date: Wed, 30 Apr 2025 22:32:48 +0300
+Subject: [PATCH] remove LiveScript submodule
+
+the repo has gone away, causing all our CI etc. to break
+
+we can keep the highlighting though because we have a .sublime-syntax file
+---
+ .gitmodules                         | 3 ---
+ assets/syntaxes/02_Extra/LiveScript | 1 -
+ 2 files changed, 4 deletions(-)
+ delete mode 160000 assets/syntaxes/02_Extra/LiveScript
+
+diff --git a/.gitmodules b/.gitmodules
+index fe159da8..3506fe33 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -197,9 +197,6 @@
+ [submodule "assets/syntaxes/02_Extra/Lean"]
+ 	path = assets/syntaxes/02_Extra/Lean
+ 	url = https://github.com/leanprover/vscode-lean.git
+-[submodule "assets/syntaxes/02_Extra/LiveScript"]
+-	path = assets/syntaxes/02_Extra/LiveScript
+-	url = https://github.com/paulmillr/LiveScript.tmbundle
+ [submodule "assets/syntaxes/02_Extra/Zig"]
+ 	path = assets/syntaxes/02_Extra/Zig
+ 	url = https://github.com/ziglang/sublime-zig-language.git
+diff --git a/assets/syntaxes/02_Extra/LiveScript b/assets/syntaxes/02_Extra/LiveScript
+deleted file mode 160000
+index d82aeb73..00000000
+--- a/assets/syntaxes/02_Extra/LiveScript
++++ /dev/null
+@@ -1 +0,0 @@
+-Subproject commit d82aeb737d4883d1a74aba7a07053f90211d427b
+-- 
+2.49.0
+

--- a/app-utils/bat/autobuild/prepare
+++ b/app-utils/bat/autobuild/prepare
@@ -1,0 +1,7 @@
+# FIXME: Does not apply with plain patch(1) due to the target file not
+# being a regular file.
+abinfo "Applying Git submodule fix ..."
+git apply "$SRCDIR"/autobuild/patches/0001-remove-LiveScript-submodule.patch.deferred
+
+abinfo "Fetching Git submodules ..."
+git submodule update --recursive

--- a/app-utils/bat/spec
+++ b/app-utils/bat/spec
@@ -1,4 +1,5 @@
 VER=0.25.0
-SRCS="git::commit=tags/v$VER::https://github.com/sharkdp/bat/"
+REL=1
+SRCS="git::commit=tags/v$VER;submodule=false;copy-repo=true::https://github.com/sharkdp/bat/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17642"


### PR DESCRIPTION
Topic Description
-----------------

- bat: workaround submodule failure
    The upstream for LiveScript is gone, upstream removed the submodule.
    Workaround build failure by backporting an upstream fix and handling
    submodule fetching manually in prepare.
    Link: https://github.com/sharkdp/bat/commit/ccfbd1ee3137b3aa5046e2336e2d1bcb4d96078c

Package(s) Affected
-------------------

- bat: 0.25.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
