### PR TITLE
niri: update to 25.05

### DIFF
--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=x11
 PKGDEP="bash cairo gcc-runtime glib glibc gnome-keyring libdisplay-info \
         libinput libxkbcommon mesa pango pipewire pixman seatd systemd \
         wayland xdg-desktop-portal-gtk xdg-desktop-portal-gnome"
-PKGRECOM="alacritty fuzzel swaylock xwayland-satellite"
+PKGRECOM="alacritty fuzzel swaylock waybar xwayland-satellite"
 PKGSUG="mako-notification-daemon swaybg swayidle"
 BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,5 +1,4 @@
-VER=25.02
+VER=25.05
 SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- niri: update to 25.05
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- niri: 25.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
