### PR TITLE
pycryptodome{,x}: update to 3.22.0x

### DIFF
--- a/lang-python/pycryptodome/autobuild/defines
+++ b/lang-python/pycryptodome/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=pycryptodome
 PKGSEC=python
-PKGDEP="gmp python-3"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+PKGRECOM="gmp"
+BUILDDEP="setuptools-python3"
 PKGDES="Collection of cryptographic algorithms and protocols"
 
 PKGBREAK="pycrypto<=2.6.1-4"

--- a/lang-python/pycryptodome/spec
+++ b/lang-python/pycryptodome/spec
@@ -1,5 +1,4 @@
-VER=3.21.0
-REL=1
-SRCS="pypi::version=$VER::pycryptodome"
-CHKSUMS="sha256::f7787e0d469bdae763b876174cf2e6c0f7be79808af26b1da96f1a64bcf47297"
+VER=3.22.0x
+SRCS="git::commit=tags/v${VER}::https://github.com/Legrandin/pycryptodome.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=36849"

--- a/lang-python/pycryptodomex/autobuild/defines
+++ b/lang-python/pycryptodomex/autobuild/defines
@@ -1,5 +1,11 @@
 PKGNAME=pycryptodomex
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+PKGRECOM="gmp"
+BUILDDEP="python-build setuptools-python3"
 PKGDES="A self-contained Python package of low-level cryptographic primitives"
+
+# FIXME: use PEP-517 after https://github.com/AOSC-Dev/autobuild4/issues/54
+#        get fixed
+ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/pycryptodomex/autobuild/prepare
+++ b/lang-python/pycryptodomex/autobuild/prepare
@@ -1,0 +1,3 @@
+# Note: required to build pycryptodomex instead of pycryptodome
+abinfo "Creating .separate_namespace ..."
+touch "$SRCDIR"/.separate_namespace

--- a/lang-python/pycryptodomex/spec
+++ b/lang-python/pycryptodomex/spec
@@ -1,5 +1,4 @@
-VER=3.9.9
-SRCS="https://pypi.org/packages/source/p/pycryptodomex/pycryptodomex-${VER}.tar.gz"
-CHKSUMS="sha256::7b5b7c5896f8172ea0beb283f7f9428e0ab88ec248ce0a5b8c98d73e26267d51"
+VER=3.22.0x
+SRCS="git::commit=tags/v${VER}::https://github.com/Legrandin/pycryptodome.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=36851"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pycryptodome: update to 3.22.0x
    - Update to 3.22.0x
    - Use git sources instead of tarballs
    - Move GMP to recommendations
- pycryptodomex: update to 3.22.0x
    - Update to 3.22.0x
    - Use git sources instead of tarballs
    - Use PEP-517 build template and drop Python-2 support
    - Recommend GMP for better performance
    Signed-off-by: xtex <xtexchooser@duck.com>

Package(s) Affected
-------------------

- pycryptodome: 3.22.0x
- pycryptodomex: 3.22.0x

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycryptodomex pycryptodome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
