### PR TITLE
libfreeaptx: fix build with Autobuild4

### DIFF
--- a/runtime-multimedia/libfreeaptx/autobuild/build
+++ b/runtime-multimedia/libfreeaptx/autobuild/build
@@ -1,9 +1,14 @@
-# FIXME: Use custom build script here because Autobuild3 is unable to pass
-# parameters correctly to `make` command.
 abinfo "Building binaries using Makefile ..."
-make V=1 VERBOSE=1 CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
+make \
+    V=1 \
+    VERBOSE=1 \
+    CFLAGS="$CFLAGS" \
+    LDFLAGS="$LDFLAGS"
 
 abinfo "Installing binaries ..."
-make install V=1 VERBOSE=1 \
-             BUILDROOT="$PKGDIR" DESTDIR="$PKGDIR" \
-             $MAKE_INSTALL_DEF
+make install \
+    V=1 \
+    VERBOSE=1 \
+    BUILDROOT="$PKGDIR" \
+    DESTDIR="$PKGDIR" \
+    ${MAKE_INSTALL_DEF[@]}

--- a/runtime-multimedia/libfreeaptx/spec
+++ b/runtime-multimedia/libfreeaptx/spec
@@ -1,4 +1,5 @@
 VER=0.1.1
-SRCS="tbl::https://github.com/iamthehorker/libfreeaptx/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::7acf514446cae59585d9bc21e4f98f4a3856f4741c3a7a09d06e8ac5bf2f7315"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/iamthehorker/libfreeaptx"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236439"


### PR DESCRIPTION
Topic Description
-----------------

- libfreeaptx: fix build with Autobuild4
    Autobuild4 requires reference to internal variables as arrays.

Package(s) Affected
-------------------

- libfreeaptx: 0.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfreeaptx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
