### PR TITLE
openssl: fix P-384 curve on POWER < 9

### DIFF
--- a/runtime-cryptography/openssl/01-shared/patches/0001-Fix-P-384-curve-on-lower-than-P9-PPC64-targets.patch
+++ b/runtime-cryptography/openssl/01-shared/patches/0001-Fix-P-384-curve-on-lower-than-P9-PPC64-targets.patch
@@ -1,0 +1,128 @@
+From 885225a4868a5b9252904ca080401e4e5846bcd3 Mon Sep 17 00:00:00 2001
+From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
+Date: Thu, 17 Apr 2025 08:51:53 -0500
+Subject: [PATCH] Fix P-384 curve on lower-than-P9 PPC64 targets
+
+The change adding an asm implementation of p384_felem_reduce incorrectly
+uses the accelerated version on both targets that support the intrinsics
+*and* targets that don't, instead of falling back to the generics on older
+targets.  This results in crashes when trying to use P-384 on < Power9.
+
+Signed-off-by: Anna Wilcox <AWilcox@Wilcox-Tech.com>
+Closes: #27350
+Fixes: 85cabd94 ("Fix Minerva timing side-channel signal for P-384 curve on PPC")
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/27429)
+
+(cherry picked from commit 29864f2b0f1046177e8048a5b17440893d3f9425)
+---
+ crypto/ec/ecp_nistp384.c | 54 ++++++++++++++++++++++++----------------
+ 1 file changed, 33 insertions(+), 21 deletions(-)
+
+diff --git a/crypto/ec/ecp_nistp384.c b/crypto/ec/ecp_nistp384.c
+index 2ceb94fe33..9d682f5a02 100644
+--- a/crypto/ec/ecp_nistp384.c
++++ b/crypto/ec/ecp_nistp384.c
+@@ -684,6 +684,22 @@ static void felem_reduce_ref(felem out, const widefelem in)
+         out[i] = acc[i];
+ }
+ 
++static ossl_inline void felem_square_reduce_ref(felem out, const felem in)
++{
++    widefelem tmp;
++
++    felem_square_ref(tmp, in);
++    felem_reduce_ref(out, tmp);
++}
++
++static ossl_inline void felem_mul_reduce_ref(felem out, const felem in1, const felem in2)
++{
++    widefelem tmp;
++
++    felem_mul_ref(tmp, in1, in2);
++    felem_reduce_ref(out, tmp);
++}
++
+ #if defined(ECP_NISTP384_ASM)
+ static void felem_square_wrapper(widefelem out, const felem in);
+ static void felem_mul_wrapper(widefelem out, const felem in1, const felem in2);
+@@ -695,10 +711,18 @@ static void (*felem_mul_p)(widefelem out, const felem in1, const felem in2) =
+ 
+ static void (*felem_reduce_p)(felem out, const widefelem in) = felem_reduce_ref;
+ 
++static void (*felem_square_reduce_p)(felem out, const felem in) =
++    felem_square_reduce_ref;
++static void (*felem_mul_reduce_p)(felem out, const felem in1, const felem in2) =
++    felem_mul_reduce_ref;
++
+ void p384_felem_square(widefelem out, const felem in);
+ void p384_felem_mul(widefelem out, const felem in1, const felem in2);
+ void p384_felem_reduce(felem out, const widefelem in);
+ 
++void p384_felem_square_reduce(felem out, const felem in);
++void p384_felem_mul_reduce(felem out, const felem in1, const felem in2);
++
+ # if defined(_ARCH_PPC64)
+ #  include "crypto/ppc_arch.h"
+ # endif
+@@ -710,6 +734,8 @@ static void felem_select(void)
+         felem_square_p = p384_felem_square;
+         felem_mul_p = p384_felem_mul;
+         felem_reduce_p = p384_felem_reduce;
++        felem_square_reduce_p = p384_felem_square_reduce;
++        felem_mul_reduce_p = p384_felem_mul_reduce;
+ 
+         return;
+     }
+@@ -718,7 +744,9 @@ static void felem_select(void)
+     /* Default */
+     felem_square_p = felem_square_ref;
+     felem_mul_p = felem_mul_ref;
+-    felem_reduce_p = p384_felem_reduce;
++    felem_reduce_p = felem_reduce_ref;
++    felem_square_reduce_p = felem_square_reduce_ref;
++    felem_mul_reduce_p = felem_mul_reduce_ref;
+ }
+ 
+ static void felem_square_wrapper(widefelem out, const felem in)
+@@ -737,31 +765,15 @@ static void felem_mul_wrapper(widefelem out, const felem in1, const felem in2)
+ # define felem_mul felem_mul_p
+ # define felem_reduce felem_reduce_p
+ 
+-void p384_felem_square_reduce(felem out, const felem in);
+-void p384_felem_mul_reduce(felem out, const felem in1, const felem in2);
+-
+-# define felem_square_reduce p384_felem_square_reduce
+-# define felem_mul_reduce p384_felem_mul_reduce
++# define felem_square_reduce felem_square_reduce_p
++# define felem_mul_reduce felem_mul_reduce_p
+ #else
+ # define felem_square felem_square_ref
+ # define felem_mul felem_mul_ref
+ # define felem_reduce felem_reduce_ref
+ 
+-static ossl_inline void felem_square_reduce(felem out, const felem in)
+-{
+-    widefelem tmp;
+-
+-    felem_square(tmp, in);
+-    felem_reduce(out, tmp);
+-}
+-
+-static ossl_inline void felem_mul_reduce(felem out, const felem in1, const felem in2)
+-{
+-    widefelem tmp;
+-
+-    felem_mul(tmp, in1, in2);
+-    felem_reduce(out, tmp);
+-}
++# define felem_square_reduce felem_square_reduce_ref
++# define felem_mul_reduce felem_mul_reduce_ref
+ #endif
+ 
+ /*-
+-- 
+2.49.0
+

--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,5 @@
 VER=3.5.0
+REL=1
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
 CHKSUMS="sha256::344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl: fix P-384 curve on POWER < 9
    Link: https://github.com/openssl/openssl/pull/27429

Package(s) Affected
-------------------

- openssl: 3.5.0-1
- openssl-static: 3.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
