### PR TITLE
file: drop Python 2 bindings

### DIFF
--- a/app-utils/file/autobuild/beyond
+++ b/app-utils/file/autobuild/beyond
@@ -1,7 +1,5 @@
 if ! ab_match_archgroup retro; then
     abinfo "Building Python bindings..."
     cd "$SRCDIR"/python
-    python2 setup.py install --root="$PKGDIR" --optimize=1
     python3 setup.py install --root="$PKGDIR" --optimize=1
-    cd "$SRCDIR"
 fi

--- a/app-utils/file/autobuild/defines
+++ b/app-utils/file/autobuild/defines
@@ -22,22 +22,17 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--enable-elf \
-                 --enable-elf-core \
-                 --enable-zlib \
-                 --enable-bzlib \
-                 --enable-xzlib \
-                 --enable-libseccomp \
-                 --enable-fsect-man5 \
-                 --enable-largefile"
-AUTOTOOLS_AFTER__RETRO=" \
-               ${AUTOTOOLS_AFTER} \
-               --disable-libseccomp"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--enable-elf'
+    '--enable-elf-core'
+    '--enable-zlib'
+    '--enable-bzlib'
+    '--enable-xzlib'
+    '--enable-libseccomp'
+    '--enable-fsect-man5'
+    '--enable-largefile'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-libseccomp'
+)

--- a/app-utils/file/spec
+++ b/app-utils/file/spec
@@ -1,4 +1,5 @@
 VER=5.45
+REL=1
 # FIXME: This upstream sucks, a lot (HTTPS when???).
 SRCS="tbl::http://ftp.astron.com/pub/file/file-$VER.tar.gz"
 CHKSUMS="sha256::fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82"


### PR DESCRIPTION
Topic Description
-----------------

- file: drop Python 2 bindings
    Also clean up AUTOTOOLS_AFTER to use the array + archgroup format.

Package(s) Affected
-------------------

- file: 5.45-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit file
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
