### PR TITLE
xdg-desktop-portal: update to 1.20.3

### DIFF
--- a/app-admin/xdg-desktop-portal/spec
+++ b/app-admin/xdg-desktop-portal/spec
@@ -1,4 +1,4 @@
-VER=1.20.1
+VER=1.20.3
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
-CHKSUMS="sha256::66cdcd12a48a28a55eda1e1925aae41d4fd15ab0fdfea43617edf764edc1c0de"
+CHKSUMS="sha256::4bfb164937f59107eb1a3cc21abaa948d903c76f3b99fac210cea38ce1da9edc"
 CHKUPDATE="anitya::id=11089"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal: update to 1.20.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- xdg-desktop-portal: 1.20.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
