### PR TITLE
rofi: update to 1.7.9.1

### DIFF
--- a/app-utils/rofi/spec
+++ b/app-utils/rofi/spec
@@ -1,4 +1,7 @@
-VER=1.7.8
-SRCS="tbl::https://github.com/DaveDavenport/rofi/releases/download/$VER/rofi-$VER.tar.xz"
-CHKSUMS="sha256::2ad90a8c492e0b64202088e788795bf0b31ecfaa59fe7441ad263298d150655e"
+VER=1.7.9.1
+# FIXME: Release tarball version and tag version are mismatching for
+# 1.7.9/1.7.9.1, use $VER when the problem is resolved.
+TAG_VER=1.7.9
+SRCS="tbl::https://github.com/davatorium/rofi/releases/download/$TAG_VER/rofi-$VER.tar.xz"
+CHKSUMS="sha256::04c128f8c56f043cd229545285ee773322d0eafaffad100b8604338108c5f5ec"
 CHKUPDATE="anitya::id=10146"


### PR DESCRIPTION
Topic Description
-----------------

- rofi: update to 1.7.9.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- rofi: 1.7.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
