### PR TITLE
libidn2: replace ronn with ronn-ng

### DIFF
--- a/runtime-network/libidn2/autobuild/defines
+++ b/runtime-network/libidn2/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libidn2
 PKGSEC=libs
 PKGDEP="libunistring"
-BUILDDEP="gtk-doc ronn"
+BUILDDEP="gtk-doc ronn-ng"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/runtime-network/libidn2/spec
+++ b/runtime-network/libidn2/spec
@@ -1,4 +1,5 @@
 VER=2.3.8
+REL=1
 SRCS="tbl::https://ftp.gnu.org/pub/gnu/libidn/libidn2-$VER.tar.gz"
 CHKSUMS="sha256::f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
 CHKUPDATE="anitya::id=5597"


### PR DESCRIPTION
Topic Description
-----------------

- libidn2: replace ronn with ronn-ng
    ronn has been dropped from the tree.

Package(s) Affected
-------------------

- libidn2: 2.3.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libidn2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
