### PR TITLE
skopeo: update to 1.19.0

### DIFF
--- a/app-containers/skopeo/autobuild/defines
+++ b/app-containers/skopeo/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=skopeo
 PKGSEC=admin
-PKGDEP="gpgme containers-common skopeo"
+PKGDEP="containers-common glibc shadow gpgme libeconf systemd
+    libxcrypt acl attr linux-pam libassuan libgpg-error gcc-runtime"
 PKGDES="Utility for operating on container images and repositories"
 BUILDDEP="go go-md2man"
 

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,5 +1,4 @@
-VER=1.18.0
+VER=1.19.0
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- skopeo: update to 1.19.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- skopeo: 1.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit skopeo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
