### PR TITLE
libcddb: fix build

### DIFF
--- a/runtime-multimedia/libcddb/autobuild/defines
+++ b/runtime-multimedia/libcddb/autobuild/defines
@@ -1,4 +1,12 @@
 PKGNAME=libcddb
-PKGDES="Library that implements the different protocols (CDDBP, HTTP, SMTP) to access data on a CDDB server (e.g. http://freedb.org)"
-PKGDEP="glibc"
 PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Library to implement protocols (CDDBP, HTTP, SMTP) for accessing data on CDDB servers"
+
+# FIXME: Re-generation fails.
+#
+# configure.ac:23: error: possibly undefined macro: AM_GNU_GETTEXT_VERSION
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+# configure.ac:135: error: possibly undefined macro: AM_ICONV
+RECONF=0

--- a/runtime-multimedia/libcddb/autobuild/patches/0001-FEDORA-fix-cddb_net.c-fix-build-with-GCC-14.patch
+++ b/runtime-multimedia/libcddb/autobuild/patches/0001-FEDORA-fix-cddb_net.c-fix-build-with-GCC-14.patch
@@ -1,0 +1,31 @@
+From 55e17af03ac9f6f355038bca691c8c0e09e068f4 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 13 May 2025 17:45:23 +0800
+Subject: [PATCH] FEDORA: fix(cddb_net.c): fix build with GCC >= 14
+
+Fix pointer type definition to suppress a new error.
+
+Signed-off-by: Gwyn Ciesla <gwync@protonmail.com>
+
+Link: https://src.fedoraproject.org/rpms/libcddb/blob/f45e07768d0a53c3edb7a9818f22cf4bebceb66a/f/pointer-types.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ lib/cddb_net.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/cddb_net.c b/lib/cddb_net.c
+index 7adf37b..231afeb 100644
+--- a/lib/cddb_net.c
++++ b/lib/cddb_net.c
+@@ -325,7 +325,7 @@ int timeout_connect(int sockfd, const struct sockaddr *addr,
+             default:
+                 /* we got connected, check error condition */
+                 l = sizeof(rv);
+-                getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &rv, &l);
++                getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &rv, (socklen_t * restrict)&l);
+                 if (rv) {
+                     /* something went wrong, simulate normal connect behaviour */
+                     errno = rv;
+-- 
+2.49.0
+

--- a/runtime-multimedia/libcddb/spec
+++ b/runtime-multimedia/libcddb/spec
@@ -1,5 +1,5 @@
 VER=1.3.2
-REL=5
+REL=7
 SRCS="tbl::https://prdownloads.sourceforge.net/libcddb/libcddb-$VER.tar.bz2"
 CHKSUMS="sha256::35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b"
 CHKUPDATE="anitya::id=1572"


### PR DESCRIPTION
Topic Description
-----------------

- libcddb: fix build
    - Disable RECONF due to re-generation failure.
    - Revise PKGDES in accordance with the Styling Manual.

Package(s) Affected
-------------------

- libcddb: 1.3.2-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcddb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
