### PR TITLE
fwupd: add readline to PKGDEP

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -3,15 +3,14 @@ PKGSEC=admin
 PKGDES="Firmware update daemon and utilities"
 PKGDEP="bluez curl flashrom fwupd-efi gcc-runtime glib glibc gnutls \
         hicolor-icon-theme json-glib libarchive libcbor libdrm libjcat \
-        libxmlb modemmanager passim polkit protobuf-c python-3 \
+        libxmlb modemmanager passim polkit protobuf-c python-3 readline \
         shared-mime-info sqlite systemd tpm2-tss udisks-2 xz zlib"
 BUILDDEP="cairo gi-docgen gobject-introspection vala valgrind"
 # FIXME: Fwupd-efi is not yet available for ppc64el & loongson3.
 PKGDEP__LOONGSON3="${PKGDEP/fwupd-efi/}"
 PKGDEP__PPC64EL="${PKGDEP/fwupd-efi/}"
-# FIXME: Valgrind is not yet available for RISC-V & LoongArch.
+# FIXME: Valgrind is not yet available for LoongArch.
 BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
-BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 
 MESON_AFTER=(
     "-Ddocs=enabled"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,5 @@
 VER=2.0.9
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: add readline to PKGDEP
    - Use readline to look up inputs from user, see: https://github.com/fwupd/fwupd/commit/4f0e934239c5d0c5197186951562c926e8a0863f.
    - Now Valgrind is available for riscv64.

Package(s) Affected
-------------------

- fwupd: 2.0.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
