### PR TITLE
libmodplug: update to 0.8.9.0

### DIFF
--- a/runtime-multimedia/libmodplug/autobuild/defines
+++ b/runtime-multimedia/libmodplug/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libmodplug
 PKGDES="Libraries for mod music based on ModPlug"
 PKGSEC=libs
 PKGDEP="glibc"
+
+ABTYPE=autotools

--- a/runtime-multimedia/libmodplug/spec
+++ b/runtime-multimedia/libmodplug/spec
@@ -1,5 +1,4 @@
-VER=0.8.8.5
-REL=4
-SRCS="tbl::https://sourceforge.net/projects/modplug-xmms/files/libmodplug/$VER/libmodplug-$VER.tar.gz"
-CHKSUMS="sha256::77462d12ee99476c8645cb5511363e3906b88b33a6b54362b4dbc0f39aa2daad"
+VER=0.8.9.0
+SRCS="tbl::https://sourceforge.net/projects/modplug-xmms/files/libmodplug/$VER/libmodplug-$VER.tar.gz/download"
+CHKSUMS="sha256::457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de"
 CHKUPDATE="anitya::id=5669"


### PR DESCRIPTION
Topic Description
-----------------

- libmodplug: update to 0.8.9.0

Package(s) Affected
-------------------

- libmodplug: 0.8.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmodplug
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
