### PR TITLE
cliphist: new, 0.6.1

### DIFF
--- a/app-utils/cliphist/autobuild/defines
+++ b/app-utils/cliphist/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=cliphist
+PKGSEC=utils
+PKGDEP="wl-clipboard xdg-utils"
+BUILDDEP="go"
+PKGDES="Wayland clipboard manager with support for multimedia"
+PKGSUG="fuzzel"
+
+ABTYPE=gomod

--- a/app-utils/cliphist/spec
+++ b/app-utils/cliphist/spec
@@ -1,0 +1,4 @@
+VER=0.6.1
+SRCS="git::commit=tags/v$VER::https://github.com/sentriz/cliphist.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242870"


### PR DESCRIPTION
Topic Description
-----------------

- cliphist: new, 0.6.1

Package(s) Affected
-------------------

- cliphist: 0.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cliphist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
