### PR TITLE
apr-util: drop Berkeley DB support

### DIFF
--- a/runtime-common/apr-util/autobuild/defines
+++ b/runtime-common/apr-util/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=apr-util
 PKGDES="The Apache Portable Runtime utilities"
-PKGSEC=utils
+PKGSEC=libs
 PKGDEP="apr expat nss openldap openssl"
 PKGSUG="db gdbm mariadb postgresql sqlite unixodbc"
 PKGSUG__RETRO="db gdbm sqlite"
@@ -23,39 +23,24 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--with-apr=/usr \
-                 --with-ldap \
-                 --with-crypto \
-                 --with-gdbm=/usr \
-                 --with-sqlite3=/usr \
-                 --with-nss=/usr \
-                 --with-odbc=/usr \
-                 --with-berkeley-db=/usr \
-                 --with-pgsql=/usr \
-                 --with-oracle=/usr \
-                 --with-openssl=/usr \
-                 --with-mysql=/usr"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-ldap \
-                 --with-crypto \
-                 --with-gdbm=/usr \
-                 --with-sqlite3=/usr \
-                 --with-nss=/usr \
-                 --without-odbc \
-                 --with-berkeley-db=/usr \
-                 --without-pgsql \
-                 --without-oracle \
-                 --with-openssl=/usr \
-                 --without-mysql"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
-
-ABSHADOW=0
-RECONF=0
+AUTOTOOLS_AFTER=(
+    '--with-apr=/usr'
+    '--with-ldap'
+    '--with-crypto'
+    '--with-gdbm=/usr'
+    '--with-sqlite3=/usr'
+    '--with-nss=/usr'
+    '--with-odbc=/usr'
+    '--with-berkeley-db=no'
+    '--with-pgsql=/usr'
+    '--with-oracle=/usr'
+    '--with-openssl=/usr'
+    '--with-mysql=/usr'
+    '--with-dbm=gdbm'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-odbc'
+    '--without-pgsql'
+    '--without-oracle'
+)

--- a/runtime-common/apr-util/spec
+++ b/runtime-common/apr-util/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
+REL=2
 SRCS="tbl::https://archive.apache.org/dist/apr/apr-util-$VER.tar.gz"
 CHKSUMS="sha256::2b74d8932703826862ca305b094eef2983c27b39d5c9414442e9976a9acf1983"
 CHKUPDATE="anitya::id=96"
-REL=1

--- a/runtime-common/apr/autobuild/defines
+++ b/runtime-common/apr/autobuild/defines
@@ -3,7 +3,10 @@ PKGDES="Apache Portable Runtime"
 PKGDEP="util-linux"
 PKGSEC=libs
 
-AUTOTOOLS_AFTER="--enable-nonportable-atomics --with-devrandom=/dev/urandom \
-                 --with-installbuilddir=/usr/share/apr-1/build"
+AUTOTOOLS_AFTER=(
+    '--enable-nonportable-atomics'
+    '--with-devrandom=/dev/urandom'
+    '--with-installbuilddir=/usr/share/apr-1/build'
+)
 ABSHADOW=0
 RECONF=0

--- a/runtime-common/apr/spec
+++ b/runtime-common/apr/spec
@@ -1,4 +1,5 @@
 VER=1.7.5
+REL=1
 SRCS="tbl::https://archive.apache.org/dist/apr/apr-$VER.tar.bz2"
 CHKSUMS="sha256::cd0f5d52b9ab1704c72160c5ee3ed5d3d4ca2df4a7f8ab564e3cb352b67232f2"
 CHKUPDATE="anitya::id=95"


### PR DESCRIPTION
Topic Description
-----------------

- apr-util: drop Berkeley DB support
    With GCC >= 14, Berkeley DB support no longer builds. We have been using
    GDBM as the default database manager so it should not affect our
    dependency tree.
    Note that Berkeley DB is installed as part of BuildKit so it is always
    available in the build environment. This revision disables this feature
    explicitly.
- apr: refactor apr/autobuild/define
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- apr: 1.7.5-1
- apr-util: 1.6.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit apr apr-util
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
