### PR TITLE
appstream: update to 1.0.4

### DIFF
--- a/app-admin/appstream/spec
+++ b/app-admin/appstream/spec
@@ -1,5 +1,4 @@
-VER=1.0.3
-REL=2
+VER=1.0.4
 SRCS="git::commit=tags/v${VER}::https://github.com/ximion/appstream.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10385"

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,4 +1,5 @@
 VER=1.16.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \

--- a/app-admin/packagekit/spec
+++ b/app-admin/packagekit/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/PackageKit/PackageKit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8932"

--- a/desktop-gnome/libadwaita/spec
+++ b/desktop-gnome/libadwaita/spec
@@ -1,5 +1,5 @@
 VER=1.7.2
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libadwaita/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=234898"

--- a/groups/appstream-rebuilds
+++ b/groups/appstream-rebuilds
@@ -1,4 +1,4 @@
 flatpak
 libadwaita
 packagekit
-gnome-software
+#gnome-software


### PR DESCRIPTION
Topic Description
-----------------

- libadwaita: rebuild for appstream 1.0.4
- gnome-software: rebuild for appstream 1.0.4
- packagekit: rebuild for appstream 1.0.4
- flatpak: rebuild for appstream 1.0.4
- appstream: update to 1.0.4

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream groups/appstream-rebuilds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
