### PR TITLE
mesa: fix build config/patches regression at 25.1

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -82,16 +82,16 @@ MESON_AFTER="-Ddri-drivers-path=/usr/lib/xorg/modules/dri \
 
 MESON_AFTER__X86=" \
              ${MESON_AFTER} \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,iris,d3d12,i915,crocus,zink \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,llvmpipe,svga,iris,d3d12,i915,crocus,zink \
              -Dintel-clc=enabled \
              -Dvulkan-drivers=amd,intel,intel_hasvk,swrast,virtio"
 MESON_AFTER__ARM=" \
              ${MESON_AFTER} \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,llvmpipe,lima,panfrost,freedreno,tegra,vc4,v3d,etnaviv,d3d12,zink,asahi \
              -Dvulkan-drivers=amd,asahi,intel,broadcom,freedreno,panfrost,swrast,virtio"
 MESON_AFTER__OTHER=" \
              ${MESON_AFTER} \
-             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,zink \
+             -Dgallium-drivers=r300,r600,radeonsi,nouveau,iris,virgl,llvmpipe,zink \
              -Dvulkan-drivers=amd,intel,swrast,virtio"
 
 MESON_AFTER__AMD64=" \

--- a/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,7 +1,7 @@
-From a763eba20b683c4f89f1a4ac6884112333133c86 Mon Sep 17 00:00:00 2001
+From 0160cc0d0b7450b05cb7ea38c6b13080dfd4368e Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
-Subject: [PATCH 3/3] FROMLIST: zink: Do not use demote on IMG blobs
+Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
 
 The implementation of demote in IMG blobs seems to be a piece of hack,
 and the current use of it in Zink leads to assertion failure with
@@ -10,13 +10,8 @@ shader".
 
 Disable usage of demote for IMG blobs.
 
-[Mingcong Bai: Resolved minor merge conflict in
-src/gallium/drivers/zink/zink_screen.c, as
-PIPE_CAP_DEMOTE_TO_HELPER_INVOCATION in zink_get_param() was refactored
-as src->demote_to_helper_invocation in zink_init_screen_caps().]
-
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33051>
 ---
  src/gallium/drivers/zink/zink_compiler.c |  3 ++-
  src/gallium/drivers/zink/zink_screen.c   | 15 +++++++++++++--

--- a/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,0 +1,36 @@
+From cae31848a9256105b716766353d771ea21b67782 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 30 Nov 2024 17:11:09 +0800
+Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
+ proprietary driver
+
+The proprietary driver for Imagination Rogue-architecture GPUs does not
+come with geometryShader support.
+
+Change the assert for it to another if condition.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 26254397268..75b60dfd5b9 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2844,10 +2844,9 @@ init_driver_workarounds(struct zink_screen *screen)
+    }
+ 
+    if (zink_driverid(screen) ==
+-       VK_DRIVER_ID_IMAGINATION_PROPRIETARY) {
+-      assert(screen->info.feats.features.geometryShader);
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+-   }
+ 
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,0 +1,34 @@
+From ed470d0533fac87c6a56034a46197629e5082cae Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 09:00:21 +0800
+Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting
+
+The closed blob from Imagination for their Rogue GPUs cannot accept
+empty VkSubmitInfo, skip them.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index c7e746829ed..c861587538e 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -674,6 +674,13 @@ submit_queue(void *data, void *gdata, int thread_index)
+       }
+    }
+ 
++   if (si[ZINK_SUBMIT_WAIT_ACQUIRE].waitSemaphoreCount != 0 &&
++       si[ZINK_SUBMIT_WAIT_FD].waitSemaphoreCount == 0) {
++      si[ZINK_SUBMIT_WAIT_FD] = si[ZINK_SUBMIT_WAIT_ACQUIRE];
++      num_si--;
++      submit++;
++   }
++
+    /* then the real submit */
+    si[ZINK_SUBMIT_CMDBUF].waitSemaphoreCount = util_dynarray_num_elements(&bs->wait_semaphores, VkSemaphore);
+    si[ZINK_SUBMIT_CMDBUF].pWaitSemaphores = bs->wait_semaphores.data;
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,0 +1,73 @@
+From 82152389e5e0dbf0c42d1c990e1e11cea6c7c528 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 20:49:58 +0800
+Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
+ Imagination Rogue
+
+The proprietary Vulkan driver for Imagination Rogue architecture GPUs
+has a broken VkQueueSubmit which cannot handle semaphore signaling w/o
+command buffers.
+
+Try to merge semaphores signaling submit to command processing one in
+this case.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c  | 9 ++++++++-
+ src/gallium/drivers/zink/zink_screen.c | 6 ++++++
+ src/gallium/drivers/zink/zink_types.h  | 1 +
+ 3 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index c861587538e..e621da37cef 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -763,8 +763,15 @@ submit_queue(void *data, void *gdata, int thread_index)
+       );
+    }
+ 
+-   if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount)
++   if (!si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount &&
++       screen->driver_workarounds.broken_submit) {
++      si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount = si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount;
++      si[ZINK_SUBMIT_CMDBUF].pSignalSemaphores = si[ZINK_SUBMIT_SIGNAL].pSignalSemaphores;
++      si[ZINK_SUBMIT_CMDBUF].pNext = si[ZINK_SUBMIT_SIGNAL].pNext;
+       num_si--;
++   } else if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount) {
++      num_si--;
++   }
+ 
+    simple_mtx_lock(&screen->queue_lock);
+    VRAM_ALLOC_LOOP(result,
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 75b60dfd5b9..9e2a29ccfd5 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2848,6 +2848,12 @@ init_driver_workarounds(struct zink_screen *screen)
+        screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+ 
++   /* Assume Rogue when no geometryShader is available */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       !screen->info.feats.features.geometryShader)
++      screen->driver_workarounds.broken_submit = true;
++
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+     * proprietary driver.
+diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
+index 66a3fc1200f..da6e92a8df9 100644
+--- a/src/gallium/drivers/zink/zink_types.h
++++ b/src/gallium/drivers/zink/zink_types.h
+@@ -1565,6 +1565,7 @@ struct zink_screen {
+       bool inconsistent_interpolation;
+       bool can_2d_view_sparse;
+       bool general_depth_layout;
++      bool broken_submit;
+       unsigned z16_unscaled_bias;
+       unsigned z24_unscaled_bias;
+    } driver_workarounds;
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,0 +1,36 @@
+From 9268c902578e5dc3540b31b7c04bdc43a445ce1f Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 29 Nov 2024 16:10:29 +0800
+Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
+ driver w/o geometryShader"
+
+This reverts commit ca087e202766872085d6d02363fd7f4961feba48.
+
+As running Zink on Rogue proprietary driver is somehow fixed now, revert
+this commit to reallow it.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 9e2a29ccfd5..44e6b6a8cbd 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3414,12 +3414,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
+-   if (zink_driverid(screen) == VK_DRIVER_ID_IMAGINATION_PROPRIETARY && !screen->info.feats.features.geometryShader) {
+-      if (!screen->driver_name_is_inferred)
+-         mesa_loge("zink: Imagination proprietary driver w/o geometryShader is unsupported");
+-      goto fail;
+-   }
+-
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,0 +1,39 @@
+From 2019daf7a1c133fac390070878313bc0b54e2961 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 26 Apr 2025 22:13:35 +0800
+Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
+ enforced
+
+Imagination closed driver 1.17@6210866 is known to be very glitchy with
+Zink.
+
+Reject it unless zink is enforced.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 44e6b6a8cbd..ec0117db081 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3414,6 +3414,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
++   /* Reject IMG blobs with DDK below 1.17@6210866 if not forced */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.props.driverVersion <= 6210866) {
++      debug_printf("zink: Imagination proprietary driver is too old to be supported\n");
++      if (screen->driver_name_is_inferred)
++         goto fail;
++   }
++
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=25.1.0
 DXHEADERS_VER=1.615.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
-REL=1
+REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
 CHKSUMS="sha256::b1c45888969ee5df997e2542654f735ab1b772924b442f3016d2293414c99c14 \


### PR DESCRIPTION
Topic Description
-----------------

- mesa: fix a few issues raised when updating to Mesa 25.1
    - Add llvmpipe to Gallium driver list \(because the "swrast" name is
    deprecated and removed\).
    - Refresh IMG Vulkan Zink related patches. The demote one is changed to
    a BACKPORT \(from mesa main branch\) and the Rogue ones are added back.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:25.1.0+dxheaders1.615.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
