### PR TITLE
nvidia: update to 575.57.08

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=12.8.1
-MIN_DRIVER_VER=570.124.06
+UPSTREAM_VER=12.9.0
+MIN_DRIVER_VER=575.51.03
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::228f6bcaf5b7618d032939f431914fc92d0e5ed39ebe37098a24502f26a19797"
+CHKSUMS__AMD64="sha256::bbce2b760fe2096ca1c86f729e03bf377c1519add7b2755ecc4e9b0a9e07ee43"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::353cbab1b57282a1001071796efd95c1e40ec27a3375e854d12637eaa1c6107c"
+CHKSUMS__ARM64="sha256::f3b7ae71f95d11de0a03ccfa1c0aff7be336d2199b50b1a15b03695fd15a6409"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,12 +1,12 @@
-_DRIVER_VER=570.133.07
+_DRIVER_VER=575.57.08
 # Note: sometimes utilities are not updated timely
-_UTILS_VERS=570.133.07
+_UTILS_VERS=575.57.08
 VER=${_DRIVER_VER}+utils${_UTILS_VERS}
 SRCS="git::rename=nvidia-driver;commit=tags/${_DRIVER_VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-persistenced"
-CHKSUMS="SKIP
-	SKIP
-	SKIP"
+CHKSUMS="SKIP \
+         SKIP \
+         SKIP"
 CHKUPDATE="anitya::id=319677"
 SUBDIR=.

--- a/runtime-display/nvidia/01-utils/build
+++ b/runtime-display/nvidia/01-utils/build
@@ -111,14 +111,12 @@ install -Dvm755 "libnvidia-cfg.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-cfg.so.$PKGVER
 install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
-if [[ $NV_ARCH == "x86_64" ]]; then
-    install -Dvm755 "libnvidia-sandboxutils.so.$PKGVER" \
-        "$PKGDIR"/usr/lib/libnvidia-sandboxutils.so.$PKGVER
-fi
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.0" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.0
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.0" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.0
+install -Dvm755 "libnvidia-sandboxutils.so.$PKGVER" \
+    "$PKGDIR"/usr/lib/libnvidia-sandboxutils.so.$PKGVER
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.2" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.2
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.2" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.2
 install -Dvm644 "20_nvidia_xlib.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json
 install -Dvm644 "20_nvidia_xcb.json" \
@@ -151,6 +149,7 @@ ln -svf "/usr/lib/libnvidia-allocator.so.${PKGVER}" \
 
 abinfo "Nvidia VM IR library..."
 install_for_all 755 "libnvidia-nvvm.so.$PKGVER" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvidia-nvvm70.so.4" "$PKGDIR"/usr/lib
 
 abinfo "Vulkan ICD data..."
 install -Dvm644 "nvidia_icd.json" \
@@ -195,6 +194,9 @@ install_if_amd64 755 "libnvidia-vksc-core.so.$PKGVER" \
 abinfo 'Optical flow library'
 install -Dvm755 "libnvidia-opticalflow.so.${PKGVER}" \
     "$PKGDIR"/usr/lib/libnvidia-opticalflow.so.${PKGVER}
+
+abinfo 'NvPresent NVIDIA Smooth Motion Vulkan layer'
+install_if_amd64 755 "libnvidia-present.so.$PKGVER" "$PKGDIR"/usr/lib
 
 abinfo "Debug and core dump utility..."
 install -Dvm755 nvidia-debugdump \

--- a/runtime-display/nvidia/01-utils/build-optenv32
+++ b/runtime-display/nvidia/01-utils/build-optenv32
@@ -33,10 +33,10 @@ install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
 install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.0" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.0
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.0" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.0
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.2" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.2
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.2" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.2
 install -Dvm755 "libnvidia-egl-gbm.so.1.1.2" \
     "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.2
 

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=570.133.07
-SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::2d43e64c581be5ef554de9888b1aa90037ef6d45f54284d3d9dcedc08dc4dc26"
-SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-${VER}.run"
-CHKSUMS__ARM64="sha256::c93a2f527a3fd5391a91e99194da4d07dd54f95d380024ccc0f1210e893b8c8d"
+VER=575.57.08
+SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
+CHKSUMS__AMD64="sha256::2aa701dac180a7b20a6e578cccd901ded8d44e57d60580f08f9d28dd1fffc6f2"
+SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
+CHKSUMS__ARM64="sha256::549e73e4f7402f66275ee665b6e3a2ae5d7bf57296b743b824d713f205203bdf"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 12.9.0+575.57.03
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 570.153.02+utils570.153.02
    Co-authored-by: Kaiyang Wu <origincode@aosc.io>
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 575.57.08
    Co-authored-by: Kaiyang Wu <origincode@aosc.io>
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 12.9.0+575.57.03
- nvidia: 575.57.08
- nvidia-firmware: 575.57.08
- nvidia-open: 575.57.08+utils575.57.08
- nvidia-utils: 575.57.08

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
