### PR TITLE
freecad: update to 1.0.1

### DIFF
--- a/app-creativity/freecad/autobuild/patches/0001-AOSCOS-Fix-HDF5-setup.patch
+++ b/app-creativity/freecad/autobuild/patches/0001-AOSCOS-Fix-HDF5-setup.patch
@@ -1,0 +1,35 @@
+From 1df9e0a526b93b450fc98235210fe21edf5e1fe7 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 17 May 2025 08:21:52 +0800
+Subject: [PATCH] AOSCOS: Fix HDF5 setup
+X-Developer-Signature: v=1; a=openpgp-sha256; l=851; i=xtexchooser@duck.com;
+ h=from:subject; bh=GFdo1JWvV+GQEnTxRQKwj7B5/2NY8RS/+IWYGCYFoQk=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBnqt8qWfnsXs6j6dUu3VcKxA7FKgf4349o3sIisqvqYf
+ V9UXPV7RykLgxgXg6yYIkuRYYM3q046v+iyclmYOaxMIEMYuDgFYCK29owML/lKPvg92bj2RH2+
+ VHzNQrO1DnPLcr8n1BbMCvx/U7lImZHh7GEdrx7j/+o71/ksUvu1hbN8z/dl1y+JGJz6HN91WU+
+ YCQA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+index cd00c0d2cce7..d226deece769 100644
+--- a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
++++ b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+@@ -97,7 +97,7 @@ macro(SetupSalomeSMESH)
+                 endif()
+                 pkg_search_module(HDF5 ${HDF5_VARIANT})
+                 if(NOT HDF5_FOUND)
+-                    find_package(HDF5 REQUIRED)
++                    find_package(HDF5 REQUIRED COMPONENTS C)
+                 else()
+                     add_compile_options(${HDF5_CFLAGS})
+                     link_directories(${HDF5_LIBRARY_DIRS})
+
+base-commit: 878f0b8c9c72c6f215833a99f2762bc3a3cf2abd
+-- 
+2.49.0
+

--- a/app-creativity/freecad/spec
+++ b/app-creativity/freecad/spec
@@ -1,5 +1,4 @@
-VER=1.0.0
-REL=1
+VER=1.0.1
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/FreeCAD/FreeCAD"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=836"


### PR DESCRIPTION
Topic Description
-----------------

- freecad: update to 1.0.1

Package(s) Affected
-------------------

- freecad: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit freecad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
