### PR TITLE
Revert "versioneer: drop, orphaned"

### DIFF
--- a/lang-python/versioneer/autobuild/defines
+++ b/lang-python/versioneer/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=versioneer
+PKGSEC=python
+PKGDES="VCS-based management of project version strings"
+PKGDEP="python-3 tomli"
+BUILDDEP="setuptools"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/versioneer/spec
+++ b/lang-python/versioneer/spec
@@ -1,0 +1,5 @@
+VER=0.29
+REL=1
+SRCS="pypi::version=$VER::versioneer"
+CHKSUMS="sha256::5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731"
+CHKUPDATE="anitya::id=221177"


### PR DESCRIPTION
Topic Description
-----------------

- Revert "versioneer: drop, orphaned"
    This reverts commit 85755c10cd9b273b2f7274402a3b67c95d766bc6.
    versioneer is stilled used by some packages as build
    dependency and cannot be dropped.
    - Use pypi source fetcher.
    - Add python-3 as runtime dependency.
    - Add CHKUPDATE.
    - Bump REL.

Package(s) Affected
-------------------

- versioneer: 0.29-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit versioneer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
