### PR TITLE
Python 2 purge: systemd dependencies

### DIFF
--- a/lang-python/pyudev/autobuild/defines
+++ b/lang-python/pyudev/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pyudev
 PKGSEC=python
-PKGDEP="six systemd"
+PKGDEP="systemd"
 BUILDDEP="setuptools"
 PKGDES="A pure Python binding for libudev"
 

--- a/lang-python/pyudev/spec
+++ b/lang-python/pyudev/spec
@@ -1,5 +1,4 @@
-VER=0.24.1
-REL=1
+VER=0.24.3
 SRCS="git::commit=tags/v$VER::https://github.com/pyudev/pyudev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8485"

--- a/runtime-common/newt/autobuild/defines
+++ b/runtime-common/newt/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=newt
 PKGSEC=libs
-PKGDEP="gpm popt slang python-2 python-3 tcl"
+PKGDEP="gpm popt slang python-3 tcl"
 PKGDEP__RETRO="gpm popt slang"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -17,12 +17,13 @@ PKGPROV="whiptail"
 # FIXME: Makefile reads hard-coded "$SRCDIR"/configure.ac (in relative path)
 # for some reason.
 ABSHADOW=0
+NOPYTHON2=1
+
 AUTOTOOLS_AFTER="--enable-largefile \
                  --enable-nls \
                  --with-python \
                  --with-tcl \
-                 --with-gpm-support \
-                 PYTHON=/usr/bin/python3"
+                 --with-gpm-support"
 AUTOTOOLS_AFTER__RETRO=" \
                  ${AUTOTOOLS_AFTER} \
                  --without-python \

--- a/runtime-common/newt/autobuild/patch
+++ b/runtime-common/newt/autobuild/patch
@@ -1,2 +1,0 @@
-sed -i "s:tcl8.4:tcl8.6:" Makefile.in
-echo '#define USE_INTERP_RESULT 1' >> config.h

--- a/runtime-common/newt/spec
+++ b/runtime-common/newt/spec
@@ -1,4 +1,4 @@
-VER=0.52.23
+VER=0.52.25
 SRCS="tbl::https://pagure.io/releases/newt/newt-$VER.tar.gz"
-CHKSUMS="sha256::caa372907b14ececfe298f0d512a62f41d33b290610244a58aed07bbc5ada12a"
+CHKSUMS="sha256::ef0ca9ee27850d1a5c863bb7ff9aa08096c9ed312ece9087b30f3a426828de82"
 CHKUPDATE="anitya::id=15129"

--- a/runtime-cryptography/libpwquality/autobuild/defines
+++ b/runtime-cryptography/libpwquality/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=libpwquality
 PKGSEC=libs
-PKGDEP="cracklib python-2"
+PKGDEP="cracklib python-3"
 PKGDES="Library for password quality checking and generating random passwords"
 
 ABSHADOW=no
+AUTOTOOLS_AFTER=(
+    "--with-python-binary=python3"
+)

--- a/runtime-cryptography/libpwquality/spec
+++ b/runtime-cryptography/libpwquality/spec
@@ -1,4 +1,4 @@
-VER=1.4.2
+VER=1.4.5
 SRCS="tbl::https://github.com/libpwquality/libpwquality/releases/download/libpwquality-$VER/libpwquality-$VER.tar.bz2"
-CHKSUMS="sha256::5263e09ee62269c092f790ac159112aed3e66826a795e3afec85fdeac4281c8e"
+CHKSUMS="sha256::6fcf18b75d305d99d04d2e42982ed5b787a081af2842220ed63287a2d6a10988"
 CHKUPDATE="anitya::id=15580"


### PR DESCRIPTION
Topic Description
-----------------

- newt: update to 0.52.23, drop python 2 binding
- pyudev: update to 0.24.3
- libpwquality: update to 1.4.5

Package(s) Affected
-------------------

- libpwquality: 1.4.5
- newt: 0.52.25
- pyudev: 0.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpwquality pyudev newt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
