### PR TITLE
[no build] pulseaudio: (stage2) sync beyond from main script

### DIFF
--- a/app-multimedia/pulseaudio/autobuild/beyond
+++ b/app-multimedia/pulseaudio/autobuild/beyond
@@ -9,7 +9,7 @@ sed -e 's|/usr/bin/pactl load-module module-x11-cork-request|#&|' \
 
 mkdir -v "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
 ln -vs ../pulseaudio.socket \
-      "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
+    "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
 
 # FIXME: GDM does not release A2DP socket.
 # Note: gdm daemon owner GID/UID are both 771.

--- a/app-multimedia/pulseaudio/autobuild/beyond.stage2
+++ b/app-multimedia/pulseaudio/autobuild/beyond.stage2
@@ -7,10 +7,10 @@ sed -e '/autospawn/iautospawn=no' \
 sed -e 's|/usr/bin/pactl load-module module-x11-cork-request|#&|' \
     -i "$PKGDIR"/usr/bin/start-pulseaudio-x11
 
-rm "$PKGDIR"/etc/dbus-1/system.d/pulseaudio-system.conf
+mkdir -v "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
+ln -vs ../pulseaudio.socket \
+    "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
 
-mkdir "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
-ln -s ../pulseaudio.socket \
-      "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
-
-abinfo "Skipped building advanced pa modules."
+# FIXME: GDM does not release A2DP socket.
+# Note: gdm daemon owner GID/UID are both 771.
+setfacl -m u:771:r "$PKGDIR"/usr/bin/pulseaudio


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: \(stage2\) sync beyond from main script
    The change in the main beyond is trivial - it had a 5-space indent on one
    of the lines.

Package(s) Affected
-------------------

- pulseaudio: 17.0+xrdp0.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
