### PR TITLE
freeglut: (no build) use GitHub source

### DIFF
--- a/runtime-display/freeglut/spec
+++ b/runtime-display/freeglut/spec
@@ -1,4 +1,4 @@
 VER=3.4.0
-SRCS="tbl::https://prdownloads.sourceforge.net/freeglut/freeglut-$VER.tar.gz"
+SRCS="tbl::https://github.com/freeglut/freeglut/releases/download/v$VER/freeglut-$VER.tar.gz"
 CHKSUMS="sha256::3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec"
 CHKUPDATE="anitya::id=846"


### PR DESCRIPTION
Topic Description
-----------------

- freeglut: \(no build\) use GitHub source
    No need to rebuild as there is no change to source checksum.

Package(s) Affected
-------------------

- freeglut: 3.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freeglut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
