### PR TITLE
Add missing setuptools-python2 build dependencies (group 7)

### DIFF
--- a/app-admin/rtslib-fb/autobuild/defines
+++ b/app-admin/rtslib-fb/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=rtslib-fb
 PKGSEC=python
-PKGDEP="pyudev six"
+PKGDEP="python-2 python-3 pyudev six"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="Python API for in-kernel LIO target"
 
 ABHOST=noarch

--- a/app-admin/rtslib-fb/spec
+++ b/app-admin/rtslib-fb/spec
@@ -2,3 +2,4 @@ VER=2.1.75
 SRCS="tbl::https://github.com/open-iscsi/rtslib-fb/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::1a4a560eb85f64d088393c0d18d2205421d20239ff95bed4b1ccbab72fe2aadb"
 CHKUPDATE="anitya::id=38954"
+REL=1

--- a/app-devel/gyp/autobuild/defines
+++ b/app-devel/gyp/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gyp
 PKGSEC=devel
-PKGDEP="setuptools ninja"
+PKGDEP="setuptools-python2 ninja"
 PKGDES="System for generating build configurations"
 
 ABHOST=noarch

--- a/app-devel/gyp/spec
+++ b/app-devel/gyp/spec
@@ -1,4 +1,4 @@
 VER=20191203
-REL=1
+REL=2
 SRCS="git::commit=e87d37d6bce611abed35e854d5ae1a401e9ce04c::https://chromium.googlesource.com/external/gyp"
 CHKSUMS="SKIP"

--- a/lang-python/configshell-fb/autobuild/defines
+++ b/lang-python/configshell-fb/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=configshell-fb
 PKGSEC=python
-PKGDEP="pyparsing six urwid"
+PKGDEP="python-2 python-3 pyparsing six urwid"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="A Python library for building configuration shells"
 
 ABHOST=noarch

--- a/lang-python/configshell-fb/spec
+++ b/lang-python/configshell-fb/spec
@@ -2,3 +2,4 @@ VER=1.1.30
 SRCS="tbl::https://github.com/open-iscsi/configshell-fb/archive/v${VER}.tar.gz"
 CHKSUMS="sha256::44696b92bea2b44c1d0bf2828477dddeb3b4dfb312ad82ce06d7b704c0985e27"
 CHKUPDATE="anitya::id=38968"
+REL=1

--- a/lang-python/dateutil/autobuild/defines
+++ b/lang-python/dateutil/autobuild/defines
@@ -1,10 +1,11 @@
 PKGNAME=dateutil
 PKGSEC=python
-PKGDEP="six"
-BUILDDEP="setuptools-scm"
+PKGDEP="python-3 six"
+BUILDDEP="setuptools setuptools-scm"
 PKGDES="Powerful extensions to the standard datetime module"
 
 ABTYPE=python
+NOPYTHON2=1
 
 PKGREP="dateutils python-dateutil"
 PKGPROV="dateutils python-dateutil"

--- a/lang-python/dateutil/spec
+++ b/lang-python/dateutil/spec
@@ -2,3 +2,4 @@ VER=2.8.2
 SRCS="tbl::https://files.pythonhosted.org/packages/source/p/python-dateutil/python-dateutil-$VER.tar.gz"
 CHKSUMS="sha256::0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
 CHKUPDATE="anitya::id=5621"
+REL=1

--- a/lang-python/lockfile/autobuild/defines
+++ b/lang-python/lockfile/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=lockfile
 PKGSEC=python
 PKGDES="A platform-independent file locking module for Python"
 PKGDEP="python-3 python-2 pbr"
+BUILDDEP="setuptools setuptools-python2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/lang-python/lockfile/spec
+++ b/lang-python/lockfile/spec
@@ -2,4 +2,4 @@ VER=0.12.2
 SRCS="https://pypi.io/packages/source/l/lockfile/lockfile-${VER}.tar.gz"
 CHKSUMS="sha256::6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"
 CHKUPDATE="anitya::id=89384"
-REL=1
+REL=2

--- a/lang-python/pastel/autobuild/defines
+++ b/lang-python/pastel/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="python-2 python-3"
 BUILDDEP="setuptools setuptools-python2"
 PKGDES="Python module that brings colors to your terminal"
 
+ABTYPE=python
 ABHOST=noarch

--- a/lang-python/pastel/autobuild/defines
+++ b/lang-python/pastel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pastel
 PKGSEC=python
 PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="Python module that brings colors to your terminal"
 
 ABHOST=noarch

--- a/lang-python/pastel/spec
+++ b/lang-python/pastel/spec
@@ -2,4 +2,4 @@ VER=0.2.0
 SRCS="tbl::https://pypi.io/packages/source/p/pastel/pastel-$VER.tar.gz"
 CHKSUMS="sha256::46155fc523bdd4efcd450bbcb3f2b94a6e3b25edc0eb493e081104ad09e1ca36"
 CHKUPDATE="anitya::id=21161"
-REL=1
+REL=2

--- a/lang-python/pastel/spec
+++ b/lang-python/pastel/spec
@@ -1,5 +1,5 @@
 VER=0.2.0
-SRCS="tbl::https://pypi.io/packages/source/p/pastel/pastel-$VER.tar.gz"
+SRCS="pypi::version=$VER::pastel"
 CHKSUMS="sha256::46155fc523bdd4efcd450bbcb3f2b94a6e3b25edc0eb493e081104ad09e1ca36"
 CHKUPDATE="anitya::id=21161"
 REL=2

--- a/lang-python/pyscard/autobuild/defines
+++ b/lang-python/pyscard/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=pyscard
 PKGSEC=python
 PKGDEP="pcsclite python-2 python-3"
-BUILDDEP="swig"
+BUILDDEP="swig setuptools-python2 setuptools-python3"
 PKGDES="A Python module for smart card support"

--- a/lang-python/pyscard/spec
+++ b/lang-python/pyscard/spec
@@ -1,5 +1,5 @@
 VER=1.9.9
 SRCS="tbl::https://pypi.io/packages/source/p/pyscard/pyscard-$VER.tar.gz"
 CHKSUMS="sha256::e6bde541990183858740793806b1c7f4e798670519ae4c96145f35d5d7944c20"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=134670"


### PR DESCRIPTION
Topic Description
-----------------

- dateutil: add missing setuptools dependencies
- rtslib-fb: add missing setuptools-python2 build dependency
- lockfile: add missing setuptools build dependency
- configshell-fb: add missing setuptools build dependency
- gyp: fix setuptools-python2 dependency
- pyscard: add missing setuptools dependencies
- pastel: use pypi sources
- pastel: use python build template
- pastel: add missing setuptools-python2 build dependency

Package(s) Affected
-------------------

- configshell-fb: 1.1.30-1
- dateutil: 2.8.2-1
- gyp: 20191203-2
- lockfile: 0.12.2-2
- pastel: 0.2.0-2
- pyscard: 1.9.9-3
- rtslib-fb: 2.1.75-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtslib-fb gyp configshell-fb dateutil lockfile pastel pyscard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
