### PR TITLE
libdecor: update to 0.2.3

### DIFF
--- a/runtime-desktop/libdecor/spec
+++ b/runtime-desktop/libdecor/spec
@@ -1,4 +1,4 @@
-VER=0.2.2
+VER=0.2.3
 SRCS="tbl::https://gitlab.freedesktop.org/libdecor/libdecor/-/releases/$VER/downloads/libdecor-$VER.tar.xz"
-CHKSUMS="sha256::16a288e24354d461b20dda9cf38e68543569134f04e4b7fa2914aa647907dfac"
+CHKSUMS="sha256::66ab953da968eb2c24c27a8641fdb00d3a6e64c3cf8780c67c14e3202698b39c"
 CHKUPDATE="anitya::id=312806"


### PR DESCRIPTION
Topic Description
-----------------

- libdecor: update to 0.2.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libdecor: 0.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdecor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
