### PR TITLE
libmbim: update to 1.32.0

### DIFF
--- a/runtime-devices/libmbim/spec
+++ b/runtime-devices/libmbim/spec
@@ -1,4 +1,4 @@
-VER=1.30.0
+VER=1.32.0
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/libmbim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7308"


### PR DESCRIPTION
Topic Description
-----------------

- libmbim: update to 1.32.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libmbim: 1.32.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmbim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
