### PR TITLE
rime-ice: update to 2025.04.06

### DIFF
--- a/app-i18n/rime-ice/spec
+++ b/app-i18n/rime-ice/spec
@@ -1,4 +1,4 @@
-VER=2024.12.12
+VER=2025.04.06
 SRCS="git::commit=tags/$VER::https://github.com/iDvel/rime-ice.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377230"


### PR DESCRIPTION
Topic Description
-----------------

- rime-ice: update to 2025.04.06
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- rime-ice: 2025.04.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit rime-ice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
