### PR TITLE
udns: update to 0.6

### DIFF
--- a/app-network/udns/autobuild/build
+++ b/app-network/udns/autobuild/build
@@ -1,15 +1,34 @@
-./configure
+abinfo "Configuring udns ..."
+"$SRCDIR"/configure
+
+abinfo "Building udns ..."
 make
+
+abinfo "Building shared libraries ..."
 make sharedlib
 
-install -D -m0755 dnsget $PKGDIR/usr/bin/dnsget
-install -D -m0755 rblcheck $PKGDIR/usr/bin/rblcheck
-install -D -m0755 ex-rdns $PKGDIR/usr/bin/ex-rdns
+abinfo "Installing executables ..."
+install -Dvm0755 "$SRCDIR"/dnsget \
+    "$PKGDIR"/usr/bin/dnsget
+install -Dvm0755 "$SRCDIR"/rblcheck \
+    "$PKGDIR"/usr/bin/rblcheck
+install -Dvm0755 "$SRCDIR"/ex-rdns \
+    "$PKGDIR"/usr/bin/ex-rdns
 
-install -D -m0644 udns.h $PKGDIR/usr/include/udns.h
-install -D -m0755 libudns.so.0 $PKGDIR/usr/lib/libudns.so.0
-ln -s libudns.so.0 $PKGDIR/usr/lib/libudns.so
+abinfo "Installing header (udns.h) ..."
+install -Dvm0644 "$SRCDIR"/udns.h \
+    "$PKGDIR"/usr/include/udns.h
 
-install -D -m0644 dnsget.1 $PKGDIR/usr/share/man/man1/dnsget.1
-install -D -m0644 rblcheck.1 $PKGDIR/usr/share/man/man1/rblcheck.1
-install -D -m0644 udns.3 $PKGDIR/usr/share/man/man3/udns.3
+abinfo "Installing shared library ..."
+install -Dvm0755 "$SRCDIR"/libudns.so.0 \
+    "$PKGDIR"/usr/lib/libudns.so.0
+ln -sv libudns.so.0 \
+    "$PKGDIR"/usr/lib/libudns.so
+
+abinfo "Installing man pages ..."
+install -Dvm0644 "$SRCDIR"/dnsget.1 \
+    "$PKGDIR"/usr/share/man/man1/dnsget.1
+install -Dvm0644 "$SRCDIR"/rblcheck.1 \
+    "$PKGDIR"/usr/share/man/man1/rblcheck.1
+install -Dvm0644 "$SRCDIR"/udns.3 \
+    "$PKGDIR"/usr/share/man/man3/udns.3

--- a/app-network/udns/autobuild/defines
+++ b/app-network/udns/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=udns
 PKGSEC=net
 PKGDEP="glibc"
-PKGDES="Stub DNS resolver library"
-
+PKGDES="DNS resolver library and utilities for both synchronous and asynchronous DNS queries"

--- a/app-network/udns/spec
+++ b/app-network/udns/spec
@@ -1,4 +1,4 @@
-VER=0.5
+VER=0.6
 SRCS="tbl::https://www.corpit.ru/mjt/udns/udns-$VER.tar.gz"
-CHKSUMS="sha256::035bfc12e3819d0aba8f40ee8220a974b7e9b29c3259d310970cc4b2d1c203c0"
+CHKSUMS="sha256::696a2d0d518da985d975a65e11d166f3f57cdbd1d42376a0b85307f49601c6e8"
 CHKUPDATE="anitya::id=5031"


### PR DESCRIPTION
Topic Description
-----------------

- udns: update to 0.6
    - Lint scripts in accordance with the Styling Manual.
    - Improve PKGDES.

Package(s) Affected
-------------------

- udns: 0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit udns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
