### PR TITLE
cpu-x: update to 5.3.1

### DIFF
--- a/app-utils/cpu-x/autobuild/defines
+++ b/app-utils/cpu-x/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=utils
 PKGDES="A tool to present information on CPU, motherboard and more"
 PKGDEP="cairomm gcc-runtime glib glibc glibmm gtkmm-3 libcl libcpuid \
         libsigc++ ncurses pangomm pciutils procps vulkan-loader polkit"
-BUILDDEP="gettext opencl-registry-api"
+BUILDDEP="gettext opencl-registry-api vulkan-headers"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
 
 CMAKE_AFTER="-DWITH_OPENCL=ON"

--- a/app-utils/cpu-x/spec
+++ b/app-utils/cpu-x/spec
@@ -1,4 +1,4 @@
-VER=5.3.0
+VER=5.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/TheTumultuousUnicornOfDarkness/CPU-X"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137672"


### PR DESCRIPTION
Topic Description
-----------------

- cpu-x: update to 5.3.1
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- cpu-x: 5.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpu-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
