### PR TITLE
qt-6: rebuild for static library stripping

### DIFF
--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=3
+REL=4
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::659d8bb5931afac9ed5d89a78e868e6bd00465a58ab566e2123db02d674be559"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: rebuild for static library stripping
    Static library stripping was fixed again with Autobuild 4.11.1.

Package(s) Affected
-------------------

- qt-6: 6.8.2-4
- qt-6-doc: 6.8.2-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
