### PR TITLE
mihomo: remove build script

### DIFF
--- a/app-network/mihomo/autobuild/build
+++ b/app-network/mihomo/autobuild/build
@@ -1,3 +1,0 @@
-abinfo "Installing a symlink to clash-meta ..."
-ln -sv mihomo \
-    "$PKGDIR"/usr/bin/clash-meta

--- a/app-network/mihomo/spec
+++ b/app-network/mihomo/spec
@@ -1,4 +1,5 @@
 VER=1.19.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"


### PR DESCRIPTION
Topic Description
-----------------

- mihomo: remove build script
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- mihomo: 1.19.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mihomo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
