### PR TITLE
rnote: update to 0.12.0

### DIFF
--- a/app-doc/rnote/autobuild/defines
+++ b/app-doc/rnote/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=rnote
 PKGDES="Vector-based drawing app for sketching and handwritten notes"
 PKGSEC=doc
 PKGDEP="gtk-4 glib libadwaita poppler gstreamer alsa-lib"
-BUILDDEP="rustc llvm gtk-update-icon-cache"
+BUILDDEP="rustc llvm gtk-update-icon-cache appstream"
 ABTYPE=meson
 MESON_AFTER="-Dcli=true"
 

--- a/app-doc/rnote/spec
+++ b/app-doc/rnote/spec
@@ -1,5 +1,4 @@
-VER=0.11.0
-REL=1
+VER=0.12.0
 SRCS="git::commit=tags/v$VER::https://github.com/flxzt/rnote.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375549"

--- a/desktop-gnome/gtk-4/01-main/patches/0001-use-compiler-to-generate-resources-binary.patch
+++ b/desktop-gnome/gtk-4/01-main/patches/0001-use-compiler-to-generate-resources-binary.patch
@@ -1,4 +1,4 @@
-From 7b224a5cf9c9eb5b79b1d3275d9f143571b8a8d2 Mon Sep 17 00:00:00 2001
+From 7871b3dd3c47b4b4417877388d5a58bd03b6ee6e Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sun, 10 Nov 2024 02:27:43 -0800
 Subject: [PATCH] use compiler to generate resources binary

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,4 @@
-VER=4.18.4
+VER=4.18.5
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
-CHKSUMS="sha256::d4783ac15037c2c4275a8f1acc94f5fede28a516243fccb92ff54a11c15775ff"
+CHKSUMS="sha256::bb5267a062f5936947d34c9999390a674b0b2b0d8aa3472fe0d05e2064955abc"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- rnote: update to 1.12.0
- gtk-4: update to 4.18.5

Package(s) Affected
-------------------

- rnote: 0.12.0
- gtk-4: 1:4.18.5
- gtk-update-icon-cache: 4.18.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4 rnote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
