### PR TITLE
hplip: skip systemctl enable cups in containers


### DIFF
--- a/app-doc/hplip/autobuild/postinst
+++ b/app-doc/hplip/autobuild/postinst
@@ -1,2 +1,9 @@
 # Avoid hp-check error.
+if systemd-detect-virt -q --container; then
+    if ! systemd-detect-virt -q --chroot ; then
+		echo "Running in a container, skipping CUPS auto-enable."
+		exit 0
+    fi
+fi
+
 systemctl enable cups --now

--- a/app-doc/hplip/spec
+++ b/app-doc/hplip/spec
@@ -1,4 +1,5 @@
 VER=3.25.2
+REL=1
 SRCS="tbl::https://prdownloads.sourceforge.net/hplip/hplip-$VER.tar.gz"
 CHKSUMS="sha256::e872ff28eb2517705a95f6e1839efa1e50a77a33aae8905278df2bd820919653"
 CHKUPDATE="anitya::id=1327"


### PR DESCRIPTION
Topic Description
-----------------

- hplip: skip systemctl enable cups in containers

Package(s) Affected
-------------------

- hplip: 2:3.25.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hplip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
