### PR TITLE
adaptivecpp: use current default llvm

### DIFF
--- a/app-devel/adaptivecpp/autobuild/defines
+++ b/app-devel/adaptivecpp/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=adaptivecpp
 PKGSEC=devel
-PKGDEP="boost gcc-runtime glibc llvm-20 python-3"
+PKGDEP="boost gcc-runtime glibc llvm python-3"
 PKGDES="Compiler for C++-based heterogeneous programming models"
-# Note: adaptivecpp explicitly links against clang-20 and libLLVM-20.
-BUILDDEP="boost llvm-20 python-3"
+BUILDDEP="boost llvm python-3"
 ABTYPE=cmakeninja
 CMAKE_AFTER__BASE=" \
     -DACPP_COMPILER_FEATURE_PROFILE=full \
@@ -14,7 +13,7 @@ CMAKE_AFTER__BASE=" \
     -DWITH_OPENCL_BACKEND=OFF \
     -DWITH_ROCM_BACKEND=OFF \
 "
-# Note: LLVM supports OpenMP 5.1, newer than GCC’s 4.5.
+# Note: LLVM supports OpenMP 5.1, newer than GCC's 4.5.
 USECLANG=1
 CMAKE_AFTER=" \
     ${CMAKE_AFTER__BASE} \

--- a/app-devel/adaptivecpp/spec
+++ b/app-devel/adaptivecpp/spec
@@ -1,4 +1,5 @@
 VER=25.02.0
+REL=1
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/AdaptiveCpp/AdaptiveCpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=176075"


### PR DESCRIPTION
Topic Description
-----------------

- adaptivecpp: use current default llvm

Package(s) Affected
-------------------

- adaptivecpp: 25.02.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit adaptivecpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
