### PR TITLE
intel-ucode: update to 20250512

### DIFF
--- a/runtime-data/intel-ucode/spec
+++ b/runtime-data/intel-ucode/spec
@@ -1,4 +1,4 @@
-VER=20250211
+VER=20250512
 SRCS="git::commit=tags/microcode-${VER}::https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20614"

--- a/topics/intel-ucode-20250512.toml
+++ b/topics/intel-ucode-20250512.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Intel Processor Microcode Package for Linux, version 20250512"
+zh_CN = "适用于 Linux 的 Intel 处理器微码包，版本 20250512"
+
+[caution]
+default = "Fixes self-training Spectre-v2 (Exposure of Sensitive Information) vulnerability codenamed \"Training Solo\""
+zh_CN = "修复代号为 \"Training Solo\" 的自训练 Spectre-v2（敏感信息泄漏）漏洞"
+
+[packages]
+intel-ucode = "20250512"


### PR DESCRIPTION
Topic Description
-----------------

- intel-ucode: update to 20250512
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- intel-ucode: 20250512

Security Update?
----------------

Yes, #10946

Build Order
-----------

```
#buildit intel-ucode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
