### PR TITLE
zoxide: update to 0.9.8

### DIFF
--- a/app-utils/zoxide/spec
+++ b/app-utils/zoxide/spec
@@ -1,4 +1,4 @@
-VER=0.9.7
+VER=0.9.8
 SRCS="git::commit=tags/v$VER::https://github.com/ajeetdsouza/zoxide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=98400"


### PR DESCRIPTION
Topic Description
-----------------

- zoxide: update to 0.9.8
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zoxide: 0.9.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit zoxide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
