### PR TITLE
gettext: fix autotools macros install


### DIFF
--- a/app-devel/gettext/autobuild/beyond
+++ b/app-devel/gettext/autobuild/beyond
@@ -1,2 +1,6 @@
 abinfo "Setting executable bit for libintl_m2 ..."
 chmod -v +x "$PKGDIR"/usr/lib/libintl_m2.so*
+
+abinfo "Moving autoconf macros to aclocal ..."
+mkdir -vp "$PKGDIR"/usr/share/aclocal
+mv -v "$PKGDIR"/usr/share/gettext/m4/* "$PKGDIR"/usr/share/aclocal/

--- a/app-devel/gettext/spec
+++ b/app-devel/gettext/spec
@@ -1,5 +1,5 @@
 VER=0.25
-REL=1
+REL=2
 SRCS="https://ftp.gnu.org/gnu/gettext/gettext-$VER.tar.xz"
 CHKSUMS="sha256::05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"
 CHKUPDATE="anitya::id=898"


### PR DESCRIPTION
Topic Description
-----------------

- gettext: fix autotools macros install

Package(s) Affected
-------------------

- gettext: 1:0.25-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gettext
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
