### PR TITLE
Vulkan 1.4.315.0

### DIFF
--- a/app-utils/vulkan-tools/spec
+++ b/app-utils/vulkan-tools/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"

--- a/groups/vulkan+32
+++ b/groups/vulkan+32
@@ -1,0 +1,5 @@
+runtime-optenv32/spirv-tools+32
+runtime-optenv32/vulkan-headers+32
+runtime-optenv32/vulkan-loader+32
+runtime-optenv32/volk-meta-loader+32
+runtime-optenv32/vulkan-tools+32

--- a/runtime-display/spirv-headers/spec
+++ b/runtime-display/spirv-headers/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230542"

--- a/runtime-display/spirv-tools/spec
+++ b/runtime-display/spirv-tools/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-display/vulkan-extensionlayer/spec
+++ b/runtime-display/vulkan-extensionlayer/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-display/vulkan-utility-libraries/spec
+++ b/runtime-display/vulkan-utility-libraries/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370173"

--- a/runtime-display/vulkan-validationlayers/spec
+++ b/runtime-display/vulkan-validationlayers/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ValidationLayers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-optenv32/spirv-tools+32/spec
+++ b/runtime-optenv32/spirv-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"

--- a/runtime-optenv32/volk-meta-loader+32/spec
+++ b/runtime-optenv32/volk-meta-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-optenv32/vulkan-headers+32/spec
+++ b/runtime-optenv32/vulkan-headers+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-optenv32/vulkan-loader+32/spec
+++ b/runtime-optenv32/vulkan-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-optenv32/vulkan-tools+32/spec
+++ b/runtime-optenv32/vulkan-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.309.0
+VER=1.4.315.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"


### PR DESCRIPTION
Topic Description
-----------------

- vulkan-tools+32: update to 1.4.315.0
- volk-meta-loader+32: update to 1.4.315.0
- vulkan-loader+32: update to 1.4.315.0
- vulkan-headers+32: update to 1.4.315.0
- spirv-tools+32: update to 1.4.315.0
- groups: add vulkan+32
- vulkan-extensionlayer: update to 1.4.315.0
- vulkan-tools: update to 1.4.315.0
- volk-meta-loader: update to 1.4.315.0
- vulkan-validationlayers: update to 1.4.315.0

... and 5 more commits

Package(s) Affected
-------------------

- spirv-headers: 1:1.4.315.0
- spirv-tools: 1:1.4.315.0
- volk-meta-loader: 1.4.315.0
- vulkan-extensionlayer: 1.4.315.0
- vulkan-headers: 1.4.315.0
- vulkan-loader: 1.4.315.0
- vulkan-tools: 1.4.315.0
- vulkan-utility-libraries: 1.4.315.0
- vulkan-validationlayers: 1.4.315.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit groups/vulkan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
