### PR TITLE
nghttp2: update to 1.65.0

### DIFF
--- a/runtime-web/nghttp2/autobuild/defines
+++ b/runtime-web/nghttp2/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=nghttp2
 PKGSEC=libs
 PKGDEP="c-ares jansson jemalloc libbpf libev spdylay"
 BUILDDEP="cython llvm"
-PKGDES="An implementation of HTTP/2 and its header compression algorithm HPACK in C"
+PKGDES="Library to implement the HTTP/2 protocol and the HPACK header compression algorithm"
 
 # Building the libbpf binding requires generating a eBPF program, which must be
 # built with Clang.
@@ -37,43 +37,44 @@ AB_FLAGS_PIE=0
 #       --enable-http3 is experimental (as of 1.58.0).
 #
 # FIXME: --disable-examples to skip broken examples (event.h incompatibility).
-AUTOTOOLS_AFTER="--disable-werror \
-                 --disable-debug \
-                 --enable-threads \
-                 --enable-app \
-                 --enable-hpack-tools \
-                 --disable-examples \
-                 --disable-failmalloc \
-                 --disable-lib-only \
-                 --disable-http3 \
-                 --disable-assert \
-                 --enable-largefile \
-                 --with-libxml2 \
-                 --with-jansson \
-                 --with-zlib \
-                 --with-libevent-openssl \
-                 --with-libcares \
-                 --with-openssl \
-                 --with-libev \
-                 --with-cunit=no \
-                 --with-jemalloc \
-                 --with-systemd \
-                 --with-mruby=no \
-                 --with-neverbleed=no \
-                 --with-libngtcp2=no \
-                 --with-libnghttp3=no \
-                 --with-libbpf \
-                 PYTHON=/usr/bin/python3"
+AUTOTOOLS_AFTER=(
+    '--disable-werror'
+    '--disable-debug'
+    '--enable-threads'
+    '--enable-app'
+    '--enable-hpack-tools'
+    '--disable-examples'
+    '--disable-failmalloc'
+    '--disable-lib-only'
+    '--disable-http3'
+    '--disable-assert'
+    '--enable-largefile'
+    '--with-libxml2'
+    '--with-jansson'
+    '--with-zlib'
+    '--with-libevent-openssl'
+    '--with-libcares'
+    '--with-openssl'
+    '--with-libev'
+    '--with-jemalloc'
+    '--with-systemd'
+    '--with-mruby=no'
+    '--with-neverbleed=no'
+    '--with-libngtcp2=no'
+    '--with-libnghttp3=no'
+    '--with-libbpf'
+)
 # FIXME: Clang build fails on loongson3, mips64r6el, ppc64el, and riscv64, disabling libbpf.
-AUTOTOOLS_AFTER__LOONGSON3=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-libbpf=no"
-AUTOTOOLS_AFTER__MIPS64R6EL=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-libbpf=no"
-AUTOTOOLS_AFTER__PPC64EL=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-libbpf=no"
-AUTOTOOLS_AFTER__RISCV64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-libbpf=no"
+AUTOTOOLS_AFTER__NOBPF=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--with-libbpf=no'
+)
+AUTOTOOLS_AFTER__LOONGSON3=(
+    "${AUTOTOOLS_AFTER__NOBPF[@]}"
+)
+AUTOTOOLS_AFTER__PPC64EL=(
+    "${AUTOTOOLS_AFTER__NOBPF[@]}"
+)
+AUTOTOOLS_AFTER__RISCV64=(
+    "${AUTOTOOLS_AFTER__NOBPF[@]}"
+)

--- a/runtime-web/nghttp2/autobuild/defines.stage2
+++ b/runtime-web/nghttp2/autobuild/defines.stage2
@@ -1,33 +1,33 @@
 PKGNAME=nghttp2
 PKGSEC=libs
 PKGDEP="c-ares jansson jemalloc libev spdylay"
-PKGDES="An implementation of HTTP/2 and its header compression algorithm HPACK in C"
+PKGDES="Library to implement the HTTP/2 protocol and the HPACK header compression algorithm"
 
 # FIXME: --disable-examples to skip broken examples (event.h incompatibility).
-AUTOTOOLS_AFTER="--disable-werror \
-                 --disable-debug \
-                 --enable-threads \
-                 --enable-app \
-                 --enable-hpack-tools \
-                 --disable-examples \
-                 --disable-failmalloc \
-                 --disable-lib-only \
-                 --disable-http3 \
-                 --disable-assert \
-                 --enable-largefile \
-                 --with-libxml2 \
-                 --with-jansson \
-                 --with-zlib \
-                 --with-libevent-openssl \
-                 --with-libcares \
-                 --with-openssl \
-                 --with-libev \
-                 --with-cunit=no \
-                 --with-jemalloc \
-                 --with-systemd=no \
-                 --with-mruby=no \
-                 --with-neverbleed=no \
-                 --with-libngtcp2=no \
-                 --with-libnghttp3=no \
-                 --without-libbpf \
-                 PYTHON=/usr/bin/python3"
+AUTOTOOLS_AFTER=(
+    '--disable-werror'
+    '--disable-debug'
+    '--enable-threads'
+    '--enable-app'
+    '--enable-hpack-tools'
+    '--disable-examples'
+    '--disable-failmalloc'
+    '--disable-lib-only'
+    '--disable-http3'
+    '--disable-assert'
+    '--enable-largefile'
+    '--with-libxml2'
+    '--with-jansson'
+    '--with-zlib'
+    '--with-libevent-openssl'
+    '--with-libcares'
+    '--with-openssl'
+    '--with-libev'
+    '--with-jemalloc'
+    '--with-systemd=no'
+    '--with-mruby=no'
+    '--with-neverbleed=no'
+    '--with-libngtcp2=no'
+    '--with-libnghttp3=no'
+    '--without-libbpf'
+)

--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,4 +1,4 @@
-VER=1.58.0
+VER=1.65.0
 SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
-CHKSUMS="sha256::4a68a3040da92fd9872c056d0f6b0cd60de8410de10b578f8ade9ecc14d297e0"
+CHKSUMS="sha256::f1b9df5f02e9942b31247e3d415483553bc4ac501c87aa39340b6d19c92a9331"
 CHKUPDATE="anitya::id=8651"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: update to 1.65.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nghttp2: 1.65.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
