### PR TITLE
gsm: rebase Makefile patch to fix build

### DIFF
--- a/runtime-multimedia/gsm/autobuild/patches/0001-fix-Makefile-miscellaneous-fix-ups.patch
+++ b/runtime-multimedia/gsm/autobuild/patches/0001-fix-Makefile-miscellaneous-fix-ups.patch
@@ -1,6 +1,22 @@
---- a/Makefile	2006-04-26 15:14:26.000000000 -0400
-+++ b/Makefile	2010-06-19 16:53:25.000000000 -0400
-@@ -96,11 +96,11 @@
+From 66c4a494c6ffc3d2d0d3ad89fab923ac14b42834 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 2 Dec 2024 18:14:27 +0800
+Subject: [PATCH] fix(Makefile): miscellaneous fix-ups
+
+- Revised from Arch Linux patch.
+- Build shared libraries.
+- Correct ln command arguments to create symlinks instead of hard links.
+
+Link: https://gitlab.archlinux.org/archlinux/packaging/packages/gsm/-/blob/42d55f147ffd712e871e2c564e12f287416fb5f5/gsm-shared.patch
+---
+ Makefile | 82 ++++++++++++++++++++++++++++----------------------------
+ 1 file changed, 41 insertions(+), 41 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index eaf94d5..5da8d79 100644
+--- a/Makefile
++++ b/Makefile
+@@ -96,11 +96,11 @@ TOAST_INSTALL_MAN = $(TOAST_INSTALL_ROOT)/man/man1
  #  Other tools
  
  SHELL		= /bin/sh
@@ -12,9 +28,9 @@
 -RMFLAGS		=
 +RMFLAGS		= -f
  FIND		= find
- COMPRESS 	= compress
+ COMPRESS 	= gzip
  COMPRESSFLAGS 	= 
-@@ -139,7 +139,7 @@
+@@ -139,7 +139,7 @@ LFLAGS	= $(LDFLAGS) $(LDINC)
  
  # Targets
  
@@ -23,7 +39,7 @@
  
  TOAST	= $(BIN)/toast
  UNTOAST	= $(BIN)/untoast
-@@ -257,7 +257,7 @@
+@@ -257,7 +257,7 @@ STUFF = 	ChangeLog			\
  # Install targets
  
  GSM_INSTALL_TARGETS =	\
@@ -32,7 +48,7 @@
  		$(GSM_INSTALL_INC)/gsm.h		\
  		$(GSM_INSTALL_MAN)/gsm.3		\
  		$(GSM_INSTALL_MAN)/gsm_explode.3	\
-@@ -279,7 +279,7 @@
+@@ -279,7 +279,7 @@ TOAST_INSTALL_TARGETS =	\
  
  # Target rules
  
@@ -41,7 +57,7 @@
  		@-echo $(ROOT): Done.
  
  tst:		$(TST)/lin2cod $(TST)/cod2lin $(TOAST) $(TST)/test-result
-@@ -299,24 +299,23 @@
+@@ -299,24 +299,23 @@ install:	toastinstall gsminstall
  
  # The basic API: libgsm
  
@@ -51,9 +67,9 @@
 -		$(RANLIB) $(LIBGSM)
 -
 +$(LIBGSMSO): $(LIB) $(GSM_OBJECTS)
-+	$(LD) -shared -Wl,-soname,libgsm.so.1 -o $@.1.0.13 $(GSM_OBJECTS)
-+	$(LN) libgsm.so.1.0.13 $(LIBGSMSO).1
-+	$(LN) libgsm.so.1.0.13 $(LIBGSMSO)
++	$(LD) -shared -Wl,-soname,libgsm.so.1 -o $@.1.0.19 $(GSM_OBJECTS)
++	$(LN) libgsm.so.1.0.19 $(LIBGSMSO).1
++	$(LN) libgsm.so.1.0.19 $(LIBGSMSO)
  
  # Toast, Untoast and Tcat -- the compress-like frontends to gsm.
  
@@ -74,7 +90,7 @@
  
  
  # The local bin and lib directories
-@@ -351,53 +350,54 @@
+@@ -351,53 +350,54 @@ toastuninstall:
  		fi
  
  $(TOAST_INSTALL_BIN)/toast:	$(TOAST)
@@ -137,15 +153,15 @@
  		chmod 444 $@
  
 +$(GSM_INSTALL_LIB)/libgsm.so:	$(LIBGSMSO)
-+		-rm $(RMFLAGS) $@ $@.1 $@.1.0.13
-+		cp $?.1.0.13 $@.1.0.13
-+		chmod 755 $@.1.0.13
-+		$(LN) libgsm.so.1.0.13 $@
-+		$(LN) libgsm.so.1.0.13 $@.1
++		-rm $(RMFLAGS) $@ $@.1 $@.1.0.19
++		cp $?.1.0.19 $@.1.0.19
++		chmod 755 $@.1.0.19
++		$(LN) libgsm.so.1.0.19 $@
++		$(LN) libgsm.so.1.0.19 $@.1
  
  # Distribution
  
-@@ -425,7 +425,7 @@
+@@ -425,7 +425,7 @@ semi-clean:
  			-print | xargs rm $(RMFLAGS)
  
  clean:	semi-clean
@@ -154,7 +170,7 @@
  			$(TOAST) $(TCAT) $(UNTOAST)	\
  			$(ROOT)/gsm-1.0.tar.Z
  
-@@ -473,22 +473,22 @@
+@@ -473,22 +473,22 @@ $(ADDTST)/add:	$(ADDTST)/add_test.o
  $(TST)/test-result:	$(TST)/lin2cod $(TST)/cod2lin $(TOAST) $(TST)/run
  			( cd $(TST); ./run ) 
  
@@ -187,3 +203,6 @@
  			$(LD) $(LFLAGS) -o $(TST)/cod2lin \
 -				$(TST)/cod2lin.o $(LIBGSM) $(LDLIB)
 +				$(TST)/cod2lin.o $(LIBGSMSO) $(LDLIB)
+-- 
+2.49.0
+

--- a/runtime-multimedia/gsm/spec
+++ b/runtime-multimedia/gsm/spec
@@ -1,4 +1,5 @@
 VER=1.0.19
+REL=1
 SRCS="tbl::http://www.quut.com/gsm/gsm-$VER.tar.gz"
 CHKSUMS="sha256::4903652f68a8c04d0041f0d19b1eb713ddcd2aa011c5e595b3b8bca2755270f6"
 CHKUPDATE="anitya::id=12587"


### PR DESCRIPTION
Topic Description
-----------------

- gsm: rebase Makefile patch to fix build
    - The original patch no longer applies cleanly.
    - Track patches at AOSC-Tracking/gsm @ aosc/v1.0.19
    \(HEAD: 66c4a494c6ffc3d2d0d3ad89fab923ac14b42834\).

Package(s) Affected
-------------------

- gsm: 1.0.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gsm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
