### PR TITLE
shadowsocks-rust: update to 1.23.3

### DIFF
--- a/app-network/shadowsocks-rust/spec
+++ b/app-network/shadowsocks-rust/spec
@@ -1,4 +1,4 @@
-VER=1.23.2
+VER=1.23.3
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/shadowsocks-rust.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230992"


### PR DESCRIPTION
Topic Description
-----------------

- shadowsocks-rust: update to 1.23.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- shadowsocks-rust: 1.23.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadowsocks-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
