### PR TITLE
bup: replace ronn with ronn-ng

### DIFF
--- a/app-utils/bup/autobuild/defines
+++ b/app-utils/bup/autobuild/defines
@@ -2,5 +2,5 @@ PKGNAME=bup
 PKGSEC=utils
 PKGDEP="fuse-python git par2cmdline pylibacl pyxattr"
 PKGSUG="tornado"
-BUILDDEP="${BUILDDEP} ronn"
+BUILDDEP="${BUILDDEP} ronn-ng"
 PKGDES="Highly efficient file backup system based on the git packfile format"

--- a/app-utils/bup/spec
+++ b/app-utils/bup/spec
@@ -1,5 +1,5 @@
 VER=0.30
+REL=2
 SRCS="tbl::https://github.com/bup/bup/archive/$VER.tar.gz"
 CHKSUMS="sha256::5238f045c220278a165fff528ea32288f2752db2e1ac15704e849b71cddda0b2"
-REL=1
 CHKUPDATE="anitya::id=8367"


### PR DESCRIPTION
Topic Description
-----------------

- bup: replace ronn with ronn-ng
    ronn has been dropped from the tree.

Package(s) Affected
-------------------

- bup: 0.30-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
