### PR TITLE
DeployKit Survey (May, 2025)

### DIFF
--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.7.7
+VER=0.8.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.9.7
+VER=0.10.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui.git \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::1e6b4fd65f35c276a6fa12db0789dafcfee6b882ba86de5129311dfc79009dda"
+         sha256::69eb9ee7cf8cd399b50d9a1e537de151570ce1d61a36c5321038e5b0084fcb77"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"

--- a/app-admin/dkcli/spec
+++ b/app-admin/dkcli/spec
@@ -1,4 +1,4 @@
-VER=0.4.5
+VER=0.4.6
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/dkcli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373533"


### PR DESCRIPTION
Topic Description
-----------------

- dkcli: update to 0.4.6
- deploykit-gui: update to 0.10.0
- deploykit-backend: update to 0.8.0

Package(s) Affected
-------------------

- deploykit-backend: 0.8.0
- deploykit-gui: 0.10.0
- dkcli: 0.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-backend deploykit-gui dkcli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
