### PR TITLE
 modemmanager: update to 1.24.0

### DIFF
--- a/app-network/modemmanager/spec
+++ b/app-network/modemmanager/spec
@@ -1,5 +1,4 @@
-VER=1.18.12
-REL=2
+VER=1.24.0
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7306"

--- a/runtime-devices/libqmi/spec
+++ b/runtime-devices/libqmi/spec
@@ -1,5 +1,4 @@
-VER=1.30.8
-REL=1
+VER=1.36.0
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/libqmi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7307"


### PR DESCRIPTION
Topic Description
-----------------

- modemmanager: update to 1.24.0
- libqmi: update to 1.36.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libqmi modemmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
