### PR TITLE
fuse: add missing Gettext macro to fix re-generation

### DIFF
--- a/app-admin/fuse/autobuild/defines
+++ b/app-admin/fuse/autobuild/defines
@@ -3,8 +3,10 @@ PKGSEC=admin
 PKGDES="Filesystem in userspace"
 PKGDEP="fuse-common glibc"
 
-AUTOTOOLS_AFTER="--enable-lib \
-                 --enable-util \
-                 --enable-example \
-                 --enable-mtab \
-                 --disable-rpath"
+AUTOTOOLS_AFTER=(
+    '--enable-lib'
+    '--enable-util'
+    '--enable-example'
+    '--enable-mtab'
+    '--disable-rpath'
+)

--- a/app-admin/fuse/autobuild/patches/0001-FEDORA-More-parentheses.patch
+++ b/app-admin/fuse/autobuild/patches/0001-FEDORA-More-parentheses.patch
@@ -1,8 +1,13 @@
+From 77e6a86073673ebedc600e5fa02eeebdf723377c Mon Sep 17 00:00:00 2001
 From: Peter Lemenkov <lemenkov@gmail.com>
 Date: Mon, 9 Aug 2010 12:10:40 +0400
-Subject: [PATCH] More parentheses
+Subject: [PATCH 01/10] FEDORA: More parentheses
 
 Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>
+---
+ lib/fuse.c          | 8 +++-----
+ lib/fuse_lowlevel.c | 2 +-
+ 2 files changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/lib/fuse.c b/lib/fuse.c
 index d1d873a..ca1709c 100644
@@ -42,3 +47,6 @@ index ff03c63..255f733 100644
  	else
  		fuse_reply_open(req, &fi);
  }
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0002-FEDORA-add-fix-for-namespace-conflict-in-fuse_kernel.patch
+++ b/app-admin/fuse/autobuild/patches/0002-FEDORA-add-fix-for-namespace-conflict-in-fuse_kernel.patch
@@ -1,8 +1,12 @@
+From 785826d5997bc58b630618fcadd96dc68c57fd99 Mon Sep 17 00:00:00 2001
 From: Tom Callaway <spot@fedoraproject.org>
 Date: Wed, 26 Jun 2013 09:34:52 -0400
-Subject: [PATCH] add fix for namespace conflict in fuse_kernel.h
+Subject: [PATCH 02/10] FEDORA: add fix for namespace conflict in fuse_kernel.h
 
 https://bugzilla.redhat.com/show_bug.cgi?id=970768
+---
+ include/fuse_kernel.h | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/include/fuse_kernel.h b/include/fuse_kernel.h
 index c632b58..9e02fe3 100644
@@ -26,3 +30,6 @@ index c632b58..9e02fe3 100644
  
  /*
   * Version negotiation:
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0003-FEDORA-make-buffer-size-match-kernel-max-transfer-si.patch
+++ b/app-admin/fuse/autobuild/patches/0003-FEDORA-make-buffer-size-match-kernel-max-transfer-si.patch
@@ -1,6 +1,7 @@
+From f7b31ea2de0b587c6e5dc16ebb8f79a0ed54ab1a Mon Sep 17 00:00:00 2001
 From: Carlos Maiolino <cmaiolino-H+wXaHxf7aLQT0dZR+AlfA@public.gmane.org>
 Date: Thu, 20 Apr 2017 14:53:01 +0200
-Subject: [PATCH] make buffer size match kernel max transfer size
+Subject: [PATCH 03/10] FEDORA: make buffer size match kernel max transfer size
 
 Currently libfuse has a hardcoded buffer limit to 128kib, while fuse
 kernel module has a limit up to 32 pages.
@@ -14,6 +15,9 @@ accommodate the header, making it easier to understand why those extra
 4096 bytes are needed
 
 Signed-off-by: Carlos Maiolino <cmaiolino-H+wXaHxf7aLQT0dZR+AlfA@public.gmane.org>
+---
+ lib/fuse_kern_chan.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/lib/fuse_kern_chan.c b/lib/fuse_kern_chan.c
 index 4a9beb8..640b91a 100644
@@ -40,3 +44,6 @@ index 4a9beb8..640b91a 100644
 +	size_t bufsize = KERNEL_BUF_PAGES * getpagesize() + HEADER_SIZE;
  	return fuse_chan_new(&op, fd, bufsize, NULL);
  }
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0004-FEDORA-Whitelist-SMB2-found-on-some-NAS-devices.patch
+++ b/app-admin/fuse/autobuild/patches/0004-FEDORA-Whitelist-SMB2-found-on-some-NAS-devices.patch
@@ -1,10 +1,14 @@
+From 73013b8c215ee1d61811099a156559e1f57e21e8 Mon Sep 17 00:00:00 2001
 From: Peter Lemenkov <lemenkov@gmail.com>
 Date: Wed, 3 Apr 2019 12:23:56 +0300
-Subject: [PATCH] Whitelist SMB2 found on some NAS devices
+Subject: [PATCH 04/10] FEDORA: Whitelist SMB2 found on some NAS devices
 
 * https://bugzilla.redhat.com/1694552#c7
 
 Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>
+---
+ util/fusermount.c | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/util/fusermount.c b/util/fusermount.c
 index 4b799d9..ef9d1ed 100644
@@ -18,3 +22,6 @@ index 4b799d9..ef9d1ed 100644
  		0x73717368 /* SQUASHFS_MAGIC */,
  		0x01021994 /* TMPFS_MAGIC */,
  		0x24051905 /* UBIFS_SUPER_MAGIC */,
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0005-FEDORA-Whitelist-UFSD-backport-to-2.9-branch-452.patch
+++ b/app-admin/fuse/autobuild/patches/0005-FEDORA-Whitelist-UFSD-backport-to-2.9-branch-452.patch
@@ -1,7 +1,12 @@
+From 9faa7554c976ae63d78b5eb05d0583045808a4b9 Mon Sep 17 00:00:00 2001
 From: tenzap <46226844+tenzap@users.noreply.github.com>
 Date: Sun, 15 Sep 2019 17:57:08 +0200
-Subject: [PATCH] Whitelist UFSD (backport to 2.9 branch) (#452)
+Subject: [PATCH 05/10] FEDORA: Whitelist UFSD (backport to 2.9 branch) (#452)
 
+---
+ ChangeLog         | 6 ++++++
+ util/fusermount.c | 1 +
+ 2 files changed, 7 insertions(+)
 
 diff --git a/ChangeLog b/ChangeLog
 index 13a369f..5574f20 100644
@@ -29,3 +34,6 @@ index ef9d1ed..63a69dc 100644
  		0x58465342 /* XFS_SB_MAGIC */,
  		0x2FC12FC1 /* ZFS_SUPER_MAGIC */,
  	};
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0006-FEDORA-Correct-errno-comparison-571.patch
+++ b/app-admin/fuse/autobuild/patches/0006-FEDORA-Correct-errno-comparison-571.patch
@@ -1,7 +1,11 @@
+From 15cf3af44ec421532680c0ee38360bc18a8c61bb Mon Sep 17 00:00:00 2001
 From: Andrew Gaul <gaul@google.com>
 Date: Mon, 14 Dec 2020 19:16:05 +0900
-Subject: [PATCH] Correct errno comparison (#571)
+Subject: [PATCH 06/10] FEDORA: Correct errno comparison (#571)
 
+---
+ lib/fuse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/lib/fuse.c b/lib/fuse.c
 index ca1709c..896aa24 100644
@@ -16,3 +20,6 @@ index ca1709c..896aa24 100644
  				continue;
  			else
  				break;
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0007-FEDORA-util-ulockmgr_server.c-conditionally-define-c.patch
+++ b/app-admin/fuse/autobuild/patches/0007-FEDORA-util-ulockmgr_server.c-conditionally-define-c.patch
@@ -1,7 +1,8 @@
+From fb1ee8f71c1e2e9ffd83f9ceb520adf22a8a4f84 Mon Sep 17 00:00:00 2001
 From: Sam James <sam@gentoo.org>
 Date: Sat, 24 Jul 2021 22:02:45 +0100
-Subject: [PATCH] util/ulockmgr_server.c: conditionally define closefrom (fix
- glibc-2.34+)
+Subject: [PATCH 07/10] FEDORA: util/ulockmgr_server.c: conditionally define
+ closefrom (fix glibc-2.34+)
 
 closefrom(3) has joined us in glibc-land from *BSD and Solaris. Since
 it's available in glibc 2.34+, we want to detect it and only define our
@@ -9,6 +10,10 @@ fallback if the libc doesn't provide it.
 
 Bug: https://bugs.gentoo.org/803923
 Signed-off-by: Sam James <sam@gentoo.org>
+---
+ configure.ac           | 1 +
+ util/ulockmgr_server.c | 6 ++++++
+ 2 files changed, 7 insertions(+)
 
 diff --git a/configure.ac b/configure.ac
 index 9946a0e..a2d481a 100644
@@ -53,3 +58,6 @@ index 273c7d9..a04dac5 100644
  
  static void send_reply(int cfd, struct message *msg)
  {
+-- 
+2.49.0
+

--- a/app-admin/fuse/autobuild/patches/0008-BACKPORT-libfuse-don-t-force-D_FILE_OFFSET_BITS-64-i.patch
+++ b/app-admin/fuse/autobuild/patches/0008-BACKPORT-libfuse-don-t-force-D_FILE_OFFSET_BITS-64-i.patch
@@ -1,8 +1,8 @@
-From d8f3ab77d99dc6603b343fdf52b64ac7fec91a21 Mon Sep 17 00:00:00 2001
+From b3cbf4ecd4ae50520b8c106caa1875392f28e01f Mon Sep 17 00:00:00 2001
 From: "Richard W.M. Jones" <rjones@redhat.com>
 Date: Tue, 20 Mar 2012 10:51:23 +0000
-Subject: [PATCH] libfuse: don't force -D_FILE_OFFSET_BITS=64 in pkgconfig
- file.
+Subject: [PATCH 08/10] BACKPORT: libfuse: don't force -D_FILE_OFFSET_BITS=64
+ in pkgconfig file.
 
 FUSE_CFLAGS defines -D_FILE_OFFSET_BITS=64.  There are three problems
 with this:
@@ -32,29 +32,14 @@ Therefore I have surrounded the static assertion with a conservative
 check that the compiler is GCC >= 4.6.  In the long run, this test can
 be removed and you can just use 'static_assert'.
 ---
- ChangeLog             |  3 +++
  include/fuse_common.h | 19 ++++++++++++++-----
- 2 files changed, 17 insertions(+), 5 deletions(-)
+ 1 file changed, 14 insertions(+), 5 deletions(-)
 
-# diff --git a/ChangeLog b/ChangeLog
-# index 511c694..2021e81 100644
-# --- a/ChangeLog
-# +++ b/ChangeLog
-# @@ -6,6 +6,9 @@
-#  	* libfuse: use O_CLOEXEC flag when opening /dev/fuse device.
-#  	Patch by Richard W.M. Jones
- 
-# +	* libfuse: don't force -D_FILE_OFFSET_BITS=64 in pkgconfig file.
-# +	Patch by Richard W.M. Jones
-# +
-#  2013-02-19  Miklos Szeredi <miklos@szeredi.hu>
- 
-#  	* fuse_daemonize(): chdir to "/" even if not running in the
 diff --git a/include/fuse_common.h b/include/fuse_common.h
-index 78d3ce4..af16203 100644
+index a4d980d..a5a6830 100644
 --- a/include/fuse_common.h
 +++ b/include/fuse_common.h
-@@ -27,11 +27,6 @@
+@@ -28,11 +28,6 @@
  #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 10 + (min))
  #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
  
@@ -66,7 +51,7 @@ index 78d3ce4..af16203 100644
  #ifdef __cplusplus
  extern "C" {
  #endif
-@@ -483,4 +478,18 @@ void fuse_remove_signal_handlers(struct fuse_session *se);
+@@ -502,4 +497,18 @@ void fuse_remove_signal_handlers(struct fuse_session *se);
  }
  #endif
  
@@ -86,5 +71,5 @@ index 78d3ce4..af16203 100644
 +
  #endif /* _FUSE_COMMON_H_ */
 -- 
-2.46.0.rc0.windows.1
+2.49.0
 

--- a/app-admin/fuse/autobuild/patches/0009-BACKPORT-fuse_common.h-fix-warning-on-_Static_assert.patch
+++ b/app-admin/fuse/autobuild/patches/0009-BACKPORT-fuse_common.h-fix-warning-on-_Static_assert.patch
@@ -1,7 +1,8 @@
-From e4e68739737b19c41efbb5ab508cfdd163c2536f Mon Sep 17 00:00:00 2001
+From b02fdaad640d0e7cf1b5e536ab6f62416cc71648 Mon Sep 17 00:00:00 2001
 From: CismonX <admin@cismon.net>
 Date: Tue, 7 May 2024 11:22:59 +0000
-Subject: [PATCH] fuse_common.h: fix warning on _Static_assert() (#939)
+Subject: [PATCH 09/10] BACKPORT: fuse_common.h: fix warning on
+ _Static_assert() (#939)
 
 _Static_assert() is an ISO C11 feature.  Make the check more
 standard-conformant so that the compiler won't give pedantic warnings.
@@ -10,10 +11,10 @@ standard-conformant so that the compiler won't give pedantic warnings.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/fuse_common.h b/include/fuse_common.h
-index 4efa53d..bafcda0 100644
+index a5a6830..7427fa1 100644
 --- a/include/fuse_common.h
 +++ b/include/fuse_common.h
-@@ -957,7 +957,7 @@ void fuse_loop_cfg_convert(struct fuse_loop_config *config,
+@@ -504,7 +504,7 @@ void fuse_remove_signal_handlers(struct fuse_session *se);
   * On 32bit systems please add -D_FILE_OFFSET_BITS=64 to your compile flags!
   */
  
@@ -23,5 +24,5 @@ index 4efa53d..bafcda0 100644
  #else
  struct _fuse_off_t_must_be_64bit_dummy_struct \
 -- 
-2.46.0.rc0.windows.1
+2.49.0
 

--- a/app-admin/fuse/autobuild/patches/0010-AOSCOS-fix-configure.ac-add-missing-Gettext-macro.patch
+++ b/app-admin/fuse/autobuild/patches/0010-AOSCOS-fix-configure.ac-add-missing-Gettext-macro.patch
@@ -1,0 +1,34 @@
+From 281d563d7683724b68ee62c902b3aab02fa2a6cc Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 15 May 2025 11:41:24 +0800
+Subject: [PATCH 10/10] AOSCOS: fix(configure.ac): add missing Gettext macro
+
+Since Gettext 0.24, it no longer exports its macros globally.
+
+Add an explicit include to fix re-generation errors:
+
+configure.ac:74: error: possibly undefined macro: AM_ICONV
+      If this token and others are legitimate, please use m4_pattern_allow.
+      See the Autoconf documentation.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index a2d481a..dabffae 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,6 +71,8 @@ AC_ARG_WITH([libiconv-prefix],
+       if test -d $dir/lib; then LDFLAGS="$LDFLAGS -L$dir/lib"; fi
+     done
+    ])
++AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_VERSION(0.25)
+ AM_ICONV
+ libfuse_libs="$libfuse_libs $LTLIBICONV"
+ AM_CONDITIONAL(ICONV, test "$am_cv_func_iconv" = yes)
+-- 
+2.49.0
+

--- a/app-admin/fuse/spec
+++ b/app-admin/fuse/spec
@@ -1,5 +1,5 @@
 VER=2.9.9
-REL=2
+REL=3
 SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.gz"
 CHKSUMS="sha256::d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
 CHKUPDATE="anitya::id=229381"


### PR DESCRIPTION
Topic Description
-----------------

- fuse: add missing Gettext macro to fix re-generation
    Since Gettext 0.24, it no longer exports its macros globally.
    Add an explicit include to fix re-generation errors:
    configure.ac:74: error: possibly undefined macro: AM_ICONV
    If this token and others are legitimate, please use m4_pattern_allow.
    See the Autoconf documentation.

Package(s) Affected
-------------------

- fuse: 2.9.9-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
