### PR TITLE
jade: fix build

### DIFF
--- a/app-doc/jade/autobuild/build
+++ b/app-doc/jade/autobuild/build
@@ -1,0 +1,16 @@
+# Note: Homebrew configure script.
+abinfo "Configuring jade ..."
+"$SRCDIR"/configure \
+    "${AUTOTOOLS_DEF[@]}" \
+    --enable-splibdir=/usr/lib \
+    --datadir=/usr/share/sgml/openjade-$PKGVER \
+    --enable-html \
+    --enable-http \
+    --enable-mif
+
+abinfo "Building jade ..."
+make
+
+abinfo "Installing jade ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-doc/jade/autobuild/defines
+++ b/app-doc/jade/autobuild/defines
@@ -2,17 +2,7 @@ PKGNAME=jade
 PKGSEC=libs
 PKGDEP="opensp sgml-common"
 BUILDDEP="perl4-corelibs"
-PKGDES="A DSSSL implementation"
+PKGDES="Implementation of the DSSSL style language"
 
 PKGEPOCH=1
 PKGPROV="openjade"
-
-AUTOTOOLS_AFTER="--enable-splibdir=/usr/lib \
-                 --datadir=/usr/share/sgml/openjade-$PKGVER \
-                 --enable-html \
-                 --enable-http \
-                 --enable-mif"
-ABSHADOW=0
-RECONF=0
-
-NOLTO__LOONGSON3=1

--- a/app-doc/jade/autobuild/prepare
+++ b/app-doc/jade/autobuild/prepare
@@ -1,2 +1,1 @@
-abinfo "Arch Linux: Appending -fno-lifetime-dse to fix a segfault ..."
-export CXXFLAGS="${CXXFLAGS} -fno-lifetime-dse"
+build_autotools_update_base

--- a/app-doc/jade/spec
+++ b/app-doc/jade/spec
@@ -1,5 +1,5 @@
 VER=1.3.2
-REL=4
+REL=5
 SRCS="tbl::https://sourceforge.net/projects/openjade/files/openjade/$VER/openjade-$VER.tar.gz"
 CHKSUMS="sha256::1d2d7996cc94f9b87d0c51cf0e028070ac177c4123ecbfd7ac1cb8d0b7d322d1"
 CHKUPDATE="anitya::id=2564"


### PR DESCRIPTION
Topic Description
-----------------

- jade: fix build
    - Introduce a build script as jade ships incomplete Autotools scripts.
    - Drop unused GCC flag hack.
    - Call internal Autobuild routines to replace config.\*.

Package(s) Affected
-------------------

- jade: 1:1.3.2-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit jade
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
