### PR TITLE
openblas: rebuild for static library stripping

### DIFF
--- a/app-scientific/openblas/spec
+++ b/app-scientific/openblas/spec
@@ -1,5 +1,5 @@
 VER=0.3.29
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/xianyi/OpenBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2540"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- openblas: rebuild for static library stripping
    Static library stripping was fixed with Autobuild 4.11.0, this should make
    the main package a lot smaller.

Package(s) Affected
-------------------

- openblas: 0.3.29-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openblas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
