### PR TITLE
qmmp: update to 1.7.6

### DIFF
--- a/app-multimedia/qmmp/autobuild/defines
+++ b/app-multimedia/qmmp/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=qmmp
 PKGSEC=sound
-PKGDEP="curl libmad libogg libvorbis qt-5 taglib xdg-utils faad2 ffmpeg flac libcddb \
-        libcdio-paranoia game-music-emu libmms libmodplug libmpcdec libsamplerate \
-        libsndfile opusfile pulseaudio wavpack wildmidi libsidplay projectm libbs2b \
-        icecast libsidplayfp mpg123"
-BUILDDEP="cmake"
+# FIXME: projectm>=4.0.0 too new for qmmp 1.x.x, can be reintroduced when qmmp 2.x.x.
+PKGDEP="alsa-lib curl enca faad2 ffmpeg flac game-music-emu gcc-runtime glibc jack \
+        libarchive libbs2b libcddb libcdio libcdio-paranoia libmad libmms libmpcdec \
+        libogg libshout libsidplayfp libsndfile libvorbis mpg123 opusfile pipewire \
+        pulseaudio qt-5 soxr taglib wavpack wildmidi x11-lib"
 PKGDES="A Qt Multimedia Player"
 
-CMAKE_AFTER="-DUSE_HAL:BOOL=FALSE"
+ABTYPE=cmakeninja

--- a/app-multimedia/qmmp/spec
+++ b/app-multimedia/qmmp/spec
@@ -1,5 +1,4 @@
-VER=1.6.5
-REL=3
-SRCS="tbl::https://qmmp.ylsoftware.com/files/qmmp/1.6/qmmp-$VER.tar.bz2"
-CHKSUMS="sha256::e0e65271beed94193dc7a470ce9727580ba3ee8b2889391efceddc219cd991e2"
+VER=1.7.6
+SRCS="tbl::https://qmmp.ylsoftware.com/files/qmmp/${VER%.*}/qmmp-$VER.tar.bz2"
+CHKSUMS="sha256::43b441f022302a43b98cca88a47e8e5ba1e73caae8acc0e9e2c6b77e5b1eb3bb"
 CHKUPDATE="anitya::id=4129"


### PR DESCRIPTION
Topic Description
-----------------

- qmmp: update to 1.7.6
    - Adjust PKGDEP, temporarily remove projectm until qmmp 2.x.x

Package(s) Affected
-------------------

- qmmp: 1.7.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit qmmp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
