### PR TITLE
thin-provisioning-tools: (loongarch64) enable LTO

### DIFF
--- a/app-admin/thin-provisioning-tools/autobuild/defines
+++ b/app-admin/thin-provisioning-tools/autobuild/defines
@@ -9,8 +9,7 @@ USECLANG=1
 CARGO_AFTER="--features=devtools"
 
 # FIXME: ld.lld is not available.
-NOLTO__LOONGARCH64=1
-NOLTO__MIPS64R6EL=1
+NOLTO__LOONGSON3=1
 
 # FIXME: unknown relocation (61) against symbol ...
 # Use regular ld (no LTO) instead.

--- a/app-admin/thin-provisioning-tools/spec
+++ b/app-admin/thin-provisioning-tools/spec
@@ -1,4 +1,5 @@
 VER=1.0.10
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/jthornber/thin-provisioning-tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5385"


### PR DESCRIPTION
Topic Description
-----------------

- thin-provisioning-tools: \(loongarch64\) enable LTO
    Linker relaxation is available since LLVM \(ld.lld\) 18.

Package(s) Affected
-------------------

- thin-provisioning-tools: 1.0.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit thin-provisioning-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
