### PR TITLE
plasma-distro-base: don't recommend kdenlive, krita

### DIFF
--- a/meta-bases/plasma-distro-base/autobuild/defines
+++ b/meta-bases/plasma-distro-base/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=plasma-distro-base
 PKGSEC=Bases
 PKGDEP="kde-base plasma-default-settings"
-PKGRECOM="gparted haruna kblocks kbreakout kdenlive kdiamond kgoldrunner \
-          kmahjongg knights kolourpaint kpat krita kshisen ksudoku kubrick \
+PKGRECOM="gparted haruna kblocks kbreakout kdiamond kgoldrunner \
+          kmahjongg knights kolourpaint kpat kshisen ksudoku kubrick \
           pidgin strawberry teeworlds gimp flatpak snapd aosc-media-writer \
           remmina kcolorchooser deb-installer"
 PKGDES="Meta package for AOSC OS Plasma distribution extras"

--- a/meta-bases/plasma-distro-base/spec
+++ b/meta-bases/plasma-distro-base/spec
@@ -1,2 +1,2 @@
-VER=8
+VER=9
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

[plasma-distro-base: remove kdenlive and krita from PKGRECOM](https://github.com/AOSC-Dev/aosc-os-abbs/pull/10852/commits/04a6c1d96c059161028e80449bda2a5e0138ab75)

A significant portion of Kdenlive's 1.3 GiB share of the total added 3 GiB
closure size comes from the Doxygen documentation included in the vtk package,
as well as large dependencies such as openjdk-21 (642 MiB) and mariadb (301 MiB).

The remainder is taken up by Kdenlive and Krita themselves, along with other
miscellaneous dependencies of the two packages.

Pre-installation removal was discussed previously amongst contributors.

Package(s) Affected
-------------------

- plasma-distro-base: 8

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-distro-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
