### PR TITLE
Fixes and improvements for SDDM default settings

### DIFF
--- a/desktop-kde/sddm-kcm/autobuild/patches/0001-sddmauthhelper-don-t-remove-the-old-background-outsi.patch
+++ b/desktop-kde/sddm-kcm/autobuild/patches/0001-sddmauthhelper-don-t-remove-the-old-background-outsi.patch
@@ -1,0 +1,54 @@
+From 1c09701e6e485d675add869aa2a51ef8549ee32f Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Thu, 29 May 2025 16:56:34 +0800
+Subject: [PATCH] sddmauthhelper: don't remove the old background outside the
+ theme dir
+
+The previously set background image file will get removed, however there
+is no check whether the file is within the theme directory. Lack of
+checks may result in unexpected behavior.
+---
+ sddmauthhelper.cpp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/sddmauthhelper.cpp b/sddmauthhelper.cpp
+index dea06ef..9087010 100644
+--- a/sddmauthhelper.cpp
++++ b/sddmauthhelper.cpp
+@@ -8,6 +8,7 @@
+ #include "sddmauthhelper.h"
+ #include "src/config.h"
+ 
++#include <qglobal.h>
+ #include <unistd.h>
+ 
+ #include <QDebug>
+@@ -260,6 +261,11 @@ ActionReply SddmAuthHelper::save(const QVariantMap &args)
+     QSharedPointer<KConfig> sddmOldConfig = openConfig(QStringLiteral(SDDM_CONFIG_FILE));
+     QSharedPointer<KConfig> themeConfig;
+     QString themeConfigFile = args[QStringLiteral("theme.conf.user")].toString();
++    // This is the path to the config file itself.
++    // cdUp() to the directory containing the theme files.
++    QDir themeDir(themeConfigFile);
++    bool bothPathsAreValid = themeDir.cdUp();
++    QString canonThemeDir = themeDir.canonicalPath();
+ 
+     if (!themeConfigFile.isEmpty()) {
+         themeConfig = openConfig(themeConfigFile);
+@@ -299,7 +305,12 @@ ActionReply SddmAuthHelper::save(const QVariantMap &args)
+                 if (backgroundChanged) {
+                     if (!previousBackground.isEmpty()) {
+                         QString previousBackgroundPath = configRootDirectory.filePath(previousBackground);
+-                        if (QFile::remove(previousBackgroundPath)) {
++                        QDir previousBackgroundDir(previousBackgroundPath);
++                        // Same, this QDir instance points to the wallpaper file.
++                        bothPathsAreValid = previousBackgroundDir.cdUp();
++                        QString canonPreviousBackgroundDir = previousBackgroundDir.canonicalPath();
++                        bool imageWithinThemeDir = canonPreviousBackgroundDir.startsWith(canonThemeDir);
++                        if (bothPathsAreValid && imageWithinThemeDir && QFile::remove(previousBackgroundPath)) {
+                             qDebug() << "Removed previous background " << previousBackgroundPath;
+                         }
+                     }
+-- 
+2.49.0
+

--- a/desktop-kde/sddm-kcm/spec
+++ b/desktop-kde/sddm-kcm/spec
@@ -1,4 +1,5 @@
 VER=5.27.12
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/sddm-kcm-$VER.tar.xz"
 CHKSUMS="sha256::6ef1a9eeb688fe1c1d13072795dc5c3a0c92265e0025b43bee82ebdd52a6e30d"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

- sddm-kcm: add patch to prevent unexpected removal of backgrounds

Package(s) Affected
-------------------

- sddm-kcm: 5.27.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sddm-kcm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
