### PR TITLE
v4l2loopback: update to 0.14.0

### DIFF
--- a/app-utils/v4l2loopback/autobuild/patches/0001-added-functionality-for-linux-6.15-626.patch
+++ b/app-utils/v4l2loopback/autobuild/patches/0001-added-functionality-for-linux-6.15-626.patch
@@ -1,0 +1,52 @@
+From 3cf949864d25d9b5c776d78a780b0ea9badbebb7 Mon Sep 17 00:00:00 2001
+From: Theodore Chiu <theochiu.me@gmail.com>
+Date: Wed, 9 Apr 2025 14:16:51 -0400
+Subject: [PATCH] added functionality for linux 6.15+ (#626)
+
+* added functionality for linux 6.15+
+
+* use macro for linux kernel version changes for timer
+---
+ v4l2loopback.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/v4l2loopback.c b/v4l2loopback.c
+index 0829163..5f46192 100644
+--- a/v4l2loopback.c
++++ b/v4l2loopback.c
+@@ -45,6 +45,10 @@
+ #define strscpy strlcpy
+ #endif
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
++#define timer_delete_sync del_timer_sync
++#endif
++
+ #if defined(timer_setup) && defined(from_timer)
+ #define HAVE_TIMER_SETUP
+ #endif
+@@ -1792,8 +1796,8 @@ static int vidioc_querybuf(struct file *file, void *fh, struct v4l2_buffer *buf)
+ static void buffer_written(struct v4l2_loopback_device *dev,
+ 			   struct v4l2l_buffer *buf)
+ {
+-	del_timer_sync(&dev->sustain_timer);
+-	del_timer_sync(&dev->timeout_timer);
++	timer_delete_sync(&dev->sustain_timer);
++	timer_delete_sync(&dev->timeout_timer);
+ 
+ 	spin_lock_bh(&dev->list_lock);
+ 	list_move_tail(&buf->list_head, &dev->outbufs_list);
+@@ -2370,8 +2374,8 @@ static int v4l2_loopback_close(struct file *file)
+ 	}
+ 
+ 	if (atomic_dec_and_test(&dev->open_count)) {
+-		del_timer_sync(&dev->sustain_timer);
+-		del_timer_sync(&dev->timeout_timer);
++		timer_delete_sync(&dev->sustain_timer);
++		timer_delete_sync(&dev->timeout_timer);
+ 		if (!dev->keep_format) {
+ 			mutex_lock(&dev->image_mutex);
+ 			free_buffers(dev);
+-- 
+2.49.0
+

--- a/app-utils/v4l2loopback/spec
+++ b/app-utils/v4l2loopback/spec
@@ -1,5 +1,5 @@
-VER=0.13.2
-SRCS="tbl::https://github.com/umlaeute/v4l2loopback/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::1e57e1e382d7451aa2a88d63cc9f146eab1f425b90e76104d4c3d73127e34771"
+VER=0.14.0
+SRCS="git::commit=tags/v${VER}::https://github.com/v4l2loopback/v4l2loopback.git"
+CHKSUMS="SKIP"
 
 CHKUPDATE="anitya::id=10956"


### PR DESCRIPTION
Topic Description
-----------------

- v4l2loopback: update to 0.14.0, fix kernel module build on 6.15.0+

Package(s) Affected
-------------------

- v4l2loopback: 0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit v4l2loopback
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
