### PR TITLE
activate-linux: new, 1.1.0

### DIFF
--- a/app-utils/activate-linux/autobuild/beyond
+++ b/app-utils/activate-linux/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing application icon ..."
+install -Dvm644 "$SRCDIR"/res/icon.png \
+    "$PKGDIR"/usr/share/pixmaps/activate-linux.png
+
+abinfo "Installing desktop entry ..."
+install -Dvm644 "$SRCDIR"/res/activate-linux.desktop \
+    -t "$PKGDIR"/usr/share/applications/

--- a/app-utils/activate-linux/autobuild/build
+++ b/app-utils/activate-linux/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building activate-linux ..."
+make
+
+abinfo "Installing activate-linux ..."
+install -Dvm755 "$SRCDIR"/activate-linux \
+    -t "$PKGDIR"/usr/bin/
+install -Dvm644 "$SRCDIR"/activate-linux.1 \
+    -t "$PKGDIR"/usr/share/man/man1/

--- a/app-utils/activate-linux/autobuild/defines
+++ b/app-utils/activate-linux/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=activate-linux
+PKGSEC=utils
+PKGDEP="cairo pango x11-lib wayland"
+BUILDDEP="wayland-protocols x11-proto"
+PKGDES="Meme program that displays an \"Activate Windows\"-like watermark on the desktop"

--- a/app-utils/activate-linux/autobuild/patches/0001-feat-use-pangocairo-to-handle-font-fallbacks.patch
+++ b/app-utils/activate-linux/autobuild/patches/0001-feat-use-pangocairo-to-handle-font-fallbacks.patch
@@ -1,0 +1,118 @@
+From bbe0d079f6ee6d43f88818346462a4d905ddb652 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 12 May 2025 18:55:16 -0700
+Subject: [PATCH 1/2] feat: use pangocairo to handle font fallbacks
+
+Backport 9f4e18826f8388118283225a962f2c6024a80198 to v1.1.0
+
+Link: https://github.com/MrGlockenspiel/activate-linux/pull/239
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ Makefile              |  2 +-
+ src/cairo_draw_text.c | 38 ++++++++++++++++++++++++++------------
+ 2 files changed, 27 insertions(+), 13 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index adc7c84..831e0ef 100644
+--- a/Makefile
++++ b/Makefile
+@@ -41,7 +41,7 @@ ifeq ($(filter wayland,$(<<backends>>)),wayland)
+ 	LDFLAGS += -lrt
+ endif
+ ifneq ($(filter wayland x11,$(<<backends>>)),)
+-	PKGS += cairo
++	PKGS += cairo pango pangocairo
+ 	CFLAGS += -DCOLOR_HELP -DCAIRO
+ endif
+ ifeq ($(filter gdi,$(<<backends>>)),gdi)
+diff --git a/src/cairo_draw_text.c b/src/cairo_draw_text.c
+index 75cca8e..5ef368c 100644
+--- a/src/cairo_draw_text.c
++++ b/src/cairo_draw_text.c
+@@ -2,10 +2,13 @@
+ 
+ #include <stdlib.h>
+ #include <cairo.h>
++#include <pango/pangocairo.h>
+ #include "options.h"
+ #include "cairo_draw_text.h"
+ 
+ void draw_text(cairo_t *const cr) {
++  PangoLayout *layout = pango_cairo_create_layout(cr);
++  PangoFontDescription *font_description = pango_font_description_new();
+   // clear surface
+   cairo_operator_t prev_operator = cairo_get_operator(cr);
+   cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+@@ -19,28 +22,34 @@ void draw_text(cairo_t *const cr) {
+   // no subpixel anti-aliasing because we are on transparent BG
+   cairo_font_options_t *font_options = cairo_font_options_create();
+   cairo_font_options_set_antialias(font_options, CAIRO_ANTIALIAS_GRAY);
+-  cairo_set_font_options(cr, font_options);
+ 
+   // set font size, and scale up or down
+-  cairo_set_font_size(cr, 24 * options.scale);
++  pango_font_description_set_absolute_size(font_description, 24 * PANGO_SCALE * options.scale);
+ 
+   // font weight and slant settings
+-  cairo_font_weight_t font_weight = CAIRO_FONT_WEIGHT_NORMAL;
++  PangoWeight font_weight = PANGO_WEIGHT_NORMAL;
+   if (options.bold_mode) {
+-    font_weight = CAIRO_FONT_WEIGHT_BOLD;
++    font_weight = PANGO_WEIGHT_BOLD;
+   }
+ 
+-  cairo_font_slant_t font_slant = CAIRO_FONT_SLANT_NORMAL;
++  PangoStyle font_style = PANGO_STYLE_NORMAL;
+   if (options.italic_mode) {
+-    font_slant = CAIRO_FONT_SLANT_ITALIC;
++    font_style = PANGO_STYLE_ITALIC;
+   }
+ 
+-  cairo_select_font_face(cr, options.custom_font, font_slant, font_weight);
++  pango_font_description_set_family(font_description, options.custom_font);
++  pango_font_description_set_weight(font_description, font_weight);
++  pango_font_description_set_style(font_description, font_style);
++
++  pango_layout_set_font_description(layout, font_description);
++  pango_cairo_context_set_font_options(pango_layout_get_context(layout), font_options);
+ 
+   cairo_move_to(cr, 20, 30 * options.scale);
+-  cairo_show_text(cr, options.title);
++  pango_layout_set_text(layout, options.title, -1);
++  pango_cairo_show_layout_line(cr, pango_layout_get_line(layout, 0));
+ 
+-  cairo_set_font_size(cr, 16 * options.scale);
++  pango_font_description_set_absolute_size(font_description, 16 * PANGO_SCALE * options.scale);
++  pango_layout_set_font_description(layout, font_description);
+   cairo_move_to(cr, 20, 55 * options.scale);
+ 
+   // handle string with \n as cairo cannot do it out of the box
+@@ -50,16 +59,21 @@ void draw_text(cairo_t *const cr) {
+     size_t first_line_len = new_line_ptr-subtitle;
+     char *first_line = calloc(1, first_line_len+1);
+     memcpy(first_line, subtitle, first_line_len);
+-    cairo_show_text(cr, first_line);
++    pango_layout_set_text(layout, first_line, -1);
++    pango_cairo_show_layout_line(cr, pango_layout_get_line(layout, 0));
+     free(first_line);
+ 
+     cairo_move_to(cr, 20, 75 * options.scale);
+-    cairo_show_text(cr, new_line_ptr + 1);
++    pango_layout_set_text(layout, new_line_ptr + 1, -1);
++    pango_cairo_show_layout_line(cr, pango_layout_get_line(layout, 0));
+   } else {
+-    cairo_show_text(cr, subtitle);
++    pango_layout_set_text(layout, subtitle, -1);
++    pango_cairo_show_layout_line(cr, pango_layout_get_line(layout, 0));
+   }
+ 
++  g_object_unref(layout);
+   cairo_font_options_destroy(font_options);
++  pango_font_description_free(font_description);
+ }
+ 
+ #endif
+-- 
+2.49.0
+

--- a/app-utils/activate-linux/autobuild/patches/0002-chore-better-description-and-icon-name-for-desktop-e.patch
+++ b/app-utils/activate-linux/autobuild/patches/0002-chore-better-description-and-icon-name-for-desktop-e.patch
@@ -1,0 +1,31 @@
+From efe228112804833a2d615e5ec1b9028c87837de2 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Mon, 12 May 2025 19:16:25 -0700
+Subject: [PATCH 2/2] chore: better description and icon name for desktop entry
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ res/activate-linux.desktop | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/res/activate-linux.desktop b/res/activate-linux.desktop
+index 27491a0..0e4621e 100644
+--- a/res/activate-linux.desktop
++++ b/res/activate-linux.desktop
+@@ -2,9 +2,9 @@
+ Type=Application
+ Version=1.0
+ Name=Activate Linux
+-Comment=a very cool software
++Comment=Meme program that displays an "Activate Windows"-like watermark on the desktop
+ Exec=activate-linux
+-Icon=icon
++Icon=activate-linux
+ GenericName=Activate Linux
+ Categories=Utility
+-Terminal=false
+\ No newline at end of file
++Terminal=false
+-- 
+2.49.0
+

--- a/app-utils/activate-linux/spec
+++ b/app-utils/activate-linux/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/MrGlockenspiel/activate-linux"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378074"


### PR DESCRIPTION
Topic Description
-----------------

- activate-linux: new, 1.1.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- activate-linux: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit activate-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
