### PR TITLE
zram-generator: update to 1.2.1

### DIFF
--- a/app-admin/zram-generator/autobuild/defines
+++ b/app-admin/zram-generator/autobuild/defines
@@ -5,10 +5,7 @@ PKGDEP="systemd"
 BUILDDEP="rustc llvm ronn-ng"
 
 USECLANG=1
-ABSPLITDBG=0
 ABTYPE=rust
 
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1
-NOLTO__MIPS64R6EL=1

--- a/app-admin/zram-generator/spec
+++ b/app-admin/zram-generator/spec
@@ -1,5 +1,4 @@
-VER=1.1.2
-REL=1
+VER=1.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/zram-generator"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18509"


### PR DESCRIPTION
Topic Description
-----------------

- zram-generator: update to 1.2.1
    - Enable LTO on loongarch64.
    - Enable ABSPLITDBG.

Package(s) Affected
-------------------

- zram-generator: 1.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zram-generator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
