### PR TITLE
poppler: update to 25.05.0

### DIFF
--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -1,4 +1,4 @@
-VER=25.04.0
+VER=25.05.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
-CHKSUMS="sha256::b010c596dce127fba88532fd2f1043e55ea30601767952d0f2c0a80e7dc0da3d"
+CHKSUMS="sha256::9b1627c5b76816ac5e4052a03f5b605ba40b45cf06b02cadd0479620b499ab38"
 CHKUPDATE="anitya::id=3686"


### PR DESCRIPTION
Topic Description
-----------------

- poppler: update to 25.05.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- poppler: 1:25.05.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
