### PR TITLE
x264: fix build with Autobuild4

### DIFF
--- a/runtime-multimedia/x264/autobuild/build
+++ b/runtime-multimedia/x264/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Configuring x264 ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    ${AUTOTOOLS_AFTER[@]}
+
+abinfo "Building x264 ..."
+make \
+    V=1
+
+abinfo "Installing x264 ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    V=1

--- a/runtime-multimedia/x264/autobuild/defines
+++ b/runtime-multimedia/x264/autobuild/defines
@@ -5,19 +5,26 @@ BUILDDEP__AMD64="${BUILDDEP} nasm"
 BUILDDEP__I486="nasm"
 PKGDES="An H.264 encoder"
 
-AUTOTOOLS_AFTER="--enable-shared \
-                 --enable-pic"
-AUTOTOOLS_AFTER__NOASM=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-asm"
-AUTOTOOLS_AFTER__ARMV4=" \
-                 ${AUTOTOOLS_AFTER__NOASM}"
-AUTOTOOLS_AFTER__LOONGSON2F=" \
-                 ${AUTOTOOLS_AFTER__NOASM}"
-AUTOTOOLS_AFTER__LOONGSON3=" \
-                 ${AUTOTOOLS_AFTER__NOASM}"
-AUTOTOOLS_AFTER__POWERPC=" \
-                 ${AUTOTOOLS_AFTER__NOASM}"
+AUTOTOOLS_AFTER=(
+    '--enable-shared'
+    '--enable-pic'
+)
+AUTOTOOLS_AFTER__NOASM=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-asm'
+)
+AUTOTOOLS_AFTER__ARMV4=(
+    "${AUTOTOOLS_AFTER__NOASM[@]}"
+)
+AUTOTOOLS_AFTER__LOONGSON2F=(
+    "${AUTOTOOLS_AFTER__NOASM[@]}"
+)
+AUTOTOOLS_AFTER__LOONGSON3=(
+    "${AUTOTOOLS_AFTER__NOASM[@]}"
+)
+AUTOTOOLS_AFTER__POWERPC=(
+    "${AUTOTOOLS_AFTER__NOASM[@]}"
+)
 
 AB_FLAGS_O3=1
 

--- a/runtime-multimedia/x264/spec
+++ b/runtime-multimedia/x264/spec
@@ -1,4 +1,5 @@
 VER=0+git20241027
+REL=1
 SRCS="git::commit=da14df5535fd46776fb1c9da3130973295c87aca::https://git.videolan.org/git/x264.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15280"


### PR DESCRIPTION
Topic Description
-----------------

- x264: fix build with Autobuild4
    - Add a build script as it is not a standard Autotools source.
    - Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- x264: 1:0+git20241027-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit x264
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
