### PR TITLE
verdict: disable broken tests to fix build

### DIFF
--- a/runtime-scientific/verdict/autobuild/defines
+++ b/runtime-scientific/verdict/autobuild/defines
@@ -7,6 +7,8 @@ PKGDES="API for compute quality functions of 2- and 3-dimensional regions"
 
 # FIXME: Documentation generation broken.
 # -DVERDICT_BUILD_DOC=ON
-CMAKE_AFTER="-DVERDICT_BUILD_DOC=OFF \
-             -DVERDICT_ENABLE_TESTING=ON \
-             -DBUILD_SHARED_LIBS=ON"
+CMAKE_AFTER=(
+    '-DVERDICT_BUILD_DOC=OFF'
+    '-DVERDICT_ENABLE_TESTING=OFF'
+    '-DBUILD_SHARED_LIBS=ON'
+)

--- a/runtime-scientific/verdict/spec
+++ b/runtime-scientific/verdict/spec
@@ -1,4 +1,5 @@
 VER=1.4.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/sandialabs/verdict"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=357553"


### PR DESCRIPTION
Topic Description
-----------------

- verdict: disable broken tests to fix build

Package(s) Affected
-------------------

- verdict: 1.4.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit verdict
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
