### PR TITLE
zig: update to 0.14.1

### DIFF
--- a/lang-ziglang/zig/spec
+++ b/lang-ziglang/zig/spec
@@ -1,4 +1,4 @@
-VER=0.14.0
+VER=0.14.1
 SRCS="git::commit=tags/$VER::https://github.com/ziglang/zig"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13871"


### PR DESCRIPTION
Topic Description
-----------------

- zig: update to 0.14.1
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- zig: 0.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
