### PR TITLE
apt: update to 3.0.2

### DIFF
--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,5 +1,4 @@
-VER=3.0.1
-REL=1
+VER=3.0.2
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"


### PR DESCRIPTION
Topic Description
-----------------

- apt: update to 3.0.2
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- apt: 2:3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
