### PR TITLE
smartdns: update to 46.1

### DIFF
--- a/app-network/smartdns/autobuild/build
+++ b/app-network/smartdns/autobuild/build
@@ -1,0 +1,12 @@
+abinfo "Creating PKGDIR..."
+mkdir -vp "${PKGDIR}"
+
+abinfo "Building binaries ..."
+make V=1 VERBOSE=1 SBINDIR=/usr/bin \
+	$ABMK "${MAKE_AFTER[@]}" \
+	|| abdie "Failed to build binaries: $?."
+
+abinfo "Installing binaries ..."
+make install V=1 VERBOSE=1 SBINDIR=/usr/bin \
+	DESTDIR="$PKGDIR" "${MAKE_AFTER[@]}" \
+	|| abdie "Failed to install binaries: $?."

--- a/app-network/smartdns/spec
+++ b/app-network/smartdns/spec
@@ -1,5 +1,4 @@
-VER=35
-SRCS="tbl::https://github.com/pymumu/smartdns/archive/refs/tags/Release$VER.tar.gz"
-CHKSUMS="sha256::2ab390389985e23f3a61a811bd11605d48976a2de0c5e6f6d71c067545c82751"
+VER=46.1
+SRCS="git::commit=tags/Release$VER::https://github.com/pymumu/smartdns"
+CHKSUMS="sha256::6307503fa409b9c6b87556d1b1f8eaf99c7be5b06a9d479ec3589c875391a6b3"
 CHKUPDATE="anitya::id=241794"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- smartdns: update to 46.1
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- smartdns: 46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit smartdns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
