### PR TITLE
mitmproxy: update to 12.0.1

### DIFF
--- a/app-network/mitmproxy/autobuild/build
+++ b/app-network/mitmproxy/autobuild/build
@@ -25,15 +25,3 @@ python3 \
     -m installer \
     --destdir="$PKGDIR" \
     "$SRCDIR"/mitmproxy_rs/target/wheels/*.whl
-
-abinfo "Building aioquic ..."
-cd "$SRCDIR"/aioquic
-python3 \
-    -m build \
-    --no-isolation \
-    --wheel
-abinfo "Installing aioquic ..."
-python3 \
-    -m installer \
-    --destdir="$PKGDIR" \
-    "$SRCDIR"/aioquic/dist/*.whl

--- a/app-network/mitmproxy/autobuild/defines
+++ b/app-network/mitmproxy/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mitmproxy
 PKGSEC=net
-PKGDEP="asgiref blinker brotli certifi click cryptography flask hyper-h11 \
+PKGDEP="mitmproxy asgiref blinker brotli certifi click cryptography flask hyper-h11 \
         hyper-h2 hyperframe python-kaitaistruct python-ldap3 python-msgpack \
         passlib protobuf pylsqpack pyopenssl pyparsing pyperclip ruamel-yaml \
         sortedcontainers tornado urwid wsproto publicsuffix2 zstandard"

--- a/app-network/mitmproxy/spec
+++ b/app-network/mitmproxy/spec
@@ -1,12 +1,9 @@
-UPSTREAM_VER=11.0.0
-MITMPROXY_RS_VER=0.10.7
-AIOQUIC_VER=0.9.21.1
-VER=$UPSTREAM_VER+rs$MITMPROXY_RS_VER+aioquic$AIOQUIC_VER
+UPSTREAM_VER=11.1.3
+MITMPROXY_RS_VER=0.11.5
+VER=$UPSTREAM_VER+rs$MITMPROXY_RS_VER
 SRCS="git::commit=tags/v$UPSTREAM_VER;rename=mitmproxy::https://github.com/mitmproxy/mitmproxy \
-      git::commit=tags/v$MITMPROXY_RS_VER;rename=mitmproxy_rs::https://github.com/mitmproxy/mitmproxy_rs \
-      git::commit=tags/$AIOQUIC_VER;rename=aioquic::https://github.com/meitinger/aioquic_mitmproxy"
+      git::commit=tags/v$MITMPROXY_RS_VER;rename=mitmproxy_rs::https://github.com/mitmproxy/mitmproxy_rs"
 CHKSUMS="SKIP \
-         SKIP \
          SKIP"
 CHKUPDATE="anitya::id=13889"
 SUBDIR=.

--- a/lang-python/aioquic/autobuild/defines
+++ b/lang-python/aioquic/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=aioquic
+PKGSEC=python
+PKGDES="QUIC and HTTP/3 implementation in Python"
+PKGDEP="python-3 certifi cryptography pylsqpack pyopenssl service-identity"
+
+ABTYPE=pep517
+
+PKGBREAK="mitmproxy<=11.0.0"

--- a/lang-python/aioquic/spec
+++ b/lang-python/aioquic/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="pypi::version=$VER::aioquic"
+CHKSUMS="sha256::f91263bb3f71948c5c8915b4d50ee370004f20a416f67fab3dcc90556c7e7199"
+CHKUPDATE="anitya::id=37053"


### PR DESCRIPTION
Topic Description
-----------------

- mitmproxy: update to 12.0.1
- aioquic: new, 1.2.0

Package(s) Affected
-------------------

- aioquic: 1.2.0
- mitmproxy: 12.0.1+rs0.12.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit aioquic mitmproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
