### PR TITLE
intel-oneapi-basekit: update to 2025.1.2

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2025.1.0
-PKG_URL=cca951e1-31e7-485e-b300-fe7627cb8c08
-PKG_CODE=651
+VER=2025.1.2
+PKG_URL=ac050ae7-da93-4108-823d-4334de3f4ee8
+PKG_CODE=9
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha384::98cad2489f2c90a2b328568a59371cf35855a3338643f61a9fc2d16a265d29f22feb2d673916dd7be18fa12a5e6d2475"
+CHKSUMS="sha384::281cb8183e18baccd001b2442dec46ca4ac70ba3e1e72e457042020cccb5a2223073df933bacf880bcb5c0023c72d237"
 CHKUPDATE="anitya::id=372585"


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.1.2

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
