### PR TITLE
kitty: update to 0.41.1

### DIFF
--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,4 +1,4 @@
-VER=0.39.1
+VER=0.41.1
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::4baa2a59de7569b3b34f44ea8536c53d312aa76d1347121a2d6557abfde21325"
+CHKSUMS="sha256::e30150fad1bcc885a7adbd87380696ef7b67a62a38f74634efbc05c3745f26aa"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.41.1
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- kitty: 0.41.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
