### PR TITLE
gperftools: disable parallelism to workaround linkage failure

### DIFF
--- a/app-devel/gperftools/autobuild/defines
+++ b/app-devel/gperftools/autobuild/defines
@@ -1,7 +1,15 @@
 PKGNAME=gperftools
 PKGSEC=utils
 PKGDEP="perl"
-PKGDES="Fast, multi-threaded malloc() and nifty performance analysis tools"
+PKGDES="Multi-threaded malloc() library and performance analysis tools"
 
-# FIXME: .a files truncated.
-NOLTO__RISCV64=1
+# FIXME: Linkage fails with parallelism.
+#
+# objcopy: .libs/stIBe5oA/libtcmalloc_and_profiler_la-tcmalloc.o: plugin needed to handle lto object
+# libtool: install: ranlib [...]/usr/lib/libprofiler.a
+# libtool: install: /usr/bin/install -c .libs/libtcmalloc_and_profiler.a [...]/usr/lib/libtcmalloc_and_profiler.a
+# libtool: install: chmod 644 [...]/usr/lib/libtcmalloc_and_profiler.a
+# libtool: install: ranlib [...]/usr/lib/libtcmalloc_and_profiler.a
+# bfd plugin: [...]/usr/lib/libtcmalloc_and_profiler.a: file too short
+# ranlib: [...]/usr/lib/libtcmalloc_and_profiler.a: error reading libtcmalloc_internal_la-heap-profile-table.o: file truncated
+NOPARALLEL=1

--- a/app-devel/gperftools/spec
+++ b/app-devel/gperftools/spec
@@ -1,4 +1,5 @@
 VER=2.13
+REL=1
 SRCS="tbl::https://github.com/gperftools/gperftools/releases/download/gperftools-$VER/gperftools-$VER.tar.gz"
 CHKSUMS="sha256::4882c5ece69f8691e51ffd6486df7d79dbf43b0c909d84d3c0883e30d27323e7"
 CHKUPDATE="anitya::id=1238"


### PR DESCRIPTION
Topic Description
-----------------

- gperftools: disable parallelism to workaround linkage failure
    Also revise PKGDES in accordance with the Styling Manual.

Package(s) Affected
-------------------

- gperftools: 2.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gperftools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
