### PR TITLE
Drop pylint build dependencies

### DIFF
--- a/desktop-gnome/libgweather/autobuild/defines
+++ b/desktop-gnome/libgweather/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=libgweather
 PKGSEC=gnome
 PKGDEP="libsoup gtk-3 geocode-glib"
 BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool itstool \
-          pygobject-3 pylint vala"
+          pygobject-3 vala"
 PKGDES="Provides access to weather information in GNOME applications"
 
 MESON_AFTER="-Denable_vala=true \

--- a/desktop-gnome/libgweather/spec
+++ b/desktop-gnome/libgweather/spec
@@ -1,5 +1,5 @@
 VER=4.1.0
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/libgweather/${VER%.*}/libgweather-$VER.tar.xz"
 CHKSUMS="sha256::00bb8998e3b9a905f3a8d3295fcc15652d6b09cda5efa224e6744ded7abda65a"
 CHKUPDATE="anitya::id=13147"

--- a/desktop-gnome/totem/autobuild/defines
+++ b/desktop-gnome/totem/autobuild/defines
@@ -3,10 +3,10 @@ PKGSEC=gnome
 PKGDES="Video player for GNOME"
 PKGDEP="clutter-gst-3.0 clutter-gtk dbus-python dconf desktop-file-utils \
         gnome-desktop grilo-plugins gsettings-desktop-schemas gstreamer \
-        hicolor-icon-theme iso-codes libpeas lirc pygobject-3 pyxdg \
-        totem-pl-parser zeitgeist"
+        hicolor-icon-theme iso-codes libhandy libpeas lirc pygobject-3 \
+        pyxdg totem-pl-parser zeitgeist"
 BUILDDEP="gobject-introspection gtk-doc intltool itstool nautilus \
-          pylint vala"
+          vala"
 
 MESON_AFTER="-Dhelp=true \
              -Denable-easy-codec-installation=yes \

--- a/desktop-gnome/totem/spec
+++ b/desktop-gnome/totem/spec
@@ -1,4 +1,5 @@
 VER=42.0
+REL=1
 SRCS="https://download.gnome.org/sources/totem/${VER%%.*}/totem-$VER.tar.xz"
 CHKSUMS="sha256::4af0491ddb95df8b33aee399d3a50f9c7ab17de88d3af63356567cf88f57e6ab"
 CHKUPDATE="anitya::id=13162"


### PR DESCRIPTION
Topic Description
-----------------

- totem: drop unused pylint build dep and add missing dependendy libhandy
    Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
    Signed-off-by: ilikara <3435193369@qq.com>
- libgweather: drop unused pylint build dep

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libgweather totem
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
