### PR TITLE
gimp: update to 3.0.4

### DIFF
--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,4 +1,4 @@
-VER=3.0.2
+VER=3.0.4
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:3}/gimp-${VER/~rc/-RC}.tar.xz"
-CHKSUMS="sha256::546ddc30cb2d0e79123c7fcb4d78211e1ee7a6aace91a6a0ad8cbcbf6ea571a2"
+CHKSUMS="sha256::8caa2ec275bf09326575654ac276afc083f8491e7cca45d19cf29e696aecab25"
 CHKUPDATE="anitya::id=1161"

--- a/runtime-imaging/babl/spec
+++ b/runtime-imaging/babl/spec
@@ -1,4 +1,4 @@
-VER=0.1.112
+VER=0.1.114
 SRCS="tbl::https://download.gimp.org/pub/babl/${VER%.*}/babl-${VER}.tar.xz"
-CHKSUMS="sha256::fb696682421787c8fecc83e8aab48121dec8ee38d119b65291cfcbe315028a79"
+CHKSUMS="sha256::bcbb7786c1e447703db3bc7fa34d62d0d2d117b22f04d8834c7b2d5ded456487"
 CHKUPDATE="anitya::id=7843"

--- a/runtime-imaging/gegl-0.4/spec
+++ b/runtime-imaging/gegl-0.4/spec
@@ -1,4 +1,4 @@
-VER=0.4.58
+VER=0.4.62
 SRCS="tbl::https://download.gimp.org/pub/gegl/${VER:0:3}/gegl-$VER.tar.xz"
-CHKSUMS="sha256::d5678bbd5fe535941b82f965b97fcc9385ce936f70c982bd565a53d5519d1bff"
+CHKSUMS="sha256::5887576371ebf1d9e90797d10e4b9a7f1658228d4827583e79e1db3d94505c6c"
 CHKUPDATE="anitya::id=229510"


### PR DESCRIPTION
Topic Description
-----------------

- gegl-0.4: update to 0.4.62
- babl: update to 0.1.114
- gimp: update to 3.0.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- babl: 0.1.114
- gegl-0.4: 0.4.62
- gimp: 3.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit babl gegl-0.4 gimp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
