### PR TITLE
Community Wallpapers (2025H1)

### DIFF
--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2024.11.0
+VER=2025.05.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,4 +1,4 @@
-VER=2024.11.0
+VER=2025.05.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=362934"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-default-settings: update to 2025.05.0
- aosc-community-wallpapers: update to 2025.05.1

Package(s) Affected
-------------------

- aosc-community-wallpapers: 1:2025.05.1
- plasma-default-settings: 1:2025.05.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-community-wallpapers plasma-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
