### PR TITLE
dracut-ng: use parallel-gnu explicitly

### DIFF
--- a/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
+++ b/app-admin/dracut-ng/autobuild/overrides/usr/bin/update-initramfs
@@ -45,11 +45,11 @@ export -f generate_initrd_if_needed
 
 # Generate initrd using Dracut.
 if [ -x /usr/bin/dracut ]; then
-	if [ -x /usr/bin/parallel ]; then
+	if [ -x /usr/bin/parallel-gnu ]; then
 		task_list=$(ls /usr/lib/modules | grep -v 'extramodules')
 		if [[ "e$task_list" != "e" ]]; then
 			echo -e "\033[36m**\033[0m\tGenerating initrd (Initialization RAM Disk) for $(echo ${task_list} | wc -w) kernel versions ..."
-			parallel \
+			parallel-gnu \
 				--tmpdir=/var/cache/dracut \
 				--halt-on-error soon,fail=1 \
 				--will-cite \

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,4 +1,5 @@
 VER=106
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: use parallel-gnu explicitly
    We also ship parallel via moreutils, curb the possibility of failures in
    case of the moreutils variant being set to default.

Package(s) Affected
-------------------

- dracut-ng: 106-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
