### PR TITLE
libteam: disable python binding

### DIFF
--- a/app-network/libteam/autobuild/beyond
+++ b/app-network/libteam/autobuild/beyond
@@ -3,10 +3,6 @@ pushd "${SRCDIR}/abbuild"
 	make html
 	mkdir -vp "${PKGDIR}/usr/share/doc/libteam"
 	cp -vra doc/api "${PKGDIR}/usr/share/doc/libteam/"
-
-	abinfo "Building and installing python bindings"
-	cd binding/python
-	python3 setup.py install --root="${PKGDIR}" --optimize=1
 popd
 
 pushd "${SRCDIR}"

--- a/app-network/libteam/spec
+++ b/app-network/libteam/spec
@@ -1,5 +1,5 @@
 VER=1.31
-REL=1
+REL=2
 SRCS="https://github.com/jpirko/libteam/archive/refs/tags/v${VER}.tar.gz"
 CHKSUMS="sha256::c69f7cf5a98203d66db10e67b396fe325b77a5a9491d1e07e8a07cba3ba841bb"
 CHKUPDATE="anitya::id=231716"


### PR DESCRIPTION
Topic Description
-----------------

- libteam: disable python binding
    link: https://github.com/jpirko/libteam/issues/73
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libteam: 1.31-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libteam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
