### PR TITLE
Split LTO symbol Survey 20250510

### DIFF
--- a/core-libs/glibc/spec
+++ b/core-libs/glibc/spec
@@ -1,5 +1,5 @@
 VER=2.40
-REL=2
+REL=3
 LOCALEGENVER=20160914
 SRCS="tbl::https://ftp.gnu.org/gnu/glibc/glibc-$VER.tar.xz \
       https://github.com/AOSC-Dev/locale-gen/archive/refs/tags/v$LOCALEGENVER.tar.gz"

--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,5 +1,5 @@
 VER=2.84.0
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
 CHKSUMS="sha256::f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"
 CHKUPDATE="anitya::id=10024"

--- a/runtime-common/jemalloc/spec
+++ b/runtime-common/jemalloc/spec
@@ -1,4 +1,5 @@
 VER=5.3.0
+REL=1
 SRCS="tbl::https://github.com/jemalloc/jemalloc/releases/download/$VER/jemalloc-$VER.tar.bz2"
 CHKSUMS="sha256::2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa"
 CHKUPDATE="anitya::id=1441"


### PR DESCRIPTION
Topic Description
-----------------

- glib: rebuild for split LTO symbol
- jemalloc: rebuild for split LTO symbol
- glibc: rebuild for split LTO symbol

Package(s) Affected
-------------------

- glib: 2.84.0-3
- glibc: 1:2.40-3
- jemalloc: 5.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glibc jemalloc glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
