### PR TITLE
guile-2.2: fix build

### DIFF
--- a/lang-lisp/guile-2.2/autobuild/defines
+++ b/lang-lisp/guile-2.2/autobuild/defines
@@ -3,10 +3,15 @@ PKGSEC=devel
 PKGDEP="gc gmp libffi libtool libunistring ncurses texinfo"
 PKGDES="A portable, embeddable Scheme implementation written in C (legacy 2.2 branch)"
 
+# FIXME: Re-generation fails.
+#
+# configure.ac:1010: error: possibly undefined macro: AM_GNU_GETTEXT
+#      If this token and others are legitimate, please use m4_pattern_allow.
+#      See the Autoconf documentation.
+RECONF=0
 AUTOTOOLS_AFTER="--disable-error-on-warning \
                  --with-threads \
                  --program-suffix=2.2"
+
 PKGBREAK="aisleriot<=3.22.7 autogen<=5.18.12-1 gdb<=8.2-1 \
           graphviz<=2.40.1-3 weechat<=2.4-1"
-
-ABSHADOW=0

--- a/lang-lisp/guile-2.2/spec
+++ b/lang-lisp/guile-2.2/spec
@@ -1,4 +1,4 @@
 VER=2.2.7
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/guile/guile-$VER.tar.xz"
 CHKSUMS="sha256::cdf776ea5f29430b1258209630555beea6d2be5481f9da4d64986b077ff37504"


### PR DESCRIPTION
Topic Description
-----------------

- guile-2.2: fix build
    - Disable RECONF due to re-generation failure.
    - Re-enable shadow build.

Package(s) Affected
-------------------

- guile-2.2: 2.2.7-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit guile-2.2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
