### PR TITLE
findlib: update to 1.9.8

### DIFF
--- a/lang-ocaml/findlib/autobuild/defines
+++ b/lang-ocaml/findlib/autobuild/defines
@@ -8,6 +8,6 @@ NOPARALLEL=1
 NOSTATIC=0
 ABSPLITDBG=0
 
-# FIXME: Enabling LTO makes ocamlc to invoke gcc with LTO enabled, resulting in
+# FIXME: Enabling LTO makes ocamlc invoke GCC with LTO enabled, resulting in
 # build-time failures.
 NOLTO=1

--- a/lang-ocaml/findlib/spec
+++ b/lang-ocaml/findlib/spec
@@ -1,5 +1,4 @@
-VER=1.9.7
-SRCS="tbl::http://download.camlcity.org/download/findlib-$VER.tar.gz"
-CHKSUMS="sha256::ccd822008f1b87abd56a12ff7f4af195a0cda2e3bc0113921779a205c9791e29"
+VER=1.9.8
+SRCS="git::commit=tags/findlib-$VER::https://github.com/ocaml/ocamlfind"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16991"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- findlib: update to 1.9.8

Package(s) Affected
-------------------

- findlib: 1.9.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit findlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
