### PR TITLE
[no build] openjdk-*: adapt for loongarch64_nosimd

### DIFF
--- a/lang-java/openjdk-17/autobuild/build
+++ b/lang-java/openjdk-17/autobuild/build
@@ -14,6 +14,7 @@ OPENJDK_SUFFIX="-17"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"

--- a/lang-java/openjdk-21/autobuild/build
+++ b/lang-java/openjdk-21/autobuild/build
@@ -14,6 +14,7 @@ OPENJDK_SUFFIX="-21"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"

--- a/lang-java/openjdk-22/autobuild/build
+++ b/lang-java/openjdk-22/autobuild/build
@@ -14,6 +14,7 @@ OPENJDK_SUFFIX="-22"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"

--- a/lang-java/openjdk-23/autobuild/build
+++ b/lang-java/openjdk-23/autobuild/build
@@ -14,6 +14,7 @@ OPENJDK_SUFFIX="-23"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"

--- a/lang-java/openjdk-24/autobuild/build
+++ b/lang-java/openjdk-24/autobuild/build
@@ -14,6 +14,7 @@ OPENJDK_SUFFIX="-24"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 __JDK_CONFIGURE_AFTER=()
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then

--- a/lang-java/openjdk-8/autobuild/build
+++ b/lang-java/openjdk-8/autobuild/build
@@ -9,6 +9,7 @@ SJAVAC=1
 [ "${CROSS:-$ARCH}" = "arm64" ] && export JARCH="aarch64" CONFARCH="aarch64"
 [ "${CROSS:-$ARCH}" = "loongson3" ] && export JARCH="mips64" CONFARCH="mips64el"
 [ "${CROSS:-$ARCH}" = "loongarch64" ] && export JARCH="loongarch64" CONFARCH="loongarch64"
+[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export JARCH="loongarch64" CONFARCH="loongarch64"
 [ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
 [ "${CROSS:-$ARCH}" = "ppc64" ] && export JARCH="ppc64" CONFARCH="ppc64"
 [ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
@@ -17,7 +18,8 @@ if [[ "${CROSS:-$ARCH}" != "amd64" && \
       "${CROSS:-$ARCH}" != "arm64" && \
       "${CROSS:-$ARCH}" != ppc64* && \
       "${CROSS:-$ARCH}" != "loongson3" && \
-      "${CROSS:-$ARCH}" != "loongarch64" ]]; then
+      "${CROSS:-$ARCH}" != "loongarch64" && \
+      "${CROSS:-$ARCH}" != "loongarch64_nosimd" ]]; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
@@ -116,7 +118,8 @@ if [[ "${CROSS:-$ARCH}" != "amd64" && \
        "${CROSS:-$ARCH}" != armv7hf && \
        "${CROSS:-$ARCH}" != ppc64* && \
        "${CROSS:-$ARCH}" != "loongson3" && \
-       "${CROSS:-$ARCH}" != "loongarch64" ]]; then
+       "${CROSS:-$ARCH}" != "loongarch64" && \
+       "${CROSS:-$ARCH}" != "loongarch64_nosimd" ]]; then
     cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
         "$PKGDIR"/usr/share/doc/openjdk-8/
 elif [[ "${CROSS:-$ARCH}" = "armv4" || \


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-24: adapt for loongarch64_nosimd
- openjdk-23: adapt for loongarch64_nosimd
- openjdk-22: adapt for loongarch64_nosimd
- openjdk-21: adapt for loongarch64_nosimd
- openjdk-17: adapt for loongarch64_nosimd
- openjdk-8: adapt for loongarch64_nosimd

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
