### PR TITLE
pfetch: new, 2.11.1

### DIFF
--- a/app-utils/pfetch/autobuild/defines
+++ b/app-utils/pfetch/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pfetch
+PKGDES="A command-line system information tool"
+PKGSEC=utils
+PKGDEP="gcc-runtime glibc sqlite"
+BUILDDEP="llvm rustc"
+ABTYPE=rust
+
+# FIXME: ld.lld not yet available on loongson3
+NOLTO__LOONGSON3=1

--- a/app-utils/pfetch/spec
+++ b/app-utils/pfetch/spec
@@ -1,0 +1,4 @@
+VER=2.11.1
+SRCS="git::commit=tags/v$VER::https://github.com/Gobidev/pfetch-rs.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373449"


### PR DESCRIPTION
Topic Description
-----------------

- pfetch: new, 2.11.1

Package(s) Affected
-------------------

- pfetch: 2.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
