### PR TITLE
powertop: fix build and enhance functionalities

### DIFF
--- a/app-utils/powertop/autobuild/defines
+++ b/app-utils/powertop/autobuild/defines
@@ -1,9 +1,18 @@
 PKGNAME=powertop
 PKGSEC=utils
-PKGDEP="gcc-runtime libnl ncurses pciutils"
-PKGDES="A tool to diagnose issues with power consumption and power management"
+PKGDEP="gcc-runtime libnl libtraceevent libtracefs ncurses pciutils"
+PKGDES="Tool to diagnose power consumption and power management"
 
-AUTOTOOLS_AFTER="--enable-nls \
-                 --disable-rpath"
+# FIXME: autogen.sh fails due to Gettext changes. Running autoreconf
+# manually in prepare.
+#
+# autopoint: File po/Makefile.in.in has been locally modified.
+# autopoint: *** Some files have been locally modified. Not overwriting them because --force has not been specified. For your convenience, you fin d the local modifications in the file '/tmp/arNknh2L/gtCA0FSW/autopoint.diff'.
+# autopoint: *** Stop.
+RECONF=0
+AUTOTOOLS_AFTER=(
+    '--enable-nls'
+    '--disable-rpath'
+)
 
 PKGEPOCH=2

--- a/app-utils/powertop/autobuild/patches/0001-tracefs-Use-libtracefs-and-libtraceevent.patch
+++ b/app-utils/powertop/autobuild/patches/0001-tracefs-Use-libtracefs-and-libtraceevent.patch
@@ -1,0 +1,10657 @@
+From 99ad9847e09db1fad32e2cd4230002fc7bdfa489 Mon Sep 17 00:00:00 2001
+From: "Steven Rostedt (Google)" <rostedt@goodmis.org>
+Date: Fri, 3 Mar 2023 15:33:50 -0500
+Subject: [PATCH 1/7] tracefs: Use libtracefs and libtraceevent
+
+It's been over 10 years that powertop used a copy of libtraceevent as a
+temporary case until the libtraceevent library was ready for use. Well,
+it's been ready for use for several years now. libtracefs has also been
+added, which is a superset of libtraceevent and takes care of accessing
+files in the tracefs file system (and will even find it for you).
+
+Currently, this update only converts over to using the libraries and
+removes its internal copy. It does not yet take advantage of libtracefs,
+but will shortly.
+
+Note, some naming convention updates have taken place in the creation of
+libtracefs. Namely, "pevent" is no longer used, and instead "tep" is (for
+trace event parser).
+
+Signed-off-by: Steven Rostedt (Google) <rostedt@goodmis.org>
+---
+ Makefile.am                |    1 -
+ README.traceevent          |   20 -
+ configure.ac               |    7 +-
+ src/Makefile.am            |   10 +-
+ src/cpu/cpu.cpp            |   12 +-
+ src/perf/perf.cpp          |   22 +-
+ src/perf/perf.h            |    4 +-
+ src/perf/perf_bundle.cpp   |   12 +-
+ src/process/do_process.cpp |   70 +-
+ traceevent/Makefile.am     |    7 -
+ traceevent/event-parse.c   | 5664 ------------------------------------
+ traceevent/event-parse.h   |  857 ------
+ traceevent/event-utils.h   |   85 -
+ traceevent/kbuffer-parse.c |  732 -----
+ traceevent/kbuffer.h       |   67 -
+ traceevent/parse-filter.c  | 2303 ---------------
+ traceevent/parse-utils.c   |  129 -
+ traceevent/trace-seq.c     |  212 --
+ 18 files changed, 71 insertions(+), 10143 deletions(-)
+ delete mode 100644 README.traceevent
+ delete mode 100644 traceevent/Makefile.am
+ delete mode 100644 traceevent/event-parse.c
+ delete mode 100644 traceevent/event-parse.h
+ delete mode 100644 traceevent/event-utils.h
+ delete mode 100644 traceevent/kbuffer-parse.c
+ delete mode 100644 traceevent/kbuffer.h
+ delete mode 100644 traceevent/parse-filter.c
+ delete mode 100644 traceevent/parse-utils.c
+ delete mode 100644 traceevent/trace-seq.c
+
+diff --git a/Makefile.am b/Makefile.am
+index 34d085c..0965e25 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,7 +2,6 @@ AUTOMAKE_OPTIONS = subdir-objects
+ ACLOCAL_AMFLAGS = --install -I m4
+ 
+ SUBDIRS = \
+-	traceevent \
+ 	src \
+ 	po \
+ 	doc \
+diff --git a/README.traceevent b/README.traceevent
+deleted file mode 100644
+index 0747766..0000000
+--- a/README.traceevent
++++ /dev/null
+@@ -1,20 +0,0 @@
+-traceevent: 
+-
+-The traceevent library being built in PowerTOP is really a effort by
+-Steven Rostedt.  The long term intent is for Steven to push the trace
+-event library to distributions, and consume it externally.  Right now the
+-PowerTOP project is keeping in sync with his code posted in the Linux
+-kernel git under tools/lib/traceevent.  We will not take patches into the
+-traceevent code directly, rather we will be re-basing against that code
+-base.
+-
+-If you find a bug in the trace event code, you should to one of two things. 
+-
+-1. Send a patch to the PowerTOP mailing list, which will get forwared to
+-   Steven if appropriate.
+-
+-2. Send a patch to the PowerTOP mailing list, and
+-   CC: Steven Rostedt <rostedt@goodmis.org>
+-
+-Please do use the PowerTOP mailing list to discuss topics about
+-traceevent as its used with PowerTOP.
+diff --git a/configure.ac b/configure.ac
+index f057463..a69cf61 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -13,7 +13,6 @@ AC_CONFIG_FILES([
+ 	Makefile
+ 	Doxyfile
+ 	src/Makefile
+-	traceevent/Makefile
+ 	po/Makefile.in
+ 	doc/Makefile
+ 	scripts/bash-completion/Makefile
+@@ -128,6 +127,12 @@ PKG_CHECK_MODULES([PCIUTILS], [libpci],[has_libpci=1], [
+ 	AC_SEARCH_LIBS([pci_get_dev], [pci],[has_libpci=1], [has_libpci=0])
+ ])
+  
++has_libtracefs=0
++PKG_CHECK_MODULES([LIBTRACEFS], [libtracefs],[has_libtracefs=1], [
++	AC_SEARCH_LIBS([tracefs_local_events], [libtracefs], [], [
++		AC_MSG_ERROR([libtracefs is required but was not found])
++	], [])
++])
+ 
+ has_libnl_ver=0
+ dnl libnl-2 provides only libnl-2.0.pc file, so we check for separate
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 6b523f6..f725fd7 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -139,11 +139,13 @@ powertop_CXXFLAGS = \
+ 	-Wshadow \
+ 	-fno-omit-frame-pointer \
+ 	-fstack-protector \
++	-fpermissive \
+ 	$(GLIB2_CFLAGS) \
+ 	$(LIBNL_CFLAGS) \
+ 	$(NCURSES_CFLAGS) \
+ 	$(PCIUTILS_CFLAGS) \
+-	$(PTHREAD_CFLAGS)
++	$(PTHREAD_CFLAGS) \
++	$(LIBTRACEFS_CFLAGS)
+ 
+ 
+ powertop_CPPFLAGS = \
+@@ -155,9 +157,6 @@ powertop_CPPFLAGS = \
+ 	$(PCIUTILS_CFLAGS) \
+ 	$(PTHREAD_CFLAGS)
+ 
+-powertop_LDADD = \
+-	../traceevent/libtraceevnet.la
+-
+ AM_LDFLAGS = \
+ 	$(LIBNL_LIBS) \
+ 	$(LIBS) \
+@@ -165,7 +164,8 @@ AM_LDFLAGS = \
+ 	$(NCURSES_LIBS) \
+ 	$(PCIUTILS_LIBS) \
+ 	$(PTHREAD_LIBS) \
+-	$(RESOLV_LIBS)
++	$(RESOLV_LIBS) \
++	$(LIBTRACEFS_LIBS)
+ 
+ BUILT_SOURCES = css.h
+ CLEANFILES = css.h
+diff --git a/src/cpu/cpu.cpp b/src/cpu/cpu.cpp
+index 1c12765..3661246 100644
+--- a/src/cpu/cpu.cpp
++++ b/src/cpu/cpu.cpp
+@@ -969,15 +969,15 @@ struct power_entry {
+ 
+ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time)
+ {
+-	struct event_format *event;
+-        struct pevent_record rec; /* holder */
++	struct tep_event *event;
++        struct tep_record rec; /* holder */
+ 	class abstract_cpu *cpu;
+ 	int type;
+ 
+ 	rec.data = trace;
+ 
+-	type = pevent_data_type(perf_event::pevent, &rec);
+-	event = pevent_find_event(perf_event::pevent, type);
++	type = tep_data_type(perf_event::tep, &rec);
++	event = tep_find_event(perf_event::tep, type);
+ 
+ 	if (!event)
+ 		return;
+@@ -1000,7 +1000,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
+ 	int ret;
+ 	if (strcmp(event->name, "cpu_idle")==0) {
+ 
+-		ret = pevent_get_field_val(NULL, event, "state", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+                 if (ret < 0) {
+                         fprintf(stderr, _("cpu_idle event returned no state?\n"));
+                         exit(-1);
+@@ -1015,7 +1015,7 @@ void perf_power_bundle::handle_trace_point(void *trace, int cpunr, uint64_t time
+ 	if (strcmp(event->name, "power_frequency") == 0
+ 	|| strcmp(event->name, "cpu_frequency") == 0){
+ 
+-		ret = pevent_get_field_val(NULL, event, "state", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+ 		if (ret < 0) {
+ 			fprintf(stderr, _("power or cpu_frequency event returned no state?\n"));
+ 			exit(-1);
+diff --git a/src/perf/perf.cpp b/src/perf/perf.cpp
+index 9ed0ba8..691baac 100644
+--- a/src/perf/perf.cpp
++++ b/src/perf/perf.cpp
+@@ -44,7 +44,7 @@
+ #include "../lib.h"
+ #include "../display.h"
+ 
+-struct pevent *perf_event::pevent;
++struct tep_handle *perf_event::tep;
+ 
+ static int get_trace_type(const char *eventname)
+ {
+@@ -169,12 +169,12 @@ perf_event::~perf_event(void)
+ {
+ 	free(name);
+ 
+-	if (perf_event::pevent->ref_count == 1) {
+-		pevent_free(perf_event::pevent);
+-		perf_event::pevent = NULL;
++	if (tep_get_ref(perf_event::tep) == 1) {
++		tep_free(perf_event::tep);
++		perf_event::tep = NULL;
+ 		clear();
+ 	} else
+-		pevent_unref(perf_event::pevent);
++		tep_unref(perf_event::tep);
+ }
+ 
+ void perf_event::set_cpu(int _cpu)
+@@ -182,17 +182,17 @@ void perf_event::set_cpu(int _cpu)
+ 	cpu = _cpu;
+ }
+ 
+-static void allocate_pevent(void)
++static void allocate_tep(void)
+ {
+-	if (!perf_event::pevent)
+-		perf_event::pevent = pevent_alloc();
++	if (!perf_event::tep)
++		perf_event::tep = tep_alloc();
+ 	else
+-		pevent_ref(perf_event::pevent);
++		tep_ref(perf_event::tep);
+ }
+ 
+ perf_event::perf_event(const char *event_name, int _cpu, int buffer_size)
+ {
+-	allocate_pevent();
++	allocate_tep();
+ 	name = NULL;
+ 	perf_fd = -1;
+ 	bufsize = buffer_size;
+@@ -204,7 +204,7 @@ perf_event::perf_event(const char *event_name, int _cpu, int buffer_size)
+ 
+ perf_event::perf_event(void)
+ {
+-	allocate_pevent();
++	allocate_tep();
+ 	name = NULL;
+ 	perf_fd = -1;
+ 	bufsize = 128;
+diff --git a/src/perf/perf.h b/src/perf/perf.h
+index ee072ae..678d71d 100644
+--- a/src/perf/perf.h
++++ b/src/perf/perf.h
+@@ -29,7 +29,7 @@
+ 
+ 
+ extern "C" {
+-	#include "../traceevent/event-parse.h"
++	#include <tracefs.h>
+ }
+ 
+ 
+@@ -69,7 +69,7 @@ public:
+ 
+ 	virtual void handle_event(struct perf_event_header *header, void *cookie) { };
+ 
+-	static struct pevent *pevent;
++	static struct tep_handle *tep;
+ 
+ };
+ 
+diff --git a/src/perf/perf_bundle.cpp b/src/perf/perf_bundle.cpp
+index 3d216ff..56788fc 100644
+--- a/src/perf/perf_bundle.cpp
++++ b/src/perf/perf_bundle.cpp
+@@ -148,7 +148,7 @@ static void parse_event_format(const char *event_name)
+ 		return;
+ 	}
+ 
+-	pevent_parse_event(perf_event::pevent, buf, strlen(buf), sys);
++	tep_parse_event(perf_event::tep, buf, strlen(buf), sys);
+ 	free(name);
+ 	free(buf);
+ }
+@@ -295,19 +295,19 @@ static bool event_sort_function (void *i, void *j)
+  */
+ static void fixup_sample_trace_cpu(struct perf_sample *sample)
+ {
+-	struct event_format *event;
+-	struct pevent_record rec;
++	struct tep_event *event;
++	struct tep_record rec;
+ 	unsigned long long cpu_nr;
+ 	int type;
+ 	int ret;
+ 
+ 	rec.data = &sample->data;
+-	type = pevent_data_type(perf_event::pevent, &rec);
+-	event = pevent_find_event(perf_event::pevent, type);
++	type = tep_data_type(perf_event::tep, &rec);
++	event = tep_find_event(perf_event::tep, type);
+ 	if (!event)
+ 		return;
+ 	/** don't touch trace if event does not contain cpu_id field*/
+-	ret = pevent_get_field_val(NULL, event, "cpu_id", &rec, &cpu_nr, 0);
++	ret = tep_get_field_val(NULL, event, "cpu_id", &rec, &cpu_nr, 0);
+ 	if (ret < 0)
+ 		return;
+ 	sample->trace.cpu = cpu_nr;
+diff --git a/src/process/do_process.cpp b/src/process/do_process.cpp
+index be8d3bd..d255a66 100644
+--- a/src/process/do_process.cpp
++++ b/src/process/do_process.cpp
+@@ -188,13 +188,13 @@ int dont_blame_me(char *comm)
+ 	return 0;
+ }
+ 
+-static char * get_pevent_field_str(void *trace, struct event_format *event, struct format_field *field)
++static char * get_tep_field_str(void *trace, struct tep_event *event, struct tep_format_field *field)
+ {
+ 	unsigned long long offset, len;
+-	if (field->flags & FIELD_IS_DYNAMIC) {
++	if (field->flags & TEP_FIELD_IS_DYNAMIC) {
+ 		offset = field->offset;
+ 		len = field->size;
+-		offset = pevent_read_number(event->pevent, (char *)trace + offset, len);
++		offset = tep_read_number(event->tep, (char *)trace + offset, len);
+ 		offset &= 0xffff;
+ 		return (char *)trace + offset;
+ 	}
+@@ -204,17 +204,17 @@ static char * get_pevent_field_str(void *trace, struct event_format *event, stru
+ 
+ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time)
+ {
+-	struct event_format *event;
+-	struct pevent_record rec; /* holder */
+-	struct format_field *field;
++	struct tep_event *event;
++	struct tep_record rec; /* holder */
++	struct tep_format_field *field;
+ 	unsigned long long val;
+ 	int type;
+ 	int ret;
+ 
+ 	rec.data = trace;
+ 
+-	type = pevent_data_type(perf_event::pevent, &rec);
+-	event = pevent_find_event(perf_event::pevent, type);
++	type = tep_data_type(perf_event::tep, &rec);
++	event = tep_find_event(perf_event::tep, type);
+ 	if (!event)
+ 		return;
+ 
+@@ -233,18 +233,18 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		int next_pid;
+ 		int prev_pid;
+ 
+-		field = pevent_find_any_field(event, "next_comm");
+-		if (!field || !(field->flags & FIELD_IS_STRING))
++		field = tep_find_any_field(event, "next_comm");
++		if (!field || !(field->flags & TEP_FIELD_IS_STRING))
+ 			return; /* ?? */
+ 
+-		next_comm = get_pevent_field_str(trace, event, field);
++		next_comm = get_tep_field_str(trace, event, field);
+ 
+-		ret = pevent_get_field_val(NULL, event, "next_pid", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "next_pid", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		next_pid = (int)val;
+ 
+-		ret = pevent_get_field_val(NULL, event, "prev_pid", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "prev_pid", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		prev_pid = (int)val;
+@@ -301,7 +301,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		int flags;
+ 		int pid;
+ 
+-		ret = pevent_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
++		ret = tep_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		flags = (int)val;
+@@ -322,14 +322,14 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		}
+ 
+ 
+-		field = pevent_find_any_field(event, "comm");
++		field = tep_find_any_field(event, "comm");
+ 
+-		if (!field || !(field->flags & FIELD_IS_STRING))
++		if (!field || !(field->flags & TEP_FIELD_IS_STRING))
+  			return;
+ 
+-		comm = get_pevent_field_str(trace, event, field);
++		comm = get_tep_field_str(trace, event, field);
+ 
+-		ret = pevent_get_field_val(NULL, event, "pid", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "pid", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		pid = (int)val;
+@@ -359,13 +359,13 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		const char *handler;
+ 		int nr;
+ 
+-		field = pevent_find_any_field(event, "name");
+-		if (!field || !(field->flags & FIELD_IS_STRING))
++		field = tep_find_any_field(event, "name");
++		if (!field || !(field->flags & TEP_FIELD_IS_STRING))
+ 			return; /* ?? */
+ 
+-		handler = get_pevent_field_str(trace, event, field);
++		handler = get_tep_field_str(trace, event, field);
+ 
+-		ret = pevent_get_field_val(NULL, event, "irq", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "irq", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		nr = (int)val;
+@@ -401,7 +401,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		const char *handler = NULL;
+ 		int vec;
+ 
+-		ret = pevent_get_field_val(NULL, event, "vec", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "vec", &rec, &val, 0);
+                 if (ret < 0) {
+                         fprintf(stderr, "softirq_entry event returned no vector number?\n");
+                         return;
+@@ -438,7 +438,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		uint64_t function;
+ 		uint64_t tmr;
+ 
+-		ret = pevent_get_field_val(NULL, event, "function", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+ 		if (ret < 0) {
+ 			fprintf(stderr, "timer_expire_entry event returned no function value?\n");
+ 			return;
+@@ -450,7 +450,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		if (timer->is_deferred())
+ 			return;
+ 
+-		ret = pevent_get_field_val(NULL, event, "timer", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "timer", &rec, &val, 0);
+ 		if (ret < 0) {
+ 			fprintf(stderr, "softirq_entry event returned no timer ?\n");
+ 			return;
+@@ -468,7 +468,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		uint64_t tmr;
+ 		uint64_t t;
+ 
+-		ret = pevent_get_field_val(NULL, event, "timer", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "timer", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		tmr = (uint64_t)val;
+@@ -490,14 +490,14 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		uint64_t function;
+ 		uint64_t tmr;
+ 
+-		ret = pevent_get_field_val(NULL, event, "function", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		function = (uint64_t)val;
+ 
+ 		timer = find_create_timer(function);
+ 
+-		ret = pevent_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		tmr = (uint64_t)val;
+@@ -518,7 +518,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 			return;
+ 		}
+ 
+-		ret = pevent_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "hrtimer", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		tmr = (uint64_t)val;
+@@ -536,12 +536,12 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		uint64_t function;
+ 		uint64_t wk;
+ 
+-		ret = pevent_get_field_val(NULL, event, "function", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "function", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		function = (uint64_t)val;
+ 
+-		ret = pevent_get_field_val(NULL, event, "work", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "work", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		wk = (uint64_t)val;
+@@ -561,7 +561,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		uint64_t t;
+ 		uint64_t wk;
+ 
+-		ret = pevent_get_field_val(NULL, event, "work", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "work", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		wk = (uint64_t)val;
+@@ -579,7 +579,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		consumer_child_time(cpu, t);
+ 	}
+ 	else if (strcmp(event->name, "cpu_idle") == 0) {
+-		pevent_get_field_val(NULL, event, "state", &rec, &val, 0);
++		tep_get_field_val(NULL, event, "state", &rec, &val, 0);
+ 		if (val == (unsigned int)-1)
+ 			consume_blame(cpu);
+ 		else
+@@ -598,7 +598,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 		class power_consumer *consumer = NULL;
+ 		int flags;
+ 
+-		ret = pevent_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
++		ret = tep_get_common_field_val(NULL, event, "common_flags", &rec, &val, 0);
+ 		if (ret < 0)
+ 			return;
+ 		flags = (int)val;
+@@ -632,7 +632,7 @@ void perf_process_bundle::handle_trace_point(void *trace, int cpu, uint64_t time
+ 
+ 		consumer = current_consumer(cpu);
+ 
+-		ret = pevent_get_field_val(NULL, event, "dev", &rec, &val, 0);
++		ret = tep_get_field_val(NULL, event, "dev", &rec, &val, 0);
+ 		if (ret < 0)
+ 
+ 			return;
+diff --git a/traceevent/Makefile.am b/traceevent/Makefile.am
+deleted file mode 100644
+index d3ee608..0000000
+--- a/traceevent/Makefile.am
++++ /dev/null
+@@ -1,7 +0,0 @@
+-noinst_LTLIBRARIES = libtraceevnet.la
+-libtraceevnet_la_SOURCES = event-parse.c \
+-			event-parse.h \
+-			event-utils.h \
+-			parse-filter.c\
+-			parse-utils.c \
+-			trace-seq.c
+diff --git a/traceevent/event-parse.c b/traceevent/event-parse.c
+deleted file mode 100644
+index 1f7eb80..0000000
+--- a/traceevent/event-parse.c
++++ /dev/null
+@@ -1,5664 +0,0 @@
+-/*
+- * Copyright (C) 2009, 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- *
+- *  The parts for function graph printing was taken and modified from the
+- *  Linux Kernel that were written by
+- *    - Copyright (C) 2009  Frederic Weisbecker,
+- *  Frederic Weisbecker gave his permission to relicense the code to
+- *  the Lesser General Public License.
+- */
+-#define _GNU_SOURCE
+-
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <stdarg.h>
+-#include <ctype.h>
+-#include <errno.h>
+-#include <stdint.h>
+-#include <limits.h>
+-
+-#include "event-parse.h"
+-#include "event-utils.h"
+-
+-static const char *input_buf;
+-static unsigned long long input_buf_ptr;
+-static unsigned long long input_buf_siz;
+-
+-static int is_flag_field;
+-static int is_symbolic_field;
+-
+-static int show_warning = 1;
+-
+-#define do_warning(fmt, ...)				\
+-	do {						\
+-		if (show_warning)			\
+-			warning(fmt, ##__VA_ARGS__);	\
+-	} while (0)
+-
+-static void init_input_buf(const char *buf, unsigned long long size)
+-{
+-	input_buf = buf;
+-	input_buf_siz = size;
+-	input_buf_ptr = 0;
+-}
+-
+-const char *pevent_get_input_buf(void)
+-{
+-	return input_buf;
+-}
+-
+-unsigned long long pevent_get_input_buf_ptr(void)
+-{
+-	return input_buf_ptr;
+-}
+-
+-struct event_handler {
+-	struct event_handler		*next;
+-	int				id;
+-	const char			*sys_name;
+-	const char			*event_name;
+-	pevent_event_handler_func	func;
+-	void				*context;
+-};
+-
+-struct pevent_func_params {
+-	struct pevent_func_params	*next;
+-	enum pevent_func_arg_type	type;
+-};
+-
+-struct pevent_function_handler {
+-	struct pevent_function_handler	*next;
+-	enum pevent_func_arg_type	ret_type;
+-	char				*name;
+-	pevent_func_handler		func;
+-	struct pevent_func_params	*params;
+-	int				nr_args;
+-};
+-
+-static unsigned long long
+-process_defined_func(struct trace_seq *s, void *data, int size,
+-		     struct event_format *event, struct print_arg *arg);
+-
+-static void free_func_handle(struct pevent_function_handler *func);
+-
+-/**
+- * pevent_buffer_init - init buffer for parsing
+- * @buf: buffer to parse
+- * @size: the size of the buffer
+- *
+- * For use with pevent_read_token(), this initializes the internal
+- * buffer that pevent_read_token() will parse.
+- */
+-void pevent_buffer_init(const char *buf, unsigned long long size)
+-{
+-	init_input_buf(buf, size);
+-}
+-
+-void breakpoint(void)
+-{
+-	static int x;
+-	x++;
+-}
+-
+-struct print_arg *alloc_arg(void)
+-{
+-	return calloc(1, sizeof(struct print_arg));
+-}
+-
+-struct cmdline {
+-	char *comm;
+-	int pid;
+-};
+-
+-static int cmdline_cmp(const void *a, const void *b)
+-{
+-	const struct cmdline *ca = a;
+-	const struct cmdline *cb = b;
+-
+-	if (ca->pid < cb->pid)
+-		return -1;
+-	if (ca->pid > cb->pid)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-struct cmdline_list {
+-	struct cmdline_list	*next;
+-	char			*comm;
+-	int			pid;
+-};
+-
+-static int cmdline_init(struct pevent *pevent)
+-{
+-	struct cmdline_list *cmdlist = pevent->cmdlist;
+-	struct cmdline_list *item;
+-	struct cmdline *cmdlines;
+-	int i;
+-
+-	cmdlines = malloc(sizeof(*cmdlines) * pevent->cmdline_count);
+-	if (!cmdlines)
+-		return -1;
+-
+-	i = 0;
+-	while (cmdlist) {
+-		cmdlines[i].pid = cmdlist->pid;
+-		cmdlines[i].comm = cmdlist->comm;
+-		i++;
+-		item = cmdlist;
+-		cmdlist = cmdlist->next;
+-		free(item);
+-	}
+-
+-	qsort(cmdlines, pevent->cmdline_count, sizeof(*cmdlines), cmdline_cmp);
+-
+-	pevent->cmdlines = cmdlines;
+-	pevent->cmdlist = NULL;
+-
+-	return 0;
+-}
+-
+-static const char *find_cmdline(struct pevent *pevent, int pid)
+-{
+-	const struct cmdline *comm;
+-	struct cmdline key;
+-
+-	if (!pid)
+-		return "<idle>";
+-
+-	if (!pevent->cmdlines && cmdline_init(pevent))
+-		return "<not enough memory for cmdlines!>";
+-
+-	key.pid = pid;
+-
+-	comm = bsearch(&key, pevent->cmdlines, pevent->cmdline_count,
+-		       sizeof(*pevent->cmdlines), cmdline_cmp);
+-
+-	if (comm)
+-		return comm->comm;
+-	return "<...>";
+-}
+-
+-/**
+- * pevent_pid_is_registered - return if a pid has a cmdline registered
+- * @pevent: handle for the pevent
+- * @pid: The pid to check if it has a cmdline registered with.
+- *
+- * Returns 1 if the pid has a cmdline mapped to it
+- * 0 otherwise.
+- */
+-int pevent_pid_is_registered(struct pevent *pevent, int pid)
+-{
+-	const struct cmdline *comm;
+-	struct cmdline key;
+-
+-	if (!pid)
+-		return 1;
+-
+-	if (!pevent->cmdlines && cmdline_init(pevent))
+-		return 0;
+-
+-	key.pid = pid;
+-
+-	comm = bsearch(&key, pevent->cmdlines, pevent->cmdline_count,
+-		       sizeof(*pevent->cmdlines), cmdline_cmp);
+-
+-	if (comm)
+-		return 1;
+-	return 0;
+-}
+-
+-/*
+- * If the command lines have been converted to an array, then
+- * we must add this pid. This is much slower than when cmdlines
+- * are added before the array is initialized.
+- */
+-static int add_new_comm(struct pevent *pevent, const char *comm, int pid)
+-{
+-	struct cmdline *newcmdlines, *cmdlines = pevent->cmdlines;
+-	const struct cmdline *cmdline;
+-	struct cmdline key;
+-
+-	if (!pid)
+-		return 0;
+-
+-	/* avoid duplicates */
+-	key.pid = pid;
+-
+-	cmdline = bsearch(&key, pevent->cmdlines, pevent->cmdline_count,
+-		       sizeof(*pevent->cmdlines), cmdline_cmp);
+-	if (cmdline) {
+-		errno = EEXIST;
+-		return -1;
+-	}
+-
+-	newcmdlines = realloc(cmdlines, sizeof(*cmdlines) * (pevent->cmdline_count + 1));
+-	if (!newcmdlines) {
+-		free(cmdlines);
+-		errno = ENOMEM;
+-		return -1;
+-	}
+-	cmdlines = newcmdlines;
+-
+-	cmdlines[pevent->cmdline_count].comm = strdup(comm);
+-	if (!cmdlines[pevent->cmdline_count].comm) {
+-		free(cmdlines);
+-		errno = ENOMEM;
+-		return -1;
+-	}
+-
+-	cmdlines[pevent->cmdline_count].pid = pid;
+-		
+-	if (cmdlines[pevent->cmdline_count].comm)
+-		pevent->cmdline_count++;
+-
+-	qsort(cmdlines, pevent->cmdline_count, sizeof(*cmdlines), cmdline_cmp);
+-	pevent->cmdlines = cmdlines;
+-
+-	return 0;
+-}
+-
+-/**
+- * pevent_register_comm - register a pid / comm mapping
+- * @pevent: handle for the pevent
+- * @comm: the command line to register
+- * @pid: the pid to map the command line to
+- *
+- * This adds a mapping to search for command line names with
+- * a given pid. The comm is duplicated.
+- */
+-int pevent_register_comm(struct pevent *pevent, const char *comm, int pid)
+-{
+-	struct cmdline_list *item;
+-
+-	if (pevent->cmdlines)
+-		return add_new_comm(pevent, comm, pid);
+-
+-	item = malloc(sizeof(*item));
+-	if (!item)
+-		return -1;
+-
+-	item->comm = strdup(comm);
+-	if (!item->comm) {
+-		free(item);
+-		return -1;
+-	}
+-	item->pid = pid;
+-	item->next = pevent->cmdlist;
+-
+-	pevent->cmdlist = item;
+-	pevent->cmdline_count++;
+-
+-	return 0;
+-}
+-
+-struct func_map {
+-	unsigned long long		addr;
+-	char				*func;
+-	char				*mod;
+-};
+-
+-struct func_list {
+-	struct func_list	*next;
+-	unsigned long long	addr;
+-	char			*func;
+-	char			*mod;
+-};
+-
+-static int func_cmp(const void *a, const void *b)
+-{
+-	const struct func_map *fa = a;
+-	const struct func_map *fb = b;
+-
+-	if (fa->addr < fb->addr)
+-		return -1;
+-	if (fa->addr > fb->addr)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-/*
+- * We are searching for a record in between, not an exact
+- * match.
+- */
+-static int func_bcmp(const void *a, const void *b)
+-{
+-	const struct func_map *fa = a;
+-	const struct func_map *fb = b;
+-
+-	if ((fa->addr == fb->addr) ||
+-
+-	    (fa->addr > fb->addr &&
+-	     fa->addr < (fb+1)->addr))
+-		return 0;
+-
+-	if (fa->addr < fb->addr)
+-		return -1;
+-
+-	return 1;
+-}
+-
+-static int func_map_init(struct pevent *pevent)
+-{
+-	struct func_list *funclist;
+-	struct func_list *item;
+-	struct func_map *func_map;
+-	int i;
+-
+-	func_map = malloc(sizeof(*func_map) * (pevent->func_count + 1));
+-	if (!func_map)
+-		return -1;
+-
+-	funclist = pevent->funclist;
+-
+-	i = 0;
+-	while (funclist) {
+-		func_map[i].func = funclist->func;
+-		func_map[i].addr = funclist->addr;
+-		func_map[i].mod = funclist->mod;
+-		i++;
+-		item = funclist;
+-		funclist = funclist->next;
+-		free(item);
+-	}
+-
+-	qsort(func_map, pevent->func_count, sizeof(*func_map), func_cmp);
+-
+-	/*
+-	 * Add a special record at the end.
+-	 */
+-	func_map[pevent->func_count].func = NULL;
+-	func_map[pevent->func_count].addr = 0;
+-	func_map[pevent->func_count].mod = NULL;
+-
+-	pevent->func_map = func_map;
+-	pevent->funclist = NULL;
+-
+-	return 0;
+-}
+-
+-static struct func_map *
+-find_func(struct pevent *pevent, unsigned long long addr)
+-{
+-	struct func_map *func;
+-	struct func_map key;
+-
+-	if (!pevent->func_map)
+-		func_map_init(pevent);
+-
+-	key.addr = addr;
+-
+-	func = bsearch(&key, pevent->func_map, pevent->func_count,
+-		       sizeof(*pevent->func_map), func_bcmp);
+-
+-	return func;
+-}
+-
+-/**
+- * pevent_find_function - find a function by a given address
+- * @pevent: handle for the pevent
+- * @addr: the address to find the function with
+- *
+- * Returns a pointer to the function stored that has the given
+- * address. Note, the address does not have to be exact, it
+- * will select the function that would contain the address.
+- */
+-const char *pevent_find_function(struct pevent *pevent, unsigned long long addr)
+-{
+-	struct func_map *map;
+-
+-	map = find_func(pevent, addr);
+-	if (!map)
+-		return NULL;
+-
+-	return map->func;
+-}
+-
+-/**
+- * pevent_find_function_address - find a function address by a given address
+- * @pevent: handle for the pevent
+- * @addr: the address to find the function with
+- *
+- * Returns the address the function starts at. This can be used in
+- * conjunction with pevent_find_function to print both the function
+- * name and the function offset.
+- */
+-unsigned long long
+-pevent_find_function_address(struct pevent *pevent, unsigned long long addr)
+-{
+-	struct func_map *map;
+-
+-	map = find_func(pevent, addr);
+-	if (!map)
+-		return 0;
+-
+-	return map->addr;
+-}
+-
+-/**
+- * pevent_register_function - register a function with a given address
+- * @pevent: handle for the pevent
+- * @function: the function name to register
+- * @addr: the address the function starts at
+- * @mod: the kernel module the function may be in (NULL for none)
+- *
+- * This registers a function name with an address and module.
+- * The @func passed in is duplicated.
+- */
+-int pevent_register_function(struct pevent *pevent, char *func,
+-			     unsigned long long addr, char *mod)
+-{
+-	struct func_list *item = malloc(sizeof(*item));
+-
+-	if (!item)
+-		return -1;
+-
+-	item->next = pevent->funclist;
+-	item->func = strdup(func);
+-	if (!item->func)
+-		goto out_free;
+-
+-	if (mod) {
+-		item->mod = strdup(mod);
+-		if (!item->mod)
+-			goto out_free_func;
+-	} else
+-		item->mod = NULL;
+-	item->addr = addr;
+-
+-	pevent->funclist = item;
+-	pevent->func_count++;
+-
+-	return 0;
+-
+-out_free_func:
+-	free(item->func);
+-	item->func = NULL;
+-out_free:
+-	free(item);
+-	errno = ENOMEM;
+-	return -1;
+-}
+-
+-/**
+- * pevent_print_funcs - print out the stored functions
+- * @pevent: handle for the pevent
+- *
+- * This prints out the stored functions.
+- */
+-void pevent_print_funcs(struct pevent *pevent)
+-{
+-	int i;
+-
+-	if (!pevent->func_map)
+-		func_map_init(pevent);
+-
+-	for (i = 0; i < (int)pevent->func_count; i++) {
+-		printf("%016llx %s",
+-		       pevent->func_map[i].addr,
+-		       pevent->func_map[i].func);
+-		if (pevent->func_map[i].mod)
+-			printf(" [%s]\n", pevent->func_map[i].mod);
+-		else
+-			printf("\n");
+-	}
+-}
+-
+-struct printk_map {
+-	unsigned long long		addr;
+-	char				*printk;
+-};
+-
+-struct printk_list {
+-	struct printk_list	*next;
+-	unsigned long long	addr;
+-	char			*printk;
+-};
+-
+-static int printk_cmp(const void *a, const void *b)
+-{
+-	const struct printk_map *pa = a;
+-	const struct printk_map *pb = b;
+-
+-	if (pa->addr < pb->addr)
+-		return -1;
+-	if (pa->addr > pb->addr)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static int printk_map_init(struct pevent *pevent)
+-{
+-	struct printk_list *printklist;
+-	struct printk_list *item;
+-	struct printk_map *printk_map;
+-	int i;
+-
+-	printk_map = malloc(sizeof(*printk_map) * (pevent->printk_count + 1));
+-	if (!printk_map)
+-		return -1;
+-
+-	printklist = pevent->printklist;
+-
+-	i = 0;
+-	while (printklist) {
+-		printk_map[i].printk = printklist->printk;
+-		printk_map[i].addr = printklist->addr;
+-		i++;
+-		item = printklist;
+-		printklist = printklist->next;
+-		free(item);
+-	}
+-
+-	qsort(printk_map, pevent->printk_count, sizeof(*printk_map), printk_cmp);
+-
+-	pevent->printk_map = printk_map;
+-	pevent->printklist = NULL;
+-
+-	return 0;
+-}
+-
+-static struct printk_map *
+-find_printk(struct pevent *pevent, unsigned long long addr)
+-{
+-	struct printk_map *printk;
+-	struct printk_map key;
+-
+-	if (!pevent->printk_map && printk_map_init(pevent))
+-		return NULL;
+-
+-	key.addr = addr;
+-
+-	printk = bsearch(&key, pevent->printk_map, pevent->printk_count,
+-			 sizeof(*pevent->printk_map), printk_cmp);
+-
+-	return printk;
+-}
+-
+-/**
+- * pevent_register_print_string - register a string by its address
+- * @pevent: handle for the pevent
+- * @fmt: the string format to register
+- * @addr: the address the string was located at
+- *
+- * This registers a string by the address it was stored in the kernel.
+- * The @fmt passed in is duplicated.
+- */
+-int pevent_register_print_string(struct pevent *pevent, char *fmt,
+-				 unsigned long long addr)
+-{
+-	struct printk_list *item = malloc(sizeof(*item));
+-
+-	if (!item)
+-		return -1;
+-
+-	item->next = pevent->printklist;
+-	item->addr = addr;
+-
+-	item->printk = strdup(fmt);
+-	if (!item->printk)
+-		goto out_free;
+-
+-	pevent->printklist = item;
+-	pevent->printk_count++;
+-
+-	return 0;
+-
+-out_free:
+-	free(item);
+-	errno = ENOMEM;
+-	return -1;
+-}
+-
+-/**
+- * pevent_print_printk - print out the stored strings
+- * @pevent: handle for the pevent
+- *
+- * This prints the string formats that were stored.
+- */
+-void pevent_print_printk(struct pevent *pevent)
+-{
+-	int i;
+-
+-	if (!pevent->printk_map)
+-		printk_map_init(pevent);
+-
+-	for (i = 0; i < (int)pevent->printk_count; i++) {
+-		printf("%016llx %s\n",
+-		       pevent->printk_map[i].addr,
+-		       pevent->printk_map[i].printk);
+-	}
+-}
+-
+-static struct event_format *alloc_event(void)
+-{
+-	return calloc(1, sizeof(struct event_format));
+-}
+-
+-static int add_event(struct pevent *pevent, struct event_format *event)
+-{
+-	int i;
+-	struct event_format **events = realloc(pevent->events, sizeof(event) *
+-					       (pevent->nr_events + 1));
+-	if (!events)
+-		return -1;
+-
+-	pevent->events = events;
+-
+-	for (i = 0; i < pevent->nr_events; i++) {
+-		if (pevent->events[i]->id > event->id)
+-			break;
+-	}
+-	if (i < pevent->nr_events)
+-		memmove(&pevent->events[i + 1],
+-			&pevent->events[i],
+-			sizeof(event) * (pevent->nr_events - i));
+-
+-	pevent->events[i] = event;
+-	pevent->nr_events++;
+-
+-	event->pevent = pevent;
+-
+-	return 0;
+-}
+-
+-static int event_item_type(enum event_type type)
+-{
+-	switch (type) {
+-	case EVENT_ITEM ... EVENT_SQUOTE:
+-		return 1;
+-	case EVENT_ERROR ... EVENT_DELIM:
+-	default:
+-		return 0;
+-	}
+-}
+-
+-static void free_flag_sym(struct print_flag_sym *fsym)
+-{
+-	struct print_flag_sym *next;
+-
+-	while (fsym) {
+-		next = fsym->next;
+-		free(fsym->value);
+-		free(fsym->str);
+-		free(fsym);
+-		fsym = next;
+-	}
+-}
+-
+-static void free_arg(struct print_arg *arg)
+-{
+-	struct print_arg *farg;
+-
+-	if (!arg)
+-		return;
+-
+-	switch (arg->type) {
+-	case PRINT_ATOM:
+-		free(arg->atom.atom);
+-		break;
+-	case PRINT_FIELD:
+-		free(arg->field.name);
+-		break;
+-	case PRINT_FLAGS:
+-		free_arg(arg->flags.field);
+-		free(arg->flags.delim);
+-		free_flag_sym(arg->flags.flags);
+-		break;
+-	case PRINT_SYMBOL:
+-		free_arg(arg->symbol.field);
+-		free_flag_sym(arg->symbol.symbols);
+-		break;
+-	case PRINT_HEX:
+-		free_arg(arg->hex.field);
+-		free_arg(arg->hex.size);
+-		break;
+-	case PRINT_TYPE:
+-		free(arg->typecast.type);
+-		free_arg(arg->typecast.item);
+-		break;
+-	case PRINT_STRING:
+-	case PRINT_BSTRING:
+-		free(arg->string.string);
+-		break;
+-	case PRINT_DYNAMIC_ARRAY:
+-		free(arg->dynarray.index);
+-		break;
+-	case PRINT_OP:
+-		free(arg->op.op);
+-		free_arg(arg->op.left);
+-		free_arg(arg->op.right);
+-		break;
+-	case PRINT_FUNC:
+-		while (arg->func.args) {
+-			farg = arg->func.args;
+-			arg->func.args = farg->next;
+-			free_arg(farg);
+-		}
+-		break;
+-
+-	case PRINT_NULL:
+-	default:
+-		break;
+-	}
+-
+-	free(arg);
+-}
+-
+-static enum event_type get_type(int ch)
+-{
+-	if (ch == '\n')
+-		return EVENT_NEWLINE;
+-	if (isspace(ch))
+-		return EVENT_SPACE;
+-	if (isalnum(ch) || ch == '_')
+-		return EVENT_ITEM;
+-	if (ch == '\'')
+-		return EVENT_SQUOTE;
+-	if (ch == '"')
+-		return EVENT_DQUOTE;
+-	if (!isprint(ch))
+-		return EVENT_NONE;
+-	if (ch == '(' || ch == ')' || ch == ',')
+-		return EVENT_DELIM;
+-
+-	return EVENT_OP;
+-}
+-
+-static int __read_char(void)
+-{
+-	if (input_buf_ptr >= input_buf_siz)
+-		return -1;
+-
+-	return input_buf[input_buf_ptr++];
+-}
+-
+-static int __peek_char(void)
+-{
+-	if (input_buf_ptr >= input_buf_siz)
+-		return -1;
+-
+-	return input_buf[input_buf_ptr];
+-}
+-
+-/**
+- * pevent_peek_char - peek at the next character that will be read
+- *
+- * Returns the next character read, or -1 if end of buffer.
+- */
+-int pevent_peek_char(void)
+-{
+-	return __peek_char();
+-}
+-
+-static int extend_token(char **tok, char *buf, int size)
+-{
+-	char *newtok = realloc(*tok, size);
+-
+-	if (!newtok) {
+-		free(*tok);
+-		*tok = NULL;
+-		return -1;
+-	}
+-
+-	if (!*tok)
+-		strcpy(newtok, buf);
+-	else
+-		strcat(newtok, buf);
+-	*tok = newtok;
+-
+-	return 0;
+-}
+-
+-static enum event_type force_token(const char *str, char **tok);
+-
+-static enum event_type __read_token(char **tok)
+-{
+-	char buf[BUFSIZ];
+-	int ch, last_ch, quote_ch, next_ch;
+-	int i = 0;
+-	int tok_size = 0;
+-	enum event_type type;
+-
+-	*tok = NULL;
+-
+-
+-	ch = __read_char();
+-	if (ch < 0)
+-		return EVENT_NONE;
+-
+-	type = get_type(ch);
+-	if (type == EVENT_NONE)
+-		return type;
+-
+-	buf[i++] = ch;
+-
+-	switch (type) {
+-	case EVENT_NEWLINE:
+-	case EVENT_DELIM:
+-		if (asprintf(tok, "%c", ch) < 0)
+-			return EVENT_ERROR;
+-
+-		return type;
+-
+-	case EVENT_OP:
+-		switch (ch) {
+-		case '-':
+-			next_ch = __peek_char();
+-			if (next_ch == '>') {
+-				buf[i++] = __read_char();
+-				break;
+-			}
+-			/* fall through */
+-		case '+':
+-		case '|':
+-		case '&':
+-		case '>':
+-		case '<':
+-			last_ch = ch;
+-			ch = __peek_char();
+-			if (ch != last_ch)
+-				goto test_equal;
+-			buf[i++] = __read_char();
+-			switch (last_ch) {
+-			case '>':
+-			case '<':
+-				goto test_equal;
+-			default:
+-				break;
+-			}
+-			break;
+-		case '!':
+-		case '=':
+-			goto test_equal;
+-		default: /* what should we do instead? */
+-			break;
+-		}
+-		buf[i] = 0;
+-		*tok = strdup(buf);
+-		return type;
+-
+- test_equal:
+-		ch = __peek_char();
+-		if (ch == '=')
+-			buf[i++] = __read_char();
+-		goto out;
+-
+-	case EVENT_DQUOTE:
+-	case EVENT_SQUOTE:
+-		/* don't keep quotes */
+-		i--;
+-		quote_ch = ch;
+-		last_ch = 0;
+- concat:
+-		do {
+-			if (i == (BUFSIZ - 1)) {
+-				buf[i] = 0;
+-				tok_size += BUFSIZ;
+-
+-				if (extend_token(tok, buf, tok_size) < 0)
+-					return EVENT_NONE;
+-				i = 0;
+-			}
+-			last_ch = ch;
+-			ch = __read_char();
+-			buf[i++] = ch;
+-			/* the '\' '\' will cancel itself */
+-			if (ch == '\\' && last_ch == '\\')
+-				last_ch = 0;
+-		} while (ch != quote_ch || last_ch == '\\');
+-		/* remove the last quote */
+-		i--;
+-
+-		/*
+-		 * For strings (double quotes) check the next token.
+-		 * If it is another string, concatinate the two.
+-		 */
+-		if (type == EVENT_DQUOTE) {
+-			unsigned long long save_input_buf_ptr = input_buf_ptr;
+-
+-			do {
+-				ch = __read_char();
+-			} while (isspace(ch));
+-			if (ch == '"')
+-				goto concat;
+-			input_buf_ptr = save_input_buf_ptr;
+-		}
+-
+-		goto out;
+-
+-	case EVENT_ERROR ... EVENT_SPACE:
+-	case EVENT_ITEM:
+-	default:
+-		break;
+-	}
+-
+-	while (get_type(__peek_char()) == type) {
+-		if (i == (BUFSIZ - 1)) {
+-			buf[i] = 0;
+-			tok_size += BUFSIZ;
+-
+-			if (extend_token(tok, buf, tok_size) < 0)
+-				return EVENT_NONE;
+-			i = 0;
+-		}
+-		ch = __read_char();
+-		buf[i++] = ch;
+-	}
+-
+- out:
+-	buf[i] = 0;
+-	if (extend_token(tok, buf, tok_size + i + 1) < 0)
+-		return EVENT_NONE;
+-
+-	if (type == EVENT_ITEM) {
+-		/*
+-		 * Older versions of the kernel has a bug that
+-		 * creates invalid symbols and will break the mac80211
+-		 * parsing. This is a work around to that bug.
+-		 *
+-		 * See Linux kernel commit:
+-		 *  811cb50baf63461ce0bdb234927046131fc7fa8b
+-		 */
+-		if (strcmp(*tok, "LOCAL_PR_FMT") == 0) {
+-			free(*tok);
+-			*tok = NULL;
+-			return force_token("\"\%s\" ", tok);
+-		} else if (strcmp(*tok, "STA_PR_FMT") == 0) {
+-			free(*tok);
+-			*tok = NULL;
+-			return force_token("\" sta:%pM\" ", tok);
+-		} else if (strcmp(*tok, "VIF_PR_FMT") == 0) {
+-			free(*tok);
+-			*tok = NULL;
+-			return force_token("\" vif:%p(%d)\" ", tok);
+-		}
+-	}
+-
+-	return type;
+-}
+-
+-static enum event_type force_token(const char *str, char **tok)
+-{
+-	const char *save_input_buf;
+-	unsigned long long save_input_buf_ptr;
+-	unsigned long long save_input_buf_siz;
+-	enum event_type type;
+-	
+-	/* save off the current input pointers */
+-	save_input_buf = input_buf;
+-	save_input_buf_ptr = input_buf_ptr;
+-	save_input_buf_siz = input_buf_siz;
+-
+-	init_input_buf(str, strlen(str));
+-
+-	type = __read_token(tok);
+-
+-	/* reset back to original token */
+-	input_buf = save_input_buf;
+-	input_buf_ptr = save_input_buf_ptr;
+-	input_buf_siz = save_input_buf_siz;
+-
+-	return type;
+-}
+-
+-static void free_token(char *tok)
+-{
+-	free(tok);
+-}
+-
+-static enum event_type read_token(char **tok)
+-{
+-	enum event_type type;
+-
+-	for (;;) {
+-		type = __read_token(tok);
+-		if (type != EVENT_SPACE)
+-			return type;
+-
+-		free_token(*tok);
+-	}
+-
+-	/* not reached */
+-	*tok = NULL;
+-	return EVENT_NONE;
+-}
+-
+-/**
+- * pevent_read_token - access to utilites to use the pevent parser
+- * @tok: The token to return
+- *
+- * This will parse tokens from the string given by
+- * pevent_init_data().
+- *
+- * Returns the token type.
+- */
+-enum event_type pevent_read_token(char **tok)
+-{
+-	return read_token(tok);
+-}
+-
+-/**
+- * pevent_free_token - free a token returned by pevent_read_token
+- * @token: the token to free
+- */
+-void pevent_free_token(char *token)
+-{
+-	free_token(token);
+-}
+-
+-/* no newline */
+-static enum event_type read_token_item(char **tok)
+-{
+-	enum event_type type;
+-
+-	for (;;) {
+-		type = __read_token(tok);
+-		if (type != EVENT_SPACE && type != EVENT_NEWLINE)
+-			return type;
+-		free_token(*tok);
+-		*tok = NULL;
+-	}
+-
+-	/* not reached */
+-	*tok = NULL;
+-	return EVENT_NONE;
+-}
+-
+-static int test_type(enum event_type type, enum event_type expect)
+-{
+-	if (type != expect) {
+-		do_warning("Error: expected type %d but read %d",
+-		    expect, type);
+-		return -1;
+-	}
+-	return 0;
+-}
+-
+-static int test_type_token(enum event_type type, const char *token,
+-		    enum event_type expect, const char *expect_tok)
+-{
+-	if (type != expect) {
+-		do_warning("Error: expected type %d but read %d",
+-		    expect, type);
+-		return -1;
+-	}
+-
+-	if (strcmp(token, expect_tok) != 0) {
+-		do_warning("Error: expected '%s' but read '%s'",
+-		    expect_tok, token);
+-		return -1;
+-	}
+-	return 0;
+-}
+-
+-static int __read_expect_type(enum event_type expect, char **tok, int newline_ok)
+-{
+-	enum event_type type;
+-
+-	if (newline_ok)
+-		type = read_token(tok);
+-	else
+-		type = read_token_item(tok);
+-	return test_type(type, expect);
+-}
+-
+-static int read_expect_type(enum event_type expect, char **tok)
+-{
+-	return __read_expect_type(expect, tok, 1);
+-}
+-
+-static int __read_expected(enum event_type expect, const char *str,
+-			   int newline_ok)
+-{
+-	enum event_type type;
+-	char *token;
+-	int ret;
+-
+-	if (newline_ok)
+-		type = read_token(&token);
+-	else
+-		type = read_token_item(&token);
+-
+-	ret = test_type_token(type, token, expect, str);
+-
+-	free_token(token);
+-
+-	return ret;
+-}
+-
+-static int read_expected(enum event_type expect, const char *str)
+-{
+-	return __read_expected(expect, str, 1);
+-}
+-
+-static int read_expected_item(enum event_type expect, const char *str)
+-{
+-	return __read_expected(expect, str, 0);
+-}
+-
+-static char *event_read_name(void)
+-{
+-	char *token;
+-
+-	if (read_expected(EVENT_ITEM, "name") < 0)
+-		return NULL;
+-
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return NULL;
+-
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto fail;
+-
+-	return token;
+-
+- fail:
+-	free_token(token);
+-	return NULL;
+-}
+-
+-static int event_read_id(void)
+-{
+-	char *token;
+-	int id;
+-
+-	if (read_expected_item(EVENT_ITEM, "ID") < 0)
+-		return -1;
+-
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return -1;
+-
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto fail;
+-
+-	id = strtoul(token, NULL, 0);
+-	free_token(token);
+-	return id;
+-
+- fail:
+-	free_token(token);
+-	return -1;
+-}
+-
+-static int field_is_string(struct format_field *field)
+-{
+-	if ((field->flags & FIELD_IS_ARRAY) &&
+-	    (strstr(field->type, "char") || strstr(field->type, "u8") ||
+-	     strstr(field->type, "s8")))
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static int field_is_dynamic(struct format_field *field)
+-{
+-	if (strncmp(field->type, "__data_loc", 10) == 0)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static int field_is_long(struct format_field *field)
+-{
+-	/* includes long long */
+-	if (strstr(field->type, "long"))
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static unsigned int type_size(const char *name)
+-{
+-	/* This covers all FIELD_IS_STRING types. */
+-	static struct {
+-		const char *type;
+-		unsigned int size;
+-	} table[] = {
+-		{ "u8",   1 },
+-		{ "u16",  2 },
+-		{ "u32",  4 },
+-		{ "u64",  8 },
+-		{ "s8",   1 },
+-		{ "s16",  2 },
+-		{ "s32",  4 },
+-		{ "s64",  8 },
+-		{ "char", 1 },
+-		{ },
+-	};
+-	int i;
+-
+-	for (i = 0; table[i].type; i++) {
+-		if (!strcmp(table[i].type, name))
+-			return table[i].size;
+-	}
+-
+-	return 0;
+-}
+-
+-static int event_read_fields(struct event_format *event, struct format_field **fields)
+-{
+-	struct format_field *field = NULL;
+-	enum event_type type;
+-	char *token;
+-	char *last_token;
+-	int count = 0;
+-
+-	do {
+-		unsigned int size_dynamic = 0;
+-
+-		type = read_token(&token);
+-		if (type == EVENT_NEWLINE) {
+-			free_token(token);
+-			return count;
+-		}
+-
+-		count++;
+-
+-		if (test_type_token(type, token, EVENT_ITEM, "field"))
+-			goto fail;
+-		free_token(token);
+-
+-		type = read_token(&token);
+-		/*
+-		 * The ftrace fields may still use the "special" name.
+-		 * Just ignore it.
+-		 */
+-		if (event->flags & EVENT_FL_ISFTRACE &&
+-		    type == EVENT_ITEM && strcmp(token, "special") == 0) {
+-			free_token(token);
+-			type = read_token(&token);
+-		}
+-
+-		if (test_type_token(type, token, EVENT_OP, ":") < 0)
+-			goto fail;
+-
+-		free_token(token);
+-		if (read_expect_type(EVENT_ITEM, &token) < 0)
+-			goto fail;
+-
+-		last_token = token;
+-
+-		field = calloc(1, sizeof(*field));
+-		if (!field)
+-			goto fail;
+-
+-		field->event = event;
+-
+-		/* read the rest of the type */
+-		for (;;) {
+-			type = read_token(&token);
+-			if (type == EVENT_ITEM ||
+-			    (type == EVENT_OP && strcmp(token, "*") == 0) ||
+-			    /*
+-			     * Some of the ftrace fields are broken and have
+-			     * an illegal "." in them.
+-			     */
+-			    (event->flags & EVENT_FL_ISFTRACE &&
+-			     type == EVENT_OP && strcmp(token, ".") == 0)) {
+-
+-				if (strcmp(token, "*") == 0)
+-					field->flags |= FIELD_IS_POINTER;
+-
+-				if (field->type) {
+-					char *new_type;
+-					new_type = realloc(field->type,
+-							   strlen(field->type) +
+-							   strlen(last_token) + 2);
+-					if (!new_type) {
+-						free(last_token);
+-						goto fail;
+-					}
+-					field->type = new_type;
+-					strcat(field->type, " ");
+-					strcat(field->type, last_token);
+-					free(last_token);
+-				} else
+-					field->type = last_token;
+-				last_token = token;
+-				continue;
+-			}
+-
+-			break;
+-		}
+-
+-		if (!field->type) {
+-			do_warning("%s: no type found", __func__);
+-			goto fail;
+-		}
+-		field->name = last_token;
+-
+-		if (test_type(type, EVENT_OP))
+-			goto fail;
+-
+-		if (strcmp(token, "[") == 0) {
+-			enum event_type last_type = type;
+-			char *brackets = token;
+-			char *new_brackets;
+-			int len;
+-
+-			field->flags |= FIELD_IS_ARRAY;
+-
+-			type = read_token(&token);
+-
+-			if (type == EVENT_ITEM)
+-				field->arraylen = strtoul(token, NULL, 0);
+-			else
+-				field->arraylen = 0;
+-
+-		        while (strcmp(token, "]") != 0) {
+-				if (last_type == EVENT_ITEM &&
+-				    type == EVENT_ITEM)
+-					len = 2;
+-				else
+-					len = 1;
+-				last_type = type;
+-
+-				new_brackets = realloc(brackets,
+-						       strlen(brackets) +
+-						       strlen(token) + len);
+-				if (!new_brackets) {
+-					free(brackets);
+-					goto fail;
+-				}
+-				brackets = new_brackets;
+-				if (len == 2)
+-					strcat(brackets, " ");
+-				strcat(brackets, token);
+-				/* We only care about the last token */
+-				field->arraylen = strtoul(token, NULL, 0);
+-				free_token(token);
+-				type = read_token(&token);
+-				if (type == EVENT_NONE) {
+-					do_warning("failed to find token");
+-					goto fail;
+-				}
+-			}
+-
+-			free_token(token);
+-
+-			new_brackets = realloc(brackets, strlen(brackets) + 2);
+-			if (!new_brackets) {
+-				free(brackets);
+-				goto fail;
+-			}
+-			brackets = new_brackets;
+-			strcat(brackets, "]");
+-
+-			/* add brackets to type */
+-
+-			type = read_token(&token);
+-			/*
+-			 * If the next token is not an OP, then it is of
+-			 * the format: type [] item;
+-			 */
+-			if (type == EVENT_ITEM) {
+-				char *new_type;
+-				new_type = realloc(field->type,
+-						   strlen(field->type) +
+-						   strlen(field->name) +
+-						   strlen(brackets) + 2);
+-				if (!new_type) {
+-					free(brackets);
+-					goto fail;
+-				}
+-				field->type = new_type;
+-				strcat(field->type, " ");
+-				strcat(field->type, field->name);
+-				size_dynamic = type_size(field->name);
+-				free_token(field->name);
+-				strcat(field->type, brackets);
+-				field->name = token;
+-				type = read_token(&token);
+-			} else {
+-				char *new_type;
+-				new_type = realloc(field->type,
+-						   strlen(field->type) +
+-						   strlen(brackets) + 1);
+-				if (!new_type) {
+-					free(brackets);
+-					goto fail;
+-				}
+-				field->type = new_type;
+-				strcat(field->type, brackets);
+-			}
+-			free(brackets);
+-		}
+-
+-		if (field_is_string(field))
+-			field->flags |= FIELD_IS_STRING;
+-		if (field_is_dynamic(field))
+-			field->flags |= FIELD_IS_DYNAMIC;
+-		if (field_is_long(field))
+-			field->flags |= FIELD_IS_LONG;
+-
+-		if (test_type_token(type, token,  EVENT_OP, ";"))
+-			goto fail;
+-		free_token(token);
+-
+-		if (read_expected(EVENT_ITEM, "offset") < 0)
+-			goto fail_expect;
+-
+-		if (read_expected(EVENT_OP, ":") < 0)
+-			goto fail_expect;
+-
+-		if (read_expect_type(EVENT_ITEM, &token))
+-			goto fail;
+-		field->offset = strtoul(token, NULL, 0);
+-		free_token(token);
+-
+-		if (read_expected(EVENT_OP, ";") < 0)
+-			goto fail_expect;
+-
+-		if (read_expected(EVENT_ITEM, "size") < 0)
+-			goto fail_expect;
+-
+-		if (read_expected(EVENT_OP, ":") < 0)
+-			goto fail_expect;
+-
+-		if (read_expect_type(EVENT_ITEM, &token))
+-			goto fail;
+-		field->size = strtoul(token, NULL, 0);
+-		free_token(token);
+-
+-		if (read_expected(EVENT_OP, ";") < 0)
+-			goto fail_expect;
+-
+-		type = read_token(&token);
+-		if (type != EVENT_NEWLINE) {
+-			/* newer versions of the kernel have a "signed" type */
+-			if (test_type_token(type, token, EVENT_ITEM, "signed"))
+-				goto fail;
+-
+-			free_token(token);
+-
+-			if (read_expected(EVENT_OP, ":") < 0)
+-				goto fail_expect;
+-
+-			if (read_expect_type(EVENT_ITEM, &token))
+-				goto fail;
+-
+-			if (strtoul(token, NULL, 0))
+-				field->flags |= FIELD_IS_SIGNED;
+-
+-			free_token(token);
+-			if (read_expected(EVENT_OP, ";") < 0)
+-				goto fail_expect;
+-
+-			if (read_expect_type(EVENT_NEWLINE, &token))
+-				goto fail;
+-		}
+-
+-		free_token(token);
+-
+-		if (field->flags & FIELD_IS_ARRAY) {
+-			if (field->arraylen)
+-				field->elementsize = field->size / field->arraylen;
+-			else if (field->flags & FIELD_IS_DYNAMIC)
+-				field->elementsize = size_dynamic;
+-			else if (field->flags & FIELD_IS_STRING)
+-				field->elementsize = 1;
+-			else if (field->flags & FIELD_IS_LONG)
+-				field->elementsize = event->pevent ?
+-						     event->pevent->long_size :
+-						     sizeof(long);
+-		} else
+-			field->elementsize = field->size;
+-
+-		*fields = field;
+-		fields = &field->next;
+-
+-	} while (1);
+-
+-	return 0;
+-
+-fail:
+-	free_token(token);
+-fail_expect:
+-	if (field) {
+-		free(field->type);
+-		free(field->name);
+-		free(field);
+-	}
+-	return -1;
+-}
+-
+-static int event_read_format(struct event_format *event)
+-{
+-	char *token;
+-	int ret;
+-
+-	if (read_expected_item(EVENT_ITEM, "format") < 0)
+-		return -1;
+-
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return -1;
+-
+-	if (read_expect_type(EVENT_NEWLINE, &token))
+-		goto fail;
+-	free_token(token);
+-
+-	ret = event_read_fields(event, &event->format.common_fields);
+-	if (ret < 0)
+-		return ret;
+-	event->format.nr_common = ret;
+-
+-	ret = event_read_fields(event, &event->format.fields);
+-	if (ret < 0)
+-		return ret;
+-	event->format.nr_fields = ret;
+-
+-	return 0;
+-
+- fail:
+-	free_token(token);
+-	return -1;
+-}
+-
+-static enum event_type
+-process_arg_token(struct event_format *event, struct print_arg *arg,
+-		  char **tok, enum event_type type);
+-
+-static enum event_type
+-process_arg(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	enum event_type type;
+-	char *token;
+-
+-	type = read_token(&token);
+-	*tok = token;
+-
+-	return process_arg_token(event, arg, tok, type);
+-}
+-
+-static enum event_type
+-process_op(struct event_format *event, struct print_arg *arg, char **tok);
+-
+-static enum event_type
+-process_cond(struct event_format *event, struct print_arg *top, char **tok)
+-{
+-	struct print_arg *arg, *left, *right;
+-	enum event_type type;
+-	char *token = NULL;
+-
+-	arg = alloc_arg();
+-	left = alloc_arg();
+-	right = alloc_arg();
+-
+-	if (!arg || !left || !right) {
+-		do_warning("%s: not enough memory!", __func__);
+-		/* arg will be freed at out_free */
+-		free_arg(left);
+-		free_arg(right);
+-		goto out_free;
+-	}
+-
+-	arg->type = PRINT_OP;
+-	arg->op.left = left;
+-	arg->op.right = right;
+-
+-	*tok = NULL;
+-	type = process_arg(event, left, &token);
+-
+- again:
+-	/* Handle other operations in the arguments */
+-	if (type == EVENT_OP && strcmp(token, ":") != 0) {
+-		type = process_op(event, left, &token);
+-		goto again;
+-	}
+-
+-	if (test_type_token(type, token, EVENT_OP, ":"))
+-		goto out_free;
+-
+-	arg->op.op = token;
+-
+-	type = process_arg(event, right, &token);
+-
+-	top->op.right = arg;
+-
+-	*tok = token;
+-	return type;
+-
+-out_free:
+-	/* Top may point to itself */
+-	top->op.right = NULL;
+-	free_token(token);
+-	free_arg(arg);
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_array(struct event_format *event, struct print_arg *top, char **tok)
+-{
+-	struct print_arg *arg;
+-	enum event_type type;
+-	char *token = NULL;
+-
+-	arg = alloc_arg();
+-	if (!arg) {
+-		do_warning("%s: not enough memory!", __func__);
+-		/* '*tok' is set to top->op.op.  No need to free. */
+-		*tok = NULL;
+-		return EVENT_ERROR;
+-	}
+-
+-	*tok = NULL;
+-	type = process_arg(event, arg, &token);
+-	if (test_type_token(type, token, EVENT_OP, "]"))
+-		goto out_free;
+-
+-	top->op.right = arg;
+-
+-	free_token(token);
+-	type = read_token_item(&token);
+-	*tok = token;
+-
+-	return type;
+-
+-out_free:
+-	free_token(token);
+-	free_arg(arg);
+-	return EVENT_ERROR;
+-}
+-
+-static int get_op_prio(char *op)
+-{
+-	if (!op[1]) {
+-		switch (op[0]) {
+-		case '~':
+-		case '!':
+-			return 4;
+-		case '*':
+-		case '/':
+-		case '%':
+-			return 6;
+-		case '+':
+-		case '-':
+-			return 7;
+-			/* '>>' and '<<' are 8 */
+-		case '<':
+-		case '>':
+-			return 9;
+-			/* '==' and '!=' are 10 */
+-		case '&':
+-			return 11;
+-		case '^':
+-			return 12;
+-		case '|':
+-			return 13;
+-		case '?':
+-			return 16;
+-		default:
+-			do_warning("unknown op '%c'", op[0]);
+-			return -1;
+-		}
+-	} else {
+-		if (strcmp(op, "++") == 0 ||
+-		    strcmp(op, "--") == 0) {
+-			return 3;
+-		} else if (strcmp(op, ">>") == 0 ||
+-			   strcmp(op, "<<") == 0) {
+-			return 8;
+-		} else if (strcmp(op, ">=") == 0 ||
+-			   strcmp(op, "<=") == 0) {
+-			return 9;
+-		} else if (strcmp(op, "==") == 0 ||
+-			   strcmp(op, "!=") == 0) {
+-			return 10;
+-		} else if (strcmp(op, "&&") == 0) {
+-			return 14;
+-		} else if (strcmp(op, "||") == 0) {
+-			return 15;
+-		} else {
+-			do_warning("unknown op '%s'", op);
+-			return -1;
+-		}
+-	}
+-}
+-
+-static int set_op_prio(struct print_arg *arg)
+-{
+-
+-	/* single ops are the greatest */
+-	if (!arg->op.left || arg->op.left->type == PRINT_NULL)
+-		arg->op.prio = 0;
+-	else
+-		arg->op.prio = get_op_prio(arg->op.op);
+-
+-	return arg->op.prio;
+-}
+-
+-/* Note, *tok does not get freed, but will most likely be saved */
+-static enum event_type
+-process_op(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct print_arg *left, *right = NULL;
+-	enum event_type type;
+-	char *token;
+-
+-	/* the op is passed in via tok */
+-	token = *tok;
+-
+-	if (arg->type == PRINT_OP && !arg->op.left) {
+-		/* handle single op */
+-		if (token[1]) {
+-			do_warning("bad op token %s", token);
+-			goto out_free;
+-		}
+-		switch (token[0]) {
+-		case '~':
+-		case '!':
+-		case '+':
+-		case '-':
+-			break;
+-		default:
+-			do_warning("bad op token %s", token);
+-			goto out_free;
+-
+-		}
+-
+-		/* make an empty left */
+-		left = alloc_arg();
+-		if (!left)
+-			goto out_warn_free;
+-
+-		left->type = PRINT_NULL;
+-		arg->op.left = left;
+-
+-		right = alloc_arg();
+-		if (!right)
+-			goto out_warn_free;
+-
+-		arg->op.right = right;
+-
+-		/* do not free the token, it belongs to an op */
+-		*tok = NULL;
+-		type = process_arg(event, right, tok);
+-
+-	} else if (strcmp(token, "?") == 0) {
+-
+-		left = alloc_arg();
+-		if (!left)
+-			goto out_warn_free;
+-
+-		/* copy the top arg to the left */
+-		*left = *arg;
+-
+-		arg->type = PRINT_OP;
+-		arg->op.op = token;
+-		arg->op.left = left;
+-		arg->op.prio = 0;
+-
+-		/* it will set arg->op.right */
+-		type = process_cond(event, arg, tok);
+-
+-	} else if (strcmp(token, ">>") == 0 ||
+-		   strcmp(token, "<<") == 0 ||
+-		   strcmp(token, "&") == 0 ||
+-		   strcmp(token, "|") == 0 ||
+-		   strcmp(token, "&&") == 0 ||
+-		   strcmp(token, "||") == 0 ||
+-		   strcmp(token, "-") == 0 ||
+-		   strcmp(token, "+") == 0 ||
+-		   strcmp(token, "*") == 0 ||
+-		   strcmp(token, "^") == 0 ||
+-		   strcmp(token, "/") == 0 ||
+-		   strcmp(token, "<") == 0 ||
+-		   strcmp(token, ">") == 0 ||
+-		   strcmp(token, "<=") == 0 ||
+-		   strcmp(token, ">=") == 0 ||
+-		   strcmp(token, "==") == 0 ||
+-		   strcmp(token, "!=") == 0) {
+-
+-		left = alloc_arg();
+-		if (!left)
+-			goto out_warn_free;
+-
+-		/* copy the top arg to the left */
+-		*left = *arg;
+-
+-		arg->type = PRINT_OP;
+-		arg->op.op = token;
+-		arg->op.left = left;
+-		arg->op.right = NULL;
+-
+-		if (set_op_prio(arg) == -1) {
+-			event->flags |= EVENT_FL_FAILED;
+-			/* arg->op.op (= token) will be freed at out_free */
+-			arg->op.op = NULL;
+-			goto out_free;
+-		}
+-
+-		type = read_token_item(&token);
+-		*tok = token;
+-
+-		/* could just be a type pointer */
+-		if ((strcmp(arg->op.op, "*") == 0) &&
+-		    type == EVENT_DELIM && (strcmp(token, ")") == 0)) {
+-			char *new_atom;
+-
+-			if (left->type != PRINT_ATOM) {
+-				do_warning("bad pointer type");
+-				goto out_free;
+-			}
+-			new_atom = realloc(left->atom.atom,
+-					    strlen(left->atom.atom) + 3);
+-			if (!new_atom)
+-				goto out_warn_free;
+-
+-			left->atom.atom = new_atom;
+-			strcat(left->atom.atom, " *");
+-			free(arg->op.op);
+-			*arg = *left;
+-			free(left);
+-
+-			return type;
+-		}
+-
+-		right = alloc_arg();
+-		if (!right)
+-			goto out_warn_free;
+-
+-		type = process_arg_token(event, right, tok, type);
+-		arg->op.right = right;
+-
+-	} else if (strcmp(token, "[") == 0) {
+-
+-		left = alloc_arg();
+-		if (!left)
+-			goto out_warn_free;
+-
+-		*left = *arg;
+-
+-		arg->type = PRINT_OP;
+-		arg->op.op = token;
+-		arg->op.left = left;
+-
+-		arg->op.prio = 0;
+-
+-		/* it will set arg->op.right */
+-		type = process_array(event, arg, tok);
+-
+-	} else {
+-		do_warning("unknown op '%s'", token);
+-		event->flags |= EVENT_FL_FAILED;
+-		/* the arg is now the left side */
+-		goto out_free;
+-	}
+-
+-	if (type == EVENT_OP && strcmp(*tok, ":") != 0) {
+-		int prio;
+-
+-		/* higher prios need to be closer to the root */
+-		prio = get_op_prio(*tok);
+-
+-		if (prio > arg->op.prio)
+-			return process_op(event, arg, tok);
+-
+-		return process_op(event, right, tok);
+-	}
+-
+-	return type;
+-
+-out_warn_free:
+-	do_warning("%s: not enough memory!", __func__);
+-out_free:
+-	free_token(token);
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_entry(struct event_format *event __maybe_unused, struct print_arg *arg,
+-	      char **tok)
+-{
+-	enum event_type type;
+-	char *field;
+-	char *token;
+-
+-	if (read_expected(EVENT_OP, "->") < 0)
+-		goto out_err;
+-
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto out_free;
+-	field = token;
+-
+-	arg->type = PRINT_FIELD;
+-	arg->field.name = field;
+-
+-	if (is_flag_field) {
+-		arg->field.field = pevent_find_any_field(event, arg->field.name);
+-		arg->field.field->flags |= FIELD_IS_FLAG;
+-		is_flag_field = 0;
+-	} else if (is_symbolic_field) {
+-		arg->field.field = pevent_find_any_field(event, arg->field.name);
+-		arg->field.field->flags |= FIELD_IS_SYMBOLIC;
+-		is_symbolic_field = 0;
+-	}
+-
+-	type = read_token(&token);
+-	*tok = token;
+-
+-	return type;
+-
+- out_free:
+-	free_token(token);
+- out_err:
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static char *arg_eval (struct print_arg *arg);
+-
+-static unsigned long long
+-eval_type_str(unsigned long long val, const char *type, int pointer)
+-{
+-	int sign = 0;
+-	char *ref;
+-	int len;
+-
+-	len = strlen(type);
+-
+-	if (pointer) {
+-
+-		if (type[len-1] != '*') {
+-			do_warning("pointer expected with non pointer type");
+-			return val;
+-		}
+-
+-		ref = malloc(len);
+-		if (!ref) {
+-			do_warning("%s: not enough memory!", __func__);
+-			return val;
+-		}
+-		memcpy(ref, type, len);
+-
+-		/* chop off the " *" */
+-		ref[len - 2] = 0;
+-
+-		val = eval_type_str(val, ref, 0);
+-		free(ref);
+-		return val;
+-	}
+-
+-	/* check if this is a pointer */
+-	if (type[len - 1] == '*')
+-		return val;
+-
+-	/* Try to figure out the arg size*/
+-	if (strncmp(type, "struct", 6) == 0)
+-		/* all bets off */
+-		return val;
+-
+-	if (strcmp(type, "u8") == 0)
+-		return val & 0xff;
+-
+-	if (strcmp(type, "u16") == 0)
+-		return val & 0xffff;
+-
+-	if (strcmp(type, "u32") == 0)
+-		return val & 0xffffffff;
+-
+-	if (strcmp(type, "u64") == 0 ||
+-	    strcmp(type, "s64"))
+-		return val;
+-
+-	if (strcmp(type, "s8") == 0)
+-		return (unsigned long long)(char)val & 0xff;
+-
+-	if (strcmp(type, "s16") == 0)
+-		return (unsigned long long)(short)val & 0xffff;
+-
+-	if (strcmp(type, "s32") == 0)
+-		return (unsigned long long)(int)val & 0xffffffff;
+-
+-	if (strncmp(type, "unsigned ", 9) == 0) {
+-		sign = 0;
+-		type += 9;
+-	}
+-
+-	if (strcmp(type, "char") == 0) {
+-		if (sign)
+-			return (unsigned long long)(char)val & 0xff;
+-		else
+-			return val & 0xff;
+-	}
+-
+-	if (strcmp(type, "short") == 0) {
+-		if (sign)
+-			return (unsigned long long)(short)val & 0xffff;
+-		else
+-			return val & 0xffff;
+-	}
+-
+-	if (strcmp(type, "int") == 0) {
+-		if (sign)
+-			return (unsigned long long)(int)val & 0xffffffff;
+-		else
+-			return val & 0xffffffff;
+-	}
+-
+-	return val;
+-}
+-
+-/*
+- * Try to figure out the type.
+- */
+-static unsigned long long
+-eval_type(unsigned long long val, struct print_arg *arg, int pointer)
+-{
+-	if (arg->type != PRINT_TYPE) {
+-		do_warning("expected type argument");
+-		return 0;
+-	}
+-
+-	return eval_type_str(val, arg->typecast.type, pointer);
+-}
+-
+-static int arg_num_eval(struct print_arg *arg, long long *val)
+-{
+-	long long left, right;
+-	int ret = 1;
+-
+-	switch (arg->type) {
+-	case PRINT_ATOM:
+-		*val = strtoll(arg->atom.atom, NULL, 0);
+-		break;
+-	case PRINT_TYPE:
+-		ret = arg_num_eval(arg->typecast.item, val);
+-		if (!ret)
+-			break;
+-		*val = eval_type(*val, arg, 0);
+-		break;
+-	case PRINT_OP:
+-		switch (arg->op.op[0]) {
+-		case '|':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			if (arg->op.op[1])
+-				*val = left || right;
+-			else
+-				*val = left | right;
+-			break;
+-		case '&':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			if (arg->op.op[1])
+-				*val = left && right;
+-			else
+-				*val = left & right;
+-			break;
+-		case '<':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			switch (arg->op.op[1]) {
+-			case 0:
+-				*val = left < right;
+-				break;
+-			case '<':
+-				*val = left << right;
+-				break;
+-			case '=':
+-				*val = left <= right;
+-				break;
+-			default:
+-				do_warning("unknown op '%s'", arg->op.op);
+-				ret = 0;
+-			}
+-			break;
+-		case '>':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			switch (arg->op.op[1]) {
+-			case 0:
+-				*val = left > right;
+-				break;
+-			case '>':
+-				*val = left >> right;
+-				break;
+-			case '=':
+-				*val = left >= right;
+-				break;
+-			default:
+-				do_warning("unknown op '%s'", arg->op.op);
+-				ret = 0;
+-			}
+-			break;
+-		case '=':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-
+-			if (arg->op.op[1] != '=') {
+-				do_warning("unknown op '%s'", arg->op.op);
+-				ret = 0;
+-			} else
+-				*val = left == right;
+-			break;
+-		case '!':
+-			ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-
+-			switch (arg->op.op[1]) {
+-			case '=':
+-				*val = left != right;
+-				break;
+-			default:
+-				do_warning("unknown op '%s'", arg->op.op);
+-				ret = 0;
+-			}
+-			break;
+-		case '-':
+-			/* check for negative */
+-			if (arg->op.left->type == PRINT_NULL)
+-				left = 0;
+-			else
+-				ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			*val = left - right;
+-			break;
+-		case '+':
+-			if (arg->op.left->type == PRINT_NULL)
+-				left = 0;
+-			else
+-				ret = arg_num_eval(arg->op.left, &left);
+-			if (!ret)
+-				break;
+-			ret = arg_num_eval(arg->op.right, &right);
+-			if (!ret)
+-				break;
+-			*val = left + right;
+-			break;
+-		default:
+-			do_warning("unknown op '%s'", arg->op.op);
+-			ret = 0;
+-		}
+-		break;
+-
+-	case PRINT_NULL:
+-	case PRINT_FIELD ... PRINT_SYMBOL:
+-	case PRINT_STRING:
+-	case PRINT_BSTRING:
+-	default:
+-		do_warning("invalid eval type %d", arg->type);
+-		ret = 0;
+-
+-	}
+-	return ret;
+-}
+-
+-static char *arg_eval (struct print_arg *arg)
+-{
+-	long long val;
+-	static char buf[20];
+-
+-	switch (arg->type) {
+-	case PRINT_ATOM:
+-		return arg->atom.atom;
+-	case PRINT_TYPE:
+-		return arg_eval(arg->typecast.item);
+-	case PRINT_OP:
+-		if (!arg_num_eval(arg, &val))
+-			break;
+-		sprintf(buf, "%lld", val);
+-		return buf;
+-
+-	case PRINT_NULL:
+-	case PRINT_FIELD ... PRINT_SYMBOL:
+-	case PRINT_STRING:
+-	case PRINT_BSTRING:
+-	default:
+-		do_warning("invalid eval type %d", arg->type);
+-		break;
+-	}
+-
+-	return NULL;
+-}
+-
+-static enum event_type
+-process_fields(struct event_format *event, struct print_flag_sym **list, char **tok)
+-{
+-	enum event_type type;
+-	struct print_arg *arg = NULL;
+-	struct print_flag_sym *field;
+-	char *token = *tok;
+-	char *value;
+-
+-	do {
+-		free_token(token);
+-		type = read_token_item(&token);
+-		if (test_type_token(type, token, EVENT_OP, "{"))
+-			break;
+-
+-		arg = alloc_arg();
+-		if (!arg)
+-			goto out_free;
+-
+-		free_token(token);
+-		type = process_arg(event, arg, &token);
+-
+-		if (type == EVENT_OP)
+-			type = process_op(event, arg, &token);
+-
+-		if (type == EVENT_ERROR)
+-			goto out_free;
+-
+-		if (test_type_token(type, token, EVENT_DELIM, ","))
+-			goto out_free;
+-
+-		field = calloc(1, sizeof(*field));
+-		if (!field)
+-			goto out_free;
+-
+-		value = arg_eval(arg);
+-		if (value == NULL)
+-			goto out_free_field;
+-		field->value = strdup(value);
+-		if (field->value == NULL)
+-			goto out_free_field;
+-
+-		free_arg(arg);
+-		arg = alloc_arg();
+-		if (!arg)
+-			goto out_free;
+-
+-		free_token(token);
+-		type = process_arg(event, arg, &token);
+-		if (test_type_token(type, token, EVENT_OP, "}"))
+-			goto out_free_field;
+-
+-		value = arg_eval(arg);
+-		if (value == NULL)
+-			goto out_free_field;
+-		field->str = strdup(value);
+-		if (field->str == NULL)
+-			goto out_free_field;
+-		free_arg(arg);
+-		arg = NULL;
+-
+-		*list = field;
+-		list = &field->next;
+-
+-		free_token(token);
+-		type = read_token_item(&token);
+-	} while (type == EVENT_DELIM && strcmp(token, ",") == 0);
+-
+-	*tok = token;
+-	return type;
+-
+-out_free_field:
+-	free_flag_sym(field);
+-out_free:
+-	free_arg(arg);
+-	free_token(token);
+-	*tok = NULL;
+-
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_flags(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct print_arg *field;
+-	enum event_type type;
+-	char *token;
+-
+-	memset(arg, 0, sizeof(*arg));
+-	arg->type = PRINT_FLAGS;
+-
+-	field = alloc_arg();
+-	if (!field) {
+-		do_warning("%s: not enough memory!", __func__);
+-		goto out;
+-	}
+-
+-	type = process_arg(event, field, &token);
+-
+-	/* Handle operations in the first argument */
+-	while (type == EVENT_OP)
+-		type = process_op(event, field, &token);
+-
+-	if (test_type_token(type, token, EVENT_DELIM, ","))
+-		goto out_free_field;
+-	free_token(token);
+-
+-	arg->flags.field = field;
+-
+-	type = read_token_item(&token);
+-	if (event_item_type(type)) {
+-		arg->flags.delim = token;
+-		type = read_token_item(&token);
+-	}
+-
+-	if (test_type_token(type, token, EVENT_DELIM, ","))
+-		goto out_free;
+-
+-	type = process_fields(event, &arg->flags.flags, &token);
+-	if (test_type_token(type, token, EVENT_DELIM, ")"))
+-		goto out_free;
+-
+-	free_token(token);
+-	type = read_token_item(tok);
+-	return type;
+-
+-out_free_field:
+-	free_arg(field);
+-out_free:
+-	free_token(token);
+-out:
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_symbols(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct print_arg *field;
+-	enum event_type type;
+-	char *token;
+-
+-	memset(arg, 0, sizeof(*arg));
+-	arg->type = PRINT_SYMBOL;
+-
+-	field = alloc_arg();
+-	if (!field) {
+-		do_warning("%s: not enough memory!", __func__);
+-		goto out;
+-	}
+-
+-	type = process_arg(event, field, &token);
+-	if (test_type_token(type, token, EVENT_DELIM, ","))
+-		goto out_free_field;
+-
+-	arg->symbol.field = field;
+-
+-	type = process_fields(event, &arg->symbol.symbols, &token);
+-	if (test_type_token(type, token, EVENT_DELIM, ")"))
+-		goto out_free;
+-
+-	free_token(token);
+-	type = read_token_item(tok);
+-	return type;
+-
+-out_free_field:
+-	free_arg(field);
+-out_free:
+-	free_token(token);
+-out:
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_hex(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct print_arg *field;
+-	enum event_type type;
+-	char *token;
+-
+-	memset(arg, 0, sizeof(*arg));
+-	arg->type = PRINT_HEX;
+-
+-	field = alloc_arg();
+-	if (!field) {
+-		do_warning("%s: not enough memory!", __func__);
+-		goto out;
+-	}
+-
+-	type = process_arg(event, field, &token);
+-
+-	if (test_type_token(type, token, EVENT_DELIM, ","))
+-		goto out_free;
+-
+-	arg->hex.field = field;
+-
+-	free_token(token);
+-
+-	field = alloc_arg();
+-	if (!field) {
+-		do_warning("%s: not enough memory!", __func__);
+-		*tok = NULL;
+-		return EVENT_ERROR;
+-	}
+-
+-	type = process_arg(event, field, &token);
+-
+-	if (test_type_token(type, token, EVENT_DELIM, ")"))
+-		goto out_free;
+-
+-	arg->hex.size = field;
+-
+-	free_token(token);
+-	type = read_token_item(tok);
+-	return type;
+-
+- out_free:
+-	free_arg(field);
+-	free_token(token);
+-out:
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_dynamic_array(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct format_field *field;
+-	enum event_type type;
+-	char *token;
+-
+-	memset(arg, 0, sizeof(*arg));
+-	arg->type = PRINT_DYNAMIC_ARRAY;
+-
+-	/*
+-	 * The item within the parenthesis is another field that holds
+-	 * the index into where the array starts.
+-	 */
+-	type = read_token(&token);
+-	*tok = token;
+-	if (type != EVENT_ITEM)
+-		goto out_free;
+-
+-	/* Find the field */
+-
+-	field = pevent_find_field(event, token);
+-	if (!field)
+-		goto out_free;
+-
+-	arg->dynarray.field = field;
+-	arg->dynarray.index = 0;
+-
+-	if (read_expected(EVENT_DELIM, ")") < 0)
+-		goto out_free;
+-
+-	free_token(token);
+-	type = read_token_item(&token);
+-	*tok = token;
+-	if (type != EVENT_OP || strcmp(token, "[") != 0)
+-		return type;
+-
+-	free_token(token);
+-	arg = alloc_arg();
+-	if (!arg) {
+-		do_warning("%s: not enough memory!", __func__);
+-		*tok = NULL;
+-		return EVENT_ERROR;
+-	}
+-
+-	type = process_arg(event, arg, &token);
+-	if (type == EVENT_ERROR)
+-		goto out_free_arg;
+-
+-	if (!test_type_token(type, token, EVENT_OP, "]"))
+-		goto out_free_arg;
+-
+-	free_token(token);
+-	type = read_token_item(tok);
+-	return type;
+-
+- out_free_arg:
+-	free_arg(arg);
+- out_free:
+-	free_token(token);
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_paren(struct event_format *event, struct print_arg *arg, char **tok)
+-{
+-	struct print_arg *item_arg;
+-	enum event_type type;
+-	char *token;
+-
+-	type = process_arg(event, arg, &token);
+-
+-	if (type == EVENT_ERROR)
+-		goto out_free;
+-
+-	if (type == EVENT_OP)
+-		type = process_op(event, arg, &token);
+-
+-	if (type == EVENT_ERROR)
+-		goto out_free;
+-
+-	if (test_type_token(type, token, EVENT_DELIM, ")"))
+-		goto out_free;
+-
+-	free_token(token);
+-	type = read_token_item(&token);
+-
+-	/*
+-	 * If the next token is an item or another open paren, then
+-	 * this was a typecast.
+-	 */
+-	if (event_item_type(type) ||
+-	    (type == EVENT_DELIM && strcmp(token, "(") == 0)) {
+-
+-		/* make this a typecast and contine */
+-
+-		/* prevous must be an atom */
+-		if (arg->type != PRINT_ATOM) {
+-			do_warning("previous needed to be PRINT_ATOM");
+-			goto out_free;
+-		}
+-
+-		item_arg = alloc_arg();
+-		if (!item_arg) {
+-			do_warning("%s: not enough memory!", __func__);
+-			goto out_free;
+-		}
+-
+-		arg->type = PRINT_TYPE;
+-		arg->typecast.type = arg->atom.atom;
+-		arg->typecast.item = item_arg;
+-		type = process_arg_token(event, item_arg, &token, type);
+-
+-	}
+-
+-	*tok = token;
+-	return type;
+-
+- out_free:
+-	free_token(token);
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-
+-static enum event_type
+-process_str(struct event_format *event __maybe_unused, struct print_arg *arg,
+-	    char **tok)
+-{
+-	enum event_type type;
+-	char *token;
+-
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto out_free;
+-
+-	arg->type = PRINT_STRING;
+-	arg->string.string = token;
+-	arg->string.offset = -1;
+-
+-	if (read_expected(EVENT_DELIM, ")") < 0)
+-		goto out_err;
+-
+-	type = read_token(&token);
+-	*tok = token;
+-
+-	return type;
+-
+- out_free:
+-	free_token(token);
+- out_err:
+-	*tok = NULL;
+-	return EVENT_ERROR;
+-}
+-
+-static struct pevent_function_handler *
+-find_func_handler(struct pevent *pevent, char *func_name)
+-{
+-	struct pevent_function_handler *func;
+-
+-	if (!pevent)
+-		return NULL;
+-
+-	for (func = pevent->func_handlers; func; func = func->next) {
+-		if (strcmp(func->name, func_name) == 0)
+-			break;
+-	}
+-
+-	return func;
+-}
+-
+-static void remove_func_handler(struct pevent *pevent, char *func_name)
+-{
+-	struct pevent_function_handler *func;
+-	struct pevent_function_handler **next;
+-
+-	next = &pevent->func_handlers;
+-	while ((func = *next)) {
+-		if (strcmp(func->name, func_name) == 0) {
+-			*next = func->next;
+-			free_func_handle(func);
+-			break;
+-		}
+-		next = &func->next;
+-	}
+-}
+-
+-static enum event_type
+-process_func_handler(struct event_format *event, struct pevent_function_handler *func,
+-		     struct print_arg *arg, char **tok)
+-{
+-	struct print_arg **next_arg;
+-	struct print_arg *farg;
+-	enum event_type type;
+-	char *token;
+-	const char *test;
+-	int i;
+-
+-	arg->type = PRINT_FUNC;
+-	arg->func.func = func;
+-
+-	*tok = NULL;
+-
+-	next_arg = &(arg->func.args);
+-	for (i = 0; i < func->nr_args; i++) {
+-		farg = alloc_arg();
+-		if (!farg) {
+-			do_warning("%s: not enough memory!", __func__);
+-			return EVENT_ERROR;
+-		}
+-
+-		type = process_arg(event, farg, &token);
+-		if (i < (func->nr_args - 1))
+-			test = ",";
+-		else
+-			test = ")";
+-
+-		if (test_type_token(type, token, EVENT_DELIM, test)) {
+-			free_arg(farg);
+-			free_token(token);
+-			return EVENT_ERROR;
+-		}
+-
+-		*next_arg = farg;
+-		next_arg = &(farg->next);
+-		free_token(token);
+-	}
+-
+-	type = read_token(&token);
+-	*tok = token;
+-
+-	return type;
+-}
+-
+-static enum event_type
+-process_function(struct event_format *event, struct print_arg *arg,
+-		 char *token, char **tok)
+-{
+-	struct pevent_function_handler *func;
+-
+-	if (strcmp(token, "__print_flags") == 0) {
+-		free_token(token);
+-		is_flag_field = 1;
+-		return process_flags(event, arg, tok);
+-	}
+-	if (strcmp(token, "__print_symbolic") == 0) {
+-		free_token(token);
+-		is_symbolic_field = 1;
+-		return process_symbols(event, arg, tok);
+-	}
+-	if (strcmp(token, "__print_hex") == 0) {
+-		free_token(token);
+-		return process_hex(event, arg, tok);
+-	}
+-	if (strcmp(token, "__get_str") == 0) {
+-		free_token(token);
+-		return process_str(event, arg, tok);
+-	}
+-	if (strcmp(token, "__get_dynamic_array") == 0) {
+-		free_token(token);
+-		return process_dynamic_array(event, arg, tok);
+-	}
+-
+-	func = find_func_handler(event->pevent, token);
+-	if (func) {
+-		free_token(token);
+-		return process_func_handler(event, func, arg, tok);
+-	}
+-
+-	do_warning("function %s not defined", token);
+-	free_token(token);
+-	return EVENT_ERROR;
+-}
+-
+-static enum event_type
+-process_arg_token(struct event_format *event, struct print_arg *arg,
+-		  char **tok, enum event_type type)
+-{
+-	char *token;
+-	char *atom;
+-
+-	token = *tok;
+-
+-	switch (type) {
+-	case EVENT_ITEM:
+-		if (strcmp(token, "REC") == 0) {
+-			free_token(token);
+-			type = process_entry(event, arg, &token);
+-			break;
+-		}
+-		atom = token;
+-		/* test the next token */
+-		type = read_token_item(&token);
+-
+-		/*
+-		 * If the next token is a parenthesis, then this
+-		 * is a function.
+-		 */
+-		if (type == EVENT_DELIM && strcmp(token, "(") == 0) {
+-			free_token(token);
+-			token = NULL;
+-			/* this will free atom. */
+-			type = process_function(event, arg, atom, &token);
+-			break;
+-		}
+-		/* atoms can be more than one token long */
+-		while (type == EVENT_ITEM) {
+-			char *new_atom;
+-			new_atom = realloc(atom,
+-					   strlen(atom) + strlen(token) + 2);
+-			if (!new_atom) {
+-				free(atom);
+-				*tok = NULL;
+-				free_token(token);
+-				return EVENT_ERROR;
+-			}
+-			atom = new_atom;
+-			strcat(atom, " ");
+-			strcat(atom, token);
+-			free_token(token);
+-			type = read_token_item(&token);
+-		}
+-
+-		arg->type = PRINT_ATOM;
+-		arg->atom.atom = atom;
+-		break;
+-
+-	case EVENT_DQUOTE:
+-	case EVENT_SQUOTE:
+-		arg->type = PRINT_ATOM;
+-		arg->atom.atom = token;
+-		type = read_token_item(&token);
+-		break;
+-	case EVENT_DELIM:
+-		if (strcmp(token, "(") == 0) {
+-			free_token(token);
+-			type = process_paren(event, arg, &token);
+-			break;
+-		}
+-	case EVENT_OP:
+-		/* handle single ops */
+-		arg->type = PRINT_OP;
+-		arg->op.op = token;
+-		arg->op.left = NULL;
+-		type = process_op(event, arg, &token);
+-
+-		/* On error, the op is freed */
+-		if (type == EVENT_ERROR)
+-			arg->op.op = NULL;
+-
+-		/* return error type if errored */
+-		break;
+-
+-	case EVENT_ERROR ... EVENT_NEWLINE:
+-	default:
+-		do_warning("unexpected type %d", type);
+-		return EVENT_ERROR;
+-	}
+-	*tok = token;
+-
+-	return type;
+-}
+-
+-static int event_read_print_args(struct event_format *event, struct print_arg **list)
+-{
+-	enum event_type type = EVENT_ERROR;
+-	struct print_arg *arg;
+-	char *token;
+-	int args = 0;
+-
+-	do {
+-		if (type == EVENT_NEWLINE) {
+-			type = read_token_item(&token);
+-			continue;
+-		}
+-
+-		arg = alloc_arg();
+-		if (!arg) {
+-			do_warning("%s: not enough memory!", __func__);
+-			return -1;
+-		}
+-
+-		type = process_arg(event, arg, &token);
+-
+-		if (type == EVENT_ERROR) {
+-			free_token(token);
+-			free_arg(arg);
+-			return -1;
+-		}
+-
+-		*list = arg;
+-		args++;
+-
+-		if (type == EVENT_OP) {
+-			type = process_op(event, arg, &token);
+-			free_token(token);
+-			if (type == EVENT_ERROR) {
+-				*list = NULL;
+-				free_arg(arg);
+-				return -1;
+-			}
+-			list = &arg->next;
+-			continue;
+-		}
+-
+-		if (type == EVENT_DELIM && strcmp(token, ",") == 0) {
+-			free_token(token);
+-			*list = arg;
+-			list = &arg->next;
+-			continue;
+-		}
+-		break;
+-	} while (type != EVENT_NONE);
+-
+-	if (type != EVENT_NONE && type != EVENT_ERROR)
+-		free_token(token);
+-
+-	return args;
+-}
+-
+-static int event_read_print(struct event_format *event)
+-{
+-	enum event_type type;
+-	char *token;
+-	int ret;
+-
+-	if (read_expected_item(EVENT_ITEM, "print") < 0)
+-		return -1;
+-
+-	if (read_expected(EVENT_ITEM, "fmt") < 0)
+-		return -1;
+-
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return -1;
+-
+-	if (read_expect_type(EVENT_DQUOTE, &token) < 0)
+-		goto fail;
+-
+- concat:
+-	event->print_fmt.format = token;
+-	event->print_fmt.args = NULL;
+-
+-	/* ok to have no arg */
+-	type = read_token_item(&token);
+-
+-	if (type == EVENT_NONE)
+-		return 0;
+-
+-	/* Handle concatenation of print lines */
+-	if (type == EVENT_DQUOTE) {
+-		char *cat;
+-
+-		if (asprintf(&cat, "%s%s", event->print_fmt.format, token) < 0)
+-			goto fail;
+-		free_token(token);
+-		free_token(event->print_fmt.format);
+-		event->print_fmt.format = NULL;
+-		token = cat;
+-		goto concat;
+-	}
+-			     
+-	if (test_type_token(type, token, EVENT_DELIM, ","))
+-		goto fail;
+-
+-	free_token(token);
+-
+-	ret = event_read_print_args(event, &event->print_fmt.args);
+-	if (ret < 0)
+-		return -1;
+-
+-	return ret;
+-
+- fail:
+-	free_token(token);
+-	return -1;
+-}
+-
+-/**
+- * pevent_find_common_field - return a common field by event
+- * @event: handle for the event
+- * @name: the name of the common field to return
+- *
+- * Returns a common field from the event by the given @name.
+- * This only searchs the common fields and not all field.
+- */
+-struct format_field *
+-pevent_find_common_field(struct event_format *event, const char *name)
+-{
+-	struct format_field *format;
+-
+-	for (format = event->format.common_fields;
+-	     format; format = format->next) {
+-		if (strcmp(format->name, name) == 0)
+-			break;
+-	}
+-
+-	return format;
+-}
+-
+-/**
+- * pevent_find_field - find a non-common field
+- * @event: handle for the event
+- * @name: the name of the non-common field
+- *
+- * Returns a non-common field by the given @name.
+- * This does not search common fields.
+- */
+-struct format_field *
+-pevent_find_field(struct event_format *event, const char *name)
+-{
+-	struct format_field *format;
+-
+-	for (format = event->format.fields;
+-	     format; format = format->next) {
+-		if (strcmp(format->name, name) == 0)
+-			break;
+-	}
+-
+-	return format;
+-}
+-
+-/**
+- * pevent_find_any_field - find any field by name
+- * @event: handle for the event
+- * @name: the name of the field
+- *
+- * Returns a field by the given @name.
+- * This searchs the common field names first, then
+- * the non-common ones if a common one was not found.
+- */
+-struct format_field *
+-pevent_find_any_field(struct event_format *event, const char *name)
+-{
+-	struct format_field *format;
+-
+-	format = pevent_find_common_field(event, name);
+-	if (format)
+-		return format;
+-	return pevent_find_field(event, name);
+-}
+-
+-/**
+- * pevent_read_number - read a number from data
+- * @pevent: handle for the pevent
+- * @ptr: the raw data
+- * @size: the size of the data that holds the number
+- *
+- * Returns the number (converted to host) from the
+- * raw data.
+- */
+-unsigned long long pevent_read_number(struct pevent *pevent,
+-				      const void *ptr, int size)
+-{
+-	switch (size) {
+-	case 1:
+-		return *(unsigned char *)ptr;
+-	case 2:
+-		return data2host2(pevent, ptr);
+-	case 4:
+-		return data2host4(pevent, ptr);
+-	case 8:
+-		return data2host8(pevent, ptr);
+-	default:
+-		/* BUG! */
+-		return 0;
+-	}
+-}
+-
+-/**
+- * pevent_read_number_field - read a number from data
+- * @field: a handle to the field
+- * @data: the raw data to read
+- * @value: the value to place the number in
+- *
+- * Reads raw data according to a field offset and size,
+- * and translates it into @value.
+- *
+- * Returns 0 on success, -1 otherwise.
+- */
+-int pevent_read_number_field(struct format_field *field, const void *data,
+-			     unsigned long long *value)
+-{
+-	if (!field)
+-		return -1;
+-	switch (field->size) {
+-	case 1:
+-	case 2:
+-	case 4:
+-	case 8:
+-		*value = pevent_read_number(field->event->pevent,
+-					    data + field->offset, field->size);
+-		return 0;
+-	default:
+-		return -1;
+-	}
+-}
+-
+-static int get_common_info(struct pevent *pevent,
+-			   const char *type, int *offset, int *size)
+-{
+-	struct event_format *event;
+-	struct format_field *field;
+-
+-	/*
+-	 * All events should have the same common elements.
+-	 * Pick any event to find where the type is;
+-	 */
+-	if (!pevent->events) {
+-		do_warning("no event_list!");
+-		return -1;
+-	}
+-
+-	event = pevent->events[0];
+-	field = pevent_find_common_field(event, type);
+-	if (!field)
+-		return -1;
+-
+-	*offset = field->offset;
+-	*size = field->size;
+-
+-	return 0;
+-}
+-
+-static int __parse_common(struct pevent *pevent, void *data,
+-			  int *size, int *offset, const char *name)
+-{
+-	int ret;
+-
+-	if (!*size) {
+-		ret = get_common_info(pevent, name, offset, size);
+-		if (ret < 0)
+-			return ret;
+-	}
+-	return pevent_read_number(pevent, data + *offset, *size);
+-}
+-
+-static int trace_parse_common_type(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->type_size, &pevent->type_offset,
+-			      "common_type");
+-}
+-
+-static int parse_common_pid(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->pid_size, &pevent->pid_offset,
+-			      "common_pid");
+-}
+-
+-static int parse_common_pc(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->pc_size, &pevent->pc_offset,
+-			      "common_preempt_count");
+-}
+-
+-static int parse_common_flags(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->flags_size, &pevent->flags_offset,
+-			      "common_flags");
+-}
+-
+-static int parse_common_lock_depth(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->ld_size, &pevent->ld_offset,
+-			      "common_lock_depth");
+-}
+-
+-static int parse_common_migrate_disable(struct pevent *pevent, void *data)
+-{
+-	return __parse_common(pevent, data,
+-			      &pevent->ld_size, &pevent->ld_offset,
+-			      "common_migrate_disable");
+-}
+-
+-static int events_id_cmp(const void *a, const void *b);
+-
+-/**
+- * pevent_find_event - find an event by given id
+- * @pevent: a handle to the pevent
+- * @id: the id of the event
+- *
+- * Returns an event that has a given @id.
+- */
+-struct event_format *pevent_find_event(struct pevent *pevent, int id)
+-{
+-	struct event_format **eventptr;
+-	struct event_format key;
+-	struct event_format *pkey = &key;
+-
+-	/* Check cache first */
+-	if (pevent->last_event && pevent->last_event->id == id)
+-		return pevent->last_event;
+-
+-	key.id = id;
+-
+-	eventptr = bsearch(&pkey, pevent->events, pevent->nr_events,
+-			   sizeof(*pevent->events), events_id_cmp);
+-
+-	if (eventptr) {
+-		pevent->last_event = *eventptr;
+-		return *eventptr;
+-	}
+-
+-	return NULL;
+-}
+-
+-/**
+- * pevent_find_event_by_name - find an event by given name
+- * @pevent: a handle to the pevent
+- * @sys: the system name to search for
+- * @name: the name of the event to search for
+- *
+- * This returns an event with a given @name and under the system
+- * @sys. If @sys is NULL the first event with @name is returned.
+- */
+-struct event_format *
+-pevent_find_event_by_name(struct pevent *pevent,
+-			  const char *sys, const char *name)
+-{
+-	struct event_format *event;
+-	int i;
+-
+-	if (pevent->last_event &&
+-	    strcmp(pevent->last_event->name, name) == 0 &&
+-	    (!sys || strcmp(pevent->last_event->system, sys) == 0))
+-		return pevent->last_event;
+-
+-	for (i = 0; i < pevent->nr_events; i++) {
+-		event = pevent->events[i];
+-		if (strcmp(event->name, name) == 0) {
+-			if (!sys)
+-				break;
+-			if (strcmp(event->system, sys) == 0)
+-				break;
+-		}
+-	}
+-	if (i == pevent->nr_events)
+-		event = NULL;
+-
+-	pevent->last_event = event;
+-	return event;
+-}
+-
+-static unsigned long long
+-eval_num_arg(void *data, int size, struct event_format *event, struct print_arg *arg)
+-{
+-	struct pevent *pevent = event->pevent;
+-	unsigned long long val = 0;
+-	unsigned long long left, right;
+-	struct print_arg *typearg = NULL;
+-	struct print_arg *larg;
+-	unsigned long offset;
+-	unsigned int field_size;
+-
+-	switch (arg->type) {
+-	case PRINT_NULL:
+-		/* ?? */
+-		return 0;
+-	case PRINT_ATOM:
+-		return strtoull(arg->atom.atom, NULL, 0);
+-	case PRINT_FIELD:
+-		if (!arg->field.field) {
+-			arg->field.field = pevent_find_any_field(event, arg->field.name);
+-			if (!arg->field.field)
+-				goto out_warning_field;
+-			
+-		}
+-		/* must be a number */
+-		val = pevent_read_number(pevent, data + arg->field.field->offset,
+-				arg->field.field->size);
+-		break;
+-	case PRINT_FLAGS:
+-	case PRINT_SYMBOL:
+-	case PRINT_HEX:
+-		break;
+-	case PRINT_TYPE:
+-		val = eval_num_arg(data, size, event, arg->typecast.item);
+-		return eval_type(val, arg, 0);
+-	case PRINT_STRING:
+-	case PRINT_BSTRING:
+-		return 0;
+-	case PRINT_FUNC: {
+-		struct trace_seq s;
+-		trace_seq_init(&s);
+-		val = process_defined_func(&s, data, size, event, arg);
+-		trace_seq_destroy(&s);
+-		return val;
+-	}
+-	case PRINT_OP:
+-		if (strcmp(arg->op.op, "[") == 0) {
+-			/*
+-			 * Arrays are special, since we don't want
+-			 * to read the arg as is.
+-			 */
+-			right = eval_num_arg(data, size, event, arg->op.right);
+-
+-			/* handle typecasts */
+-			larg = arg->op.left;
+-			while (larg->type == PRINT_TYPE) {
+-				if (!typearg)
+-					typearg = larg;
+-				larg = larg->typecast.item;
+-			}
+-
+-			/* Default to long size */
+-			field_size = pevent->long_size;
+-
+-			switch (larg->type) {
+-			case PRINT_DYNAMIC_ARRAY:
+-				offset = pevent_read_number(pevent,
+-						   data + larg->dynarray.field->offset,
+-						   larg->dynarray.field->size);
+-				if (larg->dynarray.field->elementsize)
+-					field_size = larg->dynarray.field->elementsize;
+-				/*
+-				 * The actual length of the dynamic array is stored
+-				 * in the top half of the field, and the offset
+-				 * is in the bottom half of the 32 bit field.
+-				 */
+-				offset &= 0xffff;
+-				offset += right;
+-				break;
+-			case PRINT_FIELD:
+-				if (!larg->field.field) {
+-					larg->field.field =
+-						pevent_find_any_field(event, larg->field.name);
+-					if (!larg->field.field) {
+-						arg = larg;
+-						goto out_warning_field;
+-					}
+-				}
+-				field_size = larg->field.field->elementsize;
+-				offset = larg->field.field->offset +
+-					right * larg->field.field->elementsize;
+-				break;
+-			default:
+-				goto default_op; /* oops, all bets off */
+-			}
+-			val = pevent_read_number(pevent,
+-						 data + offset, field_size);
+-			if (typearg)
+-				val = eval_type(val, typearg, 1);
+-			break;
+-		} else if (strcmp(arg->op.op, "?") == 0) {
+-			left = eval_num_arg(data, size, event, arg->op.left);
+-			arg = arg->op.right;
+-			if (left)
+-				val = eval_num_arg(data, size, event, arg->op.left);
+-			else
+-				val = eval_num_arg(data, size, event, arg->op.right);
+-			break;
+-		}
+- default_op:
+-		left = eval_num_arg(data, size, event, arg->op.left);
+-		right = eval_num_arg(data, size, event, arg->op.right);
+-		switch (arg->op.op[0]) {
+-		case '!':
+-			switch (arg->op.op[1]) {
+-			case 0:
+-				val = !right;
+-				break;
+-			case '=':
+-				val = left != right;
+-				break;
+-			default:
+-				goto out_warning_op;
+-			}
+-			break;
+-		case '~':
+-			val = ~right;
+-			break;
+-		case '|':
+-			if (arg->op.op[1])
+-				val = left || right;
+-			else
+-				val = left | right;
+-			break;
+-		case '&':
+-			if (arg->op.op[1])
+-				val = left && right;
+-			else
+-				val = left & right;
+-			break;
+-		case '<':
+-			switch (arg->op.op[1]) {
+-			case 0:
+-				val = left < right;
+-				break;
+-			case '<':
+-				val = left << right;
+-				break;
+-			case '=':
+-				val = left <= right;
+-				break;
+-			default:
+-				goto out_warning_op;
+-			}
+-			break;
+-		case '>':
+-			switch (arg->op.op[1]) {
+-			case 0:
+-				val = left > right;
+-				break;
+-			case '>':
+-				val = left >> right;
+-				break;
+-			case '=':
+-				val = left >= right;
+-				break;
+-			default:
+-				goto out_warning_op;
+-			}
+-			break;
+-		case '=':
+-			if (arg->op.op[1] != '=')
+-				goto out_warning_op;
+-
+-			val = left == right;
+-			break;
+-		case '-':
+-			val = left - right;
+-			break;
+-		case '+':
+-			val = left + right;
+-			break;
+-		case '/':
+-			val = left / right;
+-			break;
+-		case '*':
+-			val = left * right;
+-			break;
+-		default:
+-			goto out_warning_op;
+-		}
+-		break;
+-	default: /* not sure what to do there */
+-		return 0;
+-	}
+-	return val;
+-
+-out_warning_op:
+-	do_warning("%s: unknown op '%s'", __func__, arg->op.op);
+-	return 0;
+-
+-out_warning_field:
+-	do_warning("%s: field %s not found", __func__, arg->field.name);
+-	return 0;
+-}
+-
+-struct flag {
+-	const char *name;
+-	unsigned long long value;
+-};
+-
+-static const struct flag flags[] = {
+-	{ "HI_SOFTIRQ", 0 },
+-	{ "TIMER_SOFTIRQ", 1 },
+-	{ "NET_TX_SOFTIRQ", 2 },
+-	{ "NET_RX_SOFTIRQ", 3 },
+-	{ "BLOCK_SOFTIRQ", 4 },
+-	{ "BLOCK_IOPOLL_SOFTIRQ", 5 },
+-	{ "TASKLET_SOFTIRQ", 6 },
+-	{ "SCHED_SOFTIRQ", 7 },
+-	{ "HRTIMER_SOFTIRQ", 8 },
+-	{ "RCU_SOFTIRQ", 9 },
+-
+-	{ "HRTIMER_NORESTART", 0 },
+-	{ "HRTIMER_RESTART", 1 },
+-};
+-
+-static unsigned long long eval_flag(const char *flag)
+-{
+-	int i;
+-
+-	/*
+-	 * Some flags in the format files do not get converted.
+-	 * If the flag is not numeric, see if it is something that
+-	 * we already know about.
+-	 */
+-	if (isdigit(flag[0]))
+-		return strtoull(flag, NULL, 0);
+-
+-	for (i = 0; i < (int)(sizeof(flags)/sizeof(flags[0])); i++)
+-		if (strcmp(flags[i].name, flag) == 0)
+-			return flags[i].value;
+-
+-	return 0;
+-}
+-
+-static void print_str_to_seq(struct trace_seq *s, const char *format,
+-			     int len_arg, const char *str)
+-{
+-	if (len_arg >= 0)
+-		trace_seq_printf(s, format, len_arg, str);
+-	else
+-		trace_seq_printf(s, format, str);
+-}
+-
+-static void print_str_arg(struct trace_seq *s, void *data, int size,
+-			  struct event_format *event, const char *format,
+-			  int len_arg, struct print_arg *arg)
+-{
+-	struct pevent *pevent = event->pevent;
+-	struct print_flag_sym *flag;
+-	struct format_field *field;
+-	unsigned long long val, fval;
+-	unsigned long addr;
+-	char *str;
+-	unsigned char *hex;
+-	int print;
+-	int i, len;
+-
+-	switch (arg->type) {
+-	case PRINT_NULL:
+-		/* ?? */
+-		return;
+-	case PRINT_ATOM:
+-		print_str_to_seq(s, format, len_arg, arg->atom.atom);
+-		return;
+-	case PRINT_FIELD:
+-		field = arg->field.field;
+-		if (!field) {
+-			field = pevent_find_any_field(event, arg->field.name);
+-			if (!field) {
+-				str = arg->field.name;
+-				goto out_warning_field;
+-			}
+-			arg->field.field = field;
+-		}
+-		/* Zero sized fields, mean the rest of the data */
+-		len = field->size ? : size - field->offset;
+-
+-		/*
+-		 * Some events pass in pointers. If this is not an array
+-		 * and the size is the same as long_size, assume that it
+-		 * is a pointer.
+-		 */
+-		if (!(field->flags & FIELD_IS_ARRAY) &&
+-		    field->size == pevent->long_size) {
+-			addr = *(unsigned long *)(data + field->offset);
+-			trace_seq_printf(s, "%lx", addr);
+-			break;
+-		}
+-		str = malloc(len + 1);
+-		if (!str) {
+-			do_warning("%s: not enough memory!", __func__);
+-			return;
+-		}
+-		memcpy(str, data + field->offset, len);
+-		str[len] = 0;
+-		print_str_to_seq(s, format, len_arg, str);
+-		free(str);
+-		break;
+-	case PRINT_FLAGS:
+-		val = eval_num_arg(data, size, event, arg->flags.field);
+-		print = 0;
+-		for (flag = arg->flags.flags; flag; flag = flag->next) {
+-			fval = eval_flag(flag->value);
+-			if (!val && !fval) {
+-				print_str_to_seq(s, format, len_arg, flag->str);
+-				break;
+-			}
+-			if (fval && (val & fval) == fval) {
+-				if (print && arg->flags.delim)
+-					trace_seq_puts(s, arg->flags.delim);
+-				print_str_to_seq(s, format, len_arg, flag->str);
+-				print = 1;
+-				val &= ~fval;
+-			}
+-		}
+-		break;
+-	case PRINT_SYMBOL:
+-		val = eval_num_arg(data, size, event, arg->symbol.field);
+-		for (flag = arg->symbol.symbols; flag; flag = flag->next) {
+-			fval = eval_flag(flag->value);
+-			if (val == fval) {
+-				print_str_to_seq(s, format, len_arg, flag->str);
+-				break;
+-			}
+-		}
+-		break;
+-	case PRINT_HEX:
+-		field = arg->hex.field->field.field;
+-		if (!field) {
+-			str = arg->hex.field->field.name;
+-			field = pevent_find_any_field(event, str);
+-			if (!field)
+-				goto out_warning_field;
+-			arg->hex.field->field.field = field;
+-		}
+-		hex = data + field->offset;
+-		len = eval_num_arg(data, size, event, arg->hex.size);
+-		for (i = 0; i < len; i++) {
+-			if (i)
+-				trace_seq_putc(s, ' ');
+-			trace_seq_printf(s, "%02x", hex[i]);
+-		}
+-		break;
+-
+-	case PRINT_TYPE:
+-		break;
+-	case PRINT_STRING: {
+-		int str_offset;
+-
+-		if (arg->string.offset == -1) {
+-			struct format_field *f;
+-
+-			f = pevent_find_any_field(event, arg->string.string);
+-			arg->string.offset = f->offset;
+-		}
+-		str_offset = data2host4(pevent, data + arg->string.offset);
+-		str_offset &= 0xffff;
+-		print_str_to_seq(s, format, len_arg, ((char *)data) + str_offset);
+-		break;
+-	}
+-	case PRINT_BSTRING:
+-		print_str_to_seq(s, format, len_arg, arg->string.string);
+-		break;
+-	case PRINT_OP:
+-		/*
+-		 * The only op for string should be ? :
+-		 */
+-		if (arg->op.op[0] != '?')
+-			return;
+-		val = eval_num_arg(data, size, event, arg->op.left);
+-		if (val)
+-			print_str_arg(s, data, size, event,
+-				      format, len_arg, arg->op.right->op.left);
+-		else
+-			print_str_arg(s, data, size, event,
+-				      format, len_arg, arg->op.right->op.right);
+-		break;
+-	case PRINT_FUNC:
+-		process_defined_func(s, data, size, event, arg);
+-		break;
+-	default:
+-		/* well... */
+-		break;
+-	}
+-
+-	return;
+-
+-out_warning_field:
+-	do_warning("%s: field %s not found", __func__, arg->field.name);
+-}
+-
+-static unsigned long long
+-process_defined_func(struct trace_seq *s, void *data, int size,
+-		     struct event_format *event, struct print_arg *arg)
+-{
+-	struct pevent_function_handler *func_handle = arg->func.func;
+-	struct pevent_func_params *param;
+-	unsigned long long *args;
+-	unsigned long long ret;
+-	struct print_arg *farg;
+-	struct trace_seq str;
+-	struct save_str {
+-		struct save_str *next;
+-		char *str;
+-	} *strings = NULL, *string;
+-	int i;
+-
+-	if (!func_handle->nr_args) {
+-		ret = (*func_handle->func)(s, NULL);
+-		goto out;
+-	}
+-
+-	farg = arg->func.args;
+-	param = func_handle->params;
+-
+-	ret = ULLONG_MAX;
+-	args = malloc(sizeof(*args) * func_handle->nr_args);
+-	if (!args)
+-		goto out;
+-
+-	for (i = 0; i < func_handle->nr_args; i++) {
+-		switch (param->type) {
+-		case PEVENT_FUNC_ARG_INT:
+-		case PEVENT_FUNC_ARG_LONG:
+-		case PEVENT_FUNC_ARG_PTR:
+-			args[i] = eval_num_arg(data, size, event, farg);
+-			break;
+-		case PEVENT_FUNC_ARG_STRING:
+-			trace_seq_init(&str);
+-			print_str_arg(&str, data, size, event, "%s", -1, farg);
+-			trace_seq_terminate(&str);
+-			string = malloc(sizeof(*string));
+-			if (!string) {
+-				do_warning("%s(%d): malloc str", __func__, __LINE__);
+-				goto out_free;
+-			}
+-			string->next = strings;
+-			string->str = strdup(str.buffer);
+-			if (!string->str) {
+-				free(string);
+-				do_warning("%s(%d): malloc str", __func__, __LINE__);
+-				goto out_free;
+-			}
+-			args[i] = (uintptr_t)string->str;
+-			strings = string;
+-			trace_seq_destroy(&str);
+-			break;
+-		default:
+-			/*
+-			 * Something went totally wrong, this is not
+-			 * an input error, something in this code broke.
+-			 */
+-			do_warning("Unexpected end of arguments\n");
+-			goto out_free;
+-		}
+-		farg = farg->next;
+-		param = param->next;
+-	}
+-
+-	ret = (*func_handle->func)(s, args);
+-out_free:
+-	free(args);
+-	while (strings) {
+-		string = strings;
+-		strings = string->next;
+-		free(string->str);
+-		free(string);
+-	}
+-
+- out:
+-	/* TBD : handle return type here */
+-	return ret;
+-}
+-
+-static void free_args(struct print_arg *args)
+-{
+-	struct print_arg *next;
+-
+-	while (args) {
+-		next = args->next;
+-
+-		free_arg(args);
+-		args = next;
+-	}
+-}
+-
+-static struct print_arg *make_bprint_args(char *fmt, void *data, int size, struct event_format *event)
+-{
+-	struct pevent *pevent = event->pevent;
+-	struct format_field *field, *ip_field;
+-	struct print_arg *args, *arg, **next;
+-	unsigned long long ip, val;
+-	char *ptr;
+-	void *bptr;
+-	int vsize;
+-
+-	field = pevent->bprint_buf_field;
+-	ip_field = pevent->bprint_ip_field;
+-
+-	if (!field) {
+-		field = pevent_find_field(event, "buf");
+-		if (!field) {
+-			do_warning("can't find buffer field for binary printk");
+-			return NULL;
+-		}
+-		ip_field = pevent_find_field(event, "ip");
+-		if (!ip_field) {
+-			do_warning("can't find ip field for binary printk");
+-			return NULL;
+-		}
+-		pevent->bprint_buf_field = field;
+-		pevent->bprint_ip_field = ip_field;
+-	}
+-
+-	ip = pevent_read_number(pevent, data + ip_field->offset, ip_field->size);
+-
+-	/*
+-	 * The first arg is the IP pointer.
+-	 */
+-	args = alloc_arg();
+-	if (!args) {
+-		do_warning("%s(%d): not enough memory!", __func__, __LINE__);
+-		return NULL;
+-	}
+-	arg = args;
+-	arg->next = NULL;
+-	next = &arg->next;
+-
+-	arg->type = PRINT_ATOM;
+-		
+-	if (asprintf(&arg->atom.atom, "%lld", ip) < 0)
+-		goto out_free;
+-
+-	/* skip the first "%pf : " */
+-	for (ptr = fmt + 6, bptr = data + field->offset;
+-	     bptr < data + size && *ptr; ptr++) {
+-		int ls = 0;
+-
+-		if (*ptr == '%') {
+- process_again:
+-			ptr++;
+-			switch (*ptr) {
+-			case '%':
+-				break;
+-			case 'l':
+-				ls++;
+-				goto process_again;
+-			case 'L':
+-				ls = 2;
+-				goto process_again;
+-			case '0' ... '9':
+-				goto process_again;
+-			case '.':
+-				goto process_again;
+-			case 'p':
+-				ls = 1;
+-				/* fall through */
+-			case 'd':
+-			case 'u':
+-			case 'x':
+-			case 'i':
+-				switch (ls) {
+-				case 0:
+-					vsize = 4;
+-					break;
+-				case 1:
+-					vsize = pevent->long_size;
+-					break;
+-				case 2:
+-					vsize = 8;
+-					break;
+-				default:
+-					vsize = ls; /* ? */
+-					break;
+-				}
+-			/* fall through */
+-			case '*':
+-				if (*ptr == '*')
+-					vsize = 4;
+-
+-				/* the pointers are always 4 bytes aligned */
+-				bptr = (void *)(((unsigned long)bptr + 3) &
+-						~3);
+-				val = pevent_read_number(pevent, bptr, vsize);
+-				bptr += vsize;
+-				arg = alloc_arg();
+-				if (!arg) {
+-					do_warning("%s(%d): not enough memory!",
+-						   __func__, __LINE__);
+-					goto out_free;
+-				}
+-				arg->next = NULL;
+-				arg->type = PRINT_ATOM;
+-				if (asprintf(&arg->atom.atom, "%lld", val) < 0) {
+-					free(arg);
+-					goto out_free;
+-				}
+-				*next = arg;
+-				next = &arg->next;
+-				/*
+-				 * The '*' case means that an arg is used as the length.
+-				 * We need to continue to figure out for what.
+-				 */
+-				if (*ptr == '*')
+-					goto process_again;
+-
+-				break;
+-			case 's':
+-				arg = alloc_arg();
+-				if (!arg) {
+-					do_warning("%s(%d): not enough memory!",
+-						   __func__, __LINE__);
+-					goto out_free;
+-				}
+-				arg->next = NULL;
+-				arg->type = PRINT_BSTRING;
+-				arg->string.string = strdup(bptr);
+-				if (!arg->string.string)
+-					goto out_free;
+-				bptr += strlen(bptr) + 1;
+-				*next = arg;
+-				next = &arg->next;
+-			default:
+-				break;
+-			}
+-		}
+-	}
+-
+-	return args;
+-
+-out_free:
+-	free_args(args);
+-	return NULL;
+-}
+-
+-static char *
+-get_bprint_format(void *data, int size __maybe_unused,
+-		  struct event_format *event)
+-{
+-	struct pevent *pevent = event->pevent;
+-	unsigned long long addr;
+-	struct format_field *field;
+-	struct printk_map *printk;
+-	char *format;
+-	char *p;
+-
+-	field = pevent->bprint_fmt_field;
+-
+-	if (!field) {
+-		field = pevent_find_field(event, "fmt");
+-		if (!field) {
+-			do_warning("can't find format field for binary printk");
+-			return NULL;
+-		}
+-		pevent->bprint_fmt_field = field;
+-	}
+-
+-	addr = pevent_read_number(pevent, data + field->offset, field->size);
+-
+-	printk = find_printk(pevent, addr);
+-	if (!printk) {
+-		if (asprintf(&format, "%%pf : (NO FORMAT FOUND at %llx)\n", addr) < 0)
+-			return NULL;
+-		return format;
+-	}
+-
+-	p = printk->printk;
+-	/* Remove any quotes. */
+-	if (*p == '"')
+-		p++;
+-	if (asprintf(&format, "%s : %s", "%pf", p) < 0)
+-		return NULL;
+-	/* remove ending quotes and new line since we will add one too */
+-	p = format + strlen(format) - 1;
+-	if (*p == '"')
+-		*p = 0;
+-
+-	p -= 2;
+-	if (strcmp(p, "\\n") == 0)
+-		*p = 0;
+-
+-	return format;
+-}
+-
+-static void print_mac_arg(struct trace_seq *s, int mac, void *data, int size,
+-			  struct event_format *event, struct print_arg *arg)
+-{
+-	unsigned char *buf;
+-	const char *fmt = "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x";
+-
+-	if (arg->type == PRINT_FUNC) {
+-		process_defined_func(s, data, size, event, arg);
+-		return;
+-	}
+-
+-	if (arg->type != PRINT_FIELD) {
+-		trace_seq_printf(s, "ARG TYPE NOT FIELD BUT %d",
+-				 arg->type);
+-		return;
+-	}
+-
+-	if (mac == 'm')
+-		fmt = "%.2x%.2x%.2x%.2x%.2x%.2x";
+-	if (!arg->field.field) {
+-		arg->field.field =
+-			pevent_find_any_field(event, arg->field.name);
+-		if (!arg->field.field) {
+-			do_warning("%s: field %s not found",
+-				   __func__, arg->field.name);
+-			return;
+-		}
+-	}
+-	if (arg->field.field->size != 6) {
+-		trace_seq_printf(s, "INVALIDMAC");
+-		return;
+-	}
+-	buf = data + arg->field.field->offset;
+-	trace_seq_printf(s, fmt, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
+-}
+-
+-static int is_printable_array(char *p, unsigned int len)
+-{
+-	unsigned int i;
+-
+-	for (i = 0; i < len && p[i]; i++)
+-		if (!isprint(p[i]))
+-		    return 0;
+-	return 1;
+-}
+-
+-static void print_event_fields(struct trace_seq *s, void *data,
+-			       int size __maybe_unused,
+-			       struct event_format *event)
+-{
+-	struct format_field *field;
+-	unsigned long long val;
+-	unsigned int offset, len, i;
+-
+-	field = event->format.fields;
+-	while (field) {
+-		trace_seq_printf(s, " %s=", field->name);
+-		if (field->flags & FIELD_IS_ARRAY) {
+-			offset = field->offset;
+-			len = field->size;
+-			if (field->flags & FIELD_IS_DYNAMIC) {
+-				val = pevent_read_number(event->pevent, data + offset, len);
+-				offset = val;
+-				len = offset >> 16;
+-				offset &= 0xffff;
+-			}
+-			if (field->flags & FIELD_IS_STRING &&
+-			    is_printable_array(data + offset, len)) {
+-				trace_seq_printf(s, "%s", (char *)data + offset);
+-			} else {
+-				trace_seq_puts(s, "ARRAY[");
+-				for (i = 0; i < len; i++) {
+-					if (i)
+-						trace_seq_puts(s, ", ");
+-					trace_seq_printf(s, "%02x",
+-							 *((unsigned char *)data + offset + i));
+-				}
+-				trace_seq_putc(s, ']');
+-				field->flags &= ~FIELD_IS_STRING;
+-			}
+-		} else {
+-			val = pevent_read_number(event->pevent, data + field->offset,
+-						 field->size);
+-			if (field->flags & FIELD_IS_POINTER) {
+-				trace_seq_printf(s, "0x%llx", val);
+-			} else if (field->flags & FIELD_IS_SIGNED) {
+-				switch (field->size) {
+-				case 4:
+-					/*
+-					 * If field is long then print it in hex.
+-					 * A long usually stores pointers.
+-					 */
+-					if (field->flags & FIELD_IS_LONG)
+-						trace_seq_printf(s, "0x%x", (int)val);
+-					else
+-						trace_seq_printf(s, "%d", (int)val);
+-					break;
+-				case 2:
+-					trace_seq_printf(s, "%2d", (short)val);
+-					break;
+-				case 1:
+-					trace_seq_printf(s, "%1d", (char)val);
+-					break;
+-				default:
+-					trace_seq_printf(s, "%lld", val);
+-				}
+-			} else {
+-				if (field->flags & FIELD_IS_LONG)
+-					trace_seq_printf(s, "0x%llx", val);
+-				else
+-					trace_seq_printf(s, "%llu", val);
+-			}
+-		}
+-		field = field->next;
+-	}
+-}
+-
+-static void pretty_print(struct trace_seq *s, void *data, int size, struct event_format *event)
+-{
+-	struct pevent *pevent = event->pevent;
+-	struct print_fmt *print_fmt = &event->print_fmt;
+-	struct print_arg *arg = print_fmt->args;
+-	struct print_arg *args = NULL;
+-	const char *ptr = print_fmt->format;
+-	unsigned long long val;
+-	struct func_map *func;
+-	const char *saveptr;
+-	char *bprint_fmt = NULL;
+-	char format[32];
+-	int show_func;
+-	int len_as_arg;
+-	int len_arg;
+-	int len;
+-	int ls;
+-
+-	if (event->flags & EVENT_FL_FAILED) {
+-		trace_seq_printf(s, "[FAILED TO PARSE]");
+-		print_event_fields(s, data, size, event);
+-		return;
+-	}
+-
+-	if (event->flags & EVENT_FL_ISBPRINT) {
+-		bprint_fmt = get_bprint_format(data, size, event);
+-		args = make_bprint_args(bprint_fmt, data, size, event);
+-		arg = args;
+-		ptr = bprint_fmt;
+-	}
+-
+-	for (; *ptr; ptr++) {
+-		ls = 0;
+-		if (*ptr == '\\') {
+-			ptr++;
+-			switch (*ptr) {
+-			case 'n':
+-				trace_seq_putc(s, '\n');
+-				break;
+-			case 't':
+-				trace_seq_putc(s, '\t');
+-				break;
+-			case 'r':
+-				trace_seq_putc(s, '\r');
+-				break;
+-			case '\\':
+-				trace_seq_putc(s, '\\');
+-				break;
+-			default:
+-				trace_seq_putc(s, *ptr);
+-				break;
+-			}
+-
+-		} else if (*ptr == '%') {
+-			saveptr = ptr;
+-			show_func = 0;
+-			len_as_arg = 0;
+- cont_process:
+-			ptr++;
+-			switch (*ptr) {
+-			case '%':
+-				trace_seq_putc(s, '%');
+-				break;
+-			case '#':
+-				/* FIXME: need to handle properly */
+-				goto cont_process;
+-			case 'h':
+-				ls--;
+-				goto cont_process;
+-			case 'l':
+-				ls++;
+-				goto cont_process;
+-			case 'L':
+-				ls = 2;
+-				goto cont_process;
+-			case '*':
+-				/* The argument is the length. */
+-				if (!arg) {
+-					do_warning("no argument match");
+-					event->flags |= EVENT_FL_FAILED;
+-					goto out_failed;
+-				}
+-				len_arg = eval_num_arg(data, size, event, arg);
+-				len_as_arg = 1;
+-				arg = arg->next;
+-				goto cont_process;
+-			case '.':
+-			case 'z':
+-			case 'Z':
+-			case '0' ... '9':
+-				goto cont_process;
+-			case 'p':
+-				if (pevent->long_size == 4)
+-					ls = 1;
+-				else
+-					ls = 2;
+-
+-				if (*(ptr+1) == 'F' ||
+-				    *(ptr+1) == 'f') {
+-					ptr++;
+-					show_func = *ptr;
+-				} else if (*(ptr+1) == 'M' || *(ptr+1) == 'm') {
+-					print_mac_arg(s, *(ptr+1), data, size, event, arg);
+-					ptr++;
+-					arg = arg->next;
+-					break;
+-				}
+-
+-				/* fall through */
+-			case 'd':
+-			case 'i':
+-			case 'x':
+-			case 'X':
+-			case 'u':
+-				if (!arg) {
+-					do_warning("no argument match");
+-					event->flags |= EVENT_FL_FAILED;
+-					goto out_failed;
+-				}
+-
+-				len = ((unsigned long)ptr + 1) -
+-					(unsigned long)saveptr;
+-
+-				/* should never happen */
+-				if (len > 31) {
+-					do_warning("bad format!");
+-					event->flags |= EVENT_FL_FAILED;
+-					len = 31;
+-				}
+-
+-				memcpy(format, saveptr, len);
+-				format[len] = 0;
+-
+-				val = eval_num_arg(data, size, event, arg);
+-				arg = arg->next;
+-
+-				if (show_func) {
+-					func = find_func(pevent, val);
+-					if (func) {
+-						trace_seq_puts(s, func->func);
+-						if (show_func == 'F')
+-							trace_seq_printf(s,
+-							       "+0x%llx",
+-							       val - func->addr);
+-						break;
+-					}
+-				}
+-				if (pevent->long_size == 8 && ls &&
+-				    sizeof(long) != 8) {
+-					char *p;
+-
+-					ls = 2;
+-					/* make %l into %ll */
+-					p = strchr(format, 'l');
+-					if (p)
+-						memmove(p+1, p, strlen(p)+1);
+-					else if (strcmp(format, "%p") == 0)
+-						strcpy(format, "0x%llx");
+-				}
+-				switch (ls) {
+-				case -2:
+-					if (len_as_arg)
+-						trace_seq_printf(s, format, len_arg, (char)val);
+-					else
+-						trace_seq_printf(s, format, (char)val);
+-					break;
+-				case -1:
+-					if (len_as_arg)
+-						trace_seq_printf(s, format, len_arg, (short)val);
+-					else
+-						trace_seq_printf(s, format, (short)val);
+-					break;
+-				case 0:
+-					if (len_as_arg)
+-						trace_seq_printf(s, format, len_arg, (int)val);
+-					else
+-						trace_seq_printf(s, format, (int)val);
+-					break;
+-				case 1:
+-					if (len_as_arg)
+-						trace_seq_printf(s, format, len_arg, (long)val);
+-					else
+-						trace_seq_printf(s, format, (long)val);
+-					break;
+-				case 2:
+-					if (len_as_arg)
+-						trace_seq_printf(s, format, len_arg,
+-								 (long long)val);
+-					else
+-						trace_seq_printf(s, format, (long long)val);
+-					break;
+-				default:
+-					do_warning("bad count (%d)", ls);
+-					event->flags |= EVENT_FL_FAILED;
+-				}
+-				break;
+-			case 's':
+-				if (!arg) {
+-					do_warning("no matching argument");
+-					event->flags |= EVENT_FL_FAILED;
+-					goto out_failed;
+-				}
+-
+-				len = ((unsigned long)ptr + 1) -
+-					(unsigned long)saveptr;
+-
+-				/* should never happen */
+-				if (len > 31) {
+-					do_warning("bad format!");
+-					event->flags |= EVENT_FL_FAILED;
+-					len = 31;
+-				}
+-
+-				memcpy(format, saveptr, len);
+-				format[len] = 0;
+-				if (!len_as_arg)
+-					len_arg = -1;
+-				print_str_arg(s, data, size, event,
+-					      format, len_arg, arg);
+-				arg = arg->next;
+-				break;
+-			default:
+-				trace_seq_printf(s, ">%c<", *ptr);
+-
+-			}
+-		} else
+-			trace_seq_putc(s, *ptr);
+-	}
+-
+-	if (event->flags & EVENT_FL_FAILED) {
+-out_failed:
+-		trace_seq_printf(s, "[FAILED TO PARSE]");
+-	}
+-
+-	if (args) {
+-		free_args(args);
+-		free(bprint_fmt);
+-	}
+-}
+-
+-/**
+- * pevent_data_lat_fmt - parse the data for the latency format
+- * @pevent: a handle to the pevent
+- * @s: the trace_seq to write to
+- * @record: the record to read from
+- *
+- * This parses out the Latency format (interrupts disabled,
+- * need rescheduling, in hard/soft interrupt, preempt count
+- * and lock depth) and places it into the trace_seq.
+- */
+-void pevent_data_lat_fmt(struct pevent *pevent,
+-			 struct trace_seq *s, struct pevent_record *record)
+-{
+-	static int check_lock_depth = 1;
+-	static int check_migrate_disable = 1;
+-	static int lock_depth_exists;
+-	static int migrate_disable_exists;
+-	unsigned int lat_flags;
+-	unsigned int pc;
+-	int lock_depth;
+-	int migrate_disable;
+-	int hardirq;
+-	int softirq;
+-	void *data = record->data;
+-
+-	lat_flags = parse_common_flags(pevent, data);
+-	pc = parse_common_pc(pevent, data);
+-	/* lock_depth may not always exist */
+-	if (lock_depth_exists)
+-		lock_depth = parse_common_lock_depth(pevent, data);
+-	else if (check_lock_depth) {
+-		lock_depth = parse_common_lock_depth(pevent, data);
+-		if (lock_depth < 0)
+-			check_lock_depth = 0;
+-		else
+-			lock_depth_exists = 1;
+-	}
+-
+-	/* migrate_disable may not always exist */
+-	if (migrate_disable_exists)
+-		migrate_disable = parse_common_migrate_disable(pevent, data);
+-	else if (check_migrate_disable) {
+-		migrate_disable = parse_common_migrate_disable(pevent, data);
+-		if (migrate_disable < 0)
+-			check_migrate_disable = 0;
+-		else
+-			migrate_disable_exists = 1;
+-	}
+-
+-	hardirq = lat_flags & TRACE_FLAG_HARDIRQ;
+-	softirq = lat_flags & TRACE_FLAG_SOFTIRQ;
+-
+-	trace_seq_printf(s, "%c%c%c",
+-	       (lat_flags & TRACE_FLAG_IRQS_OFF) ? 'd' :
+-	       (lat_flags & TRACE_FLAG_IRQS_NOSUPPORT) ?
+-	       'X' : '.',
+-	       (lat_flags & TRACE_FLAG_NEED_RESCHED) ?
+-	       'N' : '.',
+-	       (hardirq && softirq) ? 'H' :
+-	       hardirq ? 'h' : softirq ? 's' : '.');
+-
+-	if (pc)
+-		trace_seq_printf(s, "%x", pc);
+-	else
+-		trace_seq_putc(s, '.');
+-
+-	if (migrate_disable_exists) {
+-		if (migrate_disable < 0)
+-			trace_seq_putc(s, '.');
+-		else
+-			trace_seq_printf(s, "%d", migrate_disable);
+-	}
+-
+-	if (lock_depth_exists) {
+-		if (lock_depth < 0)
+-			trace_seq_putc(s, '.');
+-		else
+-			trace_seq_printf(s, "%d", lock_depth);
+-	}
+-
+-	trace_seq_terminate(s);
+-}
+-
+-/**
+- * pevent_data_type - parse out the given event type
+- * @pevent: a handle to the pevent
+- * @rec: the record to read from
+- *
+- * This returns the event id from the @rec.
+- */
+-int pevent_data_type(struct pevent *pevent, struct pevent_record *rec)
+-{
+-	return trace_parse_common_type(pevent, rec->data);
+-}
+-
+-/**
+- * pevent_data_event_from_type - find the event by a given type
+- * @pevent: a handle to the pevent
+- * @type: the type of the event.
+- *
+- * This returns the event form a given @type;
+- */
+-struct event_format *pevent_data_event_from_type(struct pevent *pevent, int type)
+-{
+-	return pevent_find_event(pevent, type);
+-}
+-
+-/**
+- * pevent_data_pid - parse the PID from raw data
+- * @pevent: a handle to the pevent
+- * @rec: the record to parse
+- *
+- * This returns the PID from a raw data.
+- */
+-int pevent_data_pid(struct pevent *pevent, struct pevent_record *rec)
+-{
+-	return parse_common_pid(pevent, rec->data);
+-}
+-
+-/**
+- * pevent_data_comm_from_pid - return the command line from PID
+- * @pevent: a handle to the pevent
+- * @pid: the PID of the task to search for
+- *
+- * This returns a pointer to the command line that has the given
+- * @pid.
+- */
+-const char *pevent_data_comm_from_pid(struct pevent *pevent, int pid)
+-{
+-	const char *comm;
+-
+-	comm = find_cmdline(pevent, pid);
+-	return comm;
+-}
+-
+-/**
+- * pevent_data_comm_from_pid - parse the data into the print format
+- * @s: the trace_seq to write to
+- * @event: the handle to the event
+- * @record: the record to read from
+- *
+- * This parses the raw @data using the given @event information and
+- * writes the print format into the trace_seq.
+- */
+-void pevent_event_info(struct trace_seq *s, struct event_format *event,
+-		       struct pevent_record *record)
+-{
+-	int print_pretty = 1;
+-
+-	if (event->pevent->print_raw)
+-		print_event_fields(s, record->data, record->size, event);
+-	else {
+-
+-		if (event->handler)
+-			print_pretty = event->handler(s, record, event,
+-						      event->context);
+-
+-		if (print_pretty)
+-			pretty_print(s, record->data, record->size, event);
+-	}
+-
+-	trace_seq_terminate(s);
+-}
+-
+-void pevent_print_event(struct pevent *pevent, struct trace_seq *s,
+-			struct pevent_record *record)
+-{
+-	static const char *spaces = "                    "; /* 20 spaces */
+-	struct event_format *event;
+-	unsigned long secs;
+-	unsigned long usecs;
+-	unsigned long nsecs;
+-	const char *comm;
+-	void *data = record->data;
+-	int type;
+-	int pid;
+-	int len;
+-	int p;
+-
+-	secs = record->ts / NSECS_PER_SEC;
+-	nsecs = record->ts - secs * NSECS_PER_SEC;
+-
+-	if (record->size < 0) {
+-		do_warning("ug! negative record size %d", record->size);
+-		return;
+-	}
+-
+-	type = trace_parse_common_type(pevent, data);
+-
+-	event = pevent_find_event(pevent, type);
+-	if (!event) {
+-		do_warning("ug! no event found for type %d", type);
+-		return;
+-	}
+-
+-	pid = parse_common_pid(pevent, data);
+-	comm = find_cmdline(pevent, pid);
+-
+-	if (pevent->latency_format) {
+-		trace_seq_printf(s, "%8.8s-%-5d %3d",
+-		       comm, pid, record->cpu);
+-		pevent_data_lat_fmt(pevent, s, record);
+-	} else
+-		trace_seq_printf(s, "%16s-%-5d [%03d]", comm, pid, record->cpu);
+-
+-	if (pevent->flags & PEVENT_NSEC_OUTPUT) {
+-		usecs = nsecs;
+-		p = 9;
+-	} else {
+-		usecs = (nsecs + 500) / NSECS_PER_USEC;
+-		p = 6;
+-	}
+-
+-	trace_seq_printf(s, " %5lu.%0*lu: %s: ", secs, p, usecs, event->name);
+-
+-	/* Space out the event names evenly. */
+-	len = strlen(event->name);
+-	if (len < 20)
+-		trace_seq_printf(s, "%.*s", 20 - len, spaces);
+-
+-	pevent_event_info(s, event, record);
+-}
+-
+-static int events_id_cmp(const void *a, const void *b)
+-{
+-	struct event_format * const * ea = a;
+-	struct event_format * const * eb = b;
+-
+-	if ((*ea)->id < (*eb)->id)
+-		return -1;
+-
+-	if ((*ea)->id > (*eb)->id)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static int events_name_cmp(const void *a, const void *b)
+-{
+-	struct event_format * const * ea = a;
+-	struct event_format * const * eb = b;
+-	int res;
+-
+-	res = strcmp((*ea)->name, (*eb)->name);
+-	if (res)
+-		return res;
+-
+-	res = strcmp((*ea)->system, (*eb)->system);
+-	if (res)
+-		return res;
+-
+-	return events_id_cmp(a, b);
+-}
+-
+-static int events_system_cmp(const void *a, const void *b)
+-{
+-	struct event_format * const * ea = a;
+-	struct event_format * const * eb = b;
+-	int res;
+-
+-	res = strcmp((*ea)->system, (*eb)->system);
+-	if (res)
+-		return res;
+-
+-	res = strcmp((*ea)->name, (*eb)->name);
+-	if (res)
+-		return res;
+-
+-	return events_id_cmp(a, b);
+-}
+-
+-struct event_format **pevent_list_events(struct pevent *pevent, enum event_sort_type sort_type)
+-{
+-	struct event_format **events;
+-	int (*sort)(const void *a, const void *b);
+-
+-	events = pevent->sort_events;
+-
+-	if (events && pevent->last_type == sort_type)
+-		return events;
+-
+-	if (!events) {
+-		events = malloc(sizeof(*events) * (pevent->nr_events + 1));
+-		if (!events)
+-			return NULL;
+-
+-		memcpy(events, pevent->events, sizeof(*events) * pevent->nr_events);
+-		events[pevent->nr_events] = NULL;
+-
+-		pevent->sort_events = events;
+-
+-		/* the internal events are sorted by id */
+-		if (sort_type == EVENT_SORT_ID) {
+-			pevent->last_type = sort_type;
+-			return events;
+-		}
+-	}
+-
+-	switch (sort_type) {
+-	case EVENT_SORT_ID:
+-		sort = events_id_cmp;
+-		break;
+-	case EVENT_SORT_NAME:
+-		sort = events_name_cmp;
+-		break;
+-	case EVENT_SORT_SYSTEM:
+-		sort = events_system_cmp;
+-		break;
+-	default:
+-		return events;
+-	}
+-
+-	qsort(events, pevent->nr_events, sizeof(*events), sort);
+-	pevent->last_type = sort_type;
+-
+-	return events;
+-}
+-
+-static struct format_field **
+-get_event_fields(const char *type, const char *name,
+-		 int count, struct format_field *list)
+-{
+-	struct format_field **fields;
+-	struct format_field *field;
+-	int i = 0;
+-
+-	fields = malloc(sizeof(*fields) * (count + 1));
+-	if (!fields)
+-		return NULL;
+-
+-	for (field = list; field; field = field->next) {
+-		fields[i++] = field;
+-		if (i == count + 1) {
+-			do_warning("event %s has more %s fields than specified",
+-				name, type);
+-			i--;
+-			break;
+-		}
+-	}
+-
+-	if (i != count)
+-		do_warning("event %s has less %s fields than specified",
+-			name, type);
+-
+-	fields[i] = NULL;
+-
+-	return fields;
+-}
+-
+-/**
+- * pevent_event_common_fields - return a list of common fields for an event
+- * @event: the event to return the common fields of.
+- *
+- * Returns an allocated array of fields. The last item in the array is NULL.
+- * The array must be freed with free().
+- */
+-struct format_field **pevent_event_common_fields(struct event_format *event)
+-{
+-	return get_event_fields("common", event->name,
+-				event->format.nr_common,
+-				event->format.common_fields);
+-}
+-
+-/**
+- * pevent_event_fields - return a list of event specific fields for an event
+- * @event: the event to return the fields of.
+- *
+- * Returns an allocated array of fields. The last item in the array is NULL.
+- * The array must be freed with free().
+- */
+-struct format_field **pevent_event_fields(struct event_format *event)
+-{
+-	return get_event_fields("event", event->name,
+-				event->format.nr_fields,
+-				event->format.fields);
+-}
+-
+-static void print_fields(struct trace_seq *s, struct print_flag_sym *field)
+-{
+-	trace_seq_printf(s, "{ %s, %s }", field->value, field->str);
+-	if (field->next) {
+-		trace_seq_puts(s, ", ");
+-		print_fields(s, field->next);
+-	}
+-}
+-
+-/* for debugging */
+-static void print_args(struct print_arg *args)
+-{
+-	int print_paren = 1;
+-	struct trace_seq s;
+-
+-	switch (args->type) {
+-	case PRINT_NULL:
+-		printf("null");
+-		break;
+-	case PRINT_ATOM:
+-		printf("%s", args->atom.atom);
+-		break;
+-	case PRINT_FIELD:
+-		printf("REC->%s", args->field.name);
+-		break;
+-	case PRINT_FLAGS:
+-		printf("__print_flags(");
+-		print_args(args->flags.field);
+-		printf(", %s, ", args->flags.delim);
+-		trace_seq_init(&s);
+-		print_fields(&s, args->flags.flags);
+-		trace_seq_do_printf(&s);
+-		trace_seq_destroy(&s);
+-		printf(")");
+-		break;
+-	case PRINT_SYMBOL:
+-		printf("__print_symbolic(");
+-		print_args(args->symbol.field);
+-		printf(", ");
+-		trace_seq_init(&s);
+-		print_fields(&s, args->symbol.symbols);
+-		trace_seq_do_printf(&s);
+-		trace_seq_destroy(&s);
+-		printf(")");
+-		break;
+-	case PRINT_HEX:
+-		printf("__print_hex(");
+-		print_args(args->hex.field);
+-		printf(", ");
+-		print_args(args->hex.size);
+-		printf(")");
+-		break;
+-	case PRINT_STRING:
+-	case PRINT_BSTRING:
+-		printf("__get_str(%s)", args->string.string);
+-		break;
+-	case PRINT_TYPE:
+-		printf("(%s)", args->typecast.type);
+-		print_args(args->typecast.item);
+-		break;
+-	case PRINT_OP:
+-		if (strcmp(args->op.op, ":") == 0)
+-			print_paren = 0;
+-		if (print_paren)
+-			printf("(");
+-		print_args(args->op.left);
+-		printf(" %s ", args->op.op);
+-		print_args(args->op.right);
+-		if (print_paren)
+-			printf(")");
+-		break;
+-	default:
+-		/* we should warn... */
+-		return;
+-	}
+-	if (args->next) {
+-		printf("\n");
+-		print_args(args->next);
+-	}
+-}
+-
+-static void parse_header_field(const char *field,
+-			       int *offset, int *size, int mandatory)
+-{
+-	unsigned long long save_input_buf_ptr;
+-	unsigned long long save_input_buf_siz;
+-	char *token;
+-	int type;
+-
+-	save_input_buf_ptr = input_buf_ptr;
+-	save_input_buf_siz = input_buf_siz;
+-
+-	if (read_expected(EVENT_ITEM, "field") < 0)
+-		return;
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return;
+-
+-	/* type */
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto fail;
+-	free_token(token);
+-
+-	/*
+-	 * If this is not a mandatory field, then test it first.
+-	 */
+-	if (mandatory) {
+-		if (read_expected(EVENT_ITEM, field) < 0)
+-			return;
+-	} else {
+-		if (read_expect_type(EVENT_ITEM, &token) < 0)
+-			goto fail;
+-		if (strcmp(token, field) != 0)
+-			goto discard;
+-		free_token(token);
+-	}
+-
+-	if (read_expected(EVENT_OP, ";") < 0)
+-		return;
+-	if (read_expected(EVENT_ITEM, "offset") < 0)
+-		return;
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return;
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto fail;
+-	*offset = atoi(token);
+-	free_token(token);
+-	if (read_expected(EVENT_OP, ";") < 0)
+-		return;
+-	if (read_expected(EVENT_ITEM, "size") < 0)
+-		return;
+-	if (read_expected(EVENT_OP, ":") < 0)
+-		return;
+-	if (read_expect_type(EVENT_ITEM, &token) < 0)
+-		goto fail;
+-	*size = atoi(token);
+-	free_token(token);
+-	if (read_expected(EVENT_OP, ";") < 0)
+-		return;
+-	type = read_token(&token);
+-	if (type != EVENT_NEWLINE) {
+-		/* newer versions of the kernel have a "signed" type */
+-		if (type != EVENT_ITEM)
+-			goto fail;
+-
+-		if (strcmp(token, "signed") != 0)
+-			goto fail;
+-
+-		free_token(token);
+-
+-		if (read_expected(EVENT_OP, ":") < 0)
+-			return;
+-
+-		if (read_expect_type(EVENT_ITEM, &token))
+-			goto fail;
+-
+-		free_token(token);
+-		if (read_expected(EVENT_OP, ";") < 0)
+-			return;
+-
+-		if (read_expect_type(EVENT_NEWLINE, &token))
+-			goto fail;
+-	}
+- fail:
+-	free_token(token);
+-	return;
+-
+- discard:
+-	input_buf_ptr = save_input_buf_ptr;
+-	input_buf_siz = save_input_buf_siz;
+-	*offset = 0;
+-	*size = 0;
+-	free_token(token);
+-}
+-
+-/**
+- * pevent_parse_header_page - parse the data stored in the header page
+- * @pevent: the handle to the pevent
+- * @buf: the buffer storing the header page format string
+- * @size: the size of @buf
+- * @long_size: the long size to use if there is no header
+- *
+- * This parses the header page format for information on the
+- * ring buffer used. The @buf should be copied from
+- *
+- * /sys/kernel/debug/tracing/events/header_page
+- */
+-int pevent_parse_header_page(struct pevent *pevent, char *buf, unsigned long size,
+-			     int long_size)
+-{
+-	int ignore;
+-
+-	if (!size) {
+-		/*
+-		 * Old kernels did not have header page info.
+-		 * Sorry but we just use what we find here in user space.
+-		 */
+-		pevent->header_page_ts_size = sizeof(long long);
+-		pevent->header_page_size_size = long_size;
+-		pevent->header_page_data_offset = sizeof(long long) + long_size;
+-		pevent->old_format = 1;
+-		return -1;
+-	}
+-	init_input_buf(buf, size);
+-
+-	parse_header_field("timestamp", &pevent->header_page_ts_offset,
+-			   &pevent->header_page_ts_size, 1);
+-	parse_header_field("commit", &pevent->header_page_size_offset,
+-			   &pevent->header_page_size_size, 1);
+-	parse_header_field("overwrite", &pevent->header_page_overwrite,
+-			   &ignore, 0);
+-	parse_header_field("data", &pevent->header_page_data_offset,
+-			   &pevent->header_page_data_size, 1);
+-
+-	return 0;
+-}
+-
+-static int event_matches(struct event_format *event,
+-			 int id, const char *sys_name,
+-			 const char *event_name)
+-{
+-	if (id >= 0 && id != event->id)
+-		return 0;
+-
+-	if (event_name && (strcmp(event_name, event->name) != 0))
+-		return 0;
+-
+-	if (sys_name && (strcmp(sys_name, event->system) != 0))
+-		return 0;
+-
+-	return 1;
+-}
+-
+-static void free_handler(struct event_handler *handle)
+-{
+-	free((void *)handle->sys_name);
+-	free((void *)handle->event_name);
+-	free(handle);
+-}
+-
+-static int find_event_handle(struct pevent *pevent, struct event_format *event)
+-{
+-	struct event_handler *handle, **next;
+-
+-	for (next = &pevent->handlers; *next;
+-	     next = &(*next)->next) {
+-		handle = *next;
+-		if (event_matches(event, handle->id,
+-				  handle->sys_name,
+-				  handle->event_name))
+-			break;
+-	}
+-
+-	if (!(*next))
+-		return 0;
+-
+-	pr_stat("overriding event (%d) %s:%s with new print handler",
+-		event->id, event->system, event->name);
+-
+-	event->handler = handle->func;
+-	event->context = handle->context;
+-
+-	*next = handle->next;
+-	free_handler(handle);
+-
+-	return 1;
+-}
+-
+-/**
+- * __pevent_parse_format - parse the event format
+- * @buf: the buffer storing the event format string
+- * @size: the size of @buf
+- * @sys: the system the event belongs to
+- *
+- * This parses the event format and creates an event structure
+- * to quickly parse raw data for a given event.
+- *
+- * These files currently come from:
+- *
+- * /sys/kernel/debug/tracing/events/.../.../format
+- */
+-enum pevent_errno __pevent_parse_format(struct event_format **eventp,
+-					struct pevent *pevent, const char *buf,
+-					unsigned long size, const char *sys)
+-{
+-	struct event_format *event;
+-	int ret;
+-
+-	init_input_buf(buf, size);
+-
+-	*eventp = event = alloc_event();
+-	if (!event)
+-		return PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-
+-	event->name = event_read_name();
+-	if (!event->name) {
+-		/* Bad event? */
+-		ret = PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-		goto event_alloc_failed;
+-	}
+-
+-	if (strcmp(sys, "ftrace") == 0) {
+-		event->flags |= EVENT_FL_ISFTRACE;
+-
+-		if (strcmp(event->name, "bprint") == 0)
+-			event->flags |= EVENT_FL_ISBPRINT;
+-	}
+-		
+-	event->id = event_read_id();
+-	if (event->id < 0) {
+-		ret = PEVENT_ERRNO__READ_ID_FAILED;
+-		/*
+-		 * This isn't an allocation error actually.
+-		 * But as the ID is critical, just bail out.
+-		 */
+-		goto event_alloc_failed;
+-	}
+-
+-	event->system = strdup(sys);
+-	if (!event->system) {
+-		ret = PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-		goto event_alloc_failed;
+-	}
+-
+-	/* Add pevent to event so that it can be referenced */
+-	event->pevent = pevent;
+-
+-	ret = event_read_format(event);
+-	if (ret < 0) {
+-		ret = PEVENT_ERRNO__READ_FORMAT_FAILED;
+-		goto event_parse_failed;
+-	}
+-
+-	/*
+-	 * If the event has an override, don't print warnings if the event
+-	 * print format fails to parse.
+-	 */
+-	if (pevent && find_event_handle(pevent, event))
+-		show_warning = 0;
+-
+-	ret = event_read_print(event);
+-	show_warning = 1;
+-
+-	if (ret < 0) {
+-		ret = PEVENT_ERRNO__READ_PRINT_FAILED;
+-		goto event_parse_failed;
+-	}
+-
+-	if (!ret && (event->flags & EVENT_FL_ISFTRACE)) {
+-		struct format_field *field;
+-		struct print_arg *arg, **list;
+-
+-		/* old ftrace had no args */
+-		list = &event->print_fmt.args;
+-		for (field = event->format.fields; field; field = field->next) {
+-			arg = alloc_arg();
+-			if (!arg) {
+-				event->flags |= EVENT_FL_FAILED;
+-				return PEVENT_ERRNO__OLD_FTRACE_ARG_FAILED;
+-			}
+-			arg->type = PRINT_FIELD;
+-			arg->field.name = strdup(field->name);
+-			if (!arg->field.name) {
+-				event->flags |= EVENT_FL_FAILED;
+-				free_arg(arg);
+-				return PEVENT_ERRNO__OLD_FTRACE_ARG_FAILED;
+-			}
+-			arg->field.field = field;
+-			*list = arg;
+-			list = &arg->next;
+-		}
+-		return 0;
+-	}
+-
+-	return 0;
+-
+- event_parse_failed:
+-	event->flags |= EVENT_FL_FAILED;
+-	return ret;
+-
+- event_alloc_failed:
+-	free(event->system);
+-	free(event->name);
+-	free(event);
+-	*eventp = NULL;
+-	return ret;
+-}
+-
+-/**
+- * pevent_parse_format - parse the event format
+- * @buf: the buffer storing the event format string
+- * @size: the size of @buf
+- * @sys: the system the event belongs to
+- *
+- * This parses the event format and creates an event structure
+- * to quickly parse raw data for a given event.
+- *
+- * These files currently come from:
+- *
+- * /sys/kernel/debug/tracing/events/.../.../format
+- */
+-enum pevent_errno pevent_parse_format(struct event_format **eventp, const char *buf,
+-				      unsigned long size, const char *sys)
+-{
+-	return __pevent_parse_format(eventp, NULL, buf, size, sys);
+-}
+-
+-/**
+- * pevent_parse_event - parse the event format
+- * @pevent: the handle to the pevent
+- * @buf: the buffer storing the event format string
+- * @size: the size of @buf
+- * @sys: the system the event belongs to
+- *
+- * This parses the event format and creates an event structure
+- * to quickly parse raw data for a given event.
+- *
+- * These files currently come from:
+- *
+- * /sys/kernel/debug/tracing/events/.../.../format
+- */
+-enum pevent_errno pevent_parse_event(struct pevent *pevent, const char *buf,
+-				     unsigned long size, const char *sys)
+-{
+-	struct event_format *event = NULL;
+-	int ret = __pevent_parse_format(&event, pevent, buf, size, sys);
+-
+-	if (event == NULL)
+-		return ret;
+-
+-	if (add_event(pevent, event)) {
+-		ret = PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-		goto event_add_failed;
+-	}
+-
+-#define PRINT_ARGS 0
+-	if (PRINT_ARGS && event->print_fmt.args)
+-		print_args(event->print_fmt.args);
+-
+-	return 0;
+-
+-event_add_failed:
+-	pevent_free_format(event);
+-	return ret;
+-}
+-
+-#undef _PE
+-#define _PE(code, str) str
+-static const char * const pevent_error_str[] = {
+-	PEVENT_ERRORS
+-};
+-#undef _PE
+-
+-int pevent_strerror(struct pevent *pevent __maybe_unused,
+-		    enum pevent_errno errnum, char *buf, size_t buflen)
+-{
+-	int idx;
+-	const char *msg;
+-
+-	if (errnum >= 0) {
+-#if defined(__GLIBC__)
+-		msg = strerror_r(errnum, buf, buflen);
+-		if (msg != buf) {
+-			size_t len = strlen(msg);
+-			memcpy(buf, msg, min(buflen - 1, len));
+-			*(buf + min(buflen - 1, len)) = '\0';
+-		}
+-#else
+-		if (strerror_r(errnum, buf, buflen))
+-			snprintf(buf, buflen, "errnum %i", errnum);
+-#endif
+-		return 0;
+-	}
+-
+-	if (errnum <= __PEVENT_ERRNO__START ||
+-	    errnum >= __PEVENT_ERRNO__END)
+-		return -1;
+-
+-	idx = errnum - __PEVENT_ERRNO__START - 1;
+-	msg = pevent_error_str[idx];
+-
+-	switch (errnum) {
+-	case PEVENT_ERRNO__MEM_ALLOC_FAILED:
+-	case PEVENT_ERRNO__PARSE_EVENT_FAILED:
+-	case PEVENT_ERRNO__READ_ID_FAILED:
+-	case PEVENT_ERRNO__READ_FORMAT_FAILED:
+-	case PEVENT_ERRNO__READ_PRINT_FAILED:
+-	case PEVENT_ERRNO__OLD_FTRACE_ARG_FAILED:
+-	case PEVENT_ERRNO__INVALID_ARG_TYPE:
+-		snprintf(buf, buflen, "%s", msg);
+-		break;
+-
+-	default:
+-		/* cannot reach here */
+-		break;
+-	}
+-
+-	return 0;
+-}
+-
+-int get_field_val(struct trace_seq *s, struct format_field *field,
+-		  const char *name, struct pevent_record *record,
+-		  unsigned long long *val, int err)
+-{
+-	if (!field) {
+-		if (err)
+-			trace_seq_printf(s, "<CAN'T FIND FIELD %s>", name);
+-		return -1;
+-	}
+-
+-	if (pevent_read_number_field(field, record->data, val)) {
+-		if (err)
+-			trace_seq_printf(s, " %s=INVALID", name);
+-		return -1;
+-	}
+-
+-	return 0;
+-}
+-
+-/**
+- * pevent_get_field_raw - return the raw pointer into the data field
+- * @s: The seq to print to on error
+- * @event: the event that the field is for
+- * @name: The name of the field
+- * @record: The record with the field name.
+- * @len: place to store the field length.
+- * @err: print default error if failed.
+- *
+- * Returns a pointer into record->data of the field and places
+- * the length of the field in @len.
+- *
+- * On failure, it returns NULL.
+- */
+-void *pevent_get_field_raw(struct trace_seq *s, struct event_format *event,
+-			   const char *name, struct pevent_record *record,
+-			   int *len, int err)
+-{
+-	struct format_field *field;
+-	void *data = record->data;
+-	unsigned offset;
+-	int dummy;
+-
+-	if (!event)
+-		return NULL;
+-
+-	field = pevent_find_field(event, name);
+-
+-	if (!field) {
+-		if (err)
+-			trace_seq_printf(s, "<CAN'T FIND FIELD %s>", name);
+-		return NULL;
+-	}
+-
+-	/* Allow @len to be NULL */
+-	if (!len)
+-		len = &dummy;
+-
+-	offset = field->offset;
+-	if (field->flags & FIELD_IS_DYNAMIC) {
+-		offset = pevent_read_number(event->pevent,
+-					    data + offset, field->size);
+-		*len = offset >> 16;
+-		offset &= 0xffff;
+-	} else
+-		*len = field->size;
+-
+-	return data + offset;
+-}
+-
+-/**
+- * pevent_get_field_val - find a field and return its value
+- * @s: The seq to print to on error
+- * @event: the event that the field is for
+- * @name: The name of the field
+- * @record: The record with the field name.
+- * @val: place to store the value of the field.
+- * @err: print default error if failed.
+- *
+- * Returns 0 on success -1 on field not found.
+- */
+-int pevent_get_field_val(struct trace_seq *s, struct event_format *event,
+-			 const char *name, struct pevent_record *record,
+-			 unsigned long long *val, int err)
+-{
+-	struct format_field *field;
+-
+-	if (!event)
+-		return -1;
+-
+-	field = pevent_find_field(event, name);
+-
+-	return get_field_val(s, field, name, record, val, err);
+-}
+-
+-/**
+- * pevent_get_common_field_val - find a common field and return its value
+- * @s: The seq to print to on error
+- * @event: the event that the field is for
+- * @name: The name of the field
+- * @record: The record with the field name.
+- * @val: place to store the value of the field.
+- * @err: print default error if failed.
+- *
+- * Returns 0 on success -1 on field not found.
+- */
+-int pevent_get_common_field_val(struct trace_seq *s, struct event_format *event,
+-				const char *name, struct pevent_record *record,
+-				unsigned long long *val, int err)
+-{
+-	struct format_field *field;
+-
+-	if (!event)
+-		return -1;
+-
+-	field = pevent_find_common_field(event, name);
+-
+-	return get_field_val(s, field, name, record, val, err);
+-}
+-
+-/**
+- * pevent_get_any_field_val - find a any field and return its value
+- * @s: The seq to print to on error
+- * @event: the event that the field is for
+- * @name: The name of the field
+- * @record: The record with the field name.
+- * @val: place to store the value of the field.
+- * @err: print default error if failed.
+- *
+- * Returns 0 on success -1 on field not found.
+- */
+-int pevent_get_any_field_val(struct trace_seq *s, struct event_format *event,
+-			     const char *name, struct pevent_record *record,
+-			     unsigned long long *val, int err)
+-{
+-	struct format_field *field;
+-
+-	if (!event)
+-		return -1;
+-
+-	field = pevent_find_any_field(event, name);
+-
+-	return get_field_val(s, field, name, record, val, err);
+-}
+-
+-/**
+- * pevent_print_num_field - print a field and a format
+- * @s: The seq to print to
+- * @fmt: The printf format to print the field with.
+- * @event: the event that the field is for
+- * @name: The name of the field
+- * @record: The record with the field name.
+- * @err: print default error if failed.
+- *
+- * Returns: 0 on success, -1 field not found, or 1 if buffer is full.
+- */
+-int pevent_print_num_field(struct trace_seq *s, const char *fmt,
+-			   struct event_format *event, const char *name,
+-			   struct pevent_record *record, int err)
+-{
+-	struct format_field *field = pevent_find_field(event, name);
+-	unsigned long long val;
+-
+-	if (!field)
+-		goto failed;
+-
+-	if (pevent_read_number_field(field, record->data, &val))
+-		goto failed;
+-
+-	return trace_seq_printf(s, fmt, val);
+-
+- failed:
+-	if (err)
+-		trace_seq_printf(s, "CAN'T FIND FIELD \"%s\"", name);
+-	return -1;
+-}
+-
+-static void free_func_handle(struct pevent_function_handler *func)
+-{
+-	struct pevent_func_params *params;
+-
+-	free(func->name);
+-
+-	while (func->params) {
+-		params = func->params;
+-		func->params = params->next;
+-		free(params);
+-	}
+-
+-	free(func);
+-}
+-
+-/**
+- * pevent_register_print_function - register a helper function
+- * @pevent: the handle to the pevent
+- * @func: the function to process the helper function
+- * @ret_type: the return type of the helper function
+- * @name: the name of the helper function
+- * @parameters: A list of enum pevent_func_arg_type
+- *
+- * Some events may have helper functions in the print format arguments.
+- * This allows a plugin to dynamically create a way to process one
+- * of these functions.
+- *
+- * The @parameters is a variable list of pevent_func_arg_type enums that
+- * must end with PEVENT_FUNC_ARG_VOID.
+- */
+-int pevent_register_print_function(struct pevent *pevent,
+-				   pevent_func_handler func,
+-				   enum pevent_func_arg_type ret_type,
+-				   char *name, ...)
+-{
+-	struct pevent_function_handler *func_handle;
+-	struct pevent_func_params **next_param;
+-	struct pevent_func_params *param;
+-	enum pevent_func_arg_type type;
+-	va_list ap;
+-	int ret;
+-
+-	func_handle = find_func_handler(pevent, name);
+-	if (func_handle) {
+-		/*
+-		 * This is most like caused by the users own
+-		 * plugins updating the function. This overrides the
+-		 * system defaults.
+-		 */
+-		pr_stat("override of function helper '%s'", name);
+-		remove_func_handler(pevent, name);
+-	}
+-
+-	func_handle = calloc(1, sizeof(*func_handle));
+-	if (!func_handle) {
+-		do_warning("Failed to allocate function handler");
+-		return PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-	}
+-
+-	func_handle->ret_type = ret_type;
+-	func_handle->name = strdup(name);
+-	func_handle->func = func;
+-	if (!func_handle->name) {
+-		do_warning("Failed to allocate function name");
+-		free(func_handle);
+-		return PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-	}
+-
+-	next_param = &(func_handle->params);
+-	va_start(ap, name);
+-	for (;;) {
+-		type = va_arg(ap, enum pevent_func_arg_type);
+-		if (type == PEVENT_FUNC_ARG_VOID)
+-			break;
+-
+-		if (type >= PEVENT_FUNC_ARG_MAX_TYPES) {
+-			do_warning("Invalid argument type %d", type);
+-			ret = PEVENT_ERRNO__INVALID_ARG_TYPE;
+-			goto out_free;
+-		}
+-
+-		param = malloc(sizeof(*param));
+-		if (!param) {
+-			do_warning("Failed to allocate function param");
+-			ret = PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-			goto out_free;
+-		}
+-		param->type = type;
+-		param->next = NULL;
+-
+-		*next_param = param;
+-		next_param = &(param->next);
+-
+-		func_handle->nr_args++;
+-	}
+-	va_end(ap);
+-
+-	func_handle->next = pevent->func_handlers;
+-	pevent->func_handlers = func_handle;
+-
+-	return 0;
+- out_free:
+-	va_end(ap);
+-	free_func_handle(func_handle);
+-	return ret;
+-}
+-
+-/**
+- * pevent_register_event_handler - register a way to parse an event
+- * @pevent: the handle to the pevent
+- * @id: the id of the event to register
+- * @sys_name: the system name the event belongs to
+- * @event_name: the name of the event
+- * @func: the function to call to parse the event information
+- * @context: the data to be passed to @func
+- *
+- * This function allows a developer to override the parsing of
+- * a given event. If for some reason the default print format
+- * is not sufficient, this function will register a function
+- * for an event to be used to parse the data instead.
+- *
+- * If @id is >= 0, then it is used to find the event.
+- * else @sys_name and @event_name are used.
+- */
+-int pevent_register_event_handler(struct pevent *pevent, int id,
+-				  const char *sys_name, const char *event_name,
+-				  pevent_event_handler_func func, void *context)
+-{
+-	struct event_format *event;
+-	struct event_handler *handle;
+-
+-	if (id >= 0) {
+-		/* search by id */
+-		event = pevent_find_event(pevent, id);
+-		if (!event)
+-			goto not_found;
+-		if (event_name && (strcmp(event_name, event->name) != 0))
+-			goto not_found;
+-		if (sys_name && (strcmp(sys_name, event->system) != 0))
+-			goto not_found;
+-	} else {
+-		event = pevent_find_event_by_name(pevent, sys_name, event_name);
+-		if (!event)
+-			goto not_found;
+-	}
+-
+-	pr_stat("overriding event (%d) %s:%s with new print handler",
+-		event->id, event->system, event->name);
+-
+-	event->handler = func;
+-	event->context = context;
+-	return 0;
+-
+- not_found:
+-	/* Save for later use. */
+-	handle = calloc(1, sizeof(*handle));
+-	if (!handle) {
+-		do_warning("Failed to allocate event handler");
+-		return PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-	}
+-
+-	handle->id = id;
+-	if (event_name)
+-		handle->event_name = strdup(event_name);
+-	if (sys_name)
+-		handle->sys_name = strdup(sys_name);
+-
+-	if ((event_name && !handle->event_name) ||
+-	    (sys_name && !handle->sys_name)) {
+-		do_warning("Failed to allocate event/sys name");
+-		free((void *)handle->event_name);
+-		free((void *)handle->sys_name);
+-		free(handle);
+-		return PEVENT_ERRNO__MEM_ALLOC_FAILED;
+-	}
+-
+-	handle->func = func;
+-	handle->next = pevent->handlers;
+-	pevent->handlers = handle;
+-	handle->context = context;
+-
+-	return -1;
+-}
+-
+-/**
+- * pevent_alloc - create a pevent handle
+- */
+-struct pevent *pevent_alloc(void)
+-{
+-	struct pevent *pevent = calloc(1, sizeof(*pevent));
+-
+-	if (pevent)
+-		pevent->ref_count = 1;
+-
+-	return pevent;
+-}
+-
+-void pevent_ref(struct pevent *pevent)
+-{
+-	pevent->ref_count++;
+-}
+-
+-static void free_format_fields(struct format_field *field)
+-{
+-	struct format_field *next;
+-
+-	while (field) {
+-		next = field->next;
+-		free(field->type);
+-		free(field->name);
+-		free(field);
+-		field = next;
+-	}
+-}
+-
+-static void free_formats(struct format *format)
+-{
+-	free_format_fields(format->common_fields);
+-	free_format_fields(format->fields);
+-}
+-
+-void pevent_free_format(struct event_format *event)
+-{
+-	free(event->name);
+-	free(event->system);
+-
+-	free_formats(&event->format);
+-
+-	free(event->print_fmt.format);
+-	free_args(event->print_fmt.args);
+-
+-	free(event);
+-}
+-
+-/**
+- * pevent_free - free a pevent handle
+- * @pevent: the pevent handle to free
+- */
+-void pevent_free(struct pevent *pevent)
+-{
+-	struct cmdline_list *cmdlist, *cmdnext;
+-	struct func_list *funclist, *funcnext;
+-	struct printk_list *printklist, *printknext;
+-	struct pevent_function_handler *func_handler;
+-	struct event_handler *handle;
+-	int i;
+-
+-	if (!pevent)
+-		return;
+-
+-	cmdlist = pevent->cmdlist;
+-	funclist = pevent->funclist;
+-	printklist = pevent->printklist;
+-
+-	pevent->ref_count--;
+-	if (pevent->ref_count)
+-		return;
+-
+-	if (pevent->cmdlines) {
+-		for (i = 0; i < pevent->cmdline_count; i++)
+-			free(pevent->cmdlines[i].comm);
+-		free(pevent->cmdlines);
+-	}
+-
+-	while (cmdlist) {
+-		cmdnext = cmdlist->next;
+-		free(cmdlist->comm);
+-		free(cmdlist);
+-		cmdlist = cmdnext;
+-	}
+-
+-	if (pevent->func_map) {
+-		for (i = 0; i < (int)pevent->func_count; i++) {
+-			free(pevent->func_map[i].func);
+-			free(pevent->func_map[i].mod);
+-		}
+-		free(pevent->func_map);
+-	}
+-
+-	while (funclist) {
+-		funcnext = funclist->next;
+-		free(funclist->func);
+-		free(funclist->mod);
+-		free(funclist);
+-		funclist = funcnext;
+-	}
+-
+-	while (pevent->func_handlers) {
+-		func_handler = pevent->func_handlers;
+-		pevent->func_handlers = func_handler->next;
+-		free_func_handle(func_handler);
+-	}
+-
+-	if (pevent->printk_map) {
+-		for (i = 0; i < (int)pevent->printk_count; i++)
+-			free(pevent->printk_map[i].printk);
+-		free(pevent->printk_map);
+-	}
+-
+-	while (printklist) {
+-		printknext = printklist->next;
+-		free(printklist->printk);
+-		free(printklist);
+-		printklist = printknext;
+-	}
+-
+-	for (i = 0; i < pevent->nr_events; i++)
+-		pevent_free_format(pevent->events[i]);
+-
+-	while (pevent->handlers) {
+-		handle = pevent->handlers;
+-		pevent->handlers = handle->next;
+-		free_handler(handle);
+-	}
+-
+-	free(pevent->events);
+-	free(pevent->sort_events);
+-
+-	free(pevent);
+-}
+-
+-void pevent_unref(struct pevent *pevent)
+-{
+-	pevent_free(pevent);
+-}
+diff --git a/traceevent/event-parse.h b/traceevent/event-parse.h
+deleted file mode 100644
+index c37b202..0000000
+--- a/traceevent/event-parse.h
++++ /dev/null
+@@ -1,857 +0,0 @@
+-/*
+- * Copyright (C) 2009, 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#ifndef _PARSE_EVENTS_H
+-#define _PARSE_EVENTS_H
+-
+-#include <stdarg.h>
+-#include <regex.h>
+-
+-#ifndef __maybe_unused
+-#define __maybe_unused __attribute__((unused))
+-#endif
+-
+-/* ----------------------- trace_seq ----------------------- */
+-
+-
+-#ifndef TRACE_SEQ_BUF_SIZE
+-#define TRACE_SEQ_BUF_SIZE 4096
+-#endif
+-
+-#ifndef DEBUG_RECORD
+-#define DEBUG_RECORD 0
+-#endif
+-
+-struct pevent_record {
+-	unsigned long long	ts;
+-	unsigned long long	offset;
+-	long long		missed_events;	/* buffer dropped events before */
+-	int			record_size;	/* size of binary record */
+-	int			size;		/* size of data */
+-	void			*data;
+-	int			cpu;
+-	int			ref_count;
+-	int			locked;		/* Do not free, even if ref_count is zero */
+-	void			*priv;
+-#if DEBUG_RECORD
+-	struct pevent_record	*prev;
+-	struct pevent_record	*next;
+-	long			alloc_addr;
+-#endif
+-};
+-
+-/*
+- * Trace sequences are used to allow a function to call several other functions
+- * to create a string of data to use (up to a max of PAGE_SIZE).
+- */
+-
+-struct trace_seq {
+-	char			*buffer;
+-	unsigned int		buffer_size;
+-	unsigned int		len;
+-	unsigned int		readpos;
+-};
+-
+-void trace_seq_init(struct trace_seq *s);
+-void trace_seq_reset(struct trace_seq *s);
+-void trace_seq_destroy(struct trace_seq *s);
+-
+-extern int trace_seq_printf(struct trace_seq *s, const char *fmt, ...)
+-	__attribute__ ((format (printf, 2, 3)));
+-extern int trace_seq_vprintf(struct trace_seq *s, const char *fmt, va_list args)
+-	__attribute__ ((format (printf, 2, 0)));
+-
+-extern int trace_seq_puts(struct trace_seq *s, const char *str);
+-extern int trace_seq_putc(struct trace_seq *s, unsigned char c);
+-
+-extern void trace_seq_terminate(struct trace_seq *s);
+-
+-extern int trace_seq_do_printf(struct trace_seq *s);
+-
+-
+-/* ----------------------- pevent ----------------------- */
+-
+-struct pevent;
+-struct event_format;
+-
+-typedef int (*pevent_event_handler_func)(struct trace_seq *s,
+-					 struct pevent_record *record,
+-					 struct event_format *event,
+-					 void *context);
+-
+-typedef int (*pevent_plugin_load_func)(struct pevent *pevent);
+-typedef int (*pevent_plugin_unload_func)(void);
+-
+-struct plugin_option {
+-	struct plugin_option		*next;
+-	void				*handle;
+-	char				*file;
+-	char				*name;
+-	char				*plugin_alias;
+-	char				*description;
+-	char				*value;
+-	void				*priv;
+-	int				set;
+-};
+-
+-/*
+- * Plugin hooks that can be called:
+- *
+- * PEVENT_PLUGIN_LOADER:  (required)
+- *   The function name to initialized the plugin.
+- *
+- *   int PEVENT_PLUGIN_LOADER(struct pevent *pevent)
+- *
+- * PEVENT_PLUGIN_UNLOADER:  (optional)
+- *   The function called just before unloading
+- *
+- *   int PEVENT_PLUGIN_UNLOADER(void)
+- *
+- * PEVENT_PLUGIN_OPTIONS:  (optional)
+- *   Plugin options that can be set before loading
+- *
+- *   struct plugin_option PEVENT_PLUGIN_OPTIONS[] = {
+- *	{
+- *		.name = "option-name",
+- *		.plugin_alias = "overide-file-name", (optional)
+- *		.description = "description of option to show users",
+- *	},
+- *	{
+- *		.name = NULL,
+- *	},
+- *   };
+- *
+- *   Array must end with .name = NULL;
+- *
+- *
+- *   .plugin_alias is used to give a shorter name to access
+- *   the vairable. Useful if a plugin handles more than one event.
+- *
+- * PEVENT_PLUGIN_ALIAS: (optional)
+- *   The name to use for finding options (uses filename if not defined)
+- */
+-#define PEVENT_PLUGIN_LOADER pevent_plugin_loader
+-#define PEVENT_PLUGIN_UNLOADER pevent_plugin_unloader
+-#define PEVENT_PLUGIN_OPTIONS pevent_plugin_options
+-#define PEVENT_PLUGIN_ALIAS pevent_plugin_alias
+-#define _MAKE_STR(x)	#x
+-#define MAKE_STR(x)	_MAKE_STR(x)
+-#define PEVENT_PLUGIN_LOADER_NAME MAKE_STR(PEVENT_PLUGIN_LOADER)
+-#define PEVENT_PLUGIN_UNLOADER_NAME MAKE_STR(PEVENT_PLUGIN_UNLOADER)
+-#define PEVENT_PLUGIN_OPTIONS_NAME MAKE_STR(PEVENT_PLUGIN_OPTIONS)
+-#define PEVENT_PLUGIN_ALIAS_NAME MAKE_STR(PEVENT_PLUGIN_ALIAS)
+-
+-#define NSECS_PER_SEC		1000000000ULL
+-#define NSECS_PER_USEC		1000ULL
+-
+-enum format_flags {
+-	FIELD_IS_ARRAY		= 1,
+-	FIELD_IS_POINTER	= 2,
+-	FIELD_IS_SIGNED		= 4,
+-	FIELD_IS_STRING		= 8,
+-	FIELD_IS_DYNAMIC	= 16,
+-	FIELD_IS_LONG		= 32,
+-	FIELD_IS_FLAG		= 64,
+-	FIELD_IS_SYMBOLIC	= 128,
+-};
+-
+-struct format_field {
+-	struct format_field	*next;
+-	struct event_format	*event;
+-	char			*type;
+-	char			*name;
+-	int			offset;
+-	int			size;
+-	unsigned int		arraylen;
+-	unsigned int		elementsize;
+-	unsigned long		flags;
+-};
+-
+-struct format {
+-	int			nr_common;
+-	int			nr_fields;
+-	struct format_field	*common_fields;
+-	struct format_field	*fields;
+-};
+-
+-struct print_arg_atom {
+-	char			*atom;
+-};
+-
+-struct print_arg_string {
+-	char			*string;
+-	int			offset;
+-};
+-
+-struct print_arg_field {
+-	char			*name;
+-	struct format_field	*field;
+-};
+-
+-struct print_flag_sym {
+-	struct print_flag_sym	*next;
+-	char			*value;
+-	char			*str;
+-};
+-
+-struct print_arg_typecast {
+-	char 			*type;
+-	struct print_arg	*item;
+-};
+-
+-struct print_arg_flags {
+-	struct print_arg	*field;
+-	char			*delim;
+-	struct print_flag_sym	*flags;
+-};
+-
+-struct print_arg_symbol {
+-	struct print_arg	*field;
+-	struct print_flag_sym	*symbols;
+-};
+-
+-struct print_arg_hex {
+-	struct print_arg	*field;
+-	struct print_arg	*size;
+-};
+-
+-struct print_arg_dynarray {
+-	struct format_field	*field;
+-	struct print_arg	*index;
+-};
+-
+-struct print_arg;
+-
+-struct print_arg_op {
+-	char			*op;
+-	int			prio;
+-	struct print_arg	*left;
+-	struct print_arg	*right;
+-};
+-
+-struct pevent_function_handler;
+-
+-struct print_arg_func {
+-	struct pevent_function_handler	*func;
+-	struct print_arg		*args;
+-};
+-
+-enum print_arg_type {
+-	PRINT_NULL,
+-	PRINT_ATOM,
+-	PRINT_FIELD,
+-	PRINT_FLAGS,
+-	PRINT_SYMBOL,
+-	PRINT_HEX,
+-	PRINT_TYPE,
+-	PRINT_STRING,
+-	PRINT_BSTRING,
+-	PRINT_DYNAMIC_ARRAY,
+-	PRINT_OP,
+-	PRINT_FUNC,
+-};
+-
+-struct print_arg {
+-	struct print_arg		*next;
+-	enum print_arg_type		type;
+-	union {
+-		struct print_arg_atom		atom;
+-		struct print_arg_field		field;
+-		struct print_arg_typecast	typecast;
+-		struct print_arg_flags		flags;
+-		struct print_arg_symbol		symbol;
+-		struct print_arg_hex		hex;
+-		struct print_arg_func		func;
+-		struct print_arg_string		string;
+-		struct print_arg_op		op;
+-		struct print_arg_dynarray	dynarray;
+-	};
+-};
+-
+-struct print_fmt {
+-	char			*format;
+-	struct print_arg	*args;
+-};
+-
+-struct event_format {
+-	struct pevent		*pevent;
+-	char			*name;
+-	int			id;
+-	int			flags;
+-	struct format		format;
+-	struct print_fmt	print_fmt;
+-	char			*system;
+-	pevent_event_handler_func handler;
+-	void			*context;
+-};
+-
+-enum {
+-	EVENT_FL_ISFTRACE	= 0x01,
+-	EVENT_FL_ISPRINT	= 0x02,
+-	EVENT_FL_ISBPRINT	= 0x04,
+-	EVENT_FL_ISFUNCENT	= 0x10,
+-	EVENT_FL_ISFUNCRET	= 0x20,
+-
+-	EVENT_FL_FAILED		= 0x80000000
+-};
+-
+-enum event_sort_type {
+-	EVENT_SORT_ID,
+-	EVENT_SORT_NAME,
+-	EVENT_SORT_SYSTEM,
+-};
+-
+-enum event_type {
+-	EVENT_ERROR,
+-	EVENT_NONE,
+-	EVENT_SPACE,
+-	EVENT_NEWLINE,
+-	EVENT_OP,
+-	EVENT_DELIM,
+-	EVENT_ITEM,
+-	EVENT_DQUOTE,
+-	EVENT_SQUOTE,
+-};
+-
+-typedef unsigned long long (*pevent_func_handler)(struct trace_seq *s,
+-					     unsigned long long *args);
+-
+-enum pevent_func_arg_type {
+-	PEVENT_FUNC_ARG_VOID,
+-	PEVENT_FUNC_ARG_INT,
+-	PEVENT_FUNC_ARG_LONG,
+-	PEVENT_FUNC_ARG_STRING,
+-	PEVENT_FUNC_ARG_PTR,
+-	PEVENT_FUNC_ARG_MAX_TYPES
+-};
+-
+-enum pevent_flag {
+-	PEVENT_NSEC_OUTPUT		= 1,	/* output in NSECS */
+-};
+-
+-#define PEVENT_ERRORS 							      \
+-	_PE(MEM_ALLOC_FAILED,	"failed to allocate memory"),		      \
+-	_PE(PARSE_EVENT_FAILED,	"failed to parse event"),		      \
+-	_PE(READ_ID_FAILED,	"failed to read event id"),		      \
+-	_PE(READ_FORMAT_FAILED,	"failed to read event format"),		      \
+-	_PE(READ_PRINT_FAILED,	"failed to read event print fmt"), 	      \
+-	_PE(OLD_FTRACE_ARG_FAILED,"failed to allocate field name for ftrace"),\
+-	_PE(INVALID_ARG_TYPE,	"invalid argument type")
+-
+-#undef _PE
+-#define _PE(__code, __str) PEVENT_ERRNO__ ## __code
+-enum pevent_errno {
+-	PEVENT_ERRNO__SUCCESS			= 0,
+-
+-	/*
+-	 * Choose an arbitrary negative big number not to clash with standard
+-	 * errno since SUS requires the errno has distinct positive values.
+-	 * See 'Issue 6' in the link below.
+-	 *
+-	 * http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html
+-	 */
+-	__PEVENT_ERRNO__START			= -100000,
+-
+-	PEVENT_ERRORS,
+-
+-	__PEVENT_ERRNO__END,
+-};
+-#undef _PE
+-
+-struct cmdline;
+-struct cmdline_list;
+-struct func_map;
+-struct func_list;
+-struct event_handler;
+-
+-struct pevent {
+-	int ref_count;
+-
+-	int header_page_ts_offset;
+-	int header_page_ts_size;
+-	int header_page_size_offset;
+-	int header_page_size_size;
+-	int header_page_data_offset;
+-	int header_page_data_size;
+-	int header_page_overwrite;
+-
+-	int file_bigendian;
+-	int host_bigendian;
+-
+-	int latency_format;
+-
+-	int old_format;
+-
+-	int cpus;
+-	int long_size;
+-	int page_size;
+-
+-	struct cmdline *cmdlines;
+-	struct cmdline_list *cmdlist;
+-	int cmdline_count;
+-
+-	struct func_map *func_map;
+-	struct func_list *funclist;
+-	unsigned int func_count;
+-
+-	struct printk_map *printk_map;
+-	struct printk_list *printklist;
+-	unsigned int printk_count;
+-
+-
+-	struct event_format **events;
+-	int nr_events;
+-	struct event_format **sort_events;
+-	enum event_sort_type last_type;
+-
+-	int type_offset;
+-	int type_size;
+-
+-	int pid_offset;
+-	int pid_size;
+-
+- 	int pc_offset;
+-	int pc_size;
+-
+-	int flags_offset;
+-	int flags_size;
+-
+-	int ld_offset;
+-	int ld_size;
+-
+-	int print_raw;
+-
+-	int test_filters;
+-
+-	int flags;
+-
+-	struct format_field *bprint_ip_field;
+-	struct format_field *bprint_fmt_field;
+-	struct format_field *bprint_buf_field;
+-
+-	struct event_handler *handlers;
+-	struct pevent_function_handler *func_handlers;
+-
+-	/* cache */
+-	struct event_format *last_event;
+-};
+-
+-static inline void pevent_set_flag(struct pevent *pevent, int flag)
+-{
+-	pevent->flags |= flag;
+-}
+-
+-static inline unsigned short
+-__data2host2(struct pevent *pevent, unsigned short data)
+-{
+-	unsigned short swap;
+-
+-	if (pevent->host_bigendian == pevent->file_bigendian)
+-		return data;
+-
+-	swap = ((data & 0xffULL) << 8) |
+-		((data & (0xffULL << 8)) >> 8);
+-
+-	return swap;
+-}
+-
+-static inline unsigned int
+-__data2host4(struct pevent *pevent, unsigned int data)
+-{
+-	unsigned int swap;
+-
+-	if (pevent->host_bigendian == pevent->file_bigendian)
+-		return data;
+-
+-	swap = ((data & 0xffULL) << 24) |
+-		((data & (0xffULL << 8)) << 8) |
+-		((data & (0xffULL << 16)) >> 8) |
+-		((data & (0xffULL << 24)) >> 24);
+-
+-	return swap;
+-}
+-
+-static inline unsigned long long
+-__data2host8(struct pevent *pevent, unsigned long long data)
+-{
+-	unsigned long long swap;
+-
+-	if (pevent->host_bigendian == pevent->file_bigendian)
+-		return data;
+-
+-	swap = ((data & 0xffULL) << 56) |
+-		((data & (0xffULL << 8)) << 40) |
+-		((data & (0xffULL << 16)) << 24) |
+-		((data & (0xffULL << 24)) << 8) |
+-		((data & (0xffULL << 32)) >> 8) |
+-		((data & (0xffULL << 40)) >> 24) |
+-		((data & (0xffULL << 48)) >> 40) |
+-		((data & (0xffULL << 56)) >> 56);
+-
+-	return swap;
+-}
+-
+-#define data2host2(pevent, ptr)		__data2host2(pevent, *(unsigned short *)(ptr))
+-#define data2host4(pevent, ptr)		__data2host4(pevent, *(unsigned int *)(ptr))
+-#define data2host8(pevent, ptr)					\
+-({								\
+-	unsigned long long __val;				\
+-								\
+-	memcpy(&__val, (ptr), sizeof(unsigned long long));	\
+-	__data2host8(pevent, __val);				\
+-})
+-
+-/* taken from kernel/trace/trace.h */
+-enum trace_flag_type {
+-	TRACE_FLAG_IRQS_OFF		= 0x01,
+-	TRACE_FLAG_IRQS_NOSUPPORT	= 0x02,
+-	TRACE_FLAG_NEED_RESCHED		= 0x04,
+-	TRACE_FLAG_HARDIRQ		= 0x08,
+-	TRACE_FLAG_SOFTIRQ		= 0x10,
+-};
+-
+-int pevent_register_comm(struct pevent *pevent, const char *comm, int pid);
+-int pevent_register_function(struct pevent *pevent, char *name,
+-			     unsigned long long addr, char *mod);
+-int pevent_register_print_string(struct pevent *pevent, char *fmt,
+-				 unsigned long long addr);
+-int pevent_pid_is_registered(struct pevent *pevent, int pid);
+-
+-void pevent_print_event(struct pevent *pevent, struct trace_seq *s,
+-			struct pevent_record *record);
+-
+-int pevent_parse_header_page(struct pevent *pevent, char *buf, unsigned long size,
+-			     int long_size);
+-
+-enum pevent_errno pevent_parse_event(struct pevent *pevent, const char *buf,
+-				     unsigned long size, const char *sys);
+-enum pevent_errno pevent_parse_format(struct event_format **eventp, const char *buf,
+-				      unsigned long size, const char *sys);
+-void pevent_free_format(struct event_format *event);
+-
+-void *pevent_get_field_raw(struct trace_seq *s, struct event_format *event,
+-			   const char *name, struct pevent_record *record,
+-			   int *len, int err);
+-
+-int pevent_get_field_val(struct trace_seq *s, struct event_format *event,
+-			 const char *name, struct pevent_record *record,
+-			 unsigned long long *val, int err);
+-int pevent_get_common_field_val(struct trace_seq *s, struct event_format *event,
+-				const char *name, struct pevent_record *record,
+-				unsigned long long *val, int err);
+-int pevent_get_any_field_val(struct trace_seq *s, struct event_format *event,
+-			     const char *name, struct pevent_record *record,
+-			     unsigned long long *val, int err);
+-
+-int pevent_print_num_field(struct trace_seq *s, const char *fmt,
+-			   struct event_format *event, const char *name,
+-			   struct pevent_record *record, int err);
+-
+-int pevent_register_event_handler(struct pevent *pevent, int id,
+-				  const char *sys_name, const char *event_name,
+-				  pevent_event_handler_func func, void *context);
+-int pevent_register_print_function(struct pevent *pevent,
+-				   pevent_func_handler func,
+-				   enum pevent_func_arg_type ret_type,
+-				   char *name, ...);
+-
+-struct format_field *pevent_find_common_field(struct event_format *event, const char *name);
+-struct format_field *pevent_find_field(struct event_format *event, const char *name);
+-struct format_field *pevent_find_any_field(struct event_format *event, const char *name);
+-
+-const char *pevent_find_function(struct pevent *pevent, unsigned long long addr);
+-unsigned long long
+-pevent_find_function_address(struct pevent *pevent, unsigned long long addr);
+-unsigned long long pevent_read_number(struct pevent *pevent, const void *ptr, int size);
+-int pevent_read_number_field(struct format_field *field, const void *data,
+-			     unsigned long long *value);
+-
+-struct event_format *pevent_find_event(struct pevent *pevent, int id);
+-
+-struct event_format *
+-pevent_find_event_by_name(struct pevent *pevent, const char *sys, const char *name);
+-
+-void pevent_data_lat_fmt(struct pevent *pevent,
+-			 struct trace_seq *s, struct pevent_record *record);
+-int pevent_data_type(struct pevent *pevent, struct pevent_record *rec);
+-struct event_format *pevent_data_event_from_type(struct pevent *pevent, int type);
+-int pevent_data_pid(struct pevent *pevent, struct pevent_record *rec);
+-const char *pevent_data_comm_from_pid(struct pevent *pevent, int pid);
+-void pevent_event_info(struct trace_seq *s, struct event_format *event,
+-		       struct pevent_record *record);
+-int pevent_strerror(struct pevent *pevent, enum pevent_errno errnum,
+-		    char *buf, size_t buflen);
+-
+-struct event_format **pevent_list_events(struct pevent *pevent, enum event_sort_type);
+-struct format_field **pevent_event_common_fields(struct event_format *event);
+-struct format_field **pevent_event_fields(struct event_format *event);
+-
+-static inline int pevent_get_cpus(struct pevent *pevent)
+-{
+-	return pevent->cpus;
+-}
+-
+-static inline void pevent_set_cpus(struct pevent *pevent, int cpus)
+-{
+-	pevent->cpus = cpus;
+-}
+-
+-static inline int pevent_get_long_size(struct pevent *pevent)
+-{
+-	return pevent->long_size;
+-}
+-
+-static inline void pevent_set_long_size(struct pevent *pevent, int long_size)
+-{
+-	pevent->long_size = long_size;
+-}
+-
+-static inline int pevent_get_page_size(struct pevent *pevent)
+-{
+-	return pevent->page_size;
+-}
+-
+-static inline void pevent_set_page_size(struct pevent *pevent, int _page_size)
+-{
+-	pevent->page_size = _page_size;
+-}
+-
+-static inline int pevent_is_file_bigendian(struct pevent *pevent)
+-{
+-	return pevent->file_bigendian;
+-}
+-
+-static inline void pevent_set_file_bigendian(struct pevent *pevent, int endian)
+-{
+-	pevent->file_bigendian = endian;
+-}
+-
+-static inline int pevent_is_host_bigendian(struct pevent *pevent)
+-{
+-	return pevent->host_bigendian;
+-}
+-
+-static inline void pevent_set_host_bigendian(struct pevent *pevent, int endian)
+-{
+-	pevent->host_bigendian = endian;
+-}
+-
+-static inline int pevent_is_latency_format(struct pevent *pevent)
+-{
+-	return pevent->latency_format;
+-}
+-
+-static inline void pevent_set_latency_format(struct pevent *pevent, int lat)
+-{
+-	pevent->latency_format = lat;
+-}
+-
+-struct pevent *pevent_alloc(void);
+-void pevent_free(struct pevent *pevent);
+-void pevent_ref(struct pevent *pevent);
+-void pevent_unref(struct pevent *pevent);
+-
+-/* access to the internal parser */
+-void pevent_buffer_init(const char *buf, unsigned long long size);
+-enum event_type pevent_read_token(char **tok);
+-void pevent_free_token(char *token);
+-int pevent_peek_char(void);
+-const char *pevent_get_input_buf(void);
+-unsigned long long pevent_get_input_buf_ptr(void);
+-
+-/* for debugging */
+-void pevent_print_funcs(struct pevent *pevent);
+-void pevent_print_printk(struct pevent *pevent);
+-
+-/* ----------------------- filtering ----------------------- */
+-
+-enum filter_boolean_type {
+-	FILTER_FALSE,
+-	FILTER_TRUE,
+-};
+-
+-enum filter_op_type {
+-	FILTER_OP_AND = 1,
+-	FILTER_OP_OR,
+-	FILTER_OP_NOT,
+-};
+-
+-enum filter_cmp_type {
+-	FILTER_CMP_NONE,
+-	FILTER_CMP_EQ,
+-	FILTER_CMP_NE,
+-	FILTER_CMP_GT,
+-	FILTER_CMP_LT,
+-	FILTER_CMP_GE,
+-	FILTER_CMP_LE,
+-	FILTER_CMP_MATCH,
+-	FILTER_CMP_NOT_MATCH,
+-	FILTER_CMP_REGEX,
+-	FILTER_CMP_NOT_REGEX,
+-};
+-
+-enum filter_exp_type {
+-	FILTER_EXP_NONE,
+-	FILTER_EXP_ADD,
+-	FILTER_EXP_SUB,
+-	FILTER_EXP_MUL,
+-	FILTER_EXP_DIV,
+-	FILTER_EXP_MOD,
+-	FILTER_EXP_RSHIFT,
+-	FILTER_EXP_LSHIFT,
+-	FILTER_EXP_AND,
+-	FILTER_EXP_OR,
+-	FILTER_EXP_XOR,
+-	FILTER_EXP_NOT,
+-};
+-
+-enum filter_arg_type {
+-	FILTER_ARG_NONE,
+-	FILTER_ARG_BOOLEAN,
+-	FILTER_ARG_VALUE,
+-	FILTER_ARG_FIELD,
+-	FILTER_ARG_EXP,
+-	FILTER_ARG_OP,
+-	FILTER_ARG_NUM,
+-	FILTER_ARG_STR,
+-};
+-
+-enum filter_value_type {
+-	FILTER_NUMBER,
+-	FILTER_STRING,
+-	FILTER_CHAR
+-};
+-
+-struct fliter_arg;
+-
+-struct filter_arg_boolean {
+-	enum filter_boolean_type	value;
+-};
+-
+-struct filter_arg_field {
+-	struct format_field	*field;
+-};
+-
+-struct filter_arg_value {
+-	enum filter_value_type	type;
+-	union {
+-		char			*str;
+-		unsigned long long	val;
+-	};
+-};
+-
+-struct filter_arg_op {
+-	enum filter_op_type	type;
+-	struct filter_arg	*left;
+-	struct filter_arg	*right;
+-};
+-
+-struct filter_arg_exp {
+-	enum filter_exp_type	type;
+-	struct filter_arg	*left;
+-	struct filter_arg	*right;
+-};
+-
+-struct filter_arg_num {
+-	enum filter_cmp_type	type;
+-	struct filter_arg	*left;
+-	struct filter_arg	*right;
+-};
+-
+-struct filter_arg_str {
+-	enum filter_cmp_type	type;
+-	struct format_field	*field;
+-	char			*val;
+-	char			*buffer;
+-	regex_t			reg;
+-};
+-
+-struct filter_arg {
+-	enum filter_arg_type	type;
+-	union {
+-		struct filter_arg_boolean	boolean;
+-		struct filter_arg_field		field;
+-		struct filter_arg_value		value;
+-		struct filter_arg_op		op;
+-		struct filter_arg_exp		exp;
+-		struct filter_arg_num		num;
+-		struct filter_arg_str		str;
+-	};
+-};
+-
+-struct filter_type {
+-	int			event_id;
+-	struct event_format	*event;
+-	struct filter_arg	*filter;
+-};
+-
+-struct event_filter {
+-	struct pevent		*pevent;
+-	int			filters;
+-	struct filter_type	*event_filters;
+-};
+-
+-struct event_filter *pevent_filter_alloc(struct pevent *pevent);
+-
+-#define FILTER_NONE		-2
+-#define FILTER_NOEXIST		-1
+-#define FILTER_MISS		0
+-#define FILTER_MATCH		1
+-
+-enum filter_trivial_type {
+-	FILTER_TRIVIAL_FALSE,
+-	FILTER_TRIVIAL_TRUE,
+-	FILTER_TRIVIAL_BOTH,
+-};
+-
+-int pevent_filter_add_filter_str(struct event_filter *filter,
+-				 const char *filter_str,
+-				 char **error_str);
+-
+-
+-int pevent_filter_match(struct event_filter *filter,
+-			struct pevent_record *record);
+-
+-int pevent_event_filtered(struct event_filter *filter,
+-			  int event_id);
+-
+-void pevent_filter_reset(struct event_filter *filter);
+-
+-void pevent_filter_clear_trivial(struct event_filter *filter,
+-				 enum filter_trivial_type type);
+-
+-void pevent_filter_free(struct event_filter *filter);
+-
+-char *pevent_filter_make_string(struct event_filter *filter, int event_id);
+-
+-int pevent_filter_remove_event(struct event_filter *filter,
+-			       int event_id);
+-
+-int pevent_filter_event_has_trivial(struct event_filter *filter,
+-				    int event_id,
+-				    enum filter_trivial_type type);
+-
+-int pevent_filter_copy(struct event_filter *dest, struct event_filter *source);
+-
+-int pevent_update_trivial(struct event_filter *dest, struct event_filter *source,
+-			  enum filter_trivial_type type);
+-
+-int pevent_filter_compare(struct event_filter *filter1, struct event_filter *filter2);
+-
+-#endif /* _PARSE_EVENTS_H */
+diff --git a/traceevent/event-utils.h b/traceevent/event-utils.h
+deleted file mode 100644
+index e76c9ac..0000000
+--- a/traceevent/event-utils.h
++++ /dev/null
+@@ -1,85 +0,0 @@
+-/*
+- * Copyright (C) 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#ifndef __UTIL_H
+-#define __UTIL_H
+-
+-#include <ctype.h>
+-
+-/* Can be overridden */
+-void die(const char *fmt, ...);
+-void *malloc_or_die(unsigned int size);
+-void warning(const char *fmt, ...);
+-void pr_stat(const char *fmt, ...);
+-void vpr_stat(const char *fmt, va_list ap);
+-
+-/* Always available */
+-void __die(const char *fmt, ...);
+-void __warning(const char *fmt, ...);
+-void __pr_stat(const char *fmt, ...);
+-
+-void __vdie(const char *fmt, ...);
+-void __vwarning(const char *fmt, ...);
+-void __vpr_stat(const char *fmt, ...);
+-
+-#define min(x, y) ({				\
+-	typeof(x) _min1 = (x);			\
+-	typeof(y) _min2 = (y);			\
+-	(void) (&_min1 == &_min2);		\
+-	_min1 < _min2 ? _min1 : _min2; })
+-
+-static inline char *strim(char *string)
+-{
+-	char *ret;
+-
+-	if (!string)
+-		return NULL;
+-	while (*string) {
+-		if (!isspace(*string))
+-			break;
+-		string++;
+-	}
+-	ret = string;
+-
+-	string = ret + strlen(ret) - 1;
+-	while (string > ret) {
+-		if (!isspace(*string))
+-			break;
+-		string--;
+-	}
+-	string[1] = 0;
+-
+-	return ret;
+-}
+-
+-static inline int has_text(const char *text)
+-{
+-	if (!text)
+-		return 0;
+-
+-	while (*text) {
+-		if (!isspace(*text))
+-			return 1;
+-		text++;
+-	}
+-
+-	return 0;
+-}
+-
+-#endif
+diff --git a/traceevent/kbuffer-parse.c b/traceevent/kbuffer-parse.c
+deleted file mode 100644
+index 8deddc9..0000000
+--- a/traceevent/kbuffer-parse.c
++++ /dev/null
+@@ -1,732 +0,0 @@
+-/*
+- * Copyright (C) 2009, 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not, write to the Free Software
+- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-
+-#include "kbuffer.h"
+-
+-#define MISSING_EVENTS (1 << 31)
+-#define MISSING_STORED (1 << 30)
+-
+-#define COMMIT_MASK ((1 << 27) - 1)
+-
+-enum {
+-	KBUFFER_FL_HOST_BIG_ENDIAN	= (1<<0),
+-	KBUFFER_FL_BIG_ENDIAN		= (1<<1),
+-	KBUFFER_FL_LONG_8		= (1<<2),
+-	KBUFFER_FL_OLD_FORMAT		= (1<<3),
+-};
+-
+-#define ENDIAN_MASK (KBUFFER_FL_HOST_BIG_ENDIAN | KBUFFER_FL_BIG_ENDIAN)
+-
+-/** kbuffer
+- * @timestamp		- timestamp of current event
+- * @lost_events		- # of lost events between this subbuffer and previous
+- * @flags		- special flags of the kbuffer
+- * @subbuffer		- pointer to the sub-buffer page
+- * @data		- pointer to the start of data on the sub-buffer page
+- * @index		- index from @data to the @curr event data
+- * @curr		- offset from @data to the start of current event
+- *			   (includes metadata)
+- * @next		- offset from @data to the start of next event
+- * @size		- The size of data on @data
+- * @start		- The offset from @subbuffer where @data lives
+- *
+- * @read_4		- Function to read 4 raw bytes (may swap)
+- * @read_8		- Function to read 8 raw bytes (may swap)
+- * @read_long		- Function to read a long word (4 or 8 bytes with needed swap)
+- */
+-struct kbuffer {
+-	unsigned long long 	timestamp;
+-	long long		lost_events;
+-	unsigned long		flags;
+-	void			*subbuffer;
+-	void			*data;
+-	unsigned int		index;
+-	unsigned int		curr;
+-	unsigned int		next;
+-	unsigned int		size;
+-	unsigned int		start;
+-
+-	unsigned int (*read_4)(void *ptr);
+-	unsigned long long (*read_8)(void *ptr);
+-	unsigned long long (*read_long)(struct kbuffer *kbuf, void *ptr);
+-	int (*next_event)(struct kbuffer *kbuf);
+-};
+-
+-static void *zmalloc(size_t size)
+-{
+-	return calloc(1, size);
+-}
+-
+-static int host_is_bigendian(void)
+-{
+-	unsigned char str[] = { 0x1, 0x2, 0x3, 0x4 };
+-	unsigned int *ptr;
+-
+-	ptr = (unsigned int *)str;
+-	return *ptr == 0x01020304;
+-}
+-
+-static int do_swap(struct kbuffer *kbuf)
+-{
+-	return ((kbuf->flags & KBUFFER_FL_HOST_BIG_ENDIAN) + kbuf->flags) &
+-		ENDIAN_MASK;
+-}
+-
+-static unsigned long long __read_8(void *ptr)
+-{
+-	unsigned long long data = *(unsigned long long *)ptr;
+-
+-	return data;
+-}
+-
+-static unsigned long long __read_8_sw(void *ptr)
+-{
+-	unsigned long long data = *(unsigned long long *)ptr;
+-	unsigned long long swap;
+-
+-	swap = ((data & 0xffULL) << 56) |
+-		((data & (0xffULL << 8)) << 40) |
+-		((data & (0xffULL << 16)) << 24) |
+-		((data & (0xffULL << 24)) << 8) |
+-		((data & (0xffULL << 32)) >> 8) |
+-		((data & (0xffULL << 40)) >> 24) |
+-		((data & (0xffULL << 48)) >> 40) |
+-		((data & (0xffULL << 56)) >> 56);
+-
+-	return swap;
+-}
+-
+-static unsigned int __read_4(void *ptr)
+-{
+-	unsigned int data = *(unsigned int *)ptr;
+-
+-	return data;
+-}
+-
+-static unsigned int __read_4_sw(void *ptr)
+-{
+-	unsigned int data = *(unsigned int *)ptr;
+-	unsigned int swap;
+-
+-	swap = ((data & 0xffULL) << 24) |
+-		((data & (0xffULL << 8)) << 8) |
+-		((data & (0xffULL << 16)) >> 8) |
+-		((data & (0xffULL << 24)) >> 24);
+-
+-	return swap;
+-}
+-
+-static unsigned long long read_8(struct kbuffer *kbuf, void *ptr)
+-{
+-	return kbuf->read_8(ptr);
+-}
+-
+-static unsigned int read_4(struct kbuffer *kbuf, void *ptr)
+-{
+-	return kbuf->read_4(ptr);
+-}
+-
+-static unsigned long long __read_long_8(struct kbuffer *kbuf, void *ptr)
+-{
+-	return kbuf->read_8(ptr);
+-}
+-
+-static unsigned long long __read_long_4(struct kbuffer *kbuf, void *ptr)
+-{
+-	return kbuf->read_4(ptr);
+-}
+-
+-static unsigned long long read_long(struct kbuffer *kbuf, void *ptr)
+-{
+-	return kbuf->read_long(kbuf, ptr);
+-}
+-
+-static int calc_index(struct kbuffer *kbuf, void *ptr)
+-{
+-	return (unsigned long)ptr - (unsigned long)kbuf->data;
+-}
+-
+-static int __next_event(struct kbuffer *kbuf);
+-
+-/**
+- * kbuffer_alloc - allocat a new kbuffer
+- * @size;	enum to denote size of word
+- * @endian:	enum to denote endianness
+- *
+- * Allocates and returns a new kbuffer.
+- */
+-struct kbuffer *
+-kbuffer_alloc(enum kbuffer_long_size size, enum kbuffer_endian endian)
+-{
+-	struct kbuffer *kbuf;
+-	int flags = 0;
+-
+-	switch (size) {
+-	case KBUFFER_LSIZE_4:
+-		break;
+-	case KBUFFER_LSIZE_8:
+-		flags |= KBUFFER_FL_LONG_8;
+-		break;
+-	default:
+-		return NULL;
+-	}
+-
+-	switch (endian) {
+-	case KBUFFER_ENDIAN_LITTLE:
+-		break;
+-	case KBUFFER_ENDIAN_BIG:
+-		flags |= KBUFFER_FL_BIG_ENDIAN;
+-		break;
+-	default:
+-		return NULL;
+-	}
+-
+-	kbuf = zmalloc(sizeof(*kbuf));
+-	if (!kbuf)
+-		return NULL;
+-
+-	kbuf->flags = flags;
+-
+-	if (host_is_bigendian())
+-		kbuf->flags |= KBUFFER_FL_HOST_BIG_ENDIAN;
+-
+-	if (do_swap(kbuf)) {
+-		kbuf->read_8 = __read_8_sw;
+-		kbuf->read_4 = __read_4_sw;
+-	} else {
+-		kbuf->read_8 = __read_8;
+-		kbuf->read_4 = __read_4;
+-	}
+-
+-	if (kbuf->flags & KBUFFER_FL_LONG_8)
+-		kbuf->read_long = __read_long_8;
+-	else
+-		kbuf->read_long = __read_long_4;
+-
+-	/* May be changed by kbuffer_set_old_format() */
+-	kbuf->next_event = __next_event;
+-
+-	return kbuf;
+-}
+-
+-/** kbuffer_free - free an allocated kbuffer
+- * @kbuf:	The kbuffer to free
+- *
+- * Can take NULL as a parameter.
+- */
+-void kbuffer_free(struct kbuffer *kbuf)
+-{
+-	free(kbuf);
+-}
+-
+-static unsigned int type4host(struct kbuffer *kbuf,
+-			      unsigned int type_len_ts)
+-{
+-	if (kbuf->flags & KBUFFER_FL_BIG_ENDIAN)
+-		return (type_len_ts >> 29) & 3;
+-	else
+-		return type_len_ts & 3;
+-}
+-
+-static unsigned int len4host(struct kbuffer *kbuf,
+-			     unsigned int type_len_ts)
+-{
+-	if (kbuf->flags & KBUFFER_FL_BIG_ENDIAN)
+-		return (type_len_ts >> 27) & 7;
+-	else
+-		return (type_len_ts >> 2) & 7;
+-}
+-
+-static unsigned int type_len4host(struct kbuffer *kbuf,
+-				  unsigned int type_len_ts)
+-{
+-	if (kbuf->flags & KBUFFER_FL_BIG_ENDIAN)
+-		return (type_len_ts >> 27) & ((1 << 5) - 1);
+-	else
+-		return type_len_ts & ((1 << 5) - 1);
+-}
+-
+-static unsigned int ts4host(struct kbuffer *kbuf,
+-			    unsigned int type_len_ts)
+-{
+-	if (kbuf->flags & KBUFFER_FL_BIG_ENDIAN)
+-		return type_len_ts & ((1 << 27) - 1);
+-	else
+-		return type_len_ts >> 5;
+-}
+-
+-/*
+- * Linux 2.6.30 and earlier (not much earlier) had a different
+- * ring buffer format. It should be obsolete, but we handle it anyway.
+- */
+-enum old_ring_buffer_type {
+-	OLD_RINGBUF_TYPE_PADDING,
+-	OLD_RINGBUF_TYPE_TIME_EXTEND,
+-	OLD_RINGBUF_TYPE_TIME_STAMP,
+-	OLD_RINGBUF_TYPE_DATA,
+-};
+-
+-static unsigned int old_update_pointers(struct kbuffer *kbuf)
+-{
+-	unsigned long long extend;
+-	unsigned int type_len_ts;
+-	unsigned int type;
+-	unsigned int len;
+-	unsigned int delta;
+-	unsigned int length;
+-	void *ptr = kbuf->data + kbuf->curr;
+-
+-	type_len_ts = read_4(kbuf, ptr);
+-	ptr += 4;
+-
+-	type = type4host(kbuf, type_len_ts);
+-	len = len4host(kbuf, type_len_ts);
+-	delta = ts4host(kbuf, type_len_ts);
+-
+-	switch (type) {
+-	case OLD_RINGBUF_TYPE_PADDING:
+-		kbuf->next = kbuf->size;
+-		return 0;
+-
+-	case OLD_RINGBUF_TYPE_TIME_EXTEND:
+-		extend = read_4(kbuf, ptr);
+-		extend <<= TS_SHIFT;
+-		extend += delta;
+-		delta = extend;
+-		ptr += 4;
+-		break;
+-
+-	case OLD_RINGBUF_TYPE_TIME_STAMP:
+-		/* should never happen! */
+-		kbuf->curr = kbuf->size;
+-		kbuf->next = kbuf->size;
+-		kbuf->index = kbuf->size;
+-		return -1;
+-	default:
+-		if (len)
+-			length = len * 4;
+-		else {
+-			length = read_4(kbuf, ptr);
+-			length -= 4;
+-			ptr += 4;
+-		}
+-		break;
+-	}
+-
+-	kbuf->timestamp += delta;
+-	kbuf->index = calc_index(kbuf, ptr);
+-	kbuf->next = kbuf->index + length;
+-
+-	return type;
+-}
+-
+-static int __old_next_event(struct kbuffer *kbuf)
+-{
+-	int type;
+-
+-	do {
+-		kbuf->curr = kbuf->next;
+-		if (kbuf->next >= kbuf->size)
+-			return -1;
+-		type = old_update_pointers(kbuf);
+-	} while (type == OLD_RINGBUF_TYPE_TIME_EXTEND || type == OLD_RINGBUF_TYPE_PADDING);
+-
+-	return 0;
+-}
+-
+-static unsigned int
+-translate_data(struct kbuffer *kbuf, void *data, void **rptr,
+-	       unsigned long long *delta, int *length)
+-{
+-	unsigned long long extend;
+-	unsigned int type_len_ts;
+-	unsigned int type_len;
+-
+-	type_len_ts = read_4(kbuf, data);
+-	data += 4;
+-
+-	type_len = type_len4host(kbuf, type_len_ts);
+-	*delta = ts4host(kbuf, type_len_ts);
+-
+-	switch (type_len) {
+-	case KBUFFER_TYPE_PADDING:
+-		*length = read_4(kbuf, data);
+-		data += *length;
+-		break;
+-
+-	case KBUFFER_TYPE_TIME_EXTEND:
+-		extend = read_4(kbuf, data);
+-		data += 4;
+-		extend <<= TS_SHIFT;
+-		extend += *delta;
+-		*delta = extend;
+-		*length = 0;
+-		break;
+-
+-	case KBUFFER_TYPE_TIME_STAMP:
+-		data += 12;
+-		*length = 0;
+-		break;
+-	case 0:
+-		*length = read_4(kbuf, data) - 4;
+-		*length = (*length + 3) & ~3;
+-		data += 4;
+-		break;
+-	default:
+-		*length = type_len * 4;
+-		break;
+-	}
+-
+-	*rptr = data;
+-
+-	return type_len;
+-}
+-
+-static unsigned int update_pointers(struct kbuffer *kbuf)
+-{
+-	unsigned long long delta;
+-	unsigned int type_len;
+-	int length;
+-	void *ptr = kbuf->data + kbuf->curr;
+-
+-	type_len = translate_data(kbuf, ptr, &ptr, &delta, &length);
+-
+-	kbuf->timestamp += delta;
+-	kbuf->index = calc_index(kbuf, ptr);
+-	kbuf->next = kbuf->index + length;
+-
+-	return type_len;
+-}
+-
+-/**
+- * kbuffer_translate_data - read raw data to get a record
+- * @swap:	Set to 1 if bytes in words need to be swapped when read
+- * @data:	The raw data to read
+- * @size:	Address to store the size of the event data.
+- *
+- * Returns a pointer to the event data. To determine the entire
+- * record size (record metadata + data) just add the difference between
+- * @data and the returned value to @size.
+- */
+-void *kbuffer_translate_data(int swap, void *data, unsigned int *size)
+-{
+-	unsigned long long delta;
+-	struct kbuffer kbuf;
+-	int type_len;
+-	int length;
+-	void *ptr;
+-
+-	if (swap) {
+-		kbuf.read_8 = __read_8_sw;
+-		kbuf.read_4 = __read_4_sw;
+-		kbuf.flags = host_is_bigendian() ? 0 : KBUFFER_FL_BIG_ENDIAN;
+-	} else {
+-		kbuf.read_8 = __read_8;
+-		kbuf.read_4 = __read_4;
+-		kbuf.flags = host_is_bigendian() ? KBUFFER_FL_BIG_ENDIAN: 0;
+-	}
+-
+-	type_len = translate_data(&kbuf, data, &ptr, &delta, &length);
+-	switch (type_len) {
+-	case KBUFFER_TYPE_PADDING:
+-	case KBUFFER_TYPE_TIME_EXTEND:
+-	case KBUFFER_TYPE_TIME_STAMP:
+-		return NULL;
+-	};
+-
+-	*size = length;
+-
+-	return ptr;
+-}
+-
+-static int __next_event(struct kbuffer *kbuf)
+-{
+-	int type;
+-
+-	do {
+-		kbuf->curr = kbuf->next;
+-		if (kbuf->next >= kbuf->size)
+-			return -1;
+-		type = update_pointers(kbuf);
+-	} while (type == KBUFFER_TYPE_TIME_EXTEND || type == KBUFFER_TYPE_PADDING);
+-
+-	return 0;
+-}
+-
+-static int next_event(struct kbuffer *kbuf)
+-{
+-	return kbuf->next_event(kbuf);
+-}
+-
+-/**
+- * kbuffer_next_event - increment the current pointer
+- * @kbuf:	The kbuffer to read
+- * @ts:		Address to store the next record's timestamp (may be NULL to ignore)
+- *
+- * Increments the pointers into the subbuffer of the kbuffer to point to the
+- * next event so that the next kbuffer_read_event() will return a
+- * new event.
+- *
+- * Returns the data of the next event if a new event exists on the subbuffer,
+- * NULL otherwise.
+- */
+-void *kbuffer_next_event(struct kbuffer *kbuf, unsigned long long *ts)
+-{
+-	int ret;
+-
+-	if (!kbuf || !kbuf->subbuffer)
+-		return NULL;
+-
+-	ret = next_event(kbuf);
+-	if (ret < 0)
+-		return NULL;
+-
+-	if (ts)
+-		*ts = kbuf->timestamp;
+-
+-	return kbuf->data + kbuf->index;
+-}
+-
+-/**
+- * kbuffer_load_subbuffer - load a new subbuffer into the kbuffer
+- * @kbuf:	The kbuffer to load
+- * @subbuffer:	The subbuffer to load into @kbuf.
+- *
+- * Load a new subbuffer (page) into @kbuf. This will reset all
+- * the pointers and update the @kbuf timestamp. The next read will
+- * return the first event on @subbuffer.
+- *
+- * Returns 0 on succes, -1 otherwise.
+- */
+-int kbuffer_load_subbuffer(struct kbuffer *kbuf, void *subbuffer)
+-{
+-	unsigned long long flags;
+-	void *ptr = subbuffer;
+-
+-	if (!kbuf || !subbuffer)
+-		return -1;
+-
+-	kbuf->subbuffer = subbuffer;
+-
+-	kbuf->timestamp = read_8(kbuf, ptr);
+-	ptr += 8;
+-
+-	kbuf->curr = 0;
+-
+-	if (kbuf->flags & KBUFFER_FL_LONG_8)
+-		kbuf->start = 16;
+-	else
+-		kbuf->start = 12;
+-
+-	kbuf->data = subbuffer + kbuf->start;
+-
+-	flags = read_long(kbuf, ptr);
+-	kbuf->size = (unsigned int)flags & COMMIT_MASK;
+-
+-	if (flags & MISSING_EVENTS) {
+-		if (flags & MISSING_STORED) {
+-			ptr = kbuf->data + kbuf->size;
+-			kbuf->lost_events = read_long(kbuf, ptr);
+-		} else
+-			kbuf->lost_events = -1;
+-	} else
+-		kbuf->lost_events = 0;
+-
+-	kbuf->index = 0;
+-	kbuf->next = 0;
+-
+-	next_event(kbuf);
+-
+-	return 0;
+-}
+-
+-/**
+- * kbuffer_read_event - read the next event in the kbuffer subbuffer
+- * @kbuf:	The kbuffer to read from
+- * @ts:		The address to store the timestamp of the event (may be NULL to ignore)
+- *
+- * Returns a pointer to the data part of the current event.
+- * NULL if no event is left on the subbuffer.
+- */
+-void *kbuffer_read_event(struct kbuffer *kbuf, unsigned long long *ts)
+-{
+-	if (!kbuf || !kbuf->subbuffer)
+-		return NULL;
+-
+-	if (kbuf->curr >= kbuf->size)
+-		return NULL;
+-
+-	if (ts)
+-		*ts = kbuf->timestamp;
+-	return kbuf->data + kbuf->index;
+-}
+-
+-/**
+- * kbuffer_timestamp - Return the timestamp of the current event
+- * @kbuf:	The kbuffer to read from
+- *
+- * Returns the timestamp of the current (next) event.
+- */
+-unsigned long long kbuffer_timestamp(struct kbuffer *kbuf)
+-{
+-	return kbuf->timestamp;
+-}
+-
+-/**
+- * kbuffer_read_at_offset - read the event that is at offset
+- * @kbuf:	The kbuffer to read from
+- * @offset:	The offset into the subbuffer
+- * @ts:		The address to store the timestamp of the event (may be NULL to ignore)
+- *
+- * The @offset must be an index from the @kbuf subbuffer beginning.
+- * If @offset is bigger than the stored subbuffer, NULL will be returned.
+- *
+- * Returns the data of the record that is at @offset. Note, @offset does
+- * not need to be the start of the record, the offset just needs to be
+- * in the record (or beginning of it).
+- *
+- * Note, the kbuf timestamp and pointers are updated to the
+- * returned record. That is, kbuffer_read_event() will return the same
+- * data and timestamp, and kbuffer_next_event() will increment from
+- * this record.
+- */
+-void *kbuffer_read_at_offset(struct kbuffer *kbuf, int offset,
+-			     unsigned long long *ts)
+-{
+-	void *data;
+-
+-	if (offset < kbuf->start)
+-		offset = 0;
+-	else
+-		offset -= kbuf->start;
+-
+-	/* Reset the buffer */
+-	kbuffer_load_subbuffer(kbuf, kbuf->subbuffer);
+-
+-	while (kbuf->curr < offset) {
+-		data = kbuffer_next_event(kbuf, ts);
+-		if (!data)
+-			break;
+-	}
+-
+-	return data;
+-}
+-
+-/**
+- * kbuffer_subbuffer_size - the size of the loaded subbuffer
+- * @kbuf:	The kbuffer to read from
+- *
+- * Returns the size of the subbuffer. Note, this size is
+- * where the last event resides. The stored subbuffer may actually be
+- * bigger due to padding and such.
+- */
+-int kbuffer_subbuffer_size(struct kbuffer *kbuf)
+-{
+-	return kbuf->size;
+-}
+-
+-/**
+- * kbuffer_curr_index - Return the index of the record
+- * @kbuf:	The kbuffer to read from
+- *
+- * Returns the index from the start of the data part of
+- * the subbuffer to the current location. Note this is not
+- * from the start of the subbuffer. An index of zero will
+- * point to the first record. Use kbuffer_curr_offset() for
+- * the actually offset (that can be used by kbuffer_read_at_offset())
+- */
+-int kbuffer_curr_index(struct kbuffer *kbuf)
+-{
+-	return kbuf->curr;
+-}
+-
+-/**
+- * kbuffer_curr_offset - Return the offset of the record
+- * @kbuf:	The kbuffer to read from
+- *
+- * Returns the offset from the start of the subbuffer to the
+- * current location.
+- */
+-int kbuffer_curr_offset(struct kbuffer *kbuf)
+-{
+-	return kbuf->curr + kbuf->start;
+-}
+-
+-/**
+- * kbuffer_event_size - return the size of the event data
+- * @kbuf:	The kbuffer to read
+- *
+- * Returns the size of the event data (the payload not counting
+- * the meta data of the record) of the current event.
+- */
+-int kbuffer_event_size(struct kbuffer *kbuf)
+-{
+-	return kbuf->next - kbuf->index;
+-}
+-
+-/**
+- * kbuffer_curr_size - return the size of the entire record
+- * @kbuf:	The kbuffer to read
+- *
+- * Returns the size of the entire record (meta data and payload)
+- * of the current event.
+- */
+-int kbuffer_curr_size(struct kbuffer *kbuf)
+-{
+-	return kbuf->next - kbuf->curr;
+-}
+-
+-/**
+- * kbuffer_missed_events - return the # of missed events from last event.
+- * @kbuf: 	The kbuffer to read from
+- *
+- * Returns the # of missed events (if recorded) before the current
+- * event. Note, only events on the beginning of a subbuffer can
+- * have missed events, all other events within the buffer will be
+- * zero.
+- */
+-int kbuffer_missed_events(struct kbuffer *kbuf)
+-{
+-	/* Only the first event can have missed events */
+-	if (kbuf->curr)
+-		return 0;
+-
+-	return kbuf->lost_events;
+-}
+-
+-/**
+- * kbuffer_set_old_forma - set the kbuffer to use the old format parsing
+- * @kbuf:	The kbuffer to set
+- *
+- * This is obsolete (or should be). The first kernels to use the
+- * new ring buffer had a slightly different ring buffer format
+- * (2.6.30 and earlier). It is still somewhat supported by kbuffer,
+- * but should not be counted on in the future.
+- */
+-void kbuffer_set_old_format(struct kbuffer *kbuf)
+-{
+-	kbuf->flags |= KBUFFER_FL_OLD_FORMAT;
+-
+-	kbuf->next_event = __old_next_event;
+-}
+diff --git a/traceevent/kbuffer.h b/traceevent/kbuffer.h
+deleted file mode 100644
+index c831f64..0000000
+--- a/traceevent/kbuffer.h
++++ /dev/null
+@@ -1,67 +0,0 @@
+-/*
+- * Copyright (C) 2012 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not, write to the Free Software
+- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#ifndef _KBUFFER_H
+-#define _KBUFFER_H
+-
+-#ifndef TS_SHIFT
+-#define TS_SHIFT		27
+-#endif
+-
+-enum kbuffer_endian {
+-	KBUFFER_ENDIAN_BIG,
+-	KBUFFER_ENDIAN_LITTLE,
+-};
+-
+-enum kbuffer_long_size {
+-	KBUFFER_LSIZE_4,
+-	KBUFFER_LSIZE_8,
+-};
+-
+-enum {
+-	KBUFFER_TYPE_PADDING		= 29,
+-	KBUFFER_TYPE_TIME_EXTEND	= 30,
+-	KBUFFER_TYPE_TIME_STAMP		= 31,
+-};
+-
+-struct kbuffer;
+-
+-struct kbuffer *kbuffer_alloc(enum kbuffer_long_size size, enum kbuffer_endian endian);
+-void kbuffer_free(struct kbuffer *kbuf);
+-int kbuffer_load_subbuffer(struct kbuffer *kbuf, void *subbuffer);
+-void *kbuffer_read_event(struct kbuffer *kbuf, unsigned long long *ts);
+-void *kbuffer_next_event(struct kbuffer *kbuf, unsigned long long *ts);
+-unsigned long long kbuffer_timestamp(struct kbuffer *kbuf);
+-
+-void *kbuffer_translate_data(int swap, void *data, unsigned int *size);
+-
+-void *kbuffer_read_at_offset(struct kbuffer *kbuf, int offset, unsigned long long *ts);
+-
+-int kbuffer_curr_index(struct kbuffer *kbuf);
+-
+-int kbuffer_curr_offset(struct kbuffer *kbuf);
+-int kbuffer_curr_size(struct kbuffer *kbuf);
+-int kbuffer_event_size(struct kbuffer *kbuf);
+-int kbuffer_missed_events(struct kbuffer *kbuf);
+-int kbuffer_subbuffer_size(struct kbuffer *kbuf);
+-
+-void kbuffer_set_old_format(struct kbuffer *kbuf);
+-
+-#endif /* _K_BUFFER_H */
+diff --git a/traceevent/parse-filter.c b/traceevent/parse-filter.c
+deleted file mode 100644
+index ec308ae..0000000
+--- a/traceevent/parse-filter.c
++++ /dev/null
+@@ -1,2303 +0,0 @@
+-/*
+- * Copyright (C) 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <stdarg.h>
+-#include <errno.h>
+-#include <sys/types.h>
+-
+-#include "event-parse.h"
+-#include "event-utils.h"
+-
+-#define COMM "COMM"
+-
+-static struct format_field comm = {
+-	.name = "COMM",
+-};
+-
+-struct event_list {
+-	struct event_list	*next;
+-	struct event_format	*event;
+-};
+-
+-#define MAX_ERR_STR_SIZE 256
+-
+-static void show_error(char **error_str, const char *fmt, ...)
+-{
+-	unsigned long long index;
+-	const char *input;
+-	char *error;
+-	va_list ap;
+-	int len;
+-	int i;
+-
+-	if (!error_str)
+-		return;
+-
+-	input = pevent_get_input_buf();
+-	index = pevent_get_input_buf_ptr();
+-	len = input ? strlen(input) : 0;
+-
+-	error = malloc_or_die(MAX_ERR_STR_SIZE + (len*2) + 3);
+-
+-	if (len) {
+-		strcpy(error, input);
+-		error[len] = '\n';
+-		for (i = 1; i < len && i < index; i++)
+-			error[len+i] = ' ';
+-		error[len + i] = '^';
+-		error[len + i + 1] = '\n';
+-		len += i+2;
+-	}
+-
+-	va_start(ap, fmt);
+-	vsnprintf(error + len, MAX_ERR_STR_SIZE, fmt, ap);
+-	va_end(ap);
+-
+-	*error_str = error;
+-}
+-
+-static void free_token(char *token)
+-{
+-	pevent_free_token(token);
+-}
+-
+-static enum event_type read_token(char **tok)
+-{
+-	enum event_type type;
+-	char *token = NULL;
+-
+-	do {
+-		free_token(token);
+-		type = pevent_read_token(&token);
+-	} while (type == EVENT_NEWLINE || type == EVENT_SPACE);
+-
+-	/* If token is = or ! check to see if the next char is ~ */
+-	if (token &&
+-	    (strcmp(token, "=") == 0 || strcmp(token, "!") == 0) &&
+-	    pevent_peek_char() == '~') {
+-		/* append it */
+-		*tok = malloc_or_die(3);
+-		sprintf(*tok, "%c%c", *token, '~');
+-		free_token(token);
+-		/* Now remove the '~' from the buffer */
+-		pevent_read_token(&token);
+-		free_token(token);
+-	} else
+-		*tok = token;
+-
+-	return type;
+-}
+-
+-static int filter_cmp(const void *a, const void *b)
+-{
+-	const struct filter_type *ea = a;
+-	const struct filter_type *eb = b;
+-
+-	if (ea->event_id < eb->event_id)
+-		return -1;
+-
+-	if (ea->event_id > eb->event_id)
+-		return 1;
+-
+-	return 0;
+-}
+-
+-static struct filter_type *
+-find_filter_type(struct event_filter *filter, int id)
+-{
+-	struct filter_type *filter_type;
+-	struct filter_type key;
+-
+-	key.event_id = id;
+-
+-	filter_type = bsearch(&key, filter->event_filters,
+-			      filter->filters,
+-			      sizeof(*filter->event_filters),
+-			      filter_cmp);
+-
+-	return filter_type;
+-}
+-
+-static struct filter_type *
+-add_filter_type(struct event_filter *filter, int id)
+-{
+-	struct filter_type *filter_type;
+-	int i;
+-
+-	filter_type = find_filter_type(filter, id);
+-	if (filter_type)
+-		return filter_type;
+-
+-	filter->event_filters =	realloc(filter->event_filters,
+-					sizeof(*filter->event_filters) *
+-					(filter->filters + 1));
+-	if (!filter->event_filters)
+-		die("Could not allocate filter");
+-
+-	for (i = 0; i < filter->filters; i++) {
+-		if (filter->event_filters[i].event_id > id)
+-			break;
+-	}
+-
+-	if (i < filter->filters)
+-		memmove(&filter->event_filters[i+1],
+-			&filter->event_filters[i],
+-			sizeof(*filter->event_filters) *
+-			(filter->filters - i));
+-
+-	filter_type = &filter->event_filters[i];
+-	filter_type->event_id = id;
+-	filter_type->event = pevent_find_event(filter->pevent, id);
+-	filter_type->filter = NULL;
+-
+-	filter->filters++;
+-
+-	return filter_type;
+-}
+-
+-/**
+- * pevent_filter_alloc - create a new event filter
+- * @pevent: The pevent that this filter is associated with
+- */
+-struct event_filter *pevent_filter_alloc(struct pevent *pevent)
+-{
+-	struct event_filter *filter;
+-
+-	filter = malloc_or_die(sizeof(*filter));
+-	memset(filter, 0, sizeof(*filter));
+-	filter->pevent = pevent;
+-	pevent_ref(pevent);
+-
+-	return filter;
+-}
+-
+-static struct filter_arg *allocate_arg(void)
+-{
+-	struct filter_arg *arg;
+-
+-	arg = malloc_or_die(sizeof(*arg));
+-	memset(arg, 0, sizeof(*arg));
+-
+-	return arg;
+-}
+-
+-static void free_arg(struct filter_arg *arg)
+-{
+-	if (!arg)
+-		return;
+-
+-	switch (arg->type) {
+-	case FILTER_ARG_NONE:
+-	case FILTER_ARG_BOOLEAN:
+-		break;
+-
+-	case FILTER_ARG_NUM:
+-		free_arg(arg->num.left);
+-		free_arg(arg->num.right);
+-		break;
+-
+-	case FILTER_ARG_EXP:
+-		free_arg(arg->exp.left);
+-		free_arg(arg->exp.right);
+-		break;
+-
+-	case FILTER_ARG_STR:
+-		free(arg->str.val);
+-		regfree(&arg->str.reg);
+-		free(arg->str.buffer);
+-		break;
+-
+-	case FILTER_ARG_VALUE:
+-		if (arg->value.type == FILTER_STRING ||
+-		    arg->value.type == FILTER_CHAR)
+-			free(arg->value.str);
+-		break;
+-
+-	case FILTER_ARG_OP:
+-		free_arg(arg->op.left);
+-		free_arg(arg->op.right);
+-	default:
+-		break;
+-	}
+-
+-	free(arg);
+-}
+-
+-static void add_event(struct event_list **events,
+-		      struct event_format *event)
+-{
+-	struct event_list *list;
+-
+-	list = malloc_or_die(sizeof(*list));
+-	list->next = *events;
+-	*events = list;
+-	list->event = event;
+-}
+-
+-static int event_match(struct event_format *event,
+-		       regex_t *sreg, regex_t *ereg)
+-{
+-	if (sreg) {
+-		return !regexec(sreg, event->system, 0, NULL, 0) &&
+-			!regexec(ereg, event->name, 0, NULL, 0);
+-	}
+-
+-	return !regexec(ereg, event->system, 0, NULL, 0) ||
+-		!regexec(ereg, event->name, 0, NULL, 0);
+-}
+-
+-static int
+-find_event(struct pevent *pevent, struct event_list **events,
+-	   char *sys_name, char *event_name)
+-{
+-	struct event_format *event;
+-	regex_t ereg;
+-	regex_t sreg;
+-	int match = 0;
+-	char *reg;
+-	int ret;
+-	int i;
+-
+-	if (!event_name) {
+-		/* if no name is given, then swap sys and name */
+-		event_name = sys_name;
+-		sys_name = NULL;
+-	}
+-
+-	reg = malloc_or_die(strlen(event_name) + 3);
+-	sprintf(reg, "^%s$", event_name);
+-
+-	ret = regcomp(&ereg, reg, REG_ICASE|REG_NOSUB);
+-	free(reg);
+-
+-	if (ret)
+-		return -1;
+-
+-	if (sys_name) {
+-		reg = malloc_or_die(strlen(sys_name) + 3);
+-		sprintf(reg, "^%s$", sys_name);
+-		ret = regcomp(&sreg, reg, REG_ICASE|REG_NOSUB);
+-		free(reg);
+-		if (ret) {
+-			regfree(&ereg);
+-			return -1;
+-		}
+-	}
+-
+-	for (i = 0; i < pevent->nr_events; i++) {
+-		event = pevent->events[i];
+-		if (event_match(event, sys_name ? &sreg : NULL, &ereg)) {
+-			match = 1;
+-			add_event(events, event);
+-		}
+-	}
+-
+-	regfree(&ereg);
+-	if (sys_name)
+-		regfree(&sreg);
+-
+-	if (!match)
+-		return -1;
+-
+-	return 0;
+-}
+-
+-static void free_events(struct event_list *events)
+-{
+-	struct event_list *event;
+-
+-	while (events) {
+-		event = events;
+-		events = events->next;
+-		free(event);
+-	}
+-}
+-
+-static struct filter_arg *
+-create_arg_item(struct event_format *event, const char *token,
+-		enum event_type type, char **error_str)
+-{
+-	struct format_field *field;
+-	struct filter_arg *arg;
+-
+-	arg = allocate_arg();
+-
+-	switch (type) {
+-
+-	case EVENT_SQUOTE:
+-	case EVENT_DQUOTE:
+-		arg->type = FILTER_ARG_VALUE;
+-		arg->value.type =
+-			type == EVENT_DQUOTE ? FILTER_STRING : FILTER_CHAR;
+-		arg->value.str = strdup(token);
+-		if (!arg->value.str)
+-			die("malloc string");
+-		break;
+-	case EVENT_ITEM:
+-		/* if it is a number, then convert it */
+-		if (isdigit(token[0])) {
+-			arg->type = FILTER_ARG_VALUE;
+-			arg->value.type = FILTER_NUMBER;
+-			arg->value.val = strtoull(token, NULL, 0);
+-			break;
+-		}
+-		/* Consider this a field */
+-		field = pevent_find_any_field(event, token);
+-		if (!field) {
+-			if (strcmp(token, COMM) != 0) {
+-				/* not a field, Make it false */
+-				arg->type = FILTER_ARG_BOOLEAN;
+-				arg->boolean.value = FILTER_FALSE;
+-				break;
+-			}
+-			/* If token is 'COMM' then it is special */
+-			field = &comm;
+-		}
+-		arg->type = FILTER_ARG_FIELD;
+-		arg->field.field = field;
+-		break;
+-	default:
+-		free_arg(arg);
+-		show_error(error_str, "expected a value but found %s",
+-			   token);
+-		return NULL;
+-	}
+-	return arg;
+-}
+-
+-static struct filter_arg *
+-create_arg_op(enum filter_op_type btype)
+-{
+-	struct filter_arg *arg;
+-
+-	arg = allocate_arg();
+-	arg->type = FILTER_ARG_OP;
+-	arg->op.type = btype;
+-
+-	return arg;
+-}
+-
+-static struct filter_arg *
+-create_arg_exp(enum filter_exp_type etype)
+-{
+-	struct filter_arg *arg;
+-
+-	arg = allocate_arg();
+-	arg->type = FILTER_ARG_EXP;
+-	arg->op.type = etype;
+-
+-	return arg;
+-}
+-
+-static struct filter_arg *
+-create_arg_cmp(enum filter_exp_type etype)
+-{
+-	struct filter_arg *arg;
+-
+-	arg = allocate_arg();
+-	/* Use NUM and change if necessary */
+-	arg->type = FILTER_ARG_NUM;
+-	arg->op.type = etype;
+-
+-	return arg;
+-}
+-
+-static int add_right(struct filter_arg *op, struct filter_arg *arg,
+-		     char **error_str)
+-{
+-	struct filter_arg *left;
+-	char *str;
+-	int op_type;
+-	int ret;
+-
+-	switch (op->type) {
+-	case FILTER_ARG_EXP:
+-		if (op->exp.right)
+-			goto out_fail;
+-		op->exp.right = arg;
+-		break;
+-
+-	case FILTER_ARG_OP:
+-		if (op->op.right)
+-			goto out_fail;
+-		op->op.right = arg;
+-		break;
+-
+-	case FILTER_ARG_NUM:
+-		if (op->op.right)
+-			goto out_fail;
+-		/*
+-		 * The arg must be num, str, or field
+-		 */
+-		switch (arg->type) {
+-		case FILTER_ARG_VALUE:
+-		case FILTER_ARG_FIELD:
+-			break;
+-		default:
+-			show_error(error_str,
+-				   "Illegal rvalue");
+-			return -1;
+-		}
+-
+-		/*
+-		 * Depending on the type, we may need to
+-		 * convert this to a string or regex.
+-		 */
+-		switch (arg->value.type) {
+-		case FILTER_CHAR:
+-			/*
+-			 * A char should be converted to number if
+-			 * the string is 1 byte, and the compare
+-			 * is not a REGEX.
+-			 */
+-			if (strlen(arg->value.str) == 1 &&
+-			    op->num.type != FILTER_CMP_REGEX &&
+-			    op->num.type != FILTER_CMP_NOT_REGEX) {
+-				arg->value.type = FILTER_NUMBER;
+-				goto do_int;
+-			}
+-			/* fall through */
+-		case FILTER_STRING:
+-
+-			/* convert op to a string arg */
+-			op_type = op->num.type;
+-			left = op->num.left;
+-			str = arg->value.str;
+-
+-			/* reset the op for the new field */
+-			memset(op, 0, sizeof(*op));
+-
+-			/*
+-			 * If left arg was a field not found then
+-			 * NULL the entire op.
+-			 */
+-			if (left->type == FILTER_ARG_BOOLEAN) {
+-				free_arg(left);
+-				free_arg(arg);
+-				op->type = FILTER_ARG_BOOLEAN;
+-				op->boolean.value = FILTER_FALSE;
+-				break;
+-			}
+-
+-			/* Left arg must be a field */
+-			if (left->type != FILTER_ARG_FIELD) {
+-				show_error(error_str,
+-					   "Illegal lvalue for string comparison");
+-				return -1;
+-			}
+-
+-			/* Make sure this is a valid string compare */
+-			switch (op_type) {
+-			case FILTER_CMP_EQ:
+-				op_type = FILTER_CMP_MATCH;
+-				break;
+-			case FILTER_CMP_NE:
+-				op_type = FILTER_CMP_NOT_MATCH;
+-				break;
+-
+-			case FILTER_CMP_REGEX:
+-			case FILTER_CMP_NOT_REGEX:
+-				ret = regcomp(&op->str.reg, str, REG_ICASE|REG_NOSUB);
+-				if (ret) {
+-					show_error(error_str,
+-						   "RegEx '%s' did not compute",
+-						   str);
+-					return -1;
+-				}
+-				break;
+-			default:
+-				show_error(error_str,
+-					   "Illegal comparison for string");
+-				return -1;
+-			}
+-
+-			op->type = FILTER_ARG_STR;
+-			op->str.type = op_type;
+-			op->str.field = left->field.field;
+-			op->str.val = strdup(str);
+-			if (!op->str.val)
+-				die("malloc string");
+-			/*
+-			 * Need a buffer to copy data for tests
+-			 */
+-			op->str.buffer = malloc_or_die(op->str.field->size + 1);
+-			/* Null terminate this buffer */
+-			op->str.buffer[op->str.field->size] = 0;
+-
+-			/* We no longer have left or right args */
+-			free_arg(arg);
+-			free_arg(left);
+-
+-			break;
+-
+-		case FILTER_NUMBER:
+-
+- do_int:
+-			switch (op->num.type) {
+-			case FILTER_CMP_REGEX:
+-			case FILTER_CMP_NOT_REGEX:
+-				show_error(error_str,
+-					   "Op not allowed with integers");
+-				return -1;
+-
+-			default:
+-				break;
+-			}
+-
+-			/* numeric compare */
+-			op->num.right = arg;
+-			break;
+-		default:
+-			goto out_fail;
+-		}
+-		break;
+-	default:
+-		goto out_fail;
+-	}
+-
+-	return 0;
+-
+- out_fail:
+-	show_error(error_str,
+-		   "Syntax error");
+-	return -1;
+-}
+-
+-static struct filter_arg *
+-rotate_op_right(struct filter_arg *a, struct filter_arg *b)
+-{
+-	struct filter_arg *arg;
+-
+-	arg = a->op.right;
+-	a->op.right = b;
+-	return arg;
+-}
+-
+-static int add_left(struct filter_arg *op, struct filter_arg *arg)
+-{
+-	switch (op->type) {
+-	case FILTER_ARG_EXP:
+-		if (arg->type == FILTER_ARG_OP)
+-			arg = rotate_op_right(arg, op);
+-		op->exp.left = arg;
+-		break;
+-
+-	case FILTER_ARG_OP:
+-		op->op.left = arg;
+-		break;
+-	case FILTER_ARG_NUM:
+-		if (arg->type == FILTER_ARG_OP)
+-			arg = rotate_op_right(arg, op);
+-
+-		/* left arg of compares must be a field */
+-		if (arg->type != FILTER_ARG_FIELD &&
+-		    arg->type != FILTER_ARG_BOOLEAN)
+-			return -1;
+-		op->num.left = arg;
+-		break;
+-	default:
+-		return -1;
+-	}
+-	return 0;
+-}
+-
+-enum op_type {
+-	OP_NONE,
+-	OP_BOOL,
+-	OP_NOT,
+-	OP_EXP,
+-	OP_CMP,
+-};
+-
+-static enum op_type process_op(const char *token,
+-			       enum filter_op_type *btype,
+-			       enum filter_cmp_type *ctype,
+-			       enum filter_exp_type *etype)
+-{
+-	*btype = FILTER_OP_NOT;
+-	*etype = FILTER_EXP_NONE;
+-	*ctype = FILTER_CMP_NONE;
+-
+-	if (strcmp(token, "&&") == 0)
+-		*btype = FILTER_OP_AND;
+-	else if (strcmp(token, "||") == 0)
+-		*btype = FILTER_OP_OR;
+-	else if (strcmp(token, "!") == 0)
+-		return OP_NOT;
+-
+-	if (*btype != FILTER_OP_NOT)
+-		return OP_BOOL;
+-
+-	/* Check for value expressions */
+-	if (strcmp(token, "+") == 0) {
+-		*etype = FILTER_EXP_ADD;
+-	} else if (strcmp(token, "-") == 0) {
+-		*etype = FILTER_EXP_SUB;
+-	} else if (strcmp(token, "*") == 0) {
+-		*etype = FILTER_EXP_MUL;
+-	} else if (strcmp(token, "/") == 0) {
+-		*etype = FILTER_EXP_DIV;
+-	} else if (strcmp(token, "%") == 0) {
+-		*etype = FILTER_EXP_MOD;
+-	} else if (strcmp(token, ">>") == 0) {
+-		*etype = FILTER_EXP_RSHIFT;
+-	} else if (strcmp(token, "<<") == 0) {
+-		*etype = FILTER_EXP_LSHIFT;
+-	} else if (strcmp(token, "&") == 0) {
+-		*etype = FILTER_EXP_AND;
+-	} else if (strcmp(token, "|") == 0) {
+-		*etype = FILTER_EXP_OR;
+-	} else if (strcmp(token, "^") == 0) {
+-		*etype = FILTER_EXP_XOR;
+-	} else if (strcmp(token, "~") == 0)
+-		*etype = FILTER_EXP_NOT;
+-
+-	if (*etype != FILTER_EXP_NONE)
+-		return OP_EXP;
+-
+-	/* Check for compares */
+-	if (strcmp(token, "==") == 0)
+-		*ctype = FILTER_CMP_EQ;
+-	else if (strcmp(token, "!=") == 0)
+-		*ctype = FILTER_CMP_NE;
+-	else if (strcmp(token, "<") == 0)
+-		*ctype = FILTER_CMP_LT;
+-	else if (strcmp(token, ">") == 0)
+-		*ctype = FILTER_CMP_GT;
+-	else if (strcmp(token, "<=") == 0)
+-		*ctype = FILTER_CMP_LE;
+-	else if (strcmp(token, ">=") == 0)
+-		*ctype = FILTER_CMP_GE;
+-	else if (strcmp(token, "=~") == 0)
+-		*ctype = FILTER_CMP_REGEX;
+-	else if (strcmp(token, "!~") == 0)
+-		*ctype = FILTER_CMP_NOT_REGEX;
+-	else
+-		return OP_NONE;
+-
+-	return OP_CMP;
+-}
+-
+-static int check_op_done(struct filter_arg *arg)
+-{
+-	switch (arg->type) {
+-	case FILTER_ARG_EXP:
+-		return arg->exp.right != NULL;
+-
+-	case FILTER_ARG_OP:
+-		return arg->op.right != NULL;
+-
+-	case FILTER_ARG_NUM:
+-		return arg->num.right != NULL;
+-
+-	case FILTER_ARG_STR:
+-		/* A string conversion is always done */
+-		return 1;
+-
+-	case FILTER_ARG_BOOLEAN:
+-		/* field not found, is ok */
+-		return 1;
+-
+-	default:
+-		return 0;
+-	}
+-}
+-
+-enum filter_vals {
+-	FILTER_VAL_NORM,
+-	FILTER_VAL_FALSE,
+-	FILTER_VAL_TRUE,
+-};
+-
+-void reparent_op_arg(struct filter_arg *parent, struct filter_arg *old_child,
+-		  struct filter_arg *arg)
+-{
+-	struct filter_arg *other_child;
+-	struct filter_arg **ptr;
+-
+-	if (parent->type != FILTER_ARG_OP &&
+-	    arg->type != FILTER_ARG_OP)
+-		die("can not reparent other than OP");
+-
+-	/* Get the sibling */
+-	if (old_child->op.right == arg) {
+-		ptr = &old_child->op.right;
+-		other_child = old_child->op.left;
+-	} else if (old_child->op.left == arg) {
+-		ptr = &old_child->op.left;
+-		other_child = old_child->op.right;
+-	} else
+-		die("Error in reparent op, find other child");
+-
+-	/* Detach arg from old_child */
+-	*ptr = NULL;
+-
+-	/* Check for root */
+-	if (parent == old_child) {
+-		free_arg(other_child);
+-		*parent = *arg;
+-		/* Free arg without recussion */
+-		free(arg);
+-		return;
+-	}
+-
+-	if (parent->op.right == old_child)
+-		ptr = &parent->op.right;
+-	else if (parent->op.left == old_child)
+-		ptr = &parent->op.left;
+-	else
+-		die("Error in reparent op");
+-	*ptr = arg;
+-
+-	free_arg(old_child);
+-}
+-
+-enum filter_vals test_arg(struct filter_arg *parent, struct filter_arg *arg)
+-{
+-	enum filter_vals lval, rval;
+-
+-	switch (arg->type) {
+-
+-		/* bad case */
+-	case FILTER_ARG_BOOLEAN:
+-		return FILTER_VAL_FALSE + arg->boolean.value;
+-
+-		/* good cases: */
+-	case FILTER_ARG_STR:
+-	case FILTER_ARG_VALUE:
+-	case FILTER_ARG_FIELD:
+-		return FILTER_VAL_NORM;
+-
+-	case FILTER_ARG_EXP:
+-		lval = test_arg(arg, arg->exp.left);
+-		if (lval != FILTER_VAL_NORM)
+-			return lval;
+-		rval = test_arg(arg, arg->exp.right);
+-		if (rval != FILTER_VAL_NORM)
+-			return rval;
+-		return FILTER_VAL_NORM;
+-
+-	case FILTER_ARG_NUM:
+-		lval = test_arg(arg, arg->num.left);
+-		if (lval != FILTER_VAL_NORM)
+-			return lval;
+-		rval = test_arg(arg, arg->num.right);
+-		if (rval != FILTER_VAL_NORM)
+-			return rval;
+-		return FILTER_VAL_NORM;
+-
+-	case FILTER_ARG_OP:
+-		if (arg->op.type != FILTER_OP_NOT) {
+-			lval = test_arg(arg, arg->op.left);
+-			switch (lval) {
+-			case FILTER_VAL_NORM:
+-				break;
+-			case FILTER_VAL_TRUE:
+-				if (arg->op.type == FILTER_OP_OR)
+-					return FILTER_VAL_TRUE;
+-				rval = test_arg(arg, arg->op.right);
+-				if (rval != FILTER_VAL_NORM)
+-					return rval;
+-
+-				reparent_op_arg(parent, arg, arg->op.right);
+-				return FILTER_VAL_NORM;
+-
+-			case FILTER_VAL_FALSE:
+-				if (arg->op.type == FILTER_OP_AND)
+-					return FILTER_VAL_FALSE;
+-				rval = test_arg(arg, arg->op.right);
+-				if (rval != FILTER_VAL_NORM)
+-					return rval;
+-
+-				reparent_op_arg(parent, arg, arg->op.right);
+-				return FILTER_VAL_NORM;
+-			}
+-		}
+-
+-		rval = test_arg(arg, arg->op.right);
+-		switch (rval) {
+-		case FILTER_VAL_NORM:
+-			break;
+-		case FILTER_VAL_TRUE:
+-			if (arg->op.type == FILTER_OP_OR)
+-				return FILTER_VAL_TRUE;
+-			if (arg->op.type == FILTER_OP_NOT)
+-				return FILTER_VAL_FALSE;
+-
+-			reparent_op_arg(parent, arg, arg->op.left);
+-			return FILTER_VAL_NORM;
+-
+-		case FILTER_VAL_FALSE:
+-			if (arg->op.type == FILTER_OP_AND)
+-				return FILTER_VAL_FALSE;
+-			if (arg->op.type == FILTER_OP_NOT)
+-				return FILTER_VAL_TRUE;
+-
+-			reparent_op_arg(parent, arg, arg->op.left);
+-			return FILTER_VAL_NORM;
+-		}
+-
+-		return FILTER_VAL_NORM;
+-	default:
+-		die("bad arg in filter tree");
+-	}
+-	return FILTER_VAL_NORM;
+-}
+-
+-/* Remove any unknown event fields */
+-static struct filter_arg *collapse_tree(struct filter_arg *arg)
+-{
+-	enum filter_vals ret;
+-
+-	ret = test_arg(arg, arg);
+-	switch (ret) {
+-	case FILTER_VAL_NORM:
+-		return arg;
+-
+-	case FILTER_VAL_TRUE:
+-	case FILTER_VAL_FALSE:
+-		free_arg(arg);
+-		arg = allocate_arg();
+-		arg->type = FILTER_ARG_BOOLEAN;
+-		arg->boolean.value = ret == FILTER_VAL_TRUE;
+-	}
+-
+-	return arg;
+-}
+-
+-static int
+-process_filter(struct event_format *event, struct filter_arg **parg,
+-	       char **error_str, int not)
+-{
+-	enum event_type type;
+-	char *token = NULL;
+-	struct filter_arg *current_op = NULL;
+-	struct filter_arg *current_exp = NULL;
+-	struct filter_arg *left_item = NULL;
+-	struct filter_arg *arg = NULL;
+-	enum op_type op_type;
+-	enum filter_op_type btype;
+-	enum filter_exp_type etype;
+-	enum filter_cmp_type ctype;
+-	int ret;
+-
+-	*parg = NULL;
+-
+-	do {
+-		free(token);
+-		type = read_token(&token);
+-		switch (type) {
+-		case EVENT_SQUOTE:
+-		case EVENT_DQUOTE:
+-		case EVENT_ITEM:
+-			arg = create_arg_item(event, token, type, error_str);
+-			if (!arg)
+-				goto fail;
+-			if (!left_item)
+-				left_item = arg;
+-			else if (current_exp) {
+-				ret = add_right(current_exp, arg, error_str);
+-				if (ret < 0)
+-					goto fail;
+-				left_item = NULL;
+-				/* Not's only one one expression */
+-				if (not) {
+-					arg = NULL;
+-					if (current_op)
+-						goto fail_print;
+-					free(token);
+-					*parg = current_exp;
+-					return 0;
+-				}
+-			} else
+-				goto fail_print;
+-			arg = NULL;
+-			break;
+-
+-		case EVENT_DELIM:
+-			if (*token == ',') {
+-				show_error(error_str,
+-					   "Illegal token ','");
+-				goto fail;
+-			}
+-
+-			if (*token == '(') {
+-				if (left_item) {
+-					show_error(error_str,
+-						   "Open paren can not come after item");
+-					goto fail;
+-				}
+-				if (current_exp) {
+-					show_error(error_str,
+-						   "Open paren can not come after expression");
+-					goto fail;
+-				}
+-
+-				ret = process_filter(event, &arg, error_str, 0);
+-				if (ret != 1) {
+-					if (ret == 0)
+-						show_error(error_str,
+-							   "Unbalanced number of '('");
+-					goto fail;
+-				}
+-				ret = 0;
+-
+-				/* A not wants just one expression */
+-				if (not) {
+-					if (current_op)
+-						goto fail_print;
+-					*parg = arg;
+-					return 0;
+-				}
+-
+-				if (current_op)
+-					ret = add_right(current_op, arg, error_str);
+-				else
+-					current_exp = arg;
+-
+-				if (ret < 0)
+-					goto fail;
+-
+-			} else { /* ')' */
+-				if (!current_op && !current_exp)
+-					goto fail_print;
+-
+-				/* Make sure everything is finished at this level */
+-				if (current_exp && !check_op_done(current_exp))
+-					goto fail_print;
+-				if (current_op && !check_op_done(current_op))
+-					goto fail_print;
+-
+-				if (current_op)
+-					*parg = current_op;
+-				else
+-					*parg = current_exp;
+-				return 1;
+-			}
+-			break;
+-
+-		case EVENT_OP:
+-			op_type = process_op(token, &btype, &ctype, &etype);
+-
+-			/* All expect a left arg except for NOT */
+-			switch (op_type) {
+-			case OP_BOOL:
+-				/* Logic ops need a left expression */
+-				if (!current_exp && !current_op)
+-					goto fail_print;
+-				/* fall through */
+-			case OP_NOT:
+-				/* logic only processes ops and exp */
+-				if (left_item)
+-					goto fail_print;
+-				break;
+-			case OP_EXP:
+-			case OP_CMP:
+-				if (!left_item)
+-					goto fail_print;
+-				break;
+-			case OP_NONE:
+-				show_error(error_str,
+-					   "Unknown op token %s", token);
+-				goto fail;
+-			}
+-
+-			ret = 0;
+-			switch (op_type) {
+-			case OP_BOOL:
+-				arg = create_arg_op(btype);
+-				if (current_op)
+-					ret = add_left(arg, current_op);
+-				else
+-					ret = add_left(arg, current_exp);
+-				current_op = arg;
+-				current_exp = NULL;
+-				break;
+-
+-			case OP_NOT:
+-				arg = create_arg_op(btype);
+-				if (current_op)
+-					ret = add_right(current_op, arg, error_str);
+-				if (ret < 0)
+-					goto fail;
+-				current_exp = arg;
+-				ret = process_filter(event, &arg, error_str, 1);
+-				if (ret < 0)
+-					goto fail;
+-				ret = add_right(current_exp, arg, error_str);
+-				if (ret < 0)
+-					goto fail;
+-				break;
+-
+-			case OP_EXP:
+-			case OP_CMP:
+-				if (op_type == OP_EXP)
+-					arg = create_arg_exp(etype);
+-				else
+-					arg = create_arg_cmp(ctype);
+-
+-				if (current_op)
+-					ret = add_right(current_op, arg, error_str);
+-				if (ret < 0)
+-					goto fail;
+-				ret = add_left(arg, left_item);
+-				if (ret < 0) {
+-					arg = NULL;
+-					goto fail_print;
+-				}
+-				current_exp = arg;
+-				break;
+-			default:
+-				break;
+-			}
+-			arg = NULL;
+-			if (ret < 0)
+-				goto fail_print;
+-			break;
+-		case EVENT_NONE:
+-			break;
+-		default:
+-			goto fail_print;
+-		}
+-	} while (type != EVENT_NONE);
+-
+-	if (!current_op && !current_exp)
+-		goto fail_print;
+-
+-	if (!current_op)
+-		current_op = current_exp;
+-
+-	current_op = collapse_tree(current_op);
+-
+-	*parg = current_op;
+-
+-	return 0;
+-
+- fail_print:
+-	show_error(error_str, "Syntax error");
+- fail:
+-	free_arg(current_op);
+-	free_arg(current_exp);
+-	free_arg(arg);
+-	free(token);
+-	return -1;
+-}
+-
+-static int
+-process_event(struct event_format *event, const char *filter_str,
+-	      struct filter_arg **parg, char **error_str)
+-{
+-	int ret;
+-
+-	pevent_buffer_init(filter_str, strlen(filter_str));
+-
+-	ret = process_filter(event, parg, error_str, 0);
+-	if (ret == 1) {
+-		show_error(error_str,
+-			   "Unbalanced number of ')'");
+-		return -1;
+-	}
+-	if (ret < 0)
+-		return ret;
+-
+-	/* If parg is NULL, then make it into FALSE */
+-	if (!*parg) {
+-		*parg = allocate_arg();
+-		(*parg)->type = FILTER_ARG_BOOLEAN;
+-		(*parg)->boolean.value = FILTER_FALSE;
+-	}
+-
+-	return 0;
+-}
+-
+-static int filter_event(struct event_filter *filter,
+-			struct event_format *event,
+-			const char *filter_str, char **error_str)
+-{
+-	struct filter_type *filter_type;
+-	struct filter_arg *arg;
+-	int ret;
+-
+-	if (filter_str) {
+-		ret = process_event(event, filter_str, &arg, error_str);
+-		if (ret < 0)
+-			return ret;
+-
+-	} else {
+-		/* just add a TRUE arg */
+-		arg = allocate_arg();
+-		arg->type = FILTER_ARG_BOOLEAN;
+-		arg->boolean.value = FILTER_TRUE;
+-	}
+-
+-	filter_type = add_filter_type(filter, event->id);
+-	if (filter_type->filter)
+-		free_arg(filter_type->filter);
+-	filter_type->filter = arg;
+-
+-	return 0;
+-}
+-
+-/**
+- * pevent_filter_add_filter_str - add a new filter
+- * @filter: the event filter to add to
+- * @filter_str: the filter string that contains the filter
+- * @error_str: string containing reason for failed filter
+- *
+- * Returns 0 if the filter was successfully added
+- *   -1 if there was an error.
+- *
+- * On error, if @error_str points to a string pointer,
+- * it is set to the reason that the filter failed.
+- * This string must be freed with "free".
+- */
+-int pevent_filter_add_filter_str(struct event_filter *filter,
+-				 const char *filter_str,
+-				 char **error_str)
+-{
+-	struct pevent *pevent = filter->pevent;
+-	struct event_list *event;
+-	struct event_list *events = NULL;
+-	const char *filter_start;
+-	const char *next_event;
+-	char *this_event;
+-	char *event_name = NULL;
+-	char *sys_name = NULL;
+-	char *sp;
+-	int rtn = 0;
+-	int len;
+-	int ret;
+-
+-	/* clear buffer to reset show error */
+-	pevent_buffer_init("", 0);
+-
+-	if (error_str)
+-		*error_str = NULL;
+-
+-	filter_start = strchr(filter_str, ':');
+-	if (filter_start)
+-		len = filter_start - filter_str;
+-	else
+-		len = strlen(filter_str);
+-
+-
+-	do {
+-		next_event = strchr(filter_str, ',');
+-		if (next_event &&
+-		    (!filter_start || next_event < filter_start))
+-			len = next_event - filter_str;
+-		else if (filter_start)
+-			len = filter_start - filter_str;
+-		else
+-			len = strlen(filter_str);
+-
+-		this_event = malloc_or_die(len + 1);
+-		memcpy(this_event, filter_str, len);
+-		this_event[len] = 0;
+-
+-		if (next_event)
+-			next_event++;
+-
+-		filter_str = next_event;
+-
+-		sys_name = strtok_r(this_event, "/", &sp);
+-		event_name = strtok_r(NULL, "/", &sp);
+-
+-		if (!sys_name) {
+-			show_error(error_str, "No filter found");
+-			/* This can only happen when events is NULL, but still */
+-			free_events(events);
+-			free(this_event);
+-			return -1;
+-		}
+-
+-		/* Find this event */
+-		ret = find_event(pevent, &events, strim(sys_name), strim(event_name));
+-		if (ret < 0) {
+-			if (event_name)
+-				show_error(error_str,
+-					   "No event found under '%s.%s'",
+-					   sys_name, event_name);
+-			else
+-				show_error(error_str,
+-					   "No event found under '%s'",
+-					   sys_name);
+-			free_events(events);
+-			free(this_event);
+-			return -1;
+-		}
+-		free(this_event);
+-	} while (filter_str);
+-
+-	/* Skip the ':' */
+-	if (filter_start)
+-		filter_start++;
+-
+-	/* filter starts here */
+-	for (event = events; event; event = event->next) {
+-		ret = filter_event(filter, event->event, filter_start,
+-				   error_str);
+-		/* Failures are returned if a parse error happened */
+-		if (ret < 0)
+-			rtn = ret;
+-
+-		if (ret >= 0 && pevent->test_filters) {
+-			char *test;
+-			test = pevent_filter_make_string(filter, event->event->id);
+-			printf(" '%s: %s'\n", event->event->name, test);
+-			free(test);
+-		}
+-	}
+-
+-	free_events(events);
+-
+-	if (rtn >= 0 && pevent->test_filters)
+-		exit(0);
+-
+-	return rtn;
+-}
+-
+-static void free_filter_type(struct filter_type *filter_type)
+-{
+-	free_arg(filter_type->filter);
+-}
+-
+-/**
+- * pevent_filter_remove_event - remove a filter for an event
+- * @filter: the event filter to remove from
+- * @event_id: the event to remove a filter for
+- *
+- * Removes the filter saved for an event defined by @event_id
+- * from the @filter.
+- *
+- * Returns 1: if an event was removed
+- *   0: if the event was not found
+- */
+-int pevent_filter_remove_event(struct event_filter *filter,
+-			       int event_id)
+-{
+-	struct filter_type *filter_type;
+-	unsigned long len;
+-
+-	if (!filter->filters)
+-		return 0;
+-
+-	filter_type = find_filter_type(filter, event_id);
+-
+-	if (!filter_type)
+-		return 0;
+-
+-	free_filter_type(filter_type);
+-
+-	/* The filter_type points into the event_filters array */
+-	len = (unsigned long)(filter->event_filters + filter->filters) -
+-		(unsigned long)(filter_type + 1);
+-
+-	memmove(filter_type, filter_type + 1, len);
+-	filter->filters--;
+-
+-	memset(&filter->event_filters[filter->filters], 0,
+-	       sizeof(*filter_type));
+-
+-	return 1;
+-}
+-
+-/**
+- * pevent_filter_reset - clear all filters in a filter
+- * @filter: the event filter to reset
+- *
+- * Removes all filters from a filter and resets it.
+- */
+-void pevent_filter_reset(struct event_filter *filter)
+-{
+-	int i;
+-
+-	for (i = 0; i < filter->filters; i++)
+-		free_filter_type(&filter->event_filters[i]);
+-
+-	free(filter->event_filters);
+-	filter->filters = 0;
+-	filter->event_filters = NULL;
+-}
+-
+-void pevent_filter_free(struct event_filter *filter)
+-{
+-	pevent_unref(filter->pevent);
+-
+-	pevent_filter_reset(filter);
+-
+-	free(filter);
+-}
+-
+-static char *arg_to_str(struct event_filter *filter, struct filter_arg *arg);
+-
+-static int copy_filter_type(struct event_filter *filter,
+-			     struct event_filter *source,
+-			     struct filter_type *filter_type)
+-{
+-	struct filter_arg *arg;
+-	struct event_format *event;
+-	const char *sys;
+-	const char *name;
+-	char *str;
+-
+-	/* Can't assume that the pevent's are the same */
+-	sys = filter_type->event->system;
+-	name = filter_type->event->name;
+-	event = pevent_find_event_by_name(filter->pevent, sys, name);
+-	if (!event)
+-		return -1;
+-
+-	str = arg_to_str(source, filter_type->filter);
+-	if (!str)
+-		return -1;
+-
+-	if (strcmp(str, "TRUE") == 0 || strcmp(str, "FALSE") == 0) {
+-		/* Add trivial event */
+-		arg = allocate_arg();
+-		arg->type = FILTER_ARG_BOOLEAN;
+-		if (strcmp(str, "TRUE") == 0)
+-			arg->boolean.value = 1;
+-		else
+-			arg->boolean.value = 0;
+-
+-		filter_type = add_filter_type(filter, event->id);
+-		filter_type->filter = arg;
+-
+-		free(str);
+-		return 0;
+-	}
+-
+-	filter_event(filter, event, str, NULL);
+-	free(str);
+-
+-	return 0;
+-}
+-
+-/**
+- * pevent_filter_copy - copy a filter using another filter
+- * @dest - the filter to copy to
+- * @source - the filter to copy from
+- *
+- * Returns 0 on success and -1 if not all filters were copied
+- */
+-int pevent_filter_copy(struct event_filter *dest, struct event_filter *source)
+-{
+-	int ret = 0;
+-	int i;
+-
+-	pevent_filter_reset(dest);
+-
+-	for (i = 0; i < source->filters; i++) {
+-		if (copy_filter_type(dest, source, &source->event_filters[i]))
+-			ret = -1;
+-	}
+-	return ret;
+-}
+-
+-
+-/**
+- * pevent_update_trivial - update the trivial filters with the given filter
+- * @dest - the filter to update
+- * @source - the filter as the source of the update
+- * @type - the type of trivial filter to update.
+- *
+- * Scan dest for trivial events matching @type to replace with the source.
+- *
+- * Returns 0 on success and -1 if there was a problem updating, but
+- *   events may have still been updated on error.
+- */
+-int pevent_update_trivial(struct event_filter *dest, struct event_filter *source,
+-			  enum filter_trivial_type type)
+-{
+-	struct pevent *src_pevent;
+-	struct pevent *dest_pevent;
+-	struct event_format *event;
+-	struct filter_type *filter_type;
+-	struct filter_arg *arg;
+-	char *str;
+-	int i;
+-
+-	src_pevent = source->pevent;
+-	dest_pevent = dest->pevent;
+-
+-	/* Do nothing if either of the filters has nothing to filter */
+-	if (!dest->filters || !source->filters)
+-		return 0;
+-
+-	for (i = 0; i < dest->filters; i++) {
+-		filter_type = &dest->event_filters[i];
+-		arg = filter_type->filter;
+-		if (arg->type != FILTER_ARG_BOOLEAN)
+-			continue;
+-		if ((arg->boolean.value && type == FILTER_TRIVIAL_FALSE) ||
+-		    (!arg->boolean.value && type == FILTER_TRIVIAL_TRUE))
+-			continue;
+-
+-		event = filter_type->event;
+-
+-		if (src_pevent != dest_pevent) {
+-			/* do a look up */
+-			event = pevent_find_event_by_name(src_pevent,
+-							  event->system,
+-							  event->name);
+-			if (!event)
+-				return -1;
+-		}
+-
+-		str = pevent_filter_make_string(source, event->id);
+-		if (!str)
+-			continue;
+-
+-		/* Don't bother if the filter is trivial too */
+-		if (strcmp(str, "TRUE") != 0 && strcmp(str, "FALSE") != 0)
+-			filter_event(dest, event, str, NULL);
+-		free(str);
+-	}
+-	return 0;
+-}
+-
+-/**
+- * pevent_filter_clear_trivial - clear TRUE and FALSE filters
+- * @filter: the filter to remove trivial filters from
+- * @type: remove only true, false, or both
+- *
+- * Removes filters that only contain a TRUE or FALES boolean arg.
+- */
+-void pevent_filter_clear_trivial(struct event_filter *filter,
+-				 enum filter_trivial_type type)
+-{
+-	struct filter_type *filter_type;
+-	int count = 0;
+-	int *ids = NULL;
+-	int i;
+-
+-	if (!filter->filters)
+-		return;
+-
+-	/*
+-	 * Two steps, first get all ids with trivial filters.
+-	 *  then remove those ids.
+-	 */
+-	for (i = 0; i < filter->filters; i++) {
+-		filter_type = &filter->event_filters[i];
+-		if (filter_type->filter->type != FILTER_ARG_BOOLEAN)
+-			continue;
+-		switch (type) {
+-		case FILTER_TRIVIAL_FALSE:
+-			if (filter_type->filter->boolean.value)
+-				continue;
+-		case FILTER_TRIVIAL_TRUE:
+-			if (!filter_type->filter->boolean.value)
+-				continue;
+-		default:
+-			break;
+-		}
+-
+-		ids = realloc(ids, sizeof(*ids) * (count + 1));
+-		if (!ids)
+-			die("Can't allocate ids");
+-		ids[count++] = filter_type->event_id;
+-	}
+-
+-	if (!count)
+-		return;
+-
+-	for (i = 0; i < count; i++)
+-		pevent_filter_remove_event(filter, ids[i]);
+-
+-	free(ids);
+-}
+-
+-/**
+- * pevent_filter_event_has_trivial - return true event contains trivial filter
+- * @filter: the filter with the information
+- * @event_id: the id of the event to test
+- * @type: trivial type to test for (TRUE, FALSE, EITHER)
+- *
+- * Returns 1 if the event contains a matching trivial type
+- *  otherwise 0.
+- */
+-int pevent_filter_event_has_trivial(struct event_filter *filter,
+-				    int event_id,
+-				    enum filter_trivial_type type)
+-{
+-	struct filter_type *filter_type;
+-
+-	if (!filter->filters)
+-		return 0;
+-
+-	filter_type = find_filter_type(filter, event_id);
+-
+-	if (!filter_type)
+-		return 0;
+-
+-	if (filter_type->filter->type != FILTER_ARG_BOOLEAN)
+-		return 0;
+-
+-	switch (type) {
+-	case FILTER_TRIVIAL_FALSE:
+-		return !filter_type->filter->boolean.value;
+-
+-	case FILTER_TRIVIAL_TRUE:
+-		return filter_type->filter->boolean.value;
+-	default:
+-		return 1;
+-	}
+-}
+-
+-static int test_filter(struct event_format *event,
+-		       struct filter_arg *arg, struct pevent_record *record);
+-
+-static const char *
+-get_comm(struct event_format *event, struct pevent_record *record)
+-{
+-	const char *comm;
+-	int pid;
+-
+-	pid = pevent_data_pid(event->pevent, record);
+-	comm = pevent_data_comm_from_pid(event->pevent, pid);
+-	return comm;
+-}
+-
+-static unsigned long long
+-get_value(struct event_format *event,
+-	  struct format_field *field, struct pevent_record *record)
+-{
+-	unsigned long long val;
+-
+-	/* Handle our dummy "comm" field */
+-	if (field == &comm) {
+-		const char *name;
+-
+-		name = get_comm(event, record);
+-		return (unsigned long)name;
+-	}
+-
+-	pevent_read_number_field(field, record->data, &val);
+-
+-	if (!(field->flags & FIELD_IS_SIGNED))
+-		return val;
+-
+-	switch (field->size) {
+-	case 1:
+-		return (char)val;
+-	case 2:
+-		return (short)val;
+-	case 4:
+-		return (int)val;
+-	case 8:
+-		return (long long)val;
+-	}
+-	return val;
+-}
+-
+-static unsigned long long
+-get_arg_value(struct event_format *event, struct filter_arg *arg, struct pevent_record *record);
+-
+-static unsigned long long
+-get_exp_value(struct event_format *event, struct filter_arg *arg, struct pevent_record *record)
+-{
+-	unsigned long long lval, rval;
+-
+-	lval = get_arg_value(event, arg->exp.left, record);
+-	rval = get_arg_value(event, arg->exp.right, record);
+-
+-	switch (arg->exp.type) {
+-	case FILTER_EXP_ADD:
+-		return lval + rval;
+-
+-	case FILTER_EXP_SUB:
+-		return lval - rval;
+-
+-	case FILTER_EXP_MUL:
+-		return lval * rval;
+-
+-	case FILTER_EXP_DIV:
+-		return lval / rval;
+-
+-	case FILTER_EXP_MOD:
+-		return lval % rval;
+-
+-	case FILTER_EXP_RSHIFT:
+-		return lval >> rval;
+-
+-	case FILTER_EXP_LSHIFT:
+-		return lval << rval;
+-
+-	case FILTER_EXP_AND:
+-		return lval & rval;
+-
+-	case FILTER_EXP_OR:
+-		return lval | rval;
+-
+-	case FILTER_EXP_XOR:
+-		return lval ^ rval;
+-
+-	case FILTER_EXP_NOT:
+-	default:
+-		die("error in exp");
+-	}
+-	return 0;
+-}
+-
+-static unsigned long long
+-get_arg_value(struct event_format *event, struct filter_arg *arg, struct pevent_record *record)
+-{
+-	switch (arg->type) {
+-	case FILTER_ARG_FIELD:
+-		return get_value(event, arg->field.field, record);
+-
+-	case FILTER_ARG_VALUE:
+-		if (arg->value.type != FILTER_NUMBER)
+-			die("must have number field!");
+-		return arg->value.val;
+-
+-	case FILTER_ARG_EXP:
+-		return get_exp_value(event, arg, record);
+-
+-	default:
+-		die("oops in filter");
+-	}
+-	return 0;
+-}
+-
+-static int test_num(struct event_format *event,
+-		    struct filter_arg *arg, struct pevent_record *record)
+-{
+-	unsigned long long lval, rval;
+-
+-	lval = get_arg_value(event, arg->num.left, record);
+-	rval = get_arg_value(event, arg->num.right, record);
+-
+-	switch (arg->num.type) {
+-	case FILTER_CMP_EQ:
+-		return lval == rval;
+-
+-	case FILTER_CMP_NE:
+-		return lval != rval;
+-
+-	case FILTER_CMP_GT:
+-		return lval > rval;
+-
+-	case FILTER_CMP_LT:
+-		return lval < rval;
+-
+-	case FILTER_CMP_GE:
+-		return lval >= rval;
+-
+-	case FILTER_CMP_LE:
+-		return lval <= rval;
+-
+-	default:
+-		/* ?? */
+-		return 0;
+-	}
+-}
+-
+-static const char *get_field_str(struct filter_arg *arg, struct pevent_record *record)
+-{
+-	struct event_format *event;
+-	struct pevent *pevent;
+-	unsigned long long addr;
+-	const char *val = NULL;
+-	static char hex[64];
+-
+-	/* If the field is not a string convert it */
+-	if (arg->str.field->flags & FIELD_IS_STRING) {
+-		val = record->data + arg->str.field->offset;
+-
+-		/*
+-		 * We need to copy the data since we can't be sure the field
+-		 * is null terminated.
+-		 */
+-		if (*(val + arg->str.field->size - 1)) {
+-			/* copy it */
+-			memcpy(arg->str.buffer, val, arg->str.field->size);
+-			/* the buffer is already NULL terminated */
+-			val = arg->str.buffer;
+-		}
+-
+-	} else {
+-		event = arg->str.field->event;
+-		pevent = event->pevent;
+-		addr = get_value(event, arg->str.field, record);
+-
+-		if (arg->str.field->flags & (FIELD_IS_POINTER | FIELD_IS_LONG))
+-			/* convert to a kernel symbol */
+-			val = pevent_find_function(pevent, addr);
+-
+-		if (val == NULL) {
+-			/* just use the hex of the string name */
+-			snprintf(hex, 64, "0x%llx", addr);
+-			val = hex;
+-		}
+-	}
+-
+-	return val;
+-}
+-
+-static int test_str(struct event_format *event,
+-		    struct filter_arg *arg, struct pevent_record *record)
+-{
+-	const char *val;
+-
+-	if (arg->str.field == &comm)
+-		val = get_comm(event, record);
+-	else
+-		val = get_field_str(arg, record);
+-
+-	switch (arg->str.type) {
+-	case FILTER_CMP_MATCH:
+-		return strcmp(val, arg->str.val) == 0;
+-
+-	case FILTER_CMP_NOT_MATCH:
+-		return strcmp(val, arg->str.val) != 0;
+-
+-	case FILTER_CMP_REGEX:
+-		/* Returns zero on match */
+-		return !regexec(&arg->str.reg, val, 0, NULL, 0);
+-
+-	case FILTER_CMP_NOT_REGEX:
+-		return regexec(&arg->str.reg, val, 0, NULL, 0);
+-
+-	default:
+-		/* ?? */
+-		return 0;
+-	}
+-}
+-
+-static int test_op(struct event_format *event,
+-		   struct filter_arg *arg, struct pevent_record *record)
+-{
+-	switch (arg->op.type) {
+-	case FILTER_OP_AND:
+-		return test_filter(event, arg->op.left, record) &&
+-			test_filter(event, arg->op.right, record);
+-
+-	case FILTER_OP_OR:
+-		return test_filter(event, arg->op.left, record) ||
+-			test_filter(event, arg->op.right, record);
+-
+-	case FILTER_OP_NOT:
+-		return !test_filter(event, arg->op.right, record);
+-
+-	default:
+-		/* ?? */
+-		return 0;
+-	}
+-}
+-
+-static int test_filter(struct event_format *event,
+-		       struct filter_arg *arg, struct pevent_record *record)
+-{
+-	switch (arg->type) {
+-	case FILTER_ARG_BOOLEAN:
+-		/* easy case */
+-		return arg->boolean.value;
+-
+-	case FILTER_ARG_OP:
+-		return test_op(event, arg, record);
+-
+-	case FILTER_ARG_NUM:
+-		return test_num(event, arg, record);
+-
+-	case FILTER_ARG_STR:
+-		return test_str(event, arg, record);
+-
+-	case FILTER_ARG_EXP:
+-	case FILTER_ARG_VALUE:
+-	case FILTER_ARG_FIELD:
+-		/*
+-		 * Expressions, fields and values evaluate
+-		 * to true if they return non zero
+-		 */
+-		return !!get_arg_value(event, arg, record);
+-
+-	default:
+-		die("oops!");
+-		/* ?? */
+-		return 0;
+-	}
+-}
+-
+-/**
+- * pevent_event_filtered - return true if event has filter
+- * @filter: filter struct with filter information
+- * @event_id: event id to test if filter exists
+- *
+- * Returns 1 if filter found for @event_id
+- *   otherwise 0;
+- */
+-int pevent_event_filtered(struct event_filter *filter,
+-			  int event_id)
+-{
+-	struct filter_type *filter_type;
+-
+-	if (!filter->filters)
+-		return 0;
+-
+-	filter_type = find_filter_type(filter, event_id);
+-
+-	return filter_type ? 1 : 0;
+-}
+-
+-/**
+- * pevent_filter_match - test if a record matches a filter
+- * @filter: filter struct with filter information
+- * @record: the record to test against the filter
+- *
+- * Returns:
+- *  1 - filter found for event and @record matches
+- *  0 - filter found for event and @record does not match
+- * -1 - no filter found for @record's event
+- * -2 - if no filters exist
+- */
+-int pevent_filter_match(struct event_filter *filter,
+-			struct pevent_record *record)
+-{
+-	struct pevent *pevent = filter->pevent;
+-	struct filter_type *filter_type;
+-	int event_id;
+-
+-	if (!filter->filters)
+-		return FILTER_NONE;
+-
+-	event_id = pevent_data_type(pevent, record);
+-
+-	filter_type = find_filter_type(filter, event_id);
+-
+-	if (!filter_type)
+-		return FILTER_NOEXIST;
+-
+-	return test_filter(filter_type->event, filter_type->filter, record) ?
+-		FILTER_MATCH : FILTER_MISS;
+-}
+-
+-static char *op_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *str = NULL;
+-	char *left = NULL;
+-	char *right = NULL;
+-	char *op = NULL;
+-	int left_val = -1;
+-	int right_val = -1;
+-	int val;
+-	int len;
+-
+-	switch (arg->op.type) {
+-	case FILTER_OP_AND:
+-		op = "&&";
+-		/* fall through */
+-	case FILTER_OP_OR:
+-		if (!op)
+-			op = "||";
+-
+-		left = arg_to_str(filter, arg->op.left);
+-		right = arg_to_str(filter, arg->op.right);
+-		if (!left || !right)
+-			break;
+-
+-		/* Try to consolidate boolean values */
+-		if (strcmp(left, "TRUE") == 0)
+-			left_val = 1;
+-		else if (strcmp(left, "FALSE") == 0)
+-			left_val = 0;
+-
+-		if (strcmp(right, "TRUE") == 0)
+-			right_val = 1;
+-		else if (strcmp(right, "FALSE") == 0)
+-			right_val = 0;
+-
+-		if (left_val >= 0) {
+-			if ((arg->op.type == FILTER_OP_AND && !left_val) ||
+-			    (arg->op.type == FILTER_OP_OR && left_val)) {
+-				/* Just return left value */
+-				str = left;
+-				left = NULL;
+-				break;
+-			}
+-			if (right_val >= 0) {
+-				/* just evaluate this. */
+-				val = 0;
+-				switch (arg->op.type) {
+-				case FILTER_OP_AND:
+-					val = left_val && right_val;
+-					break;
+-				case FILTER_OP_OR:
+-					val = left_val || right_val;
+-					break;
+-				default:
+-					break;
+-				}
+-				str = malloc_or_die(6);
+-				if (val)
+-					strcpy(str, "TRUE");
+-				else
+-					strcpy(str, "FALSE");
+-				break;
+-			}
+-		}
+-		if (right_val >= 0) {
+-			if ((arg->op.type == FILTER_OP_AND && !right_val) ||
+-			    (arg->op.type == FILTER_OP_OR && right_val)) {
+-				/* Just return right value */
+-				str = right;
+-				right = NULL;
+-				break;
+-			}
+-			/* The right value is meaningless */
+-			str = left;
+-			left = NULL;
+-			break;
+-		}
+-
+-		len = strlen(left) + strlen(right) + strlen(op) + 10;
+-		str = malloc_or_die(len);
+-		snprintf(str, len, "(%s) %s (%s)",
+-			 left, op, right);
+-		break;
+-
+-	case FILTER_OP_NOT:
+-		op = "!";
+-		right = arg_to_str(filter, arg->op.right);
+-		if (!right)
+-			break;
+-
+-		/* See if we can consolidate */
+-		if (strcmp(right, "TRUE") == 0)
+-			right_val = 1;
+-		else if (strcmp(right, "FALSE") == 0)
+-			right_val = 0;
+-		if (right_val >= 0) {
+-			/* just return the opposite */
+-			str = malloc_or_die(6);
+-			if (right_val)
+-				strcpy(str, "FALSE");
+-			else
+-				strcpy(str, "TRUE");
+-			break;
+-		}
+-		len = strlen(right) + strlen(op) + 3;
+-		str = malloc_or_die(len);
+-		snprintf(str, len, "%s(%s)", op, right);
+-		break;
+-
+-	default:
+-		/* ?? */
+-		break;
+-	}
+-	free(left);
+-	free(right);
+-	return str;
+-}
+-
+-static char *val_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *str;
+-
+-	str = malloc_or_die(30);
+-
+-	snprintf(str, 30, "%lld", arg->value.val);
+-
+-	return str;
+-}
+-
+-static char *field_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	return strdup(arg->field.field->name);
+-}
+-
+-static char *exp_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *lstr;
+-	char *rstr;
+-	char *op;
+-	char *str = NULL;
+-	int len;
+-
+-	lstr = arg_to_str(filter, arg->exp.left);
+-	rstr = arg_to_str(filter, arg->exp.right);
+-	if (!lstr || !rstr)
+-		goto out;
+-
+-	switch (arg->exp.type) {
+-	case FILTER_EXP_ADD:
+-		op = "+";
+-		break;
+-	case FILTER_EXP_SUB:
+-		op = "-";
+-		break;
+-	case FILTER_EXP_MUL:
+-		op = "*";
+-		break;
+-	case FILTER_EXP_DIV:
+-		op = "/";
+-		break;
+-	case FILTER_EXP_MOD:
+-		op = "%";
+-		break;
+-	case FILTER_EXP_RSHIFT:
+-		op = ">>";
+-		break;
+-	case FILTER_EXP_LSHIFT:
+-		op = "<<";
+-		break;
+-	case FILTER_EXP_AND:
+-		op = "&";
+-		break;
+-	case FILTER_EXP_OR:
+-		op = "|";
+-		break;
+-	case FILTER_EXP_XOR:
+-		op = "^";
+-		break;
+-	default:
+-		die("oops in exp");
+-	}
+-
+-	len = strlen(op) + strlen(lstr) + strlen(rstr) + 4;
+-	str = malloc_or_die(len);
+-	snprintf(str, len, "%s %s %s", lstr, op, rstr);
+-out:
+-	free(lstr);
+-	free(rstr);
+-
+-	return str;
+-}
+-
+-static char *num_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *lstr;
+-	char *rstr;
+-	char *str = NULL;
+-	char *op = NULL;
+-	int len;
+-
+-	lstr = arg_to_str(filter, arg->num.left);
+-	rstr = arg_to_str(filter, arg->num.right);
+-	if (!lstr || !rstr)
+-		goto out;
+-
+-	switch (arg->num.type) {
+-	case FILTER_CMP_EQ:
+-		op = "==";
+-		/* fall through */
+-	case FILTER_CMP_NE:
+-		if (!op)
+-			op = "!=";
+-		/* fall through */
+-	case FILTER_CMP_GT:
+-		if (!op)
+-			op = ">";
+-		/* fall through */
+-	case FILTER_CMP_LT:
+-		if (!op)
+-			op = "<";
+-		/* fall through */
+-	case FILTER_CMP_GE:
+-		if (!op)
+-			op = ">=";
+-		/* fall through */
+-	case FILTER_CMP_LE:
+-		if (!op)
+-			op = "<=";
+-
+-		len = strlen(lstr) + strlen(op) + strlen(rstr) + 4;
+-		str = malloc_or_die(len);
+-		sprintf(str, "%s %s %s", lstr, op, rstr);
+-
+-		break;
+-
+-	default:
+-		/* ?? */
+-		break;
+-	}
+-
+-out:
+-	free(lstr);
+-	free(rstr);
+-	return str;
+-}
+-
+-static char *str_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *str = NULL;
+-	char *op = NULL;
+-	int len;
+-
+-	switch (arg->str.type) {
+-	case FILTER_CMP_MATCH:
+-		op = "==";
+-		/* fall through */
+-	case FILTER_CMP_NOT_MATCH:
+-		if (!op)
+-			op = "!=";
+-		/* fall through */
+-	case FILTER_CMP_REGEX:
+-		if (!op)
+-			op = "=~";
+-		/* fall through */
+-	case FILTER_CMP_NOT_REGEX:
+-		if (!op)
+-			op = "!~";
+-
+-		len = strlen(arg->str.field->name) + strlen(op) +
+-			strlen(arg->str.val) + 6;
+-		str = malloc_or_die(len);
+-		snprintf(str, len, "%s %s \"%s\"",
+-			 arg->str.field->name,
+-			 op, arg->str.val);
+-		break;
+-
+-	default:
+-		/* ?? */
+-		break;
+-	}
+-	return str;
+-}
+-
+-static char *arg_to_str(struct event_filter *filter, struct filter_arg *arg)
+-{
+-	char *str;
+-
+-	switch (arg->type) {
+-	case FILTER_ARG_BOOLEAN:
+-		str = malloc_or_die(6);
+-		if (arg->boolean.value)
+-			strcpy(str, "TRUE");
+-		else
+-			strcpy(str, "FALSE");
+-		return str;
+-
+-	case FILTER_ARG_OP:
+-		return op_to_str(filter, arg);
+-
+-	case FILTER_ARG_NUM:
+-		return num_to_str(filter, arg);
+-
+-	case FILTER_ARG_STR:
+-		return str_to_str(filter, arg);
+-
+-	case FILTER_ARG_VALUE:
+-		return val_to_str(filter, arg);
+-
+-	case FILTER_ARG_FIELD:
+-		return field_to_str(filter, arg);
+-
+-	case FILTER_ARG_EXP:
+-		return exp_to_str(filter, arg);
+-
+-	default:
+-		/* ?? */
+-		return NULL;
+-	}
+-
+-}
+-
+-/**
+- * pevent_filter_make_string - return a string showing the filter
+- * @filter: filter struct with filter information
+- * @event_id: the event id to return the filter string with
+- *
+- * Returns a string that displays the filter contents.
+- *  This string must be freed with free(str).
+- *  NULL is returned if no filter is found.
+- */
+-char *
+-pevent_filter_make_string(struct event_filter *filter, int event_id)
+-{
+-	struct filter_type *filter_type;
+-
+-	if (!filter->filters)
+-		return NULL;
+-
+-	filter_type = find_filter_type(filter, event_id);
+-
+-	if (!filter_type)
+-		return NULL;
+-
+-	return arg_to_str(filter, filter_type->filter);
+-}
+-
+-/**
+- * pevent_filter_compare - compare two filters and return if they are the same
+- * @filter1: Filter to compare with @filter2
+- * @filter2: Filter to compare with @filter1
+- *
+- * Returns:
+- *  1 if the two filters hold the same content.
+- *  0 if they do not.
+- */
+-int pevent_filter_compare(struct event_filter *filter1, struct event_filter *filter2)
+-{
+-	struct filter_type *filter_type1;
+-	struct filter_type *filter_type2;
+-	char *str1, *str2;
+-	int result;
+-	int i;
+-
+-	/* Do the easy checks first */
+-	if (filter1->filters != filter2->filters)
+-		return 0;
+-	if (!filter1->filters && !filter2->filters)
+-		return 1;
+-
+-	/*
+-	 * Now take a look at each of the events to see if they have the same
+-	 * filters to them.
+-	 */
+-	for (i = 0; i < filter1->filters; i++) {
+-		filter_type1 = &filter1->event_filters[i];
+-		filter_type2 = find_filter_type(filter2, filter_type1->event_id);
+-		if (!filter_type2)
+-			break;
+-		if (filter_type1->filter->type != filter_type2->filter->type)
+-			break;
+-		switch (filter_type1->filter->type) {
+-		case FILTER_TRIVIAL_FALSE:
+-		case FILTER_TRIVIAL_TRUE:
+-			/* trivial types just need the type compared */
+-			continue;
+-		default:
+-			break;
+-		}
+-		/* The best way to compare complex filters is with strings */
+-		str1 = arg_to_str(filter1, filter_type1->filter);
+-		str2 = arg_to_str(filter2, filter_type2->filter);
+-		if (str1 && str2)
+-			result = strcmp(str1, str2) != 0;
+-		else
+-			/* bail out if allocation fails */
+-			result = 1;
+-
+-		free(str1);
+-		free(str2);
+-		if (result)
+-			break;
+-	}
+-
+-	if (i < filter1->filters)
+-		return 0;
+-	return 1;
+-}
+-
+diff --git a/traceevent/parse-utils.c b/traceevent/parse-utils.c
+deleted file mode 100644
+index bba701c..0000000
+--- a/traceevent/parse-utils.c
++++ /dev/null
+@@ -1,129 +0,0 @@
+-/*
+- * Copyright (C) 2010 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <stdarg.h>
+-#include <errno.h>
+-
+-#define __weak __attribute__((weak))
+-
+-void __vdie(const char *fmt, va_list ap)
+-{
+-	int ret = errno;
+-
+-	if (errno)
+-		perror("trace-cmd");
+-	else
+-		ret = -1;
+-
+-	fprintf(stderr, "  ");
+-	vfprintf(stderr, fmt, ap);
+-
+-	fprintf(stderr, "\n");
+-	exit(ret);
+-}
+-
+-void __die(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vdie(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __weak die(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vdie(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __vwarning(const char *fmt, va_list ap)
+-{
+-	if (errno)
+-		perror("trace-cmd");
+-	errno = 0;
+-
+-	fprintf(stderr, "  ");
+-	vfprintf(stderr, fmt, ap);
+-
+-	fprintf(stderr, "\n");
+-}
+-
+-void __warning(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vwarning(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __weak warning(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vwarning(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __vpr_stat(const char *fmt, va_list ap)
+-{
+-	vprintf(fmt, ap);
+-	printf("\n");
+-}
+-
+-void __pr_stat(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vpr_stat(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __weak vpr_stat(const char *fmt, va_list ap)
+-{
+-	__vpr_stat(fmt, ap);
+-}
+-
+-void __weak pr_stat(const char *fmt, ...)
+-{
+-	va_list ap;
+-
+-	va_start(ap, fmt);
+-	__vpr_stat(fmt, ap);
+-	va_end(ap);
+-}
+-
+-void __weak *malloc_or_die(unsigned int size)
+-{
+-	void *data;
+-
+-	data = malloc(size);
+-	if (!data)
+-		die("malloc");
+-	return data;
+-}
+diff --git a/traceevent/trace-seq.c b/traceevent/trace-seq.c
+deleted file mode 100644
+index d7f2e68..0000000
+--- a/traceevent/trace-seq.c
++++ /dev/null
+@@ -1,212 +0,0 @@
+-/*
+- * Copyright (C) 2009 Red Hat Inc, Steven Rostedt <srostedt@redhat.com>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU Lesser General Public
+- * License as published by the Free Software Foundation;
+- * version 2.1 of the License (not later!)
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public
+- * License along with this program; if not,  see <http://www.gnu.org/licenses>
+- *
+- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- */
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <stdarg.h>
+-
+-#include "event-parse.h"
+-#include "event-utils.h"
+-
+-/*
+- * The TRACE_SEQ_POISON is to catch the use of using
+- * a trace_seq structure after it was destroyed.
+- */
+-#define TRACE_SEQ_POISON	((void *)0xdeadbeef)
+-#define TRACE_SEQ_CHECK(s)						\
+-do {									\
+-	if ((s)->buffer == TRACE_SEQ_POISON)			\
+-		die("Usage of trace_seq after it was destroyed");	\
+-} while (0)
+-
+-/**
+- * trace_seq_init - initialize the trace_seq structure
+- * @s: a pointer to the trace_seq structure to initialize
+- */
+-void trace_seq_init(struct trace_seq *s)
+-{
+-	s->len = 0;
+-	s->readpos = 0;
+-	s->buffer_size = TRACE_SEQ_BUF_SIZE;
+-	s->buffer = malloc_or_die(s->buffer_size);
+-}
+-
+-/**
+- * trace_seq_reset - re-initialize the trace_seq structure
+- * @s: a pointer to the trace_seq structure to reset
+- */
+-void trace_seq_reset(struct trace_seq *s)
+-{
+-	if (!s)
+-		return;
+-	TRACE_SEQ_CHECK(s);
+-	s->len = 0;
+-	s->readpos = 0;
+-}
+-
+-/**
+- * trace_seq_destroy - free up memory of a trace_seq
+- * @s: a pointer to the trace_seq to free the buffer
+- *
+- * Only frees the buffer, not the trace_seq struct itself.
+- */
+-void trace_seq_destroy(struct trace_seq *s)
+-{
+-	if (!s)
+-		return;
+-	TRACE_SEQ_CHECK(s);
+-	free(s->buffer);
+-	s->buffer = TRACE_SEQ_POISON;
+-}
+-
+-static void expand_buffer(struct trace_seq *s)
+-{
+-	s->buffer_size += TRACE_SEQ_BUF_SIZE;
+-	s->buffer = realloc(s->buffer, s->buffer_size);
+-	if (!s->buffer)
+-		die("Can't allocate trace_seq buffer memory");
+-}
+-
+-/**
+- * trace_seq_printf - sequence printing of trace information
+- * @s: trace sequence descriptor
+- * @fmt: printf format string
+- *
+- * It returns 0 if the trace oversizes the buffer's free
+- * space, 1 otherwise.
+- *
+- * The tracer may use either sequence operations or its own
+- * copy to user routines. To simplify formating of a trace
+- * trace_seq_printf is used to store strings into a special
+- * buffer (@s). Then the output may be either used by
+- * the sequencer or pulled into another buffer.
+- */
+-int
+-trace_seq_printf(struct trace_seq *s, const char *fmt, ...)
+-{
+-	va_list ap;
+-	int len;
+-	int ret;
+-
+-	TRACE_SEQ_CHECK(s);
+-
+- try_again:
+-	len = (s->buffer_size - 1) - s->len;
+-
+-	va_start(ap, fmt);
+-	ret = vsnprintf(s->buffer + s->len, len, fmt, ap);
+-	va_end(ap);
+-
+-	if (ret >= len) {
+-		expand_buffer(s);
+-		goto try_again;
+-	}
+-
+-	s->len += ret;
+-
+-	return 1;
+-}
+-
+-/**
+- * trace_seq_vprintf - sequence printing of trace information
+- * @s: trace sequence descriptor
+- * @fmt: printf format string
+- *
+- * The tracer may use either sequence operations or its own
+- * copy to user routines. To simplify formating of a trace
+- * trace_seq_printf is used to store strings into a special
+- * buffer (@s). Then the output may be either used by
+- * the sequencer or pulled into another buffer.
+- */
+-int
+-trace_seq_vprintf(struct trace_seq *s, const char *fmt, va_list args)
+-{
+-	int len;
+-	int ret;
+-
+-	TRACE_SEQ_CHECK(s);
+-
+- try_again:
+-	len = (s->buffer_size - 1) - s->len;
+-
+-	ret = vsnprintf(s->buffer + s->len, len, fmt, args);
+-
+-	if (ret >= len) {
+-		expand_buffer(s);
+-		goto try_again;
+-	}
+-
+-	s->len += ret;
+-
+-	return len;
+-}
+-
+-/**
+- * trace_seq_puts - trace sequence printing of simple string
+- * @s: trace sequence descriptor
+- * @str: simple string to record
+- *
+- * The tracer may use either the sequence operations or its own
+- * copy to user routines. This function records a simple string
+- * into a special buffer (@s) for later retrieval by a sequencer
+- * or other mechanism.
+- */
+-int trace_seq_puts(struct trace_seq *s, const char *str)
+-{
+-	int len;
+-
+-	TRACE_SEQ_CHECK(s);
+-
+-	len = strlen(str);
+-
+-	while (len > ((s->buffer_size - 1) - s->len))
+-		expand_buffer(s);
+-
+-	memcpy(s->buffer + s->len, str, len);
+-	s->len += len;
+-
+-	return len;
+-}
+-
+-int trace_seq_putc(struct trace_seq *s, unsigned char c)
+-{
+-	TRACE_SEQ_CHECK(s);
+-
+-	while (s->len >= (s->buffer_size - 1))
+-		expand_buffer(s);
+-
+-	s->buffer[s->len++] = c;
+-
+-	return 1;
+-}
+-
+-void trace_seq_terminate(struct trace_seq *s)
+-{
+-	TRACE_SEQ_CHECK(s);
+-
+-	/* There's always one character left on the buffer */
+-	s->buffer[s->len] = 0;
+-}
+-
+-int trace_seq_do_printf(struct trace_seq *s)
+-{
+-	TRACE_SEQ_CHECK(s);
+-	return printf("%.*s", s->len, s->buffer);
+-}
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0002-tracefs-Use-tracefs_event_file_read-to-find-the-even.patch
+++ b/app-utils/powertop/autobuild/patches/0002-tracefs-Use-tracefs_event_file_read-to-find-the-even.patch
@@ -1,0 +1,320 @@
+From 3cc5125374a7bc9b4b11d61b0b0a8378aeff4495 Mon Sep 17 00:00:00 2001
+From: "Steven Rostedt (Google)" <rostedt@goodmis.org>
+Date: Fri, 3 Mar 2023 16:19:18 -0500
+Subject: [PATCH 2/7] tracefs: Use tracefs_event_file_read() to find the events
+
+Use the libtracefs tracefs_event_file_read() function to find the format
+file of the event. It simplifies the code as it handle not only allocating
+the buffer to pass the file into, but also will search for where the
+tracefs file system is mounted. As not all systems mount debugfs anymore
+(tracefs is its own file system and some distros only mount it in
+/sys/kernel/tracing).
+
+Signed-off-by: Steven Rostedt (Google) <rostedt@goodmis.org>
+---
+ src/cpu/cpu.cpp            | 10 +++---
+ src/perf/perf.cpp          | 55 +++++++++++++++---------------
+ src/perf/perf.h            |  4 +--
+ src/perf/perf_bundle.cpp   | 69 ++------------------------------------
+ src/perf/perf_bundle.h     |  3 +-
+ src/process/do_process.cpp | 36 ++++++++++----------
+ 6 files changed, 55 insertions(+), 122 deletions(-)
+
+diff --git a/src/cpu/cpu.cpp b/src/cpu/cpu.cpp
+index 3661246..eb1578d 100644
+--- a/src/cpu/cpu.cpp
++++ b/src/cpu/cpu.cpp
+@@ -325,12 +325,12 @@ void enumerate_cpus(void)
+ 
+ 	perf_events = new perf_power_bundle();
+ 
+-	if (!perf_events->add_event("power:cpu_idle")){
+-		perf_events->add_event("power:power_start");
+-		perf_events->add_event("power:power_end");
++	if (!perf_events->add_event("power","cpu_idle")){
++		perf_events->add_event("power","power_start");
++		perf_events->add_event("power","power_end");
+ 	}
+-	if (!perf_events->add_event("power:cpu_frequency"))
+-		perf_events->add_event("power:power_frequency");
++	if (!perf_events->add_event("power","cpu_frequency"))
++		perf_events->add_event("power","power_frequency");
+ 
+ }
+ 
+diff --git a/src/perf/perf.cpp b/src/perf/perf.cpp
+index 691baac..1f088cb 100644
+--- a/src/perf/perf.cpp
++++ b/src/perf/perf.cpp
+@@ -46,20 +46,6 @@
+ 
+ struct tep_handle *perf_event::tep;
+ 
+-static int get_trace_type(const char *eventname)
+-{
+-	string str;
+-	int this_trace;
+-
+-	str = read_sysfs_string("/sys/kernel/debug/tracing/events/%s/id",
+-					eventname);
+-	if (str.length() < 1)
+-		return -1;
+-
+-	this_trace = strtoull(str.c_str(), NULL, 10);
+-	return this_trace;
+-}
+-
+ static inline int sys_perf_event_open(struct perf_event_attr *attr,
+                       pid_t pid, int cpu, int group_fd,
+                       unsigned long flags)
+@@ -147,22 +133,35 @@ void perf_event::create_perf_event(char *eventname, int _cpu)
+ 
+ }
+ 
+-void perf_event::set_event_name(const char *event_name)
++static int parse_event_format(const char *system_name, const char *event_name)
+ {
+-	free(name);
+-	name = strdup(event_name);
+-	if (!name) {
+-		fprintf(stderr, "failed to allocate event name\n");
+-		return;
+-	}
++	char *buf;
++	int size;
++
++	buf = tracefs_event_file_read(NULL, system_name, event_name, "format", &size);
++	if (!buf)
++		return -1;
+ 
+-	char *c;
++	tep_parse_event(perf_event::tep, buf, size, system_name);
++	free(buf);
++	return 0;
++}
+ 
+-	c = strchr(name, ':');
+-	if (c)
+-		*c = '/';
++void perf_event::set_event_name(const char *system_name, const char *event_name)
++{
++	struct tep_event *event;
++	int ret;
+ 
+-	trace_type = get_trace_type(name);
++	event = tep_find_event_by_name(perf_event::tep, system_name, event_name);
++	if (!event) {
++		ret = parse_event_format(system_name, event_name);
++		if (ret < 0) {
++			trace_type = -1;
++			return;
++		}
++		event = tep_find_event_by_name(perf_event::tep, system_name, event_name);
++	}
++	trace_type = event->id;
+ }
+ 
+ perf_event::~perf_event(void)
+@@ -190,7 +189,7 @@ static void allocate_tep(void)
+ 		tep_ref(perf_event::tep);
+ }
+ 
+-perf_event::perf_event(const char *event_name, int _cpu, int buffer_size)
++perf_event::perf_event(const char *system_name, const char *event_name, int _cpu, int buffer_size)
+ {
+ 	allocate_tep();
+ 	name = NULL;
+@@ -199,7 +198,7 @@ perf_event::perf_event(const char *event_name, int _cpu, int buffer_size)
+ 	cpu = _cpu;
+ 	perf_mmap = NULL;
+ 	trace_type = 0;
+-	set_event_name(event_name);
++	set_event_name(system_name, event_name);
+ }
+ 
+ perf_event::perf_event(void)
+diff --git a/src/perf/perf.h b/src/perf/perf.h
+index 678d71d..f2c0f34 100644
+--- a/src/perf/perf.h
++++ b/src/perf/perf.h
+@@ -53,12 +53,12 @@ public:
+ 	unsigned int trace_type;
+ 
+ 	perf_event(void);
+-	perf_event(const char *event_name, int cpu = 0, int buffer_size = 128);
++	perf_event(const char *system_name, const char *event_name, int cpu = 0, int buffer_size = 128);
+ 
+ 	virtual ~perf_event(void);
+ 
+ 
+-	void set_event_name(const char *event_name);
++	void set_event_name(const char *system_name, const char *event_name);
+ 	void set_cpu(int cpu);
+ 
+ 	void start(void);
+diff --git a/src/perf/perf_bundle.cpp b/src/perf/perf_bundle.cpp
+index 56788fc..d46f789 100644
+--- a/src/perf/perf_bundle.cpp
++++ b/src/perf/perf_bundle.cpp
+@@ -86,74 +86,13 @@ void perf_bundle::release(void)
+ 	}
+ 	events.clear();
+ 
+-	for (i = 0; i < event_names.size(); i++) {
+-		free((void*)event_names[i]);
+-	}
+-	event_names.clear();
+-
+ 	for(i = 0; i < records.size(); i++) {
+ 		free(records[i]);
+ 	}
+ 	records.clear();
+ }
+ 
+-static char * read_file(const char *file)
+-{
+-	char *buffer = NULL; /* quient gcc */
+-	char buf[4096];
+-	int len = 0;
+-	int fd;
+-	int r;
+-
+-	fd = open(file, O_RDONLY);
+-	if (fd < 0)
+-		exit(-1);
+-
+-	while((r = read(fd, buf, 4096)) > 0) {
+-		if (len) {
+-			char *tmp = (char *)realloc(buffer, len + r + 1);
+-			if (!tmp)
+-				free(buffer);
+-			buffer = tmp;
+-		} else
+-			buffer = (char *)malloc(r + 1);
+-		if (!buffer)
+-			goto out;
+-		memcpy(buffer + len, buf, r);
+-		len += r;
+-		buffer[len] = '\0';
+-	}
+-out:
+-	close(fd);
+-	return buffer;
+-}
+-
+-static void parse_event_format(const char *event_name)
+-{
+-	char *tptr;
+-	char *name = strdup(event_name);
+-	char *sys = strtok_r(name, ":", &tptr);
+-	char *event = strtok_r(NULL, ":", &tptr);
+-	char *file;
+-	char *buf;
+-
+-	file = (char *)malloc(strlen(sys) + strlen(event) +
+-		      strlen("/sys/kernel/debug/tracing/events////format") + 2);
+-	sprintf(file, "/sys/kernel/debug/tracing/events/%s/%s/format", sys, event);
+-
+-	buf = read_file(file);
+-	free(file);
+-	if (!buf) {
+-		free(name);
+-		return;
+-	}
+-
+-	tep_parse_event(perf_event::tep, buf, strlen(buf), sys);
+-	free(name);
+-	free(buf);
+-}
+-
+-bool perf_bundle::add_event(const char *event_name)
++bool perf_bundle::add_event(const char *system_name, const char *event_name)
+ {
+ 	unsigned int i;
+ 	int event_added = false;
+@@ -167,14 +106,10 @@ bool perf_bundle::add_event(const char *event_name)
+ 
+ 		ev = new class perf_bundle_event();
+ 
+-		ev->set_event_name(event_name);
++		ev->set_event_name(system_name, event_name);
+ 		ev->set_cpu(i);
+ 
+ 		if ((int)ev->trace_type >= 0) {
+-			if (event_names.find(ev->trace_type) == event_names.end()) {
+-				event_names[ev->trace_type] = strdup(event_name);
+-				parse_event_format(event_name);
+-			}
+ 			events.push_back(ev);
+ 			event_added = true;
+ 		} else {
+diff --git a/src/perf/perf_bundle.h b/src/perf/perf_bundle.h
+index ec50744..7664a2c 100644
+--- a/src/perf/perf_bundle.h
++++ b/src/perf/perf_bundle.h
+@@ -38,13 +38,12 @@ class perf_event;
+ class  perf_bundle {
+ protected:
+ 	vector<class perf_event *> events;
+-	std::map<int, char*> event_names;
+ public:
+ 	vector<void *> records;
+ 	virtual ~perf_bundle() {};
+ 
+ 	virtual void release(void);
+-	bool add_event(const char *event_name);
++	bool add_event(const char *system_name, const char *event_name);
+ 
+ 	void start(void);
+ 	void stop(void);
+diff --git a/src/process/do_process.cpp b/src/process/do_process.cpp
+index d255a66..97d7c2c 100644
+--- a/src/process/do_process.cpp
++++ b/src/process/do_process.cpp
+@@ -656,25 +656,25 @@ void start_process_measurement(void)
+ {
+ 	if (!perf_events) {
+ 		perf_events = new perf_process_bundle();
+-		perf_events->add_event("sched:sched_switch");
+-		perf_events->add_event("sched:sched_wakeup");
+-		perf_events->add_event("irq:irq_handler_entry");
+-		perf_events->add_event("irq:irq_handler_exit");
+-		perf_events->add_event("irq:softirq_entry");
+-		perf_events->add_event("irq:softirq_exit");
+-		perf_events->add_event("timer:timer_expire_entry");
+-		perf_events->add_event("timer:timer_expire_exit");
+-		perf_events->add_event("timer:hrtimer_expire_entry");
+-		perf_events->add_event("timer:hrtimer_expire_exit");
+-		if (!perf_events->add_event("power:cpu_idle")){
+-			perf_events->add_event("power:power_start");
+-			perf_events->add_event("power:power_end");
++		perf_events->add_event("sched","sched_switch");
++		perf_events->add_event("sched","sched_wakeup");
++		perf_events->add_event("irq","irq_handler_entry");
++		perf_events->add_event("irq","irq_handler_exit");
++		perf_events->add_event("irq","softirq_entry");
++		perf_events->add_event("irq","softirq_exit");
++		perf_events->add_event("timer","timer_expire_entry");
++		perf_events->add_event("timer","timer_expire_exit");
++		perf_events->add_event("timer","hrtimer_expire_entry");
++		perf_events->add_event("timer","hrtimer_expire_exit");
++		if (!perf_events->add_event("power","cpu_idle")){
++			perf_events->add_event("power","power_start");
++			perf_events->add_event("power","power_end");
+ 		}
+-		perf_events->add_event("workqueue:workqueue_execute_start");
+-		perf_events->add_event("workqueue:workqueue_execute_end");
+-		perf_events->add_event("i915:i915_gem_ring_dispatch");
+-		perf_events->add_event("i915:i915_gem_request_submit");
+-		perf_events->add_event("writeback:writeback_inode_dirty");
++		perf_events->add_event("workqueue","workqueue_execute_start");
++		perf_events->add_event("workqueue","workqueue_execute_end");
++		perf_events->add_event("i915","i915_gem_ring_dispatch");
++		perf_events->add_event("i915","i915_gem_request_submit");
++		perf_events->add_event("writeback","writeback_inode_dirty");
+ 	}
+ 
+ 	first_stamp = ~0ULL;
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0003-Fixed-RISCV-T-Head-1520-CPU-identification.patch
+++ b/app-utils/powertop/autobuild/patches/0003-Fixed-RISCV-T-Head-1520-CPU-identification.patch
@@ -1,0 +1,41 @@
+From 088792587aa0e4161b52daccafa696a880d7cd12 Mon Sep 17 00:00:00 2001
+From: Renat Sabitov <r.sabitov@gmail.com>
+Date: Thu, 2 Nov 2023 22:03:05 +1000
+Subject: [PATCH 3/7] Fixed RISCV T-Head 1520 CPU identification
+
+---
+ src/cpu/cpu.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/cpu/cpu.cpp b/src/cpu/cpu.cpp
+index eb1578d..ca1e3a7 100644
+--- a/src/cpu/cpu.cpp
++++ b/src/cpu/cpu.cpp
+@@ -174,6 +174,8 @@ static void handle_one_cpu(unsigned int number, char *vendor, int family, int mo
+ 	file.open(filename, ios::in);
+ 	if (file) {
+ 		file >> core_number;
++		if (core_number == (unsigned int) -1)
++			core_number = number;
+ 		file.close();
+ 	}
+ 
+@@ -300,11 +302,13 @@ void enumerate_cpus(void)
+ 		}
+ 		/* on x86 and others 'bogomips' is last
+ 		 * on ARM it *can* be bogomips, or 'CPU revision'
+-		 * on POWER, it's revision
++		 * on POWER, it's 'revision'
++		 * on RISCV64 it's 'isa'
+ 		 */
+ 		if (strncasecmp(line, "bogomips\t", 9) == 0
+ 		    || strncasecmp(line, "CPU revision\t", 13) == 0
+-		    || strncmp(line, "revision", 8) == 0) {
++		    || strncmp(line, "revision", 8) == 0
++		    || strncmp(line, "isa\t", 4) == 0) {
+ 			if (number == -1) {
+ 				/* Not all /proc/cpuinfo include "processor\t". */
+ 				number = 0;
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0004-on-is-also-good-as-reported-by-Paul-Menzel.patch
+++ b/app-utils/powertop/autobuild/patches/0004-on-is-also-good-as-reported-by-Paul-Menzel.patch
@@ -1,0 +1,25 @@
+From 8e8f8c1238bfba759fa9dd16f1242d062b0e57f6 Mon Sep 17 00:00:00 2001
+From: Arjan van de Ven <arjan@linux.intel.com>
+Date: Sat, 2 Mar 2024 16:21:37 +0000
+Subject: [PATCH 4/7] "on" is also good, as reported by Paul Menzel
+
+---
+ src/tuning/runtime.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/tuning/runtime.cpp b/src/tuning/runtime.cpp
+index cb62533..e62fc6c 100644
+--- a/src/tuning/runtime.cpp
++++ b/src/tuning/runtime.cpp
+@@ -95,6 +95,8 @@ int runtime_tunable::good_bad(void)
+ 
+ 	if (strcmp(content.c_str(), "auto") == 0)
+ 		return TUNE_GOOD;
++	if (strcmp(content.c_str(), "on") == 0)
++		return TUNE_GOOD;
+ 
+ 	return TUNE_BAD;
+ }
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0005-Add-Intel-Arrow-Lake-support.patch
+++ b/app-utils/powertop/autobuild/patches/0005-Add-Intel-Arrow-Lake-support.patch
@@ -1,0 +1,76 @@
+From fe99e5224453897b5d2c0f870ad84fdba8627f35 Mon Sep 17 00:00:00 2001
+From: Pascal Nasahl <nasahlpa@lowrisc.org>
+Date: Sat, 21 Dec 2024 07:54:54 +0100
+Subject: [PATCH 5/7] Add Intel Arrow Lake support
+
+This commit adds the model numbers for Intel Arrow
+Lake (ARL) processors.
+
+Signed-off-by: Pascal Nasahl <nasahlpa@vol.at>
+---
+ src/cpu/intel_cpus.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/cpu/intel_cpus.cpp b/src/cpu/intel_cpus.cpp
+index a7145d7..3e59ea9 100644
+--- a/src/cpu/intel_cpus.cpp
++++ b/src/cpu/intel_cpus.cpp
+@@ -91,10 +91,13 @@ static int intel_cpu_models[] = {
+ 	0xA7,	/* RKL_DESKTOP */
+ 	0xAA,	/* MTL_MOBILE */
+ 	0xAC,	/* MTL_DESKTOP */
++	0xB5,   /* ARL_U */
+ 	0xB7,	/* RPL_DESKTOP */
+ 	0xBA,	/* RPL_P */
+ 	0xBE,	/* ADL_N */
+ 	0xBF,	/* RPL_S */
++	0xC5,   /* ARL_H */
++	0xC6,   /* ARL_DESKTOP */
+ 	0	/* last entry must be zero */
+ };
+ 
+@@ -216,10 +219,13 @@ nhm_core::nhm_core(int model)
+ 		case 0xA7:	/* RKL_DESKTOP */
+ 		case 0xAA:	/* MTL_MOBILE */
+ 		case 0xAC:	/* MTL_DESKTOP */
++		case 0xB5:	/* ARL_U */
+ 		case 0xB7:	/* RPL_DESKTOP */
+ 		case 0xBA:	/* RPL_P */
+ 		case 0xBE:	/* ADL_N */
+ 		case 0xBF:	/* RPL_S */
++		case 0xC5:	/* ARL_H */
++		case 0xC6:	/* ARL_DESKTOP */
+ 			has_c7_res = 1;
+ 	}
+ 
+@@ -417,10 +423,13 @@ nhm_package::nhm_package(int model)
+ 		case 0xA7:	/* RKL_DESKTOP */
+ 		case 0xAA:	/* MTL_MOBILE */
+ 		case 0xAC:	/* MTL_DESKTOP */
++		case 0xB5:	/* ARL_U */
+ 		case 0xB7:	/* RPL_DESKTOP */
+ 		case 0xBA:	/* RPL_P */
+ 		case 0xBE:	/* ADL_N */
+ 		case 0xBF:	/* RPL_S */
++		case 0xC5:	/* ARL_H */
++		case 0xC6:	/* ARL_DESKTOP */
+ 			has_c2c6_res=1;
+ 			has_c7_res = 1;
+ 	}
+@@ -471,10 +480,13 @@ nhm_package::nhm_package(int model)
+ 		case 0xA7:	/* RKL_DESKTOP */
+ 		case 0xAA:	/* MTL_MOBILE */
+ 		case 0xAC:	/* MTL_DESKTOP */
++		case 0xB5:	/* ARL_U */
+ 		case 0xB7:	/* RPL_DESKTOP */
+ 		case 0xBA:	/* RPL_P */
+ 		case 0xBE:	/* ADL_N */
+ 		case 0xBF:	/* RPL_S */
++		case 0xC5:	/* ARL_H */
++		case 0xC6:	/* ARL_DESKTOP */
+ 			has_c8c9c10_res = 1;
+ 			break;
+ 	}
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0006-Fix-battery-runtime-estimation-with-negative-sysfs-v.patch
+++ b/app-utils/powertop/autobuild/patches/0006-Fix-battery-runtime-estimation-with-negative-sysfs-v.patch
@@ -1,0 +1,50 @@
+From d360e3f6c9a394ff34b0c0a8e5ba956651f45f9b Mon Sep 17 00:00:00 2001
+From: Anthony Ruhier <aruhier@mailbox.org>
+Date: Thu, 20 Feb 2025 01:28:46 +0100
+Subject: [PATCH 6/7] Fix battery runtime estimation with negative sysfs values
+
+Some drivers (example: qualcomm-battmgr, present on Snapdragon X1
+laptops) expose the current_now and power_now values in sysfs as
+negative int when the device is discharging, positive when charging.
+
+This breaks the battery runtime estimation in Powertop, as it expects a
+uint for power_now.
+
+Change to use the absolute values of current_now and power_now.
+---
+ src/measurement/sysfs.cpp | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/src/measurement/sysfs.cpp b/src/measurement/sysfs.cpp
+index c5a7a12..6cc7f43 100644
+--- a/src/measurement/sysfs.cpp
++++ b/src/measurement/sysfs.cpp
+@@ -75,8 +75,10 @@ bool sysfs_power_meter::set_rate_from_power()
+ 	if (!get_sysfs_attr("power_now", &power))
+ 		return false;
+ 
+-	/* µW to W */
+-	rate = power / 1000000.0;
++	/* µW to W
++	 * Some drivers (example: Qualcomm) exposes use a negative value when
++	 * discharging, positive value when charging, so use the absolute value. */
++	rate = std::abs(power) / 1000000.0;
+ 	return true;
+ }
+ 
+@@ -89,8 +91,10 @@ bool sysfs_power_meter::set_rate_from_current(double voltage)
+ 
+ 	/* current: µA
+ 	 * voltage: V
+-	 * rate: W */
+-	rate = (current / 1000000.0) * voltage;
++	 * rate: W
++	 * Documentation ABI allows a negative value when discharging, positive
++	 * value when charging, so use the absolute value. */
++	rate = (std::abs(current) / 1000000.0) * voltage;
+ 	return true;
+ }
+ 
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/patches/0007-Use-AM_GNU_GETTEXT_REQUIRE_VERSION-to-avoid-version-.patch
+++ b/app-utils/powertop/autobuild/patches/0007-Use-AM_GNU_GETTEXT_REQUIRE_VERSION-to-avoid-version-.patch
@@ -1,0 +1,38 @@
+From 7ee40eddf390d9649b5246702fb453a2423645d9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Thu, 27 Feb 2025 11:05:38 +0100
+Subject: [PATCH 7/7] Use AM_GNU_GETTEXT_REQUIRE_VERSION to avoid version
+ mismatch
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This should resolve problems with distros that have newer version of
+gettext.
+
+https://www.gnu.org/software/gettext/manual/html_node/autopoint-Invocation.html
+
+Credit Yaakov Selkowitz in:
+https://src.fedoraproject.org/rpms/powertop/pull-request/2
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index a69cf61..23b689b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,7 +25,7 @@ GETTEXT_PACKAGE=powertop
+ AC_SUBST([GETTEXT_PACKAGE])
+ AM_SILENT_RULES([yes])
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.18.2])
++AM_GNU_GETTEXT_REQUIRE_VERSION([0.18.2])
+ 
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ AX_REQUIRE_DEFINED([AX_ADD_FORTIFY_SOURCE])
+-- 
+2.49.0
+

--- a/app-utils/powertop/autobuild/prepare
+++ b/app-utils/powertop/autobuild/prepare
@@ -1,3 +1,2 @@
-abinfo "Writing verion information ..."
-echo v"$PKGVER" > "$SRCDIR"/version-long
-echo v"$PKGVER" > "$SRCDIR"/version-short
+abinfo "Generating configure ..."
+autoreconf -fvi

--- a/app-utils/powertop/spec
+++ b/app-utils/powertop/spec
@@ -1,4 +1,5 @@
 VER=2.15
-SRCS="tbl::https://github.com/fenrus75/powertop/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::e58ab3fd7b8ff5f4dd0d17f11848817e7d83c0a6918145ac81de03b5dccf8f49"
+REL=1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/fenrus75/powertop"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3702"


### PR DESCRIPTION
Topic Description
-----------------

- powertop: fix build and enhance functionalities
    - Backport a patch to fix build with newer Gettext.
    - Backport patches to use system libtraceevent, libtracefs instead of the
    bundled version \(very old!\).
    - Backport patches to fix functionalities on newer platforms: Intel Arrow
    Lake, Qualcomm Snapdragon X1, T-Head 1520, etc.
    - Track patches at AOSC-Tracking/powertop @ aosc/v2.15
    \(HEAD: d360e3f6c9a394ff34b0c0a8e5ba956651f45f9b\).

Package(s) Affected
-------------------

- powertop: 2:2.15-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit powertop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
