### PR TITLE
axel: fix build

### DIFF
--- a/app-web/axel/autobuild/defines
+++ b/app-web/axel/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=axel
 PKGSEC=web
 PKGDEP="openssl"
-PKGDES="A download accelerator"
+PKGDES="Command-line multithreaded download accelerator"

--- a/app-web/axel/autobuild/patches/0001-AOSCOS-chore-run-Gettextize-to-fix-autoreconf-failur.patch
+++ b/app-web/axel/autobuild/patches/0001-AOSCOS-chore-run-Gettextize-to-fix-autoreconf-failur.patch
@@ -1,0 +1,203 @@
+From 28a81d64d55442ca0e8d7322834b857edd274bda Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 15 May 2025 14:52:43 +0800
+Subject: [PATCH] AOSCOS: chore: run Gettextize to fix autoreconf failure
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ ChangeLog             |  6 ++++++
+ Makefile.am           |  2 +-
+ configure.ac          |  2 +-
+ po/ChangeLog          | 11 +++++++++++
+ po/boldquot.sed       | 11 +++++++++++
+ po/en@boldquot.header | 12 +++++++++++-
+ po/en@quot.header     | 12 +++++++++++-
+ po/insert-header.sed  | 31 +++++++++++++++++++++++++++++++
+ po/quot.sed           | 11 +++++++++++
+ 9 files changed, 94 insertions(+), 4 deletions(-)
+ create mode 100644 po/ChangeLog
+ create mode 100644 po/insert-header.sed
+
+diff --git a/ChangeLog b/ChangeLog
+index 12c9adb..cf73ce2 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,9 @@
++2025-05-15  gettextize  <bug-gnu-gettext@gnu.org>
++
++	* Makefile.am (EXTRA_DIST): Add m4/ChangeLog.
++	* configure.ac (AC_CONFIG_FILES): Add po/Makefile.in.
++	(AM_GNU_GETTEXT_VERSION): Bump to 0.25.
++
+ Version: 2.17.14, 2024-04-07
+ 
+   [ Ismael Luceno ]
+diff --git a/Makefile.am b/Makefile.am
+index 7216bc2..a9b328f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,7 +6,7 @@ ACLOCAL = touch $@; @ACLOCAL@
+ 
+ SUBDIRS = po
+ 
+-EXTRA_DIST = \
++EXTRA_DIST = m4/ChangeLog  \
+ 	scripts/pocheck.awk \
+ 	README.md \
+ 	CONTRIBUTING.md
+diff --git a/configure.ac b/configure.ac
+index 836d954..c1b5fef 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -237,7 +237,7 @@ AS_IF([test "x$with_ssl" != xno], [
+ 
+ # Add Gettext
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.11.1])
++AM_GNU_GETTEXT_VERSION([0.25])
+ 
+ # POSIX threads
+ AX_PTHREAD()
+diff --git a/po/ChangeLog b/po/ChangeLog
+new file mode 100644
+index 0000000..34c96c9
+--- /dev/null
++++ b/po/ChangeLog
+@@ -0,0 +1,11 @@
++2025-05-15  gettextize  <bug-gnu-gettext@gnu.org>
++
++	* Makefile.in.in: New file, from gettext-0.25.
++	* boldquot.sed: Upgrade to gettext-0.25.
++	* en@boldquot.header: Upgrade to gettext-0.25.
++	* en@quot.header: Upgrade to gettext-0.25.
++	* insert-header.sed: New file, from gettext-0.25.
++	* quot.sed: Upgrade to gettext-0.25.
++	* remove-potcdate.sed: New file, from gettext-0.25.
++	* Rules-quot: New file, from gettext-0.25.
++
+diff --git a/po/boldquot.sed b/po/boldquot.sed
+index 4b937aa..3c1de54 100644
+--- a/po/boldquot.sed
++++ b/po/boldquot.sed
+@@ -1,3 +1,14 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks and highlighting the quotations in bold face.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
+ s/"\([^"]*\)"/“\1”/g
+ s/`\([^`']*\)'/‘\1’/g
+ s/ '\([^`']*\)' / ‘\1’ /g
+diff --git a/po/en@boldquot.header b/po/en@boldquot.header
+index fedb6a0..ac96ad9 100644
+--- a/po/en@boldquot.header
++++ b/po/en@boldquot.header
+@@ -1,8 +1,18 @@
++%% A header that gets inserted into message catalogs named en@boldquot.po.
++%%
++%% Copyright (C) 2001 Free Software Foundation, Inc.
++%% This file is free software; the Free Software Foundation
++%% gives unlimited permission to copy and/or distribute it,
++%% with or without modifications, as long as this notice is preserved.
++%% This file is offered as-is, without any warranty.
++%%
++%% Written by Bruno Haible <bruno@clisp.org>, 2001.
++%%
+ # All this catalog "translates" are quotation characters.
+ # The msgids must be ASCII and therefore cannot contain real quotation
+ # characters, only substitutes like grave accent (0x60), apostrophe (0x27)
+ # and double quote (0x22). These substitutes look strange; see
+-# http://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
++# https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
+ #
+ # This catalog translates grave accent (0x60) and apostrophe (0x27) to
+ # left single quotation mark (U+2018) and right single quotation mark (U+2019).
+diff --git a/po/en@quot.header b/po/en@quot.header
+index a9647fc..287e2e7 100644
+--- a/po/en@quot.header
++++ b/po/en@quot.header
+@@ -1,8 +1,18 @@
++%% A header that gets inserted into message catalogs named en@quot.po.
++%%
++%% Copyright (C) 2001 Free Software Foundation, Inc.
++%% This file is free software; the Free Software Foundation
++%% gives unlimited permission to copy and/or distribute it,
++%% with or without modifications, as long as this notice is preserved.
++%% This file is offered as-is, without any warranty.
++%%
++%% Written by Bruno Haible <bruno@clisp.org>, 2001.
++%%
+ # All this catalog "translates" are quotation characters.
+ # The msgids must be ASCII and therefore cannot contain real quotation
+ # characters, only substitutes like grave accent (0x60), apostrophe (0x27)
+ # and double quote (0x22). These substitutes look strange; see
+-# http://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
++# https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
+ #
+ # This catalog translates grave accent (0x60) and apostrophe (0x27) to
+ # left single quotation mark (U+2018) and right single quotation mark (U+2019).
+diff --git a/po/insert-header.sed b/po/insert-header.sed
+new file mode 100644
+index 0000000..f9534e7
+--- /dev/null
++++ b/po/insert-header.sed
+@@ -0,0 +1,31 @@
++# Sed script that inserts the file called HEADER before the header entry.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++# At each occurrence of a line starting with "msgid ", we execute the following
++# commands. At the first occurrence, insert the file. At the following
++# occurrences, do nothing. The distinction between the first and the following
++# occurrences is achieved by looking at the hold space.
++/^msgid /{
++x
++# Test if the hold space is empty.
++s/m/m/
++ta
++# Yes it was empty. First occurrence. Read the file.
++r HEADER
++# Output the file's contents by reading the next line. But don't lose the
++# current line while doing this.
++g
++N
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+diff --git a/po/quot.sed b/po/quot.sed
+index 0122c46..eb0e08d 100644
+--- a/po/quot.sed
++++ b/po/quot.sed
+@@ -1,3 +1,14 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
+ s/"\([^"]*\)"/“\1”/g
+ s/`\([^`']*\)'/‘\1’/g
+ s/ '\([^`']*\)' / ‘\1’ /g
+-- 
+2.49.0
+

--- a/app-web/axel/spec
+++ b/app-web/axel/spec
@@ -1,4 +1,5 @@
 VER=2.17.14
+REL=1
 SRCS="tbl::https://github.com/axel-download-accelerator/axel/releases/download/v$VER/axel-$VER.tar.xz"
 CHKSUMS="sha256::938ee7c8c478bf6fcc82359bbf9576f298033e8b13908e53e3ea9c45c1443693"
 CHKUPDATE="anitya::id=9344"


### PR DESCRIPTION
Topic Description
-----------------

- axel: fix build
    - Run gettextize as a patch to fix build with Gettext >= 0.24.
    - Revise PKGDES in accordance with the Styling Manual.

Package(s) Affected
-------------------

- axel: 2.17.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit axel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
