### PR TITLE
libatomic-ops: use Git source

### DIFF
--- a/runtime-common/libatomic-ops/spec
+++ b/runtime-common/libatomic-ops/spec
@@ -1,4 +1,5 @@
 VER=7.8.0
-SRCS="tbl::https://github.com/ivmai/libatomic_ops/releases/download/v$VER/libatomic_ops-$VER.tar.gz"
-CHKSUMS="sha256::15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/ivmai/libatomic_ops"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1561"


### PR DESCRIPTION
Topic Description
-----------------

- libatomic-ops: use Git source
    The upstream removed all release tarballs... why?

Package(s) Affected
-------------------

- libatomic-ops: 7.8.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libatomic-ops
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
