### PR TITLE
wavpack: fix build

### DIFF
--- a/app-multimedia/wavpack/autobuild/defines
+++ b/app-multimedia/wavpack/autobuild/defines
@@ -2,3 +2,10 @@ PKGNAME=wavpack
 PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Audio compression format with lossless, lossy and hybrid compression modes"
+
+# FIXME: Re-generation fails.
+#
+# configure.ac:64: error: possibly undefined macro: AM_ICONV
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+RECONF=0

--- a/app-multimedia/wavpack/spec
+++ b/app-multimedia/wavpack/spec
@@ -1,4 +1,5 @@
 VER=5.8.1
+REL=1
 SRCS="tbl::http://www.wavpack.com/wavpack-$VER.tar.xz"
 CHKSUMS="sha256::7322775498602c8850afcfc1ae38f99df4cbcd51386e873d6b0f8047e55c0c26"
 CHKUPDATE="anitya::id=5121"


### PR DESCRIPTION
Topic Description
-----------------

- wavpack: fix build
    Disable RECONF due to re-generation failure:
    configure.ac:64: error: possibly undefined macro: AM_ICONV
    If this token and others are legitimate, please use m4_pattern_allow.
    See the Autoconf documentation.

Package(s) Affected
-------------------

- wavpack: 5.8.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wavpack
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
