### PR TITLE
rustc: update to 1.87.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From f1ff69bcb00bd3f94295db317e77a0600629c6a2 Mon Sep 17 00:00:00 2001
+From 5b726d1b6494e3a537cd633b3ade50c462b9be12 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/2] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 794d6457cb..17da20a2c4 100644
+index 7234d1dc63..4d4d9469a6 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1676,6 +1676,7 @@ supported_targets! {
+@@ -1737,6 +1737,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-Add-MIPS-definitions-to-vendored-libffi-sys.patch
@@ -1,4 +1,4 @@
-From 35bcf8f8e24aeefe961d240f20d877db896a5a7b Mon Sep 17 00:00:00 2001
+From 13cee413c1ce8351b043adb190c255ce7b457b4f Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:40 -0800
 Subject: [PATCH 2/2] Add MIPS definitions to vendored libffi-sys

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,14 +1,14 @@
-VER=1.86.0
+VER=1.87.0
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::d939eada065dc827a9d4dbb55bd48533ad14c16e7f0a42e70147029c82a7707b"
+CHKSUMS="sha256::8623b8651893e8c6aebfa45b6a90645a4f652f7b18189a0992a90d11ac2631f4"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.
 #
 # Comment the following segment if this is not the case.
-#SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.x \
+#SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz \
 #      tbl::rename=rustc-bootstrap-${VER}-loongson3.tar.xz::https://repo.aosc.io/aosc-repacks/rust-loongson3/rustc-bootstrap-${VER}-loongson3.tar.xz"
 #CHKSUMS="sha256::bc2c1639f26814c7b17a323992f1e08c3b01fe88cdff9a27d951987d886e00b3 \
 #         sha256::c8bad5abe44f459fd7983a66337543952fea756fcfa73ddd10a869c4c753c336"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.87.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.87.0
    \(HEAD: 13cee413c1ce8351b043adb190c255ce7b457b4f\).

Package(s) Affected
-------------------

- rustc: 1:1.87.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
