### PR TITLE
vscodium: update to 1.100.03093

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -10,6 +10,7 @@ export SKIP_LINUX_PACKAGES="True"
 export SHOULD_BUILD=yes
 export SHOULD_BUILD_REH=no
 export SHOULD_BUILD_REH_WEB=no
+export SHOULD_BUILD_CLI=no
 export CI_BUILD=yes
 export OS_NAME=linux
 export RELEASE_VERSION="$PKGVER"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.99.32704
+VER=1.100.03093
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.100.03093

Package(s) Affected
-------------------

- vscodium: 1.100.03093

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
