### PR TITLE
argon2: fix build and improve packaging

### DIFF
--- a/runtime-cryptography/argon2/autobuild/build
+++ b/runtime-cryptography/argon2/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Building argon2 ..."
+make \
+    OPTTARGET=none \
+    LIBRARY_REL='lib'
+
+abinfo "Installing argon2 ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    OPTTARGET=none \
+    LIBRARY_REL='lib'

--- a/runtime-cryptography/argon2/autobuild/defines
+++ b/runtime-cryptography/argon2/autobuild/defines
@@ -3,6 +3,4 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="A password-hashing function (reference C implementation)"
 
-ABMK="OPTTARGET=none LIBRARY_REL='lib'"
-MAKE_AFTER="OPTTARGET=none LIBRARY_REL='lib'"
 AB_FLAGS_O3=1

--- a/runtime-cryptography/argon2/spec
+++ b/runtime-cryptography/argon2/spec
@@ -1,5 +1,5 @@
 VER=20190702
-REL=3
-SRCS="tbl::https://github.com/P-H-C/phc-winner-argon2/archive/$VER.tar.gz"
-CHKSUMS="sha256::daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
+REL=4
+SRCS="git::commit=tags/$VER::https://github.com/P-H-C/phc-winner-argon2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15244"


### PR DESCRIPTION
Topic Description
-----------------

- argon2: fix build and improve packaging
    - Add a build script as Autobuild4 no longer supplies plainmake ABTYPE.
    - Use Git snapshot to replace GitHub's platform-generated tarball, per the
    Styling Manual.

Package(s) Affected
-------------------

- argon2: 20190702-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit argon2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
