### PR TITLE
Libvirt 11 and friends

### DIFF
--- a/app-virtualization/libvirt/autobuild/beyond
+++ b/app-virtualization/libvirt/autobuild/beyond
@@ -5,7 +5,3 @@ chmod -v 0770 "$PKGDIR"/var/lib/libvirt/qemu
 abinfo "Fixing permissions for PolicyKit rules ..."
 chown -v 0:27 "$PKGDIR"/usr/share/polkit-1/rules.d
 chmod -v 0750 "$PKGDIR"/usr/share/polkit-1/rules.d
-
-abinfo "Dropping unnecessary directories ..."
-rm -rv \
-    "$PKGDIR"/var/run

--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -58,7 +58,6 @@ MESON_AFTER=(
     -Dselinux_mount=disabled
     -Dudev=enabled
     -Dwireshark_dissector=enabled
-    -Dyajl=enabled
     -Ddriver_bhyve=disabled
     -Ddriver_esx=enabled
     -Ddriver_hyperv=disabled

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,4 @@
-VER=10.5.0
+VER=11.3.0
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
-CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
+CHKSUMS="sha256::6bcb0c42c4580436fea262ced56f68a6afe20f7390b1bea2116718cc034a0283"
 CHKUPDATE="anitya::id=13830"

--- a/app-virtualization/qemu/01-shared/build
+++ b/app-virtualization/qemu/01-shared/build
@@ -5,6 +5,7 @@ if ! ab_match_arch loongarch64 && \
 	--prefix=/usr
 	--sysconfdir=/etc
 	--localstatedir=/var
+	-Dbuildtype=debugoptimized
 	--python=/usr/bin/python3
 	--disable-strip
 	--enable-lto
@@ -14,6 +15,7 @@ else
 	--prefix=/usr
 	--sysconfdir=/etc
 	--localstatedir=/var
+	-Dbuildtype=debugoptimized
 	--python=/usr/bin/python3
 	--disable-strip
 	--disable-lto

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=9.2.2
-REL=1
+VER=10.0.0
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
+CHKSUMS="sha256::22c075601fdcf8c7b2671a839ebdcef1d4f2973eb6735254fd2e1bd0f30b3896"
 CHKUPDATE="anitya::id=13607"

--- a/app-virtualization/virglrenderer/autobuild/defines
+++ b/app-virtualization/virglrenderer/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=virglrenderer
 PKGSEC=libs
-PKGDEP="libdrm libepoxy mesa x11-lib"
+PKGDEP="libdrm libepoxy mesa x11-lib vulkan-loader"
+BUILDDEP="pyyaml"
 PKGDES="Virtual 3D GPU library"
 
 ABTYPE=meson
@@ -16,14 +17,18 @@ PKGBREAK="qemu<=5.1.0"
 # 7887 |       gr->size += gbm_bo_get_plane_size(bo, plane);
 #      |                   ^~~~~~~~~~~~~~~~~~~~~
 #      |                   gbm_bo_get_plane_count
-MESON_AFTER="-Dplatforms=auto \
-             -Dminigbm_allocation=false \
-             -Dvenus-validate=false \
-             -Dcheck-gl-errors=true \
-             -Ddrm-msm-experimental=false \
-             -Drender-server=false \
-             -Drender-server-worker=process \
-             -Dvideo=true \
-             -Dfuzzer=false \
-             -Dvalgrind=false \
-             -Dtracing=none"
+MESON_AFTER=(
+	-Dcheck-gl-errors=true
+	-Ddrm-renderers=amdgpu-experimental,msm
+	-Dfuzzer=false
+	-Dminigbm_allocation=true
+	-Dplatforms=auto
+	-Drender-server-worker=process
+	-Dtests=false
+	-Dtracing=none
+	-Dunstable-apis=false
+	-Dvalgrind=false
+	-Dvenus=true
+	-Dvenus-validate=true
+	-Dvideo=true
+)

--- a/app-virtualization/virglrenderer/spec
+++ b/app-virtualization/virglrenderer/spec
@@ -1,4 +1,4 @@
-VER=0.10.4
+VER=1.1.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/virgl/virglrenderer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15968"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: upgrade to 11.3.0
- qemu: update to 10.0.0
- virglrenderer: update to 1.1.1

Package(s) Affected
-------------------

- libvirt: 11.3.0
- qemu: 10.0.0
- qemu-aarch64-static: 10.0.0
- qemu-alpha-static: 10.0.0
- qemu-arm-static: 10.0.0
- qemu-armeb-static: 10.0.0
- qemu-guest-agent: 10.0.0
- qemu-i386-static: 10.0.0
- qemu-loongarch64-static: 10.0.0
- qemu-m68k-static: 10.0.0
- qemu-microblaze-static: 10.0.0
- qemu-microblazeel-static: 10.0.0
- qemu-mips-static: 10.0.0
- qemu-mips64-static: 10.0.0
- qemu-mips64el-static: 10.0.0
- qemu-mipsel-static: 10.0.0
- qemu-mipsn32-static: 10.0.0
- qemu-mipsn32el-static: 10.0.0
- qemu-or32-static: 10.0.0
- qemu-ppc-static: 10.0.0
- qemu-ppc64-static: 10.0.0
- qemu-ppc64le-static: 10.0.0
- qemu-riscv32-static: 10.0.0
- qemu-riscv64-static: 10.0.0
- qemu-s390x-static: 10.0.0
- qemu-sh4-static: 10.0.0
- qemu-sh4eb-static: 10.0.0
- qemu-sparc-static: 10.0.0
- qemu-sparc32plus-static: 10.0.0
- qemu-sparc64-static: 10.0.0
- qemu-user-static: 10.0.0
- qemu-x86-64-static: 10.0.0
- virglrenderer: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit virglrenderer qemu libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
