### PR TITLE
mise: update to 2025.5.6

### DIFF
--- a/app-devel/mise/spec
+++ b/app-devel/mise/spec
@@ -1,4 +1,4 @@
-VER=2025.2.8
+VER=2025.5.6
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/mise.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376460"


### PR DESCRIPTION
Topic Description
-----------------

- mise: update to 2025.5.6
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- mise: 2025.5.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit mise
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
