### PR TITLE
fcitx5-pinyin-moegirl: update to 20250509

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250409
+VER=20250509
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::3ae0096ee42cff2882149006d6a912fb420d7699a377073bbefcf9599aee43df \
-         sha256::fcc0585f565beba44ae8da30932e0b74c07a56dff89f8500c514cdd0a3837709 \
+CHKSUMS="sha256::334a2ab85a11e3821163776f4e3a59e3cb514e2f8e3fe1aa31f6f9b1d51cbab6
+         sha256::2ed7b5c6381aca146b930d519010b2f848adcec45bc0586d62b8654ea6cebed0
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250509

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250509
- rime-pinyin-moegirl: 20250509

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
