### PR TITLE
niri: update to 25.05.1

### DIFF
--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,4 +1,4 @@
-VER=25.05
+VER=25.05.1
 SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"


### PR DESCRIPTION
Topic Description
-----------------

- niri: update to 25.05.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- niri: 25.05.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
