### PR TITLE
xmlto: update to 0.0.29

### DIFF
--- a/app-doc/xmlto/autobuild/defines
+++ b/app-doc/xmlto/autobuild/defines
@@ -1,8 +1,5 @@
 PKGNAME=xmlto
 PKGSEC=utils
-PKGDES="Utility to convert xml to many other formats"
 PKGDEP="libxslt"
 BUILDDEP="docbook-xsl"
-
-AUTOTOOLS_AFTER="--mandir=/usr/share/man"
-RECONF=0
+PKGDES="Utility to convert XML to many other formats"

--- a/app-doc/xmlto/spec
+++ b/app-doc/xmlto/spec
@@ -1,5 +1,4 @@
-VER=0.0.28
-REL=3
+VER=0.0.29
 SRCS="tbl::https://releases.pagure.org/xmlto/xmlto-$VER.tar.gz"
-CHKSUMS="sha256::2f986b7c9a0e9ac6728147668e776d405465284e13c74d4146c9cbc51fd8aad3"
+CHKSUMS="sha256::40504db68718385a4eaa9154a28f59e51e59d006d1aa14f5bc9d6fded1d6017a"
 CHKUPDATE="anitya::id=13307"


### PR DESCRIPTION
Topic Description
-----------------

- xmlto: update to 0.0.29
    This version fixes build with GCC >= 14.

Package(s) Affected
-------------------

- xmlto: 0.0.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit xmlto
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
