### PR TITLE
DTK libraries 6.0.37

### DIFF
--- a/desktop-dde/dtk6core/autobuild/defines
+++ b/desktop-dde/dtk6core/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=dtk6core
+PKGSEC=dde
+PKGDEP="dtkcommon dtk6log gcc-runtime glibc icu lshw qt-6 uchardet"
+BUILDDEP="cmake ninja doxygen gtest"
+PKGDES="Base development tools and libraries for deepin C++/Qt development"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=ON'
+    '-DBUILD_TESTING=ON'
+    '-DCMAKE_INSTALL_LIBDIR=lib'
+    '-DCMAKE_INSTALL_LIBEXECDIR=lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)

--- a/desktop-dde/dtk6core/spec
+++ b/desktop-dde/dtk6core/spec
@@ -1,0 +1,4 @@
+VER=6.0.37
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtk6core"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372487"

--- a/desktop-dde/dtk6declarative/autobuild/defines
+++ b/desktop-dde/dtk6declarative/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=dtk6declarative
+PKGSEC=dde
+PKGDEP="dtk6core dtk6gui gcc-runtime glibc librsvg qt-6"
+BUILDDEP="cmake ninja doxygen gtest"
+PKGDES="QML development toolkit for deepin based on QtQuick"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_LIBDIR=lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+    '-DBUILD_DOCS=ON'
+)

--- a/desktop-dde/dtk6declarative/spec
+++ b/desktop-dde/dtk6declarative/spec
@@ -1,0 +1,4 @@
+VER=6.0.37
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtk6declarative"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=linuxdeepin/dtk6declarative"

--- a/desktop-dde/dtk6gui/autobuild/defines
+++ b/desktop-dde/dtk6gui/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=dtk6gui
+PKGSEC=dde
+PKGDEP="dtk6core gcc-runtime glibc librsvg qt-6"
+BUILDDEP="cmake ninja doxygen gtest"
+PKGDES="Graphical user interface development libraries for deepin C++/Qt development"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=ON'
+    '-DBUILD_TESTING=ON'
+    '-DCMAKE_INSTALL_LIBDIR=lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)

--- a/desktop-dde/dtk6gui/spec
+++ b/desktop-dde/dtk6gui/spec
@@ -1,0 +1,4 @@
+VER=6.0.37
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtk6gui"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=372488"

--- a/desktop-dde/dtk6log/autobuild/defines
+++ b/desktop-dde/dtk6log/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=dtk6log
+PKGSEC=dde
+PKGDEP="glibc gcc-runtime qt-6 spdlog systemd"
+BUILDDEP="cmake ninja"
+PKGDES="Thread-safe logger for DTK-based applications and components"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_LIBDIR=lib'
+    '-DCMAKE_INSTALL_INCLUDEDIR=include'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+    '-DBUILD_WITH_SYSTEMD=ON'
+    '-DBUILD_WITH_QT6=ON'
+)

--- a/desktop-dde/dtk6log/spec
+++ b/desktop-dde/dtk6log/spec
@@ -1,0 +1,4 @@
+VER=0.0.4
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtk6log.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373592"

--- a/desktop-dde/dtk6widget/autobuild/defines
+++ b/desktop-dde/dtk6widget/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=dtk6widget
+PKGSEC=dde
+PKGDEP="dtk6core dtk6gui gcc-runtime glibc librsvg qt-6 startup-notification"
+BUILDDEP="cmake ninja doxygen gtest"
+PKGDES="Additional Qt widgets for deepin application development"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=ON'
+    '-DCMAKE_INSTALL_LIBDIR=lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)

--- a/desktop-dde/dtk6widget/spec
+++ b/desktop-dde/dtk6widget/spec
@@ -1,0 +1,4 @@
+VER=6.0.37
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtk6widget"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373767"

--- a/desktop-dde/dtkcommon/autobuild/defines
+++ b/desktop-dde/dtkcommon/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=dtkcommon
+PKGSEC=dde
+PKGDEP="dconf"
+BUILDDEP="cmake ninja"
+PKGDES="Common build configurations and tools for DTK-based applications and components"
+
+ABTYPE=cmakeninja
+ABHOST=noarch
+
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_LIBDIR=/usr/lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)

--- a/desktop-dde/dtkcommon/spec
+++ b/desktop-dde/dtkcommon/spec
@@ -1,0 +1,4 @@
+VER=5.7.17
+SRCS="git::commit=tags/$VER::https://github.com/linuxdeepin/dtkcommon"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371945"


### PR DESCRIPTION
Topic Description
-----------------

As a bootstrap of DDE 移植 https://github.com/AOSC-Dev/aosc-os-abbs/issues/10916

- dtk6widget: new, 6.0.35
- dtk6declarative: new, 6.0.35
- dtk6gui: new, 6.0.35
- dtk6core: new, 6.0.35
- dtk6log: new, 0.0.2
- dtkcommon: new, 5.7.15

Package(s) Affected
-------------------

- dtk6widget: 6.0.35
- dtk6declarative: 6.0.35
- dtk6gui: 6.0.35
- dtk6core: 6.0.35
- dtk6log: 0.0.2
- dtkcommon: 5.7.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit dtkcommon dtk6log dtk6core dtk6gui dtk6declarative dtk6widget
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
