### PR TITLE
cracklib: fix build with Autobuild4

### DIFF
--- a/runtime-cryptography/cracklib/autobuild/beyond
+++ b/runtime-cryptography/cracklib/autobuild/beyond
@@ -6,7 +6,7 @@ if ab_match_archgroup mainline; then
     cd "$PYBLDDIR"
 
     abinfo "Configuring Python binding source tree ..."
-    "$SRCDIR"/configure $AUTOTOOLS_DEF ${AUTOTOOLS_AFTER/--without-python/}
+    "$SRCDIR"/configure ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]}
     rm -rv "$PYBLDDIR"/lib
     ln -sv "$BLDDIR"/lib "$PYBLDDIR"/lib
 

--- a/runtime-cryptography/cracklib/autobuild/defines
+++ b/runtime-cryptography/cracklib/autobuild/defines
@@ -4,5 +4,10 @@ PKGDEP="gzip python-3"
 BUILDDEP="setuptools"
 PKGDES="A library used to enforce strong passwords"
 
-AUTOTOOLS_AFTER="--without-python \
-                 --with-default-dict=/usr/share/cracklib/pw_dict"
+# Note: --without-python: We are building Python bindings separately as
+# the build system does not seem capable of building main libraries and
+# bindings in one go.
+AUTOTOOLS_AFTER=(
+    '--without-python'
+    '--with-default-dict=/usr/share/cracklib/pw_dict'
+)

--- a/runtime-cryptography/cracklib/spec
+++ b/runtime-cryptography/cracklib/spec
@@ -1,4 +1,5 @@
 VER=2.9.8
+REL=1
 SRCS="tbl::https://github.com/cracklib/cracklib/releases/download/v$VER/cracklib-$VER.tar.bz2 \
       file::rename=cracklib-words-$VER.gz::https://github.com/cracklib/cracklib/releases/download/v$VER/cracklib-words-$VER.gz"
 CHKSUMS="sha256::1f9d34385ea3aa7cd7c07fa388dc25810aea9d3c33e260c713a3a5873d70e386 \


### PR DESCRIPTION
Topic Description
-----------------

- cracklib: fix build with Autobuild4
    Use array to reference AUTOTOOLS_{DEF,AFTER}.

Package(s) Affected
-------------------

- cracklib: 2.9.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cracklib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
