### PR TITLE
lxml: update to 5.4.0

### DIFF
--- a/lang-python/lxml/autobuild/defines
+++ b/lang-python/lxml/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=lxml
 PKGSEC=python
-PKGDEP="beautifulsoup4 html5lib-python libxslt python-3 python-cssselect"
-BUILDDEP="cython pygments sphinx sphinx-rtd-theme"
+PKGDEP="html5lib-python libxslt python-3 python-cssselect"
+BUILDDEP="cython pygments sphinx sphinx-rtd-theme setuptools wheel"
 PKGDES="Python bindings for the libxml2 and libxslt libraries"
 
 NOPYTHON2=1

--- a/lang-python/lxml/autobuild/patches/0001-Add-missing-import.patch
+++ b/lang-python/lxml/autobuild/patches/0001-Add-missing-import.patch
@@ -1,0 +1,35 @@
+From 5659e2da2a5a01c7ed036108cf11853469daadf9 Mon Sep 17 00:00:00 2001
+From: Stefan Behnel <stefan_ml@behnel.de>
+Date: Sun, 9 Feb 2025 14:54:22 +0100
+Subject: [PATCH 1/3] Add missing import.
+X-Developer-Signature: v=1; a=openpgp-sha256; l=751; i=xtexchooser@duck.com;
+ h=from:subject; bh=upP0B1NolAQkMaGx0EJx+fbHLJEwbqhE2Uv+6k9szhI=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBny7nNXMrc12RS7+nofPFlrPO/3m+tNNi8vJvipfY/Vk
+ potscuro5SFQYyLQVZMkaXIsMGbVSedX3RZuSzMHFYmkCEMXJwCMBHvdEaGtiJNXr+9XHPs+789
+ av289kzbu0uWOu2txqELeJvP8vdfYPif8q7zlyuX3ebHrCfbE6/ISm7cE/O4MiM6oEO+xn+q5kc
+ OAA==
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+(cherry picked from commit f1027a5c51453a38b695d5cbd43e87ad486173de)
+---
+ src/lxml/objectify.pyx | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/lxml/objectify.pyx b/src/lxml/objectify.pyx
+index 0ff922262ed5..3efac00516c7 100644
+--- a/src/lxml/objectify.pyx
++++ b/src/lxml/objectify.pyx
+@@ -18,6 +18,7 @@ from lxml.includes cimport tree
+ cimport lxml.includes.etreepublic as cetree
+ cimport libc.string as cstring_h   # not to be confused with stdlib 'string'
+ from libc.string cimport const_char
++from libc cimport limits
+ 
+ __all__ = ['BoolElement', 'DataElement', 'E', 'Element', 'ElementMaker',
+            'FloatElement', 'IntElement', 'NoneElement',
+
+base-commit: 4660da0bd7e3670919a20aef8fba1e9f7cb9391e
+-- 
+2.49.0
+

--- a/lang-python/lxml/autobuild/patches/0002-Build-Switch-to-Cython-3.1.patch
+++ b/lang-python/lxml/autobuild/patches/0002-Build-Switch-to-Cython-3.1.patch
@@ -1,0 +1,53 @@
+From 1b2d7dfad91a3e6c27d38e0595e6a33b79d453a8 Mon Sep 17 00:00:00 2001
+From: Stefan Behnel <stefan_ml@behnel.de>
+Date: Tue, 18 Feb 2025 14:26:30 +0100
+Subject: [PATCH 2/3] Build: Switch to Cython 3.1.
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1076; i=xtexchooser@duck.com;
+ h=from:subject; bh=1oST4LM/z1MkWMaZKGEAOGimBgdtOzoGGAVGYo8x/b0=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBny7vMOXKuTiNqcUsb7N5znzf7im96/z/8WbPnCmnP6T
+ dJWLZG5HaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIkIJTMyrJBeFT1lgoX77A3W
+ k/oS2B/e+nRin/2BSQfmfNjSl7ntZQzDX7nu25szVodXPvHYcifn/Sb5FsWi7ZaiH848KhZrZjh
+ vxQ8A
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+(cherry picked from commit ffad0f5da7a6c8541a1414dc903abd79b77027f8)
+---
+ CHANGES.txt      | 1 +
+ pyproject.toml   | 2 +-
+ requirements.txt | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CHANGES.txt b/CHANGES.txt
+index 3e12547a4196..33216136bb44 100644
+--- a/CHANGES.txt
++++ b/CHANGES.txt
+@@ -23,6 +23,7 @@ Bugs fixed
+ 
+ * Binary wheels use libxml2 2.12.10 and libxslt 1.1.42.
+ 
++* Built using Cython 3.1.0a1.
+ * Binary wheels for Windows use a patched libxml2 2.11.9 and libxslt 1.1.39.
+ 
+ 
+diff --git a/pyproject.toml b/pyproject.toml
+index 1f692e7e3c0e..1d5c50dd8d94 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["Cython>=3.0.11, < 3.1.0", "setuptools", "wheel"]
++requires = ["Cython>=3.1.0a1", "setuptools", "wheel"]
+ 
+ [tool.cibuildwheel]
+ build-verbosity = 1
+diff --git a/requirements.txt b/requirements.txt
+index e0c052464622..8b337a4f4e29 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1 +1 @@
+-Cython>=3.0.11, < 3.1.0
++Cython>=3.1.0a1
+-- 
+2.49.0
+

--- a/lang-python/lxml/autobuild/patches/0003-Avoid-custom-tp_new-call-and-add-a-safe-guard-that-e.patch
+++ b/lang-python/lxml/autobuild/patches/0003-Avoid-custom-tp_new-call-and-add-a-safe-guard-that-e.patch
@@ -1,0 +1,103 @@
+From 4dcf5bbf6ca9b8695ce6e5f7410f28770ee8f7be Mon Sep 17 00:00:00 2001
+From: Stefan Behnel <stefan_ml@behnel.de>
+Date: Wed, 28 Aug 2024 11:16:55 +0200
+Subject: [PATCH 3/3] Avoid custom "tp_new()" call and add a safe-guard that
+ element lookups actually return a type.
+X-Developer-Signature: v=1; a=openpgp-sha256; l=3631; i=xtexchooser@duck.com;
+ h=from:subject; bh=l4kS98TObsdQjPaJujyeNx8gqWaqmE/hVWy+aUkhQ9U=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBny7vPSpBu/N5mIh5bNL2HdHTQj9qvPpOebbKwXbeFPc
+ lNbrTqno5SFQYyLQVZMkaXIsMGbVSedX3RZuSzMHFYmkCEMXJwCMBENVUaGzid3it7v2cGzz33O
+ 4d4bq07KxpyvvOxi+unL5Y/lKo+3LGFkuJD4vYt3ZWf5BfaQnW16Vb37sqddvPPjrXGgh+7itRO
+ q2QA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+(cherry picked from commit 6d5d6aed2e38e1abc625f29c0b3e97fc8c60ae3b)
+---
+ src/lxml/etree.pyx             | 12 +++++-------
+ src/lxml/includes/etree_defs.h |  8 ++------
+ src/lxml/python.pxd            |  1 -
+ 3 files changed, 7 insertions(+), 14 deletions(-)
+
+diff --git a/src/lxml/etree.pyx b/src/lxml/etree.pyx
+index f7da01c1a7c5..1979c634ed53 100644
+--- a/src/lxml/etree.pyx
++++ b/src/lxml/etree.pyx
+@@ -1637,11 +1637,6 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
+         return CSSSelector(expr, translator=translator)(self)
+ 
+ 
+-cdef extern from "includes/etree_defs.h":
+-    # macro call to 't->tp_new()' for fast instantiation
+-    cdef object NEW_ELEMENT "PY_NEW" (object t)
+-
+-
+ @cython.linetrace(False)
+ cdef _Element _elementFactory(_Document doc, xmlNode* c_node):
+     cdef _Element result
+@@ -1651,12 +1646,15 @@ cdef _Element _elementFactory(_Document doc, xmlNode* c_node):
+     if c_node is NULL:
+         return None
+ 
+-    element_class = LOOKUP_ELEMENT_CLASS(
++    element_class = <type> LOOKUP_ELEMENT_CLASS(
+         ELEMENT_CLASS_LOOKUP_STATE, doc, c_node)
++    if type(element_class) is not type:
++        if not isinstance(element_class, type):
++            raise TypeError(f"Element class is not a type, got {type(element_class)}")
+     if hasProxy(c_node):
+         # prevent re-entry race condition - we just called into Python
+         return getProxy(c_node)
+-    result = NEW_ELEMENT(element_class)
++    result = element_class.__new__(element_class)
+     if hasProxy(c_node):
+         # prevent re-entry race condition - we just called into Python
+         result._c_node = NULL
+diff --git a/src/lxml/includes/etree_defs.h b/src/lxml/includes/etree_defs.h
+index 17d470d03ae2..8645869ffd4a 100644
+--- a/src/lxml/includes/etree_defs.h
++++ b/src/lxml/includes/etree_defs.h
+@@ -177,7 +177,7 @@ long _ftol2( double dblSource ) { return _ftol( dblSource ); }
+ 
+ #ifdef __GNUC__
+ /* Test for GCC > 2.95 */
+-#if __GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95)) 
++#if __GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95))
+ #define unlikely_condition(x) __builtin_expect((x), 0)
+ #else /* __GNUC__ > 2 ... */
+ #define unlikely_condition(x) (x)
+@@ -190,10 +190,6 @@ long _ftol2( double dblSource ) { return _ftol( dblSource ); }
+   #define Py_TYPE(ob)   (((PyObject*)(ob))->ob_type)
+ #endif
+ 
+-#define PY_NEW(T) \
+-     (((PyTypeObject*)(T))->tp_new( \
+-             (PyTypeObject*)(T), __pyx_empty_tuple, NULL))
+-
+ #define _fqtypename(o)  ((Py_TYPE(o))->tp_name)
+ 
+ #define lxml_malloc(count, item_size) \
+@@ -268,7 +264,7 @@ static void* lxml_unpack_xmldoc_capsule(PyObject* capsule, int* is_owned) {
+  * 'inclusive' is 1).  The _ELEMENT_ variants will only stop on nodes
+  * that match _isElement(), the normal variant will stop on every node
+  * except text nodes.
+- * 
++ *
+  * To traverse the node and all of its children and siblings in Pyrex, call
+  *    cdef xmlNode* some_node
+  *    BEGIN_FOR_EACH_ELEMENT_FROM(some_node.parent, some_node, 1)
+diff --git a/src/lxml/python.pxd b/src/lxml/python.pxd
+index d087735528b0..e0ec762ea31e 100644
+--- a/src/lxml/python.pxd
++++ b/src/lxml/python.pxd
+@@ -131,7 +131,6 @@ cdef extern from "includes/etree_defs.h": # redefines some functions as macros
+     cdef void* lxml_unpack_xmldoc_capsule(object capsule, bint* is_owned) except? NULL
+     cdef bint _isString(object obj)
+     cdef const_char* _fqtypename(object t)
+-    cdef object PY_NEW(object t)
+     cdef bint IS_PYPY
+     cdef object PyOS_FSPath(object obj)
+ 
+-- 
+2.49.0
+

--- a/lang-python/lxml/spec
+++ b/lang-python/lxml/spec
@@ -1,4 +1,4 @@
-VER=4.7.1
-SRCS="tbl::https://github.com/lxml/lxml/archive/refs/tags/lxml-$VER.tar.gz"
-CHKSUMS="sha256::c495545191397b26ce33a2749e13a64bc2b44894e39fd92c4243922e36f7d5a9"
+VER=5.4.0
+SRCS="git::commit=tags/lxml-$VER::https://github.com/lxml/lxml"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3914"


### PR DESCRIPTION
Topic Description
-----------------

- lxml: update to 5.4.0
    - Add patches to fix build with Cython >= 3.1.0.
    - Use Git source to replace GitHub-generated tarball in accordance with
    the Styling Manual.

Package(s) Affected
-------------------

- lxml: 5.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
