### PR TITLE
waydroid: update to 1.5.2

### DIFF
--- a/app-emulation/waydroid/spec
+++ b/app-emulation/waydroid/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.5.2
 SRCS="git::commit=tags/$VER::https://github.com/waydroid/waydroid"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=314286"


### PR DESCRIPTION
Topic Description
-----------------

- waydroid: update to 1.5.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- waydroid: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit waydroid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
