### PR TITLE
automake: update to 1.18

### DIFF
--- a/app-devel/automake/spec
+++ b/app-devel/automake/spec
@@ -1,4 +1,4 @@
-VER=1.17
+VER=1.18
 SRCS="git::commit=tags/v$VER::https://git.savannah.gnu.org/git/automake.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=144"


### PR DESCRIPTION
Topic Description
-----------------

- automake: update to 1.18
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- automake: 2:1.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit automake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
