### PR TITLE
bc: update to 1.08.2

### DIFF
--- a/app-utils/bc/spec
+++ b/app-utils/bc/spec
@@ -1,4 +1,4 @@
-VER=1.08.1
+VER=1.08.2
 SRCS="tbl::https://ftp.gnu.org/gnu/bc/bc-$VER.tar.gz"
-CHKSUMS="sha256::b71457ffeb210d7ea61825ff72b3e49dc8f2c1a04102bbe23591d783d1bfe996"
+CHKSUMS="sha256::ae470fec429775653e042015edc928d07c8c3b2fc59765172a330d3d87785f86"
 CHKUPDATE="anitya::id=170"


### PR DESCRIPTION
Topic Description
-----------------

- bc: update to 1.08.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bc: 1.08.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
