### PR TITLE
qrencode: fix source link

### DIFF
--- a/runtime-imaging/qrencode/spec
+++ b/runtime-imaging/qrencode/spec
@@ -1,4 +1,5 @@
 VER=4.0.2
-SRCS="tbl::http://megaui.net/fukuchi/works/qrencode/qrencode-$VER.tar.bz2"
-CHKSUMS="sha256::c9cb278d3b28dcc36b8d09e8cad51c0eca754eb004cb0247d4703cb4472b58b4"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/fukuchi/libqrencode"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12834"


### PR DESCRIPTION
Topic Description
-----------------

- qrencode: fix source link

Package(s) Affected
-------------------

- qrencode: 4.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qrencode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
