### PR TITLE
adaptivecpp: update to 25.02.0

### DIFF
--- a/app-devel/adaptivecpp/autobuild/defines
+++ b/app-devel/adaptivecpp/autobuild/defines
@@ -1,18 +1,28 @@
 PKGNAME=adaptivecpp
 PKGSEC=devel
-PKGDEP="boost gcc-runtime glibc llvm python-3"
+PKGDEP="boost gcc-runtime glibc llvm-20 python-3"
 PKGDES="Compiler for C++-based heterogeneous programming models"
-
-BUILDDEP="boost llvm python-3"
+# Note: adaptivecpp explicitly links against clang-20 and libLLVM-20.
+BUILDDEP="boost llvm-20 python-3"
 ABTYPE=cmakeninja
-CMAKE_AFTER=" \
+CMAKE_AFTER__BASE=" \
     -DACPP_COMPILER_FEATURE_PROFILE=full \
     -DACPP_CONFIG_FILE_GLOBAL_INSTALLATION=ON \
     -DCMAKE_SKIP_INSTALL_RPATH=OFF \
-    -DDEFAULT_TARGETS='omp.accelerated' \
-    -DLLVM_DIR=$(llvm-config --cmakedir) \
     -DWITH_CUDA_BACKEND=OFF \
     -DWITH_LEVEL_ZERO_BACKEND=OFF \
     -DWITH_OPENCL_BACKEND=OFF \
     -DWITH_ROCM_BACKEND=OFF \
+"
+# Note: LLVM supports OpenMP 5.1, newer than GCC’s 4.5.
+USECLANG=1
+CMAKE_AFTER=" \
+    ${CMAKE_AFTER__BASE} \
+    -DDEFAULT_TARGETS='omp.accelerated' \
+"
+# FIXME: LLVM OpenMP runtime is not available on loongson3.
+USECLANG__LOONGSON3=0
+CMAKE_AFTER__LOONGSON3=" \
+    ${CMAKE_AFTER__BASE} \
+    -DDEFAULT_TARGETS='omp.library-only' \
 "

--- a/app-devel/adaptivecpp/spec
+++ b/app-devel/adaptivecpp/spec
@@ -1,4 +1,4 @@
-VER=24.10.0
+VER=25.02.0
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/AdaptiveCpp/AdaptiveCpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=176075"


### PR DESCRIPTION
Topic Description
-----------------

- adaptivecpp: update to 25.02.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- adaptivecpp: 25.02.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit adaptivecpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
