### PR TITLE
mission-center: detect CPU name on LoongArch

### DIFF
--- a/app-utils/mission-center/autobuild/patches/0002-Update-sysinfo-to-detect-CPU-name-on-LoongArch.patch
+++ b/app-utils/mission-center/autobuild/patches/0002-Update-sysinfo-to-detect-CPU-name-on-LoongArch.patch
@@ -1,0 +1,12 @@
+diff -ruN a/subprojects/magpie/platform-linux/Cargo.toml b/subprojects/magpie/platform-linux/Cargo.toml
+--- a/subprojects/magpie/platform-linux/Cargo.toml	2025-05-14 17:30:00.214703570 +0800
++++ b/subprojects/magpie/platform-linux/Cargo.toml	2025-05-14 17:32:28.554693871 +0800
+@@ -14,7 +14,7 @@
+ libc = "0.2"
+ libloading = "0.8"
+ log = "0.4"
+-sysinfo = "0.33"
++sysinfo = "0.35.1"
+ thiserror = "2.0"
+ trim-in-place = "0.1"
+ udisks2 = "0.3"

--- a/app-utils/mission-center/spec
+++ b/app-utils/mission-center/spec
@@ -1,4 +1,5 @@
 VER=1.0.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://gitlab.com/mission-center-devs/mission-center"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377664"

--- a/desktop-gnome/libadwaita/autobuild/defines
+++ b/desktop-gnome/libadwaita/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libadwaita
 PKGSEC=gnome
-PKGDEP="gtk-4"
+PKGDEP="appstream fribidi glib glibc graphene gtk-4 pango"
 BUILDDEP="gi-docgen gobject-introspection gtk-doc sassc vala"
 PKGDES="Common API and runtime library for GNOME applications"
 

--- a/desktop-gnome/libadwaita/spec
+++ b/desktop-gnome/libadwaita/spec
@@ -1,4 +1,5 @@
 VER=1.7.2
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libadwaita/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234898"


### PR DESCRIPTION
Topic Description
-----------------

- mission-center: detetct CPU name on LoongArch
    - Update sysinfo to support detecting CPU name on LoongArch
    Signed-off-by: Qing Yun <kf@aosc.io>
- libadwaita: add missing dependencies
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- libadwaita: 1.7.2-1
- mission-center: 1.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libadwaita mission-center
```

Test Build(s) Done
------------------

