### PR TITLE
usb-modeswitch: add tplink device '01da:1a2b' data

### DIFF
--- a/app-utils/usb-modeswitch/autobuild/build
+++ b/app-utils/usb-modeswitch/autobuild/build
@@ -13,7 +13,7 @@ make \
 
 abinfo "Installing usb-modeswitch-data ..."
 make \
-    -C "$SRCDIR"/usb-modeswitch-data-20170120 \
+    -C "$SRCDIR"/../usb-modeswitch-data-${__DATA_VER} \
     DESTDIR="$PKGDIR" \
     RULESDIR="$PKGDIR"/usr/lib/udev/rules.d \
     install

--- a/app-utils/usb-modeswitch/autobuild/patch
+++ b/app-utils/usb-modeswitch/autobuild/patch
@@ -1,8 +1,11 @@
-abinfo "Tweaking scripts and configuration to use /usr/bin ..."
-sed -e 's|/usr/sbin/usb_mode|/usr/bin/usb_mode|g' \
-    -i "$SRCDIR"/usb_modeswitch.{conf,sh} \
-    -i "$SRCDIR"/usb_modeswitch_dispatcher.tcl
+abinfo "Applying usb-modeswitch src patches ..."
+for PATCH_FILE in autobuild/patches/*src.patch; do
+    abinfo "Applying  $PATCH_FILE ..."
+    patch -p2 -d ./ < "$PATCH_FILE"
+done
 
-abinfo "Downloading usb-modeswitch-data ..."
-wget http://www.draisberghof.de/usb_modeswitch/usb-modeswitch-data-20170120.tar.bz2
-tar xvf usb-modeswitch-data-20170120.tar.bz2
+abinfo "Applying usb-modeswitch-data patches ..."
+for PATCH_FILE in autobuild/patches/*data.patch; do
+    abinfo "Applying  $PATCH_FILE ..."
+    patch -p1 -d ../ < "$PATCH_FILE"
+done

--- a/app-utils/usb-modeswitch/autobuild/patches/0001-used-usr-bin-src.patch
+++ b/app-utils/usb-modeswitch/autobuild/patches/0001-used-usr-bin-src.patch
@@ -1,0 +1,54 @@
+diff -ruN a/usb-modeswitch-2.6.0/usb_modeswitch.conf b/usb-modeswitch-2.6.0/usb_modeswitch.conf
+--- a/usb-modeswitch-2.6.0/usb_modeswitch.conf	2019-11-28 05:24:38.000000000 +0800
++++ b/usb-modeswitch-2.6.0/usb_modeswitch.conf	2025-05-27 14:03:10.007219409 +0800
+@@ -1,7 +1,7 @@
+ # Configuration for the usb_modeswitch package, a mode switching tool for
+ # USB devices providing multiple states or modes
+ #
+-# Evaluated by the wrapper script /usr/sbin/usb_modeswitch_dispatcher
++# Evaluated by the wrapper script /usr/bin/usb_modeswitch_dispatcher
+ #
+ # To enable an option, set it to "1", "yes" or "true" (case doesn't matter)
+ # Everything else counts as "disable"
+diff -ruN a/usb-modeswitch-2.6.0/usb_modeswitch_dispatcher.tcl b/usb-modeswitch-2.6.0/usb_modeswitch_dispatcher.tcl
+--- a/usb-modeswitch-2.6.0/usb_modeswitch_dispatcher.tcl	2019-11-29 04:14:34.000000000 +0800
++++ b/usb-modeswitch-2.6.0/usb_modeswitch_dispatcher.tcl	2025-05-27 14:03:10.010198299 +0800
+@@ -285,7 +285,7 @@
+ 	if [CheckMBIM] {
+ 		Log " driver for MBIM devices is available"
+ 		Log "Find MBIM configuration number ..."
+-		if [catch {set cfgno [exec /usr/sbin/usb_modeswitch -j -Q $busParam $devParam -v $usb(idVendor) -p $usb(idProduct)]} err] {
++		if [catch {set cfgno [exec /usr/bin/usb_modeswitch -j -Q $busParam $devParam -v $usb(idVendor) -p $usb(idProduct)]} err] {
+ 			Log "Error when trying to find MBIM configuration, switch to legacy modem mode"
+ 		} else {
+ 			set cfgno [string trim $cfgno]
+@@ -321,7 +321,7 @@
+ 	# Now we are actually switching
+ 	if $flags(logging) {
+ 		Log "Command line:\nusb_modeswitch -W -D $configParam $busParam $devParam -v $usb(idVendor) -p $usb(idProduct) -f \$flags(config)"
+-		catch {set report [exec /usr/sbin/usb_modeswitch -W -D $configParam $busParam $devParam -v $usb(idVendor) -p $usb(idProduct) -f "$flags(config)" 2>@1]} report
++		catch {set report [exec /usr/bin/usb_modeswitch -W -D $configParam $busParam $devParam -v $usb(idVendor) -p $usb(idProduct) -f "$flags(config)" 2>@1]} report
+ 		Log "\nVerbose debug output of usb_modeswitch and libusb follows"
+ 		Log "(Note that some USB errors are to be expected in the process)"
+ 		Log "--------------------------------"
+@@ -329,7 +329,7 @@
+ 		Log "--------------------------------"
+ 		Log "(end of usb_modeswitch output)\n"
+ 	} else {
+-		catch {set report [exec /usr/sbin/usb_modeswitch -Q -D $configParam $busParam $devParam -v $usb(idVendor) -p $usb(idProduct) -f "$flags(config)" 2>@1]} report
++		catch {set report [exec /usr/bin/usb_modeswitch -Q -D $configParam $busParam $devParam -v $usb(idVendor) -p $usb(idProduct) -f "$flags(config)" 2>@1]} report
+ 	}
+ }
+ 
+diff -ruN a/usb-modeswitch-2.6.0/usb_modeswitch.sh b/usb-modeswitch-2.6.0/usb_modeswitch.sh
+--- a/usb-modeswitch-2.6.0/usb_modeswitch.sh	2019-11-28 04:04:55.000000000 +0800
++++ b/usb-modeswitch-2.6.0/usb_modeswitch.sh	2025-05-27 14:03:10.009456515 +0800
+@@ -46,7 +46,7 @@
+ 	--symlink-name)
+ 		device_in "link_list" $v_id $p_id
+ 		if [ "$?" = "1" ]; then
+-			if [ -e "/usr/sbin/usb_modeswitch_dispatcher" ]; then
++			if [ -e "/usr/bin/usb_modeswitch_dispatcher" ]; then
+ 				exec usb_modeswitch_dispatcher $1 $2 2>>/dev/null
+ 			fi
+ 		fi

--- a/app-utils/usb-modeswitch/autobuild/patches/0002-add-01da:1a2b-data.patch
+++ b/app-utils/usb-modeswitch/autobuild/patches/0002-add-01da:1a2b-data.patch
@@ -1,0 +1,21 @@
+diff -ruN a/usb-modeswitch-data-20170120/40-usb_modeswitch.rules b/usb-modeswitch-data-20170120/40-usb_modeswitch.rules
+--- a/usb-modeswitch-data-20170120/40-usb_modeswitch.rules	2017-01-21 05:41:17.000000000 +0800
++++ b/usb-modeswitch-data-20170120/40-usb_modeswitch.rules	2025-05-27 05:34:00.897289788 +0800
+@@ -395,6 +395,9 @@
+ # Olivetti Olicard 500
+ ATTR{idVendor}=="0b3c", ATTR{idProduct}=="f017", RUN+="usb_modeswitch '/%k'"
+ 
++# Realtek Semiconductor Corp. RTL8188GU 802.11n WLAN Adapter
++ATTR{idVendor}=="0bda", ATTR{idProduct}=="1a2b", RUN+="usb_modeswitch '/%k'"
++
+ # Ericsson F5521gw
+ ATTR{idVendor}=="0bdb", ATTR{idProduct}=="190d", RUN+="usb_modeswitch '/%k'"
+ 
+diff -ruN a/usb-modeswitch-data-20170120/usb_modeswitch.d/0bda:1a2b b/usb-modeswitch-data-20170120/usb_modeswitch.d/0bda:1a2b
+--- a/usb-modeswitch-data-20170120/usb_modeswitch.d/0bda:1a2b	1970-01-01 08:00:00.000000000 +0800
++++ b/usb-modeswitch-data-20170120/usb_modeswitch.d/0bda:1a2b	2025-05-27 06:00:23.611517886 +0800
+@@ -0,0 +1,4 @@
++# Realtek Semiconductor Corp. RTL8188GU 802.11n WLAN Adapter
++TargetVendor=0x0bda
++TargetProduct=0xb711
++StandardEject=1

--- a/app-utils/usb-modeswitch/spec
+++ b/app-utils/usb-modeswitch/spec
@@ -1,5 +1,10 @@
-VER=2.6.0
-REL=3
-SRCS="tbl::https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-$VER.tar.bz2"
-CHKSUMS="sha256::c215236e6bada6e659fc195a31d611ea298a4bdb4d57a0d68c553b56585f8ba3"
+UPSTREAM_VER=2.6.0
+__DATA_VER=20170120
+VER=$UPSTREAM_VER+data${__DATA_VER}
+REL=4
+SRCS="tbl::https://www.draisberghof.de/usb_modeswitch/usb-modeswitch-$UPSTREAM_VER.tar.bz2 \
+      tbl::http://www.draisberghof.de/usb_modeswitch/usb-modeswitch-data-${__DATA_VER}.tar.bz2"
+CHKSUMS="sha256::c215236e6bada6e659fc195a31d611ea298a4bdb4d57a0d68c553b56585f8ba3 \
+         sha256::172df3dfb6e211914bbeca074d1c9c849a35bdaafa63e42b72b784bf2992b3ad"
 CHKUPDATE="anitya::id=5059"
+SUBDIR="usb-modeswitch-$UPSTREAM_VER"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
为 usb-modeswitch 增加 tplink 无线网卡（01da:1a2b）的补丁数据
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
否
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
否
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->


Build Order
-----------


<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->


```
#buildit usb-modeswitch
```


Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
