### PR TITLE
ldns: update to 1.8.4

### DIFF
--- a/runtime-network/ldns/autobuild/defines
+++ b/runtime-network/ldns/autobuild/defines
@@ -5,16 +5,24 @@ BUILDDEP="doxygen swig perl-devel-checklib"
 PKGDES="Fast DNS library supporting recent RFCs"
 
 ABTYPE=autotools
-AUTOTOOLS_AFTER="PYTHON=/usr/bin/python3 \
-                 --disable-static \
-                 --disable-rpath \
-                 --with-drill \
-                 --with-examples \
-                 --with-pyldns \
-                 --with-pyldnsx \
-                 --with-p5-dns-ldns \
-                 --with-trust-anchor=/etc/unbound/trusted-key.key \
-                 --with-ca-file=/etc/ssl/certs/ca-certificates.crt \
-                 --with-ca-path=/etc/ssl/certs/"
+# FIXME: --without-pyldns, --without-pyldnsx
+#
+# Incompatibility with newer SWIG:
+#
+# .../ldns-1.8.4/contrib/python/ldns_wrapper.c:8421:15: error: too few arguments to function 'SWIG_Python_AppendOutput'
+#  8421 |   resultobj = SWIG_Python_AppendOutput(resultobj,
+#       |               ^~~~~~~~~~~~~~~~~~~~~~~~
+AUTOTOOLS_AFTER=(
+    '--disable-static'
+    '--disable-rpath'
+    '--with-drill'
+    '--with-examples'
+    '--without-pyldns'
+    '--without-pyldnsx'
+    '--with-p5-dns-ldns'
+    '--with-trust-anchor=/etc/unbound/trusted-key.key'
+    '--with-ca-file=/etc/ssl/certs/ca-certificates.crt'
+    '--with-ca-path=/etc/ssl/certs/'
+)
 
 PKGBREAK="dnscrypt<=2.0.39-1 openssh<=8.1p1 openssh-hpn<=7.8p1"

--- a/runtime-network/ldns/spec
+++ b/runtime-network/ldns/spec
@@ -1,5 +1,4 @@
-VER=1.8.3
-REL=1
+VER=1.8.4
 SRCS="tbl::https://www.nlnetlabs.nl/downloads/ldns/ldns-$VER.tar.gz"
-CHKSUMS="sha256::c3f72dd1036b2907e3a56e6acf9dfb2e551256b3c1bbd9787942deeeb70e7860"
+CHKSUMS="sha256::838b907594baaff1cd767e95466a7745998ae64bc74be038dccc62e2de2e4247"
 CHKUPDATE="anitya::id=14817"


### PR DESCRIPTION
Topic Description
-----------------

- ldns: update to 1.8.4
    Disable Python bindings due to incompatibility with newer SWIG:
    .../ldns-1.8.4/contrib/python/ldns_wrapper.c:8421:15: error: too few arguments to function 'SWIG_Python_AppendOutput'
    8421 |   resultobj = SWIG_Python_AppendOutput\(resultobj,
    |               ^\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~

Package(s) Affected
-------------------

- ldns: 1.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ldns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
