### PR TITLE
jimtcl: new, 0.83

### DIFF
--- a/lang-tcl/jimtcl/autobuild/build
+++ b/lang-tcl/jimtcl/autobuild/build
@@ -1,0 +1,14 @@
+# Note: Homebrew configure script.
+abinfo "Configuring Jim Tcl ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    --with-jim-shared \
+    --docs \
+    --docdir=/usr/share/doc/jimtcl
+
+abinfo "Building Jim Tcl ..."
+make
+
+abinfo "Installing Jim Tcl ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/lang-tcl/jimtcl/autobuild/defines
+++ b/lang-tcl/jimtcl/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=jimtcl
+PKGSEC=devel
+PKGDEP="openssl zlib"
+BUILDDEP="asciidoc"
+PKGDES="Small-footprint implementation of the Tcl programming language"

--- a/lang-tcl/jimtcl/spec
+++ b/lang-tcl/jimtcl/spec
@@ -1,0 +1,4 @@
+VER=0.83
+SRCS="git::commit=tags/$VER::https://github.com/msteveb/jimtcl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1459"


### PR DESCRIPTION
Topic Description
-----------------

- jimtcl: new, 0.83

Package(s) Affected
-------------------

- jimtcl: 0.83

Security Update?
----------------

No

Build Order
-----------

```
#buildit jimtcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
