### PR TITLE
man-pages: update to 6.14+posix2017a

### DIFF
--- a/runtime-data/man-pages/spec
+++ b/runtime-data/man-pages/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=6.13
+UPSTREAM_VER=6.14
 POSIXVER=2017-a
 VER=${UPSTREAM_VER}+posix${POSIXVER/-a/a}
 SRCS="tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${UPSTREAM_VER}.tar.xz \
       tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${POSIXVER}.tar.xz"
 SUBDIR="man-pages-${UPSTREAM_VER}"
-CHKSUMS="sha256::a2c8a0c2efe8a978ce51ce800461eb9e8931f12cc7ba4b7faa3082b69ba7f12c \
+CHKSUMS="sha256::71e13067b780044b2f372eec25f4209bc0413cc32af714141ef3d22d21eae8e3 \
          sha256::ce67bb25b5048b20dad772e405a83f4bc70faf051afa289361c81f9660318bc3"
 CHKUPDATE="anitya::id=1883"


### PR DESCRIPTION
Topic Description
-----------------

- man-pages: update to 6.14+posix2017a
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- man-pages: 6.14+posix2017a

Security Update?
----------------

No

Build Order
-----------

```
#buildit man-pages
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
