### PR TITLE
kea: upgrade to 2.6.3

### DIFF
--- a/app-network/kea/autobuild/defines
+++ b/app-network/kea/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=kea
 PKGSEC=net
 PKGDES="IPv4 and IPv6 DHCP server from ISC"
-PKGDEP="boost openssl log4cplus bison postgresql mariadb"
+PKGDEP="boost openssl log4cplus bison pwgen postgresql mariadb"
 
 AUTOTOOLS_AFTER="--with-pgsql --with-mysql --enable-shell --enable-perfdhcp"

--- a/app-network/kea/autobuild/overrides/usr/lib/tmpfiles.d/kea.conf
+++ b/app-network/kea/autobuild/overrides/usr/lib/tmpfiles.d/kea.conf
@@ -1,2 +1,2 @@
-d /run/kea 0755 kea kea -
+d /run/kea 0750 kea kea -
 d /var/lib/kea 0755 kea kea -

--- a/app-network/kea/autobuild/patches/0001-default-config-log-format.patch
+++ b/app-network/kea/autobuild/patches/0001-default-config-log-format.patch
@@ -1,32 +1,13 @@
 diff --git a/src/bin/keactrl/kea-ctrl-agent.conf.pre b/src/bin/keactrl/kea-ctrl-agent.conf.pre
-index d8e0429..b13b723 100644
+index 9569919..fb3f297 100644
 --- a/src/bin/keactrl/kea-ctrl-agent.conf.pre
 +++ b/src/bin/keactrl/kea-ctrl-agent.conf.pre
-@@ -32,15 +32,15 @@
-     "control-sockets": {
-         "dhcp4": {
-             "socket-type": "unix",
--            "socket-name": "/tmp/kea4-ctrl-socket"
-+            "socket-name": "/run/kea/kea4-ctrl-socket"
-         },
-         "dhcp6": {
-             "socket-type": "unix",
--            "socket-name": "/tmp/kea6-ctrl-socket"
-+            "socket-name": "/run/kea/kea6-ctrl-socket"
-         },
-         "d2": {
-             "socket-type": "unix",
--            "socket-name": "/tmp/kea-ddns-ctrl-socket"
-+            "socket-name": "/run/kea/kea-ddns-ctrl-socket"
-         }
-     },
- 
-@@ -73,11 +73,12 @@
+@@ -107,11 +107,12 @@
                  // - syslog (logs to syslog)
                  // - syslog:name (logs to syslog using specified name)
                  // Any other value is considered a name of the file
--                "output": "@localstatedir@/log/kea-ctrl-agent.log"
-+                // "output": "@localstatedir@/log/kea-ctrl-agent.log"
+-                "output": "kea-ctrl-agent.log"
++                // "output": "kea-ctrl-agent.log"
 +                "output": "syslog",
  
                  // Shorter log pattern suitable for use with systemd,
@@ -37,24 +18,15 @@ index d8e0429..b13b723 100644
                  // This governs whether the log output is flushed to disk after
                  // every write.
 diff --git a/src/bin/keactrl/kea-dhcp-ddns.conf.pre b/src/bin/keactrl/kea-dhcp-ddns.conf.pre
-index b75b51f..a7c5a43 100644
+index 867f018..f065470 100644
 --- a/src/bin/keactrl/kea-dhcp-ddns.conf.pre
 +++ b/src/bin/keactrl/kea-dhcp-ddns.conf.pre
-@@ -23,7 +23,7 @@
-   "port": 53001,
-   "control-socket": {
-       "socket-type": "unix",
--      "socket-name": "/tmp/kea-ddns-ctrl-socket"
-+      "socket-name": "/run/kea/kea-ddns-ctrl-socket"
-   },
-   "tsig-keys": [],
-   "forward-ddns" : {},
 @@ -44,11 +44,12 @@
                  // - syslog (logs to syslog)
                  // - syslog:name (logs to syslog using specified name)
                  // Any other value is considered a name of the file
--                "output": "@localstatedir@/log/kea-ddns.log"
-+                // "output": "@localstatedir@/log/kea-ddns.log"
+-                "output": "kea-ddns.log"
++                // "output": "kea-ddns.log"
 +                "output": "syslog",
  
                  // Shorter log pattern suitable for use with systemd,
@@ -65,24 +37,15 @@ index b75b51f..a7c5a43 100644
                  // This governs whether the log output is flushed to disk after
                  // every write.
 diff --git a/src/bin/keactrl/kea-dhcp4.conf.pre b/src/bin/keactrl/kea-dhcp4.conf.pre
-index 55af9db..96bcbb8 100644
+index 07511cc..4965e83 100644
 --- a/src/bin/keactrl/kea-dhcp4.conf.pre
 +++ b/src/bin/keactrl/kea-dhcp4.conf.pre
-@@ -49,7 +49,7 @@
-     // more. For detailed description, see Sections 8.8, 16 and 15.
-     "control-socket": {
-         "socket-type": "unix",
--        "socket-name": "/tmp/kea4-ctrl-socket"
-+        "socket-name": "/run/kea/kea4-ctrl-socket"
-     },
- 
-     // Use Memfile lease database backend to store leases in a CSV file.
 @@ -436,11 +436,12 @@
                  // - syslog (logs to syslog)
                  // - syslog:name (logs to syslog using specified name)
                  // Any other value is considered a name of the file
--                "output": "@localstatedir@/log/kea-dhcp4.log"
-+                // "output": "@localstatedir@/log/kea-dhcp4.log"
+-                "output": "kea-dhcp4.log"
++                // "output": "kea-dhcp4.log"
 +                "output": "syslog",
  
                  // Shorter log pattern suitable for use with systemd,
@@ -93,24 +56,15 @@ index 55af9db..96bcbb8 100644
                  // This governs whether the log output is flushed to disk after
                  // every write.
 diff --git a/src/bin/keactrl/kea-dhcp6.conf.pre b/src/bin/keactrl/kea-dhcp6.conf.pre
-index 271021b..3173ba4 100644
+index 221381e..ff5b12f 100644
 --- a/src/bin/keactrl/kea-dhcp6.conf.pre
 +++ b/src/bin/keactrl/kea-dhcp6.conf.pre
-@@ -43,7 +43,7 @@
-     // description, see Sections 9.12, 16 and 15.
-     "control-socket": {
-         "socket-type": "unix",
--        "socket-name": "/tmp/kea6-ctrl-socket"
-+        "socket-name": "/run/kea/kea6-ctrl-socket"
-     },
- 
-     // Use Memfile lease database backend to store leases in a CSV file.
 @@ -395,11 +395,12 @@
                  // - syslog (logs to syslog)
                  // - syslog:name (logs to syslog using specified name)
                  // Any other value is considered a name of the file
--                "output": "@localstatedir@/log/kea-dhcp6.log"
-+                // "output": "@localstatedir@/log/kea-dhcp6.log"
+-                "output": "kea-dhcp6.log"
++                // "output": "kea-dhcp6.log"
 +                "output": "syslog",
  
                  // Shorter log pattern suitable for use with systemd,
@@ -121,31 +75,15 @@ index 271021b..3173ba4 100644
                  // This governs whether the log output is flushed to disk after
                  // every write.
 diff --git a/src/bin/keactrl/kea-netconf.conf.pre b/src/bin/keactrl/kea-netconf.conf.pre
-index c8a3878..5bce47c 100644
+index b559604..9f61162 100644
 --- a/src/bin/keactrl/kea-netconf.conf.pre
 +++ b/src/bin/keactrl/kea-netconf.conf.pre
-@@ -30,13 +30,13 @@
-         "dhcp4": {
-             "control-socket": {
-                 "socket-type": "unix",
--                "socket-name": "/tmp/kea4-ctrl-socket"
-+                "socket-name": "/run/kea/kea4-ctrl-socket"
-             }
-         },
-         "dhcp6": {
-             "control-socket": {
-                 "socket-type": "unix",
--                "socket-name": "/tmp/kea6-ctrl-socket"
-+                "socket-name": "/run/kea/kea6-ctrl-socket"
-             }
-         }
-     },
 @@ -69,11 +69,12 @@
                  // - syslog (logs to syslog)
                  // - syslog:name (logs to syslog using specified name)
                  // Any other value is considered a name of a time
--                "output": "@localstatedir@/log/kea-netconf.log"
-+                // "output": "@localstatedir@/log/kea-netconf.log"
+-                "output": "kea-netconf.log"
++                // "output": "kea-netconf.log"
 +                "output": "syslog",
  
                  // Shorter log pattern suitable for use with systemd,

--- a/app-network/kea/autobuild/postinst
+++ b/app-network/kea/autobuild/postinst
@@ -3,3 +3,10 @@ systemd-sysusers kea.conf
 
 echo "Setting up kea runtime directory ..."
 systemd-tmpfiles --create kea.conf
+
+if [ ! -f /etc/kea/kea-api-password ]
+then echo "Generate a new kea API password ..."
+umask 137
+pwgen -sB 12 1 > /etc/kea/kea-api-password
+chown kea:kea /etc/kea/kea-api-password
+fi

--- a/app-network/kea/spec
+++ b/app-network/kea/spec
@@ -1,4 +1,4 @@
-VER=2.6.1
+VER=2.6.3
 SRCS="tbl::https://ftp.isc.org/isc/kea/${VER}/kea-${VER}.tar.gz"
-CHKSUMS="sha256::d2ce14a91c2e248ad2876e29152d647bcc5e433bc68dafad0ee96ec166fcfad1"
+CHKSUMS="sha256::00241a5955ffd3d215a2c098c4527f9d7f4b203188b276f9a36250dd3d9dd612"
 CHKUPDATE="anitya::id=12915"


### PR DESCRIPTION
Topic Description
-----------------

- kea: upgrade to 2.6.3

Package(s) Affected
-------------------

- kea: 2.6.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit kea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
