### PR TITLE
rtkit: use sysusers.d for user/group creation

### DIFF
--- a/app-admin/rtkit/autobuild/overrides/usr/lib/sysusers.d/rtkit.conf
+++ b/app-admin/rtkit/autobuild/overrides/usr/lib/sysusers.d/rtkit.conf
@@ -1,0 +1,2 @@
+g rtkit 133
+u rtkit 133:133 "RealtimeKit Daemon Owner" /proc /usr/bin/nologin

--- a/app-admin/rtkit/autobuild/postinst
+++ b/app-admin/rtkit/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Creating daemon owner and group ..."
+systemd-sysusers rtkit.conf

--- a/app-admin/rtkit/autobuild/usergroup
+++ b/app-admin/rtkit/autobuild/usergroup
@@ -1,2 +1,0 @@
-group rtkit 133
-user rtkit 133 rtkit /proc "RealtimeKit User" /sbin/nologin

--- a/app-admin/rtkit/spec
+++ b/app-admin/rtkit/spec
@@ -1,4 +1,5 @@
 VER=0.13
+REL=1
 SRCS="https://github.com/heftig/rtkit/releases/download/v$VER/rtkit-$VER.tar.xz"
 CHKSUMS="sha256::a157144cd95cf6d25200e74b74a8f01e4fe51fd421bb63c1f00d471394b640ab"
 CHKUPDATE="anitya::id=138132"


### PR DESCRIPTION
Topic Description
-----------------

- rtkit: use sysusers.d for user/group creation
    Autobuild4 no longer allows the usage of autobuild/usergroup.

Package(s) Affected
-------------------

- rtkit: 0.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
