### PR TITLE
pv: add a build script

### DIFF
--- a/app-utils/pv/autobuild/build
+++ b/app-utils/pv/autobuild/build
@@ -1,0 +1,12 @@
+# FIXME: This is an incomplete Autotools source.
+abinfo "Configuring pv ..."
+"$SRCDIR"/configure \
+    ${AUTOTOOLS_DEF[@]} \
+    ${AUTOTOOLS_AFTER[@]}
+
+abinfo "Building pv ..."
+make
+
+abinfo "Installing pv ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-utils/pv/autobuild/defines
+++ b/app-utils/pv/autobuild/defines
@@ -1,16 +1,14 @@
 PKGNAME=pv
 PKGSEC=utils
 PKGDEP="glibc"
-PKGDES="A command line tool for monitoring the progress of data through a pipeline"
+PKGDES="Command-line tool for monitoring the progress of data through a pipeline"
 
-# FIXME: Source tree provides no files for re-generating Autotools scripts, but
-# provides a genuine Autotools configure script.
-RECONF=0
-NOLTO__MIPS64R6EL=1
-AUTOTOOLS_AFTER="--disable-debugging \
-                 --disable-profiling \
-                 --enable-lfs \
-                 --disable-static-nls \
-                 --enable-nls \
-                 --enable-splice \
-                 --enable-ipc"
+AUTOTOOLS_AFTER=(
+    '--disable-debugging'
+    '--disable-profiling'
+    '--enable-lfs'
+    '--disable-static-nls'
+    '--enable-nls'
+    '--enable-splice'
+    '--enable-ipc'
+)

--- a/app-utils/pv/autobuild/prepare
+++ b/app-utils/pv/autobuild/prepare
@@ -1,4 +1,0 @@
-if [[ "${CROSS:-$ARCH}" = "mips64r6el" ]] ; then
-	abinfo "Setting default ld emulation for mips64r6el..."
-	export LDEMULATION="elf64ltsmip"
-fi

--- a/app-utils/pv/spec
+++ b/app-utils/pv/spec
@@ -1,4 +1,5 @@
 VER=1.6.20
+REL=1
 SRCS="tbl::https://www.ivarch.com/programs/sources/pv-$VER.tar.gz"
 CHKSUMS="sha256::b5f1ee79a370c5287e092b6e8f1084f026521fe0aecf25c44b9460b870319a9e"
 CHKUPDATE="anitya::id=3736"


### PR DESCRIPTION
Topic Description
-----------------

- pv: add a build script
    This is an incomplete Autotools source.

Package(s) Affected
-------------------

- pv: 1.6.20-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
