### PR TITLE
wheel: add flit-core dep

### DIFF
--- a/lang-python/wheel/autobuild/defines
+++ b/lang-python/wheel/autobuild/defines
@@ -1,8 +1,6 @@
 PKGNAME=wheel
 PKGSEC=python
-PKGDEP="keyring"
-# FIXME: mips64r6el does not have Rust support (no setuptools-rust => cryptography).
-PKGDEP__MIPS64R6EL="python-2 python-3"
+PKGDEP="keyring flit-core"
 BUILDDEP="setuptools"
 PKGDES="A built-package format for Python"
 

--- a/lang-python/wheel/spec
+++ b/lang-python/wheel/spec
@@ -1,4 +1,5 @@
 VER=0.45.0
+REL=1
 SRCS="tbl::https://pypi.io/packages/source/w/wheel/wheel-$VER.tar.gz"
 CHKSUMS="sha256::a57353941a3183b3d5365346b567a260a0602a0f8a635926a7dede41b94c674a"
 CHKUPDATE="anitya::id=11428"


### PR DESCRIPTION
Topic Description
-----------------

- wheel: add flit-core dep

Package(s) Affected
-------------------

- wheel: 0.45.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wheel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
