### PR TITLE
rofi-wayland: new, 1.7.9+wayland

### DIFF
--- a/app-utils/rofi-wayland/autobuild/defines
+++ b/app-utils/rofi-wayland/autobuild/defines
@@ -1,10 +1,10 @@
-PKGNAME=rofi
+PKGNAME=rofi-wayland
 PKGSEC=utils
 PKGDEP="freetype libxdg-basedir libxkbcommon pango startup-notification \
         xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf \
         xcb-util-keysyms xcb-util libxcb xcb-imdkit"
-PKGDES="A pop-up window switcher"
-PKGCONFL="rofi-wayland"
+PKGCONFL="rofi"    
+PKGDES="A pop-up window switcher (Wayland fork)"
 
 ABTYPE=meson
 MESON_AFTER=(

--- a/app-utils/rofi-wayland/spec
+++ b/app-utils/rofi-wayland/spec
@@ -1,0 +1,4 @@
+VER=1.7.9+wayland1
+SRCS="git::commit=tags/${VER}::https://github.com/lbonn/rofi.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=235175"

--- a/app-utils/rofi/spec
+++ b/app-utils/rofi/spec
@@ -1,4 +1,5 @@
 VER=1.7.9.1
+REL=1
 # FIXME: Release tarball version and tag version are mismatching for
 # 1.7.9/1.7.9.1, use $VER when the problem is resolved.
 TAG_VER=1.7.9


### PR DESCRIPTION
Topic Description
-----------------

- rofi-wayland: new, 1.7.9+wayland1

Package(s) Affected
-------------------

- rofi-wayland: 1.7.9+wayland1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi-wayland,rofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
