### PR TITLE
rofi-wayland: fix missing PKGDEP

### DIFF
--- a/app-utils/rofi-wayland/autobuild/defines
+++ b/app-utils/rofi-wayland/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=rofi-wayland
 PKGSEC=utils
 PKGDEP="freetype libxdg-basedir libxkbcommon pango startup-notification \
         xcb-util-wm xcb-util-xrm librsvg cairo xcb-util-cursor glib gdk-pixbuf \
-        xcb-util-keysyms xcb-util libxcb xcb-imdkit"
+        xcb-util-keysyms xcb-util libxcb xcb-imdkit wayland"
 PKGCONFL="rofi"    
 PKGDES="A pop-up window switcher (Wayland fork)"
 


### PR DESCRIPTION
Topic Description
-----------------

- rofi-wayland: fix missing PKGDEP

Package(s) Affected
-------------------

- rofi-wayland: 1.7.9+wayland1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi-wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
