### PR TITLE
gconf: fix build

### DIFF
--- a/app-admin/gconf/autobuild/defines
+++ b/app-admin/gconf/autobuild/defines
@@ -1,6 +1,16 @@
 PKGNAME=gconf
-PKGDES="GConf configuration database system"
+PKGSEC=gnome
 PKGDEP="dbus-glib polkit libxml2"
 BUILDDEP="gtk-doc gobject-introspection intltool"
-PKGSEC=gnome
-AUTOTOOLS_AFTER="--disable-orbit --enable-defaults-service"
+PKGDES="GConf configuration database system"
+
+# FIXME: Re-generation fails.
+#
+# configure:20829: error: possibly undefined macro: AM_NLS
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+RECONF=0
+AUTOTOOLS_AFTER=(
+    '--disable-orbit'
+    '--enable-defaults-service'
+)

--- a/app-admin/gconf/spec
+++ b/app-admin/gconf/spec
@@ -1,5 +1,5 @@
 VER=3.2.6
-REL=7
+REL=8
 SRCS="tbl::https://download.gnome.org/sources/GConf/${VER:0:3}/GConf-$VER.tar.xz"
 CHKSUMS="sha256::1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
 CHKUPDATE="anitya::id=8423"


### PR DESCRIPTION
Topic Description
-----------------

- gconf: fix build
    - Disable RECONF due to re-generation failure.
    - Refactor AUTOTOOLS_AFTER as array.

Package(s) Affected
-------------------

- gconf: 3.2.6-8

Security Update?
----------------

No

Build Order
-----------

```
#buildit gconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
