### PR TITLE
a52dec: fix build

### DIFF
--- a/runtime-multimedia/a52dec/autobuild/beyond
+++ b/runtime-multimedia/a52dec/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing a52_internal.h ..."
+install -Dvm644 "$SRCDIR"/liba52/a52_internal.h \
+    "$PKGDIR"/usr/include/a52dec/

--- a/runtime-multimedia/a52dec/autobuild/build
+++ b/runtime-multimedia/a52dec/autobuild/build
@@ -1,6 +1,0 @@
-./configure --prefix=/usr \
-            --enable-shared
-make
-make DESTDIR=$PKGDIR install
-
-install -m644 liba52/a52_internal.h $PKGDIR/usr/include/a52dec/

--- a/runtime-multimedia/a52dec/autobuild/defines
+++ b/runtime-multimedia/a52dec/autobuild/defines
@@ -1,7 +1,12 @@
 PKGNAME=a52dec
-PKGDES="A free library for decoding ATSC A/52 streams"
 PKGSEC=libs
-PKGDEP=glibc
+PKGDEP="glibc"
+PKGDES="Free library for decoding ATSC A/52 streams"
 
 PKGREP="a52dev"
 PKGPROV="a52dev"
+
+AUTOTOOLS_AFTER=(
+	"--prefix=/usr"
+	"--enable-shared"
+)

--- a/runtime-multimedia/a52dec/autobuild/prepare
+++ b/runtime-multimedia/a52dec/autobuild/prepare
@@ -1,3 +1,0 @@
-for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
-done

--- a/runtime-multimedia/a52dec/spec
+++ b/runtime-multimedia/a52dec/spec
@@ -1,5 +1,7 @@
 VER=0.7.4
-REL=2
-SRCS="tbl::http://liba52.sourceforge.net/files/a52dec-$VER.tar.gz"
+REL=3
+# FIXME: Upstream URL is now gone https://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz.
+# Use BLFS mirror until we update to 0.8.0.
+SRCS="tbl::https://ftp2.osuosl.org/pub/blfs/conglomeration/a52dec/a52dec-$VER.tar.gz"
 CHKSUMS="sha256::a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33"
 CHKUPDATE="anitya::id=13972"


### PR DESCRIPTION
Topic Description
-----------------

- a52dec: fix build
    - Use BLFS mirror to download source as it is gone upstream.
    - Drop build script an use autotools ABTYPE.
    Co-Authored-By: Mingcong Bai <jeffbai@aosc.io>
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- a52dec: 0.7.4-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit a52dec
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
