### PR TITLE
gconf: re-add missing runtime Spiral provides

### DIFF
--- a/app-admin/gconf/autobuild/defines
+++ b/app-admin/gconf/autobuild/defines
@@ -14,3 +14,8 @@ AUTOTOOLS_AFTER=(
     '--disable-orbit'
     '--enable-defaults-service'
 )
+
+# Note: Extra Provides for Spiral, gconf has been removed from Ubuntu's
+# repository and, as such, no Provides for the runtime components were
+# available.
+PKGPROV="libgconf-2-4_spiral libgconf2-dev_spiral"

--- a/app-admin/gconf/spec
+++ b/app-admin/gconf/spec
@@ -1,5 +1,5 @@
 VER=3.2.6
-REL=8
+REL=9
 SRCS="tbl::https://download.gnome.org/sources/GConf/${VER:0:3}/GConf-$VER.tar.xz"
 CHKSUMS="sha256::1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
 CHKUPDATE="anitya::id=8423"


### PR DESCRIPTION
Topic Description
-----------------

- gconf: re-add missing runtime Spiral provides
    gconf has been removed from Ubuntu's repository and, as such, no Provides
    for the runtime components were available.

Package(s) Affected
-------------------

- gconf: 3.2.6-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit gconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
