### PR TITLE
freetds: fix build

### DIFF
--- a/runtime-database/freetds/autobuild/defines
+++ b/runtime-database/freetds/autobuild/defines
@@ -3,4 +3,17 @@ PKGSEC=database
 PKGDEP="openssl unixodbc"
 PKGDES="Library for accessing Sybase and MS SQL Server databases"
 
-AUTOTOOLS_AFTER="--sysconfdir=/etc/freetds --enable-msdblib --with-tdsver=7.0 --with-unixodbc=/usr --with-openssl"
+# FIXME: Re-generation fails.
+#
+# configure.ac:121: error: possibly undefined macro: AM_ICONV
+#      If this token and others are legitimate, please use m4_pattern_allow.
+#      See the Autoconf documentation.
+RECONF=0
+
+AUTOTOOLS_AFTER=(
+    '--sysconfdir=/etc/freetds'
+    '--enable-msdblib'
+    '--with-tdsver=7.0'
+    '--with-unixodbc=/usr'
+    '--with-openssl'
+)

--- a/runtime-database/freetds/spec
+++ b/runtime-database/freetds/spec
@@ -1,5 +1,5 @@
 VER=1.00.112
+REL=2
 SRCS="tbl::https://www.freetds.org/files/stable/freetds-$VER.tar.gz"
 CHKSUMS="sha256::0cfde9c30e92af7f9579a5da2033b9a8dc6252c09088c7831b6d56323479374d"
 CHKUPDATE="anitya::id=8198"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- freetds: fix build
    - Disable RECONF due to re-generation failure.
    - Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- freetds: 1.00.112-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit freetds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
