### PR TITLE
bup: drop, orphaned

### DIFF
--- a/app-utils/bup/autobuild/build
+++ b/app-utils/bup/autobuild/build
@@ -1,2 +1,0 @@
-make
-make install DESTDIR="$PKGDIR" PREFIX=/usr

--- a/app-utils/bup/autobuild/defines
+++ b/app-utils/bup/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=bup
-PKGSEC=utils
-PKGDEP="fuse-python git par2cmdline pylibacl pyxattr"
-PKGSUG="tornado"
-BUILDDEP="${BUILDDEP} ronn"
-PKGDES="Highly efficient file backup system based on the git packfile format"

--- a/app-utils/bup/spec
+++ b/app-utils/bup/spec
@@ -1,5 +1,0 @@
-VER=0.30
-SRCS="tbl::https://github.com/bup/bup/archive/$VER.tar.gz"
-CHKSUMS="sha256::5238f045c220278a165fff528ea32288f2752db2e1ac15704e849b71cddda0b2"
-REL=1
-CHKUPDATE="anitya::id=8367"


### PR DESCRIPTION
Topic Description
-----------------

- bup: drop, orphaned
- subversion: apply loongarch64-specific options to loongarch64_nosimd
- python-3: apply loongarch64-specific options to loongarch64_nosimd
- pixman: apply loongarch64-specific options to loongarch64_nosimd
- pcre: apply loongarch64-specific options to loongarch64_nosimd
- os-prober: apply loongarch64-specific options to loongarch64_nosimd
- openssl: apply loongarch64-specific options to loongarch64_nosimd
- openmpi: apply loongarch64-specific options to loongarch64_nosimd
- nss: apply loongarch64-specific options to loongarch64_nosimd
- mpdecimal: apply loongarch64-specific options to loongarch64_nosimd

... and 13 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit bup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
