### PR TITLE
usage: update to mise

### DIFF
--- a/app-utils/usage/spec
+++ b/app-utils/usage/spec
@@ -1,4 +1,4 @@
-VER=2.0.3
+VER=mise
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/usage.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376568"


### PR DESCRIPTION
Topic Description
-----------------

- usage: update to mise
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- usage: mise

Security Update?
----------------

No

Build Order
-----------

```
#buildit usage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
