### PR TITLE
vscode: update to 1.100.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.100.0
+VER=1.100.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::e2a0fdfda3f9106bf4de745c197e56e2617de9b8a8148e9fb28ac4b48849a7e9"
-CHKSUMS__ARM64="sha256::af96d7bde1f4e2dd2db96ebf5b26c7cee9bba37089d8a7438b52f09025bb6284"
+CHKSUMS__AMD64="sha256::42cdfa55cb63d707e21457b37672491735e79c7d3818e658438a07cb3871b5c2"
+CHKSUMS__ARM64="sha256::d35abce8cfb3fef24c8b34876be554a5e597caa4f5d4822207bea040b8778735"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.100.2
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- vscode: 1.100.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
