### PR TITLE
freerdp: update to 3.15.0

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,5 +1,4 @@
-VER=3.9.0
+VER=3.15.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::2eef25f2b421dbe7b6ca64a96045afe57a4b8c559339baca8cb8528c42518b83"
+CHKSUMS="sha256::e8cd58decef4c970faea2fbea675970eea60e440ebe8033c54889acb83787371"
 CHKUPDATE="anitya::id=10442"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.15.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- freerdp: 2:3.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
