### PR TITLE
systemd: move libxkbcommon to build dependency

### DIFF
--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -1,14 +1,14 @@
 PKGNAME=systemd
 PKGSEC=admin
-PKGDEP="glib lz4 xz acl bash cryptsetup curl elfutils gnutls kbd kmod \
-        libcap libidn2 libmicrohttpd linux-pam util-linux-runtime libgcrypt hwdata \
-        libgpg-error iptables libxkbcommon qrencode aosc-aaa \
-        libseccomp pcre2 zstd libfido2 tpm2-tss p11-kit openssl zlib bzip2"
+PKGDEP="glib lz4 xz acl bash cryptsetup curl elfutils gnutls kbd kmod libcap \
+        libidn2 libmicrohttpd linux-pam util-linux-runtime libgcrypt hwdata \
+        libgpg-error iptables qrencode aosc-aaa libseccomp pcre2 zstd \
+        libfido2 tpm2-tss p11-kit openssl zlib bzip2"
 # See comments for MESON_AFTER__LOONGSON3.
-PKGDEP__LOONGSON3="glib lz4 xz acl bash cryptsetup curl elfutils gnutls kbd kmod \
-        libcap libidn2 libmicrohttpd linux-pam util-linux-runtime libgcrypt hwdata \
-        libgpg-error iptables libxkbcommon qrencode aosc-aaa \
-        pcre2 zstd libfido2 tpm2-tss p11-kit openssl zlib bzip2"
+PKGDEP__LOONGSON3="glib lz4 xz acl bash cryptsetup curl elfutils gnutls kbd \
+        kmod libcap libidn2 libmicrohttpd linux-pam util-linux-runtime \
+        libgcrypt hwdata libgpg-error iptables qrencode aosc-aaa pcre2 zstd \
+        libfido2 tpm2-tss p11-kit openssl zlib bzip2"
 PKGDEP__RETRO="glib acl bash kbd libcap linux-pam util-linux hwdata \
                aosc-aaa kmod polkit dbus openssl zlib bzip2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
@@ -19,7 +19,8 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="gobject-introspection gperf gtk-doc intltool jinja2 llvm lxml pyelftools"
+BUILDDEP="gobject-introspection gperf gtk-doc intltool jinja2 llvm lxml \
+          pyelftools libxkbcommon"
 BUILDDEP__RETRO="docbook-xsl gperf intltool jinja2 libxslt"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=257.2
 
 # Use this for stable releases.
-REL=2
+REL=3
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 


### PR DESCRIPTION
Topic Description
-----------------

- systemd: move libxkbcommon to build dep
    libxkbcommon.so is only loaded via dlopen\(\) for locale and logind and not
    a runtime dependency.

Package(s) Affected
-------------------

- systemd: 1:257.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
