### PR TITLE
xwayland-satellite: update to 0.6

### DIFF
--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,5 +1,4 @@
-VER=0.5.1
+VER=0.6
 SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: update to 0.6
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- xwayland-satellite: 0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
