### PR TITLE
rofi: update to 1.7.9

### DIFF
--- a/app-utils/rofi/spec
+++ b/app-utils/rofi/spec
@@ -1,4 +1,6 @@
-VER=1.7.8
-SRCS="tbl::https://github.com/DaveDavenport/rofi/releases/download/$VER/rofi-$VER.tar.xz"
-CHKSUMS="sha256::2ad90a8c492e0b64202088e788795bf0b31ecfaa59fe7441ad263298d150655e"
+VER=1.7.9
+# FIXME: Use $VER once the release tarball's version matches $VER
+TAG_VER=1.7.9.1
+SRCS="tbl::https://github.com/DaveDavenport/rofi/releases/download/$VER/rofi-$TAG_VER.tar.xz"
+CHKSUMS="sha256::04c128f8c56f043cd229545285ee773322d0eafaffad100b8604338108c5f5ec"
 CHKUPDATE="anitya::id=10146"


### PR DESCRIPTION
Topic Description
-----------------

- rofi: update to 1.7.9
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- rofi: 1.7.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
