### PR TITLE
git-branchless: update to 0.10.0

### DIFF
--- a/app-utils/git-branchless/spec
+++ b/app-utils/git-branchless/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.0
 SRCS="tbl::https://github.com/arxanas/git-branchless/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::fa64dc92ec522520a6407ff61241fc1819a3093337b4e3d0f80248ae76938d43"
+CHKSUMS="sha256::1eb8dbb85839c5b0d333e8c3f9011c3f725e0244bb92f4db918fce9d69851ff7"
 CHKUPDATE="anitya::id=243307"


### PR DESCRIPTION
Topic Description
-----------------

- git-branchless: update to 0.10.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- git-branchless: 0.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-branchless
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
