### PR TITLE
cdparanoia: fix build

### DIFF
--- a/app-multimedia/cdparanoia/autobuild/beyond
+++ b/app-multimedia/cdparanoia/autobuild/beyond
@@ -1,1 +1,0 @@
-chmod 755 "$PKGDIR"/usr/lib/*

--- a/app-multimedia/cdparanoia/autobuild/defines
+++ b/app-multimedia/cdparanoia/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=cdparanoia
 PKGSEC=utils
-PKGDES="A CD audio extraction tool"
 PKGDEP="glibc"
+PKGDES="CD audio extraction tool"
 
+# FIXME: .../main.c:599:(.text+0x1000): undefined reference to `paranoia_free'
 NOPARALLEL=1
-ABSHADOW=no
+
+# FIXME: install: cannot stat '.../cdparanoia-III-10.2/cdparanoia': No such file or directory
+ABSHADOW=0

--- a/app-multimedia/cdparanoia/autobuild/patches/series
+++ b/app-multimedia/cdparanoia/autobuild/patches/series
@@ -1,9 +1,0 @@
-01-typos-and-spelling.patch
-02-ide-devices.patch
-03-gcc4.3.patch
-04-endian.patch
-05-kfreebsd.patch
-06-autoconf.patch
-07-jpmanfix.patch
-cdparanoia-force-progress-bar.diff
-cdparanoia-10.2-install.patch

--- a/app-multimedia/cdparanoia/autobuild/prepare
+++ b/app-multimedia/cdparanoia/autobuild/prepare
@@ -1,3 +1,5 @@
-cp -v /usr/share/automake-1.16/config.* .
-cp config.guess configure.guess
-cp config.sub configure.sub
+abinfo "Copying replacement autotools base files ..."
+cp -v /usr/bin/config.guess \
+    "$SRCDIR"/configure.guess
+cp -v /usr/bin/config.sub \
+    "$SRCDIR"/configure.sub

--- a/app-multimedia/cdparanoia/spec
+++ b/app-multimedia/cdparanoia/spec
@@ -1,5 +1,5 @@
 VER=10.2
-REL=4
+REL=5
 SRCS="tbl::https://downloads.xiph.org/releases/cdparanoia/cdparanoia-III-$VER.src.tgz"
 CHKSUMS="sha256::005db45ef4ee017f5c32ec124f913a0546e77014266c6a1c50df902a55fe64df"
 CHKUPDATE="anitya::id=15309"


### PR DESCRIPTION
Topic Description
-----------------

- cdparanoia: fix build
    - Use build_autotools_update_base\(\) to replace config.\*.
    - Add missing FIXME comments for hacks.
    - Drop unused beyond script.

Package(s) Affected
-------------------

- cdparanoia: 10.2-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit cdparanoia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
