### PR TITLE
m4: update to 1.4.20

### DIFF
--- a/app-utils/m4/spec
+++ b/app-utils/m4/spec
@@ -1,5 +1,4 @@
-VER=1.4.19
-REL=1
+VER=1.4.20
 SRCS="tbl::https://ftp.gnu.org/gnu/m4/m4-$VER.tar.xz"
-CHKSUMS="sha256::63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96"
+CHKSUMS="sha256::e236ea3a1ccf5f6c270b1c4bb60726f371fa49459a8eaaebc90b216b328daf2b"
 CHKUPDATE="anitya::id=1871"


### PR DESCRIPTION
Topic Description
-----------------

- m4: update to 1.4.20
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- m4: 1.4.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit m4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
