### PR TITLE
parallel: update to 20250422

### DIFF
--- a/app-utils/parallel/spec
+++ b/app-utils/parallel/spec
@@ -1,4 +1,4 @@
-VER=20191122
+VER=20250422
 SRCS="tbl::https://ftp.gnu.org/gnu/parallel/parallel-$VER.tar.bz2"
-CHKSUMS="sha256::182a93155dea12ddc36b7e85fd2d8342d7a88e7a449e4161a5a291e1f4989507"
+CHKSUMS="sha256::10f0a7b7fbed87edcbd63a403fdc0ee1a1f86c241a3605f33162b4b9aff248dd"
 CHKUPDATE="anitya::id=5448"


### PR DESCRIPTION
Topic Description
-----------------

- parallel: update to 20250422
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- parallel: 20250422

Security Update?
----------------

No

Build Order
-----------

```
#buildit parallel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
