### PR TITLE
ubuntu-keyring: update to 2023.11.28.1

### DIFF
--- a/runtime-data/ubuntu-keyring/autobuild/build
+++ b/runtime-data/ubuntu-keyring/autobuild/build
@@ -1,1 +1,2 @@
+abinfo "Installing keyring files ..."
 install -Dm644 keyrings/*-{keyring,keys}.gpg -t "$PKGDIR"/usr/share/keyrings/

--- a/runtime-data/ubuntu-keyring/spec
+++ b/runtime-data/ubuntu-keyring/spec
@@ -1,4 +1,4 @@
-VER=2021.03.26
-SRCS="tbl::https://mirrors.kernel.org/ubuntu/pool/main/u/ubuntu-keyring/ubuntu-keyring_${VER}.tar.gz"
-CHKSUMS="sha256::492eed5c06408c6f632577adb0796130af5d6542013ef418f47187a209e49bb1"
+VER=2023.11.28.1
+SRCS="tbl::https://mirrors.kernel.org/ubuntu/pool/main/u/ubuntu-keyring/ubuntu-keyring_${VER}.tar.xz"
+CHKSUMS="sha256::aecd455ae15561371d6e454f121f079f0641d5e1b579a5563a2bc363fc74aa2e"
 CHKUPDATE="anitya::id=12357"


### PR DESCRIPTION
Topic Description
-----------------

- ubuntu-keyring: update to 2023.11.28.1

Package(s) Affected
-------------------

- ubuntu-keyring: 2023.11.28.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ubuntu-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
