### PR TITLE
pycairo: update to 1.28.0

### DIFF
--- a/app-utils/variety/autobuild/defines
+++ b/app-utils/variety/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=variety
 PKGSEC=x11
-PKGDEP="desktop-file-utils gtk-3 imagemagick libnotify beautifulsoup4 py2cairo \
+PKGDEP="desktop-file-utils gtk-3 imagemagick libnotify beautifulsoup4 pycairo \
         configobj dbus-python gexiv2 pygobject-3 httplib2 lxml pillow pycurl yelp \
         requests gexiv2"
 BUILDDEP="python-distutils-extra intltool"

--- a/app-utils/variety/spec
+++ b/app-utils/variety/spec
@@ -1,5 +1,5 @@
 VER=0.7.1
-REL=4
+REL=5
 SRCS="tbl::https://github.com/varietywalls/variety/archive/$VER.tar.gz"
 CHKSUMS="sha256::de27d35f386b3ce71f4e0b25675936da196a7daf85fbc3611441ad1c2783e2d6"
 CHKUPDATE="anitya::id=16322"

--- a/desktop-gnome/meld/autobuild/defines
+++ b/desktop-gnome/meld/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=meld
 PKGSEC=gnome
-PKGDEP="gsettings-desktop-schemas gtksourceview-4 py2cairo \
+PKGDEP="gsettings-desktop-schemas gtksourceview-4 pycairo \
         pygobject-3 dbus-python"
 BUILDDEP="appstream-glib gtk-4 intltool itstool"
 PKGDES="A visual diff and merge tool targeted at developers"

--- a/desktop-gnome/meld/spec
+++ b/desktop-gnome/meld/spec
@@ -1,4 +1,5 @@
 VER=3.22.2
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/meld/${VER:0:4}/meld-$VER.tar.xz"
 CHKSUMS="sha256::46a0a713fbcd1b153b377a1e0757c8ce255c9822467658eacfbd89b1e92316ef"
 CHKUPDATE="anitya::id=5520"

--- a/desktop-gnome/terminator/autobuild/defines
+++ b/desktop-gnome/terminator/autobuild/defines
@@ -2,7 +2,7 @@ ABTYPE=python
 PKGNAME=terminator
 PKGDES="Terminal emulator that supports tabs and grids"
 PKGSEC=x11
-PKGDEP="dbus-python keybinder-3.0 libnotify py2cairo pygobject-3 pypsutil \
+PKGDEP="dbus-python keybinder-3.0 libnotify pycairo pygobject-3 pypsutil \
         vte-gtk3 xdg-utils pypsutil gsettings-desktop-schemas configobj"
 BUILDDEP="gettext desktop-file-utils intltool"
 

--- a/desktop-gnome/terminator/spec
+++ b/desktop-gnome/terminator/spec
@@ -2,3 +2,4 @@ VER=2.1.4
 SRCS="https://github.com/gnome-terminator/terminator/releases/download/v$VER/terminator-$VER.tar.gz"
 CHKSUMS="sha256::af27b0ece862e61dde71d0827afa4a29a414e44599effe3edeebc52cbdf0c5e8"
 CHKUPDATE="anitya::id=228590"
+REL=1

--- a/lang-python/meson-python/autobuild/defines
+++ b/lang-python/meson-python/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=meson-python
+PKGSEC=python
+PKGDEP="meson packaging tomli pyproject-metadata patchelf"
+BUILDDEP="python-build"
+PKGDES="Meson PEP-517 Python build backend"
+
+ABTYPE=pep517
+ABSPLITDBG=0

--- a/lang-python/meson-python/spec
+++ b/lang-python/meson-python/spec
@@ -1,0 +1,4 @@
+VER=0.17.1
+SRCS="git::commit=tags/${VER}::https://github.com/mesonbuild/meson-python"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=248985"

--- a/lang-python/py2cairo/autobuild/build
+++ b/lang-python/py2cairo/autobuild/build
@@ -1,1 +1,0 @@
-mkdir "$PKGDIR"

--- a/lang-python/py2cairo/autobuild/defines
+++ b/lang-python/py2cairo/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=py2cairo
-PKGSEC=python
-PKGDEP="pycairo"
-PKGDES="Transitional package for PyCairo"
-
-ABHOST=noarch
-PKGEPOCH=1

--- a/lang-python/py2cairo/spec
+++ b/lang-python/py2cairo/spec
@@ -1,2 +1,0 @@
-VER=0
-DUMMYSRC=1

--- a/lang-python/pycairo/autobuild/defines
+++ b/lang-python/pycairo/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=pycairo
 PKGSEC=python
-PKGDEP="cairo python-2 python-3"
+PKGDEP="cairo python-3"
+BUILDDEP="meson-python"
 PKGDES="Python bindings to the Cairo Graphics Library"
 
 PKGREP="py2cairo<=1.10.0-5 py3cairo<=1.10.0-4"
 PKGBREAK="py2cairo<=1.10.0-5 py3cairo<=1.10.0-4"
 
-ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/pycairo/spec
+++ b/lang-python/pycairo/spec
@@ -1,5 +1,4 @@
-VER=1.18.2
+VER=1.28.0
 SRCS="tbl::https://github.com/pygobject/pycairo/releases/download/v$VER/pycairo-$VER.tar.gz"
-CHKSUMS="sha256::dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531"
-REL=2
+CHKSUMS="sha256::26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc"
 CHKUPDATE="anitya::id=31975"


### PR DESCRIPTION
Topic Description
-----------------

- pycairo: update to 1.28.0
- meson-python: new, 0.17.1
- py2cairo: drop, PyCairo no longer supports Python 2.x
    X-AOSC-dropit-package: py2cairo
    X-AOSC-dropit-directory: lang-python/py2cairo
- variety: rename py2cairo dependency to pycairo
- terminator: rename py2cairo dependency to pycairo
- meld: rename py2cairo dependency to pycairo

Package(s) Affected
-------------------

- meld: 3.22.2-1
- meson-python: 0.17.1
- pycairo: 1.28.0
- terminator: 2.1.4-1
- variety: 0.7.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit variety terminator meld meson-python pycairo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
