### PR TITLE
oma: update to 1.17.2

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -1,3 +1,10 @@
+abinfo "Generate completions and manpages ..."
+mkdir -pv "$SRCDIR"/completions
+COMPLETE=bash "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/oma.bash
+COMPLETE=zsh "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/_oma
+COMPLETE=fish "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/oma.fish
+"$PKGDIR"/usr/bin/oma generate-manpages
+
 abinfo "Installing command-not-found handler shell script to /etc/bashrc.d ..."
 mkdir -pv "$PKGDIR"/etc/bashrc.d
 cp -v "$SRCDIR"/data/command-not-found/command-not-found.sh \
@@ -15,7 +22,7 @@ cp -v "$SRCDIR"/data/command-not-found/command-not-found.fish \
 
 abinfo "Installing man to /usr/share/man/man1 ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
-cp -v "$SRCDIR"/data/man/*.1 \
+cp -v "$SRCDIR"/man/*.1 \
 	"$PKGDIR"/usr/share/man/man1
 
 abinfo "Installing Policykit config file ..."
@@ -25,12 +32,17 @@ cp -v "$SRCDIR"/data/policykit/io.aosc.oma.apply.policy \
 
 abinfo "Installing bash completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
-cp -v "$SRCDIR"/data/completions/oma.bash \
+cp -v "$SRCDIR"/completions/oma.bash \
 	"$PKGDIR"/usr/share/bash-completion/completions/oma.bash
+
+abinfo "Installing zsh completions ..."
+mkdir -pv "$PKGDIR"/usr/share/zsh/functions/Completion/Linux
+cp -v "$SRCDIR"/completions/_oma \
+	"$PKGDIR"/usr/share/zsh/functions/Completion/Linux/_oma
 
 abinfo "Installing fish completions ..."
 mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d/
-cp -v "$SRCDIR"/data/completions/oma.fish \
+cp -v "$SRCDIR"/completions/oma.fish \
 	"$PKGDIR"/usr/share/fish/vendor_completions.d/oma.fish
 
 abinfo "Installing config file ..."

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.16.6
+VER=1.17.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.17.2.toml
+++ b/topics/oma-1.17.2.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.17.2"
+zh_CN = "小熊猫包管理 (oma) 1.17.2"
+
+[caution]
+default = "With newly introduced disk usage analyzer, low storage warning, Zsh shell completions, and more"
+zh_CN = "包含全新磁盘占用分析器、磁盘将满警告、Zsh 补全等新特性"
+
+[packages]
+oma = "1.17.2"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.17.2

Package(s) Affected
-------------------

- oma: 1.17.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



