### PR TITLE
v4l-utils: fix build

### DIFF
--- a/app-multimedia/v4l-utils/autobuild/defines
+++ b/app-multimedia/v4l-utils/autobuild/defines
@@ -22,10 +22,16 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-NOPARALLEL=1
-ABSHADOW=0
+# FIXME: Re-generation fails.
+#
+# configure.ac:100: error: possibly undefined macro: AM_GNU_GETTEXT_VERSION
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+# configure.ac:101: error: possibly undefined macro: AM_GNU_GETTEXT
+# configure.ac:348: error: possibly undefined macro: AM_ICONV
+RECONF=0
 
-# FIXME:
+# FIXME: --disable-pbf
 #
 # bpf_load.c:66:38: error: storage size of ‘load_attr’ isn’t known
 #    66 |         struct bpf_load_program_attr load_attr;
@@ -33,19 +39,14 @@ ABSHADOW=0
 # bpf_load.c:69:38: error: invalid application of ‘sizeof’ to incomplete type
 # ‘struct bpf_load_program_attr’
 #    69 |         memset(&load_attr, 0, sizeof(struct bpf_load_program_attr));
-AUTOTOOLS_AFTER="--enable-libdvbv5 \
-                 --enable-doxygen-man \
-                 --disable-qv4l2 \
-                 --disable-qvidcap \
-                 --disable-bpf"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-doxygen-man"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--enable-libdvbv5'
+    '--enable-doxygen-man'
+    '--disable-qv4l2'
+    '--disable-qvidcap'
+    '--disable-bpf'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-doxygen-man'
+)

--- a/app-multimedia/v4l-utils/spec
+++ b/app-multimedia/v4l-utils/spec
@@ -1,5 +1,5 @@
 VER=1.22.1
-REL=3
+REL=4
 SRCS="tbl::https://www.linuxtv.org/downloads/v4l-utils/v4l-utils-$VER.tar.bz2"
 CHKSUMS="sha256::65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31"
 CHKUPDATE="anitya::id=9998"


### PR DESCRIPTION
Topic Description
-----------------

- v4l-utils: fix build
    - Disable RECONF due to re-generation failure.
    - Re-enable shadow build and parallelism.
    - Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- v4l-utils: 1.22.1-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit v4l-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
