### PR TITLE
gdb: disable simulator

### DIFF
--- a/app-devel/gdb/autobuild/defines
+++ b/app-devel/gdb/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=gdb
 PKGSEC=devel
-PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline xz xxhash source-highlight ncurses libipt"
+PKGDEP="babeltrace elfutils expat glibc-dbg guile isl python-3 readline \
+        xz xxhash source-highlight ncurses libipt"
 PKGDEP__RETRO="expat glibc-dbg isl readline"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -12,31 +13,32 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="GNU source-level debugger for multiple programming languages"
 
-AUTOTOOLS_STRICT=0
-AUTOTOOLS_DEF="--prefix=/usr"
-AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
-                 --with-python=/usr/bin/python3 \
-                 --with-system-gdbinit=/etc/gdb/gdbinit \
-                 --with-intel-pt \
-                 --enable-guile --enable-tui --enable-sim \
-                 --enable-source-highlight --enable-threading \
-                 --enable-64-bit-bfd --disable-install-libbfd \
-                 --enable-targets=all --enable-languages=all"
-# TODO: Re-check this when updating this package in Retro
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-python \
-                 --disable-guile \
-                 --without-babeltrace \
-                 --disable-source-highlight"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
-
+# FIXME: configure.ac:35: error: Please use exactly Autoconf 2.69 instead of 2.72.
 RECONF=0
+
+# Note: Multi-level source.
+AUTOTOOLS_STRICT=0
+
+AUTOTOOLS_AFTER=(
+    '--with-system-readline'
+    '--with-xxhash'
+    '--with-python=/usr/bin/python3'
+    '--with-system-gdbinit=/etc/gdb/gdbinit'
+    '--with-intel-pt'
+    '--enable-guile'
+    '--enable-tui'
+    '--enable-source-highlight'
+    '--enable-threading'
+    '--enable-64-bit-bfd'
+    '--disable-install-libbfd'
+    '--enable-targets=all'
+    '--enable-languages=all'
+    '--disable-sim'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-python'
+    '--disable-guile'
+    '--without-babeltrace'
+    '--disable-source-highlight'
+)

--- a/app-devel/gdb/autobuild/defines.stage2
+++ b/app-devel/gdb/autobuild/defines.stage2
@@ -10,25 +10,32 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="GNU source-level debugger for multiple programming languages"
 
-AUTOTOOLS_STRICT=0
-AUTOTOOLS_DEF="--prefix=/usr"
-AUTOTOOLS_AFTER="--with-system-readline --with-xxhash \
-                 --with-python=/usr/bin/python3 \
-                 --with-system-gdbinit=/etc/gdb/gdbinit \
-                 --disable-guile --disable-tui --disable-sim \
-                 --disable-source-highlight --enable-threading \
-                 --enable-64-bit-bfd \
-                 --enable-targets=aarch64-linux-gnu,alpha-linux-gnu,arm-linux-gnueabi,arm-linux-gnueabihf,i486-linux-gnu,mips64el-linux-gnu,powerpc64le-linux-gnu,x86_64-linux-gnu,riscv64-linux-gnu,loongarch64-linux-gnu"
-# TODO: Re-check this when updating this package in Retro
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-python --disable-guile \
-                 --without-babeltrace"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+# FIXME: configure.ac:35: error: Please use exactly Autoconf 2.69 instead of 2.72.
 RECONF=0
+
+# Note: Multi-level source.
+AUTOTOOLS_STRICT=0
+
+AUTOTOOLS_AFTER=(
+    '--with-system-readline'
+    '--with-xxhash'
+    '--with-python=/usr/bin/python3'
+    '--with-system-gdbinit=/etc/gdb/gdbinit'
+    '--with-intel-pt'
+    '--disable-guile'
+    '--disable-tui'
+    '--disable-source-highlight'
+    '--enable-threading'
+    '--enable-64-bit-bfd'
+    '--disable-install-libbfd'
+    '--enable-targets=all'
+    '--enable-languages=all'
+    '--disable-sim'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-python'
+    '--disable-guile'
+    '--without-babeltrace'
+    '--disable-source-highlight'
+)

--- a/app-devel/gdb/spec
+++ b/app-devel/gdb/spec
@@ -1,4 +1,5 @@
 VER=16.3
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gdb/gdb-$VER.tar.xz"
 CHKSUMS="sha256::bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
 CHKUPDATE="anitya::id=11798"


### PR DESCRIPTION
Topic Description
-----------------

- gdb: disable simulator
    The GDB simulators \(run-\*\) are rarely used and bloated the package
    multiple folds.

Package(s) Affected
-------------------

- gdb: 16.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
