### PR TITLE
funcsigs: drop, orphaned

### DIFF
--- a/app-web/certbot-apache/autobuild/defines
+++ b/app-web/certbot-apache/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=certbot-apache
 PKGSEC=net
-PKGDEP="certbot python-augeas acme mock setuptools zope-interface"
+PKGDEP="certbot python-augeas acme setuptools zope-interface"
 PKGDES="Apache plugin for CertBot"
 
 NOPYTHON2=1

--- a/app-web/certbot-apache/spec
+++ b/app-web/certbot-apache/spec
@@ -2,3 +2,4 @@ VER=2.10.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-apache/certbot-apache-$VER.tar.gz"
 CHKSUMS="sha256::c7a46ff67eac2834a3e3b975e7a1d1bc7a7be889f51c2cdc87825abd5ccc825a"
 CHKUPDATE="anitya::id=10837"
+REL=1

--- a/app-web/certbot-dns-cloudflare/autobuild/defines
+++ b/app-web/certbot-dns-cloudflare/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=certbot-dns-cloudflare
 PKGSEC=python
-PKGDEP="certbot acme mock python-cloudflare setuptools zope-interface"
+PKGDEP="certbot acme python-cloudflare setuptools zope-interface"
 PKGDES="Cloudflare DNS challenge plugin for Certbot"
 
 NOPYTHON2=1

--- a/app-web/certbot-dns-cloudflare/spec
+++ b/app-web/certbot-dns-cloudflare/spec
@@ -2,3 +2,4 @@ VER=2.10.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-dns-cloudflare/certbot-dns-cloudflare-$VER.tar.gz"
 CHKSUMS="sha256::45b058c3e515a1853b33dcc3367c12978c0930990a563d26c879d9883a639c07"
 CHKUPDATE="anitya::id=17035"
+REL=1

--- a/app-web/certbot-nginx/autobuild/defines
+++ b/app-web/certbot-nginx/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=certbot-nginx
 PKGSEC=python
-PKGDEP="certbot pyparsing acme mock setuptools zope-interface"
+PKGDEP="certbot pyparsing acme setuptools zope-interface"
 PKGDES="Nginx plugin for CertBot"
 
 NOPYTHON2=1

--- a/app-web/certbot-nginx/spec
+++ b/app-web/certbot-nginx/spec
@@ -2,3 +2,4 @@ VER=2.10.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot-nginx/certbot-nginx-$VER.tar.gz"
 CHKSUMS="sha256::9add7e8b7005fe6d8405cb74fd868d4b3689a572957a9112d654a5ac1e7f4d91"
 CHKUPDATE="anitya::id=15248"
+REL=1

--- a/app-web/certbot/autobuild/defines
+++ b/app-web/certbot/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=certbot
 PKGSEC=net
 # Really should have been acme=${PKGVER} but alas acbs doesn't have that yet
 # - cth451
-PKGDEP="acme ca-certs configargparse configobj future josepy mock parsedatetime pyopenssl \
+PKGDEP="acme ca-certs configargparse configobj future josepy parsedatetime pyopenssl \
         pypsutil pyrfc3339 pythondialog pytz requests setuptools six toolbelt zope-component zope-interface distro"
 PKGDES="A tool to automatically receive and install X.509 certificates to enable TLS on servers"
 

--- a/app-web/certbot/spec
+++ b/app-web/certbot/spec
@@ -2,3 +2,4 @@ VER=2.11.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
 CHKSUMS="sha256::257ae1cb0a534373ca50dd807c9ae96f27660e41379c45afb9b50cab0e6a7a97"
 CHKUPDATE="anitya::id=10690"
+REL=1

--- a/lang-python/funcsigs/autobuild/defines
+++ b/lang-python/funcsigs/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=funcsigs
-PKGSEC=python
-PKGDEP="python-2"
-BUILDDEP="setuptools"
-PKGDES="Python function signatures from PEP362"
-
-NOPYTHON3=1
-
-ABHOST=noarch

--- a/lang-python/funcsigs/spec
+++ b/lang-python/funcsigs/spec
@@ -1,5 +1,0 @@
-VER=1.0.2
-REL=2
-SRCS="tbl::https://pypi.io/packages/source/f/funcsigs/funcsigs-$VER.tar.gz"
-CHKSUMS="sha256::a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-CHKUPDATE="anitya::id=8268"

--- a/lang-python/logfury/autobuild/defines
+++ b/lang-python/logfury/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=logfury
 PKGSEC=python
-PKGDEP="python-3 funcsigs six"
+PKGDEP="python-3 six"
 BUILDDEP="setuptools"
 PKGDES="Responsible, reusable logging toolkit"
 

--- a/lang-python/logfury/spec
+++ b/lang-python/logfury/spec
@@ -2,3 +2,4 @@ VER=1.0.1
 SRCS="tbl::https://pypi.io/packages/source/l/logfury/logfury-$VER.tar.gz"
 CHKSUMS="sha256::130a5daceab9ad534924252ddf70482aa2c96662b3a3825a7d30981d03b76a26"
 CHKUPDATE="anitya::id=231357"
+REL=1

--- a/lang-python/mock/autobuild/defines
+++ b/lang-python/mock/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=mock
-PKGSEC=python
-PKGDEP="six funcsigs pbr"
-BUILDDEP="setuptools"
-PKGDES="A library for testing in Python"
-
-ABHOST=noarch

--- a/lang-python/mock/spec
+++ b/lang-python/mock/spec
@@ -1,5 +1,0 @@
-VER=2.0.0
-REL=5
-SRCS="tbl::https://pypi.io/packages/source/m/mock/mock-$VER.tar.gz"
-CHKSUMS="sha256::b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
-CHKUPDATE="anitya::id=21272"

--- a/lang-python/pywbem/autobuild/defines
+++ b/lang-python/pywbem/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=pywbem
 PKGSEC=python
-PKGDEP="m2crypto ply pyyaml pbr"
+PKGDEP="m2crypto ply pyyaml"
+BUILDDEP="pbr"
 PKGDES="Simplified data deserialization"
 
 ABHOST=noarch

--- a/lang-python/pywbem/autobuild/defines
+++ b/lang-python/pywbem/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pywbem
 PKGSEC=python
-PKGDEP="m2crypto ply pyyaml"
-BUILDDEP="pbr"
+PKGDEP="python-2 python-3 m2crypto ply pyyaml"
+BUILDDEP="pbr setuptools-python2 setuptools"
 PKGDES="Simplified data deserialization"
 
 ABHOST=noarch

--- a/lang-python/pywbem/autobuild/defines
+++ b/lang-python/pywbem/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pywbem
 PKGSEC=python
-PKGDEP="m2crypto ply pyyaml pbr mock"
+PKGDEP="m2crypto ply pyyaml pbr"
 PKGDES="Simplified data deserialization"
 
 ABHOST=noarch

--- a/lang-python/pywbem/spec
+++ b/lang-python/pywbem/spec
@@ -1,5 +1,5 @@
 VER=0.13.0
-REL=3
+REL=4
 SRCS="tbl::https://pypi.io/packages/source/p/pywbem/pywbem-$VER.tar.gz"
 CHKSUMS="sha256::ad6f2a5e95b051446153167f96b8437103f9bb6d30e8e7200dacb56822ef7875"
 CHKUPDATE="anitya::id=26924"


### PR DESCRIPTION
Topic Description
-----------------

- funcsigs: drop, orphaned
    X-AOSC-dropit-package: funcsigs
    X-AOSC-dropit-directory: lang-python/funcsigs
- mock: drop, orphaned
    X-AOSC-dropit-package: mock
    X-AOSC-dropit-directory: lang-python/mock
- certbot-nginx: remove mock dependency
    certbot have replaced it with unittest.mock
- certbot-dns-cloudflare: remove mock dependency
    certbot have replaced it with unittest.mock
- certbot-apache: remove mock dependency
    certbot have replaced it with unittest.mock
- certbot: remove mock dependency
    certbot have replaced it with unittest.mock
- pywbem: remove mock dependency
- logfury: remove funcsigs dependency
    How can a Python-3-only package depend on
    a Python-2-only package...

Package(s) Affected
-------------------

- certbot: 2.11.0-1
- certbot-apache: 2.10.0-1
- certbot-dns-cloudflare: 2.10.0-1
- certbot-nginx: 2.10.0-1
- logfury: 1.0.1-1
- pywbem: 0.13.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit certbot certbot-apache certbot-dns-cloudflare certbot-nginx logfury pywbem
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
