### PR TITLE
aosc-aaa: fix /var/run to ../run symlink

### DIFF
--- a/core-misc/aosc-aaa/autobuild/build
+++ b/core-misc/aosc-aaa/autobuild/build
@@ -20,8 +20,8 @@ mkdir -v  "$PKGDIR"/usr/libexec
 mkdir -pv "$PKGDIR"/usr/share/man/man{1..8}
 
 mkdir -v "$PKGDIR"/var/{log,mail,spool}
-ln -sv /run "$PKGDIR"/var/run
-ln -sv /run/lock "$PKGDIR"/var/lock
+ln -sv ../run "$PKGDIR"/var/run
+ln -sv ../run/lock "$PKGDIR"/var/lock
 mkdir -pv "$PKGDIR"/var/{opt,cache,local}
 
 #

--- a/core-misc/aosc-aaa/spec
+++ b/core-misc/aosc-aaa/spec
@@ -1,4 +1,5 @@
 VER=12.1.3
+REL=1
 __CODENAME="localhost"
 __BUILD_ID="20250415"
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-aaa: fix /var/run to ../run symlink
    When using aoscbootstrap to make a system, unpacking
    the \`aosc-aaa\` package causes \`/var/run\` to be symlink to \`/run\` on the host system

Package(s) Affected
-------------------

- aosc-aaa: 12.1.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-aaa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
