### PR TITLE
dosfstools: fix build

### DIFF
--- a/app-admin/dosfstools/autobuild/defines
+++ b/app-admin/dosfstools/autobuild/defines
@@ -3,8 +3,14 @@ PKGSEC=otherosfs
 PKGDEP="glibc"
 PKGDES="DOS filesystem utilities"
 
-AUTOTOOLS_AFTER="--enable-compat-symlinks \
-                 --enable-atari-check \
-                 --enable-largefile \
-                 --disable-rpath"
-MAKE_AFTER="PREFIX=/usr"
+# FIXME: Re-generation fails.
+# configure.ac:75: error: possibly undefined macro: AM_ICONV
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+RECONF=0
+
+AUTOTOOLS_AFTER=(
+    '--enable-compat-symlinks'
+    '--enable-atari-check'
+    '--enable-largefile'
+)

--- a/app-admin/dosfstools/autobuild/prepare
+++ b/app-admin/dosfstools/autobuild/prepare
@@ -1,1 +1,0 @@
-chmod a-s "$SRCDIR"

--- a/app-admin/dosfstools/spec
+++ b/app-admin/dosfstools/spec
@@ -1,5 +1,5 @@
 VER=4.2
-REL=1
+REL=2
 SRCS="tbl::https://github.com/dosfstools/dosfstools/releases/download/v$VER/dosfstools-$VER.tar.gz"
 CHKSUMS="sha256::64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527"
 CHKUPDATE="anitya::id=455"


### PR DESCRIPTION
Topic Description
-----------------

- dosfstools: fix build
    - Disable RECONF as it currently fails with Gettext >= 0.24.
    - Drop unused prepare script.

Package(s) Affected
-------------------

- dosfstools: 4.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit dosfstools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
