### PR TITLE
etherwake: new, 1.09

### DIFF
--- a/app-network/etherwake/autobuild/build
+++ b/app-network/etherwake/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Building etherwake ..."
+install -dv "$PKGDIR"/usr/bin "$PKGDIR"/usr/share/man/man8/
+"$CC" $CPPFLAGS $CFLAGS -o "$PKGDIR"/usr/bin/etherwake ether-wake.c
+install -Dvm644 "$SRCDIR"/etherwake.8 "$PKGDIR"/usr/share/man/man8/

--- a/app-network/etherwake/autobuild/defines
+++ b/app-network/etherwake/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=etherwake
+PKGSEC=net
+PKGDEP="glibc"
+PKGDES="Tool to send magic Wake-on-LAN packets"

--- a/app-network/etherwake/autobuild/patches/0001-clean-man-file.patch
+++ b/app-network/etherwake/autobuild/patches/0001-clean-man-file.patch
@@ -1,0 +1,12 @@
+clean man page
+--- a/etherwake.8
++++ b/etherwake.8
+@@ -39,7 +39,7 @@
+ .BR nsswitch.conf (5)
+ .
+ .SH OPTIONS
+-\fBetherwake\fP needs a single dash (´-´) in front of options.
++\fBetherwake\fP needs a single dash ('-') in front of options.
+ A summary of options is included below.
+ .TP
+ .B \-b

--- a/app-network/etherwake/autobuild/patches/0002-rename-binary.patch
+++ b/app-network/etherwake/autobuild/patches/0002-rename-binary.patch
@@ -1,0 +1,40 @@
+Rename ether-wake to etherwake
+--- a/ether-wake.c
++++ b/ether-wake.c
+@@ -1,12 +1,12 @@
+ /* ether-wake.c: Send a magic packet to wake up sleeping machines. */
+ 
+ static char version_msg[] =
+-"ether-wake.c: v1.09 11/12/2003 Donald Becker, http://www.scyld.com/";
++"etherwake.c: v1.09 11/12/2003 Donald Becker, http://www.scyld.com/";
+ static char brief_usage_msg[] =
+-"usage: ether-wake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
++"usage: etherwake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
+ "   Use '-u' to see the complete set of options.\n";
+ static char usage_msg[] =
+-"usage: ether-wake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
++"usage: etherwake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
+ "\n"
+ "	This program generates and transmits a Wake-On-LAN (WOL)\n"
+ "	\"Magic Packet\", used for restarting machines that have been\n"
+@@ -159,9 +159,9 @@
+ #endif
+ 	if (s < 0) {
+ 		if (errno == EPERM)
+-			fprintf(stderr, "ether-wake: This program must be run as root.\n");
++			fprintf(stderr, "etherwake: This program must be run as root.\n");
+ 		else
+-			perror("ether-wake: socket");
++			perror("etherwake: socket");
+ 		perm_failure++;
+ 	}
+ 	/* Don't revert if debugging allows a normal user to get the raw socket. */
+@@ -295,7 +295,7 @@
+ 					hostid, ether_ntoa(eaddr));
+ 	} else {
+ 		(void)fprintf(stderr,
+-					  "ether-wake: The Magic Packet host address must be "
++					  "etherwake: The Magic Packet host address must be "
+ 					  "specified as\n"
+ 					  "  - a station address, 00:11:22:33:44:55, or\n"
+ 					  "  - a hostname with a known 'ethers' entry.\n");

--- a/app-network/etherwake/autobuild/patches/0003-fix-hardening.patch
+++ b/app-network/etherwake/autobuild/patches/0003-fix-hardening.patch
@@ -1,0 +1,30 @@
+Fix the pointer targets in initialization which differ in signedness
+--- a/ether-wake.c
++++ b/ether-wake.c
+@@ -131,7 +131,7 @@
+ 		case 'D': debug++;			break;
+ 		case 'i': ifname = optarg;	break;
+ 		case 'p': get_wol_pw(optarg); break;
+-		case 'u': printf(usage_msg); return 0;
++		case 'u': printf("%s",usage_msg); return 0;
+ 		case 'v': verbose++;		break;
+ 		case 'V': do_version++;		break;
+ 		case '?':
+@@ -140,7 +140,7 @@
+ 	if (verbose || do_version)
+ 		printf("%s\n", version_msg);
+ 	if (errflag) {
+-		fprintf(stderr, brief_usage_msg);
++		fprintf(stderr,"%s", brief_usage_msg);
+ 		return 3;
+ 	}
+ 
+@@ -181,7 +181,7 @@
+ 	   The code to retrieve the local station address is Linux specific. */
+ 	if (! opt_no_src_addr) {
+ 		struct ifreq if_hwaddr;
+-		unsigned char *hwaddr = if_hwaddr.ifr_hwaddr.sa_data;
++		const char *hwaddr = if_hwaddr.ifr_hwaddr.sa_data;
+ 
+ 		strcpy(if_hwaddr.ifr_name, ifname);
+ 		if (ioctl(s, SIOCGIFHWADDR, &if_hwaddr) < 0) {

--- a/app-network/etherwake/autobuild/patches/0004-Use-the-first-available-interface-instead-of-always-.patch
+++ b/app-network/etherwake/autobuild/patches/0004-Use-the-first-available-interface-instead-of-always-.patch
@@ -1,0 +1,97 @@
+From: =?utf-8?b?0L3QsNCx?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Tue, 24 Sep 2024 17:36:39 +0200
+Subject: Use the first available interface instead of always eth0 (Closes:
+ #816411)
+
+---
+ ether-wake.c | 21 ++++++++++++++++++---
+ etherwake.8  |  6 +++---
+ 2 files changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/ether-wake.c b/ether-wake.c
+index 00ea53c..5839346 100644
+--- a/ether-wake.c
++++ b/ether-wake.c
+@@ -22,7 +22,7 @@ static char usage_msg[] =
+ "	Options:\n"
+ "		-b	Send wake-up packet to the broadcast address.\n"
+ "		-D	Increase the debug level.\n"
+-"		-i ifname	Use interface IFNAME instead of the default 'eth0'.\n"
++"		-i ifname	Use interface IFNAME instead of the default '%s'.\n"
+ "		-p <pw>		Append the four or six byte password PW to the packet.\n"
+ "					A password is only required for a few adapter types.\n"
+ "					The password may be specified in ethernet hex format\n"
+@@ -66,6 +66,7 @@ static char usage_msg[] =
+ #include <errno.h>
+ #include <ctype.h>
+ #include <string.h>
++#include <ifaddrs.h>
+ 
+ #if 0							/* Only exists on some versions. */
+ #include <ioctls.h>
+@@ -110,9 +111,20 @@ static int get_dest_addr(const char *arg, struct ether_addr *eaddr);
+ static int get_fill(unsigned char *pkt, struct ether_addr *eaddr);
+ static int get_wol_pw(const char *optarg);
+ 
++static const char *default_ifname(void) {
++	struct ifaddrs *itr = NULL;
++	if(getifaddrs(&itr) == -1)
++		return "eth0";
++
++	for(; itr; itr = itr->ifa_next)
++		if((itr->ifa_flags & IFF_UP) && (itr->ifa_flags & IFF_BROADCAST))
++			return itr->ifa_name;
++	return "eth0";
++}
++
+ int main(int argc, char *argv[])
+ {
+-	char *ifname = "eth0";
++	const char *ifname = NULL;
+ 	int one = 1;				/* True, for socket options. */
+ 	int s;						/* Raw socket */
+ 	int errflag = 0, verbose = 0, do_version = 0;
+@@ -131,7 +143,7 @@ int main(int argc, char *argv[])
+ 		case 'D': debug++;			break;
+ 		case 'i': ifname = optarg;	break;
+ 		case 'p': get_wol_pw(optarg); break;
+-		case 'u': printf("%s",usage_msg); return 0;
++		case 'u': printf(usage_msg, default_ifname()); return 0;
+ 		case 'v': verbose++;		break;
+ 		case 'V': do_version++;		break;
+ 		case '?':
+@@ -149,6 +161,9 @@ int main(int argc, char *argv[])
+ 		return 3;
+ 	}
+ 
++	if (!ifname)
++		ifname = default_ifname();
++
+ 	/* Note: PF_INET, SOCK_DGRAM, IPPROTO_UDP would allow SIOCGIFHWADDR to
+ 	   work as non-root, but we need SOCK_PACKET to specify the Ethernet
+ 	   destination address. */
+diff --git a/etherwake.8 b/etherwake.8
+index 5f807c5..53190b9 100644
+--- a/etherwake.8
++++ b/etherwake.8
+@@ -26,9 +26,9 @@ .SH DESCRIPTION
+ command.
+ .PP
+ .\" TeX users may be more comfortable with the \fB<whatever>\fP and
+-.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
++.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+ .\" respectively.
+-\fBetherwake\fP is a program that generates and transmits a Wake-On-LAN 
++\fBetherwake\fP is a program that generates and transmits a Wake-On-LAN
+ (WOL) "Magic Packet", used for restarting machines that have been
+ soft-powered-down (ACPI D3-warm state). It generates the standard
+ AMD Magic Packet format, optionally with a password included.  The
+@@ -49,7 +49,7 @@ .SH OPTIONS
+ Increase the Debug Level.
+ .TP
+ .B \-i ifname
+-Use interface ifname instead of the default "eth0".
++Use interface ifname instead of the default (first available interface or "eth0").
+ .TP
+ .B \-p passwd
+ Append a four or six byte password to the packet. Only a few adapters

--- a/app-network/etherwake/autobuild/patches/0005-Format-MAC-addresses-correctly-Closes-1082673.patch
+++ b/app-network/etherwake/autobuild/patches/0005-Format-MAC-addresses-correctly-Closes-1082673.patch
@@ -1,0 +1,21 @@
+From: =?utf-8?b?0L3QsNCx?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Tue, 24 Sep 2024 17:38:04 +0200
+Subject: Format MAC addresses correctly (Closes: #1082673)
+
+---
+ ether-wake.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ether-wake.c b/ether-wake.c
+index 5839346..fcfeac5 100644
+--- a/ether-wake.c
++++ b/ether-wake.c
+@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
+ 
+ 		if (verbose) {
+ 			printf("The hardware address (SIOCGIFHWADDR) of %s is type %d  "
+-				   "%2.2x:%2.2x:%2.2x:%2.2x:%2.2x:%2.2x.\n", ifname,
++				   "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx.\n", ifname,
+ 				   if_hwaddr.ifr_hwaddr.sa_family, hwaddr[0], hwaddr[1],
+ 				   hwaddr[2], hwaddr[3], hwaddr[4], hwaddr[5]);
+ 		}

--- a/app-network/etherwake/spec
+++ b/app-network/etherwake/spec
@@ -1,0 +1,4 @@
+VER=1.09
+SRCS="tbl::http://deb.debian.org/debian/pool/main/e/etherwake/etherwake_$VER.orig.tar.gz"
+CHKSUMS="sha256::54241c7689579dc86e29e6afbc6d60e69f97135091a1395c8a10f6d5a2daec1d"
+CHKUPDATE="anitya::id=378351"


### PR DESCRIPTION
Topic Description
-----------------

- etherwake: new, 1.09
    Reviewed-by: liushuyu <liushuyu011@gmail.com>
    Co-authored-by: liushuyu <liushuyu011@gmail.com>
    Signed-off-by: Ayden Meng <aydenmeng@yeah.net>

Package(s) Affected
-------------------

- etherwake: 1.09

Security Update?
----------------

No

Build Order
-----------

```
#buildit etherwake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
