### PR TITLE
tealdeer: update to 1.7.2

### DIFF
--- a/app-doc/tealdeer/autobuild/defines
+++ b/app-doc/tealdeer/autobuild/defines
@@ -5,3 +5,6 @@ BUILDDEP="rustc llvm"
 PKGSEC="doc"
 
 USECLANG=1
+
+# ld.lld does not support loongson3
+NOLTO__LOONGSON3=1

--- a/app-doc/tealdeer/autobuild/defines
+++ b/app-doc/tealdeer/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME="tealdeer"
 PKGDES="Simplified, example based and community-driven man page"
+PKGDEP="glibc gcc-runtime"
 BUILDDEP="rustc llvm"
 PKGSEC="doc"
 
 USECLANG=1
-FAIL_ARCH="!(amd64|arm64)"
-ABSPLITDBG=0

--- a/app-doc/tealdeer/spec
+++ b/app-doc/tealdeer/spec
@@ -1,5 +1,4 @@
-VER=1.6.1
+VER=1.7.2
 SRCS="git::commit=tags/v$VER::https://github.com/dbrgn/tealdeer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=84521"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- tealdeer: allow more architecture build
- tealdeer: update to 1.7.2
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- tealdeer: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tealdeer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
