### PR TITLE
snowball: improve patch record

### DIFF
--- a/runtime-common/snowball/autobuild/patches/0001-AOSCOS-feat-build-dynamic-libraries-by-default.patch
+++ b/runtime-common/snowball/autobuild/patches/0001-AOSCOS-feat-build-dynamic-libraries-by-default.patch
@@ -1,8 +1,19 @@
-diff --git c/GNUmakefile i/GNUmakefile
-index 1693f5a..b33a42e 100644
---- c/GNUmakefile
-+++ i/GNUmakefile
-@@ -112,10 +112,10 @@ C_OTHER_OBJECTS = $(C_OTHER_SOURCES:.c=.o)
+From d8e1f0325233aab16da8cbd4f031c42abcfc9ebd Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 1 May 2025 21:36:31 +0800
+Subject: [PATCH] AOSCOS: feat: build dynamic libraries by default
+
+---
+ GNUmakefile           | 7 +++++--
+ libstemmer/symbol.map | 6 ++++++
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+ create mode 100644 libstemmer/symbol.map
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 5cb2179..e57789a 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -162,10 +162,10 @@ C_OTHER_OBJECTS = $(C_OTHER_SOURCES:.c=.o)
  JAVA_CLASSES = $(JAVA_SOURCES:.java=.class)
  JAVA_RUNTIME_CLASSES=$(JAVARUNTIME_SOURCES:.java=.class)
  
@@ -15,7 +26,7 @@ index 1693f5a..b33a42e 100644
  
  clean:
  	rm -f $(COMPILER_OBJECTS) $(RUNTIME_OBJECTS) \
-@@ -158,6 +158,9 @@ libstemmer/libstemmer.o: libstemmer/modules.h $(C_LIB_HEADERS)
+@@ -212,6 +212,9 @@ libstemmer/libstemmer.o: libstemmer/modules.h $(C_LIB_HEADERS)
  libstemmer.o: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
  	$(AR) -cru $@ $^
  
@@ -23,13 +34,13 @@ index 1693f5a..b33a42e 100644
 +	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname,libstemmer.so.0,-version-script,libstemmer/symbol.map -o $@.0.0.0 $^
 +
  stemwords: $(STEMWORDS_OBJECTS) libstemmer.o
- 	$(CC) -o $@ $^
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
  
-diff --git c/libstemmer/symbol.map i/libstemmer/symbol.map
+diff --git a/libstemmer/symbol.map b/libstemmer/symbol.map
 new file mode 100644
 index 0000000..7a3d423
 --- /dev/null
-+++ i/libstemmer/symbol.map
++++ b/libstemmer/symbol.map
 @@ -0,0 +1,6 @@
 +SB_STEMMER_0 {
 +    global:
@@ -37,3 +48,6 @@ index 0000000..7a3d423
 +    local:
 +        *;
 +};
+-- 
+2.49.0
+

--- a/runtime-common/snowball/spec
+++ b/runtime-common/snowball/spec
@@ -1,4 +1,5 @@
 VER=2.1.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/snowballstem/snowball"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230535"


### PR DESCRIPTION
Topic Description
-----------------

- snowball: improve patch record
    The original patch no longer applies against 2.1.0 due to fuzz \(which is
    no longer allowed with Autobuild4\).
    Also add a more detailed description for what the patch is for.

Package(s) Affected
-------------------

- snowball: 1:2.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit snowball
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
