### PR TITLE
glab: new, 1.57.0


### DIFF
--- a/app-devel/glab/autobuild/beyond
+++ b/app-devel/glab/autobuild/beyond
@@ -1,0 +1,13 @@
+abinfo "Installing man pages ..."
+go run "$SRCDIR"/cmd/gen-docs/docs.go --manpage --path "$PKGDIR"/usr/share/man/man1
+
+abinfo "Installing README ..."
+install -Dvm644 "$SRCDIR/README.md" "$PKGDIR/usr/share/doc/$PKGNAME/README.md"
+
+abinfo "Installing shell completions ..."
+"$PKGDIR"/usr/bin/glab completion -s bash |
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/bash-completion/completions/glab
+"$PKGDIR"/usr/bin/glab completion -s zsh |
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/zsh/site-functions/_glab
+"$PKGDIR"/usr/bin/glab completion -s fish |
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/fish/vendor_completions.d/glab.fish

--- a/app-devel/glab/autobuild/defines
+++ b/app-devel/glab/autobuild/defines
@@ -1,0 +1,17 @@
+PKGNAME=glab
+PKGSEC=vcs
+PKGDES="Command-line tool to work with GitLab servers"
+PKGDEP="glibc git"
+BUILDDEP="go"
+
+ABTYPE=gomod
+GO_LDFLAGS=(
+    "-X main.debugMode=false"
+    "-X main.commit=AOSC"
+    "-X main.version='v${PKGVER}'"
+)
+GO_PACKAGES=("cmd/glab")
+
+# FIXME: Autobuild does not yet support splitting debug symbols out of Go
+# executables.
+ABSPLITDBG=0

--- a/app-devel/glab/spec
+++ b/app-devel/glab/spec
@@ -1,0 +1,4 @@
+VER=1.57.0
+SRCS="git::commit=tags/v$VER::https://gitlab.com/gitlab-org/cli.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=127208"


### PR DESCRIPTION
Topic Description
-----------------

- glab: new, 1.57.0

Package(s) Affected
-------------------

- glab: 1.57.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit glab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
