### PR TITLE
enca: disable RECONF due to re-generation failure

### DIFF
--- a/app-utils/enca/autobuild/defines
+++ b/app-utils/enca/autobuild/defines
@@ -3,6 +3,15 @@ PKGSEC=utils
 PKGDEP="recode"
 PKGDES="Charset analyzer and converter"
 
-AUTOTOOLS_AFTER="--with-librecode=/usr \
-                 --enable-external"
-ABSHADOW=0
+# FIXME: Re-generation fails.
+#
+# configure.ac:158: the top level
+# configure:16653: error: possibly undefined macro: AM_ICONV
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+# **ERROR**: Re-generating failed.  You are allowed to shoot Enca maintainer.
+RECONF=0
+AUTOTOOLS_AFTER=(
+    '--with-librecode=/usr'
+    '--enable-external'
+)

--- a/app-utils/enca/spec
+++ b/app-utils/enca/spec
@@ -1,5 +1,5 @@
 VER=1.19
-REL=2
+REL=3
 SRCS="tbl::https://dl.cihar.com/enca/enca-$VER.tar.gz"
 CHKSUMS="sha256::4c305cc59f3e57f2cfc150a6ac511690f43633595760e1cb266bf23362d72f8a"
 CHKUPDATE="anitya::id=11686"


### PR DESCRIPTION
Topic Description
-----------------

- enca: disable RECONF due to re-generation failure
    Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- enca: 1.19-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit enca
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
