### PR TITLE
pushpkg: update to 0+git20250528

### DIFF
--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,14 +1,13 @@
-VER=0+git20240731
-__COMMIT="1c5c510db3db467c9c8e950f2a177a8e5516094a"
+VER=0+git20250528
+__COMMIT="ec2a6ce198b38ebe065c500a959c24acad8ba263"
 SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
       file::rename=pushpkg.bash::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.bash \
       file::rename=pushpkg.fish::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.fish \
       file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
       file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::0c63aaeb24ffee4d1665136ba46c3f9a266f7029ff40f252f022569b0fa75b4c \
+CHKSUMS="sha256::55edcedb332ac81d4092d31f795cea3c226b9afef048f6c025dbfb994c0a19af \
          sha256::48101ed7b8c871f8d315e889816e31502682290b3ca03f8075409247b7a4724e \
          sha256::9a7d8167284bbe2e36b6fe3f7e5bbe4e125a89685a9213db9caa83512ec48026 \
          sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
          sha256::c62c3891a4629143a7dd9ec135e0c12a5f4287fe705f01832ad1bd478195e014"
 SUBDIR="."
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to 0+git20250528

Package(s) Affected
-------------------

- pushpkg: 1:0+git20250528

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
