### PR TITLE
php: update to 8.4.7

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,4 +1,4 @@
-VER=8.4.6
+VER=8.4.7
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::089b08a5efef02313483325f3bacd8c4fe311cf1e1e56749d5cc7d059e225631"
+CHKSUMS="sha256::e29f4c23be2816ed005aa3f06bbb8eae0f22cc133863862e893515fc841e65e3"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.4.7
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- php: 1:8.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
