### PR TITLE
malcontent: update to 0.13.0

### DIFF
--- a/runtime-desktop/malcontent/autobuild/defines
+++ b/runtime-desktop/malcontent/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=malcontent
 PKGSEC=libs
-PKGDEP="accountsservice dbus desktop-file-utils flatpak gtk-3 polkit"
+PKGDEP="accountsservice dbus desktop-file-utils flatpak \
+        gtk-update-icon-cache gtk-4 libadwaita polkit"
 BUILDDEP="appstream-glib gobject-introspection gtk-doc"
 PKGDES="Implements content accessibility restrictions to non-administrator accounts"
 

--- a/runtime-desktop/malcontent/autobuild/defines.stage2
+++ b/runtime-desktop/malcontent/autobuild/defines.stage2
@@ -1,6 +1,7 @@
 PKGNAME=malcontent
 PKGSEC=libs
-PKGDEP="accountsservice dbus desktop-file-utils glib gtk-3 polkit"
+PKGDEP="accountsservice dbus desktop-file-utils gtk-update-icon-cache \
+        gtk-4 libadwaita polkit"
 BUILDDEP="appstream-glib gobject-introspection gtk-doc"
 PKGDES="Implements content accessibility restrictions to non-administrator accounts"
 

--- a/runtime-desktop/malcontent/spec
+++ b/runtime-desktop/malcontent/spec
@@ -1,5 +1,4 @@
-VER=0.10.5
-REL=2
-SRCS="https://gitlab.freedesktop.org/pwithnall/malcontent/-/archive/$VER/malcontent-$VER.tar.gz"
-CHKSUMS="sha256::f4c120c223c1a6ef6ea14e8f66d471cd20bb1a8033dcaf81720b3294b6dab830"
+VER=0.13.0
+SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pwithnall/malcontent.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230451"


### PR DESCRIPTION
Topic Description
-----------------

- malcontent: update to 0.13.0
    - Add a patch to disable test building, which requires not-yet-maintained
    glib-testing.
    - Track patches at AOSC-Tracking/malcontent @ aosc/0.13.0
    \(HEAD: 51a5fd4eecca1a3fb61952824f70ab66e466b78e\).
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
    - Add defines.stage2
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- malcontent: 0.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit malcontent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
