### PR TITLE
rfkill: add a build script

### DIFF
--- a/app-utils/rfkill/autobuild/build
+++ b/app-utils/rfkill/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Building rfkill ..."
+make \
+    V=1
+
+abinfo "Installing rfkill ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    SBINDIR=/usr/bin \
+    V=1

--- a/app-utils/rfkill/autobuild/defines
+++ b/app-utils/rfkill/autobuild/defines
@@ -1,6 +1,4 @@
 PKGNAME=rfkill
 PKGSEC=net
 PKGDEP="glibc"
-PKGDES="A tool for enabling and disabling wireless devices"
-
-
+PKGDES="Tool for enabling and disabling wireless devices"

--- a/app-utils/rfkill/spec
+++ b/app-utils/rfkill/spec
@@ -1,4 +1,5 @@
 VER=1.0
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/software/network/rfkill/rfkill-$VER.tar.xz"
 CHKSUMS="sha256::dffc631c611520478b8a286f57c67a35e8cb5802d376c6ca13b057365432389c"
 CHKUPDATE="anitya::id=4196"


### PR DESCRIPTION
Topic Description
-----------------

- rfkill: add a build script
    The previously \(implied\) used plainmake ABTYPE is no longer available.

Package(s) Affected
-------------------

- rfkill: 1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rfkill
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
