### PR TITLE
init-system-helpers: new, 1.68

### DIFF
--- a/app-admin/init-system-helpers/autobuild/build
+++ b/app-admin/init-system-helpers/autobuild/build
@@ -1,0 +1,28 @@
+abinfo "Installing scripts ..."
+install -Dvm755 "$SRCDIR"/script/* \
+    -t "$PKGDIR"/usr/bin
+
+# From d/rules (1.68).
+
+abinfo "Generating man pages ..."
+for file in "$SRCDIR"/script/deb-*; do \
+    pod2man \
+        --section=1p \
+        --utf8 \
+        --center="init-system-helpers" \
+        --release="$PKGVER" \
+        $file $file.1p
+done
+for file in "$SRCDIR"/man8/*.rst ; do \
+    rst2man $file ${file%.rst}.8
+done
+
+abinfo "Installing man pages ..."
+install -Dvm644 "$SRCDIR"/script/*.1p \
+    -t "$PKGDIR"/usr/share/man/man1/
+install -Dvm644 "$SRCDIR"/man8/*.8 \
+    -t "$PKGDIR"/usr/share/man/man8/
+
+abinfo "Setting version information for service(8) ..."
+sed -e "s|__VERSION__|$PKGDIR|g" \
+    -i "$PKGDIR"/usr/bin/service

--- a/app-admin/init-system-helpers/autobuild/defines
+++ b/app-admin/init-system-helpers/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=init-system-helpers
+PKGSEC=admin
+PKGDEP="bash init-functions perl"
+BUILDDEP="docutils"
+PKGDES="Utilities for handling scripts and services for various init systems"
+
+ABHOST=noarch

--- a/app-admin/init-system-helpers/spec
+++ b/app-admin/init-system-helpers/spec
@@ -1,0 +1,4 @@
+VER=1.68
+SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/debian/init-system-helpers.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378356"

--- a/runtime-admin/init-functions/autobuild/build
+++ b/runtime-admin/init-functions/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Installing init-functions ..."
+install -Dvm644 "$SRCDIR"/src/lsb-base/init-functions \
+    "$PKGDIR"/usr/lib/lsb/init-functions
+install -Dvm644 "$SRCDIR"/src/lsb-base/init-functions.d/* \
+    -t "$PKGDIR"/usr/lib/lsb/init-functions.d/

--- a/runtime-admin/init-functions/autobuild/defines
+++ b/runtime-admin/init-functions/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=init-functions
+PKGSEC=libs
+PKGDEP="bash"
+PKGDES="LSB-compliant init script functions"
+
+ABHOST=noarch

--- a/runtime-admin/init-functions/spec
+++ b/runtime-admin/init-functions/spec
@@ -1,0 +1,5 @@
+UPSTREAM_VER=3.14-4
+VER=${UPSTREAM_VER/\-/+}
+SRCS="tbl::http://deb.debian.org/debian/pool/main/s/sysvinit/sysvinit_${UPSTREAM_VER}.debian.tar.xz"
+CHKSUMS="sha256::2ba0aa763232112696bce50ee5acc707a515fcbd5b2c194193bfa7a0a525bff6"
+# Note: No need to check for updates, we go by Debian versions.


### PR DESCRIPTION
Topic Description
-----------------

- init-system-helpers: new, 1.68
- init-functions: new, 3.14+4

Package(s) Affected
-------------------

- init-functions: 3.14+4
- init-system-helpers: 1.68

Security Update?
----------------

No

Build Order
-----------

```
#buildit init-functions init-system-helpers
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
