### PR TITLE
iotop: update to 1.30

### DIFF
--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,4 +1,4 @@
-VER=1.29
+VER=1.30
 SRCS="git::commit=tags/v$VER::https://github.com/Tomas-M/iotop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=259120"


### PR DESCRIPTION
Topic Description
-----------------

- iotop: update to 1.30
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iotop: 1.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
