### PR TITLE
[no build] mpg123: (stage2) sync --disable-portable

### DIFF
--- a/app-multimedia/mpg123/autobuild/defines.stage2
+++ b/app-multimedia/mpg123/autobuild/defines.stage2
@@ -20,6 +20,8 @@ BUILDDEP__AMD64="${BUILDDEP} yasm"
 #
 # --disable-runtime-tables: calculate tables at runtime saving size at the
 # expense of additional computation at load time
+#
+# --enable-portable: *only* enable portable (as in devices) APIs.
 AUTOTOOLS_AFTER=(
     '--enable-modules'
     '--enable-libmpg123'
@@ -54,7 +56,7 @@ AUTOTOOLS_AFTER=(
     '--enable-layer1'
     '--enable-layer2'
     '--enable-layer3'
-    '--enable-portable'
+    '--disable-portable'
     '--enable-largefile'
     '--enable-feature_report'
     '--enable-ipv6'


### PR DESCRIPTION
Topic Description
-----------------

- mpg123: \(stage2\) sync --disable-portable
    --enable-portable: \*only\* enable portable \(as in devices\) APIs.

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
