### PR TITLE
 el8-compac-libs: new el8 compatibility libraries

### DIFF
--- a/runtime-imaging/libpng-1.2/autobuild/beyond
+++ b/runtime-imaging/libpng-1.2/autobuild/beyond
@@ -1,0 +1,8 @@
+abinfo "Cleaning up to leave only libraries ..."
+cd "$SRCDIR/abbuild"
+DESTDIR="$PKGDIR" make uninstall-pkgconfigDATA
+DESTDIR="$PKGDIR" make uninstall-man
+DESTDIR="$PKGDIR" make uninstall-pkgincludeHEADERS
+DESTDIR="$PKGDIR" make uninstall-hook
+rm -rf "$PKGDIR"/usr/share
+rm -rf "$PKGDIR"/usr/include

--- a/runtime-imaging/libpng-1.2/autobuild/defines
+++ b/runtime-imaging/libpng-1.2/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=libpng-1.2
+PKGSEC=libs
+PKGDEP="zlib"
+PKGDES="Library and programs for reading and writing PNG files (Version 1.2)"
+
+AUTOTOOLS_AFTER=(
+	"--prefix=/usr"
+	"--libdir=/usr/lib/legacy/$PKGNAME"
+	"--libexecdir=/usr/lib/legacy/$PKGNAME"
+        "--with-binconfigs=no"
+	"--program-suffix=-1.2"
+)

--- a/runtime-imaging/libpng-1.2/autobuild/overrides/etc/ld.so.conf.d/libpng-1.2.conf
+++ b/runtime-imaging/libpng-1.2/autobuild/overrides/etc/ld.so.conf.d/libpng-1.2.conf
@@ -1,0 +1,1 @@
+/usr/lib/legacy/libpng-1.2

--- a/runtime-imaging/libpng-1.2/spec
+++ b/runtime-imaging/libpng-1.2/spec
@@ -1,0 +1,4 @@
+VER=1.2.59
+SRCS="git::commit=tags/v$VER::https://github.com/pnggroup/libpng"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1705"


### PR DESCRIPTION
Topic Description
-----------------

- libpng-1.2: new, 1.2.59

Package(s) Affected
-------------------

- libpng-1.2: 1.2.59

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpng-1.2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
