### PR TITLE
mihomo: remove ABTYPE

### DIFF
--- a/app-network/mihomo/autobuild/defines
+++ b/app-network/mihomo/autobuild/defines
@@ -8,7 +8,6 @@ PKGDES="A rule-based tunnel for VMess, Shadowsocks, Trojan, Snell protocols (Cla
 # Golang executables.
 ABSPLITDBG=0
 
-ABTYPE=gomod
 GO_BUILD_AFTER=(
     -trimpath
     -tags "with_gvisor"

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,4 +1,5 @@
 VER=1.19.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: remove ABTYPE
    Mihomo has a build script, so its ABTYPE should be deleted.
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- mihomo: 1.19.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
