### PR TITLE
owntone: update to 28.12

### DIFF
--- a/app-multimedia/owntone/autobuild/defines
+++ b/app-multimedia/owntone/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="avahi confuse mxml ffmpeg libwebsockets protobuf-c libplist"
 BUILDDEP="gperf"
 PKGDES="Linux DAAP (iTunes) and MPD media server with Airplay speakers support and more"
 PKGREP="forked-daapd"
+
+RECONF=0
+ABTYPE=autotools

--- a/app-multimedia/owntone/spec
+++ b/app-multimedia/owntone/spec
@@ -1,5 +1,4 @@
-VER=28.9
-REL=2
+VER=28.12
 SRCS="tbl::https://github.com/owntone/owntone-server/releases/download/$VER/owntone-$VER.tar.xz"
-CHKSUMS="sha256::76671ab46315566541018fd404cec315b7d0f9d4c9b9dbc51fcdae7fca7be832"
+CHKSUMS="sha256::731ce61f83b111e3c329fdf8182f3eb6310a212063e6025f307d3a10efbc6b1e"
 CHKUPDATE="anitya::id=230673"


### PR DESCRIPTION
Topic Description
-----------------

- owntone: update to 28.12

Package(s) Affected
-------------------

- owntone: 28.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit owntone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
