### PR TITLE
libvoikko: fix build

### DIFF
--- a/runtime-i18n/libvoikko/autobuild/defines
+++ b/runtime-i18n/libvoikko/autobuild/defines
@@ -1,9 +1,15 @@
 PKGNAME=libvoikko
 PKGSEC=libs
 PKGDEP="gcc-runtime"
-PKGDES="A finnish spelling and grammar checker, and a collection of linguistic data"
+PKGDES="Finnish spelling and grammar checker with built-in linguistic data"
 
-ABSHADOW=0
-AUTOTOOLS_AFTER="--enable-hfst=false \
-                 --with-dictionary-path=/usr/share/voikko \
-                 PYTHON=/usr/bin/python3"
+# FIXME: ./voikko.h:306:6: error: 'voikkoFreeGrammarError' violates the C++ One Definition Rule [-Werror=odr]
+#
+# Link: https://github.com/voikko/corevoikko/issues/62
+# Link: https://github.com/voikko/corevoikko/commit/2744023a69ae9e469f9458c34b34d3cd4f336dd1
+NOLTO=1
+
+AUTOTOOLS_AFTER=(
+    '--enable-hfst=false'
+    '--with-dictionary-path=/usr/share/voikko'
+)

--- a/runtime-i18n/libvoikko/spec
+++ b/runtime-i18n/libvoikko/spec
@@ -1,5 +1,5 @@
 VER=4.3.1
+REL=2
 SRCS="tbl::https://www.puimula.org/voikko-sources/libvoikko/libvoikko-$VER.tar.gz"
 CHKSUMS="sha256::368240d4cfa472c2e2c43dc04b63e6464a3e6d282045848f420d0f7a6eb09a13"
 CHKUPDATE="anitya::id=6145"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libvoikko: fix build
    - Disable LTO due to -Werror=odr.
    - Refactor AUTOTOOLS_AFTER as an array.
    - Revise PKGDES in accordance with the Styling Manual.

Package(s) Affected
-------------------

- libvoikko: 4.3.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvoikko
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
