### PR TITLE
gettext: update to 0.25

### DIFF
--- a/app-devel/gettext/autobuild/beyond
+++ b/app-devel/gettext/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Setting executable bit for libintl_m2 ..."
+chmod -v +x "$PKGDIR"/usr/lib/libintl_m2.so*

--- a/app-devel/gettext/autobuild/defines
+++ b/app-devel/gettext/autobuild/defines
@@ -3,7 +3,23 @@ PKGDES="GNU internationalization (i18n) library and utilities"
 PKGDEP="glibc libunistring acl glib libcroco ncurses"
 PKGSEC=devel
 
+# FIXME: *** Subdirectory 'gnulib' does not yet exist. Use './gitsub.sh pull' to create it, or set the environment variable GNULIB_SRCDIR.
 RECONF=0
+
+# Note: Multi-level source.
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--disable-csharp --disable-java"
+AUTOTOOLS_AFTER=(
+    '--disable-csharp'
+    '--disable-java'
+)
+
 PKGEPOCH=1
+
+# FIXME: Race condition during installation.
+#
+# libtool: install: /usr/bin/install -c .libs/libintl_m2.so.0.0.0 [...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0
+# libtool: install: /usr/bin/install -c -m 644 .libs/libintl_m2.so.0.0.0 [...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0
+# install: cannot create regular file '[...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0': File exists
+# make[5]: *** [Makefile:2356: install-libLTLIBRARIES] Error 1
+# make[5]: *** Waiting for unfinished jobs....
+NOPARALLEL=1

--- a/app-devel/gettext/autobuild/defines.stage2
+++ b/app-devel/gettext/autobuild/defines.stage2
@@ -3,9 +3,24 @@ PKGDES="GNU internationalization (i18n) library and utilities"
 PKGDEP="glibc libunistring acl ncurses"
 PKGSEC=devel
 
+# FIXME: *** Subdirectory 'gnulib' does not yet exist. Use './gitsub.sh pull' to create it, or set the environment variable GNULIB_SRCDIR.
 RECONF=0
+
+# Note: Multi-level source.
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--disable-shared \
-                 --disable-csharp \
-                 --disable-java"
+AUTOTOOLS_AFTER=(
+    '--disable-shared'
+    '--disable-csharp'
+    '--disable-java'
+)
+
 PKGEPOCH=1
+
+# FIXME: Race condition during installation.
+#
+# libtool: install: /usr/bin/install -c .libs/libintl_m2.so.0.0.0 [...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0
+# libtool: install: /usr/bin/install -c -m 644 .libs/libintl_m2.so.0.0.0 [...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0
+# install: cannot create regular file '[...]/gettext-0.25/abdist/usr/lib/libintl_m2.so.0.0.0': File exists
+# make[5]: *** [Makefile:2356: install-libLTLIBRARIES] Error 1
+# make[5]: *** Waiting for unfinished jobs....
+NOPARALLEL=1

--- a/app-devel/gettext/autobuild/prepare
+++ b/app-devel/gettext/autobuild/prepare
@@ -1,1 +1,0 @@
-export LDFLAGS="${LDFLAGS} -lm"

--- a/app-devel/gettext/spec
+++ b/app-devel/gettext/spec
@@ -1,4 +1,4 @@
-VER=0.24
+VER=0.25
 SRCS="https://ftp.gnu.org/gnu/gettext/gettext-$VER.tar.xz"
-CHKSUMS="sha256::e1620d518b26d7d3b16ac570e5018206e8b0d725fb65c02d048397718b5cf318"
+CHKSUMS="sha256::05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"
 CHKUPDATE="anitya::id=898"


### PR DESCRIPTION
Topic Description
-----------------

- gettext: update to 0.25
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gettext: 1:0.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit gettext
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
