### PR TITLE
mission-center: detect CPU frequency on LoongArch

### DIFF
--- a/app-utils/mission-center/autobuild/defines
+++ b/app-utils/mission-center/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=mission-center
 PKGSEC=utils
 PKGDES="A GUI tool displays CPU, memory, disk, network and GPU usage"
-PKGDEP="cairo gcc-runtime gdk-pixbuf glib glibc graphene gtk-4 libadwaita pango mesa systemd"
+PKGDEP="cairo gcc-runtime gdk-pixbuf glib glibc graphene gtk-4 libadwaita \
+        pango mesa systemd nethogs polkit"
 BUILDDEP="rustc llvm gtk-update-icon-cache desktop-file-utils blueprint-compiler appdata-tools"
 
 ABTYPE=meson

--- a/app-utils/mission-center/autobuild/patches/0003-Fix-read_proc_cpuinfo-on-LoongArch.patch
+++ b/app-utils/mission-center/autobuild/patches/0003-Fix-read_proc_cpuinfo-on-LoongArch.patch
@@ -1,0 +1,12 @@
+diff -ruN a/subprojects/magpie/platform-linux/src/cpu/cpufreq.rs b/subprojects/magpie/platform-linux/src/cpu/cpufreq.rs
+--- a/subprojects/magpie/platform-linux/src/cpu/cpufreq.rs	2025-05-17 18:33:25.031795029 +0800
++++ b/subprojects/magpie/platform-linux/src/cpu/cpufreq.rs	2025-05-17 18:43:15.651773600 +0800
+@@ -102,7 +102,7 @@
+         let mut result = 0;
+         for line in cpuinfo
+             .split('\n')
+-            .filter(|line| line.starts_with("cpu MHz\t") || line.starts_with("clock\t"))
++            .filter(|line| line.starts_with("cpu MHz\t") || line.starts_with("CPU MHz\t") || line.starts_with("clock\t"))
+         {
+             result = line
+                 .split(':')

--- a/app-utils/mission-center/autobuild/patches/0004-Change-memory-default-base-to-2.patch
+++ b/app-utils/mission-center/autobuild/patches/0004-Change-memory-default-base-to-2.patch
@@ -1,0 +1,50 @@
+From ca66bea68d29cb1a69f7af24e73e7c5ffebf37eb Mon Sep 17 00:00:00 2001
+From: jojo2357 <11406210-jojo2357@users.noreply.gitlab.com>
+Date: Sat, 17 May 2025 03:52:00 +0000
+Subject: [PATCH] Change memory default base to 2
+
+---
+ data/io.missioncenter.MissionCenter.gschema.xml | 8 ++++----
+ src/main.rs                                     | 3 ++-
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/data/io.missioncenter.MissionCenter.gschema.xml b/data/io.missioncenter.MissionCenter.gschema.xml
+index 869cee70..67fc1aa6 100644
+--- a/data/io.missioncenter.MissionCenter.gschema.xml
++++ b/data/io.missioncenter.MissionCenter.gschema.xml
+@@ -70,14 +70,14 @@
+             <summary>How many points should be displayed on each chart?</summary>
+         </key>
+ 
+-        <key name="performance-page-memory-use-bytes" type="b">
++        <key name="performance-page-memory2-use-bytes" type="b">
+             <default>true</default>
+             <summary>Whether or not to use bits or bytes (default) for memory</summary>
+         </key>
+ 
+-        <key name="performance-page-memory-use-base2" type="b">
+-            <default>false</default>
+-            <summary>Whether or not to use base-10 (default) or base-2 for memory</summary>
++        <key name="performance-page-memory2-use-base2" type="b">
++            <default>true</default>
++            <summary>Whether or not to use base-10 or base-2 (default) for memory</summary>
+         </key>
+ 
+         <key name="performance-page-drive-use-bytes" type="b">
+diff --git a/src/main.rs b/src/main.rs
+index f0aab64a..7d7b7f6d 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -212,7 +212,8 @@ pub enum DataType {
+ 
+ fn data_type_setting_name(data_type: &DataType) -> &'static str {
+     match data_type {
+-        DataType::MemoryBytes => "memory",
++        // because we biffed it. see https://gitlab.com/mission-center-devs/mission-center/-/issues/385
++        DataType::MemoryBytes => "memory2",
+         DataType::DriveBytes => "drive",
+         DataType::DriveBytesPerSecond => "drive",
+         DataType::NetworkBytes => "network",
+-- 
+GitLab
+

--- a/app-utils/mission-center/spec
+++ b/app-utils/mission-center/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://gitlab.com/mission-center-devs/mission-center"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377664"


### PR DESCRIPTION
Topic Description
-----------------

- mission-center: detect CPU frequency on LoongArch
    - Detect CPU frequency on LoongArch
    - Backport patch to change memory default base to 2
    - Add missing dependencies
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- mission-center: 1.0.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mission-center
```

Test Build(s) Done
------------------

