### PR TITLE
epson-inkjet-printer-escpr: new, 1.8.6

### DIFF
--- a/runtime-doc/epson-inkjet-printer-escpr/autobuild/defines
+++ b/runtime-doc/epson-inkjet-printer-escpr/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=epson-inkjet-printer-escpr
+PKGSEC=libs
+PKGDEP="cups ghostscript"
+PKGDES="Drivers for Epson Multifunction Inkjet Printers (Epson ESC/P-R Driver)"
+
+ABTYPE=autotools
+ABSHADOW=0

--- a/runtime-doc/epson-inkjet-printer-escpr/spec
+++ b/runtime-doc/epson-inkjet-printer-escpr/spec
@@ -1,0 +1,4 @@
+VER=1.8.6
+SRCS="git::commit=tags/aosc/${VER}%${REL:-0}::https://github.com/AOSC-Tracking/epson-inkjet-printer-escpr.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=374686"


### PR DESCRIPTION
Topic Description
-----------------

- epson-inkjet-printer-escpr: new, 1.8.6
    - Track patches at AOSC-Tracking/epson-inkjet-printer-escpr
    HEAD: 19951500506e922499375e8bb1198dc9830fc708

Package(s) Affected
-------------------

- epson-inkjet-printer-escpr: 1.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit epson-inkjet-printer-escpr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
