### PR TITLE
catch2: update to 3.8.1

### DIFF
--- a/runtime-common/catch2/spec
+++ b/runtime-common/catch2/spec
@@ -1,4 +1,4 @@
-VER=2.13.8
-SRCS="tbl::https://github.com/catchorg/Catch2/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
+VER=3.8.1
+SRCS="git::commit=tags/v$VER::https://github.com/catchorg/Catch2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7680"

--- a/runtime-common/tl-expected/spec
+++ b/runtime-common/tl-expected/spec
@@ -1,5 +1,4 @@
-VER=1.0.0
-REL=1
-SRCS="tbl::https://github.com/TartanLlama/expected/archive/v$VER.tar.gz"
-CHKSUMS="sha256::8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee"
+VER=1.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/TartanLlama/expected"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112689"

--- a/runtime-multimedia/libkeyfinder/autobuild/defines
+++ b/runtime-multimedia/libkeyfinder/autobuild/defines
@@ -3,3 +3,8 @@ PKGSEC=sound
 PKGDES="A library for estimating the musical key of digital audio"
 PKGDEP="fftw"
 BUILDDEP="catch2"
+
+CMAKE_AFTER=(
+    '-DBUILD_TESTING=OFF'
+    '-DBUILD_SHARED_LIBS=ON'
+)

--- a/runtime-multimedia/libkeyfinder/spec
+++ b/runtime-multimedia/libkeyfinder/spec
@@ -1,4 +1,4 @@
-VER=2.2.5
-SRCS="tbl::https://github.com/mixxxdj/libkeyfinder/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::516570e310f5bb5d87146fbefb129eb972dab3347987783554001e2cac26d9d6"
+VER=2.2.8
+SRCS="git::commit=tags/$VER::https://github.com/mixxxdj/libkeyfinder"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15669"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
catch2: update to 3.8.1
Upgrade the programs that depend on it after updating catch2
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
catch2: update to 3.8.1
tl-expected: update to 1.1.0
libkeyfinder: update to 2.2.8
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Build Order
-----------


<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->


```
#buildit catch2 tl-expected libkeyfinder
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
