### PR TITLE
linux-kernel: backport fixes for LoongArch

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
@@ -1,7 +1,7 @@
 From 8fcd4b7cbe8866e88bada4c97edbae359f4ebbe3 Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:29 +0800
-Subject: [PATCH 001/328] FROMGIT: dt-bindings: display: rockchip: Fix label
+Subject: [PATCH 001/330] FROMGIT: dt-bindings: display: rockchip: Fix label
  name of hdptxphy for RK3588 HDMI TX Controller
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Documentation/devicetree/bindings/display/rockchip/rockchip,rk3588-dw-hdmi-qp.yaml b/Documentation/devicetree/bindings/display/rockchip/rockchip,rk3588-dw-hdmi-qp.yaml
-index d8e761865f27e..7a1ae31cc5359 100644
+index d8e761865f27..7a1ae31cc535 100644
 --- a/Documentation/devicetree/bindings/display/rockchip/rockchip,rk3588-dw-hdmi-qp.yaml
 +++ b/Documentation/devicetree/bindings/display/rockchip/rockchip,rk3588-dw-hdmi-qp.yaml
 @@ -156,7 +156,7 @@ examples:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
@@ -1,7 +1,7 @@
 From 1b451052fd86e80e103159bf7f21bf074cca7089 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:04 +0200
-Subject: [PATCH 002/328] FROMGIT: dt-bindings: display: vop2: Add optional PLL
+Subject: [PATCH 002/330] FROMGIT: dt-bindings: display: vop2: Add optional PLL
  clock properties
 
 On RK3588, HDMI PHY PLL can be used as an alternative and more accurate
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml b/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
-index 2531726af306b..46d956e63338e 100644
+index 2531726af306..46d956e63338 100644
 --- a/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
 +++ b/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
 @@ -53,6 +53,8 @@ properties:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
@@ -1,7 +1,7 @@
 From 868d3187541cc8106871d39917ed172c85b8ab0c Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:05 +0200
-Subject: [PATCH 003/328] FROMGIT: drm/rockchip: vop2: Drop unnecessary
+Subject: [PATCH 003/330] FROMGIT: drm/rockchip: vop2: Drop unnecessary
  if_pixclk_rate computation
 
 The if_pixclk_rate variable is not being used outside of the if-block in
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
-index bcbd498823928..853687b0b5019 100644
+index bcbd49882392..853687b0b501 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
 @@ -1910,8 +1910,8 @@ static unsigned long rk3588_calc_cru_cfg(struct vop2_video_port *vp, int id,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
@@ -1,7 +1,7 @@
 From 1b054568395be506c296fdbdf7f8d28e26a805fc Mon Sep 17 00:00:00 2001
 From: Jianfeng Liu <liujianfeng1994@gmail.com>
 Date: Wed, 15 Jan 2025 10:33:21 +0800
-Subject: [PATCH 004/328] FROMGIT: arm64: dts: rockchip: Enable HDMI on
+Subject: [PATCH 004/330] FROMGIT: arm64: dts: rockchip: Enable HDMI on
  armsom-sige7
 
 Add the necessary DT changes to enable HDMI on ArmSoM Sige7.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 47 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
-index 08f09053a0664..b3e9ffe523474 100644
+index 08f09053a066..b3e9ffe52347 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 @@ -4,6 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
@@ -1,7 +1,7 @@
 From d2c5ea748f66f91c30b5830e6bfd75dddfb45794 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:07 +0200
-Subject: [PATCH 005/328] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
+Subject: [PATCH 005/330] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
  provider on RK3588
 
 Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index c3abdfb04f8f4..5d9fb331db497 100644
+index c3abdfb04f8f..5d9fb331db49 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 @@ -2812,6 +2812,7 @@ hdptxphy_hdmi0: phy@fed60000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
@@ -1,7 +1,7 @@
 From 66182a5c54910afa4b4a288ec66907113fbcd262 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:08 +0200
-Subject: [PATCH 006/328] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
+Subject: [PATCH 006/330] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
  clock source to VOP2 on RK3588
 
 VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index 5d9fb331db497..ef2fda18150c2 100644
+index 5d9fb331db49..ef2fda18150c 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 @@ -1261,14 +1261,16 @@ vop: vop@fdd90000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
@@ -1,7 +1,7 @@
 From 797ef753c3fcdc7ecfb8b04ad7f8e0266734ef5a Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:30 +0800
-Subject: [PATCH 007/328] FROMGIT: arm64: dts: rockchip: Fix label name of
+Subject: [PATCH 007/330] FROMGIT: arm64: dts: rockchip: Fix label name of
  hdptxphy for RK3588
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
@@ -42,7 +42,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  21 files changed, 23 insertions(+), 23 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
-index b3e9ffe523474..b89888fe5d464 100644
+index b3e9ffe52347..b89888fe5d46 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 @@ -192,7 +192,7 @@ hdmi0_out_con: endpoint {
@@ -55,7 +55,7 @@ index b3e9ffe523474..b89888fe5d464 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-index ef2fda18150c2..b229e593b9fc8 100644
+index ef2fda18150c..b229e593b9fc 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 @@ -1262,7 +1262,7 @@ vop: vop@fdd90000 {
@@ -86,7 +86,7 @@ index ef2fda18150c2..b229e593b9fc8 100644
  		reg = <0x0 0xfed60000 0x0 0x2000>;
  		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX0>;
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-evb.dts b/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-evb.dts
-index 9d525c8ff725b..9eda69722665f 100644
+index 9d525c8ff725..9eda69722665 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-evb.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-evb.dts
 @@ -129,7 +129,7 @@ hdmi0_out_con: endpoint {
@@ -99,7 +99,7 @@ index 9d525c8ff725b..9eda69722665f 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-genbook.dts b/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-genbook.dts
-index bc6b43a771537..6dc10da5215f9 100644
+index bc6b43a77153..6dc10da5215f 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-genbook.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-coolpi-cm5-genbook.dts
 @@ -166,7 +166,7 @@ hdmi0_out_con: endpoint {
@@ -112,7 +112,7 @@ index bc6b43a771537..6dc10da5215f9 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-evb1-v10.dts b/arch/arm64/boot/dts/rockchip/rk3588-evb1-v10.dts
-index ba49f0bbaac62..3fd0665cde2ca 100644
+index ba49f0bbaac6..3fd0665cde2c 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-evb1-v10.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-evb1-v10.dts
 @@ -364,7 +364,7 @@ hdmi0_out_con: endpoint {
@@ -125,7 +125,7 @@ index ba49f0bbaac62..3fd0665cde2ca 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts b/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts
-index 2be5251d3e3be..e086114c76348 100644
+index 2be5251d3e3b..e086114c7634 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts
 @@ -337,7 +337,7 @@ hdmi0_out_con: endpoint {
@@ -138,7 +138,7 @@ index 2be5251d3e3be..e086114c76348 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
-index b3a04ca370bb9..8171fbfd819a7 100644
+index b3a04ca370bb..8171fbfd819a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
 @@ -335,7 +335,7 @@ hdmi0_out_con: endpoint {
@@ -151,7 +151,7 @@ index b3a04ca370bb9..8171fbfd819a7 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-h96-max-v58.dts b/arch/arm64/boot/dts/rockchip/rk3588-h96-max-v58.dts
-index 4791b77f3571d..c8bc85b7d1339 100644
+index 4791b77f3571..c8bc85b7d133 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-h96-max-v58.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-h96-max-v58.dts
 @@ -207,7 +207,7 @@ hdmi0_out_con: endpoint {
@@ -164,7 +164,7 @@ index 4791b77f3571d..c8bc85b7d1339 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-jaguar.dts b/arch/arm64/boot/dts/rockchip/rk3588-jaguar.dts
-index 7f457ab78015a..20b566d4168f0 100644
+index 7f457ab78015..20b566d4168f 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-jaguar.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-jaguar.dts
 @@ -303,7 +303,7 @@ hdmi0_out_con: endpoint {
@@ -177,7 +177,7 @@ index 7f457ab78015a..20b566d4168f0 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-index cb350727d1168..0d9b5020acc09 100644
+index cb350727d116..0d9b5020acc0 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 @@ -360,7 +360,7 @@ hdmi0_out_con: endpoint {
@@ -190,7 +190,7 @@ index cb350727d1168..0d9b5020acc09 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
-index ce44549babf48..9baca7f9ce483 100644
+index ce44549babf4..9baca7f9ce48 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 @@ -39,7 +39,7 @@ hdmi0_out_con: endpoint {
@@ -203,7 +203,7 @@ index ce44549babf48..9baca7f9ce483 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
-index 255e33c5dbdc0..0f874b87b47e4 100644
+index 255e33c5dbdc..0f874b87b47e 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
 @@ -125,7 +125,7 @@ hdmi0_out_con: endpoint {
@@ -216,7 +216,7 @@ index 255e33c5dbdc0..0f874b87b47e4 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-index d597112f1d5b8..86a9f2f35e667 100644
+index d597112f1d5b..86a9f2f35e66 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 @@ -220,7 +220,7 @@ hdmi0_out_con: endpoint {
@@ -229,7 +229,7 @@ index d597112f1d5b8..86a9f2f35e667 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-tiger-haikou.dts b/arch/arm64/boot/dts/rockchip/rk3588-tiger-haikou.dts
-index 3187b4918a300..795d8175e6542 100644
+index 3187b4918a30..795d8175e654 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-tiger-haikou.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-tiger-haikou.dts
 @@ -189,7 +189,7 @@ hdmi0_out_con: endpoint {
@@ -242,7 +242,7 @@ index 3187b4918a300..795d8175e6542 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-coolpi-4b.dts b/arch/arm64/boot/dts/rockchip/rk3588s-coolpi-4b.dts
-index b2c30122aacc5..75ce13b9e85a0 100644
+index b2c30122aacc..75ce13b9e85a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-coolpi-4b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-coolpi-4b.dts
 @@ -236,7 +236,7 @@ hdmi0_out_con: endpoint {
@@ -255,7 +255,7 @@ index b2c30122aacc5..75ce13b9e85a0 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-indiedroid-nova.dts b/arch/arm64/boot/dts/rockchip/rk3588s-indiedroid-nova.dts
-index 4a3aa80f2226f..74a4f03e05e35 100644
+index 4a3aa80f2226..74a4f03e05e3 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-indiedroid-nova.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-indiedroid-nova.dts
 @@ -278,7 +278,7 @@ hdmi0_out_con: endpoint {
@@ -268,7 +268,7 @@ index 4a3aa80f2226f..74a4f03e05e35 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
-index d2eddea1840f4..cd47969fadba0 100644
+index d2eddea1840f..cd47969fadba 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
 @@ -251,7 +251,7 @@ hdmi0_out_con: endpoint {
@@ -281,7 +281,7 @@ index d2eddea1840f4..cd47969fadba0 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
-index 8f034c6d494c4..1463bd36b1b2e 100644
+index 8f034c6d494c..1463bd36b1b2 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-odroid-m2.dts
 @@ -264,7 +264,7 @@ hdmi0_out_con: endpoint {
@@ -294,7 +294,7 @@ index 8f034c6d494c4..1463bd36b1b2e 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
-index d86aeacca238d..9e16960b87055 100644
+index d86aeacca238..9e16960b8705 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
 @@ -197,7 +197,7 @@ hdmi0_out_con: endpoint {
@@ -307,7 +307,7 @@ index d86aeacca238d..9e16960b87055 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-index 70a43432bdc57..676cc4fec269e 100644
+index 70a43432bdc5..676cc4fec269 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 @@ -334,7 +334,7 @@ hdmi0_out_con: endpoint {
@@ -320,7 +320,7 @@ index 70a43432bdc57..676cc4fec269e 100644
  };
  
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
-index 9b14d5383cdc1..bf74789e3f51f 100644
+index 9b14d5383cdc..bf74789e3f51 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
 @@ -278,7 +278,7 @@ hdmi0_out_con: endpoint {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
@@ -1,7 +1,7 @@
 From ea11e5a778962fc56d6c3d0fd2435939f5372aae Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:15 +0200
-Subject: [PATCH 008/328] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
+Subject: [PATCH 008/330] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
  for HDMI1 TX port on RK3588
 
 In preparation to enable the second HDMI output port found on RK3588
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 21 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
-index 840b638af1c24..a1cfea5881514 100644
+index 840b638af1c2..a1cfea588151 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 @@ -67,6 +67,11 @@ u2phy1_otg: otg-port {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
@@ -1,7 +1,7 @@
 From 786d7c9c8cd05e0ea628aa8f71f3729eddc0b2b1 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:16 +0200
-Subject: [PATCH 009/328] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
+Subject: [PATCH 009/330] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
  RK3588
 
 Add support for the second HDMI TX port found on RK3588 SoC.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 41 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
-index a1cfea5881514..83113a1098104 100644
+index a1cfea588151..83113a109810 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
 @@ -140,6 +140,47 @@ i2s10_8ch: i2s@fde00000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
@@ -1,7 +1,7 @@
 From 0add2ed34644c5ff7d7c3a86549f63e48de28971 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:17 +0200
-Subject: [PATCH 010/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
+Subject: [PATCH 010/330] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
  rock-5b
 
 Add the necessary DT changes to enable the second HDMI output port on
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 42 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-index 86a9f2f35e667..5acec6b97a46a 100644
+index 86a9f2f35e66..5acec6b97a46 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
 @@ -49,6 +49,17 @@ hdmi0_con_in: endpoint {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
@@ -1,7 +1,7 @@
 From aa6d5b0ac787bd9c875053115455d99ba195caee Mon Sep 17 00:00:00 2001
 From: Jagan Teki <jagan@edgeble.ai>
 Date: Fri, 27 Dec 2024 18:59:36 +0530
-Subject: [PATCH 011/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
+Subject: [PATCH 011/330] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
  Edgeble-6TOPS Modules
 
 Edgeble-6TOPS modules configure HDMI1 for HDMI Out from RK3588.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 47 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-edgeble-neu6a-io.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-edgeble-neu6a-io.dtsi
-index 7125790bbed22..08920344a4b8d 100644
+index 7125790bbed2..08920344a4b8 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-edgeble-neu6a-io.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-edgeble-neu6a-io.dtsi
 @@ -4,12 +4,24 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
@@ -1,7 +1,7 @@
 From ac29fecaedf881a74ae6acdb8cf61d3e8762be7f Mon Sep 17 00:00:00 2001
 From: Jimmy Hon <honyuenkwun@gmail.com>
 Date: Wed, 8 Jan 2025 23:16:18 -0600
-Subject: [PATCH 012/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
+Subject: [PATCH 012/330] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
  Pi 5 Max
 
 Enable the second HDMI output port on the Orange Pi 5 Max
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 41 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
-index 9baca7f9ce483..26421ca7843b6 100644
+index 9baca7f9ce48..26421ca7843b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
 @@ -21,6 +21,17 @@ hdmi0_con_in: endpoint {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
@@ -1,7 +1,7 @@
 From 581b45fe3b084963d7d3cda32265a284ae8f8968 Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko.stuebner@cherry.de>
 Date: Fri, 6 Dec 2024 11:34:00 +0100
-Subject: [PATCH 013/328] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
+Subject: [PATCH 013/330] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
  regmap register-callback
 
 The variant of the driver in the vendor-tree contained those handy
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-index 920abf6fa9bdd..dfcc37b1c8a6d 100644
+index 920abf6fa9bd..dfcc37b1c8a6 100644
 --- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
 +++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
 @@ -571,13 +571,13 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
@@ -1,7 +1,7 @@
 From c0d8cbaf6628d412c7749e9a154a2d150005090f Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:40 -0800
-Subject: [PATCH 014/328] FROMGIT: perf trace: Allocate syscall stats only if
+Subject: [PATCH 014/330] FROMGIT: perf trace: Allocate syscall stats only if
  summary is on
 
 The syscall stats are used only when summary is requested.  Let's avoid
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index d466447ae928a..e4d03f3d22ea3 100644
+index d466447ae928..e4d03f3d22ea 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -1522,13 +1522,14 @@ struct thread_trace {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
@@ -1,7 +1,7 @@
 From d917c799a7a7becf247d865185ca33cefb95cf1a Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:41 -0800
-Subject: [PATCH 015/328] FROMGIT: perf trace: Convert syscall_stats to hashmap
+Subject: [PATCH 015/330] FROMGIT: perf trace: Convert syscall_stats to hashmap
 
 It was using a RBtree-based int-list as a hash and a custom resort
 logic for that.  As we have hashmap, let's convert to it and add a
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 86 insertions(+), 29 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index e4d03f3d22ea3..ee3d6b1bf4fe6 100644
+index e4d03f3d22ea..ee3d6b1bf4fe 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -39,6 +39,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
@@ -1,7 +1,7 @@
 From 7f4e137d64d80ead8e7a3a5eac662300d8a002ca Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:42 -0800
-Subject: [PATCH 016/328] FROMGIT: perf tools: Get rid of now-unused
+Subject: [PATCH 016/330] FROMGIT: perf tools: Get rid of now-unused
  rb_resort.h
 
 It was only used in perf trace and it switched to use hashmap instead.
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/tools/perf/util/rb_resort.h b/tools/perf/util/rb_resort.h
 deleted file mode 100644
-index d927a0d250528..0000000000000
+index d927a0d25052..000000000000
 --- a/tools/perf/util/rb_resort.h
 +++ /dev/null
 @@ -1,146 +0,0 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
@@ -1,7 +1,7 @@
 From f36d4a64986abd44d97531f4d17ecc0633e81445 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:43 -0800
-Subject: [PATCH 017/328] FROMGIT: perf trace: Add --summary-mode option
+Subject: [PATCH 017/330] FROMGIT: perf trace: Add --summary-mode option
 
 The --summary-mode option will select how to show the syscall summary at
 the end.  By default, it'll show the summary for each thread and it's
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 114 insertions(+), 19 deletions(-)
 
 diff --git a/tools/perf/Documentation/perf-trace.txt b/tools/perf/Documentation/perf-trace.txt
-index fb3d2af33844c..887dc37773d0f 100644
+index fb3d2af33844..887dc37773d0 100644
 --- a/tools/perf/Documentation/perf-trace.txt
 +++ b/tools/perf/Documentation/perf-trace.txt
 @@ -150,6 +150,10 @@ the thread executes on the designated CPUs. Default is to monitor all CPUs.
@@ -63,7 +63,7 @@ index fb3d2af33844c..887dc37773d0f 100644
  	Show tool stats such as number of times fd->pathname was discovered thru
  	hooking the open syscall return + vfs_getname or via reading /proc/pid/fd, etc.
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index ee3d6b1bf4fe6..fb01c9f973266 100644
+index ee3d6b1bf4fe..fb01c9f97326 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -139,6 +139,12 @@ struct syscall_fmt {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
@@ -1,7 +1,7 @@
 From f5a6161e2add63abacf9860c2ffd1782f43c129a Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:01 -0800
-Subject: [PATCH 018/328] FROMGIT: perf tools: Add dummy functions for
+Subject: [PATCH 018/330] FROMGIT: perf tools: Add dummy functions for
  !HAVE_LZMA_SUPPORT
 
 This allows us to use them without needing to ifdef the calling code.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/tools/perf/util/compress.h b/tools/perf/util/compress.h
-index b29109cd36095..a7650353c6622 100644
+index b29109cd3609..a7650353c662 100644
 --- a/tools/perf/util/compress.h
 +++ b/tools/perf/util/compress.h
 @@ -5,6 +5,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
@@ -1,7 +1,7 @@
 From 877b2f3363c9ebcfdb099a854aa96e26047e8e37 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:02 -0800
-Subject: [PATCH 019/328] FROMGIT: perf tools: Add LZMA decompression from FILE
+Subject: [PATCH 019/330] FROMGIT: perf tools: Add LZMA decompression from FILE
 
 Internally lzma_decompress_to_file() creates a FILE from the filename.
 Add an API that takes an existing FILE directly. This allows
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 26 insertions(+), 11 deletions(-)
 
 diff --git a/tools/perf/util/compress.h b/tools/perf/util/compress.h
-index a7650353c6622..6cfecfca16f24 100644
+index a7650353c662..6cfecfca16f2 100644
 --- a/tools/perf/util/compress.h
 +++ b/tools/perf/util/compress.h
 @@ -4,6 +4,7 @@
@@ -53,7 +53,7 @@ index a7650353c6622..6cfecfca16f24 100644
  			    int output_fd __maybe_unused)
  {
 diff --git a/tools/perf/util/lzma.c b/tools/perf/util/lzma.c
-index af9a97612f9df..bbcd2ffcf4bd1 100644
+index af9a97612f9d..bbcd2ffcf4bd 100644
 --- a/tools/perf/util/lzma.c
 +++ b/tools/perf/util/lzma.c
 @@ -32,7 +32,7 @@ static const char *lzma_strerror(lzma_ret ret)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
@@ -1,7 +1,7 @@
 From 3325115148e50fa9b234b961235c98bc7a274ae6 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:03 -0800
-Subject: [PATCH 020/328] FROMGIT: perf symbol: Support .gnu_debugdata for
+Subject: [PATCH 020/330] FROMGIT: perf symbol: Support .gnu_debugdata for
  symbols
 
 Fedora introduced a "MiniDebuginfo" feature, in which an LZMA-compressed
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 110 insertions(+), 2 deletions(-)
 
 diff --git a/tools/perf/util/dso.c b/tools/perf/util/dso.c
-index 5c6e85fdae0de..7576e8e248386 100644
+index 5c6e85fdae0d..7576e8e24838 100644
 --- a/tools/perf/util/dso.c
 +++ b/tools/perf/util/dso.c
 @@ -67,6 +67,7 @@ char dso__symtab_origin(const struct dso *dso)
@@ -58,7 +58,7 @@ index 5c6e85fdae0de..7576e8e248386 100644
  		break;
  
 diff --git a/tools/perf/util/dso.h b/tools/perf/util/dso.h
-index c0472a41147c3..5d05280cb762b 100644
+index c0472a41147c..5d05280cb762 100644
 --- a/tools/perf/util/dso.h
 +++ b/tools/perf/util/dso.h
 @@ -33,6 +33,7 @@ enum dso_binary_type {
@@ -70,7 +70,7 @@ index c0472a41147c3..5d05280cb762b 100644
  	DSO_BINARY_TYPE__GUEST_KMODULE,
  	DSO_BINARY_TYPE__GUEST_KMODULE_COMP,
 diff --git a/tools/perf/util/symbol-elf.c b/tools/perf/util/symbol-elf.c
-index 66fd1249660a3..3fa92697c457b 100644
+index 66fd1249660a..3fa92697c457 100644
 --- a/tools/perf/util/symbol-elf.c
 +++ b/tools/perf/util/symbol-elf.c
 @@ -7,6 +7,7 @@
@@ -210,7 +210,7 @@ index 66fd1249660a3..3fa92697c457b 100644
  
  static int elf_read_maps(Elf *elf, bool exe, mapfn_t mapfn, void *data)
 diff --git a/tools/perf/util/symbol.c b/tools/perf/util/symbol.c
-index 49b08adc6ee34..a0767762d4d73 100644
+index 49b08adc6ee3..a0767762d4d7 100644
 --- a/tools/perf/util/symbol.c
 +++ b/tools/perf/util/symbol.c
 @@ -84,6 +84,7 @@ static enum dso_binary_type binary_type_symtab[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
@@ -1,7 +1,7 @@
 From 238fc8603ac8dcbf0705c862ce151011f67c00aa Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:49 -0700
-Subject: [PATCH 021/328] FROMGIT: perf mutex: Add annotations for
+Subject: [PATCH 021/330] FROMGIT: perf mutex: Add annotations for
  LOCKS_EXCLUDED and LOCKS_RETURNED
 
 Used to annotate when locks shouldn't be held for a function or if a
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/tools/perf/util/mutex.h b/tools/perf/util/mutex.h
-index 40661120caccb..62d258c71ded8 100644
+index 40661120cacc..62d258c71ded 100644
 --- a/tools/perf/util/mutex.h
 +++ b/tools/perf/util/mutex.h
 @@ -33,6 +33,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
@@ -1,7 +1,7 @@
 From 7b84d1a1dd128fb43a62dc7823c3e89c7ce7a3b7 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:50 -0700
-Subject: [PATCH 022/328] FROMGIT: perf dso: Use lock annotations to fix asan
+Subject: [PATCH 022/330] FROMGIT: perf dso: Use lock annotations to fix asan
  deadlock
 
 dso__list_del with address sanitizer and/or reference count checking
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 66 insertions(+), 43 deletions(-)
 
 diff --git a/tools/perf/tests/dso-data.c b/tools/perf/tests/dso-data.c
-index 5286ae8bd2d70..06be7c5d84955 100644
+index 5286ae8bd2d7..06be7c5d8495 100644
 --- a/tools/perf/tests/dso-data.c
 +++ b/tools/perf/tests/dso-data.c
 @@ -106,9 +106,9 @@ struct test_data_offset offsets[] = {
@@ -46,7 +46,7 @@ index 5286ae8bd2d70..06be7c5d84955 100644
  
  	return fd;
 diff --git a/tools/perf/util/dso.c b/tools/perf/util/dso.c
-index 7576e8e248386..e0111049f6b03 100644
+index 7576e8e24838..e0111049f6b0 100644
 --- a/tools/perf/util/dso.c
 +++ b/tools/perf/util/dso.c
 @@ -493,11 +493,25 @@ void dso__set_module_info(struct dso *dso, struct kmod_path *m,
@@ -263,7 +263,7 @@ index 7576e8e248386..e0111049f6b03 100644
  		dso__data_put_fd(dso);
  	}
 diff --git a/tools/perf/util/dso.h b/tools/perf/util/dso.h
-index 5d05280cb762b..30f7f58e2a9cf 100644
+index 5d05280cb762..30f7f58e2a9c 100644
 --- a/tools/perf/util/dso.h
 +++ b/tools/perf/util/dso.h
 @@ -232,6 +232,8 @@ DECLARE_RC_STRUCT(dso) {
@@ -310,7 +310,7 @@ index 5d05280cb762b..30f7f58e2a9cf 100644
  int dso__data_file_size(struct dso *dso, struct machine *machine);
  off_t dso__data_size(struct dso *dso, struct machine *machine);
 diff --git a/tools/perf/util/unwind-libunwind-local.c b/tools/perf/util/unwind-libunwind-local.c
-index 16c2b03831f39..4c076eba86226 100644
+index 16c2b03831f3..4c076eba8622 100644
 --- a/tools/perf/util/unwind-libunwind-local.c
 +++ b/tools/perf/util/unwind-libunwind-local.c
 @@ -330,8 +330,7 @@ static int read_unwind_spec_eh_frame(struct dso *dso, struct unwind_info *ui,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
@@ -1,7 +1,7 @@
 From c0a9a75a28e6debf27f4ca6e457b81002e10dd6e Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:51 -0700
-Subject: [PATCH 023/328] FROMGIT: perf test dso-data: Correctly free test file
+Subject: [PATCH 023/330] FROMGIT: perf test dso-data: Correctly free test file
  in read test
 
 The DSO data read test opens a file but as dsos__exit is used the test
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/tools/perf/tests/dso-data.c b/tools/perf/tests/dso-data.c
-index 06be7c5d84955..a1fff4203b75f 100644
+index 06be7c5d8495..a1fff4203b75 100644
 --- a/tools/perf/tests/dso-data.c
 +++ b/tools/perf/tests/dso-data.c
 @@ -114,6 +114,17 @@ static int dso__data_fd(struct dso *dso, struct machine *machine)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
@@ -1,7 +1,7 @@
 From 34af1bb3fb157b9a4101b44bf8ecd756122afb2e Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:28 -0700
-Subject: [PATCH 024/328] FROMGIT: perf dso: Move libunwind dso_data variables
+Subject: [PATCH 024/330] FROMGIT: perf dso: Move libunwind dso_data variables
  into ifdef
 
 The variables elf_base_addr, debug_frame_offset, eh_frame_hdr_addr and
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/tools/perf/util/dso.h b/tools/perf/util/dso.h
-index 30f7f58e2a9cf..fc43f037b4104 100644
+index 30f7f58e2a9c..fc43f037b410 100644
 --- a/tools/perf/util/dso.h
 +++ b/tools/perf/util/dso.h
 @@ -155,10 +155,12 @@ struct dso_data {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
@@ -1,7 +1,7 @@
 From be3b23514c2a0f78ed81abd38191e85566fe76f9 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:29 -0700
-Subject: [PATCH 025/328] FROMGIT: perf dso: kernel-doc for enum
+Subject: [PATCH 025/330] FROMGIT: perf dso: kernel-doc for enum
  dso_binary_type
 
 There are many and non-obvious meanings to the dso_binary_type enum
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 57 insertions(+)
 
 diff --git a/tools/perf/util/dso.h b/tools/perf/util/dso.h
-index fc43f037b4104..a4980101e22b6 100644
+index fc43f037b410..a4980101e22b 100644
 --- a/tools/perf/util/dso.h
 +++ b/tools/perf/util/dso.h
 @@ -20,31 +20,88 @@ struct perf_env;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
@@ -1,7 +1,7 @@
 From bb0632fea64565c34abd34a2f0e69f09f53a52da Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:30 -0700
-Subject: [PATCH 026/328] FROMGIT: perf syscalltbl: Remove syscall_table.h
+Subject: [PATCH 026/330] FROMGIT: perf syscalltbl: Remove syscall_table.h
 
 The definition of "static const char *const syscalltbl[] = {" is done
 in a generated syscalls_32.h or syscalls_64.h that is architecture
@@ -73,7 +73,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/tools/perf/arch/alpha/include/syscall_table.h b/tools/perf/arch/alpha/include/syscall_table.h
 deleted file mode 100644
-index b53e31c158053..0000000000000
+index b53e31c15805..000000000000
 --- a/tools/perf/arch/alpha/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -81,7 +81,7 @@ index b53e31c158053..0000000000000
 -#include <asm/syscalls_64.h>
 diff --git a/tools/perf/arch/arc/include/syscall_table.h b/tools/perf/arch/arc/include/syscall_table.h
 deleted file mode 100644
-index 4c942821662d9..0000000000000
+index 4c942821662d..000000000000
 --- a/tools/perf/arch/arc/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -89,7 +89,7 @@ index 4c942821662d9..0000000000000
 -#include <asm/syscalls_32.h>
 diff --git a/tools/perf/arch/arm/include/syscall_table.h b/tools/perf/arch/arm/include/syscall_table.h
 deleted file mode 100644
-index 4c942821662d9..0000000000000
+index 4c942821662d..000000000000
 --- a/tools/perf/arch/arm/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -97,7 +97,7 @@ index 4c942821662d9..0000000000000
 -#include <asm/syscalls_32.h>
 diff --git a/tools/perf/arch/arm64/include/syscall_table.h b/tools/perf/arch/arm64/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/arm64/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -111,7 +111,7 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/csky/include/syscall_table.h b/tools/perf/arch/csky/include/syscall_table.h
 deleted file mode 100644
-index 4c942821662d9..0000000000000
+index 4c942821662d..000000000000
 --- a/tools/perf/arch/csky/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -119,7 +119,7 @@ index 4c942821662d9..0000000000000
 -#include <asm/syscalls_32.h>
 diff --git a/tools/perf/arch/loongarch/include/syscall_table.h b/tools/perf/arch/loongarch/include/syscall_table.h
 deleted file mode 100644
-index b53e31c158053..0000000000000
+index b53e31c15805..000000000000
 --- a/tools/perf/arch/loongarch/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -127,7 +127,7 @@ index b53e31c158053..0000000000000
 -#include <asm/syscalls_64.h>
 diff --git a/tools/perf/arch/mips/include/syscall_table.h b/tools/perf/arch/mips/include/syscall_table.h
 deleted file mode 100644
-index b53e31c158053..0000000000000
+index b53e31c15805..000000000000
 --- a/tools/perf/arch/mips/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -135,7 +135,7 @@ index b53e31c158053..0000000000000
 -#include <asm/syscalls_64.h>
 diff --git a/tools/perf/arch/parisc/include/syscall_table.h b/tools/perf/arch/parisc/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/parisc/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -149,7 +149,7 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/powerpc/include/syscall_table.h b/tools/perf/arch/powerpc/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/powerpc/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -163,7 +163,7 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/riscv/include/syscall_table.h b/tools/perf/arch/riscv/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/riscv/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -177,7 +177,7 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/s390/include/syscall_table.h b/tools/perf/arch/s390/include/syscall_table.h
 deleted file mode 100644
-index b53e31c158053..0000000000000
+index b53e31c15805..000000000000
 --- a/tools/perf/arch/s390/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -185,7 +185,7 @@ index b53e31c158053..0000000000000
 -#include <asm/syscalls_64.h>
 diff --git a/tools/perf/arch/sh/include/syscall_table.h b/tools/perf/arch/sh/include/syscall_table.h
 deleted file mode 100644
-index 4c942821662d9..0000000000000
+index 4c942821662d..000000000000
 --- a/tools/perf/arch/sh/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -193,7 +193,7 @@ index 4c942821662d9..0000000000000
 -#include <asm/syscalls_32.h>
 diff --git a/tools/perf/arch/sparc/include/syscall_table.h b/tools/perf/arch/sparc/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/sparc/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -207,7 +207,7 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/x86/include/syscall_table.h b/tools/perf/arch/x86/include/syscall_table.h
 deleted file mode 100644
-index 7ff51b783000d..0000000000000
+index 7ff51b783000..000000000000
 --- a/tools/perf/arch/x86/include/syscall_table.h
 +++ /dev/null
 @@ -1,8 +0,0 @@
@@ -221,14 +221,14 @@ index 7ff51b783000d..0000000000000
 -#endif
 diff --git a/tools/perf/arch/xtensa/include/syscall_table.h b/tools/perf/arch/xtensa/include/syscall_table.h
 deleted file mode 100644
-index 4c942821662d9..0000000000000
+index 4c942821662d..000000000000
 --- a/tools/perf/arch/xtensa/include/syscall_table.h
 +++ /dev/null
 @@ -1,2 +0,0 @@
 -/* SPDX-License-Identifier: GPL-2.0 */
 -#include <asm/syscalls_32.h>
 diff --git a/tools/perf/util/syscalltbl.c b/tools/perf/util/syscalltbl.c
-index 928aca4cd6e9f..2f76241494c85 100644
+index 928aca4cd6e9..2f76241494c8 100644
 --- a/tools/perf/util/syscalltbl.c
 +++ b/tools/perf/util/syscalltbl.c
 @@ -7,13 +7,19 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
@@ -1,7 +1,7 @@
 From ae8c5e80f44bda2cc78f910c2602c0259be58a5d Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:31 -0700
-Subject: [PATCH 027/328] FROMGIT: perf trace: Reorganize syscalls
+Subject: [PATCH 027/330] FROMGIT: perf trace: Reorganize syscalls
 
 Identify struct syscall information in the syscalls table by a machine
 type and syscall number, not just system call number. Having the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 132 insertions(+), 65 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index fb01c9f973266..0ebd7b42bdb9f 100644
+index fb01c9f97326..0ebd7b42bdb9 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -66,6 +66,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
@@ -1,7 +1,7 @@
 From 815e28f683840f22c9243fb9c162cac135811741 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:32 -0700
-Subject: [PATCH 028/328] FROMGIT: perf syscalltbl: Remove struct syscalltbl
+Subject: [PATCH 028/330] FROMGIT: perf syscalltbl: Remove struct syscalltbl
 
 The syscalltbl held entries of system call name and number pairs,
 generated from a native syscalltbl at start up. As there are gaps in
@@ -42,7 +42,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 117 insertions(+), 160 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index 0ebd7b42bdb9f..ae6cb5bd92e87 100644
+index 0ebd7b42bdb9..ae6cb5bd92e8 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -149,7 +149,6 @@ enum summary_mode {
@@ -367,7 +367,7 @@ index 0ebd7b42bdb9f..ae6cb5bd92e87 100644
  		err = -ENOMEM;
  		goto out;
 diff --git a/tools/perf/scripts/syscalltbl.sh b/tools/perf/scripts/syscalltbl.sh
-index 1ce0d5aa8b506..a39b3013b103b 100755
+index 1ce0d5aa8b50..a39b3013b103 100755
 --- a/tools/perf/scripts/syscalltbl.sh
 +++ b/tools/perf/scripts/syscalltbl.sh
 @@ -50,37 +50,27 @@ fi
@@ -422,7 +422,7 @@ index 1ce0d5aa8b506..a39b3013b103b 100755
 -echo "#define SYSCALLTBL_MAX_ID ${max_nr}" >> $outfile
 +rm -f $sorted_table
 diff --git a/tools/perf/util/syscalltbl.c b/tools/perf/util/syscalltbl.c
-index 2f76241494c85..760ac4d0869ff 100644
+index 2f76241494c8..760ac4d0869f 100644
 --- a/tools/perf/util/syscalltbl.c
 +++ b/tools/perf/util/syscalltbl.c
 @@ -9,6 +9,7 @@
@@ -580,7 +580,7 @@ index 2f76241494c85..760ac4d0869ff 100644
 +	return syscalltbl__strglobmatch_next(e_machine, syscall_glob, idx);
  }
 diff --git a/tools/perf/util/syscalltbl.h b/tools/perf/util/syscalltbl.h
-index 362411a6d849b..2bb628eff367e 100644
+index 362411a6d849..2bb628eff367 100644
 --- a/tools/perf/util/syscalltbl.h
 +++ b/tools/perf/util/syscalltbl.h
 @@ -2,22 +2,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
@@ -1,7 +1,7 @@
 From af9980704e3f6482da4c6e30f55a7888dcf78f4c Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:33 -0700
-Subject: [PATCH 029/328] FROMGIT: perf dso: Add support for reading the
+Subject: [PATCH 029/330] FROMGIT: perf dso: Add support for reading the
  e_machine type for a dso
 
 For ELF file dsos read the e_machine from the ELF header. For kernel
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 92 insertions(+), 27 deletions(-)
 
 diff --git a/tools/perf/util/dso.c b/tools/perf/util/dso.c
-index e0111049f6b03..8619b6eea62de 100644
+index e0111049f6b0..8619b6eea62d 100644
 --- a/tools/perf/util/dso.c
 +++ b/tools/perf/util/dso.c
 @@ -1194,6 +1194,68 @@ ssize_t dso__data_read_offset(struct dso *dso, struct machine *machine,
@@ -134,7 +134,7 @@ index e0111049f6b03..8619b6eea62de 100644
  {
  	RC_CHK_ACCESS(dso)->bid = *bid;
 diff --git a/tools/perf/util/dso.h b/tools/perf/util/dso.h
-index a4980101e22b6..c87564471f9b0 100644
+index a4980101e22b..c87564471f9b 100644
 --- a/tools/perf/util/dso.h
 +++ b/tools/perf/util/dso.h
 @@ -737,6 +737,8 @@ bool dso__sorted_by_name(const struct dso *dso);
@@ -155,7 +155,7 @@ index a4980101e22b6..c87564471f9b0 100644
  			    struct machine *machine, u64 addr,
  			    u8 *data, ssize_t size);
 diff --git a/tools/perf/util/symbol-elf.c b/tools/perf/util/symbol-elf.c
-index 3fa92697c457b..fbf6d0f73af91 100644
+index 3fa92697c457..fbf6d0f73af9 100644
 --- a/tools/perf/util/symbol-elf.c
 +++ b/tools/perf/util/symbol-elf.c
 @@ -1174,33 +1174,6 @@ int filename__read_debuglink(const char *filename, char *debuglink,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
@@ -1,7 +1,7 @@
 From 1ae77fcb27026a80af228d99c57e4e8ba1ebd703 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:34 -0700
-Subject: [PATCH 030/328] FROMGIT: perf thread: Add support for reading the
+Subject: [PATCH 030/330] FROMGIT: perf thread: Add support for reading the
  e_machine type for a thread
 
 First try to read the e_machine from the dsos associated with the
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 115 insertions(+), 22 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index ae6cb5bd92e87..e61d1d1915337 100644
+index ae6cb5bd92e8..e61d1d191533 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -2731,16 +2731,16 @@ static int trace__sys_enter(struct trace *trace, struct evsel *evsel,
@@ -129,7 +129,7 @@ index ae6cb5bd92e87..e61d1d1915337 100644
  	return printed;
  }
 diff --git a/tools/perf/util/thread.c b/tools/perf/util/thread.c
-index 0ffdd52d86d70..89585f53c1d5c 100644
+index 0ffdd52d86d7..89585f53c1d5 100644
 --- a/tools/perf/util/thread.c
 +++ b/tools/perf/util/thread.c
 @@ -1,5 +1,7 @@
@@ -240,7 +240,7 @@ index 0ffdd52d86d70..89585f53c1d5c 100644
  {
  	if (thread__pid(thread) == thread__tid(thread))
 diff --git a/tools/perf/util/thread.h b/tools/perf/util/thread.h
-index 6cbf6eb2812e0..cd574a896418a 100644
+index 6cbf6eb2812e..cd574a896418 100644
 --- a/tools/perf/util/thread.h
 +++ b/tools/perf/util/thread.h
 @@ -60,7 +60,11 @@ DECLARE_RC_STRUCT(thread) {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
@@ -1,7 +1,7 @@
 From ecdb06f1fb94dd17179385484a38e23866e89802 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:35 -0700
-Subject: [PATCH 031/328] FROMGIT: perf trace beauty: Add syscalltbl.sh
+Subject: [PATCH 031/330] FROMGIT: perf trace beauty: Add syscalltbl.sh
  generating all system call tables
 
 Rather than generating individual syscall header files generate a
@@ -38,7 +38,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100755 tools/perf/trace/beauty/syscalltbl.sh
 
 diff --git a/tools/perf/Makefile.perf b/tools/perf/Makefile.perf
-index eea8877c7cba3..53efea62096d9 100644
+index eea8877c7cba..53efea62096d 100644
 --- a/tools/perf/Makefile.perf
 +++ b/tools/perf/Makefile.perf
 @@ -518,6 +518,14 @@ beauty_ioctl_outdir := $(beauty_outdir)/ioctl
@@ -66,7 +66,7 @@ index eea8877c7cba3..53efea62096d9 100644
  	$(drm_ioctl_array) \
 diff --git a/tools/perf/trace/beauty/syscalltbl.sh b/tools/perf/trace/beauty/syscalltbl.sh
 new file mode 100755
-index 0000000000000..1199618dc1782
+index 000000000000..1199618dc178
 --- /dev/null
 +++ b/tools/perf/trace/beauty/syscalltbl.sh
 @@ -0,0 +1,274 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
@@ -1,7 +1,7 @@
 From 803a93ba3fde51a74acd472dadd8bfe902a6cec5 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:36 -0700
-Subject: [PATCH 032/328] FROMGIT: perf syscalltbl: Use lookup table containing
+Subject: [PATCH 032/330] FROMGIT: perf syscalltbl: Use lookup table containing
  multiple architectures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -84,7 +84,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 64 insertions(+), 25 deletions(-)
 
 diff --git a/tools/perf/util/syscalltbl.c b/tools/perf/util/syscalltbl.c
-index 760ac4d0869ff..4e6018e2e0b34 100644
+index 760ac4d0869f..4e6018e2e0b3 100644
 --- a/tools/perf/util/syscalltbl.c
 +++ b/tools/perf/util/syscalltbl.c
 @@ -15,16 +15,39 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
@@ -1,7 +1,7 @@
 From fd36ce5789a798c393227895e222af0490dc5a0b Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:37 -0700
-Subject: [PATCH 033/328] FROMGIT: perf build: Remove Makefile.syscalls
+Subject: [PATCH 033/330] FROMGIT: perf build: Remove Makefile.syscalls
 
 Now a single beauty file is generated and used by all architectures,
 remove the per-architecture Makefiles, Kbuild files and previous
@@ -96,7 +96,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  delete mode 100755 tools/perf/scripts/syscalltbl.sh
 
 diff --git a/tools/perf/Makefile.perf b/tools/perf/Makefile.perf
-index 53efea62096d9..6bd566b04e3e1 100644
+index 53efea62096d..6bd566b04e3e 100644
 --- a/tools/perf/Makefile.perf
 +++ b/tools/perf/Makefile.perf
 @@ -298,7 +298,6 @@ ifeq ($(filter feature-dump,$(MAKECMDGOALS)),feature-dump)
@@ -109,7 +109,7 @@ index 53efea62096d9..6bd566b04e3e1 100644
  
 diff --git a/tools/perf/arch/alpha/entry/syscalls/Kbuild b/tools/perf/arch/alpha/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9a41e3572c3af..0000000000000
+index 9a41e3572c3a..000000000000
 --- a/tools/perf/arch/alpha/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -117,7 +117,7 @@ index 9a41e3572c3af..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/alpha/entry/syscalls/Makefile.syscalls b/tools/perf/arch/alpha/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 690168aac34db..0000000000000
+index 690168aac34d..000000000000
 --- a/tools/perf/arch/alpha/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -128,7 +128,7 @@ index 690168aac34db..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/alpha/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/arc/entry/syscalls/Kbuild b/tools/perf/arch/arc/entry/syscalls/Kbuild
 deleted file mode 100644
-index 11707c481a24e..0000000000000
+index 11707c481a24..000000000000
 --- a/tools/perf/arch/arc/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -136,7 +136,7 @@ index 11707c481a24e..0000000000000
 -syscall-y += syscalls_32.h
 diff --git a/tools/perf/arch/arc/entry/syscalls/Makefile.syscalls b/tools/perf/arch/arc/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 391d30ab7a831..0000000000000
+index 391d30ab7a83..000000000000
 --- a/tools/perf/arch/arc/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -145,7 +145,7 @@ index 391d30ab7a831..0000000000000
 -syscall_abis_32 += arc time32 renameat stat64 rlimit
 diff --git a/tools/perf/arch/arm/entry/syscalls/Kbuild b/tools/perf/arch/arm/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9d777540f0898..0000000000000
+index 9d777540f089..000000000000
 --- a/tools/perf/arch/arm/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,4 +0,0 @@
@@ -155,7 +155,7 @@ index 9d777540f0898..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/arm/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/arm/entry/syscalls/Makefile.syscalls b/tools/perf/arch/arm/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 11707c481a24e..0000000000000
+index 11707c481a24..000000000000
 --- a/tools/perf/arch/arm/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -163,7 +163,7 @@ index 11707c481a24e..0000000000000
 -syscall-y += syscalls_32.h
 diff --git a/tools/perf/arch/arm64/entry/syscalls/Kbuild b/tools/perf/arch/arm64/entry/syscalls/Kbuild
 deleted file mode 100644
-index 84c6599b4ea6a..0000000000000
+index 84c6599b4ea6..000000000000
 --- a/tools/perf/arch/arm64/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -172,7 +172,7 @@ index 84c6599b4ea6a..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/arm64/entry/syscalls/Makefile.syscalls b/tools/perf/arch/arm64/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index e7e78c2d1c025..0000000000000
+index e7e78c2d1c02..000000000000
 --- a/tools/perf/arch/arm64/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -184,7 +184,7 @@ index e7e78c2d1c025..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/arm64/entry/syscalls/syscall_%.tbl
 diff --git a/tools/perf/arch/csky/entry/syscalls/Kbuild b/tools/perf/arch/csky/entry/syscalls/Kbuild
 deleted file mode 100644
-index 11707c481a24e..0000000000000
+index 11707c481a24..000000000000
 --- a/tools/perf/arch/csky/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -192,7 +192,7 @@ index 11707c481a24e..0000000000000
 -syscall-y += syscalls_32.h
 diff --git a/tools/perf/arch/csky/entry/syscalls/Makefile.syscalls b/tools/perf/arch/csky/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index ea2dd10d0571d..0000000000000
+index ea2dd10d0571..000000000000
 --- a/tools/perf/arch/csky/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -201,7 +201,7 @@ index ea2dd10d0571d..0000000000000
 -syscall_abis_32 += csky time32 stat64 rlimit
 diff --git a/tools/perf/arch/loongarch/entry/syscalls/Kbuild b/tools/perf/arch/loongarch/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9a41e3572c3af..0000000000000
+index 9a41e3572c3a..000000000000
 --- a/tools/perf/arch/loongarch/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -209,7 +209,7 @@ index 9a41e3572c3af..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/loongarch/entry/syscalls/Makefile.syscalls b/tools/perf/arch/loongarch/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 47d32da2aed8d..0000000000000
+index 47d32da2aed8..000000000000
 --- a/tools/perf/arch/loongarch/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -218,7 +218,7 @@ index 47d32da2aed8d..0000000000000
 -syscall_abis_64 +=
 diff --git a/tools/perf/arch/mips/entry/syscalls/Kbuild b/tools/perf/arch/mips/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9a41e3572c3af..0000000000000
+index 9a41e3572c3a..000000000000
 --- a/tools/perf/arch/mips/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -226,7 +226,7 @@ index 9a41e3572c3af..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/mips/entry/syscalls/Makefile.syscalls b/tools/perf/arch/mips/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 9ee914bdfb058..0000000000000
+index 9ee914bdfb05..000000000000
 --- a/tools/perf/arch/mips/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -237,7 +237,7 @@ index 9ee914bdfb058..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/mips/entry/syscalls/syscall_n64.tbl
 diff --git a/tools/perf/arch/parisc/entry/syscalls/Kbuild b/tools/perf/arch/parisc/entry/syscalls/Kbuild
 deleted file mode 100644
-index 84c6599b4ea6a..0000000000000
+index 84c6599b4ea6..000000000000
 --- a/tools/perf/arch/parisc/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -246,7 +246,7 @@ index 84c6599b4ea6a..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/parisc/entry/syscalls/Makefile.syscalls b/tools/perf/arch/parisc/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index ae326fecb83b3..0000000000000
+index ae326fecb83b..000000000000
 --- a/tools/perf/arch/parisc/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -258,7 +258,7 @@ index ae326fecb83b3..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/parisc/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/powerpc/entry/syscalls/Kbuild b/tools/perf/arch/powerpc/entry/syscalls/Kbuild
 deleted file mode 100644
-index 84c6599b4ea6a..0000000000000
+index 84c6599b4ea6..000000000000
 --- a/tools/perf/arch/powerpc/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -267,7 +267,7 @@ index 84c6599b4ea6a..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/powerpc/entry/syscalls/Makefile.syscalls b/tools/perf/arch/powerpc/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index e35afbc57c796..0000000000000
+index e35afbc57c79..000000000000
 --- a/tools/perf/arch/powerpc/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -279,7 +279,7 @@ index e35afbc57c796..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/powerpc/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/riscv/entry/syscalls/Kbuild b/tools/perf/arch/riscv/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9a41e3572c3af..0000000000000
+index 9a41e3572c3a..000000000000
 --- a/tools/perf/arch/riscv/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -287,7 +287,7 @@ index 9a41e3572c3af..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/riscv/entry/syscalls/Makefile.syscalls b/tools/perf/arch/riscv/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 9668fd1faf60e..0000000000000
+index 9668fd1faf60..000000000000
 --- a/tools/perf/arch/riscv/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,4 +0,0 @@
@@ -297,7 +297,7 @@ index 9668fd1faf60e..0000000000000
 -syscall_abis_64 += riscv rlimit memfd_secret
 diff --git a/tools/perf/arch/s390/entry/syscalls/Kbuild b/tools/perf/arch/s390/entry/syscalls/Kbuild
 deleted file mode 100644
-index 9a41e3572c3af..0000000000000
+index 9a41e3572c3a..000000000000
 --- a/tools/perf/arch/s390/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -305,7 +305,7 @@ index 9a41e3572c3af..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/s390/entry/syscalls/Makefile.syscalls b/tools/perf/arch/s390/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 9762d7abf17c3..0000000000000
+index 9762d7abf17c..000000000000
 --- a/tools/perf/arch/s390/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -316,7 +316,7 @@ index 9762d7abf17c3..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/s390/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/sh/entry/syscalls/Kbuild b/tools/perf/arch/sh/entry/syscalls/Kbuild
 deleted file mode 100644
-index 11707c481a24e..0000000000000
+index 11707c481a24..000000000000
 --- a/tools/perf/arch/sh/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -324,7 +324,7 @@ index 11707c481a24e..0000000000000
 -syscall-y += syscalls_32.h
 diff --git a/tools/perf/arch/sh/entry/syscalls/Makefile.syscalls b/tools/perf/arch/sh/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 25080390e4ed4..0000000000000
+index 25080390e4ed..000000000000
 --- a/tools/perf/arch/sh/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,4 +0,0 @@
@@ -334,7 +334,7 @@ index 25080390e4ed4..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/sh/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/sparc/entry/syscalls/Kbuild b/tools/perf/arch/sparc/entry/syscalls/Kbuild
 deleted file mode 100644
-index 84c6599b4ea6a..0000000000000
+index 84c6599b4ea6..000000000000
 --- a/tools/perf/arch/sparc/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -343,7 +343,7 @@ index 84c6599b4ea6a..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/sparc/entry/syscalls/Makefile.syscalls b/tools/perf/arch/sparc/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index 212c1800b6447..0000000000000
+index 212c1800b644..000000000000
 --- a/tools/perf/arch/sparc/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,5 +0,0 @@
@@ -354,7 +354,7 @@ index 212c1800b6447..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/sparc/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/arch/x86/entry/syscalls/Kbuild b/tools/perf/arch/x86/entry/syscalls/Kbuild
 deleted file mode 100644
-index 84c6599b4ea6a..0000000000000
+index 84c6599b4ea6..000000000000
 --- a/tools/perf/arch/x86/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -363,7 +363,7 @@ index 84c6599b4ea6a..0000000000000
 -syscall-y += syscalls_64.h
 diff --git a/tools/perf/arch/x86/entry/syscalls/Makefile.syscalls b/tools/perf/arch/x86/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index db3d5d6d4e569..0000000000000
+index db3d5d6d4e56..000000000000
 --- a/tools/perf/arch/x86/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,6 +0,0 @@
@@ -375,7 +375,7 @@ index db3d5d6d4e569..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/x86/entry/syscalls/syscall_%.tbl
 diff --git a/tools/perf/arch/xtensa/entry/syscalls/Kbuild b/tools/perf/arch/xtensa/entry/syscalls/Kbuild
 deleted file mode 100644
-index 11707c481a24e..0000000000000
+index 11707c481a24..000000000000
 --- a/tools/perf/arch/xtensa/entry/syscalls/Kbuild
 +++ /dev/null
 @@ -1,2 +0,0 @@
@@ -383,7 +383,7 @@ index 11707c481a24e..0000000000000
 -syscall-y += syscalls_32.h
 diff --git a/tools/perf/arch/xtensa/entry/syscalls/Makefile.syscalls b/tools/perf/arch/xtensa/entry/syscalls/Makefile.syscalls
 deleted file mode 100644
-index d4aa2358460c1..0000000000000
+index d4aa2358460c..000000000000
 --- a/tools/perf/arch/xtensa/entry/syscalls/Makefile.syscalls
 +++ /dev/null
 @@ -1,4 +0,0 @@
@@ -393,7 +393,7 @@ index d4aa2358460c1..0000000000000
 -syscalltbl = $(srctree)/tools/perf/arch/xtensa/entry/syscalls/syscall.tbl
 diff --git a/tools/perf/scripts/Makefile.syscalls b/tools/perf/scripts/Makefile.syscalls
 deleted file mode 100644
-index 8bf55333262e4..0000000000000
+index 8bf55333262e..000000000000
 --- a/tools/perf/scripts/Makefile.syscalls
 +++ /dev/null
 @@ -1,61 +0,0 @@
@@ -460,7 +460,7 @@ index 8bf55333262e4..0000000000000
 -.PHONY: $(PHONY)
 diff --git a/tools/perf/scripts/syscalltbl.sh b/tools/perf/scripts/syscalltbl.sh
 deleted file mode 100755
-index a39b3013b103b..0000000000000
+index a39b3013b103..000000000000
 --- a/tools/perf/scripts/syscalltbl.sh
 +++ /dev/null
 @@ -1,76 +0,0 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
@@ -1,7 +1,7 @@
 From f6e485ed21931c3360f32fe4ad105ff8ac337d03 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:38 -0700
-Subject: [PATCH 034/328] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
+Subject: [PATCH 034/330] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
  system calls
 
 Arnd Bergmann described that MIPS system calls don't necessarily start
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/tools/perf/util/syscalltbl.c b/tools/perf/util/syscalltbl.c
-index 4e6018e2e0b34..67a8ec10e9e4b 100644
+index 4e6018e2e0b3..67a8ec10e9e4 100644
 --- a/tools/perf/util/syscalltbl.c
 +++ b/tools/perf/util/syscalltbl.c
 @@ -46,6 +46,14 @@ const char *syscalltbl__name(int e_machine, int id)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
@@ -1,7 +1,7 @@
 From 40c899db72974af5d57460c9652b021705c77404 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:39 -0700
-Subject: [PATCH 035/328] FROMGIT: perf trace: Make syscall table stable
+Subject: [PATCH 035/330] FROMGIT: perf trace: Make syscall table stable
 
 Namhyung fixed the syscall table being reallocated and moving by
 reloading the system call pointer after a move:
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 53 insertions(+), 34 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index e61d1d1915337..f1a533f9e0a00 100644
+index e61d1d191533..f1a533f9e0a0 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -151,7 +151,7 @@ struct trace {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
@@ -1,7 +1,7 @@
 From 4a6293322d121d4e81c67251f2c258e8db3f2f89 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:40 -0700
-Subject: [PATCH 036/328] FROMGIT: perf trace: Fix BTF memory leak
+Subject: [PATCH 036/330] FROMGIT: perf trace: Fix BTF memory leak
 
 Add missing btf__free in trace__exit.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index f1a533f9e0a00..74d5c7243543a 100644
+index f1a533f9e0a0..74d5c7243543 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -5335,6 +5335,10 @@ static void trace__exit(struct trace *trace)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
@@ -1,7 +1,7 @@
 From 98f64cada9826d286aa7750566dff7602b17e256 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:41 -0700
-Subject: [PATCH 037/328] FROMGIT: perf trace: Fix evlist memory leak
+Subject: [PATCH 037/330] FROMGIT: perf trace: Fix evlist memory leak
 
 Leak sanitizer was reporting a memory leak in the "perf record and
 replay" test. Add evlist__delete to trace__exit, also ensure
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/tools/perf/builtin-trace.c b/tools/perf/builtin-trace.c
-index 74d5c7243543a..8dfaa0ea8e638 100644
+index 74d5c7243543..8dfaa0ea8e63 100644
 --- a/tools/perf/builtin-trace.c
 +++ b/tools/perf/builtin-trace.c
 @@ -5335,6 +5335,8 @@ static void trace__exit(struct trace *trace)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
@@ -1,7 +1,7 @@
 From ab74f8bf801d004e1de289f9e8df03f6136791c8 Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Sat, 22 Feb 2025 19:45:31 +0800
-Subject: [PATCH 038/328] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
+Subject: [PATCH 038/330] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
  Support for mic and audio mute LEDs
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -38,7 +38,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index c0d5232a473b8..23e881157d37d 100644
+index c0d5232a473b..23e881157d37 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13151,6 +13151,12 @@ S:	Maintained
@@ -55,7 +55,7 @@ index c0d5232a473b8..23e881157d37d 100644
  M:	Hans de Goede <hdegoede@redhat.com>
  L:	linux-input@vger.kernel.org
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 0258dd879d64b..b5ac61a0f2fbf 100644
+index 0258dd879d64..b5ac61a0f2fb 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -475,6 +475,17 @@ config IDEAPAD_LAPTOP
@@ -77,7 +77,7 @@ index 0258dd879d64b..b5ac61a0f2fbf 100644
  	tristate "Lenovo Yoga Tablet Mode Control"
  	depends on ACPI_WMI
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index e1b1429470674..131fcf9744779 100644
+index e1b142947067..131fcf974477 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
 @@ -61,6 +61,7 @@ obj-$(CONFIG_UV_SYSFS)       += uv_sysfs.o
@@ -90,7 +90,7 @@ index e1b1429470674..131fcf9744779 100644
  obj-$(CONFIG_THINKPAD_ACPI)	+= thinkpad_acpi.o
 diff --git a/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c b/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 new file mode 100644
-index 0000000000000..89153afd70154
+index 000000000000..89153afd7015
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 @@ -0,0 +1,212 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
@@ -1,7 +1,7 @@
 From 949411326f0197250d454c43547aa4d458578a8f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:51 +0800
-Subject: [PATCH 039/328] FROMGIT: dt-bindings: gpio: loongson: Add new
+Subject: [PATCH 039/330] FROMGIT: dt-bindings: gpio: loongson: Add new
  loongson gpio chip compatible
 
 Add the devicetree compatibles for Loongson-7A2000 and Loongson-3A6000
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml b/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
-index cf3b1b270aa89..b68159600e2bd 100644
+index cf3b1b270aa8..b68159600e2b 100644
 --- a/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
 +++ b/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
 @@ -20,7 +20,10 @@ properties:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
@@ -1,7 +1,7 @@
 From bc7f0a2f09a32d47f78dbda9ecb17e27281e8fb0 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:52 +0800
-Subject: [PATCH 040/328] FROMGIT: gpio: loongson-64bit: Add more gpio chip
+Subject: [PATCH 040/330] FROMGIT: gpio: loongson-64bit: Add more gpio chip
  support
 
 The Loongson-7A2000 and Loongson-3A6000 share the same gpio chip model.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 51 insertions(+)
 
 diff --git a/drivers/gpio/gpio-loongson-64bit.c b/drivers/gpio/gpio-loongson-64bit.c
-index 7f4d78fd800e7..7b0738fd4a24f 100644
+index 7f4d78fd800e..7b0738fd4a24 100644
 --- a/drivers/gpio/gpio-loongson-64bit.c
 +++ b/drivers/gpio/gpio-loongson-64bit.c
 @@ -258,6 +258,33 @@ static const struct loongson_gpio_chip_data loongson_gpio_ls7a_data = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
@@ -1,7 +1,7 @@
 From 590bed431f42bc23d5fc2feda2463bec5c0a6e69 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 12 Mar 2025 21:39:54 +0800
-Subject: [PATCH 041/328] FROMGIT: ata: libata: Improve return value of
+Subject: [PATCH 041/330] FROMGIT: ata: libata: Improve return value of
  atapi_check_dma()
 
 atapi_check_dma() allows a LLD to filter ATAPI commands, returning a
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index 05bfcb359f92c..773799cfd4430 100644
+index 05bfcb359f92..773799cfd443 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
 @@ -4583,7 +4583,7 @@ int atapi_check_dma(struct ata_queued_cmd *qc)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
@@ -1,7 +1,7 @@
 From c5889146b51c397f3c151d1e7aceb144adef948d Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:13 +0800
-Subject: [PATCH 042/328] FROMGIT: objtool/LoongArch: Add support for switch
+Subject: [PATCH 042/330] FROMGIT: objtool/LoongArch: Add support for switch
  table
 
 The objtool program need to analysis the control flow of each object file
@@ -58,7 +58,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 130 insertions(+), 1 deletion(-)
 
 diff --git a/tools/objtool/arch/loongarch/special.c b/tools/objtool/arch/loongarch/special.c
-index 87230ed570fd0..4fa6877d5b2b2 100644
+index 87230ed570fd..4fa6877d5b2b 100644
 --- a/tools/objtool/arch/loongarch/special.c
 +++ b/tools/objtool/arch/loongarch/special.c
 @@ -1,5 +1,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
@@ -1,7 +1,7 @@
 From 3116cf7478b090712f23223c5135971fe5d90882 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:14 +0800
-Subject: [PATCH 043/328] FROMGIT: objtool/LoongArch: Add support for goto
+Subject: [PATCH 043/330] FROMGIT: objtool/LoongArch: Add support for goto
  table
 
 The objtool program need to analysis the control flow of each object file
@@ -56,7 +56,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 30 insertions(+), 2 deletions(-)
 
 diff --git a/tools/objtool/arch/loongarch/special.c b/tools/objtool/arch/loongarch/special.c
-index 4fa6877d5b2b2..e39f86d97002b 100644
+index 4fa6877d5b2b..e39f86d97002 100644
 --- a/tools/objtool/arch/loongarch/special.c
 +++ b/tools/objtool/arch/loongarch/special.c
 @@ -116,6 +116,30 @@ static struct reloc *find_reloc_by_table_annotate(struct objtool_file *file,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
@@ -1,7 +1,7 @@
 From c23b1b0fbec8855e4480b70a990d21d1cb3d038b Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 17 Dec 2024 09:09:03 +0800
-Subject: [PATCH 044/328] FROMGIT: LoongArch: Enable jump table for objtool
+Subject: [PATCH 044/330] FROMGIT: LoongArch: Enable jump table for objtool
 
 For now, it is time to remove -fno-jump-tables to enable jump table for
 objtool if the compiler has -mannotate-tablejump, otherwise it is better
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index b744bd73f08ee..ad56d6daa5883 100644
+index b744bd73f08e..ad56d6daa588 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -292,6 +292,9 @@ config AS_HAS_LBT_EXTENSION
@@ -35,7 +35,7 @@ index b744bd73f08ee..ad56d6daa5883 100644
  
  source "kernel/Kconfig.hz"
 diff --git a/arch/loongarch/Makefile b/arch/loongarch/Makefile
-index 567bd122a9ee4..0304eabbe6066 100644
+index 567bd122a9ee..0304eabbe606 100644
 --- a/arch/loongarch/Makefile
 +++ b/arch/loongarch/Makefile
 @@ -101,7 +101,11 @@ KBUILD_AFLAGS			+= $(call cc-option,-mthin-add-sub) $(call cc-option,-Wa$(comma)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
@@ -1,7 +1,7 @@
 From 32910cab64d753061e57730d20c82a7dbcf1dfd7 Mon Sep 17 00:00:00 2001
 From: Masahiro Yamada <masahiroy@kernel.org>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 045/328] FROMGIT: LoongArch: KVM: Remove unnecessary header
+Subject: [PATCH 045/330] FROMGIT: LoongArch: KVM: Remove unnecessary header
  include path
 
 arch/loongarch/kvm/ includes local headers with the double-quote form
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/arch/loongarch/kvm/Makefile b/arch/loongarch/kvm/Makefile
-index 8e8f6bc87f89c..cb41d9265662f 100644
+index 8e8f6bc87f89..cb41d9265662 100644
 --- a/arch/loongarch/kvm/Makefile
 +++ b/arch/loongarch/kvm/Makefile
 @@ -3,8 +3,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
@@ -1,7 +1,7 @@
 From efb23e50c8233592edb1c75e7495e57d6f73c534 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 046/328] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
+Subject: [PATCH 046/330] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
  context switch
 
 PGD table for primary mmu keeps unchanged once VM is created, it is not
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 15 insertions(+), 10 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index 590982cd986ec..d8b543b3fa259 100644
+index 590982cd986e..d8b543b3fa25 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -176,6 +176,9 @@ struct kvm_vcpu_arch {
@@ -36,7 +36,7 @@ index 590982cd986ec..d8b543b3fa259 100644
  	unsigned long host_sp;
  	unsigned long host_tp;
 diff --git a/arch/loongarch/kernel/asm-offsets.c b/arch/loongarch/kernel/asm-offsets.c
-index 8be1c38ad8eb2..c19f446ad0db9 100644
+index 8be1c38ad8eb..c19f446ad0db 100644
 --- a/arch/loongarch/kernel/asm-offsets.c
 +++ b/arch/loongarch/kernel/asm-offsets.c
 @@ -296,6 +296,7 @@ static void __used output_kvm_defines(void)
@@ -48,7 +48,7 @@ index 8be1c38ad8eb2..c19f446ad0db9 100644
  	OFFSET(KVM_ARCH_HEENTRY, kvm_vcpu_arch, host_eentry);
  	OFFSET(KVM_ARCH_GEENTRY, kvm_vcpu_arch, guest_eentry);
 diff --git a/arch/loongarch/kvm/switch.S b/arch/loongarch/kvm/switch.S
-index 1be185e948072..f1768b7a61949 100644
+index 1be185e94807..f1768b7a6194 100644
 --- a/arch/loongarch/kvm/switch.S
 +++ b/arch/loongarch/kvm/switch.S
 @@ -60,16 +60,8 @@
@@ -71,7 +71,7 @@ index 1be185e948072..f1768b7a61949 100644
  
  	/* Mix GID and RID */
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index 92b8177f193bd..1dd018c754a4f 100644
+index 92b8177f193b..1dd018c754a4 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -1470,6 +1470,15 @@ int kvm_arch_vcpu_create(struct kvm_vcpu *vcpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
@@ -1,7 +1,7 @@
 From f3961bd241bd6ffdf3e89b9a7295b8b10b3f3c6a Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 047/328] FROMGIT: LoongArch: KVM: Add stub for
+Subject: [PATCH 047/330] FROMGIT: LoongArch: KVM: Add stub for
  kvm_arch_vcpu_preempted_in_kernel()
 
 Pause-Loop Exiting is not supported by LoongArch hardware, nor is pv
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index 1dd018c754a4f..a723a98d79ee1 100644
+index 1dd018c754a4..a723a98d79ee 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -365,6 +365,11 @@ bool kvm_arch_vcpu_in_kernel(struct kvm_vcpu *vcpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
@@ -1,7 +1,7 @@
 From 12101c3210fe0f7b1c9e7e4a29c35cf0cd59fbfe Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 048/328] FROMGIT: LoongArch: KVM: Implement arch-specific
+Subject: [PATCH 048/330] FROMGIT: LoongArch: KVM: Implement arch-specific
  functions for guest perf
 
 Three architecture specific functions are added for the guest perf
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 27 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index d8b543b3fa259..2281293a5f590 100644
+index d8b543b3fa25..2281293a5f59 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -12,6 +12,7 @@
@@ -41,7 +41,7 @@ index d8b543b3fa259..2281293a5f590 100644
  int kvm_arch_vcpu_dump_regs(struct kvm_vcpu *vcpu);
  
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index a723a98d79ee1..c092cfd00e0b6 100644
+index a723a98d79ee..c092cfd00e0b 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -362,9 +362,32 @@ int kvm_arch_vcpu_should_kick(struct kvm_vcpu *vcpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
@@ -1,7 +1,7 @@
 From 608f8c1b9ff41f38f09e6cd424a9d4a9d828a186 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 049/328] FROMGIT: LoongArch: KVM: Register perf callbacks for
+Subject: [PATCH 049/330] FROMGIT: LoongArch: KVM: Register perf callbacks for
  guest
 
 Add selection for GUEST_PERF_EVENTS if KVM is enabled, also add perf
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+)
 
 diff --git a/arch/loongarch/kvm/Kconfig b/arch/loongarch/kvm/Kconfig
-index 97a811077ac3a..40eea6da7c259 100644
+index 97a811077ac3..40eea6da7c25 100644
 --- a/arch/loongarch/kvm/Kconfig
 +++ b/arch/loongarch/kvm/Kconfig
 @@ -33,6 +33,7 @@ config KVM
@@ -31,7 +31,7 @@ index 97a811077ac3a..40eea6da7c259 100644
  	  Support hosting virtualized guest machines using
  	  hardware virtualization extensions. You will need
 diff --git a/arch/loongarch/kvm/main.c b/arch/loongarch/kvm/main.c
-index f5d6317814825..80ea63d465b8e 100644
+index f5d631781482..80ea63d465b8 100644
 --- a/arch/loongarch/kvm/main.c
 +++ b/arch/loongarch/kvm/main.c
 @@ -394,6 +394,7 @@ static int kvm_loongarch_env_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From cd5cf771823cfadc54b5e9a27a2d8077f6487640 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 050/328] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 050/330] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index bee222967f6b1..b22fa05e20ee5 100644
+index bee222967f6b..b22fa05e20ee 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
@@ -1,7 +1,7 @@
 From 3ca32eac062835adfbdebb8a860e675dd3232641 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 051/328] FROMLIST: drm/Makefile: Move tiny drivers before
+Subject: [PATCH 051/330] FROMLIST: drm/Makefile: Move tiny drivers before
  native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
@@ -38,7 +38,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index 19fb370fbc567..4242b24f2e5c9 100644
+index 19fb370fbc56..4242b24f2e5c 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -163,6 +163,7 @@ obj-y			+= clients/

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From 20a98995be888ef1bf783b6c6fc18317804cab06 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 052/328] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 052/330] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of
@@ -51,7 +51,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 581ae20c46e4b..346f0e49bb2ea 100644
+index 581ae20c46e4..346f0e49bb2e 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,6 +185,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From 9af5d2ec27f17f6aba245ffc4947031a2d373a7d Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 053/328] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 053/330] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/mm/cache.c b/arch/loongarch/mm/cache.c
-index 6be04d36ca076..89eeb9a97dd5d 100644
+index 6be04d36ca07..89eeb9a97dd5 100644
 --- a/arch/loongarch/mm/cache.c
 +++ b/arch/loongarch/mm/cache.c
 @@ -63,6 +63,27 @@ static void flush_cache_leaf(unsigned int leaf)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
@@ -1,7 +1,7 @@
 From 976d54041ddda288626dfe4b3926e33f66c7dc23 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
-Subject: [PATCH 054/328] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
+Subject: [PATCH 054/330] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
  when selected cpu is offline
 
 Call work_on_cpu(cpu, fn, arg) in pci_call_probe() while the argument
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index f57ea36d125d6..1644ada3ee736 100644
+index f57ea36d125d..1644ada3ee73 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -386,7 +386,7 @@ static int pci_call_probe(struct pci_driver *drv, struct pci_dev *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From 5a484027f837d692ffb77ee89838fa83583adfba Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 4 Aug 2024 09:24:18 +0800
-Subject: [PATCH 055/328] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 055/330] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 1644ada3ee736..f27bc09eeb1da 100644
+index 1644ada3ee73..f27bc09eeb1d 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -517,7 +517,7 @@ static void pci_device_shutdown(struct device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
 From 161ab385e26e8981c671245f3b9318986532053b Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 056/328] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 056/330] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/serial/loongson,uart.yaml b/Documentation/devicetree/bindings/serial/loongson,uart.yaml
 new file mode 100644
-index 0000000000000..19a65dd5be9f8
+index 000000000000..19a65dd5be9f
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/serial/loongson,uart.yaml
 @@ -0,0 +1,63 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
 From 64bd6acbc9c7afdd1c5ff359defd6c1e2f9f7b2e Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 057/328] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 057/330] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/tty/serial/8250/8250_loongson.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 23e881157d37d..41a4c9151f038 100644
+index 23e881157d37..41a4c9151f03 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13624,6 +13624,13 @@ S:	Maintained
@@ -41,7 +41,7 @@ index 23e881157d37d..41a4c9151f038 100644
  L:	linux-clk@vger.kernel.org
 diff --git a/drivers/tty/serial/8250/8250_loongson.c b/drivers/tty/serial/8250/8250_loongson.c
 new file mode 100644
-index 0000000000000..88205fed4fd30
+index 000000000000..88205fed4fd3
 --- /dev/null
 +++ b/drivers/tty/serial/8250/8250_loongson.c
 @@ -0,0 +1,228 @@
@@ -274,7 +274,7 @@ index 0000000000000..88205fed4fd30
 +MODULE_AUTHOR("Haowei Zheng <zhenghaowei@loongson.cn>");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
-index 886e40f680d45..4db3fcdb1228c 100644
+index 886e40f680d4..4db3fcdb1228 100644
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
 @@ -319,6 +319,14 @@ static const struct serial8250_config uart_config[] = {
@@ -293,7 +293,7 @@ index 886e40f680d45..4db3fcdb1228c 100644
  
  /* Uart divisor latch read */
 diff --git a/drivers/tty/serial/8250/Kconfig b/drivers/tty/serial/8250/Kconfig
-index 55d26d16df9b9..9ba14bb746e36 100644
+index 55d26d16df9b..9ba14bb746e3 100644
 --- a/drivers/tty/serial/8250/Kconfig
 +++ b/drivers/tty/serial/8250/Kconfig
 @@ -569,6 +569,15 @@ config SERIAL_8250_BCM7271
@@ -313,7 +313,7 @@ index 55d26d16df9b9..9ba14bb746e36 100644
  	tristate "Devicetree based probing for 8250 ports"
  	depends on SERIAL_8250 && OF
 diff --git a/drivers/tty/serial/8250/Makefile b/drivers/tty/serial/8250/Makefile
-index 1516de629b617..e9587bf69f655 100644
+index 1516de629b61..e9587bf69f65 100644
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
 @@ -51,5 +51,6 @@ obj-$(CONFIG_SERIAL_8250_RT288X)	+= 8250_rt288x.o
@@ -324,7 +324,7 @@ index 1516de629b617..e9587bf69f655 100644
  
  CFLAGS_8250_ingenic.o += -I$(srctree)/scripts/dtc/libfdt
 diff --git a/include/uapi/linux/serial_core.h b/include/uapi/linux/serial_core.h
-index 9c007a106330b..9e316b9295e52 100644
+index 9c007a106330..9e316b9295e5 100644
 --- a/include/uapi/linux/serial_core.h
 +++ b/include/uapi/linux/serial_core.h
 @@ -31,6 +31,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
 From 9278f571a1758e30643e3ba3f6bd020cf732c167 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 058/328] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 058/330] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/boot/dts/loongson-2k0500.dtsi b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
-index 3b38ff8853a7d..63c77d70639c2 100644
+index 3b38ff8853a7..63c77d70639c 100644
 --- a/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 @@ -220,7 +220,7 @@ tsensor: thermal-sensor@1fe11500 {
@@ -31,7 +31,7 @@ index 3b38ff8853a7d..63c77d70639c2 100644
  			clock-frequency = <100000000>;
  			interrupt-parent = <&eiointc>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k1000.dtsi b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
-index 8dff2aa524171..a0abcd890d4a7 100644
+index 8dff2aa52417..a0abcd890d4a 100644
 --- a/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 @@ -297,7 +297,7 @@ dma-controller@1fe00c40 {
@@ -44,7 +44,7 @@ index 8dff2aa524171..a0abcd890d4a7 100644
  			clock-frequency = <125000000>;
  			interrupt-parent = <&liointc0>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k2000.dtsi b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
-index b4ff55a33e90b..dcd7c8c5cd901 100644
+index b4ff55a33e90..dcd7c8c5cd90 100644
 --- a/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 @@ -190,7 +190,7 @@ i2c@1fe00130 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From 69cdb23ae551752d5aa0809795613cce4a82af42 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 059/328] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 059/330] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/mouse/pixart_ps2.h
 
 diff --git a/drivers/input/mouse/Kconfig b/drivers/input/mouse/Kconfig
-index 833b643f06164..8a27a20d04b01 100644
+index 833b643f0616..8a27a20d04b0 100644
 --- a/drivers/input/mouse/Kconfig
 +++ b/drivers/input/mouse/Kconfig
 @@ -69,6 +69,18 @@ config MOUSE_PS2_LOGIPS2PP
@@ -54,7 +54,7 @@ index 833b643f06164..8a27a20d04b01 100644
  	bool "Synaptics PS/2 mouse protocol extension" if EXPERT
  	default y
 diff --git a/drivers/input/mouse/Makefile b/drivers/input/mouse/Makefile
-index a1336d5bee6f3..5630295515291 100644
+index a1336d5bee6f..563029551529 100644
 --- a/drivers/input/mouse/Makefile
 +++ b/drivers/input/mouse/Makefile
 @@ -32,6 +32,7 @@ psmouse-$(CONFIG_MOUSE_PS2_ELANTECH)	+= elantech.o
@@ -67,7 +67,7 @@ index a1336d5bee6f3..5630295515291 100644
  psmouse-$(CONFIG_MOUSE_PS2_TOUCHKIT)	+= touchkit_ps2.o
 diff --git a/drivers/input/mouse/pixart_ps2.c b/drivers/input/mouse/pixart_ps2.c
 new file mode 100644
-index 0000000000000..d5cd009361716
+index 000000000000..d5cd00936171
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.c
 @@ -0,0 +1,310 @@
@@ -383,7 +383,7 @@ index 0000000000000..d5cd009361716
 +}
 diff --git a/drivers/input/mouse/pixart_ps2.h b/drivers/input/mouse/pixart_ps2.h
 new file mode 100644
-index 0000000000000..47a1d040f2d10
+index 000000000000..47a1d040f2d1
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.h
 @@ -0,0 +1,36 @@
@@ -424,7 +424,7 @@ index 0000000000000..47a1d040f2d10
 +
 +#endif  /* _PIXART_PS2_H */
 diff --git a/drivers/input/mouse/psmouse-base.c b/drivers/input/mouse/psmouse-base.c
-index a2c9f7144864e..5a4defe9cf325 100644
+index a2c9f7144864..5a4defe9cf32 100644
 --- a/drivers/input/mouse/psmouse-base.c
 +++ b/drivers/input/mouse/psmouse-base.c
 @@ -36,6 +36,7 @@
@@ -466,7 +466,7 @@ index a2c9f7144864e..5a4defe9cf325 100644
  		if (psmouse_try_protocol(psmouse, PSMOUSE_GENPS,
  					 &max_proto, set_properties, true))
 diff --git a/drivers/input/mouse/psmouse.h b/drivers/input/mouse/psmouse.h
-index 4d8acfe0d82aa..23f7fa7243cb5 100644
+index 4d8acfe0d82a..23f7fa7243cb 100644
 --- a/drivers/input/mouse/psmouse.h
 +++ b/drivers/input/mouse/psmouse.h
 @@ -69,6 +69,7 @@ enum psmouse_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
@@ -1,7 +1,7 @@
 From b3679a8b3021a7764acfd41cde62a2dc8e327929 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 11 Nov 2024 21:21:49 +0800
-Subject: [PATCH 060/328] FROMLIST: drm: Remove redundant statement in
+Subject: [PATCH 060/330] FROMLIST: drm: Remove redundant statement in
  drm_crtc_helper_set_mode()
 
 Commit dbbfaf5f2641a ("drm: Remove bridge support from legacy helpers")
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/drm_crtc_helper.c b/drivers/gpu/drm/drm_crtc_helper.c
-index 0955f1c385dd2..39497493f74ca 100644
+index 0955f1c385dd..39497493f74c 100644
 --- a/drivers/gpu/drm/drm_crtc_helper.c
 +++ b/drivers/gpu/drm/drm_crtc_helper.c
 @@ -334,7 +334,6 @@ bool drm_crtc_helper_set_mode(struct drm_crtc *crtc,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From b29ddb57ec77e93484f8d748247ff315c4fee8d5 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 061/328] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 061/330] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 1924f2d839323..ee163940d8407 100644
+index 1924f2d83932..ee163940d840 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2874,9 +2874,6 @@ config ARCH_SUPPORTS_KEXEC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
 From 32b1785a66dd54f9259a50ab91f68a5e51f152e6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:08 +0800
-Subject: [PATCH 062/328] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 062/330] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC MFD Core driver
 
 The Loongson-2K Board Management Controller provides an PCIe
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/mfd/ls2kbmc-mfd.c
 
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 6b0682af6e32b..cbfc9f66d64ef 100644
+index 6b0682af6e32..cbfc9f66d64e 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2439,5 +2439,20 @@ config MFD_UPBOARD_FPGA
@@ -51,7 +51,7 @@ index 6b0682af6e32b..cbfc9f66d64ef 100644
  endmenu
  endif
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 9220eaf7cf125..c7b114f028707 100644
+index 9220eaf7cf12..c7b114f02870 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -294,3 +294,5 @@ obj-$(CONFIG_MFD_RSMU_I2C)	+= rsmu_i2c.o rsmu_core.o
@@ -62,7 +62,7 @@ index 9220eaf7cf125..c7b114f028707 100644
 +obj-$(CONFIG_MFD_LS2K_BMC)	+= ls2kbmc-mfd.o
 diff --git a/drivers/mfd/ls2kbmc-mfd.c b/drivers/mfd/ls2kbmc-mfd.c
 new file mode 100644
-index 0000000000000..2912112c41c80
+index 000000000000..2912112c41c8
 --- /dev/null
 +++ b/drivers/mfd/ls2kbmc-mfd.c
 @@ -0,0 +1,145 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
 From 3b242681579fe88b4cfb850f71503259e184fe76 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:09 +0800
-Subject: [PATCH 063/328] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 063/330] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/char/ipmi/ipmi_si_ls2k.c
 
 diff --git a/drivers/char/ipmi/Makefile b/drivers/char/ipmi/Makefile
-index e0944547c9d0e..614be45863b4e 100644
+index e0944547c9d0..614be45863b4 100644
 --- a/drivers/char/ipmi/Makefile
 +++ b/drivers/char/ipmi/Makefile
 @@ -7,6 +7,7 @@ ipmi_si-y := ipmi_si_intf.o ipmi_kcs_sm.o ipmi_smic_sm.o ipmi_bt_sm.o \
@@ -40,7 +40,7 @@ index e0944547c9d0e..614be45863b4e 100644
  ipmi_si-$(CONFIG_PARISC) += ipmi_si_parisc.o
  
 diff --git a/drivers/char/ipmi/ipmi_si.h b/drivers/char/ipmi/ipmi_si.h
-index a7ead2a4c753b..0a4af352a42cc 100644
+index a7ead2a4c753..0a4af352a42c 100644
 --- a/drivers/char/ipmi/ipmi_si.h
 +++ b/drivers/char/ipmi/ipmi_si.h
 @@ -101,6 +101,14 @@ static inline void ipmi_si_parisc_init(void) { }
@@ -59,7 +59,7 @@ index a7ead2a4c753b..0a4af352a42cc 100644
  int ipmi_si_mem_setup(struct si_sm_io *io);
  
 diff --git a/drivers/char/ipmi/ipmi_si_intf.c b/drivers/char/ipmi/ipmi_si_intf.c
-index eea23a3b966ef..7227bc61be798 100644
+index eea23a3b966e..7227bc61be79 100644
 --- a/drivers/char/ipmi/ipmi_si_intf.c
 +++ b/drivers/char/ipmi/ipmi_si_intf.c
 @@ -2108,6 +2108,7 @@ static int __init init_ipmi_si(void)
@@ -81,7 +81,7 @@ index eea23a3b966ef..7227bc61be798 100644
  		cleanup_one_si(e);
 diff --git a/drivers/char/ipmi/ipmi_si_ls2k.c b/drivers/char/ipmi/ipmi_si_ls2k.c
 new file mode 100644
-index 0000000000000..cb31bb989fca8
+index 000000000000..cb31bb989fca
 --- /dev/null
 +++ b/drivers/char/ipmi/ipmi_si_ls2k.c
 @@ -0,0 +1,250 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
@@ -1,7 +1,7 @@
 From bff94d0d2b8cdf36f04a41579aa2ea3943d91656 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:10 +0800
-Subject: [PATCH 064/328] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
+Subject: [PATCH 064/330] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
  BMC display
 
 Adds a driver for the Loongson-2K BMC display as a sub-function of
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpu/drm/tiny/ls2kbmc.c
 
 diff --git a/drivers/gpu/drm/tiny/Kconfig b/drivers/gpu/drm/tiny/Kconfig
-index 94cbdb1337c07..5412f639a9648 100644
+index 94cbdb1337c0..5412f639a964 100644
 --- a/drivers/gpu/drm/tiny/Kconfig
 +++ b/drivers/gpu/drm/tiny/Kconfig
 @@ -171,6 +171,24 @@ config TINYDRM_ILI9486
@@ -53,7 +53,7 @@ index 94cbdb1337c07..5412f639a9648 100644
  	tristate "DRM support for MI0283QT"
  	depends on DRM && SPI
 diff --git a/drivers/gpu/drm/tiny/Makefile b/drivers/gpu/drm/tiny/Makefile
-index 60816d2eb4ff9..39105716de9d3 100644
+index 60816d2eb4ff..39105716de9d 100644
 --- a/drivers/gpu/drm/tiny/Makefile
 +++ b/drivers/gpu/drm/tiny/Makefile
 @@ -12,6 +12,7 @@ obj-$(CONFIG_TINYDRM_ILI9163)		+= ili9163.o
@@ -66,7 +66,7 @@ index 60816d2eb4ff9..39105716de9d3 100644
  obj-$(CONFIG_TINYDRM_SHARP_MEMORY)	+= sharp-memory.o
 diff --git a/drivers/gpu/drm/tiny/ls2kbmc.c b/drivers/gpu/drm/tiny/ls2kbmc.c
 new file mode 100644
-index 0000000000000..909d6c687193b
+index 000000000000..909d6c687193
 --- /dev/null
 +++ b/drivers/gpu/drm/tiny/ls2kbmc.c
 @@ -0,0 +1,636 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
 From 623e622fe31d3db9a54cd9351a7c2cadb496fe42 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:36 +0800
-Subject: [PATCH 065/328] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 065/330] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 283 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/tiny/ls2kbmc.c b/drivers/gpu/drm/tiny/ls2kbmc.c
-index 909d6c687193b..4b440f20cb4db 100644
+index 909d6c687193..4b440f20cb4d 100644
 --- a/drivers/gpu/drm/tiny/ls2kbmc.c
 +++ b/drivers/gpu/drm/tiny/ls2kbmc.c
 @@ -8,10 +8,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 4f08061cc57c7495875fd042d73c7a7189b8ab16 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 066/328] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 066/330] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/fpu/xstate.h b/arch/x86/kernel/fpu/xstate.h
-index aa16f1a1bbcf1..4d966c6c794ad 100644
+index aa16f1a1bbcf..4d966c6c794a 100644
 --- a/arch/x86/kernel/fpu/xstate.h
 +++ b/arch/x86/kernel/fpu/xstate.h
 @@ -80,6 +80,9 @@ static inline int update_pkru_in_sigframe(struct xregs_state __user *buf, u64 ma

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
@@ -1,7 +1,7 @@
 From 68ddfd15d3c6beb99c2d394d9388626fe71a236e Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:29:56 +0800
-Subject: [PATCH 067/328] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
+Subject: [PATCH 067/330] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/os_types.h b/drivers/gpu/drm/amd/display/dc/os_types.h
-index f2ba76c1e0c09..f0f4e22b43cd0 100644
+index f2ba76c1e0c0..f0f4e22b43cd 100644
 --- a/drivers/gpu/drm/amd/display/dc/os_types.h
 +++ b/drivers/gpu/drm/amd/display/dc/os_types.h
 @@ -79,6 +79,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
@@ -1,7 +1,7 @@
 From 1133f1e2eee4fd905748aa5bd7d58207fb6fdf28 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:15 +0800
-Subject: [PATCH 068/328] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
+Subject: [PATCH 068/330] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/spl/spl_debug.h b/drivers/gpu/drm/amd/display/dc/spl/spl_debug.h
-index a6f6132df2416..d31988c647e55 100644
+index a6f6132df241..d31988c647e5 100644
 --- a/drivers/gpu/drm/amd/display/dc/spl/spl_debug.h
 +++ b/drivers/gpu/drm/amd/display/dc/spl/spl_debug.h
 @@ -11,18 +11,29 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
@@ -1,7 +1,7 @@
 From c8f26fc4543302aea2a503865888af8046efd0b1 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:35 +0800
-Subject: [PATCH 069/328] FROMLIST: drm/amd/display: Harden callers of division
+Subject: [PATCH 069/330] FROMLIST: drm/amd/display: Harden callers of division
  functions
 
 There are objtool warnings compiled with the latest mainline LLVM:
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/basics/fixpt31_32.c b/drivers/gpu/drm/amd/display/dc/basics/fixpt31_32.c
-index 88d3f9d7dd556..f78c6702bc423 100644
+index 88d3f9d7dd55..f78c6702bc42 100644
 --- a/drivers/gpu/drm/amd/display/dc/basics/fixpt31_32.c
 +++ b/drivers/gpu/drm/amd/display/dc/basics/fixpt31_32.c
 @@ -51,7 +51,7 @@ static inline unsigned long long complete_integer_division_u64(
@@ -61,7 +61,7 @@ index 88d3f9d7dd556..f78c6702bc423 100644
  	result = div64_u64_rem(dividend, divisor, remainder);
  
 diff --git a/drivers/gpu/drm/amd/display/dc/spl/spl_fixpt31_32.c b/drivers/gpu/drm/amd/display/dc/spl/spl_fixpt31_32.c
-index 52d97918a3bd2..ec1096caab0c1 100644
+index 52d97918a3bd..ec1096caab0c 100644
 --- a/drivers/gpu/drm/amd/display/dc/spl/spl_fixpt31_32.c
 +++ b/drivers/gpu/drm/amd/display/dc/spl/spl_fixpt31_32.c
 @@ -29,7 +29,7 @@ static inline unsigned long long spl_complete_integer_division_u64(

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
@@ -1,7 +1,7 @@
 From d299415caa9d91295a9d96a1c9c6a089e63bfbfa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 21 Jan 2025 19:42:25 +0800
-Subject: [PATCH 070/328] FROMLIST: PCI: loongson: Add quirk for OHCI device
+Subject: [PATCH 070/330] FROMLIST: PCI: loongson: Add quirk for OHCI device
  rev 0x02
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/pci/controller/pci-loongson.c b/drivers/pci/controller/pci-loongson.c
-index bc630ab8a2831..977f7b15f3a73 100644
+index bc630ab8a283..977f7b15f3a7 100644
 --- a/drivers/pci/controller/pci-loongson.c
 +++ b/drivers/pci/controller/pci-loongson.c
 @@ -32,6 +32,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From 072a260e27b38c2bc143c41745ba28a9a1b9b170 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 071/328] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 071/330] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index dcba4281ea486..dffe3bc45865b 100644
+index dcba4281ea48..dffe3bc45865 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3491,6 +3491,7 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
@@ -1,7 +1,7 @@
 From bae74d74f63177be90f55653c7bb2efe18a02842 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:24 +0800
-Subject: [PATCH 072/328] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
+Subject: [PATCH 072/330] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
  PWM controller
 
 Add Loongson PWM controller binding with DT schema format using
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 new file mode 100644
-index 0000000000000..46814773e0cc8
+index 000000000000..46814773e0cc
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 @@ -0,0 +1,66 @@
@@ -93,7 +93,7 @@ index 0000000000000..46814773e0cc8
 +        #pwm-cells = <3>;
 +    };
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 41a4c9151f038..9a51cd55272c2 100644
+index 41a4c9151f03..9a51cd55272c 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13624,6 +13624,12 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,7 +1,7 @@
 From 9e0d8ec32791a7378c08dc569f79ee5fb8719030 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:25 +0800
-Subject: [PATCH 073/328] FROMLIST: pwm: Add Loongson PWM controller support
+Subject: [PATCH 073/330] FROMLIST: pwm: Add Loongson PWM controller support
 
 This commit adds a generic PWM framework driver for the PWM controller
 found on Loongson family chips.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/pwm/pwm-loongson.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 9a51cd55272c2..d29ee6d2ce9a4 100644
+index 9a51cd55272c..d29ee6d2ce9a 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13629,6 +13629,7 @@ M:	Binbin Zhou <zhoubinbin@loongson.cn>
@@ -34,7 +34,7 @@ index 9a51cd55272c2..d29ee6d2ce9a4 100644
  LOONGSON UART DRIVER
  M:	Haowei Zheng <zhenghaowei@loongson.cn>
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index 0915c1e7df16d..ef02a44d83a77 100644
+index 0915c1e7df16..ef02a44d83a7 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -351,6 +351,18 @@ config PWM_KEEMBAY
@@ -57,7 +57,7 @@ index 0915c1e7df16d..ef02a44d83a77 100644
  	tristate "TI/National Semiconductor LP3943 PWM support"
  	depends on MFD_LP3943
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index 9081e0c0e9e09..7c18c9be419ff 100644
+index 9081e0c0e9e0..7c18c9be419f 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -30,6 +30,7 @@ obj-$(CONFIG_PWM_INTEL_LGM)	+= pwm-intel-lgm.o
@@ -70,7 +70,7 @@ index 9081e0c0e9e09..7c18c9be419ff 100644
  obj-$(CONFIG_PWM_LPC32XX)	+= pwm-lpc32xx.o
 diff --git a/drivers/pwm/pwm-loongson.c b/drivers/pwm/pwm-loongson.c
 new file mode 100644
-index 0000000000000..e34a450e38382
+index 000000000000..e34a450e3838
 --- /dev/null
 +++ b/drivers/pwm/pwm-loongson.c
 @@ -0,0 +1,278 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
 From b1a4b53f1a2765731339b4792196b6998c4d8460 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:40 +0800
-Subject: [PATCH 074/328] FROMLIST: riscv: vDSO: Remove --hash-style=both
+Subject: [PATCH 074/330] FROMLIST: riscv: vDSO: Remove --hash-style=both
 
 When RISC-V borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/riscv/kernel/vdso/Makefile b/arch/riscv/kernel/vdso/Makefile
-index 9a1b555e87331..ecee348af9cea 100644
+index 9a1b555e8733..ecee348af9ce 100644
 --- a/arch/riscv/kernel/vdso/Makefile
 +++ b/arch/riscv/kernel/vdso/Makefile
 @@ -47,7 +47,7 @@ $(obj)/vdso.o: $(obj)/vdso.so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
 From 28cde97236a093b7b2fb87659c13ce38b75b404c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:41 +0800
-Subject: [PATCH 075/328] FROMLIST: csky: vDSO: Remove --hash-style=both
+Subject: [PATCH 075/330] FROMLIST: csky: vDSO: Remove --hash-style=both
 
 When CSKY borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/csky/kernel/vdso/Makefile b/arch/csky/kernel/vdso/Makefile
-index 069ef0b17fe52..3e100e6cf72f4 100644
+index 069ef0b17fe5..3e100e6cf72f 100644
 --- a/arch/csky/kernel/vdso/Makefile
 +++ b/arch/csky/kernel/vdso/Makefile
 @@ -29,7 +29,7 @@ SYSCFLAGS_vdso.so.dbg = $(c_flags)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
@@ -1,7 +1,7 @@
 From 4a38af30d15e57236693ee15f326c0b09637ae0a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:42 +0800
-Subject: [PATCH 076/328] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
+Subject: [PATCH 076/330] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
 
 glibc added support for .gnu.hash in 2006 and .hash has been obsoleted
 far before the first LoongArch CPU was taped.  Using
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/vdso/Makefile b/arch/loongarch/vdso/Makefile
-index fdde1bcd4e266..abaf87c58f9d0 100644
+index fdde1bcd4e26..abaf87c58f9d 100644
 --- a/arch/loongarch/vdso/Makefile
 +++ b/arch/loongarch/vdso/Makefile
 @@ -37,7 +37,7 @@ endif

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
@@ -1,7 +1,7 @@
 From 780d966f54f66518f852c6693f875fd1a3a6ecf6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 077/328] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
+Subject: [PATCH 077/330] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
  page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU
@@ -101,7 +101,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
-index 2070aa12059ce..8a99293914845 100644
+index 2070aa12059c..8a9929391484 100644
 --- a/drivers/gpu/drm/xe/xe_bo.c
 +++ b/drivers/gpu/drm/xe/xe_bo.c
 @@ -1456,9 +1456,9 @@ struct xe_bo *___xe_bo_create_locked(struct xe_device *xe, struct xe_bo *bo,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From fba5146cef00ca1de0fe08608ac48199182510b2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 078/328] FROMLIST: drm/xe/guc: use SZ_4K for alignment
+Subject: [PATCH 078/330] FROMLIST: drm/xe/guc: use SZ_4K for alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66,7 +66,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  6 files changed, 27 insertions(+), 27 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
-index 408365dfe4eed..595873780a577 100644
+index 408365dfe4ee..595873780a57 100644
 --- a/drivers/gpu/drm/xe/xe_guc.c
 +++ b/drivers/gpu/drm/xe/xe_guc.c
 @@ -88,7 +88,7 @@ static u32 guc_ctl_feature_flags(struct xe_guc *guc)
@@ -88,7 +88,7 @@ index 408365dfe4eed..595873780a577 100644
  
  	return flags;
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index bcbbe0d99306f..8225959f30db6 100644
+index bcbbe0d99306..8225959f30db 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -143,17 +143,17 @@ static size_t guc_ads_regset_size(struct xe_guc_ads *ads)
@@ -214,7 +214,7 @@ index bcbbe0d99306f..8225959f30db6 100644
  
  		xe_map_memcpy_to(xe, ads_to_map(ads), offset,
 diff --git a/drivers/gpu/drm/xe/xe_guc_capture.c b/drivers/gpu/drm/xe/xe_guc_capture.c
-index 9095618648bcb..f77d20e9e9a2c 100644
+index 9095618648bc..f77d20e9e9a2 100644
 --- a/drivers/gpu/drm/xe/xe_guc_capture.c
 +++ b/drivers/gpu/drm/xe/xe_guc_capture.c
 @@ -590,8 +590,8 @@ guc_capture_getlistsize(struct xe_guc *guc, u32 owner, u32 type,
@@ -247,7 +247,7 @@ index 9095618648bcb..f77d20e9e9a2c 100644
  
  static int guc_capture_output_size_est(struct xe_guc *guc)
 diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
-index 72ad576fc18eb..a58c58e599122 100644
+index 72ad576fc18e..a58c58e59912 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ct.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ct.c
 @@ -212,7 +212,7 @@ int xe_guc_ct_init(struct xe_guc_ct *ct)
@@ -260,7 +260,7 @@ index 72ad576fc18eb..a58c58e599122 100644
  	ct->g2h_wq = alloc_ordered_workqueue("xe-g2h-wq", WQ_MEM_RECLAIM);
  	if (!ct->g2h_wq)
 diff --git a/drivers/gpu/drm/xe/xe_guc_log.c b/drivers/gpu/drm/xe/xe_guc_log.c
-index 80514a446ba28..2d5fc8be52fd3 100644
+index 80514a446ba2..2d5fc8be52fd 100644
 --- a/drivers/gpu/drm/xe/xe_guc_log.c
 +++ b/drivers/gpu/drm/xe/xe_guc_log.c
 @@ -58,7 +58,7 @@ static size_t guc_log_size(void)
@@ -282,7 +282,7 @@ index 80514a446ba28..2d5fc8be52fd3 100644
  	for (i = GUC_LOG_BUFFER_CRASH_DUMP; i < GUC_LOG_BUFFER_TYPE_MAX; ++i) {
  		if (i == type)
 diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
-index 2276d85926fcb..6f192aef2609e 100644
+index 2276d85926fc..6f192aef2609 100644
 --- a/drivers/gpu/drm/xe/xe_guc_pc.c
 +++ b/drivers/gpu/drm/xe/xe_guc_pc.c
 @@ -1017,7 +1017,7 @@ int xe_guc_pc_start(struct xe_guc_pc *pc)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From b462b49cb7f3d57618221e0662df6b3d9880be7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 079/328] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 079/330] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),
@@ -84,7 +84,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index b732c89816dff..e48bf80d144a1 100644
+index b732c89816df..e48bf80d144a 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -52,7 +52,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From c50b45c7da20c201f5b3d7f1d68e88ce4f1c77c6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 080/328] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 080/330] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 
@@ -94,7 +94,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index fb93345b37706..9defa6db1b774 100644
+index fb93345b3770..9defa6db1b77 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
 @@ -593,7 +593,7 @@ static void emit_pte(struct xe_migrate *m,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From 7e5c8c1a1a4cad7dd7aeca4036c82d95ff30c316 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 081/328] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 081/330] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
-index c059639613f7b..8a017c526942d 100644
+index c059639613f7..8a017c526942 100644
 --- a/drivers/gpu/drm/xe/xe_query.c
 +++ b/drivers/gpu/drm/xe/xe_query.c
 @@ -336,7 +336,7 @@ static int query_config(struct xe_device *xe, struct drm_xe_device_query *query)
@@ -42,7 +42,7 @@ index c059639613f7b..8a017c526942d 100644
  	config->info[DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY] =
  		xe_exec_queue_device_get_max_priority(xe);
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index f62689ca861a4..db7cf904926eb 100644
+index f62689ca861a..db7cf904926e 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -394,7 +394,7 @@ struct drm_xe_query_mem_regions {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 09609e1200abc5763921b9707a633ae53d9c1699 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 4 Mar 2025 14:33:51 +0800
-Subject: [PATCH 082/328] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 082/330] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 124 insertions(+), 32 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/Kconfig b/drivers/gpu/drm/ast/Kconfig
-index da0663542e8a4..ed07ef70072f2 100644
+index da0663542e8a..ed07ef70072f 100644
 --- a/drivers/gpu/drm/ast/Kconfig
 +++ b/drivers/gpu/drm/ast/Kconfig
 @@ -5,6 +5,9 @@ config DRM_AST
@@ -41,7 +41,7 @@ index da0663542e8a4..ed07ef70072f2 100644
  	select I2C_ALGOBIT
  	help
 diff --git a/drivers/gpu/drm/ast/ast_drv.c b/drivers/gpu/drm/ast/ast_drv.c
-index ff3bcdd1cff2a..a0c693844f1e0 100644
+index ff3bcdd1cff2..a0c693844f1e 100644
 --- a/drivers/gpu/drm/ast/ast_drv.c
 +++ b/drivers/gpu/drm/ast/ast_drv.c
 @@ -33,9 +33,12 @@
@@ -113,7 +113,7 @@ index ff3bcdd1cff2a..a0c693844f1e0 100644
  	if (ret)
  		return ret;
 diff --git a/drivers/gpu/drm/ast/ast_drv.h b/drivers/gpu/drm/ast/ast_drv.h
-index 6b4305ac07d4f..3fcf6717ad8a0 100644
+index 6b4305ac07d4..3fcf6717ad8a 100644
 --- a/drivers/gpu/drm/ast/ast_drv.h
 +++ b/drivers/gpu/drm/ast/ast_drv.h
 @@ -29,6 +29,7 @@
@@ -144,7 +144,7 @@ index 6b4305ac07d4f..3fcf6717ad8a0 100644
  	unsigned long size;
  };
 diff --git a/drivers/gpu/drm/ast/ast_mm.c b/drivers/gpu/drm/ast/ast_mm.c
-index 6dfe6d9777d46..588326b7d53ed 100644
+index 6dfe6d9777d4..588326b7d53e 100644
 --- a/drivers/gpu/drm/ast/ast_mm.c
 +++ b/drivers/gpu/drm/ast/ast_mm.c
 @@ -28,6 +28,7 @@
@@ -173,7 +173,7 @@ index 6dfe6d9777d46..588326b7d53ed 100644
  	ast->vram_base = base;
  	ast->vram_size = vram_size;
 diff --git a/drivers/gpu/drm/ast/ast_mode.c b/drivers/gpu/drm/ast/ast_mode.c
-index a29fe1ae803f1..4fc4d9712020b 100644
+index a29fe1ae803f..4fc4d9712020 100644
 --- a/drivers/gpu/drm/ast/ast_mode.c
 +++ b/drivers/gpu/drm/ast/ast_mode.c
 @@ -41,6 +41,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 0b51b6246a93d25badb82ba0f70b7565737ac14b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 083/328] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 083/330] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index ee163940d8407..0fa2a14f84a0b 100644
+index ee163940d840..0fa2a14f84a0 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -504,6 +504,7 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 7779d1fa57b01a02166fa9b3eb41da6493f88b24 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 084/328] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 084/330] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/scsi/lpfc/lpfc_compat.h b/drivers/scsi/lpfc/lpfc_compat.h
-index 43cf46a3a71fe..0cd1e3c82d875 100644
+index 43cf46a3a71f..0cd1e3c82d87 100644
 --- a/drivers/scsi/lpfc/lpfc_compat.h
 +++ b/drivers/scsi/lpfc/lpfc_compat.h
 @@ -91,8 +91,8 @@ lpfc_memcpy_to_slim( void __iomem *dest, void *src, unsigned int bytes)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From 920161c121203bf37d0d08913f18264408bc2479 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 085/328] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 085/330] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 32 insertions(+)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index c89e70df43d82..cc0360e8dd62c 100644
+index c89e70df43d8..cc0360e8dd62 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,6 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 85ccdb322ffa04c7b1376f4d916e59ef88132994 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 086/328] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 086/330] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  9 files changed, 51 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/include/asm/cpu-info.h b/arch/mips/include/asm/cpu-info.h
-index a600670d00e97..d2ea1476aaae8 100644
+index a600670d00e9..d2ea1476aaae 100644
 --- a/arch/mips/include/asm/cpu-info.h
 +++ b/arch/mips/include/asm/cpu-info.h
 @@ -125,7 +125,9 @@ extern void cpu_probe(void);
@@ -62,7 +62,7 @@ index a600670d00e97..d2ea1476aaae8 100644
  struct seq_file;
  struct notifier_block;
 diff --git a/arch/mips/include/asm/mach-loongson64/boot_param.h b/arch/mips/include/asm/mach-loongson64/boot_param.h
-index 3a11ce85762be..943c576220732 100644
+index 3a11ce85762b..943c57622073 100644
 --- a/arch/mips/include/asm/mach-loongson64/boot_param.h
 +++ b/arch/mips/include/asm/mach-loongson64/boot_param.h
 @@ -66,6 +66,7 @@ struct efi_cpuinfo_loongson {
@@ -74,7 +74,7 @@ index 3a11ce85762be..943c576220732 100644
  
  #define MAX_UARTS 64
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index e855a3611d922..3ba2bc06ae778 100644
+index e855a3611d92..3ba2bc06ae77 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -22,6 +22,8 @@ extern spinlock_t rtc_lock;
@@ -87,7 +87,7 @@ index e855a3611d922..3ba2bc06ae778 100644
   * mips_hpt_frequency - must be set if you intend to use an R4k-compatible
   * counter as a timer interrupt source.
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index af7412549e6ea..6934ee44852b4 100644
+index af7412549e6e..6934ee44852b 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1248,32 +1248,44 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)
@@ -180,7 +180,7 @@ index af7412549e6ea..6934ee44852b4 100644
  const char *__elf_base_platform;
  
 diff --git a/arch/mips/kernel/proc.c b/arch/mips/kernel/proc.c
-index 8f0a0001540c7..9b2e85a2a932e 100644
+index 8f0a0001540c..9b2e85a2a932 100644
 --- a/arch/mips/kernel/proc.c
 +++ b/arch/mips/kernel/proc.c
 @@ -15,6 +15,7 @@
@@ -204,7 +204,7 @@ index 8f0a0001540c7..9b2e85a2a932e 100644
  		      cpu_data[n].udelay_val / (500000/HZ),
  		      (cpu_data[n].udelay_val / (5000/HZ)) % 100);
 diff --git a/arch/mips/kernel/time.c b/arch/mips/kernel/time.c
-index ed339d7979f3f..849c6be53b296 100644
+index ed339d7979f3..849c6be53b29 100644
 --- a/arch/mips/kernel/time.c
 +++ b/arch/mips/kernel/time.c
 @@ -120,6 +120,8 @@ EXPORT_SYMBOL(perf_irq);
@@ -217,7 +217,7 @@ index ed339d7979f3f..849c6be53b296 100644
  EXPORT_SYMBOL_GPL(mips_hpt_frequency);
  
 diff --git a/arch/mips/loongson64/env.c b/arch/mips/loongson64/env.c
-index be8d2ad10750f..c15a68c72dd46 100644
+index be8d2ad10750..c15a68c72dd4 100644
 --- a/arch/mips/loongson64/env.c
 +++ b/arch/mips/loongson64/env.c
 @@ -18,6 +18,7 @@
@@ -271,7 +271,7 @@ index be8d2ad10750f..c15a68c72dd46 100644
  	id = readl(HOST_BRIDGE_CONFIG_ADDR);
  	vendor = id & 0xffff;
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 147acd972a07b..69c1e77e6bfc7 100644
+index 147acd972a07..69c1e77e6bfc 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -418,6 +418,7 @@ static void loongson3_init_secondary(void)
@@ -283,7 +283,7 @@ index 147acd972a07b..69c1e77e6bfc7 100644
  
  static void loongson3_smp_finish(void)
 diff --git a/arch/mips/loongson64/smp.h b/arch/mips/loongson64/smp.h
-index 957bde81e0e4e..6112d9d7dd226 100644
+index 957bde81e0e4..6112d9d7dd22 100644
 --- a/arch/mips/loongson64/smp.h
 +++ b/arch/mips/loongson64/smp.h
 @@ -3,6 +3,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 0ea7d5ad8e67fe1deff2ef5d4e80acdacd0f6e89 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 087/328] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 087/330] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six
@@ -54,7 +54,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.c
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 0fa2a14f84a0b..f1c381b2a3278 100644
+index 0fa2a14f84a0..f1c381b2a327 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -28,6 +28,7 @@ config MIPS
@@ -106,7 +106,7 @@ index 0fa2a14f84a0b..f1c381b2a3278 100644
  	  Select this option if you want to run n32 binaries.  These are
  	  64-bit binaries using 32-bit quantities for addressing and certain
 diff --git a/arch/mips/include/asm/abi.h b/arch/mips/include/asm/abi.h
-index dba7f4b6bebfa..6e717a4a13ceb 100644
+index dba7f4b6bebf..6e717a4a13ce 100644
 --- a/arch/mips/include/asm/abi.h
 +++ b/arch/mips/include/asm/abi.h
 @@ -21,6 +21,7 @@ struct mips_abi {
@@ -118,7 +118,7 @@ index dba7f4b6bebfa..6e717a4a13ceb 100644
  	unsigned	off_sc_fpregs;
  	unsigned	off_sc_fpc_csr;
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index ba83d3fb0a848..1c054e3096db8 100644
+index ba83d3fb0a84..1c054e3096db 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,4 +64,14 @@
@@ -137,7 +137,7 @@ index ba83d3fb0a848..1c054e3096db8 100644
 +
  #endif /* _ASM_UNISTD_H */
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index 4abe387549ad2..b501ea16ccd40 100644
+index 4abe387549ad..b501ea16ccd4 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,34 +6,37 @@
@@ -188,7 +188,7 @@ index 4abe387549ad2..b501ea16ccd40 100644
  
  #endif /* _UAPI_ASM_UNISTD_H */
 diff --git a/arch/mips/kernel/Makefile b/arch/mips/kernel/Makefile
-index ecf3278a32f70..5e56641a4e3e0 100644
+index ecf3278a32f7..5e56641a4e3e 100644
 --- a/arch/mips/kernel/Makefile
 +++ b/arch/mips/kernel/Makefile
 @@ -105,6 +105,10 @@ obj-$(CONFIG_HW_PERF_EVENTS)	+= perf_event_mipsxx.o
@@ -204,7 +204,7 @@ index ecf3278a32f70..5e56641a4e3e0 100644
  
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
 new file mode 100644
-index 0000000000000..2248badc3acb6
+index 000000000000..2248badc3acb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -0,0 +1,58 @@
@@ -268,7 +268,7 @@ index 0000000000000..2248badc3acb6
 +__initcall(audit_classes_n32_init);
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
 new file mode 100644
-index 0000000000000..09ae3dbcfecbc
+index 000000000000..09ae3dbcfecb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-native.c
 @@ -0,0 +1,97 @@
@@ -371,7 +371,7 @@ index 0000000000000..09ae3dbcfecbc
 +__initcall(audit_classes_init);
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
 new file mode 100644
-index 0000000000000..e8b9b50f7d267
+index 000000000000..e8b9b50f7d26
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -0,0 +1,60 @@
@@ -436,7 +436,7 @@ index 0000000000000..e8b9b50f7d267
 +
 +__initcall(audit_classes_o32_init);
 diff --git a/arch/mips/kernel/signal.c b/arch/mips/kernel/signal.c
-index 4a10f18a88060..c803c39f5cbe5 100644
+index 4a10f18a8806..c803c39f5cbe 100644
 --- a/arch/mips/kernel/signal.c
 +++ b/arch/mips/kernel/signal.c
 @@ -8,6 +8,7 @@
@@ -472,7 +472,7 @@ index 4a10f18a88060..c803c39f5cbe5 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_n32.c b/arch/mips/kernel/signal_n32.c
-index 139d2596b0d40..fb9ddefae9648 100644
+index 139d2596b0d4..fb9ddefae964 100644
 --- a/arch/mips/kernel/signal_n32.c
 +++ b/arch/mips/kernel/signal_n32.c
 @@ -2,6 +2,7 @@
@@ -498,7 +498,7 @@ index 139d2596b0d40..fb9ddefae9648 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_o32.c b/arch/mips/kernel/signal_o32.c
-index 4f04584596507..ea3f280a18aa0 100644
+index 4f0458459650..ea3f280a18aa 100644
 --- a/arch/mips/kernel/signal_o32.c
 +++ b/arch/mips/kernel/signal_o32.c
 @@ -8,6 +8,7 @@
@@ -524,7 +524,7 @@ index 4f04584596507..ea3f280a18aa0 100644
  	.off_sc_fpregs = offsetof(struct sigcontext32, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext32, sc_fpc_csr),
 diff --git a/include/uapi/linux/audit.h b/include/uapi/linux/audit.h
-index d9a069b4a775e..d8ed5e9b170d5 100644
+index d9a069b4a775..d8ed5e9b170d 100644
 --- a/include/uapi/linux/audit.h
 +++ b/include/uapi/linux/audit.h
 @@ -189,7 +189,11 @@
@@ -553,7 +553,7 @@ index d9a069b4a775e..d8ed5e9b170d5 100644
   * are currently used in an audit field constant understood by the kernel.
   * If you are adding a new #define AUDIT_<whatever>, please ensure that
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index 9c853cde9abe4..079b24df3ba3c 100644
+index 9c853cde9abe..079b24df3ba3 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -189,6 +189,19 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 30c70df6c0c313e7ef732025d37164a5bdcdce32 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 088/328] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 088/330] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index a35dd73117958..95602736a74f5 100644
+index a35dd7311795..95602736a74f 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -22,6 +22,16 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From 473a23bff9fad27611aed78e637d313447234879 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 089/328] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 089/330] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index fbfe0771317ea..448caaff87f36 100644
+index fbfe0771317e..448caaff87f3 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -357,8 +357,10 @@ static int __init early_parse_mem(char *p)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From cc887d23fb203ad6e5628dc89eba10e84fc657cc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 090/328] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 090/330] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 62 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 448caaff87f36..2910588154500 100644
+index 448caaff87f3..291058815450 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -54,6 +54,10 @@ struct cpuinfo_mips cpu_data[NR_CPUS] __read_mostly;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 71069e72e4c867dea22d764f24d602f1efcf3310 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 091/328] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 091/330] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index f1c381b2a3278..e857b79e77d26 100644
+index f1c381b2a327..e857b79e77d2 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -18,6 +18,7 @@ config MIPS
@@ -36,7 +36,7 @@ index f1c381b2a3278..e857b79e77d26 100644
  	select ARCH_USE_BUILTIN_BSWAP
  	select ARCH_USE_CMPXCHG_LOCKREF if 64BIT
 diff --git a/arch/mips/include/asm/pgtable-64.h b/arch/mips/include/asm/pgtable-64.h
-index 6e854bb11f37d..1f2c3e5d0ad43 100644
+index 6e854bb11f37..1f2c3e5d0ad4 100644
 --- a/arch/mips/include/asm/pgtable-64.h
 +++ b/arch/mips/include/asm/pgtable-64.h
 @@ -260,7 +260,7 @@ static inline int pmd_present(pmd_t pmd)
@@ -49,7 +49,7 @@ index 6e854bb11f37d..1f2c3e5d0ad43 100644
  
  	return pmd_val(pmd) != (unsigned long) invalid_pte_table;
 diff --git a/arch/mips/include/asm/pgtable-bits.h b/arch/mips/include/asm/pgtable-bits.h
-index 088623ba7b8b1..9ee6e189d329f 100644
+index 088623ba7b8b..9ee6e189d329 100644
 --- a/arch/mips/include/asm/pgtable-bits.h
 +++ b/arch/mips/include/asm/pgtable-bits.h
 @@ -52,6 +52,9 @@ enum pgtable_bits {
@@ -105,7 +105,7 @@ index 088623ba7b8b1..9ee6e189d329f 100644
  # define _PAGE_SPECIAL		(1 << _PAGE_SPECIAL_SHIFT)
  #else
 diff --git a/arch/mips/include/asm/pgtable.h b/arch/mips/include/asm/pgtable.h
-index c29a551eb0ca8..24d0c4b6b17ad 100644
+index c29a551eb0ca..24d0c4b6b17a 100644
 --- a/arch/mips/include/asm/pgtable.h
 +++ b/arch/mips/include/asm/pgtable.h
 @@ -160,7 +160,7 @@ static inline void pte_clear(struct mm_struct *mm, unsigned long addr, pte_t *pt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From a1277952666cea3f7c06432f46ee428e1cfb854e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 092/328] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 092/330] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/numa.c b/arch/mips/loongson64/numa.c
-index 8388400d052fe..4efe3d50f1f8f 100644
+index 8388400d052f..4efe3d50f1f8 100644
 --- a/arch/mips/loongson64/numa.c
 +++ b/arch/mips/loongson64/numa.c
 @@ -60,7 +60,7 @@ static int __init compute_node_distance(int row, int col)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From 45074a17ce8cfbc686649e54607945f6fec866f0 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 093/328] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 093/330] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+), 15 deletions(-)
 
 diff --git a/arch/mips/mm/tlbex.c b/arch/mips/mm/tlbex.c
-index 69ea54bdc0c36..33f613d6665b8 100644
+index 69ea54bdc0c3..33f613d6665b 100644
 --- a/arch/mips/mm/tlbex.c
 +++ b/arch/mips/mm/tlbex.c
 @@ -676,13 +676,12 @@ static void build_huge_tlb_write_entry(u32 **p, struct uasm_label **l,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 41eb7c563dfb674c5696c160003227ef6e7364f4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 094/328] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 094/330] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index e857b79e77d26..6b38e6da99fd4 100644
+index e857b79e77d2..6b38e6da99fd 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -507,7 +507,6 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From 7a779c3fffbbb478a61829ff2fca6845bafb47d3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 095/328] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 095/330] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/irqchip/irq-loongson-eiointc.c b/drivers/irqchip/irq-loongson-eiointc.c
-index bb79e19dfb590..06b39b0a3ec15 100644
+index bb79e19dfb59..06b39b0a3ec1 100644
 --- a/drivers/irqchip/irq-loongson-eiointc.c
 +++ b/drivers/irqchip/irq-loongson-eiointc.c
 @@ -129,21 +129,46 @@ static void veiointc_set_irq_route(unsigned int vector, unsigned int cpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
@@ -1,7 +1,7 @@
 From b98c9351cd8de32fb08da96d96d03a73d8f40cfd Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 25 Feb 2025 17:24:20 +0800
-Subject: [PATCH 096/328] LOONGSON: LoongArch: Always select
+Subject: [PATCH 096/330] LOONGSON: LoongArch: Always select
  HAVE_VIRT_CPU_ACCOUNTING_GEN
 
 Option HAVE_VIRT_CPU_ACCOUNTING_GEN is selected by default for 64bit
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index ad56d6daa5883..2d13b20f08973 100644
+index ad56d6daa588..2d13b20f0897 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -176,7 +176,7 @@ config LOONGARCH

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
@@ -1,7 +1,7 @@
 From 81ba88b864ad5e44bacb9ff09444b24a835503f4 Mon Sep 17 00:00:00 2001
 From: Yuli Wang <wangyuli@uniontech.com>
 Date: Thu, 6 Feb 2025 14:38:20 +0800
-Subject: [PATCH 097/328] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
+Subject: [PATCH 097/330] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
  Sanitizer)
 
 Select ARCH_HAS_UBSAN in order to allow the user to enable CONFIG_UBSAN
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 2d13b20f08973..b931ef9c60659 100644
+index 2d13b20f0897..b931ef9c6065 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -30,6 +30,7 @@ config LOONGARCH

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
@@ -1,7 +1,7 @@
 From 85502d9c3c1b156f7b8d7cbdd51e71846325098e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 21 Feb 2025 19:32:43 +0800
-Subject: [PATCH 098/328] LOONGSON: LoongArch: vDSO: Make use of the t8
+Subject: [PATCH 098/330] LOONGSON: LoongArch: vDSO: Make use of the t8
  register for vgetrandom-chacha
 
 Make use of the t8 register for vgetrandom-chacha, so we don't need to
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 10 deletions(-)
 
 diff --git a/arch/loongarch/vdso/vgetrandom-chacha.S b/arch/loongarch/vdso/vgetrandom-chacha.S
-index c2733e6c3a8de..c4dd2bab88255 100644
+index c2733e6c3a8d..c4dd2bab8825 100644
 --- a/arch/loongarch/vdso/vgetrandom-chacha.S
 +++ b/arch/loongarch/vdso/vgetrandom-chacha.S
 @@ -58,9 +58,7 @@ SYM_FUNC_START(__arch_chacha20_blocks_nostack)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 3f316724bf9ff8d788067e53ac49fe441411d877 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 099/328] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 099/330] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/loongarch/cpu_hwmon.c
 
 diff --git a/drivers/platform/loongarch/Kconfig b/drivers/platform/loongarch/Kconfig
-index 447528797d07a..b87f51c4e4b66 100644
+index 447528797d07..b87f51c4e4b6 100644
 --- a/drivers/platform/loongarch/Kconfig
 +++ b/drivers/platform/loongarch/Kconfig
 @@ -16,6 +16,14 @@ menuconfig LOONGARCH_PLATFORM_DEVICES
@@ -37,7 +37,7 @@ index 447528797d07a..b87f51c4e4b66 100644
  	tristate "Generic Loongson-3 Laptop Driver"
  	depends on ACPI_EC
 diff --git a/drivers/platform/loongarch/Makefile b/drivers/platform/loongarch/Makefile
-index f43ab03db1a2d..8038291bae3aa 100644
+index f43ab03db1a2..8038291bae3a 100644
 --- a/drivers/platform/loongarch/Makefile
 +++ b/drivers/platform/loongarch/Makefile
 @@ -1 +1,2 @@
@@ -45,7 +45,7 @@ index f43ab03db1a2d..8038291bae3aa 100644
  obj-$(CONFIG_LOONGSON_LAPTOP) += loongson-laptop.o
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
 new file mode 100644
-index 0000000000000..93a05993745aa
+index 000000000000..93a05993745a
 --- /dev/null
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -0,0 +1,194 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From fce05dadaf1eb2da874f595460b7d05244bed38d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 100/328] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 100/330] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:
@@ -43,7 +43,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index 7c5c03f274b95..3ec52765ec416 100644
+index 7c5c03f274b9..3ec52765ec41 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -211,4 +211,4 @@ static __init int sysfb_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 42b873752b46a99d2ac8f32a94cf329fa0daac55 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 101/328] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 101/330] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 11a492f21157f..b1e4155ef31b6 100644
+index 11a492f21157..b1e4155ef31b 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8093,6 +8093,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -33,7 +33,7 @@ index 11a492f21157f..b1e4155ef31b6 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index bc4ab71613a55..1ce165c627a6c 100644
+index bc4ab71613a5..1ce165c627a6 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4919,6 +4919,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -45,7 +45,7 @@ index bc4ab71613a55..1ce165c627a6c 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 8b62f7faa5b99..88e38fb3f3476 100644
+index 8b62f7faa5b9..88e38fb3f347 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -57,7 +57,7 @@ index 8b62f7faa5b99..88e38fb3f3476 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 6c95575ce109f..465859e2fcff9 100644
+index 6c95575ce109..465859e2fcff 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6423,6 +6423,7 @@ int si_irq_process(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 3d268637c6d5bf6c3b8a5aac8a75daba66d4b008 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 102/328] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 102/330] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index 02f9248f7c84d..a5aa73631e310 100644
+index 02f9248f7c84..a5aa73631e31 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -265,6 +265,14 @@ config ARCH_PENSANDO

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From abb78678f10717910e819a42e8faaee67f49662c Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 103/328] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 103/330] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 2a9ca3dbaa0e9..05020db0d436a 100644
+index 2a9ca3dbaa0e..05020db0d436 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -3248,4 +3248,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From 3665718c82db1920ed4c84dba1d48efae6938552 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 104/328] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 104/330] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d29ee6d2ce9a4..1599bda120388 100644
+index d29ee6d2ce9a..1599bda12038 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -2894,6 +2894,12 @@ S:	Maintained
@@ -42,7 +42,7 @@ index d29ee6d2ce9a4..1599bda120388 100644
  R:	cros-qcom-dts-watchers@chromium.org
  F:	arch/arm64/boot/dts/qcom/sc7180*
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 4cc85a36a1ab6..7130ed15f6e0e 100644
+index 4cc85a36a1ab..7130ed15f6e0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -121,6 +121,16 @@ config DWMAC_MESON
@@ -63,7 +63,7 @@ index 4cc85a36a1ab6..7130ed15f6e0e 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index b26f0e79c2b32..9225c4fd850c8 100644
+index b26f0e79c2b3..9225c4fd850c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -76,7 +76,7 @@ index b26f0e79c2b32..9225c4fd850c8 100644
  obj-$(CONFIG_DWMAC_RZN1)	+= dwmac-rzn1.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 0000000000000..db1672deae824
+index 000000000000..db1672deae82
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,229 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From e9afc183ebbc8e89d1bd5cfee498aa493dff1528 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 105/328] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 105/330] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index c660eb933f24b..531a3788aeb76 100644
+index c660eb933f24..531a3788aeb7 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -51,10 +51,10 @@
@@ -38,7 +38,7 @@ index c660eb933f24b..531a3788aeb76 100644
  
  #undef FRAME_FILTER_DEBUG
 diff --git a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
-index 68a7cfcb1d8f3..40088a390f7b3 100644
+index 68a7cfcb1d8f..40088a390f7b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 @@ -200,6 +200,10 @@ static void ndesc_prepare_tx_desc(struct dma_desc *p, int is_fs, int len,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From 99284bc9d1cc7ab74b4ed02e63195fb4fe46d94b Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 106/328] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 106/330] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index db1672deae824..86f491ea569e6 100644
+index db1672deae82..86f491ea569e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -73,14 +73,14 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From fd340327ff81e795395f739d4a6cd67c0cc74df1 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 107/328] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 107/330] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
@@ -113,7 +113,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 86f491ea569e6..a930cea6280b6 100644
+index 86f491ea569e..a930cea6280b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -2,7 +2,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From 30971b1b763140de3d1018a66ea4459778664d60 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 108/328] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 108/330] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 1599bda120388..33ce7ffa1403d 100644
+index 1599bda12038..33ce7ffa1403 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -2894,12 +2894,6 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From eb68fcd0133c1c71c27e63d74cd0061c15d347b8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 109/328] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 109/330] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 16 insertions(+), 22 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 33ce7ffa1403d..11e23589cad27 100644
+index 33ce7ffa1403..11e23589cad2 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -19238,6 +19238,7 @@ ARM/PHYTIUM SOC SUPPORT
@@ -32,7 +32,7 @@ index 33ce7ffa1403d..11e23589cad27 100644
  QAT DRIVER
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index a930cea6280b6..d31b8e870f647 100644
+index a930cea6280b..d31b8e870f64 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -37,8 +37,7 @@ static int phytium_get_mac_mode(struct fwnode_handle *fwnode)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From e295d41e4fb4169212df7c1478de759320cb561e Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 110/328] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 110/330] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d31b8e870f647..6e8e44730bec6 100644
+index d31b8e870f64..6e8e44730bec 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -209,6 +209,7 @@ static struct platform_driver phytium_dwmac_driver = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 1a43e9be228843fc2686d8a076cf143d80e85b6b Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 111/328] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 111/330] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/phytium/phytmac_v2.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 11e23589cad27..5dfbe75ae9e44 100644
+index 11e23589cad2..5dfbe75ae9e4 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -19238,6 +19238,9 @@ ARM/PHYTIUM SOC SUPPORT
@@ -61,7 +61,7 @@ index 11e23589cad27..5dfbe75ae9e44 100644
  
  QAT DRIVER
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 977b42bc1e8c1..5ce336e93b48c 100644
+index 977b42bc1e8c..5ce336e93b48 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -172,6 +172,7 @@ config OA_TC6
@@ -73,7 +73,7 @@ index 977b42bc1e8c1..5ce336e93b48c 100644
  source "drivers/net/ethernet/brocade/Kconfig"
  source "drivers/net/ethernet/qualcomm/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 99fa180dedb80..d29f86067c486 100644
+index 99fa180dedb8..d29f86067c48 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -76,6 +76,7 @@ obj-$(CONFIG_NET_VENDOR_OKI) += oki-semi/
@@ -86,7 +86,7 @@ index 99fa180dedb80..d29f86067c486 100644
  obj-$(CONFIG_NET_VENDOR_REALTEK) += realtek/
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
 new file mode 100644
-index 0000000000000..14a77adbfdc12
+index 000000000000..14a77adbfdc1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -0,0 +1,58 @@
@@ -150,7 +150,7 @@ index 0000000000000..14a77adbfdc12
 +endif # NET_VENDOR_PHYTIUM
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
 new file mode 100644
-index 0000000000000..6e710d4d54b66
+index 000000000000..6e710d4d54b6
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -0,0 +1,17 @@
@@ -173,7 +173,7 @@ index 0000000000000..6e710d4d54b66
 +phytmac-pci-objs := phytmac_pci.o
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
 new file mode 100644
-index 0000000000000..b90e1551499ef
+index 000000000000..b90e1551499e
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -0,0 +1,591 @@
@@ -770,7 +770,7 @@ index 0000000000000..b90e1551499ef
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 new file mode 100644
-index 0000000000000..592d2d9dc6d4b
+index 000000000000..592d2d9dc6d4
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -0,0 +1,544 @@
@@ -1320,7 +1320,7 @@ index 0000000000000..592d2d9dc6d4b
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
 new file mode 100644
-index 0000000000000..b0977f5cae755
+index 000000000000..b0977f5cae75
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -0,0 +1,2236 @@
@@ -3562,7 +3562,7 @@ index 0000000000000..b0977f5cae755
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
 new file mode 100644
-index 0000000000000..fd21bf80f1388
+index 000000000000..fd21bf80f138
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -0,0 +1,318 @@
@@ -3886,7 +3886,7 @@ index 0000000000000..fd21bf80f1388
 +MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
 new file mode 100644
-index 0000000000000..305ff5866e2fe
+index 000000000000..305ff5866e2f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -0,0 +1,255 @@
@@ -4147,7 +4147,7 @@ index 0000000000000..305ff5866e2fe
 +MODULE_ALIAS("platform:phytmac");
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
 new file mode 100644
-index 0000000000000..26b1b75edbde1
+index 000000000000..26b1b75edbde
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -0,0 +1,304 @@
@@ -4457,7 +4457,7 @@ index 0000000000000..26b1b75edbde1
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
 new file mode 100644
-index 0000000000000..72c8b7c674137
+index 000000000000..72c8b7c67413
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -0,0 +1,55 @@
@@ -4518,7 +4518,7 @@ index 0000000000000..72c8b7c674137
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
 new file mode 100644
-index 0000000000000..2d9f67c82050c
+index 000000000000..2d9f67c82050
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -0,0 +1,1370 @@
@@ -5894,7 +5894,7 @@ index 0000000000000..2d9f67c82050c
 +EXPORT_SYMBOL_GPL(phytmac_1p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
 new file mode 100644
-index 0000000000000..6f2b521aaebdb
+index 000000000000..6f2b521aaebd
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -0,0 +1,453 @@
@@ -6353,7 +6353,7 @@ index 0000000000000..6f2b521aaebdb
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
 new file mode 100644
-index 0000000000000..df142aa6797f6
+index 000000000000..df142aa6797f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -0,0 +1,1254 @@
@@ -7613,7 +7613,7 @@ index 0000000000000..df142aa6797f6
 +EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
 new file mode 100644
-index 0000000000000..92e4806ac2c1f
+index 000000000000..92e4806ac2c1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -0,0 +1,362 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From 101839f08f3c59a301622ebab9ea351e67a931c1 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 112/328] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 112/330] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 19 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index b0977f5cae755..da4e067362803 100644
+index b0977f5cae75..da4e06736280 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1508,7 +1508,7 @@ int phytmac_mdio_register(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From d029c0c4c0548e8570fc5053f0cfa6d2e5207c28 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 113/328] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 113/330] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 2d9f67c82050c..79df9a7f981f1 100644
+index 2d9f67c82050..79df9a7f981f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -357,8 +357,11 @@ static int phytmac_init_hw(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From adfd9c9d82e151efe4fde9917247bfd652a401e2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 114/328] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 114/330] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index da4e067362803..c172103a97362 100644
+index da4e06736280..c172103a9736 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1560,6 +1560,7 @@ static void phytmac_validate(struct phylink_config *config,
@@ -30,7 +30,7 @@ index da4e067362803..c172103a97362 100644
  	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
  	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 79df9a7f981f1..ec95c6c79b066 100644
+index 79df9a7f981f..ec95c6c79b06 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -161,6 +161,20 @@ static int phytmac_enable_autoneg(struct phytmac *pdata, int enable)
@@ -105,7 +105,7 @@ index 79df9a7f981f1..ec95c6c79b066 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NSTATUS, PCS_LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 6f2b521aaebdb..d8de2c26cab4b 100644
+index 6f2b521aaebd..d8de2c26cab4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -228,6 +228,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From 0c9bbe29772deaccd94451b20bbf499dfd3edc6f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 115/328] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 115/330] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 74 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c172103a97362..07f8476946bc6 100644
+index c172103a9736..07f8476946bc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -46,6 +46,7 @@ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 3e5931425d6463f4c3d5ed1238e25bc1faee926e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 116/328] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 116/330] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 07f8476946bc6..ca1a03fa35526 100644
+index 07f8476946bc..ca1a03fa3552 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1416,10 +1416,12 @@ void phytmac_pcs_link_up(struct phylink_pcs *pcs, unsigned int mode,
@@ -46,7 +46,7 @@ index 07f8476946bc6..ca1a03fa35526 100644
  		goto reset_hw;
  	}
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index ec95c6c79b066..4a690b6a96cfe 100644
+index ec95c6c79b06..4a690b6a96cf 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -414,7 +414,7 @@ static int phytmac_init_hw(struct phytmac *pdata)
@@ -68,7 +68,7 @@ index ec95c6c79b066..4a690b6a96cfe 100644
  	if (pdata->capacities & PHYTMAC_CAPS_START)
  		PHYTMAC_WRITE(pdata, PHYTMAC_NCTRL,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index d8de2c26cab4b..2cabadfed2f11 100644
+index d8de2c26cab4..2cabadfed2f1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -356,6 +356,14 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From 2f8bfc0405a75f4e73bd69f70f30e5a50affb524 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 117/328] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 117/330] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index ca1a03fa35526..058f9647b8551 100644
+index ca1a03fa3552..058f9647b855 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1843,7 +1843,7 @@ static int phytmac_close(struct net_device *ndev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From 8f476d1831f9a5a18ffe111141292278f5ced8e9 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 118/328] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 118/330] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 19 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 592d2d9dc6d4b..7cddb01802f21 100644
+index 592d2d9dc6d4..7cddb01802f2 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -382,43 +382,32 @@ static int phytmac_get_link_ksettings(struct net_device *ndev,
@@ -88,7 +88,7 @@ index 592d2d9dc6d4b..7cddb01802f21 100644
  
  		ethtool_convert_legacy_u32_to_link_mode(kset->link_modes.supported,
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index fd21bf80f1388..af69329fe06de 100644
+index fd21bf80f138..af69329fe06d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -225,7 +225,7 @@ struct phytmac_data phytmac_1000basex = {
@@ -101,7 +101,7 @@ index fd21bf80f1388..af69329fe06de 100644
  };
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index df142aa6797f6..41e5df41226e9 100644
+index df142aa6797f..41e5df41226e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -842,6 +842,7 @@ static int phytmac_pcs_linkdown(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From bb81253cfd3d3855b86198babeddabf1a842b087 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 119/328] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 119/330] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 26 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 058f9647b8551..28b6dc86f6688 100644
+index 058f9647b855..28b6dc86f668 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1732,12 +1732,6 @@ static int phytmac_open(struct net_device *ndev)
@@ -51,7 +51,7 @@ index 058f9647b8551..28b6dc86f6688 100644
  		dev_dbg(pdata->dev, "probe successfully! Phytium %s at 0x%08lx irq %d (%pM)\n",
  			"MAC", ndev->base_addr, ndev->irq, ndev->dev_addr);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 4a690b6a96cfe..b96547e54d822 100644
+index 4a690b6a96cf..b96547e54d82 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -489,6 +489,15 @@ static int phytmac_set_wake(struct phytmac *pdata, int wake)
@@ -71,7 +71,7 @@ index 4a690b6a96cfe..b96547e54d822 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 2cabadfed2f11..1f49d4ec79a04 100644
+index 2cabadfed2f1..1f49d4ec79a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -140,6 +140,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From caa41f9a3ca929efd3b1210b37761f81c1619d60 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 120/328] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 120/330] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 16 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index b90e1551499ef..33c0fc78415b2 100644
+index b90e1551499e..33c0fc78415b 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -38,7 +38,6 @@
@@ -39,7 +39,7 @@ index b90e1551499ef..33c0fc78415b2 100644
  	void (*restart)(struct phytmac *pdata);
  	int (*tx_complete)(const struct phytmac_dma_desc *desc);
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 28b6dc86f6688..0053412c2632c 100644
+index 28b6dc86f668..0053412c2632 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -793,16 +793,12 @@ static void phytmac_rx_clean(struct phytmac_queue *queue)
@@ -107,7 +107,7 @@ index 28b6dc86f6688..0053412c2632c 100644
  	unsigned int offset, size, count = 0;
  	unsigned int f, nr_frags = skb_shinfo(skb)->nr_frags;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b96547e54d822..b823a07a731b6 100644
+index b96547e54d82..b823a07a731b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -927,22 +927,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From 9adfee3d0dc19140218de2a7cd5e71469a9d7279 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 121/328] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 121/330] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 341 insertions(+), 137 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 33c0fc78415b2..363bc65c72d47 100644
+index 33c0fc78415b..363bc65c72d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -307,6 +307,13 @@ struct phytmac_tx_ts {
@@ -80,7 +80,7 @@ index 33c0fc78415b2..363bc65c72d47 100644
  					  unsigned int index);
  inline struct phytmac_dma_desc *phytmac_get_tx_desc(struct phytmac_queue *queue,
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 0053412c2632c..a2b3ed84e895a 100644
+index 0053412c2632..a2b3ed84e895 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -36,6 +36,8 @@
@@ -715,7 +715,7 @@ index 0053412c2632c..a2b3ed84e895a 100644
  
  	ret = phytmac_phylink_connect(pdata);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b823a07a731b6..9582b587342bb 100644
+index b823a07a731b..9582b587342b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -986,16 +986,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de
@@ -744,7 +744,7 @@ index b823a07a731b6..9582b587342bb 100644
  	.rx_map = phytmac_rx_map_desc,
  	.rx_checksum = phytmac_rx_checksum,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 41e5df41226e9..bcfc8ad68edc1 100644
+index 41e5df41226e..bcfc8ad68edc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -952,16 +952,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From a283b2c09605bc512b9bd56b44d3bb1f60b66226 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 122/328] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 122/330] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index a2b3ed84e895a..72b5a15870a08 100644
+index a2b3ed84e895..72b5a15870a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -298,9 +298,9 @@ static struct net_device_stats *phytmac_get_stats(struct net_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 93f38035d8aad24e0fa006f61f215917c3ed8a1d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 123/328] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 123/330] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 363bc65c72d47..7e6cf22d7b4f7 100644
+index 363bc65c72d4..7e6cf22d7b4f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -37,7 +37,7 @@ index 363bc65c72d47..7e6cf22d7b4f7 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 7cddb01802f21..4f632591142fc 100644
+index 7cddb01802f2..4f632591142f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -2,6 +2,8 @@
@@ -78,7 +78,7 @@ index 7cddb01802f21..4f632591142fc 100644
  
  void phytmac_set_ethtool_ops(struct net_device *ndev)
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 72b5a15870a08..79170097fd830 100644
+index 72b5a15870a0..79170097fd83 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2488,4 +2488,5 @@ MODULE_LICENSE("GPL");
@@ -88,7 +88,7 @@ index 72b5a15870a08..79170097fd830 100644
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index af69329fe06de..60bd296d8f0b6 100644
+index af69329fe06d..60bd296d8f0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -316,3 +316,4 @@ module_pci_driver(phytmac_driver);
@@ -97,7 +97,7 @@ index af69329fe06de..60bd296d8f0b6 100644
  MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 305ff5866e2fe..9390056fdc7a9 100644
+index 305ff5866e2f..9390056fdc7a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -253,3 +253,4 @@ MODULE_LICENSE("GPL");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From d7fc96e6fca8765ea219d304fa90e41b279212fc Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 124/328] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 124/330] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 56 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
+index 7e6cf22d7b4f..6eb1d7d1b829 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -54,7 +54,7 @@ index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
  	void (*clear_tx_desc)(struct phytmac_queue *queue);
  	/* ptp */
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 79170097fd830..d932d011b261f 100644
+index 79170097fd83..d932d011b261 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -442,6 +442,7 @@ static int phytmac_alloc_tx_resource(struct phytmac *pdata)
@@ -133,7 +133,7 @@ index 79170097fd830..d932d011b261f 100644
  		if (offset + frag_len > total_len) {
  			if (unlikely(frag != last_frag)) {
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 9582b587342bb..1d7c2e1759178 100644
+index 9582b587342b..1d7c2e175917 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -940,6 +940,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -191,7 +191,7 @@ index 9582b587342bb..1d7c2e1759178 100644
  	.init_ts_hw = phytmac_ptp_init_hw,
  	.set_time = phytmac_set_time,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 1f49d4ec79a04..32bb129491096 100644
+index 1f49d4ec79a0..32bb12949109 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -374,7 +374,6 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -203,7 +203,7 @@ index 1f49d4ec79a04..32bb129491096 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index bcfc8ad68edc1..25f1ba6c1d6ef 100644
+index bcfc8ad68edc..25f1ba6c1d6e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -934,14 +934,32 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue, u32 index,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From 98c60fe8a7ecb040844f089b62a17da573f9700e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 125/328] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 125/330] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 6eb1d7d1b8293..cb9359c7bd4db 100644
+index 6eb1d7d1b829..cb9359c7bd4d 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -33,7 +33,7 @@ index 6eb1d7d1b8293..cb9359c7bd4db 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index d932d011b261f..732358ea40afe 100644
+index d932d011b261..732358ea40af 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2208,7 +2208,6 @@ static int phytmac_init(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 46425ae808654a7dbd5db5860fad39a8f55ea8f9 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 126/328] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 126/330] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index cb9359c7bd4db..bc0d2670c2f59 100644
+index cb9359c7bd4d..bc0d2670c2f5 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -34,7 +34,7 @@ index cb9359c7bd4db..bc0d2670c2f59 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 4f632591142fc..a97a4c28c04fe 100644
+index 4f632591142f..a97a4c28c04f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -429,7 +429,7 @@ static int phytmac_set_link_ksettings(struct net_device *ndev,
@@ -47,7 +47,7 @@ index 4f632591142fc..a97a4c28c04fe 100644
  	} else {
  		phy_ethtool_set_link_ksettings(ndev, kset);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 1d7c2e1759178..20595aca17834 100644
+index 1d7c2e175917..20595aca1783 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -182,7 +182,7 @@ static int phytmac_mac_linkup(struct phytmac *pdata, phy_interface_t interface,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 808e1cab566feca68f95f2ff70f2fe531843e24c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 127/328] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 127/330] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 23 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index bc0d2670c2f59..a4e0d4e4fa1f3 100644
+index bc0d2670c2f5..a4e0d4e4fa1f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -32,7 +32,7 @@ index bc0d2670c2f59..a4e0d4e4fa1f3 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 732358ea40afe..43c15b8baf0b7 100644
+index 732358ea40af..43c15b8baf0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1726,6 +1726,9 @@ static void phytmac_mac_link_up(struct phylink_config *config,
@@ -62,7 +62,7 @@ index 732358ea40afe..43c15b8baf0b7 100644
  		phylink_set(mask, 10baseT_Half);
  		phylink_set(mask, 10baseT_Full);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 20595aca17834..72a6eeaec3563 100644
+index 20595aca1783..72a6eeaec356 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1078,12 +1078,15 @@ static void phytmac_mac_interface_config(struct phytmac *pdata, unsigned int mod

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 8acac7a55e6b3eb9eedc533dce6337d67fba7431 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 128/328] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 128/330] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index a4e0d4e4fa1f3..df4ec49a08512 100644
+index a4e0d4e4fa1f..df4ec49a0851 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -40,7 +40,7 @@ index a4e0d4e4fa1f3..df4ec49a08512 100644
 +void phytmac_set_bios_wol_enable(struct phytmac *pdata, u32 wol);
  #endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index a97a4c28c04fe..306a9934deabd 100644
+index a97a4c28c04f..306a9934deab 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -131,6 +131,7 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
@@ -52,7 +52,7 @@ index a97a4c28c04fe..306a9934deabd 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 43c15b8baf0b7..fd29c647e2775 100644
+index 43c15b8baf0b..fd29c647e277 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -111,6 +111,8 @@ static int phytmac_set_mac_address(struct net_device *netdev, void *addr)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From cd227e288caeea667da01a63b9291aaa798cbbc0 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 129/328] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 129/330] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 306a9934deabd..8bba0af005be8 100644
+index 306a9934deab..8bba0af005be 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -116,7 +116,8 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From f8550ec3dd7f4c5f490487f4bfc1de1b6177d701 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 130/328] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 130/330] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 8bba0af005be8..e1698fa10b095 100644
+index 8bba0af005be..e1698fa10b09 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -89,23 +89,23 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From cee58bd142ba90da8a94faca9660d3b1bcba4183 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 131/328] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 131/330] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/fpu-probe.c b/arch/mips/kernel/fpu-probe.c
-index 6bf3f19b1c335..404d753120582 100644
+index 6bf3f19b1c33..404d75312058 100644
 --- a/arch/mips/kernel/fpu-probe.c
 +++ b/arch/mips/kernel/fpu-probe.c
 @@ -144,7 +144,12 @@ static void cpu_set_fpu_2008(struct cpuinfo_mips *c)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 168948244cdf0973129d9181026258c258fa6f9d Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 132/328] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 132/330] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/hwmon-aaeon.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 4cbaba15d86ef..eb18733ea9997 100644
+index 4cbaba15d86e..eb18733ea999 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -38,6 +38,18 @@ config HWMON_DEBUG_CHIP
@@ -49,7 +49,7 @@ index 4cbaba15d86ef..eb18733ea9997 100644
  	tristate "Abit uGuru (rev 1 & 2)"
  	depends on (X86 && DMI) || COMPILE_TEST && HAS_IOPORT
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index b7ef0f0562d37..f8c822a542999 100644
+index b7ef0f0562d3..f8c822a54299 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -15,6 +15,7 @@ obj-$(CONFIG_SENSORS_HP_WMI)	+= hp-wmi-sensors.o
@@ -62,7 +62,7 @@ index b7ef0f0562d37..f8c822a542999 100644
  obj-$(CONFIG_SENSORS_W83773G)	+= w83773g.o
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
 new file mode 100644
-index 0000000000000..146da10309bbb
+index 000000000000..146da10309bb
 --- /dev/null
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -0,0 +1,568 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 6f6dd127608f1d5c74cbaf5bd47693c9d57fc32b Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 133/328] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 133/330] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/leds/leds-aaeon.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 8859e8fe292a9..fa52352fe2b04 100644
+index 8859e8fe292a..fa52352fe2b0 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -65,6 +65,18 @@ config LEDS_88PM860X
@@ -49,7 +49,7 @@ index 8859e8fe292a9..fa52352fe2b04 100644
  	tristate "LED support for Panasonic AN30259A"
  	depends on LEDS_CLASS && I2C && OF
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 6ad52e219ec6d..a88d151bf192c 100644
+index 6ad52e219ec6..a88d151bf192 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -9,6 +9,7 @@ obj-$(CONFIG_LEDS_TRIGGERS)		+= led-triggers.o
@@ -62,7 +62,7 @@ index 6ad52e219ec6d..a88d151bf192c 100644
  obj-$(CONFIG_LEDS_AN30259A)		+= leds-an30259a.o
 diff --git a/drivers/leds/leds-aaeon.c b/drivers/leds/leds-aaeon.c
 new file mode 100644
-index 0000000000000..10090a4bff654
+index 000000000000..10090a4bff65
 --- /dev/null
 +++ b/drivers/leds/leds-aaeon.c
 @@ -0,0 +1,142 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 077ff3d5dfa8db788cb680e84d037b4ab67f2e0e Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 134/328] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 134/330] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-aaeon.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 98b4d1633b258..5d2439f32dee6 100644
+index 98b4d1633b25..5d2439f32dee 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1655,6 +1655,18 @@ endmenu
@@ -49,7 +49,7 @@ index 98b4d1633b258..5d2439f32dee6 100644
  	tristate "AMD 8111 GPIO driver"
  	depends on X86 || COMPILE_TEST
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index af3ba4d81b583..b03c53f6de196 100644
+index af3ba4d81b58..b03c53f6de19 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -24,6 +24,7 @@ obj-$(CONFIG_GPIO_104_IDI_48)		+= gpio-104-idi-48.o
@@ -62,7 +62,7 @@ index af3ba4d81b583..b03c53f6de196 100644
  obj-$(CONFIG_GPIO_ADP5585)		+= gpio-adp5585.o
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
 new file mode 100644
-index 0000000000000..3183c45dd1946
+index 000000000000..3183c45dd194
 --- /dev/null
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -0,0 +1,205 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From b5e7ed1dd64122c82284bd1cb95f5d008152838e Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 135/328] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 135/330] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/mfd/mfd-aaeon.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 5dfbe75ae9e44..84496a35b7da1 100644
+index 5dfbe75ae9e4..84496a35b7da 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -199,6 +199,18 @@ M:	Linus Walleij <linus.walleij@linaro.org>
@@ -60,7 +60,7 @@ index 5dfbe75ae9e44..84496a35b7da1 100644
  L:	linux-api@vger.kernel.org
  F:	include/linux/syscalls.h
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index cbfc9f66d64ef..422dcf0004ffc 100644
+index cbfc9f66d64e..422dcf0004ff 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2269,6 +2269,18 @@ config MFD_QCOM_PM8008
@@ -83,7 +83,7 @@ index cbfc9f66d64ef..422dcf0004ffc 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index c7b114f028707..62c32422e1787 100644
+index c7b114f02870..62c32422e178 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -287,6 +287,7 @@ obj-$(CONFIG_MFD_INTEL_M10_BMC_PMCI)   += intel-m10-bmc-pmci.o
@@ -96,7 +96,7 @@ index c7b114f028707..62c32422e1787 100644
  
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
 new file mode 100644
-index 0000000000000..9d2efde53cad3
+index 000000000000..9d2efde53cad
 --- /dev/null
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -0,0 +1,77 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From 40d024d402d898ca44f92230e8e54cd2311aceb7 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 136/328] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 136/330] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
-index 9d2efde53cad3..74211d01ce656 100644
+index 9d2efde53cad..74211d01ce65 100644
 --- a/drivers/mfd/mfd-aaeon.c
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -16,12 +16,17 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From a13ff5fea24b19d907fead019e9fc791fae0006e Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 137/328] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 137/330] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
-index 146da10309bbb..80bf4d1224f3f 100644
+index 146da10309bb..80bf4d1224f3 100644
 --- a/drivers/hwmon/hwmon-aaeon.c
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -49,7 +49,7 @@ static ssize_t name_show(struct device *dev, struct device_attribute *devattr,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
@@ -1,7 +1,7 @@
 From 71951cfd1924bf32de8af948f9963553030fc6ec Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:31 +0800
-Subject: [PATCH 138/328] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
+Subject: [PATCH 138/330] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
  support for MPAM
 
 maillist inclusion
@@ -51,7 +51,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/arm64/include/asm/mpam.h b/arch/arm64/include/asm/mpam.h
 new file mode 100644
-index 0000000000000..a4a969be233ab
+index 000000000000..a4a969be233a
 --- /dev/null
 +++ b/arch/arm64/include/asm/mpam.h
 @@ -0,0 +1,76 @@
@@ -132,7 +132,7 @@ index 0000000000000..a4a969be233ab
 +
 +#endif /* __ASM__MPAM_H */
 diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
-index 59e9dca1595d3..0e7c3f479d078 100644
+index 59e9dca1595d..0e7c3f479d07 100644
 --- a/arch/arm64/kernel/cpufeature.c
 +++ b/arch/arm64/kernel/cpufeature.c
 @@ -85,6 +85,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
@@ -1,7 +1,7 @@
 From 6b5840472214a1e4d24d74a374f295267a84e7ff Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:32 +0800
-Subject: [PATCH 139/328] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
+Subject: [PATCH 139/330] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
  guest accesses to the MPAM registers
 
 maillist inclusion
@@ -76,7 +76,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/include/asm/mpam.h b/arch/arm64/include/asm/mpam.h
-index a4a969be233ab..576102d510add 100644
+index a4a969be233a..576102d510ad 100644
 --- a/arch/arm64/include/asm/mpam.h
 +++ b/arch/arm64/include/asm/mpam.h
 @@ -51,7 +51,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
@@ -1,7 +1,7 @@
 From cf423f8ca305420e0034f10f5bb96bbff14b5c94 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Sat, 1 Jun 2024 14:38:28 +0800
-Subject: [PATCH 140/328] BACKPORT: OPENEULER: arm64: cpufeature: Both the
+Subject: [PATCH 140/330] BACKPORT: OPENEULER: arm64: cpufeature: Both the
  major and the minor version numbers need to be checked
 
 hulk inclusion
@@ -33,7 +33,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 18 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index e0e4478f5fb52..e04e783d46388 100644
+index e0e4478f5fb5..e04e783d4638 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -620,6 +620,13 @@ static inline bool id_aa64pfr0_mpam(u64 pfr0)
@@ -51,7 +51,7 @@ index e0e4478f5fb52..e04e783d46388 100644
  {
  	u32 val = cpuid_feature_extract_unsigned_field(pfr1, ID_AA64PFR1_EL1_MTE_SHIFT);
 diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
-index 0e7c3f479d078..b62752a65bc72 100644
+index 0e7c3f479d07..b62752a65bc7 100644
 --- a/arch/arm64/kernel/cpufeature.c
 +++ b/arch/arm64/kernel/cpufeature.c
 @@ -1197,7 +1197,8 @@ void __init init_cpu_features(struct cpuinfo_arm64 *info)
@@ -96,7 +96,7 @@ index 0e7c3f479d078..b62752a65bc72 100644
  	{
  		.desc = "Memory Partitioning And Monitoring Virtualisation",
 diff --git a/arch/arm64/kernel/cpuinfo.c b/arch/arm64/kernel/cpuinfo.c
-index 285d7d5383420..b058db3570604 100644
+index 285d7d538342..b058db357060 100644
 --- a/arch/arm64/kernel/cpuinfo.c
 +++ b/arch/arm64/kernel/cpuinfo.c
 @@ -494,7 +494,8 @@ static void __cpuinfo_store_cpu(struct cpuinfo_arm64 *info)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
@@ -1,7 +1,7 @@
 From 8a130bd3bebd8a92948f36129b2f1f517083da6c Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:52 +0800
-Subject: [PATCH 141/328] BACKPORT: OPENEULER: Revert "arm64: head.S:
+Subject: [PATCH 141/330] BACKPORT: OPENEULER: Revert "arm64: head.S:
  Initialise MPAM EL2 registers and disable traps"
 
 hulk inclusion
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 14 deletions(-)
 
 diff --git a/arch/arm64/include/asm/el2_setup.h b/arch/arm64/include/asm/el2_setup.h
-index ebceaae3c749b..8db261d42ad84 100644
+index ebceaae3c749..8db261d42ad8 100644
 --- a/arch/arm64/include/asm/el2_setup.h
 +++ b/arch/arm64/include/asm/el2_setup.h
 @@ -294,19 +294,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
@@ -1,7 +1,7 @@
 From f19a40a584b555954c20d66cf08bb85a47cc5c0d Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:53 +0800
-Subject: [PATCH 142/328] BACKPORT: OPENEULER: arm64/mpam: Check
+Subject: [PATCH 142/330] BACKPORT: OPENEULER: arm64/mpam: Check
  mpam_detect_is_enabled() before accessing MPAM registers
 
 hulk inclusion
@@ -32,7 +32,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 47 insertions(+), 6 deletions(-)
 
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index e04e783d46388..f42920422e8b0 100644
+index e04e783d4638..f42920422e8b 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -873,6 +873,15 @@ static __always_inline bool system_supports_mpam_hcr(void)
@@ -52,7 +52,7 @@ index e04e783d46388..f42920422e8b0 100644
  bool try_emulate_mrs(struct pt_regs *regs, u32 isn);
  
 diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
-index b62752a65bc72..a812d7c385ed9 100644
+index b62752a65bc7..a812d7c385ed 100644
 --- a/arch/arm64/kernel/cpufeature.c
 +++ b/arch/arm64/kernel/cpufeature.c
 @@ -1197,8 +1197,9 @@ void __init init_cpu_features(struct cpuinfo_arm64 *info)
@@ -130,7 +130,7 @@ index b62752a65bc72..a812d7c385ed9 100644
  	 * Access by the kernel (at EL1) should use the reserved PARTID
  	 * which is configured unrestricted. This avoids priority-inversion
 diff --git a/arch/arm64/kernel/cpuinfo.c b/arch/arm64/kernel/cpuinfo.c
-index b058db3570604..b9e0f439f9e37 100644
+index b058db357060..b9e0f439f9e3 100644
 --- a/arch/arm64/kernel/cpuinfo.c
 +++ b/arch/arm64/kernel/cpuinfo.c
 @@ -494,8 +494,9 @@ static void __cpuinfo_store_cpu(struct cpuinfo_arm64 *info)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
@@ -1,7 +1,7 @@
 From 05a50e582a73d7d69d67f28d3757ff6801945fd9 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Thu, 26 Sep 2024 17:28:18 +0800
-Subject: [PATCH 143/328] OPENEULER: arm64/mpam: Fix redefined reference of
+Subject: [PATCH 143/330] OPENEULER: arm64/mpam: Fix redefined reference of
  'mpam_detect_is_enabled'
 
 hulk inclusion
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 deletions(-)
 
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index f42920422e8b0..dfac038c9bf5b 100644
+index f42920422e8b..dfac038c9bf5 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -873,14 +873,7 @@ static __always_inline bool system_supports_mpam_hcr(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From e2fb4ba2f76865beb127d15b1ca762ef55c201c7 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 144/328] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 144/330] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6e8e44730bec6..078e3ee52bdcb 100644
+index 6e8e44730bec..078e3ee52bdc 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -198,6 +198,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From ca348c19a878853ce1f81692f946050ff2dee33e Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 145/328] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 145/330] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index b9340f8bd1828..5f20f574ebebf 100644
+index b9340f8bd182..5f20f574ebeb 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1988,13 +1988,18 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From ebc38b82cd3fcd0296aceb48f73b0c5a7dc752df Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 146/328] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 146/330] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 078e3ee52bdcb..ba86b6bb047dc 100644
+index 078e3ee52bdc..ba86b6bb047d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -68,6 +68,21 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
 From a763675674a043c0e1dfd8a80b3cbab20ec7b4d4 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 147/328] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 147/330] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses
@@ -69,7 +69,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 
 diff --git a/arch/loongarch/configs/loongson3_defconfig b/arch/loongarch/configs/loongson3_defconfig
-index 73c77500ac467..8961acf005475 100644
+index 73c77500ac46..8961acf00547 100644
 --- a/arch/loongarch/configs/loongson3_defconfig
 +++ b/arch/loongarch/configs/loongson3_defconfig
 @@ -593,6 +593,7 @@ CONFIG_IXGBE=y
@@ -81,7 +81,7 @@ index 73c77500ac467..8961acf005475 100644
  # CONFIG_NET_VENDOR_ROCKER is not set
  # CONFIG_NET_VENDOR_SAMSUNG is not set
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 5ce336e93b48c..4b809622b9b06 100644
+index 5ce336e93b48..4b809622b9b0 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -125,6 +125,7 @@ source "drivers/net/ethernet/mellanox/Kconfig"
@@ -93,7 +93,7 @@ index 5ce336e93b48c..4b809622b9b06 100644
  source "drivers/net/ethernet/microsoft/Kconfig"
  source "drivers/net/ethernet/moxa/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index d29f86067c486..302bca5c5f858 100644
+index d29f86067c48..302bca5c5f85 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -62,6 +62,7 @@ obj-$(CONFIG_NET_VENDOR_MELLANOX) += mellanox/
@@ -106,7 +106,7 @@ index d29f86067c486..302bca5c5f858 100644
  obj-$(CONFIG_NET_VENDOR_MYRI) += myricom/
 diff --git a/drivers/net/ethernet/motorcomm/Kconfig b/drivers/net/ethernet/motorcomm/Kconfig
 new file mode 100644
-index 0000000000000..2d058928936f0
+index 000000000000..2d058928936f
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Kconfig
 @@ -0,0 +1,27 @@
@@ -139,7 +139,7 @@ index 0000000000000..2d058928936f0
 +endif # NET_VENDOR_MOTORCOMM
 diff --git a/drivers/net/ethernet/motorcomm/Makefile b/drivers/net/ethernet/motorcomm/Makefile
 new file mode 100644
-index 0000000000000..af0a439d54a16
+index 000000000000..af0a439d54a1
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Makefile
 @@ -0,0 +1,4 @@
@@ -149,7 +149,7 @@ index 0000000000000..af0a439d54a16
 +obj-$(CONFIG_YT6801) += yt6801/
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/Makefile b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 new file mode 100644
-index 0000000000000..93b5c4510eb05
+index 000000000000..93b5c4510eb0
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 @@ -0,0 +1,15 @@
@@ -170,7 +170,7 @@ index 0000000000000..93b5c4510eb05
 +	fuxi-gmac-debugfs.o
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 new file mode 100644
-index 0000000000000..24282f8e22303
+index 000000000000..24282f8e2230
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 @@ -0,0 +1,15 @@
@@ -192,7 +192,7 @@ index 0000000000000..24282f8e22303
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 new file mode 100644
-index 0000000000000..ae4ca3d59ac4c
+index 000000000000..ae4ca3d59ac4
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 @@ -0,0 +1,1344 @@
@@ -1543,7 +1543,7 @@ index 0000000000000..ae4ca3d59ac4c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 new file mode 100644
-index 0000000000000..fa0446958719c
+index 000000000000..fa0446958719
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 @@ -0,0 +1,25 @@
@@ -1575,7 +1575,7 @@ index 0000000000000..fa0446958719c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 new file mode 100644
-index 0000000000000..63cbf948cbfa2
+index 000000000000..63cbf948cbfa
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 @@ -0,0 +1,939 @@
@@ -2520,7 +2520,7 @@ index 0000000000000..63cbf948cbfa2
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 new file mode 100644
-index 0000000000000..4596d91b6e282
+index 000000000000..4596d91b6e28
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 @@ -0,0 +1,787 @@
@@ -3313,7 +3313,7 @@ index 0000000000000..4596d91b6e282
 +#endif /* HAVE_XLGMAC_DEBUG_FS */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 new file mode 100644
-index 0000000000000..969d84eb44e2a
+index 000000000000..969d84eb44e2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 @@ -0,0 +1,601 @@
@@ -3920,7 +3920,7 @@ index 0000000000000..969d84eb44e2a
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 new file mode 100644
-index 0000000000000..05aa42f90ad83
+index 000000000000..05aa42f90ad8
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -0,0 +1,1114 @@
@@ -5040,7 +5040,7 @@ index 0000000000000..05aa42f90ad83
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 new file mode 100644
-index 0000000000000..0517968365d74
+index 000000000000..0517968365d7
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 @@ -0,0 +1,6256 @@
@@ -11302,7 +11302,7 @@ index 0000000000000..0517968365d74
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 new file mode 100644
-index 0000000000000..b8734efb36426
+index 000000000000..b8734efb3642
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 @@ -0,0 +1,2329 @@
@@ -13637,7 +13637,7 @@ index 0000000000000..b8734efb36426
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 new file mode 100644
-index 0000000000000..f6f8f4f6a5e9b
+index 000000000000..f6f8f4f6a5e9
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 @@ -0,0 +1,250 @@
@@ -13893,7 +13893,7 @@ index 0000000000000..f6f8f4f6a5e9b
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 new file mode 100644
-index 0000000000000..88066a110f410
+index 000000000000..88066a110f41
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 @@ -0,0 +1,256 @@
@@ -14155,7 +14155,7 @@ index 0000000000000..88066a110f410
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 new file mode 100644
-index 0000000000000..65d6288e6869a
+index 000000000000..65d6288e6869
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 @@ -0,0 +1,1894 @@
@@ -16055,7 +16055,7 @@ index 0000000000000..65d6288e6869a
 +#endif /* __FUXI_GMAC_REG_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 new file mode 100644
-index 0000000000000..ea01ebdadc4e3
+index 000000000000..ea01ebdadc4e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 @@ -0,0 +1,934 @@
@@ -16995,7 +16995,7 @@ index 0000000000000..ea01ebdadc4e3
 +#endif /* __FUXI_GMAC_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 new file mode 100644
-index 0000000000000..1a40267e1fa2e
+index 000000000000..1a40267e1fa2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 @@ -0,0 +1,515 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
@@ -1,7 +1,7 @@
 From 2dcc89ca969cb25d48e19e22597bfde888e78c9a Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:51:08 +0800
-Subject: [PATCH 148/328] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
+Subject: [PATCH 148/330] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
  of the number of packages
 
 Signed-off-by: wanghongliang <wanghongliang@loongson.cn>
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/topology.h b/arch/loongarch/include/asm/topology.h
-index 50273c9187d02..f36bb0e7074e5 100644
+index 50273c9187d0..f36bb0e7074e 100644
 --- a/arch/loongarch/include/asm/topology.h
 +++ b/arch/loongarch/include/asm/topology.h
 @@ -30,10 +30,14 @@ void numa_set_distance(int from, int to, int distance);
@@ -37,7 +37,7 @@ index 50273c9187d02..f36bb0e7074e5 100644
  
  #include <asm-generic/topology.h>
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 90cb3ca96f085..4e3e2692b4d95 100644
+index 90cb3ca96f08..4e3e2692b4d9 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -127,6 +127,7 @@ static void __init parse_cpu_table(const struct dmi_header *dm)
@@ -49,7 +49,7 @@ index 90cb3ca96f085..4e3e2692b4d95 100644
  	pr_info("CpuClock = %llu\n", cpu_clock_freq);
  }
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 4b24589c0b565..25885da7d9cd5 100644
+index 4b24589c0b56..25885da7d9cd 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -76,6 +76,9 @@ static const char *ipi_types[NR_IPI] __tracepoint_string = {
@@ -63,7 +63,7 @@ index 4b24589c0b565..25885da7d9cd5 100644
  {
  	unsigned int cpu, i;
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
-index 93a05993745aa..57e771f39781e 100644
+index 93a05993745a..57e771f39781 100644
 --- a/drivers/platform/loongarch/cpu_hwmon.c
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -154,8 +154,7 @@ static int __init loongson_hwmon_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
@@ -1,7 +1,7 @@
 From 9784e806980106c96afff9372d920434625236be Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 149/328] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
+Subject: [PATCH 149/330] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
  devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 31 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 82b21e34c545e..1c22112e71bf8 100644
+index 82b21e34c545..1c22112e71bf 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -401,6 +401,36 @@ static void quirk_tigerpoint_bm_sts(struct pci_dev *dev)
@@ -65,7 +65,7 @@ index 82b21e34c545e..1c22112e71bf8 100644
  static void quirk_nopcipci(struct pci_dev *dev)
  {
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index 8e028620642f3..142d815054c2e 100644
+index 8e028620642f..142d815054c2 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -247,6 +247,7 @@ enum pci_dev_flags {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
 From 9013e5d6dabeb2c56536a15d09a5999edf7a20b8 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 150/328] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 150/330] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 18 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
-index 05aa42f90ad83..d0989eac966ac 100644
+index 05aa42f90ad8..d0989eac966a 100644
 --- a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -262,8 +262,8 @@ static void fxgmac_get_reta(struct fxgmac_pdata *pdata, u32 *indir)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From fc44fe6aac194b5854be87d00deaf758edaae460 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 151/328] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 151/330] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index ba86b6bb047dc..eea8421955134 100644
+index ba86b6bb047d..eea842195513 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From ab6f83bc3debb13ac92bfcb0024a74ec36b1a981 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 152/328] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 152/330] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 9390056fdc7a9..1bba9cfed53c7 100644
+index 9390056fdc7a..1bba9cfed53c 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -14,6 +14,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From 53d182d3be5f88721eaa6db1b9b643b0fbe3b414 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 153/328] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 153/330] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 12 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index fd29c647e2775..964ef68e06ce9 100644
+index fd29c647e277..964ef68e06ce 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1599,7 +1599,7 @@ static int phytmac_phylink_connect(struct phytmac *pdata)
@@ -59,7 +59,7 @@ index fd29c647e2775..964ef68e06ce9 100644
  	struct net_device *ndev = pdata->ndev;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 1bba9cfed53c7..28f280d178a7b 100644
+index 1bba9cfed53c..28f280d178a7 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,7 +77,6 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)
@@ -71,7 +71,7 @@ index 1bba9cfed53c7..28f280d178a7b 100644
  	struct phytmac *pdata;
  	int ret, i;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 25f1ba6c1d6ef..a157957d80bf0 100644
+index 25f1ba6c1d6e..a157957d80bf 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -60,7 +60,7 @@ static int phytmac_msg_send(struct phytmac *pdata, u16 cmd_id,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From 9a5d19c3a34673e2ecdd277cbbe71aa1d37b0a68 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 154/328] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 154/330] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 28f280d178a7b..7b068a54dcb4d 100644
+index 28f280d178a7..7b068a54dcb4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,6 +77,7 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From 685d70d27d4b6a862e91dcc7e74094347fde11b8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 155/328] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 155/330] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 65 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 964ef68e06ce9..73502cb34cc64 100644
+index 964ef68e06ce..73502cb34cc6 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1803,72 +1803,7 @@ static void phytmac_pcs_get_state(struct phylink_config *config,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 6f2b3a07c787d6b07cf46a29986d67fcc852d0d5 Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 156/328] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 156/330] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 51c6aa26d8285..b33a0882d671e 100644
+index 51c6aa26d828..b33a0882d671 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -317,7 +317,7 @@ &gmac {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From 13da2583cd07a7e43ad05f5b46bf350b2aec0f2c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 157/328] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 157/330] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 31 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index 5f997becdbaa2..9a9929424513a 100644
+index 5f997becdbaa..9a9929424513 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -1702,9 +1702,21 @@ mwifiex_pcie_send_boot_cmd(struct mwifiex_adapter *adapter, struct sk_buff *skb)
@@ -65,7 +65,7 @@ index 5f997becdbaa2..9a9929424513a 100644
  	mwifiex_write_reg(adapter, reg->rx_rdptr, card->rxbd_rdptr | tx_wrap);
  }
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index dd6d21f1dbfd7..f46b06f8d6435 100644
+index dd6d21f1dbfd..f46b06f8d643 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -13,7 +13,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -158,7 +158,7 @@ index dd6d21f1dbfd7..f46b06f8d6435 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index d6ff964aec5bf..5d30ae39d65ec 100644
+index d6ff964aec5b..5d30ae39d65e 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -4,6 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From cfe49cf9f25128b3c5e4cf4fefe9113f424b0165 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 158/328] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 158/330] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 27 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index 9a9929424513a..2273e30297766 100644
+index 9a9929424513..2273e3029776 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -377,6 +377,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
@@ -49,7 +49,7 @@ index 9a9929424513a..2273e30297766 100644
  }
  
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index f46b06f8d6435..99b024ecbadea 100644
+index f46b06f8d643..99b024ecbade 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -14,7 +14,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -143,7 +143,7 @@ index f46b06f8d6435..99b024ecbadea 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index 5d30ae39d65ec..c14eb56eb9118 100644
+index 5d30ae39d65e..c14eb56eb911 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -5,6 +5,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
 From 356d6d007e6efa5917fedeb156cd2df3c81e55f8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 159/328] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 159/330] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index b15f3ed767c53..c314adde36a12 100644
+index b15f3ed767c5..c314adde36a1 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -66,6 +66,7 @@ static struct usb_driver btusb_driver;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 22f9eda5983ec390719b63dc384ecf2e998390b1 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 160/328] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 160/330] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 2 insertions(+)
 
 diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
-index bc40b940ae214..45fbd856d4162 100644
+index bc40b940ae21..45fbd856d416 100644
 --- a/drivers/misc/mei/hw-me-regs.h
 +++ b/drivers/misc/mei/hw-me-regs.h
 @@ -92,6 +92,7 @@
@@ -26,7 +26,7 @@ index bc40b940ae214..45fbd856d4162 100644
  
  #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
 diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
-index 3f9c60b579ae4..853a677533333 100644
+index 3f9c60b579ae..853a67753333 100644
 --- a/drivers/misc/mei/pci-me.c
 +++ b/drivers/misc/mei/pci-me.c
 @@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
@@ -1,7 +1,7 @@
 From 06723144dea3c8113dbf17cf04674fe0fa1ffe82 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 161/328] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
+Subject: [PATCH 161/330] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
 Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 580d24dd4edd9..93c18f862e6c9 100644
+index 580d24dd4edd..93c18f862e6c 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -39,6 +39,11 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
@@ -1,7 +1,7 @@
 From bbf3a842012e288fb965ac49f01f746e8fba6372 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 162/328] BACKPORT: SURFACE: hid: Add support for Intel Precise
+Subject: [PATCH 162/330] BACKPORT: SURFACE: hid: Add support for Intel Precise
  Touch and Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268
@@ -71,7 +71,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hid/ipts/thread.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 76be97c5fc2ff..0d1446b45c366 100644
+index 76be97c5fc2f..0d1446b45c36 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1402,6 +1402,8 @@ source "drivers/hid/surface-hid/Kconfig"
@@ -84,7 +84,7 @@ index 76be97c5fc2ff..0d1446b45c366 100644
  
  # USB support may be used with HID disabled
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index c7ecfbb3e2280..7b2939c8a4776 100644
+index c7ecfbb3e228..7b2939c8a477 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -173,3 +173,5 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
@@ -95,7 +95,7 @@ index c7ecfbb3e2280..7b2939c8a4776 100644
 +obj-$(CONFIG_HID_IPTS)          += ipts/
 diff --git a/drivers/hid/ipts/Kconfig b/drivers/hid/ipts/Kconfig
 new file mode 100644
-index 0000000000000..297401bd388dd
+index 000000000000..297401bd388d
 --- /dev/null
 +++ b/drivers/hid/ipts/Kconfig
 @@ -0,0 +1,14 @@
@@ -115,7 +115,7 @@ index 0000000000000..297401bd388dd
 +	  module will be called ipts.
 diff --git a/drivers/hid/ipts/Makefile b/drivers/hid/ipts/Makefile
 new file mode 100644
-index 0000000000000..883896f68e6ad
+index 000000000000..883896f68e6a
 --- /dev/null
 +++ b/drivers/hid/ipts/Makefile
 @@ -0,0 +1,16 @@
@@ -137,7 +137,7 @@ index 0000000000000..883896f68e6ad
 +ipts-objs += thread.o
 diff --git a/drivers/hid/ipts/cmd.c b/drivers/hid/ipts/cmd.c
 new file mode 100644
-index 0000000000000..63a4934bbc5fa
+index 000000000000..63a4934bbc5f
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.c
 @@ -0,0 +1,61 @@
@@ -204,7 +204,7 @@ index 0000000000000..63a4934bbc5fa
 +}
 diff --git a/drivers/hid/ipts/cmd.h b/drivers/hid/ipts/cmd.h
 new file mode 100644
-index 0000000000000..2b4079075b642
+index 000000000000..2b4079075b64
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.h
 @@ -0,0 +1,60 @@
@@ -270,7 +270,7 @@ index 0000000000000..2b4079075b642
 +#endif /* IPTS_CMD_H */
 diff --git a/drivers/hid/ipts/context.h b/drivers/hid/ipts/context.h
 new file mode 100644
-index 0000000000000..ba33259f1f7c5
+index 000000000000..ba33259f1f7c
 --- /dev/null
 +++ b/drivers/hid/ipts/context.h
 @@ -0,0 +1,52 @@
@@ -328,7 +328,7 @@ index 0000000000000..ba33259f1f7c5
 +#endif /* IPTS_CONTEXT_H */
 diff --git a/drivers/hid/ipts/control.c b/drivers/hid/ipts/control.c
 new file mode 100644
-index 0000000000000..5360842d260ba
+index 000000000000..5360842d260b
 --- /dev/null
 +++ b/drivers/hid/ipts/control.c
 @@ -0,0 +1,486 @@
@@ -820,7 +820,7 @@ index 0000000000000..5360842d260ba
 +}
 diff --git a/drivers/hid/ipts/control.h b/drivers/hid/ipts/control.h
 new file mode 100644
-index 0000000000000..26629c5144edb
+index 000000000000..26629c5144ed
 --- /dev/null
 +++ b/drivers/hid/ipts/control.h
 @@ -0,0 +1,126 @@
@@ -952,7 +952,7 @@ index 0000000000000..26629c5144edb
 +#endif /* IPTS_CONTROL_H */
 diff --git a/drivers/hid/ipts/desc.h b/drivers/hid/ipts/desc.h
 new file mode 100644
-index 0000000000000..307438c7c80cd
+index 000000000000..307438c7c80c
 --- /dev/null
 +++ b/drivers/hid/ipts/desc.h
 @@ -0,0 +1,80 @@
@@ -1038,7 +1038,7 @@ index 0000000000000..307438c7c80cd
 +#endif /* IPTS_DESC_H */
 diff --git a/drivers/hid/ipts/eds1.c b/drivers/hid/ipts/eds1.c
 new file mode 100644
-index 0000000000000..7b9f54388a9f6
+index 000000000000..7b9f54388a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.c
 @@ -0,0 +1,104 @@
@@ -1148,7 +1148,7 @@ index 0000000000000..7b9f54388a9f6
 +}
 diff --git a/drivers/hid/ipts/eds1.h b/drivers/hid/ipts/eds1.h
 new file mode 100644
-index 0000000000000..eeeb6575e3e89
+index 000000000000..eeeb6575e3e8
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.h
 @@ -0,0 +1,35 @@
@@ -1189,7 +1189,7 @@ index 0000000000000..eeeb6575e3e89
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/eds2.c b/drivers/hid/ipts/eds2.c
 new file mode 100644
-index 0000000000000..639940794615d
+index 000000000000..639940794615
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.c
 @@ -0,0 +1,145 @@
@@ -1340,7 +1340,7 @@ index 0000000000000..639940794615d
 +}
 diff --git a/drivers/hid/ipts/eds2.h b/drivers/hid/ipts/eds2.h
 new file mode 100644
-index 0000000000000..064e3716907ab
+index 000000000000..064e3716907a
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.h
 @@ -0,0 +1,35 @@
@@ -1381,7 +1381,7 @@ index 0000000000000..064e3716907ab
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/hid.c b/drivers/hid/ipts/hid.c
 new file mode 100644
-index 0000000000000..e34a1a4f9fa77
+index 000000000000..e34a1a4f9fa7
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.c
 @@ -0,0 +1,225 @@
@@ -1612,7 +1612,7 @@ index 0000000000000..e34a1a4f9fa77
 +}
 diff --git a/drivers/hid/ipts/hid.h b/drivers/hid/ipts/hid.h
 new file mode 100644
-index 0000000000000..1ebe77447903a
+index 000000000000..1ebe77447903
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.h
 @@ -0,0 +1,24 @@
@@ -1642,7 +1642,7 @@ index 0000000000000..1ebe77447903a
 +#endif /* IPTS_HID_H */
 diff --git a/drivers/hid/ipts/main.c b/drivers/hid/ipts/main.c
 new file mode 100644
-index 0000000000000..fb5b5c13ee3ea
+index 000000000000..fb5b5c13ee3e
 --- /dev/null
 +++ b/drivers/hid/ipts/main.c
 @@ -0,0 +1,126 @@
@@ -1774,7 +1774,7 @@ index 0000000000000..fb5b5c13ee3ea
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/ipts/mei.c b/drivers/hid/ipts/mei.c
 new file mode 100644
-index 0000000000000..1e0395ceae4a4
+index 000000000000..1e0395ceae4a
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.c
 @@ -0,0 +1,188 @@
@@ -1968,7 +1968,7 @@ index 0000000000000..1e0395ceae4a4
 +}
 diff --git a/drivers/hid/ipts/mei.h b/drivers/hid/ipts/mei.h
 new file mode 100644
-index 0000000000000..973bade6b0fdd
+index 000000000000..973bade6b0fd
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.h
 @@ -0,0 +1,66 @@
@@ -2040,7 +2040,7 @@ index 0000000000000..973bade6b0fdd
 +#endif /* IPTS_MEI_H */
 diff --git a/drivers/hid/ipts/receiver.c b/drivers/hid/ipts/receiver.c
 new file mode 100644
-index 0000000000000..977724c728c3e
+index 000000000000..977724c728c3
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.c
 @@ -0,0 +1,251 @@
@@ -2297,7 +2297,7 @@ index 0000000000000..977724c728c3e
 +}
 diff --git a/drivers/hid/ipts/receiver.h b/drivers/hid/ipts/receiver.h
 new file mode 100644
-index 0000000000000..3de7da62d40c1
+index 000000000000..3de7da62d40c
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.h
 @@ -0,0 +1,16 @@
@@ -2319,7 +2319,7 @@ index 0000000000000..3de7da62d40c1
 +#endif /* IPTS_RECEIVER_H */
 diff --git a/drivers/hid/ipts/resources.c b/drivers/hid/ipts/resources.c
 new file mode 100644
-index 0000000000000..cc14653b2a9f5
+index 000000000000..cc14653b2a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.c
 @@ -0,0 +1,131 @@
@@ -2456,7 +2456,7 @@ index 0000000000000..cc14653b2a9f5
 +}
 diff --git a/drivers/hid/ipts/resources.h b/drivers/hid/ipts/resources.h
 new file mode 100644
-index 0000000000000..2068e13285f0e
+index 000000000000..2068e13285f0
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.h
 @@ -0,0 +1,41 @@
@@ -2503,7 +2503,7 @@ index 0000000000000..2068e13285f0e
 +#endif /* IPTS_RESOURCES_H */
 diff --git a/drivers/hid/ipts/spec-data.h b/drivers/hid/ipts/spec-data.h
 new file mode 100644
-index 0000000000000..e8dd98895a7ee
+index 000000000000..e8dd98895a7e
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-data.h
 @@ -0,0 +1,100 @@
@@ -2609,7 +2609,7 @@ index 0000000000000..e8dd98895a7ee
 +#endif /* IPTS_SPEC_DATA_H */
 diff --git a/drivers/hid/ipts/spec-device.h b/drivers/hid/ipts/spec-device.h
 new file mode 100644
-index 0000000000000..41845f9d90257
+index 000000000000..41845f9d9025
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-device.h
 @@ -0,0 +1,290 @@
@@ -2905,7 +2905,7 @@ index 0000000000000..41845f9d90257
 +#endif /* IPTS_SPEC_DEVICE_H */
 diff --git a/drivers/hid/ipts/spec-hid.h b/drivers/hid/ipts/spec-hid.h
 new file mode 100644
-index 0000000000000..5a58d4a0a610f
+index 000000000000..5a58d4a0a610
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-hid.h
 @@ -0,0 +1,34 @@
@@ -2945,7 +2945,7 @@ index 0000000000000..5a58d4a0a610f
 +#endif /* IPTS_SPEC_HID_H */
 diff --git a/drivers/hid/ipts/thread.c b/drivers/hid/ipts/thread.c
 new file mode 100644
-index 0000000000000..355e92bea26f8
+index 000000000000..355e92bea26f
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.c
 @@ -0,0 +1,84 @@
@@ -3035,7 +3035,7 @@ index 0000000000000..355e92bea26f8
 +}
 diff --git a/drivers/hid/ipts/thread.h b/drivers/hid/ipts/thread.h
 new file mode 100644
-index 0000000000000..1f966b8b32c45
+index 000000000000..1f966b8b32c4
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.h
 @@ -0,0 +1,59 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From c3ef21e91e5d96e2003463b893b72721ddf8dcd5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 163/328] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 163/330] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index e50887a6d22c2..4ce18f21a141e 100644
+index e50887a6d22c..4ce18f21a141 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From 0b58ee13b0d93de2da2f9e68ddbffd1b7375096d Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 164/328] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 164/330] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 4ce18f21a141e..f5e4d52bd2eb3 100644
+index 4ce18f21a141..f5e4d52bd2eb 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -78,6 +78,7 @@ MODULE_LICENSE("GPL");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 9030cec67f107596b725eb0b230cd0c88c3240b3 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 165/328] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 165/330] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices
@@ -61,7 +61,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index 9f4efa8f75a61..7c7ef03cafa45 100644
+index 9f4efa8f75a6..7c7ef03cafa4 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2204,6 +2204,9 @@ static acpi_status acpi_bus_check_add_2(acpi_handle handle, u32 lvl_not_used,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
@@ -1,7 +1,7 @@
 From 4e88dab36bf6a544f9d3bc9cfe6cb4895efb5e05 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 166/328] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
+Subject: [PATCH 166/330] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
  for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 93c18f862e6c9..1acf7906fbb9b 100644
+index 93c18f862e6c..1acf7906fbb9 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -44,6 +44,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 8db60838d17327798f02760bddd72c427e7d8031 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 167/328] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 167/330] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 81ac4c6919630..f453c90430429 100644
+index 81ac4c691963..f453c9043042 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -46,6 +46,13 @@ static int tps68470_chip_init(struct device *dev, struct regmap *regmap)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 958394e7d4f1048ec13bfe516bb7b5ae3f655daa Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 168/328] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 168/330] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/ov7251.c b/drivers/media/i2c/ov7251.c
-index 3226888d77e9c..3bfe45b764f7a 100644
+index 3226888d77e9..3bfe45b764f7 100644
 --- a/drivers/media/i2c/ov7251.c
 +++ b/drivers/media/i2c/ov7251.c
 @@ -1053,7 +1053,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From 43c31271c01945cf7cdf561f9611d284d62f9268 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 169/328] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 169/330] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
-index ee884a8221fbd..4f6bafd900eee 100644
+index ee884a8221fb..4f6bafd900ee 100644
 --- a/drivers/media/v4l2-core/v4l2-async.c
 +++ b/drivers/media/v4l2-core/v4l2-async.c
 @@ -799,6 +799,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
@@ -35,7 +35,7 @@ index ee884a8221fbd..4f6bafd900eee 100644
  	 * No reference taken. The reference is held by the device (struct
  	 * v4l2_subdev.dev), and async sub-device does not exist independently
 diff --git a/drivers/media/v4l2-core/v4l2-fwnode.c b/drivers/media/v4l2-core/v4l2-fwnode.c
-index cb153ce42c45d..f11b499e14bba 100644
+index cb153ce42c45..f11b499e14bb 100644
 --- a/drivers/media/v4l2-core/v4l2-fwnode.c
 +++ b/drivers/media/v4l2-core/v4l2-fwnode.c
 @@ -1260,10 +1260,6 @@ int v4l2_async_register_subdev_sensor(struct v4l2_subdev *sd)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From 94ae8441e5ddb1c6bd6a237e0c61de081db22006 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 170/328] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 170/330] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index f453c90430429..b8ad6b413e8b4 100644
+index f453c9043042..b8ad6b413e8b 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -17,7 +17,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From 90ab9ce2ddb644248283f924a175ccac0582c644 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 171/328] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 171/330] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/include/linux/mfd/tps68470.h b/include/linux/mfd/tps68470.h
-index 7807fa329db00..2d2abb25b944f 100644
+index 7807fa329db0..2d2abb25b944 100644
 --- a/include/linux/mfd/tps68470.h
 +++ b/include/linux/mfd/tps68470.h
 @@ -34,6 +34,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From c7ab17c3f14bee6886225816bcba06af6ed6f96c Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 172/328] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 172/330] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/leds/leds-tps68470.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index fa52352fe2b04..9353ff643ee6c 100644
+index fa52352fe2b0..9353ff643ee6 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -998,6 +998,18 @@ config LEDS_TPS6105X
@@ -47,7 +47,7 @@ index fa52352fe2b04..9353ff643ee6c 100644
  	tristate "LED support for SGI Octane machines"
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index a88d151bf192c..051b9ac254d3d 100644
+index a88d151bf192..051b9ac254d3 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -92,6 +92,7 @@ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
@@ -60,7 +60,7 @@ index a88d151bf192c..051b9ac254d3d 100644
  obj-$(CONFIG_LEDS_WM831X_STATUS)	+= leds-wm831x-status.o
 diff --git a/drivers/leds/leds-tps68470.c b/drivers/leds/leds-tps68470.c
 new file mode 100644
-index 0000000000000..35aeb5db89c8f
+index 000000000000..35aeb5db89c8
 --- /dev/null
 +++ b/drivers/leds/leds-tps68470.c
 @@ -0,0 +1,185 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From f32ccd3a5993fe8a8c9e82237296b2ff16ca0369 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 173/328] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 173/330] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
-index c626ed845928c..0094cfda57ea8 100644
+index c626ed845928..0094cfda57ea 100644
 --- a/drivers/media/i2c/dw9719.c
 +++ b/drivers/media/i2c/dw9719.c
 @@ -82,6 +82,9 @@ static int dw9719_power_up(struct dw9719_device *dw9719)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
@@ -1,7 +1,7 @@
 From d97849d79f0a62183972f0a16fd647ad36072384 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Mon, 16 Sep 2024 05:55:58 -0400
-Subject: [PATCH 174/328] FROMEXT:
+Subject: [PATCH 174/330] FROMEXT:
  more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -130,7 +130,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 511 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 42e6a40876ea4..c813af849d8d0 100644
+index 42e6a40876ea..c813af849d8d 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -155,9 +155,8 @@ config MPENTIUM4
@@ -576,7 +576,7 @@ index 42e6a40876ea4..c813af849d8d0 100644
  #
  # P6_NOPs are a relatively minor optimization that require a family >=
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 5b773b34768d1..5f57fd8750c6c 100644
+index 5b773b34768d..5f57fd8750c6 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -182,15 +182,98 @@ else
@@ -682,7 +682,7 @@ index 5b773b34768d1..5f57fd8750c6c 100644
  
          KBUILD_CFLAGS += -mno-red-zone
 diff --git a/arch/x86/include/asm/vermagic.h b/arch/x86/include/asm/vermagic.h
-index 75884d2cdec37..2fdae271f47fe 100644
+index 75884d2cdec3..2fdae271f47f 100644
 --- a/arch/x86/include/asm/vermagic.h
 +++ b/arch/x86/include/asm/vermagic.h
 @@ -17,6 +17,56 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
@@ -1,7 +1,7 @@
 From c33f22b5dcd11d97f2da51242f110e5cbeb63df4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 18 Dec 2024 12:31:33 +0800
-Subject: [PATCH 175/328] FROMEXT: cjktty-6.9.patch
+Subject: [PATCH 175/330] FROMEXT: cjktty-6.9.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 lib/fonts/font_cjk_32x32.h
 
 diff --git a/drivers/tty/vt/selection.c b/drivers/tty/vt/selection.c
-index 791e2f1f7c0b6..b615c568ba9d0 100644
+index 791e2f1f7c0b..b615c568ba9d 100644
 --- a/drivers/tty/vt/selection.c
 +++ b/drivers/tty/vt/selection.c
 @@ -243,6 +243,8 @@ static int vc_selection_store_chars(struct vc_data *vc, bool unicode)
@@ -48,7 +48,7 @@ index 791e2f1f7c0b6..b615c568ba9d0 100644
  	vc_sel.buf_len = bp - vc_sel.buffer;
  
 diff --git a/drivers/tty/vt/vt.c b/drivers/tty/vt/vt.c
-index be5564ed8c018..92282f43b6634 100644
+index be5564ed8c01..92282f43b663 100644
 --- a/drivers/tty/vt/vt.c
 +++ b/drivers/tty/vt/vt.c
 @@ -302,6 +302,14 @@ static void con_putc(struct vc_data *vc, u16 ca, unsigned int y, unsigned int x)
@@ -677,7 +677,7 @@ index be5564ed8c018..92282f43b6634 100644
  		c |= 0x100;
  	return c;
 diff --git a/drivers/video/fbdev/core/bitblit.c b/drivers/video/fbdev/core/bitblit.c
-index f9475c14f7339..5c039c47589cf 100644
+index f9475c14f733..5c039c47589c 100644
 --- a/drivers/video/fbdev/core/bitblit.c
 +++ b/drivers/video/fbdev/core/bitblit.c
 @@ -16,6 +16,7 @@
@@ -770,7 +770,7 @@ index f9475c14f7339..5c039c47589cf 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
-index 07d127110ca4c..bba58806f5d59 100644
+index 07d127110ca4..bba58806f5d5 100644
 --- a/drivers/video/fbdev/core/fbcon.c
 +++ b/drivers/video/fbdev/core/fbcon.c
 @@ -1070,7 +1070,7 @@ static void fbcon_init(struct vc_data *vc, bool init)
@@ -852,7 +852,7 @@ index 07d127110ca4c..bba58806f5d59 100644
  
  	updatescrollmode(p, info, vc);
 diff --git a/drivers/video/fbdev/core/fbcon.h b/drivers/video/fbdev/core/fbcon.h
-index 4d97e6d8a16a2..c53b83de80875 100644
+index 4d97e6d8a16a..c53b83de8087 100644
 --- a/drivers/video/fbdev/core/fbcon.h
 +++ b/drivers/video/fbdev/core/fbcon.h
 @@ -82,10 +82,12 @@ struct fbcon_ops {
@@ -869,7 +869,7 @@ index 4d97e6d8a16a2..c53b83de80875 100644
      /*
       *  Attribute Decoding
 diff --git a/drivers/video/fbdev/core/fbcon_ccw.c b/drivers/video/fbdev/core/fbcon_ccw.c
-index 89ef4ba7e8672..ba76f80617e12 100644
+index 89ef4ba7e867..ba76f80617e1 100644
 --- a/drivers/video/fbdev/core/fbcon_ccw.c
 +++ b/drivers/video/fbdev/core/fbcon_ccw.c
 @@ -18,6 +18,8 @@
@@ -900,7 +900,7 @@ index 89ef4ba7e8672..ba76f80617e12 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_cw.c b/drivers/video/fbdev/core/fbcon_cw.c
-index b9dac7940fb77..f2711c7faf059 100644
+index b9dac7940fb7..f2711c7faf05 100644
 --- a/drivers/video/fbdev/core/fbcon_cw.c
 +++ b/drivers/video/fbdev/core/fbcon_cw.c
 @@ -18,6 +18,8 @@
@@ -931,7 +931,7 @@ index b9dac7940fb77..f2711c7faf059 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_rotate.c b/drivers/video/fbdev/core/fbcon_rotate.c
-index ec3c883400f7b..d549b0880862e 100644
+index ec3c883400f7..d549b0880862 100644
 --- a/drivers/video/fbdev/core/fbcon_rotate.c
 +++ b/drivers/video/fbdev/core/fbcon_rotate.c
 @@ -14,10 +14,74 @@
@@ -1038,7 +1038,7 @@ index ec3c883400f7b..d549b0880862e 100644
  	return err;
  }
 diff --git a/drivers/video/fbdev/core/fbcon_ud.c b/drivers/video/fbdev/core/fbcon_ud.c
-index 0af7913a2abdc..e2da1f6340809 100644
+index 0af7913a2abd..e2da1f634080 100644
 --- a/drivers/video/fbdev/core/fbcon_ud.c
 +++ b/drivers/video/fbdev/core/fbcon_ud.c
 @@ -18,6 +18,8 @@
@@ -1078,7 +1078,7 @@ index 0af7913a2abdc..e2da1f6340809 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/include/linux/font.h b/include/linux/font.h
-index 81caffd51bb49..c073140557d74 100644
+index 81caffd51bb4..c073140557d7 100644
 --- a/include/linux/font.h
 +++ b/include/linux/font.h
 @@ -35,6 +35,8 @@ struct font_desc {
@@ -1102,7 +1102,7 @@ index 81caffd51bb49..c073140557d74 100644
  /* Find a font with a specific name */
  
 diff --git a/lib/fonts/Kconfig b/lib/fonts/Kconfig
-index ae59b5b4e225e..dd7ab91926b74 100644
+index ae59b5b4e225..dd7ab91926b7 100644
 --- a/lib/fonts/Kconfig
 +++ b/lib/fonts/Kconfig
 @@ -128,6 +128,26 @@ config FONT_6x8
@@ -1142,7 +1142,7 @@ index ae59b5b4e225e..dd7ab91926b74 100644
  
  endif # FONT_SUPPORT
 diff --git a/lib/fonts/Makefile b/lib/fonts/Makefile
-index e16f68492174a..3e1091d15bbb7 100644
+index e16f68492174..3e1091d15bbb 100644
 --- a/lib/fonts/Makefile
 +++ b/lib/fonts/Makefile
 @@ -16,6 +16,8 @@ font-objs-$(CONFIG_FONT_MINI_4x6)  += font_mini_4x6.o
@@ -1156,7 +1156,7 @@ index e16f68492174a..3e1091d15bbb7 100644
  
 diff --git a/lib/fonts/font_cjk_16x16.c b/lib/fonts/font_cjk_16x16.c
 new file mode 100644
-index 0000000000000..a0c56bd9f65b2
+index 000000000000..a0c56bd9f65b
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.c
 @@ -0,0 +1,27 @@
@@ -1189,7 +1189,7 @@ index 0000000000000..a0c56bd9f65b2
 +};
 diff --git a/lib/fonts/font_cjk_16x16.h b/lib/fonts/font_cjk_16x16.h
 new file mode 100644
-index 0000000000000..54e7e0db4a5e7
+index 000000000000..54e7e0db4a5e
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.h
 @@ -0,0 +1,196609 @@
@@ -197804,7 +197804,7 @@ index 0000000000000..54e7e0db4a5e7
 +0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 diff --git a/lib/fonts/font_cjk_32x32.c b/lib/fonts/font_cjk_32x32.c
 new file mode 100644
-index 0000000000000..88ba3f2783f54
+index 000000000000..88ba3f2783f5
 --- /dev/null
 +++ b/lib/fonts/font_cjk_32x32.c
 @@ -0,0 +1,27 @@
@@ -197837,9 +197837,9 @@ index 0000000000000..88ba3f2783f54
 +};
 diff --git a/lib/fonts/font_cjk_32x32.h b/lib/fonts/font_cjk_32x32.h
 new file mode 100644
-index 0000000000000..e69de29bb2d1d
+index 000000000000..e69de29bb2d1
 diff --git a/lib/fonts/fonts.c b/lib/fonts/fonts.c
-index 47e34950b665c..9e3ac0d00f49c 100644
+index 47e34950b665..9e3ac0d00f49 100644
 --- a/lib/fonts/fonts.c
 +++ b/lib/fonts/fonts.c
 @@ -60,6 +60,12 @@ static const struct font_desc *fonts[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
@@ -1,7 +1,7 @@
 From 87f84446b5d7d6da3729e692a149466e3ce3b916 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 13 Sep 2024 17:30:35 +0300
-Subject: [PATCH 176/328] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
+Subject: [PATCH 176/330] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
  clock ratio and scrambling support
 
 Enable use of HDMI 2.0 display modes, e.g. 4K@60Hz, by permitting TMDS
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 120 insertions(+), 23 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
-index b281cabfe992e..dae5486fa3774 100644
+index b281cabfe992..dae5486fa377 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
 @@ -18,6 +18,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From f5f19fc3e5504b7f23b92158f8566e1c4dbf159b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 177/328] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 177/330] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index e4ce33e69a48b..fd8ba060e4156 100644
+index e4ce33e69a48..fd8ba060e415 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -617,13 +617,8 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
@@ -53,7 +53,7 @@ index e4ce33e69a48b..fd8ba060e4156 100644
  module_param_named(cik_support, amdgpu_cik_support, int, 0444);
  #endif
 diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
-index 267f082bc430a..3ffe9f539683f 100644
+index 267f082bc430..3ffe9f539683 100644
 --- a/drivers/gpu/drm/radeon/radeon_drv.c
 +++ b/drivers/gpu/drm/radeon/radeon_drv.c
 @@ -240,12 +240,12 @@ module_param_named(uvd, radeon_uvd, int, 0444);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From c7ec140e0dfa07f284cb20e7df30ce9c50209709 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 178/328] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 178/330] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
-index 84745b2453abe..e728f6c55768b 100644
+index 84745b2453ab..e728f6c55768 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 @@ -2122,6 +2122,13 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -47,7 +47,7 @@ index 84745b2453abe..e728f6c55768b 100644
  	/* Then send the real EOP event down the pipe. */
  	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
-index 6a025438f9d04..4d71377d7b1c3 100644
+index 6a025438f9d0..4d71377d7b1c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 @@ -6169,6 +6169,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -73,7 +73,7 @@ index 6a025438f9d04..4d71377d7b1c3 100644
  	/* Then send the real EOP event down the pipe:
  	 * EVENT_WRITE_EOP - flush caches, send int */
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index b1e4155ef31b6..f20fd5ae6c45c 100644
+index b1e4155ef31b..f20fd5ae6c45 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From 2e13e81ad47a5e4c98083411c5ab76dcd173a0e4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 179/328] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 179/330] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index eea8421955134..ea37d120113d1 100644
+index eea842195513..ea37d120113d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 6e00d4698cff537e482d1d4d2737914a94233cd4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 180/328] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 180/330] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index e1698fa10b095..d28690ca5c0fa 100644
+index e1698fa10b09..d28690ca5c0f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -180,7 +180,7 @@ static int phytmac_set_ringparam(struct net_device *ndev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From b9a6c81a1e96324d6ef389b50853dcfa429e68cb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 181/328] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 181/330] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 7b068a54dcb4d..b1fa7478a676d 100644
+index 7b068a54dcb4..b1fa7478a676 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -204,14 +204,12 @@ static int phytmac_plat_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 41214eedc7567556bd33532ffbbcf540e6d32166 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 182/328] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 182/330] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index 98e75df8b1582..439e6ce0c818d 100644
+index 98e75df8b158..439e6ce0c818 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -790,6 +790,10 @@ &usb_host0_xhci {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 97e46141d4793f7ee67ddb3a852181a148c294a2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 183/328] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 183/330] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 48dcc8381ea75..a62ab2f0766f0 100644
+index 48dcc8381ea7..a62ab2f0766f 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 787985c7978fec8443b9ed4c373e38e34928f7ed Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 184/328] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 184/330] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index de21e72759eeb..a4f0ea213d1d6 100644
+index de21e72759ee..a4f0ea213d1d 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -98,6 +98,23 @@ static void __init init_screen_info(void)
@@ -67,7 +67,7 @@ index de21e72759eeb..a4f0ea213d1d6 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index aed901c57fb43..86d37a447eec1 100644
+index aed901c57fb4..86d37a447eec 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -79,7 +79,7 @@ index aed901c57fb43..86d37a447eec1 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  		mem_end = mem_start + mem_size;
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index 3782d0a187d1f..8bea96492ef21 100644
+index 3782d0a187d1..8bea96492ef2 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From 8dbac38f55108d71a181ca11f37dc44ad5f154a1 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 185/328] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 185/330] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index f9dcaa60033d9..76836e5622e67 100644
+index f9dcaa60033d..76836e5622e6 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -79,3 +79,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -45,7 +45,7 @@ index f9dcaa60033d9..76836e5622e67 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index a4f0ea213d1d6..c5493c8a17ffe 100644
+index a4f0ea213d1d..c5493c8a17ff 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -67,7 +67,7 @@ index a4f0ea213d1d6..c5493c8a17ffe 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 0000000000000..30c01c8b22a0a
+index 000000000000..30c01c8b22a0
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -370,7 +370,7 @@ index 0000000000000..30c01c8b22a0a
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 0000000000000..6d3a36ebaab71
+index 000000000000..6d3a36ebaab7
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -393,7 +393,7 @@ index 0000000000000..6d3a36ebaab71
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 86d37a447eec1..b24b3db96018d 100644
+index 86d37a447eec..b24b3db96018 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -415,7 +415,7 @@ index 86d37a447eec1..b24b3db96018d 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 84fe7f8548209..2633620c1246a 100644
+index 84fe7f854820..2633620c1246 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -26,6 +26,8 @@
@@ -436,7 +436,7 @@ index 84fe7f8548209..2633620c1246a 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 4e3e2692b4d95..66209f3cc253a 100644
+index 4e3e2692b4d9..66209f3cc253 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -457,7 +457,7 @@ index 4e3e2692b4d95..66209f3cc253a 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 25885da7d9cd5..da510eac05650 100644
+index 25885da7d9cd..da510eac0565 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -36,6 +36,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From d964087fa24f4f1590b9ec91b79240a7214b3b2f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 186/328] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 186/330] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 313f66f7913af..ba78288a26e3f 100644
+index 313f66f7913a..ba78288a26e3 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -45,6 +45,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -37,7 +37,7 @@ index 313f66f7913af..ba78288a26e3f 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0a..841d8db85a3cb 100644
+index 30c01c8b22a0..841d8db85a3c 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -381,7 +381,7 @@ index 30c01c8b22a0a..841d8db85a3cb 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index 2295abbecd14f..f79c4a44036b9 100644
+index 2295abbecd14..f79c4a44036b 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -693,6 +693,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -401,7 +401,7 @@ index 2295abbecd14f..f79c4a44036b9 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 4e495b29c640f..73cafb48c0713 100644
+index 4e495b29c640..73cafb48c071 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -773,6 +773,16 @@ int acpi_get_local_u64_address(acpi_handle handle, u64 *addr);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From 99eaab192f2473b56f07a8c55e0759a9d1afc924 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 187/328] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 187/330] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index ba78288a26e3f..c954d15d0a47c 100644
+index ba78288a26e3..c954d15d0a47 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -49,6 +49,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -44,7 +44,7 @@ index ba78288a26e3f..c954d15d0a47c 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 841d8db85a3cb..7043bfd0399d6 100644
+index 841d8db85a3c..7043bfd0399d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -85,7 +85,7 @@ index 841d8db85a3cb..7043bfd0399d6 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index d0b6a024daaec..307874be36da3 100644
+index d0b6a024daae..307874be36da 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -909,6 +909,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -97,7 +97,7 @@ index d0b6a024daaec..307874be36da3 100644
  				acpi_pci_root_remap_iospace(&device->fwnode,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d48..1c22ca4ec794c 100644
+index 078225b514d4..1c22ca4ec794 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From 4a75506a1346b9ec024bd60002700e05a72be554 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 188/328] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 188/330] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 49 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index c954d15d0a47c..8d8551c2b6c04 100644
+index c954d15d0a47..8d8551c2b6c0 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -51,6 +51,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -42,7 +42,7 @@ index c954d15d0a47c..8d8551c2b6c04 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 7043bfd0399d6..3ec69ffd8b942 100644
+index 7043bfd0399d..3ec69ffd8b94 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From 00d6e427636adeffd8f3a1b481113eaf788b64c6 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 189/328] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 189/330] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 3ec69ffd8b942..2888e2b9fb456 100644
+index 3ec69ffd8b94..2888e2b9fb45 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -46,6 +46,19 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From 15c0a3ee7a0ba280b36e41f69818455259d58118 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 190/328] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 190/330] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 2888e2b9fb456..204b33109f37d 100644
+index 2888e2b9fb45..204b33109f37 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -59,6 +59,16 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From f66c0e09b6bb9486f578462fd84e2dc65f5a7c78 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 191/328] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 191/330] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/systable.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index beb8499dd8ed8..42a6b4c6adbe3 100644
+index beb8499dd8ed..42a6b4c6adbe 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -7,3 +7,5 @@ obj-$(CONFIG_KVM) += kvm/
@@ -51,7 +51,7 @@ index beb8499dd8ed8..42a6b4c6adbe3 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..65cd78995176f
+index 000000000000..65cd78995176
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,38 @@
@@ -95,7 +95,7 @@ index 0000000000000..65cd78995176f
 +clean-files += kernel_feature.h feat_test.syms module_version.h
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 0000000000000..d159169d10508
+index 000000000000..d159169d1050
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -440,7 +440,7 @@ index 0000000000000..d159169d10508
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 0000000000000..e975aa1cdb7af
+index 000000000000..e975aa1cdb7a
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -483,7 +483,7 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..25c6757983896
+index 000000000000..25c675798389
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,77 @@
@@ -566,14 +566,14 @@ index 0000000000000..25c6757983896
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..17e51c385ea38
+index 000000000000..17e51c385ea3
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
 +0.1.1
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..ad9aec128e6f8
+index 000000000000..ad9aec128e6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,11 @@
@@ -590,7 +590,7 @@ index 0000000000000..ad9aec128e6f8
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/feat_test.c b/arch/loongarch/ow_syscall/feat_test.c
 new file mode 100644
-index 0000000000000..5fc3b8709364d
+index 000000000000..5fc3b8709364
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/feat_test.c
 @@ -0,0 +1,16 @@
@@ -612,7 +612,7 @@ index 0000000000000..5fc3b8709364d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..1f5c336f52ec1
+index 000000000000..1f5c336f52ec
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,87 @@
@@ -705,7 +705,7 @@ index 0000000000000..1f5c336f52ec1
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..fa40914afa414
+index 000000000000..fa40914afa41
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,4 @@
@@ -715,7 +715,7 @@ index 0000000000000..fa40914afa414
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..4ae3fc6d70785
+index 000000000000..4ae3fc6d7078
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,274 @@
@@ -995,7 +995,7 @@ index 0000000000000..4ae3fc6d70785
 +MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..90eb34727680d
+index 000000000000..90eb34727680
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,239 @@
@@ -1240,7 +1240,7 @@ index 0000000000000..90eb34727680d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..adcd53bedc662
+index 000000000000..adcd53bedc66
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,44 @@
@@ -1290,7 +1290,7 @@ index 0000000000000..adcd53bedc662
 +#endif
 diff --git a/arch/loongarch/ow_syscall/systable.c b/arch/loongarch/ow_syscall/systable.c
 new file mode 100644
-index 0000000000000..8b311954d62ef
+index 000000000000..8b311954d62e
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.c
 @@ -0,0 +1,65 @@
@@ -1361,7 +1361,7 @@ index 0000000000000..8b311954d62ef
 +};
 diff --git a/arch/loongarch/ow_syscall/systable.h b/arch/loongarch/ow_syscall/systable.h
 new file mode 100644
-index 0000000000000..f2b6602cc7ef4
+index 000000000000..f2b6602cc7ef
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.h
 @@ -0,0 +1,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 8839cc120c3c41f6521861542be89da5d17eff4d Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 192/328] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 192/330] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index b931ef9c60659..2cc3c248c0cc9 100644
+index b931ef9c6065..2cc3c248c0cc 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -739,3 +739,5 @@ source "drivers/cpufreq/Kconfig"
@@ -23,7 +23,7 @@ index b931ef9c60659..2cc3c248c0cc9 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 0000000000000..c28a37145b6f6
+index 000000000000..c28a37145b6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,15 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From f5592ac9965186505743ddaf0e6bb99cb31af03b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 193/328] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 193/330] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom
@@ -100,7 +100,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/kernel/rcu/tree.c b/kernel/rcu/tree.c
-index b7bf9db9bb461..c2aa414b3de56 100644
+index b7bf9db9bb46..c2aa414b3de5 100644
 --- a/kernel/rcu/tree.c
 +++ b/kernel/rcu/tree.c
 @@ -4357,15 +4357,11 @@ void rcutree_migrate_callbacks(int cpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From 906599fa4a4dd2cd4dc73a17cd2153c245dc46b2 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 194/328] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 194/330] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Makefile.postlink b/arch/mips/Makefile.postlink
-index 6cfdc149d3bcd..22b151c343b01 100644
+index 6cfdc149d3bc..22b151c343b0 100644
 --- a/arch/mips/Makefile.postlink
 +++ b/arch/mips/Makefile.postlink
 @@ -24,9 +24,6 @@ quiet_cmd_relocs = RELOCS  $@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 89a178731a0e6f716b51bda65bfb895c46478514 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 195/328] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 195/330] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index d2a51bd395f6c..89915a33ec718 100644
+index d2a51bd395f6..89915a33ec71 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -17,6 +17,10 @@ int loongson_vblank = 1;
@@ -38,7 +38,7 @@ index d2a51bd395f6c..89915a33ec718 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 931c17521bf01..0dcc9646d2ff1 100644
+index 931c17521bf0..0dcc9646d2ff 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -7,6 +7,7 @@
@@ -50,7 +50,7 @@ index 931c17521bf01..0dcc9646d2ff1 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index 12193d2a301ac..ada66e809f364 100644
+index 12193d2a301a..ada66e809f36 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -265,6 +265,14 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 79d56a8e49d82a692c5a86255af0f0d97c5dbf5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 196/328] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 196/330] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/hp/hp-wmi.c b/drivers/platform/x86/hp/hp-wmi.c
-index db5fdee2109ce..fcc0fdda0b38f 100644
+index db5fdee2109c..fcc0fdda0b38 100644
 --- a/drivers/platform/x86/hp/hp-wmi.c
 +++ b/drivers/platform/x86/hp/hp-wmi.c
 @@ -68,7 +68,7 @@ static const char * const omen_thermal_profile_boards[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From b42235dc7f2cb2a953dbd7144cded329f1df806d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 197/328] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 197/330] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index fd8ba060e4156..91f5e9a1678b2 100644
+index fd8ba060e415..91f5e9a1678b 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -884,9 +884,9 @@ module_param_named(visualconfirm, amdgpu_dc_visual_confirm, uint, 0444);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From ce2edd6ea8d153633ff92c1d8360f569fc7fe085 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 198/328] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 198/330] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/unaligned.c b/arch/mips/kernel/unaligned.c
-index db652c99b72e3..4f2055afbd7e8 100644
+index db652c99b72e..4f2055afbd7e 100644
 --- a/arch/mips/kernel/unaligned.c
 +++ b/arch/mips/kernel/unaligned.c
 @@ -1514,14 +1514,37 @@ static void emulate_load_store_MIPS16e(struct pt_regs *regs, void __user * addr)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From db6e31f0a6bfa2e5236971a84e757416fa390eee Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 199/328] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 199/330] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 deletions(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 5d2439f32dee6..ee0fda391f334 100644
+index 5d2439f32dee..ee0fda391f33 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1658,7 +1658,6 @@ menu "PCI GPIO expanders"
@@ -28,7 +28,7 @@ index 5d2439f32dee6..ee0fda391f334 100644
  	help
  	  Say yes here to support GPIO pins on Single Board Computers produced
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index eb18733ea9997..c1b908c934395 100644
+index eb18733ea999..c1b908c93439 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -41,7 +41,6 @@ comment "Native drivers"
@@ -40,7 +40,7 @@ index eb18733ea9997..c1b908c934395 100644
  	help
  	  This hwmon driver adds support for reporting temperature or fan
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 9353ff643ee6c..2edd48322d94e 100644
+index 9353ff643ee6..2edd48322d94 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -68,7 +68,6 @@ config LEDS_88PM860X
@@ -52,7 +52,7 @@ index 9353ff643ee6c..2edd48322d94e 100644
  	help
  	  This led driver adds support for LED brightness control on Single
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 422dcf0004ffc..be1469dc9ec00 100644
+index 422dcf0004ff..be1469dc9ec0 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2272,7 +2272,6 @@ config MFD_QCOM_PM8008

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
@@ -1,7 +1,7 @@
 From 752c0d9bfc65240aeae223ed8451616484d5cb7d Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 31 Dec 2024 15:56:52 +0800
-Subject: [PATCH 200/328] AOSCOS: drm/ls2kbmc: Add id_table for
+Subject: [PATCH 200/330] AOSCOS: drm/ls2kbmc: Add id_table for
  ls2kbmc_platform_driver
 
 Try to fix device binding for the driver.
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/tiny/ls2kbmc.c b/drivers/gpu/drm/tiny/ls2kbmc.c
-index 4b440f20cb4db..55c2b65686421 100644
+index 4b440f20cb4d..55c2b6568642 100644
 --- a/drivers/gpu/drm/tiny/ls2kbmc.c
 +++ b/drivers/gpu/drm/tiny/ls2kbmc.c
 @@ -904,10 +904,17 @@ static void ls2kbmc_remove(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From 9a33e02849c6c73e3a1eaa94d0972e8a6a5cdf98 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 201/328] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 201/330] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling
@@ -34,7 +34,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index ba0327e2d0d33..c6a7f719b570a 100644
+index ba0327e2d0d3..c6a7f719b570 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -5466,7 +5466,7 @@ static struct miscdevice kvm_dev = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 4788e2e6377086b9b6f034adcbf56c4b21a75eca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 202/328] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 202/330] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index 89915a33ec718..99e5fef3f2d9d 100644
+index 89915a33ec71..99e5fef3f2d9 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -21,6 +21,10 @@ int loongson_ls7a1000_support = 0;
@@ -41,7 +41,7 @@ index 89915a33ec718..99e5fef3f2d9d 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 0dcc9646d2ff1..183a8a0586605 100644
+index 0dcc9646d2ff..183a8a058660 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -8,6 +8,7 @@
@@ -53,7 +53,7 @@ index 0dcc9646d2ff1..183a8a0586605 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index ada66e809f364..31d187fe3d24f 100644
+index ada66e809f36..31d187fe3d24 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -273,6 +273,13 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 36578d5d86df38df85d86288ba5b17451340da1a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 203/328] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 203/330] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 6b38e6da99fd4..aae3b2d2b9fdd 100644
+index 6b38e6da99fd..aae3b2d2b9fd 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -25,7 +25,7 @@ config MIPS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From b2f912a9183f71ed7c66e206a9350c0b11191f9d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 204/328] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 204/330] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/cpu_hwmon.c b/drivers/platform/mips/cpu_hwmon.c
-index 2ac2f31090f96..93619227f0396 100644
+index 2ac2f31090f9..93619227f039 100644
 --- a/drivers/platform/mips/cpu_hwmon.c
 +++ b/drivers/platform/mips/cpu_hwmon.c
 @@ -135,9 +135,22 @@ static int __init loongson_hwmon_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
@@ -1,7 +1,7 @@
 From ee325e1fc0d830edc20ab59b81222c509051fe9f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:06:44 +0800
-Subject: [PATCH 205/328] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
+Subject: [PATCH 205/330] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
 
 Following upstream name changes.
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/tiny/ls2kbmc.c b/drivers/gpu/drm/tiny/ls2kbmc.c
-index 55c2b65686421..0bbb9c0646288 100644
+index 55c2b6568642..0bbb9c064628 100644
 --- a/drivers/gpu/drm/tiny/ls2kbmc.c
 +++ b/drivers/gpu/drm/tiny/ls2kbmc.c
 @@ -17,7 +17,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 44d51a300b3c020a2d2840f25d856130d1e9dc16 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:41:10 +0800
-Subject: [PATCH 206/328] AOSCOS: drm/ls2kbmc: remove driver date
+Subject: [PATCH 206/330] AOSCOS: drm/ls2kbmc: remove driver date
 
 Following upstream changes.
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/tiny/ls2kbmc.c b/drivers/gpu/drm/tiny/ls2kbmc.c
-index 0bbb9c0646288..0ad2da1d162e9 100644
+index 0bbb9c064628..0ad2da1d162e 100644
 --- a/drivers/gpu/drm/tiny/ls2kbmc.c
 +++ b/drivers/gpu/drm/tiny/ls2kbmc.c
 @@ -381,7 +381,6 @@ static struct drm_driver ls2kbmc_driver = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From f709c2ee34720af833db69163d0a8feb36def2f7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 207/328] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 207/330] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 346f0e49bb2ea..92aa8e1364c31 100644
+index 346f0e49bb2e..92aa8e1364c3 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,7 +185,9 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 416a8c94733dab0736ea7eabe50b8dc38bc248a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 208/328] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 208/330] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index dffe3bc45865b..1b6c6822dd377 100644
+index dffe3bc45865..1b6c6822dd37 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3491,7 +3491,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From fb6479a7c014f32a9469b632d856f77a0c679ad9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 209/328] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 209/330] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 73502cb34cc64..da430dc35953f 100644
+index 73502cb34cc6..da430dc35953 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -38,6 +38,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 9cfbb269682585c0872bc5d95aa434752a8f8a44 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 210/328] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 210/330] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tools/bpf/bpftool/Makefile b/tools/bpf/bpftool/Makefile
-index 6ea4823b770cb..3713bf770571f 100644
+index 6ea4823b770c..3713bf770571 100644
 --- a/tools/bpf/bpftool/Makefile
 +++ b/tools/bpf/bpftool/Makefile
 @@ -268,8 +268,8 @@ clean: $(LIBBPF)-clean $(LIBBPF_BOOTSTRAP)-clean feature-detect-clean

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From a8d379b70015ae322342644bbef27373ba7b0485 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 211/328] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 211/330] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index aae3b2d2b9fdd..a104c742a0959 100644
+index aae3b2d2b9fd..a104c742a095 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -507,6 +507,7 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From 93db20eafd54b24125e59ca699fcc84b92556b59 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 212/328] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 212/330] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00.h b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
-index dfb4bb370f01b..9475fbf7a6657 100644
+index dfb4bb370f01..9475fbf7a665 100644
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 @@ -1167,23 +1167,27 @@ static inline bool rt2x00_intf(struct rt2x00_dev *rt2x00dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From 10aa992197927dcaa1b348cd668c5d54f8fd5f89 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 213/328] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 213/330] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index 92f7e752f8620..34d3538c6885d 100644
+index 92f7e752f862..34d3538c6885 100644
 --- a/drivers/tty/serial/serial_core.c
 +++ b/drivers/tty/serial/serial_core.c
 @@ -1972,6 +1972,8 @@ static int uart_open(struct tty_struct *tty, struct file *filp)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From af173838578c7e4ed35576311114aac9535b9383 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 214/328] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 214/330] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/constant_timer.c
 
 diff --git a/arch/mips/include/asm/cpu-features.h b/arch/mips/include/asm/cpu-features.h
-index 404390bb87eaf..e522efa1b53d0 100644
+index 404390bb87ea..e522efa1b53d 100644
 --- a/arch/mips/include/asm/cpu-features.h
 +++ b/arch/mips/include/asm/cpu-features.h
 @@ -659,6 +659,10 @@
@@ -55,7 +55,7 @@ index 404390bb87eaf..e522efa1b53d0 100644
   * Guest capabilities
   */
 diff --git a/arch/mips/include/asm/cpu.h b/arch/mips/include/asm/cpu.h
-index ecb9854cb4324..3c1299b718e10 100644
+index ecb9854cb432..3c1299b718e1 100644
 --- a/arch/mips/include/asm/cpu.h
 +++ b/arch/mips/include/asm/cpu.h
 @@ -421,6 +421,7 @@ enum cpu_type_enum {
@@ -67,7 +67,7 @@ index ecb9854cb4324..3c1299b718e10 100644
  /*
   * CPU ASE encodings
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_regs.h b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
-index fec7675076049..47294ab78a2cd 100644
+index fec767507604..47294ab78a2c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 @@ -131,6 +131,9 @@ static inline u32 read_cpucfg(u32 reg)
@@ -120,7 +120,7 @@ index fec7675076049..47294ab78a2cd 100644
 +
  #endif
 diff --git a/arch/mips/include/asm/mipsregs.h b/arch/mips/include/asm/mipsregs.h
-index c025558754d57..b47833b7e5269 100644
+index c025558754d5..b47833b7e526 100644
 --- a/arch/mips/include/asm/mipsregs.h
 +++ b/arch/mips/include/asm/mipsregs.h
 @@ -838,6 +838,7 @@
@@ -132,7 +132,7 @@ index c025558754d57..b47833b7e5269 100644
  #define MTI_CONF6_FTLBEN	(_ULCAST_(1) << 15)
  /* Disable load/store bonding */
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 3ba2bc06ae778..8a91ad684fc87 100644
+index 3ba2bc06ae77..8a91ad684fc8 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -42,11 +42,19 @@ extern int __weak get_c0_perfcount_int(void);
@@ -178,7 +178,7 @@ index 3ba2bc06ae778..8a91ad684fc87 100644
  	return 0;
  #endif
 diff --git a/arch/mips/include/asm/vdso/clocksource.h b/arch/mips/include/asm/vdso/clocksource.h
-index 510e1671d8985..7fd43ca06eb11 100644
+index 510e1671d898..7fd43ca06eb1 100644
 --- a/arch/mips/include/asm/vdso/clocksource.h
 +++ b/arch/mips/include/asm/vdso/clocksource.h
 @@ -4,6 +4,7 @@
@@ -191,7 +191,7 @@ index 510e1671d8985..7fd43ca06eb11 100644
  
  #endif /* __ASM_VDSOCLOCKSOURCE_H */
 diff --git a/arch/mips/include/asm/vdso/gettimeofday.h b/arch/mips/include/asm/vdso/gettimeofday.h
-index 44a45f3fa4b01..c1b15b0f07689 100644
+index 44a45f3fa4b0..c1b15b0f0768 100644
 --- a/arch/mips/include/asm/vdso/gettimeofday.h
 +++ b/arch/mips/include/asm/vdso/gettimeofday.h
 @@ -183,6 +183,22 @@ static __always_inline u64 read_gic_count(const struct vdso_data *data)
@@ -229,7 +229,7 @@ index 44a45f3fa4b01..c1b15b0f07689 100644
  	/*
  	 * Core checks mode already. So this raced against a concurrent
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index 6934ee44852b4..782b41d14d4ea 100644
+index 6934ee44852b..782b41d14d4e 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -33,6 +33,10 @@
@@ -270,7 +270,7 @@ index 6934ee44852b4..782b41d14d4ea 100644
  				  LOONGSON_CONF6_INTIMER);
  		break;
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index cbba30dfddf5d..ba083beb6ca81 100644
+index cbba30dfddf5..ba083beb6ca8 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,6 +4,7 @@
@@ -283,7 +283,7 @@ index cbba30dfddf5d..ba083beb6ca81 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
 new file mode 100644
-index 0000000000000..b8bdbb2c47b51
+index 000000000000..b8bdbb2c47b5
 --- /dev/null
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -0,0 +1,256 @@
@@ -544,7 +544,7 @@ index 0000000000000..b8bdbb2c47b51
 +	return res;
 +}
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 69c1e77e6bfc7..f8e2fb4c7cd8c 100644
+index 69c1e77e6bfc..f8e2fb4c7cd8 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -425,7 +425,9 @@ static void loongson3_smp_finish(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 8ef7834586d6a500235382a00a6cb2c2b11b3e7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 215/328] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 215/330] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index b8bdbb2c47b51..975fb93c4efa2 100644
+index b8bdbb2c47b5..975fb93c4efa 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -42,12 +42,6 @@ static irqreturn_t constant_timer_interrupt(int irq, void *data)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From 6c22ae7b86d4794f5e7e1ee991d0fd9ba97f4d62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 216/328] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 216/330] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index 975fb93c4efa2..c1fda4a3ae165 100644
+index 975fb93c4efa..c1fda4a3ae16 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -252,7 +252,7 @@ int __init init_constant_clocksource(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 627b35c23383d364ade801dd500958b310df4ac6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 217/328] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 217/330] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 new file mode 100644
-index 0000000000000..3d2ca3245a3e2
+index 000000000000..3d2ca3245a3e
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -0,0 +1,381 @@
@@ -417,7 +417,7 @@ index 0000000000000..3d2ca3245a3e2
 +
 +#endif /* __EC_WPCE775L_H__ */
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index ba083beb6ca81..0cb1654f346ab 100644
+index ba083beb6ca8..0cb1654f346a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -431,7 +431,7 @@ index ba083beb6ca81..0cb1654f346ab 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/ec_wpce775l.c b/arch/mips/loongson64/ec_wpce775l.c
 new file mode 100644
-index 0000000000000..f407ddbe933a1
+index 000000000000..f407ddbe933a
 --- /dev/null
 +++ b/arch/mips/loongson64/ec_wpce775l.c
 @@ -0,0 +1,249 @@
@@ -685,7 +685,7 @@ index 0000000000000..f407ddbe933a1
 +}
 +EXPORT_SYMBOL(ec_query_get_event_num);
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index cab5a4c5baf52..23fda821d6b38 100644
+index cab5a4c5baf5..23fda821d6b3 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -142,7 +142,7 @@ static struct fwnode_handle *i8042_kbd_fwnode;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From f25936ce1117b7b4874315f49160ab1fcdad7f11 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 218/328] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 218/330] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index 3d2ca3245a3e2..fc60026bc6741 100644
+index 3d2ca3245a3e..fc60026bc674 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -374,6 +374,7 @@ extern int ec_write_noindex(unsigned char command, unsigned char data);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 947981323ee1237a568d5f19ce40f789c1b95812 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 219/328] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 219/330] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/wpce_fan.c
 
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
-index 721eafc4644e5..071e8f445f5c9 100644
+index 721eafc4644e..071e8f445f5c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 @@ -36,7 +36,7 @@ struct temp_range {
@@ -66,7 +66,7 @@ index 721eafc4644e5..071e8f445f5c9 100644
 +
  #endif /* __LOONGSON_HWMON_H_*/
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 0cb1654f346ab..16b0c555b52ae 100644
+index 0cb1654f346a..16b0c555b52a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -80,7 +80,7 @@ index 0cb1654f346ab..16b0c555b52ae 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/platform.c b/arch/mips/loongson64/platform.c
 new file mode 100644
-index 0000000000000..a447eab0218d2
+index 000000000000..a447eab0218d
 --- /dev/null
 +++ b/arch/mips/loongson64/platform.c
 @@ -0,0 +1,67 @@
@@ -152,7 +152,7 @@ index 0000000000000..a447eab0218d2
 +	.type = CONSTANT_SPEED_POLICY,
 +};
 diff --git a/drivers/hwmon/lm93.c b/drivers/hwmon/lm93.c
-index be4853fad80fd..649c5e1cf8200 100644
+index be4853fad80f..649c5e1cf820 100644
 --- a/drivers/hwmon/lm93.c
 +++ b/drivers/hwmon/lm93.c
 @@ -2497,8 +2497,9 @@ ATTRIBUTE_GROUPS(lm93);
@@ -194,7 +194,7 @@ index be4853fad80fd..649c5e1cf8200 100644
  	for (i = 0; i < 20; i++) {
  		msleep(10);
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index fb4ac4b08e891..59b6027eeadf5 100644
+index fb4ac4b08e89..59b6027eeadf 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -37,4 +37,20 @@ config LS2K_RESET
@@ -219,7 +219,7 @@ index fb4ac4b08e891..59b6027eeadf5 100644
 +
  endif # MIPS_PLATFORM_DEVICES
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4c71444e453a6..4dcbbcfcf7a1e 100644
+index 4c71444e453a..4dcbbcfcf7a1 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -2,3 +2,6 @@
@@ -231,7 +231,7 @@ index 4c71444e453a6..4dcbbcfcf7a1e 100644
 +obj-$(CONFIG_LEMOTE3A_LAPTOP) += lemote3a-laptop.o
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
 new file mode 100644
-index 0000000000000..02f2284743ed3
+index 000000000000..02f2284743ed
 --- /dev/null
 +++ b/drivers/platform/mips/emc1412.c
 @@ -0,0 +1,454 @@
@@ -691,7 +691,7 @@ index 0000000000000..02f2284743ed3
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
 new file mode 100644
-index 0000000000000..b06e7b6ae97c7
+index 000000000000..b06e7b6ae97c
 --- /dev/null
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -0,0 +1,1179 @@
@@ -1876,7 +1876,7 @@ index 0000000000000..b06e7b6ae97c7
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
 new file mode 100644
-index 0000000000000..6331e09722a1f
+index 000000000000..6331e09722a1
 --- /dev/null
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -0,0 +1,767 @@
@@ -2649,7 +2649,7 @@ index 0000000000000..6331e09722a1f
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
 new file mode 100644
-index 0000000000000..be42c58822901
+index 000000000000..be42c5882290
 --- /dev/null
 +++ b/drivers/platform/mips/sd5075.c
 @@ -0,0 +1,211 @@
@@ -2866,7 +2866,7 @@ index 0000000000000..be42c58822901
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/tmp75.c b/drivers/platform/mips/tmp75.c
 new file mode 100644
-index 0000000000000..0582c8fa2e2b2
+index 000000000000..0582c8fa2e2b
 --- /dev/null
 +++ b/drivers/platform/mips/tmp75.c
 @@ -0,0 +1,24 @@
@@ -2896,7 +2896,7 @@ index 0000000000000..0582c8fa2e2b2
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/wpce_fan.c b/drivers/platform/mips/wpce_fan.c
 new file mode 100644
-index 0000000000000..ecef3158c59bc
+index 000000000000..ecef3158c59b
 --- /dev/null
 +++ b/drivers/platform/mips/wpce_fan.c
 @@ -0,0 +1,311 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 1812270f0dda73454a5b0ca33debd742a7460310 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 220/328] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 220/330] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 59b6027eeadf5..7ef9a47556d59 100644
+index 59b6027eeadf..7ef9a47556d5 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -39,7 +39,7 @@ config LS2K_RESET

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From a1bdb04860fffd69066fb97595f1c007fd37d4de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 221/328] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 221/330] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index be42c58822901..02bb998210191 100644
+index be42c5882290..02bb99821019 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -93,7 +93,7 @@ static int sd5075_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From 71412268842ebe3c625ff093d35dc65aa9ed4fd3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 222/328] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 222/330] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 02f2284743ed3..3fb2dcd600106 100644
+index 02f2284743ed..3fb2dcd60010 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -143,7 +143,7 @@ static int emc1412_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 84a5756639bd716bf7802123651792f79eb96f3c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 223/328] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 223/330] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index 02bb998210191..27e9fb359b9f6 100644
+index 02bb99821019..27e9fb359b9f 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -128,7 +128,7 @@ static ssize_t get_sd5075_label(struct device *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From 9193e04ba31fcbbe6b39706c538ce0dbd077d0b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 224/328] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 224/330] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 3fb2dcd600106..bf2fa4b815c8f 100644
+index 3fb2dcd60010..bf2fa4b815c8 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -182,7 +182,7 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From b8b56314474fb8f6a6a4ea68d70f05959ab49e75 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 225/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 225/330] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 60 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index bf2fa4b815c8f..6524baddd6ca2 100644
+index bf2fa4b815c8..6524baddd6ca 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -336,66 +336,6 @@ static void do_thermal_timer(struct work_struct *work)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From fbf191befdd7ac91e4e6ff60673506985930763a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 226/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 226/330] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 6524baddd6ca2..fc1a26cd34fe0 100644
+index 6524baddd6ca..fc1a26cd34fe 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -174,30 +174,6 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From b5a97a1fe0cfe1ec037c0d4e8a3cd898ba523b24 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 227/328] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 227/330] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b06e7b6ae97c7..6e6b0c46aca4c 100644
+index b06e7b6ae97c..6e6b0c46aca4 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -625,9 +625,8 @@ static int lemote3a_set_brightness(struct backlight_device * pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From bd23f4d14766609544224b9847442e6dd4912cc1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 228/328] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 228/330] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index 6e6b0c46aca4c..a8d339a3e30b7 100644
+index 6e6b0c46aca4..a8d339a3e30b 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -542,10 +542,16 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 1950d4db09bda92997efc876656e8a5807bd4082 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 229/328] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 229/330] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
-index 6331e09722a1f..51c2017ebe1d6 100644
+index 6331e09722a1..51c2017ebe1d 100644
 --- a/drivers/platform/mips/sbx00_fan.c
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -97,10 +97,44 @@ static struct loongson_fan_policy fan_policy[MAX_SBX00_FANS];

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From ce95e391a5e82cc1ca6bdbda46a865f653db84ec Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 230/328] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 230/330] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 73 insertions(+)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 5b8f9cc325893..35d2be41a54c4 100644
+index 5b8f9cc32589..35d2be41a54c 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -1,10 +1,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From 37d048f60e36c78e1508e69caf6b0d735fb545f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 231/328] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 231/330] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 35d2be41a54c4..6e53355be9d9f 100644
+index 35d2be41a54c..6e53355be9d9 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -95,7 +95,7 @@ static int __init power_button_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From 9bfa19e968f0fc4bedf73d6d478b92bf15ab1ac9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 232/328] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 232/330] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/keyboard/lmps2atkbd.h
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 721ab69e84ac6..2678b3132036a 100644
+index 721ab69e84ac..2678b3132036 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -156,6 +156,17 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -44,7 +44,7 @@ index 721ab69e84ac6..2678b3132036a 100644
  	tristate "Microchip AT42QT1050 Touch Sensor Chip"
  	depends on I2C
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index adf0f311996c9..49c14416379c6 100644
+index adf0f311996c..49c14416379c 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -77,7 +77,13 @@ MODULE_PARM_DESC(terminal, "Enable break codes on an IBM Terminal keyboard conne
@@ -98,7 +98,7 @@ index adf0f311996c9..49c14416379c6 100644
  
 diff --git a/drivers/input/keyboard/lmps2atkbd.h b/drivers/input/keyboard/lmps2atkbd.h
 new file mode 100644
-index 0000000000000..95d4ac5365c0d
+index 000000000000..95d4ac5365c0
 --- /dev/null
 +++ b/drivers/input/keyboard/lmps2atkbd.h
 @@ -0,0 +1,32 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From e70b4573423ef7adf949eb2a3bebaf66ade1e107 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 233/328] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 233/330] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 2678b3132036a..dd127dac0b783 100644
+index 2678b3132036..dd127dac0b78 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -158,7 +158,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From a623408c62e80b04ad30256c7f246d1933b22252 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 234/328] AOSCOS: input: atkbd: disable
+Subject: [PATCH 234/330] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index dd127dac0b783..ac2612f2fa7d7 100644
+index dd127dac0b78..ac2612f2fa7d 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -159,7 +159,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 72893cf1da4b4f8bd4e2ca08f4e345f840e63a77 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 235/328] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 235/330] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ec_rom.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
+index 4dcbbcfcf7a1..5929b5ad7b6c 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,3 +5,4 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -27,7 +27,7 @@ index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
 +obj-m += ec_rom.o
 diff --git a/drivers/platform/mips/ec_rom.c b/drivers/platform/mips/ec_rom.c
 new file mode 100644
-index 0000000000000..b7b1624191f7a
+index 000000000000..b7b1624191f7
 --- /dev/null
 +++ b/drivers/platform/mips/ec_rom.c
 @@ -0,0 +1,179 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 8fb43c20673808828831f8d42ae5df5a0665d90a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 236/328] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 236/330] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/pmon_flash.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 5929b5ad7b6cd..98eef2e092264 100644
+index 5929b5ad7b6c..98eef2e09226 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -6,3 +6,7 @@ obj-$(CONFIG_I2C_PIIX4) += emc1412.o sd5075.o tmp75.o
@@ -38,7 +38,7 @@ index 5929b5ad7b6cd..98eef2e092264 100644
 +endif
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
 new file mode 100644
-index 0000000000000..8fd5f4bf8b1bb
+index 000000000000..8fd5f4bf8b1b
 --- /dev/null
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -0,0 +1,100 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 418a1dbb40b1c8efbbed661805c488de9e42be03 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 237/328] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 237/330] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
-index 8fd5f4bf8b1bb..6c5a3c4342b29 100644
+index 8fd5f4bf8b1b..6c5a3c4342b2 100644
 --- a/drivers/platform/mips/pmon_flash.c
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -53,7 +53,7 @@ struct mtd_partition flash_parts[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 2ef3bcdbcaa1cbdc2de36a476f20af87c0e197ec Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 238/328] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 238/330] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/at24c04.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 98eef2e092264..4dde0988fdadb 100644
+index 98eef2e09226..4dde0988fdad 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,7 +5,7 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -30,7 +30,7 @@ index 98eef2e092264..4dde0988fdadb 100644
  obj-m += pmon_flash.o
 diff --git a/drivers/platform/mips/at24c04.c b/drivers/platform/mips/at24c04.c
 new file mode 100644
-index 0000000000000..7ba3d1c8692e1
+index 000000000000..7ba3d1c8692e
 --- /dev/null
 +++ b/drivers/platform/mips/at24c04.c
 @@ -0,0 +1,26 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 5f92a10ceb4e691ebd1402aeed8f36ded998e6a5 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 239/328] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 239/330] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ioremap.h b/arch/mips/include/asm/mach-loongson64/ioremap.h
 new file mode 100644
-index 0000000000000..155dafe2ef346
+index 000000000000..155dafe2ef34
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ioremap.h
 @@ -0,0 +1,44 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 28791d3c644891ea37560d14e740f94eb3d87a38 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 240/328] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 240/330] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/mouse/sentelic.c b/drivers/input/mouse/sentelic.c
-index 44b136fc29aaf..6ccdec46e1f44 100644
+index 44b136fc29aa..6ccdec46e1f4 100644
 --- a/drivers/input/mouse/sentelic.c
 +++ b/drivers/input/mouse/sentelic.c
 @@ -899,8 +899,8 @@ static int fsp_activate_protocol(struct psmouse *psmouse)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 68139fd3dfd28a34dfe95fe84b2463fc50748ff4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 241/328] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 241/330] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 42 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_64xx.c b/drivers/scsi/mvsas/mv_64xx.c
-index 1f2b61de8c632..855d8465b30f2 100644
+index 1f2b61de8c63..855d8465b30f 100644
 --- a/drivers/scsi/mvsas/mv_64xx.c
 +++ b/drivers/scsi/mvsas/mv_64xx.c
 @@ -376,10 +376,14 @@ static int mvs_64xx_init(struct mvs_info *mvi)
@@ -81,7 +81,7 @@ index 1f2b61de8c632..855d8465b30f2 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_94xx.c b/drivers/scsi/mvsas/mv_94xx.c
-index fc0b8eb682045..1d1042ab82c8c 100644
+index fc0b8eb68204..1d1042ab82c8 100644
 --- a/drivers/scsi/mvsas/mv_94xx.c
 +++ b/drivers/scsi/mvsas/mv_94xx.c
 @@ -515,10 +515,14 @@ static int mvs_94xx_init(struct mvs_info *mvi)
@@ -115,7 +115,7 @@ index fc0b8eb682045..1d1042ab82c8c 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 2c72da6b8cf0c..83cf8d6379491 100644
+index 2c72da6b8cf0..83cf8d637949 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -10,7 +10,11 @@
@@ -139,7 +139,7 @@ index 2c72da6b8cf0c..83cf8d6379491 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index 1444b1f1c4c88..2b22f30e39a68 100644
+index 1444b1f1c4c8..2b22f30e39a6 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -265,6 +265,20 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -205,7 +205,7 @@ index 1444b1f1c4c88..2b22f30e39a68 100644
  
  	case SAS_PROTOCOL_SATA:
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index 19b01f7c47677..30c7d450fb9dd 100644
+index 19b01f7c4767..30c7d450fb9d 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -430,6 +430,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From 7b617ebeabd292cc47224ca264a7ad9a0f2176aa Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 242/328] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 242/330] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-nct6102.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index ee0fda391f334..783d0afa70c10 100644
+index ee0fda391f33..783d0afa70c1 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -521,6 +521,13 @@ config GPIO_NPCM_SGPIO
@@ -37,7 +37,7 @@ index ee0fda391f334..783d0afa70c10 100644
  	tristate "Cavium OCTEON GPIO"
  	depends on CAVIUM_OCTEON_SOC
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index b03c53f6de196..5d0535eada2b0 100644
+index b03c53f6de19..5d0535eada2b 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -124,6 +124,7 @@ obj-$(CONFIG_GPIO_MXC)			+= gpio-mxc.o
@@ -50,7 +50,7 @@ index b03c53f6de196..5d0535eada2b0 100644
  obj-$(CONFIG_GPIO_PALMAS)		+= gpio-palmas.o
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
 new file mode 100644
-index 0000000000000..25efc588c7612
+index 000000000000..25efc588c761
 --- /dev/null
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -0,0 +1,191 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From f2f28f060713d98681e1e636bc003fbb68b0aa29 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 243/328] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 243/330] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 783d0afa70c10..31bc5ae3d705a 100644
+index 783d0afa70c1..31bc5ae3d705 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -524,7 +524,7 @@ config GPIO_NPCM_SGPIO

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From 57702ca889552e8cd30be6ccc8e653b60e262e46 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 244/328] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 244/330] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 25efc588c7612..547b61008390d 100644
+index 25efc588c761..547b61008390 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -6,6 +6,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 80876e51d884a3047e4443938b8818508cf45542 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 245/328] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 245/330] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 547b61008390d..c376f9fd6d076 100644
+index 547b61008390..c376f9fd6d07 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -47,15 +47,6 @@ static unsigned char read_gbl(u8 gbl_reg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From 998ccc492d0f9571d1fe71c035611230f25bd627 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 246/328] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 246/330] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index c376f9fd6d076..1bb29ea5f5f2d 100644
+index c376f9fd6d07..1bb29ea5f5f2 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -170,7 +170,6 @@ static struct gpio_chip nct6102_chip = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 6db473d29fbd0f2a3b5f4314b667ed6a7bd1a38e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 247/328] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 247/330] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 1bb29ea5f5f2d..143f0a139e212 100644
+index 1bb29ea5f5f2..143f0a139e21 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -177,6 +177,6 @@ static int __init nct6102_gpio_setup(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From 1ec360c53fabc943c3d879141958145bd05c9b0f Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 248/328] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 248/330] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/nct7511.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index c1b908c934395..2cb1a554ce3cd 100644
+index c1b908c93439..2cb1a554ce3c 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -1705,6 +1705,17 @@ config SENSORS_NCT7363
@@ -44,7 +44,7 @@ index c1b908c934395..2cb1a554ce3cd 100644
  	tristate "Nuvoton NCT7802Y"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index f8c822a542999..90841dde88f5e 100644
+index f8c822a54299..90841dde88f5 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -174,6 +174,7 @@ nct6775-objs			:= nct6775-platform.o
@@ -57,7 +57,7 @@ index f8c822a542999..90841dde88f5e 100644
  obj-$(CONFIG_SENSORS_NPCM7XX)	+= npcm750-pwm-fan.o
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
 new file mode 100644
-index 0000000000000..a945ffc2ab3d5
+index 000000000000..a945ffc2ab3d
 --- /dev/null
 +++ b/drivers/hwmon/nct7511.c
 @@ -0,0 +1,801 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From f67f9939f501c9900548923597f8ebc39a52af0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 249/328] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 249/330] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index a945ffc2ab3d5..e5006ecd83465 100644
+index a945ffc2ab3d..e5006ecd8346 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -709,7 +709,7 @@ static int nct7511_detect(struct i2c_client *client,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From 0e9bfd68b0d1d7d70160d8fabb0b9da4dbb2384c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 250/328] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 250/330] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index e5006ecd83465..808755e2c37d5 100644
+index e5006ecd8346..808755e2c37d 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -744,8 +744,7 @@ static int nct7511_init_chip(struct nct7511_data *data)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 9647734f1170bbc7d61e9f7003db8c5e7a634c4f Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 251/328] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 251/330] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 74 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 34874039ad453..0df06250f5d42 100644
+index 34874039ad45..0df06250f5d4 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1178,6 +1178,78 @@ static void add_cx5051_fake_mutes(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From cb9875debdc63aef0472d928da45e55a9d15ce1b Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 252/328] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 252/330] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 20 insertions(+)
 
 diff --git a/include/sound/hda_codec.h b/include/sound/hda_codec.h
-index c1fe6290d04dc..1ef7175a7caed 100644
+index c1fe6290d04d..1ef7175a7cae 100644
 --- a/include/sound/hda_codec.h
 +++ b/include/sound/hda_codec.h
 @@ -369,6 +369,8 @@ struct hda_verb {
@@ -31,7 +31,7 @@ index c1fe6290d04dc..1ef7175a7caed 100644
  			    const struct hda_verb *seq);
  
 diff --git a/sound/pci/hda/hda_codec.c b/sound/pci/hda/hda_codec.c
-index 46a2204049993..51598637e9a21 100644
+index 46a220404999..51598637e9a2 100644
 --- a/sound/pci/hda/hda_codec.c
 +++ b/sound/pci/hda/hda_codec.c
 @@ -68,6 +68,24 @@ static int codec_exec_verb(struct hdac_device *dev, unsigned int cmd,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From 0ce573843cb52cf5d7319dbff4221831fb3ad8e1 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 253/328] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 253/330] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 0df06250f5d42..716e882e0bcf4 100644
+index 0df06250f5d4..716e882e0bcf 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -43,6 +43,9 @@ struct conexant_spec {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From 877aac55ca4d0c71badd2dafc4341c45faf28f01 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 254/328] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 254/330] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 716e882e0bcf4..203204378bdda 100644
+index 716e882e0bcf..203204378bdd 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -295,6 +295,7 @@ enum {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 5095a38b7b5aa446c394aa502d599192a32d2be2 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 255/328] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 255/330] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index 27879cc575365..e0ab0481329fc 100644
+index 27879cc57536..e0ab0481329f 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
 @@ -2091,6 +2091,7 @@ static const struct usb_device_id option_ids[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 9aa413406f8e697413f558540782037efcac69d4 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 256/328] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 256/330] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 203204378bdda..a0e183107088c 100644
+index 203204378bdd..a0e183107088 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1334,6 +1334,13 @@ static int patch_conexant_auto(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 4c9409eeb132945ddd9bae339830d2039336a175 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 257/328] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 257/330] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index a0e183107088c..bc57b3092e598 100644
+index a0e183107088..bc57b3092e59 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1334,8 +1334,9 @@ static int patch_conexant_auto(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From cd639f23cbd79fedeff9be1c9acdc81426c53c0a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 258/328] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 258/330] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 82 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/e1000e/e1000.h b/drivers/net/ethernet/intel/e1000e/e1000.h
-index ba9c19e6994c9..0e56b992dd3c5 100644
+index ba9c19e6994c..0e56b992dd3c 100644
 --- a/drivers/net/ethernet/intel/e1000e/e1000.h
 +++ b/drivers/net/ethernet/intel/e1000e/e1000.h
 @@ -228,6 +228,7 @@ struct e1000_adapter {
@@ -43,7 +43,7 @@ index ba9c19e6994c9..0e56b992dd3c5 100644
  	u16 tx_ring_count;
  	u16 rx_ring_count;
 diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
-index 286155efcedf7..1a1eb31f4b6e0 100644
+index 286155efcedf..1a1eb31f4b6e 100644
 --- a/drivers/net/ethernet/intel/e1000e/netdev.c
 +++ b/drivers/net/ethernet/intel/e1000e/netdev.c
 @@ -637,6 +637,69 @@ static void e1000e_update_tdt_wa(struct e1000_ring *tx_ring, unsigned int i)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From bc25b387f567fb45c68b5e8543439c6443b009e6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 259/328] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 259/330] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/message.c b/drivers/usb/core/message.c
-index d2b2787be4092..8128bd0fc00b7 100644
+index d2b2787be409..8128bd0fc00b 100644
 --- a/drivers/usb/core/message.c
 +++ b/drivers/usb/core/message.c
 @@ -1999,7 +1999,7 @@ int usb_set_configuration(struct usb_device *dev, int configuration)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From 8b44f129418988956b3307ebf40ca1abf457fe43 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 260/328] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 260/330] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 52 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index fc60026bc6741..f1c686ef7a54b 100644
+index fc60026bc674..f1c686ef7a54 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -127,6 +127,13 @@ enum
@@ -36,7 +36,7 @@ index fc60026bc6741..f1c686ef7a54b 100644
  /*
   * The reported battery die temperature.
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 7ef9a47556d59..a5a80e0a399ff 100644
+index 7ef9a47556d5..a5a80e0a399f 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -49,6 +49,7 @@ config LEMOTE3A_LAPTOP
@@ -48,7 +48,7 @@ index 7ef9a47556d59..a5a80e0a399ff 100644
  	help
  	  Lemote Loongson-3A/2Gq family laptops driver.
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index a8d339a3e30b7..b6f585b0f7d35 100644
+index a8d339a3e30b..b6f585b0f7d3 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -19,12 +19,14 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 15d29362f490a2c432fb3dd24910d6889f99fed4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 261/328] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 261/330] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 61 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index f1c686ef7a54b..e1f8577a6ed61 100644
+index f1c686ef7a54..e1f8577a6ed6 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -320,6 +320,17 @@ enum
@@ -36,7 +36,7 @@ index f1c686ef7a54b..e1f8577a6ed61 100644
  /* EC Status query, by direct read 66h port. */
  #define EC_SMI_EVT		(1 << 6)	/* 1 = SMI event padding */
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b6f585b0f7d35..dbb37e376ee80 100644
+index b6f585b0f7d3..dbb37e376ee8 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -160,6 +160,7 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 119602bcc540671604f6ab136b88943299d333df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 262/328] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 262/330] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.h
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2248badc3acb6..2e9ac29588c81 100644
+index 2248badc3acb..2e9ac29588c8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -4,6 +4,7 @@
@@ -39,7 +39,7 @@ index 2248badc3acb6..2e9ac29588c81 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-n32.h b/arch/mips/kernel/audit-n32.h
 new file mode 100644
-index 0000000000000..781de2e9ad66b
+index 000000000000..781de2e9ad66
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.h
 @@ -0,0 +1,5 @@
@@ -49,7 +49,7 @@ index 0000000000000..781de2e9ad66b
 +int audit_classify_syscall_n32(int abi, unsigned syscall);
 +#endif /* CONFIG_AUDITSYSCALL_N32 */
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 09ae3dbcfecbc..88e283f8df385 100644
+index 09ae3dbcfecb..88e283f8df38 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -2,6 +2,8 @@
@@ -72,7 +72,7 @@ index 09ae3dbcfecbc..88e283f8df385 100644
  {
  	int res;
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index e8b9b50f7d267..6bf302c04e5d3 100644
+index e8b9b50f7d26..6bf302c04e5d 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -4,6 +4,7 @@
@@ -85,7 +85,7 @@ index e8b9b50f7d267..6bf302c04e5d3 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-o32.h b/arch/mips/kernel/audit-o32.h
 new file mode 100644
-index 0000000000000..8a782fdd1c6e7
+index 000000000000..8a782fdd1c6e
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.h
 @@ -0,0 +1,5 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From 56e74fce01675982a95779f93782eb956be59c40 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 263/328] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 263/330] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 16 insertions(+), 13 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2e9ac29588c81..8d114bf854254 100644
+index 2e9ac29588c8..8d114bf85425 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -35,11 +35,11 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -38,7 +38,7 @@ index 2e9ac29588c81..8d114bf854254 100644
  		return 0;
  	}
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 88e283f8df385..4a0fecd0e4867 100644
+index 88e283f8df38..4a0fecd0e486 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -45,20 +45,20 @@ int audit_classify_syscall(int abi, unsigned syscall)
@@ -67,7 +67,7 @@ index 88e283f8df385..4a0fecd0e4867 100644
  	default:
  #ifdef CONFIG_AUDITSYSCALL_O32
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index 6bf302c04e5d3..818f91ce14acf 100644
+index 6bf302c04e5d..818f91ce14ac 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -35,15 +35,15 @@ int audit_classify_syscall_o32(int abi, unsigned syscall)
@@ -92,7 +92,7 @@ index 6bf302c04e5d3..818f91ce14acf 100644
  }
  
 diff --git a/include/linux/audit_arch.h b/include/linux/audit_arch.h
-index 0e34d673ef171..0436757bfc33e 100644
+index 0e34d673ef17..0436757bfc33 100644
 --- a/include/linux/audit_arch.h
 +++ b/include/linux/audit_arch.h
 @@ -17,6 +17,9 @@ enum auditsc_class_t {
@@ -106,7 +106,7 @@ index 0e34d673ef171..0436757bfc33e 100644
  	AUDITSC_NVALS /* count */
  };
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index 079b24df3ba3c..b240756e0c214 100644
+index 079b24df3ba3..b240756e0c21 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -190,7 +190,7 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 7e3480ba542527caf3633838d564931edaed6847 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 264/328] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 264/330] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 27 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 8d114bf854254..76c95ff924f83 100644
+index 8d114bf85425..76c95ff924f8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -41,7 +41,7 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -29,7 +29,7 @@ index 8d114bf854254..76c95ff924f83 100644
  }
  
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 4a0fecd0e4867..763f0e6b3636a 100644
+index 4a0fecd0e486..763f0e6b3636 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -41,45 +41,26 @@ int audit_classify_arch(int arch)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From 539a89f0ee96ccbc97fc50235bccb3ebd933b7f5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 265/328] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 265/330] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index 8605c074d9f75..d18e1f3ca9cd3 100644
+index 8605c074d9f7..d18e1f3ca9cd 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -2406,6 +2406,8 @@ struct radeon_device {
@@ -31,7 +31,7 @@ index 8605c074d9f75..d18e1f3ca9cd3 100644
  	struct mutex dc_hw_i2c_mutex; /* display controller hw i2c mutex */
  	bool has_uvd;
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 6f071e61f7648..56be34a0e6fc4 100644
+index 6f071e61f764..56be34a0e6fc 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1643,7 +1643,28 @@ int radeon_suspend_kms(struct drm_device *dev, bool suspend,
@@ -89,7 +89,7 @@ index 6f071e61f7648..56be34a0e6fc4 100644
  }
  
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 9961251b44ba0..e5d5ea218579f 100644
+index 9961251b44ba..e5d5ea218579 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -307,6 +307,8 @@ static bool radeon_msi_ok(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From b10fdcd2cc2dc51cc39d15a1c966532b3c5f8b5c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 266/328] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 266/330] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.h b/drivers/gpu/drm/radeon/radeon_device.h
-index 31a0ae295cc8f..e7f6d468b5674 100644
+index 31a0ae295cc8..e7f6d468b567 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.h
 +++ b/drivers/gpu/drm/radeon/radeon_device.h
 @@ -29,4 +29,6 @@
@@ -28,7 +28,7 @@ index 31a0ae295cc8f..e7f6d468b5674 100644
 +
  #endif                         /* __RADEON_DEVICE_H__ */
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index e5d5ea218579f..d4ad1fa826454 100644
+index e5d5ea218579..d4ad1fa82645 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -40,6 +40,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 46fa0e93010bd3e049aa0ce902900fcd0aae831b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 267/328] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 267/330] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 56be34a0e6fc4..10d2ae804de28 100644
+index 56be34a0e6fc..10d2ae804de2 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1799,6 +1799,7 @@ int radeon_gpu_reset(struct radeon_device *rdev)
@@ -55,7 +55,7 @@ index 56be34a0e6fc4..10d2ae804de28 100644
  	rdev->needs_reset = false;
  
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index b4fb7e70320b8..54b4b9b161f71 100644
+index b4fb7e70320b..54b4b9b161f7 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1854,10 +1854,11 @@ static bool radeon_pm_debug_check_in_vbl(struct radeon_device *rdev, bool finish
@@ -80,7 +80,7 @@ index b4fb7e70320b8..54b4b9b161f71 100644
  
  /*
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 72c675191a022..2c6e67872637f 100644
+index 72c675191a02..2c6e67872637 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -329,6 +329,20 @@ void ttm_bo_put(struct ttm_buffer_object *bo)
@@ -105,7 +105,7 @@ index 72c675191a022..2c6e67872637f 100644
  				     struct ttm_operation_ctx *ctx,
  				     struct ttm_place *hop)
 diff --git a/include/drm/ttm/ttm_bo.h b/include/drm/ttm/ttm_bo.h
-index 8ea11cd8df397..3c671490511e7 100644
+index 8ea11cd8df39..3c671490511e 100644
 --- a/include/drm/ttm/ttm_bo.h
 +++ b/include/drm/ttm/ttm_bo.h
 @@ -356,6 +356,22 @@ static inline void ttm_bo_move_null(struct ttm_buffer_object *bo,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 9ff1140ca4a0476ec28ec8c607252a7b6b35b717 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 268/328] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 268/330] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 10d2ae804de28..7c80605afecd9 100644
+index 10d2ae804de2..7c80605afecd 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1659,7 +1659,7 @@ void radeon_recover_callback(struct work_struct *work)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From 6a2ce88b7b4074a6b8c58577688eda3b5c23732d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 269/328] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 269/330] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 2c6e67872637f..20de0096c9fd9 100644
+index 2c6e67872637..20de0096c9fd 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -331,14 +331,14 @@ EXPORT_SYMBOL(ttm_bo_put);
@@ -47,7 +47,7 @@ index 2c6e67872637f..20de0096c9fd9 100644
  }
  EXPORT_SYMBOL(ttm_bo_unlock_delayed_workqueue);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index 39b8636b18451..07594b72de636 100644
+index 39b8636b1845..07594b72de63 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -267,6 +267,11 @@ struct ttm_device {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 69225c17de204642b6db14ffda80bc7ca4263d3e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 270/328] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 270/330] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1ce165c627a6c..493022119c1a7 100644
+index 1ce165c627a6..493022119c1a 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,6 +1010,9 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -27,7 +27,7 @@ index 1ce165c627a6c..493022119c1a7 100644
  						 evergreen_golden_registers,
  						 (const u32)ARRAY_SIZE(evergreen_golden_registers));
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 54b4b9b161f71..c6c60f1b64cbf 100644
+index 54b4b9b161f7..c6c60f1b64cb 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,6 +1520,7 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From 737ba971bcd62d0acce289a967fb8c5470077a40 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 271/328] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 271/330] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 493022119c1a7..1a15f9264ead0 100644
+index 493022119c1a..1a15f9264ead 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,8 +1010,10 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -31,7 +31,7 @@ index 493022119c1a7..1a15f9264ead0 100644
  		radeon_program_register_sequence(rdev,
  						 evergreen_golden_registers,
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index c6c60f1b64cbf..539065746db08 100644
+index c6c60f1b64cb..539065746db0 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,7 +1520,9 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 8c0d68f692a12f2ee4782f7cb10e557ea309bb45 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 272/328] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 272/330] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 539065746db08..f5ee0cc05c2d0 100644
+index 539065746db0..f5ee0cc05c2d 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1354,7 +1354,7 @@ static int radeon_pm_init_old(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From d86457697d8f9059e0cddd378be3a3fa01c43772 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 273/328] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 273/330] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  12 files changed, 35 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index f20fd5ae6c45c..61f254f270f0e 100644
+index f20fd5ae6c45..61f254f270f0 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -5435,6 +5435,7 @@ static int cik_pcie_gart_enable(struct radeon_device *rdev)
@@ -39,7 +39,7 @@ index f20fd5ae6c45c..61f254f270f0e 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1a15f9264ead0..4a7774c35e850 100644
+index 1a15f9264ead..4a7774c35e85 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -2414,6 +2414,7 @@ static int evergreen_pcie_gart_enable(struct radeon_device *rdev)
@@ -51,7 +51,7 @@ index 1a15f9264ead0..4a7774c35e850 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/ni.c b/drivers/gpu/drm/radeon/ni.c
-index 3890911fe693c..03335fa3367bb 100644
+index 3890911fe693..03335fa3367b 100644
 --- a/drivers/gpu/drm/radeon/ni.c
 +++ b/drivers/gpu/drm/radeon/ni.c
 @@ -1256,6 +1256,7 @@ static int cayman_pcie_gart_enable(struct radeon_device *rdev)
@@ -63,7 +63,7 @@ index 3890911fe693c..03335fa3367bb 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/r100.c b/drivers/gpu/drm/radeon/r100.c
-index 80703417d8a18..c926e3b27df89 100644
+index 80703417d8a1..c926e3b27df8 100644
 --- a/drivers/gpu/drm/radeon/r100.c
 +++ b/drivers/gpu/drm/radeon/r100.c
 @@ -672,6 +672,7 @@ int r100_pci_gart_enable(struct radeon_device *rdev)
@@ -75,7 +75,7 @@ index 80703417d8a18..c926e3b27df89 100644
  	tmp = RREG32(RADEON_AIC_CNTL) | RADEON_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32(RADEON_AIC_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r300.c b/drivers/gpu/drm/radeon/r300.c
-index d22889fbfa9c8..59404a4605727 100644
+index d22889fbfa9c..59404a460572 100644
 --- a/drivers/gpu/drm/radeon/r300.c
 +++ b/drivers/gpu/drm/radeon/r300.c
 @@ -161,6 +161,7 @@ int rv370_pcie_gart_enable(struct radeon_device *rdev)
@@ -87,7 +87,7 @@ index d22889fbfa9c8..59404a4605727 100644
  	tmp = RADEON_PCIE_TX_GART_UNMAPPED_ACCESS_DISCARD;
  	WREG32_PCIE(RADEON_PCIE_TX_GART_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 88e38fb3f3476..4c57b429af216 100644
+index 88e38fb3f347..4c57b429af21 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -1137,6 +1137,7 @@ static int r600_pcie_gart_enable(struct radeon_device *rdev)
@@ -99,7 +99,7 @@ index 88e38fb3f3476..4c57b429af216 100644
  	/* Setup L2 cache */
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index d18e1f3ca9cd3..3e98e8db9f9a8 100644
+index d18e1f3ca9cd..3e98e8db9f9a 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -628,6 +628,7 @@ void radeon_gart_unbind(struct radeon_device *rdev, unsigned offset,
@@ -111,7 +111,7 @@ index d18e1f3ca9cd3..3e98e8db9f9a8 100644
  
  /*
 diff --git a/drivers/gpu/drm/radeon/radeon_gart.c b/drivers/gpu/drm/radeon/radeon_gart.c
-index 4bb242437ff60..b34b8b9066947 100644
+index 4bb242437ff6..b34b8b906694 100644
 --- a/drivers/gpu/drm/radeon/radeon_gart.c
 +++ b/drivers/gpu/drm/radeon/radeon_gart.c
 @@ -317,6 +317,30 @@ int radeon_gart_bind(struct radeon_device *rdev, unsigned int offset,
@@ -146,7 +146,7 @@ index 4bb242437ff60..b34b8b9066947 100644
   * radeon_gart_init - init the driver info for managing the gart
   *
 diff --git a/drivers/gpu/drm/radeon/rs400.c b/drivers/gpu/drm/radeon/rs400.c
-index 13cd0a688a65c..6dad165e90fcc 100644
+index 13cd0a688a65..6dad165e90fc 100644
 --- a/drivers/gpu/drm/radeon/rs400.c
 +++ b/drivers/gpu/drm/radeon/rs400.c
 @@ -113,6 +113,7 @@ int rs400_gart_enable(struct radeon_device *rdev)
@@ -158,7 +158,7 @@ index 13cd0a688a65c..6dad165e90fcc 100644
  	tmp |= RS690_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32_MC(RS690_AIC_CTRL_SCRATCH, tmp);
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 88c8e91ea6512..7cfe137d7dcdd 100644
+index 88c8e91ea651..7cfe137d7dcd 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -571,6 +571,7 @@ static int rs600_gart_enable(struct radeon_device *rdev)
@@ -170,7 +170,7 @@ index 88c8e91ea6512..7cfe137d7dcdd 100644
  	tmp = RREG32(RADEON_BUS_CNTL) & ~RS600_BUS_MASTER_DIS;
  	WREG32(RADEON_BUS_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/rv770.c b/drivers/gpu/drm/radeon/rv770.c
-index 7d4b0bf591090..c7317aff4cd64 100644
+index 7d4b0bf59109..c7317aff4cd6 100644
 --- a/drivers/gpu/drm/radeon/rv770.c
 +++ b/drivers/gpu/drm/radeon/rv770.c
 @@ -903,6 +903,7 @@ static int rv770_pcie_gart_enable(struct radeon_device *rdev)
@@ -182,7 +182,7 @@ index 7d4b0bf591090..c7317aff4cd64 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 465859e2fcff9..361e6d7c25330 100644
+index 465859e2fcff..361e6d7c2533 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -4273,6 +4273,7 @@ static int si_pcie_gart_enable(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From 418bb743459b9703543153acc75d3608267326cb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 274/328] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 274/330] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 7cfe137d7dcdd..8fb559af1a37f 100644
+index 7cfe137d7dcd..8fb559af1a37 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -654,6 +654,9 @@ uint64_t rs600_gart_get_page_entry(uint64_t addr, uint32_t flags)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From 7fa1ad0465b83112fdf32f4b1874745bd5cd6fb2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 275/328] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 275/330] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 04c1b32a22c5e..9bdf3248556bd 100644
+index 04c1b32a22c5..9bdf3248556b 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -34,7 +34,7 @@ static int g_hwcursor = 1;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From ccc3f796da6099b7471039c2fbafcda2862ec4d2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 276/328] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 276/330] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 9bdf3248556bd..f6a2b00f7215b 100644
+index 9bdf3248556b..f6a2b00f7215 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -30,7 +30,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 957f1c0df5202dc98dd0d76cf973f584dee71a1a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 277/328] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 277/330] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index 23fda821d6b38..f4ac256d91dd3 100644
+index 23fda821d6b3..f4ac256d91dd 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -131,7 +131,9 @@ MODULE_PARM_DESC(unmask_kbd_data, "Unconditional enable (may reveal sensitive da

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From eb1307c4743abde83c431db1a7ca231b9e99893f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 278/328] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 278/330] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 76 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/igb/igb.h b/drivers/net/ethernet/intel/igb/igb.h
-index 02f340280d20a..0fd182feb0c18 100644
+index 02f340280d20..0fd182feb0c1 100644
 --- a/drivers/net/ethernet/intel/igb/igb.h
 +++ b/drivers/net/ethernet/intel/igb/igb.h
 @@ -380,6 +380,13 @@ struct igb_q_vector {
@@ -30,7 +30,7 @@ index 02f340280d20a..0fd182feb0c18 100644
  	struct igb_ring ring[] ____cacheline_internodealigned_in_smp;
  };
 diff --git a/drivers/net/ethernet/intel/igb/igb_main.c b/drivers/net/ethernet/intel/igb/igb_main.c
-index d368b753a4675..3ec7c8c476f08 100644
+index d368b753a467..3ec7c8c476f0 100644
 --- a/drivers/net/ethernet/intel/igb/igb_main.c
 +++ b/drivers/net/ethernet/intel/igb/igb_main.c
 @@ -4192,6 +4192,15 @@ static int __igb_open(struct net_device *netdev, bool resuming)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 75c5f1b9ec6029e074c8cc3551e44db295979eac Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 279/328] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 279/330] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/staging/sb105x/sb_ser_core.h
 
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 075e775d3868b..bd2999a91b31f 100644
+index 075e775d3868..bd2999a91b31 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -36,6 +36,8 @@ source "drivers/staging/nvec/Kconfig"
@@ -44,7 +44,7 @@ index 075e775d3868b..bd2999a91b31f 100644
  
  source "drivers/staging/most/Kconfig"
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index e681e403509ce..7d80e07d27583 100644
+index e681e403509c..7d80e07d2758 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_VME_BUS)		+= vme_user/
@@ -57,7 +57,7 @@ index e681e403509ce..7d80e07d27583 100644
  obj-$(CONFIG_GREYBUS)		+= greybus/
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
 new file mode 100644
-index 0000000000000..245e7847a3542
+index 000000000000..245e7847a354
 --- /dev/null
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -0,0 +1,9 @@
@@ -72,7 +72,7 @@ index 0000000000000..245e7847a3542
 +	  will be called "sb105x".
 diff --git a/drivers/staging/sb105x/Makefile b/drivers/staging/sb105x/Makefile
 new file mode 100644
-index 0000000000000..b1bf3779acaed
+index 000000000000..b1bf3779acae
 --- /dev/null
 +++ b/drivers/staging/sb105x/Makefile
 @@ -0,0 +1,3 @@
@@ -81,7 +81,7 @@ index 0000000000000..b1bf3779acaed
 +sb105x-y :=  sb_pci_mp.o
 diff --git a/drivers/staging/sb105x/sb_mp_register.h b/drivers/staging/sb105x/sb_mp_register.h
 new file mode 100644
-index 0000000000000..276c1bbcc18dd
+index 000000000000..276c1bbcc18d
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_mp_register.h
 @@ -0,0 +1,295 @@
@@ -382,7 +382,7 @@ index 0000000000000..276c1bbcc18dd
 +#endif 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
 new file mode 100644
-index 0000000000000..c9d6ee3903adc
+index 000000000000..c9d6ee3903ad
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -0,0 +1,3189 @@
@@ -3577,7 +3577,7 @@ index 0000000000000..c9d6ee3903adc
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
 new file mode 100644
-index 0000000000000..80ae4ab046031
+index 000000000000..80ae4ab04603
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -0,0 +1,291 @@
@@ -3874,7 +3874,7 @@ index 0000000000000..80ae4ab046031
 +
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
 new file mode 100644
-index 0000000000000..c8fb991732997
+index 000000000000..c8fb99173299
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -0,0 +1,368 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From 2f046c664812aafdab4684c5790da8e73f901543 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 280/328] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 280/330] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
 new file mode 100644
-index 0000000000000..a780ee51a7188
+index 000000000000..a780ee51a718
 --- /dev/null
 +++ b/arch/mips/include/asm/serial.h
 @@ -0,0 +1,19 @@
@@ -45,7 +45,7 @@ index 0000000000000..a780ee51a7188
 +
 +#endif /* __ASM__SERIAL_H */
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
-index 245e7847a3542..c5f741e71c14b 100644
+index 245e7847a354..c5f741e71c14 100644
 --- a/drivers/staging/sb105x/Kconfig
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -1,7 +1,7 @@
@@ -58,7 +58,7 @@ index 245e7847a3542..c5f741e71c14b 100644
  	  A driver for the SystemBase Multi-2/PCI serial card
  
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c9d6ee3903adc..18e91bc61ba16 100644
+index c9d6ee3903ad..18e91bc61ba1 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1,6 +1,7 @@
@@ -314,7 +314,7 @@ index c9d6ee3903adc..18e91bc61ba16 100644
              
  	   		     	if (status != 0)
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
-index 80ae4ab046031..0920beb31c15e 100644
+index 80ae4ab04603..0920beb31c15 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.h
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -287,5 +287,4 @@ static const struct sb105x_uart_config uart_config[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From be612a60997b16695d65c05acccbe9d81cc65613 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 281/328] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 281/330] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index c8fb991732997..8835415e1d3df 100644
+index c8fb99173299..8835415e1d3d 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -196,13 +196,13 @@ struct uart_driver {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From b2e7d6da193ad239bd7b5c417cb442d78f5b8ed0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 282/328] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 282/330] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 18e91bc61ba16..e333245ec9c5d 100644
+index 18e91bc61ba1..e333245ec9c5 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -480,7 +480,7 @@ static void __mp_start(struct tty_struct *tty)
@@ -41,7 +41,7 @@ index 18e91bc61ba16..e333245ec9c5d 100644
  
  	return put_user(result, value);
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index 8835415e1d3df..d8664e723b4a3 100644
+index 8835415e1d3d..d8664e723b4a 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -52,7 +52,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From a6428164a6f6219d62317921c934198f4167a476 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 283/328] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 283/330] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index e333245ec9c5d..963f3091a5c95 100644
+index e333245ec9c5..963f3091a5c9 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1051,7 +1051,7 @@ static int mp_wait_modem_status(struct sb_uart_state *state, unsigned long arg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 9f83d3e0a763e9282c10bb64d55031b1217d0fb1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 284/328] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 284/330] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 963f3091a5c95..cd98d3b0183da 100644
+index 963f3091a5c9..cd98d3b0183d 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1624,7 +1624,7 @@ static inline void mp_report_port(struct uart_driver *drv, struct sb_uart_port *

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From 7b7332900bc2208b178a9f0903e7cf07a22dd536 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 285/328] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 285/330] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index cd98d3b0183da..ccf02cfeb2fcc 100644
+index cd98d3b0183d..ccf02cfeb2fc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1728,12 +1728,10 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From cdc77eda85cecb36789e992e91421129d82b1766 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 286/328] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 286/330] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index ccf02cfeb2fcc..c5e1c39e7a7a2 100644
+index ccf02cfeb2fc..c5e1c39e7a7a 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1765,7 +1765,7 @@ for (i = 0; i < drv->nr; i++) {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From 25307fd0b8569b3947b7a48cd72df69913acdd11 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 287/328] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 287/330] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
-index a780ee51a7188..2777148dbfc5a 100644
+index a780ee51a718..2777148dbfc5 100644
 --- a/arch/mips/include/asm/serial.h
 +++ b/arch/mips/include/asm/serial.h
 @@ -12,7 +12,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From 3596a3dd0f5aaa3a90fd7d499e9789b54bbb6346 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 288/328] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 288/330] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c5e1c39e7a7a2..32f60de269ccb 100644
+index c5e1c39e7a7a..32f60de269cc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2808,7 +2808,7 @@ static void __init multi_init_ports(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 45fcb0239b8345bf303530acf7814865dd63c4a3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 289/328] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 289/330] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 32f60de269ccb..841e9b15486b0 100644
+index 32f60de269cc..841e9b15486b 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1736,7 +1736,6 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From c03f3edb2671e29b6000b454568815baf6fb99d5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 290/328] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 290/330] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 841e9b15486b0..0d7e216fad94a 100644
+index 841e9b15486b..0d7e216fad94 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -33,7 +33,7 @@ static void mp_tasklet_action(unsigned long data);
@@ -78,7 +78,7 @@ index 841e9b15486b0..0d7e216fad94a 100644
  	struct mp_port *mtpt = (struct mp_port *)port;
  	unsigned char cval, fcr = 0;
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index d8664e723b4a3..978b4b26ddbb1 100644
+index d8664e723b4a..978b4b26ddbb 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -77,7 +77,7 @@ struct sb_uart_ops {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 23a1cfa6b1083ad861c80b4afd8f13fc0c51dfd8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 291/328] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 291/330] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 0d7e216fad94a..f61451fabdcd0 100644
+index 0d7e216fad94..f61451fabdcd 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -39,7 +39,7 @@ static inline int __mp_put_char(struct sb_uart_port *port, struct circ_buf *circ

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From f9d832f868ba3a0a018dbc18930ca47231051189 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 292/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 292/330] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index f61451fabdcd0..593835f0ad11c 100644
+index f61451fabdcd..593835f0ad11 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -40,7 +40,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 5bce332afab8c0d4981a65ffdc70c7c0dc0e1cb2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 293/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 293/330] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 593835f0ad11c..8712e74230648 100644
+index 593835f0ad11..8712e7423064 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -41,7 +41,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 3e9fd5735de2c7b0ea08956ef3916261d0059261 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 294/328] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 294/330] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 8712e74230648..19098bbfa113e 100644
+index 8712e7423064..19098bbfa113 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -43,7 +43,7 @@ static ssize_t mp_write(struct tty_struct *tty, const unsigned char *buf, long u

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 2bf8cbfa04e8f2e4414d3e1e408af88493113d4e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 295/328] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 295/330] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 22 insertions(+)
 
 diff --git a/drivers/parport/parport_serial.c b/drivers/parport/parport_serial.c
-index 24d4f3a3ec3d0..9e1af7103d603 100644
+index 24d4f3a3ec3d..9e1af7103d60 100644
 --- a/drivers/parport/parport_serial.c
 +++ b/drivers/parport/parport_serial.c
 @@ -60,6 +60,7 @@ enum parport_pc_pci_cards {
@@ -63,7 +63,7 @@ index 24d4f3a3ec3d0..9e1af7103d603 100644
  		.flags		= FL_BASE2,
  		.num_ports	= 5,
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 73c200127b089..ce9ea66d4ca5e 100644
+index 73c200127b08..ce9ea66d4ca5 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,6 +74,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 507a7e1a14cc01d7a0b7d3b915543a2180d6cd6c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 296/328] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 296/330] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index ce9ea66d4ca5e..0a268b20c3ade 100644
+index ce9ea66d4ca5..0a268b20c3ad 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -332,6 +332,12 @@ static int pci_plx9050_init(struct pci_dev *dev)
@@ -63,7 +63,7 @@ index ce9ea66d4ca5e..0a268b20c3ade 100644
  		PCI_VENDOR_ID_PLX,
  		PCI_SUBDEVICE_ID_UNKNOWN_0x1588, 0, 0,
 diff --git a/drivers/tty/serial/8250/8250_pcilib.c b/drivers/tty/serial/8250/8250_pcilib.c
-index d8d0ae0d72387..cd70b62dbbb94 100644
+index d8d0ae0d7238..cd70b62dbbb9 100644
 --- a/drivers/tty/serial/8250/8250_pcilib.c
 +++ b/drivers/tty/serial/8250/8250_pcilib.c
 @@ -27,6 +27,12 @@ int serial8250_pci_setup_port(struct pci_dev *dev, struct uart_8250_port *port,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From 7b6c9d184b9a48a1d979fb185beebce69d932c8b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 297/328] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 297/330] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 288a2b864cc41..8c564389812ce 100644
+index 288a2b864cc4..8c564389812c 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -659,7 +659,17 @@
@@ -36,7 +36,7 @@ index 288a2b864cc41..8c564389812ce 100644
  #define USB_VENDOR_ID_INTEL_0		0x8086
  #define USB_VENDOR_ID_INTEL_1		0x8087
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index f5e4d52bd2eb3..98b283adb9da4 100644
+index f5e4d52bd2eb..98b283adb9da 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -2299,7 +2299,47 @@ static const struct hid_device_id mt_devices[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From 2065e8a1e79dc4d3969c676d529ebdcecd40eecd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 298/328] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 298/330] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/host/ohci-hcd.c b/drivers/usb/host/ohci-hcd.c
-index 9b24181fee601..f9adf45938c58 100644
+index 9b24181fee60..f9adf45938c5 100644
 --- a/drivers/usb/host/ohci-hcd.c
 +++ b/drivers/usb/host/ohci-hcd.c
 @@ -1138,8 +1138,10 @@ int ohci_resume(struct usb_hcd *hcd, bool hibernated)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 2dbb1cc362d04d0ad87b57b871f00a1a0123a6d5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 299/328] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 299/330] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ls7a_fan.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dde0988fdadb..a3e9e6b2f38fb 100644
+index 4dde0988fdad..a3e9e6b2f38f 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -3,7 +3,7 @@ obj-$(CONFIG_CPU_HWMON) += cpu_hwmon.o
@@ -28,7 +28,7 @@ index 4dde0988fdadb..a3e9e6b2f38fb 100644
  
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
 new file mode 100644
-index 0000000000000..cc188d4d05762
+index 000000000000..cc188d4d0576
 --- /dev/null
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -0,0 +1,598 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 882f5584ba7fcf93dc291d0f06f49c145b9d5fda Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 300/328] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 300/330] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
-index cc188d4d05762..e9cf2dded39e4 100644
+index cc188d4d0576..e9cf2dded39e 100644
 --- a/drivers/platform/mips/ls7a_fan.c
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -9,10 +9,16 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From 36fe24b20be1fae41b22dc2448fc15cadacf28b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 301/328] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 301/330] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index cc0360e8dd62c..fc1d0c83b554a 100644
+index cc0360e8dd62..fc1d0c83b554 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,7 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From 6dd0341b812c802d49e1ce504f230cd42469f17c Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 302/328] AOSCOS: Optimize clear_page
+Subject: [PATCH 302/330] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 56 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/uasm.h b/arch/mips/include/asm/uasm.h
-index b43bfd4452521..2573d559320e6 100644
+index b43bfd445252..2573d559320e 100644
 --- a/arch/mips/include/asm/uasm.h
 +++ b/arch/mips/include/asm/uasm.h
 @@ -42,6 +42,10 @@ void uasm_i##op(u32 **buf, unsigned int a, signed int b, unsigned int c)
@@ -37,7 +37,7 @@ index b43bfd4452521..2573d559320e6 100644
  Ip_u3u2u1(_sllv);
  Ip_s3s1s2(_slt);
 diff --git a/arch/mips/include/uapi/asm/inst.h b/arch/mips/include/uapi/asm/inst.h
-index c29dbc8c1d491..6d41c8bbbdec2 100644
+index c29dbc8c1d49..6d41c8bbbdec 100644
 --- a/arch/mips/include/uapi/asm/inst.h
 +++ b/arch/mips/include/uapi/asm/inst.h
 @@ -137,6 +137,13 @@ enum ddivu_op {
@@ -55,7 +55,7 @@ index c29dbc8c1d491..6d41c8bbbdec2 100644
   * rt field of bcond opcodes.
   */
 diff --git a/arch/mips/mm/page.c b/arch/mips/mm/page.c
-index 1df237bd4a72b..21c9d35ec25e8 100644
+index 1df237bd4a72..21c9d35ec25e 100644
 --- a/arch/mips/mm/page.c
 +++ b/arch/mips/mm/page.c
 @@ -206,6 +206,11 @@ static void set_prefetch_parameters(void)
@@ -87,7 +87,7 @@ index 1df237bd4a72b..21c9d35ec25e8 100644
  
  static inline void build_clear_pref(u32 **buf, int off)
 diff --git a/arch/mips/mm/uasm-mips.c b/arch/mips/mm/uasm-mips.c
-index e15c6700cd088..7e44ea365795b 100644
+index e15c6700cd08..7e44ea365795 100644
 --- a/arch/mips/mm/uasm-mips.c
 +++ b/arch/mips/mm/uasm-mips.c
 @@ -27,6 +27,10 @@
@@ -143,7 +143,7 @@ index e15c6700cd088..7e44ea365795b 100644
  		op |= build_simm(va_arg(ap, s32));
  	if (ip->fields & UIMM)
 diff --git a/arch/mips/mm/uasm.c b/arch/mips/mm/uasm.c
-index 125140979d62c..2a9ca7de43760 100644
+index 125140979d62..2a9ca7de4376 100644
 --- a/arch/mips/mm/uasm.c
 +++ b/arch/mips/mm/uasm.c
 @@ -26,6 +26,8 @@ enum fields {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 8a7bb8bf849d64224a52ed790eb2935c0c063572 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 303/328] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 303/330] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memset.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 16b0c555b52ae..f6a1fd6cb736e 100644
+index 16b0c555b52a..f6a1fd6cb736 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,6 +5,7 @@
@@ -30,7 +30,7 @@ index 16b0c555b52ae..f6a1fd6cb736e 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
 new file mode 100644
-index 0000000000000..227b2d67082e3
+index 000000000000..227b2d67082e
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -0,0 +1,206 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 4fbd2d172917f0c2f3ed408569f4c52f2597d99a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 304/328] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 304/330] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 227b2d67082e3..0a35c013f6df4 100644
+index 227b2d67082e..0a35c013f6df 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -8,9 +8,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From d857acfedacc301355ca16efce7d046a06417c2d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 305/328] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 305/330] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 0a35c013f6df4..55c3b8d7bc458 100644
+index 0a35c013f6df..55c3b8d7bc45 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -22,7 +22,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From 1c6b252eb87211418a57a6316b2516bfd11175f3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 306/328] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 306/330] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/lib/Makefile b/arch/mips/lib/Makefile
-index 9c024e6d5e54c..0b175c5ec9df2 100644
+index 9c024e6d5e54..0b175c5ec9df 100644
 --- a/arch/mips/lib/Makefile
 +++ b/arch/mips/lib/Makefile
 @@ -10,6 +10,7 @@ lib-y	+= bitops.o csum_partial.o delay.o memcpy.o memset.o \

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From ad8a023cb718524f682dbdf4233a05fcafad2c1f Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 307/328] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 307/330] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memcpy.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index f6a1fd6cb736e..9783e54388902 100644
+index f6a1fd6cb736..9783e5438890 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,7 +5,7 @@
@@ -31,7 +31,7 @@ index f6a1fd6cb736e..9783e54388902 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
 new file mode 100644
-index 0000000000000..28b785363351c
+index 000000000000..28b785363351
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -0,0 +1,506 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 9adc2d7a27a71578e81bafb655427123c6a358db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 308/328] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 308/330] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 28b785363351c..4c0b6b8474f04 100644
+index 28b785363351..4c0b6b8474f0 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -37,13 +37,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 78293e0db8f8414f0f0cf760722ad71aca3e4a28 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 309/328] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 309/330] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 4c0b6b8474f04..2021e75d5dd2e 100644
+index 4c0b6b8474f0..2021e75d5dd2 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -29,9 +29,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From 84e3f7a196ebd2e275f0416bf27d9ff8d1bf2597 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 310/328] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 310/330] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index a104c742a0959..1d22ab5c9be73 100644
+index a104c742a095..1d22ab5c9be7 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -1341,6 +1341,7 @@ config CPU_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 2741110a2b05f81d91ef45a296821afcd0e4b4db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 311/328] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 311/330] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 2021e75d5dd2e..c5dd2e2866c3c 100644
+index 2021e75d5dd2..c5dd2e2866c3 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -119,8 +119,10 @@ LEAF(memcpy)				/* a0=dst a1=src a2=len */

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 84f8832360609bacc39daabc1eca198250e76210 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 312/328] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 312/330] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index ea8a310329274..5eebda3c1a8ea 100644
+index ea8a31032927..5eebda3c1a8e 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -565,12 +565,12 @@ config SPI_LM70_LLP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 0fcffd3a159e36b608726a5549e2038b54c3fa69 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 313/328] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 313/330] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 1d22ab5c9be73..78535c2d043fa 100644
+index 1d22ab5c9be7..78535c2d043f 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2113,9 +2113,9 @@ config ZBOOT_LOAD_ADDRESS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From c80b237a3c588fb8e1cbdcd60dd23e0f2e88e52b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 314/328] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 314/330] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index 522fac29949ad..3dc26e40f3e39 100644
+index 522fac29949a..3dc26e40f3e3 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -948,6 +948,7 @@ config NUMA_BALANCING

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From 1f01b884845bb0513e31af62a90b57f895abd92f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 315/328] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 315/330] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/lib/audit.c b/lib/audit.c
-index 738bda22dd39b..5f68998fdaf60 100644
+index 738bda22dd39..5f68998fdaf6 100644
 --- a/lib/audit.c
 +++ b/lib/audit.c
 @@ -29,6 +29,7 @@ static unsigned signal_class[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From e9ecd3a14aa8df32f6e3ae5b4308cff2e6ac8b1b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 316/328] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 316/330] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 10 deletions(-)
 
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index 1c054e3096db8..ba83d3fb0a848 100644
+index 1c054e3096db..ba83d3fb0a84 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,14 +64,4 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 1557f9b332e6d57d6186aca06e3125ba0b0b90a8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 317/328] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 317/330] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index b501ea16ccd40..63bfa241b3aa5 100644
+index b501ea16ccd4..63bfa241b3aa 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,6 +6,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From f95bad568a3f6c5c27d9e21a1e101341ac044ce6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 318/328] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 318/330] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 2910588154500..caf0601730e36 100644
+index 291058815450..caf0601730e3 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -622,7 +622,9 @@ static void __init bootcmdline_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 6b7af4f888aaf14e8d5d5c2704b38f83079c910d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 319/328] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 319/330] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 9783e54388902..04eba1ce8ff54 100644
+index 9783e5438890..04eba1ce8ff5 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From c378d8360e61ebca9584226d019fffa6b05f5078 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 320/328] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 320/330] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes.
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 83cf8d6379491..d6b1f893dec2f 100644
+index 83cf8d637949..d6b1f893dec2 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -36,7 +36,7 @@ static const struct attribute_group *mvst_sdev_groups[];
@@ -29,7 +29,7 @@ index 83cf8d6379491..d6b1f893dec2f 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index 2b22f30e39a68..2a5813382c2b4 100644
+index 2b22f30e39a6..2a5813382c2b 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -265,11 +265,11 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -47,7 +47,7 @@ index 2b22f30e39a68..2a5813382c2b4 100644
  #if defined(CONFIG_MIPS) && defined(CONFIG_CPU_LOONGSON64)
  	if (!dev_is_sata(dev))
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index 30c7d450fb9dd..2deae46b5b260 100644
+index 30c7d450fb9d..2deae46b5b26 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -430,7 +430,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 4412038bfc50163904d66c8bb64493b9089c7550 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 321/328] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 321/330] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 0a268b20c3ade..2e6ef2196f82c 100644
+index 0a268b20c3ad..2e6ef2196f82 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,7 +74,6 @@
@@ -27,7 +27,7 @@ index 0a268b20c3ade..2e6ef2196f82c 100644
  
  #define PCI_DEVICE_ID_MOXA_CP102E	0x1024
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 05020db0d436a..78ff23fc8edb0 100644
+index 05020db0d436..78ff23fc8edb 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2597,6 +2597,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From e8a2530598552e6681ce1f8a8710ff4ab8cb657a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 322/328] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 322/330] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 78535c2d043fa..7d12850fea047 100644
+index 78535c2d043f..7d12850fea04 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -507,7 +507,6 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
 From f331f74145dff0c6cecf7bc485e83119771222ef Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 323/328] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 323/330] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 10 insertions(+)
 
 diff --git a/drivers/acpi/acpica/evglock.c b/drivers/acpi/acpica/evglock.c
-index 989dc01af03fb..bc205b3309043 100644
+index 989dc01af03f..bc205b330904 100644
 --- a/drivers/acpi/acpica/evglock.c
 +++ b/drivers/acpi/acpica/evglock.c
 @@ -42,6 +42,10 @@ acpi_status acpi_ev_init_global_lock_handler(void)
@@ -36,7 +36,7 @@ index 989dc01af03fb..bc205b3309043 100644
  
  	status = acpi_install_fixed_event_handler(ACPI_EVENT_GLOBAL,
 diff --git a/include/acpi/acpixf.h b/include/acpi/acpixf.h
-index 78b24b0904888..a799bc8d25ff3 100644
+index 78b24b090488..a799bc8d25ff 100644
 --- a/include/acpi/acpixf.h
 +++ b/include/acpi/acpixf.h
 @@ -213,6 +213,12 @@ ACPI_INIT_GLOBAL(u8, acpi_gbl_osi_data, 0);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
 From 82e1818c080d564c2612bcd3a51f1076b4fc7247 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 324/328] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 324/330] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 66209f3cc253a..67d26ef78501b 100644
+index 66209f3cc253..67d26ef78501 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -357,6 +357,7 @@ void __init platform_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
@@ -1,7 +1,7 @@
 From 38fd36b3a5161c47a8fa2d3e4c09ff7e78e5a66d Mon Sep 17 00:00:00 2001
 From: Qunqin Zhao <zhaoqunqin@loongson.cn>
 Date: Tue, 1 Apr 2025 17:41:54 +0800
-Subject: [PATCH 325/328] LOONGSON: input: atkbd: do not init atkbd_reset
+Subject: [PATCH 325/330] LOONGSON: input: atkbd: do not init atkbd_reset
  variable to true on Loongson
 
 The keyboard will not be confused on Loongson platform, so do not need a
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 49c14416379c6..1d0a602b4f796 100644
+index 49c14416379c..1d0a602b4f79 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -37,7 +37,7 @@ static int atkbd_set = 2;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
@@ -1,7 +1,7 @@
 From 1c595ceb69ffdc5760fe4a0c3a6399fb1905b371 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 22 Apr 2025 14:17:54 +0800
-Subject: [PATCH 326/328] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
+Subject: [PATCH 326/330] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
  RTL8723BE with subsystem ID 11ad:1723
 
 RTL8723BE found on some ASUSTek laptops, such as F441U and X555UQ with
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 insertions(+)
 
 diff --git a/drivers/net/wireless/realtek/rtlwifi/pci.c b/drivers/net/wireless/realtek/rtlwifi/pci.c
-index 0eafc4d125f91..898f597f70a96 100644
+index 0eafc4d125f9..898f597f70a9 100644
 --- a/drivers/net/wireless/realtek/rtlwifi/pci.c
 +++ b/drivers/net/wireless/realtek/rtlwifi/pci.c
 @@ -155,6 +155,16 @@ static void _rtl_pci_update_default_setting(struct ieee80211_hw *hw)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
@@ -1,7 +1,7 @@
 From 2c1a091965b3d3517a773d4d6668ff9c27615620 Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Mon, 26 May 2025 04:18:07 +0800
-Subject: [PATCH 328/328] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
+Subject: [PATCH 328/330] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
  usleep_range() for EC polling
 
 It was reported that ideapad-laptop sometimes causes some recent (since
@@ -60,7 +60,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/ideapad-laptop.c b/drivers/platform/x86/ideapad-laptop.c
-index b740c7bb81015..d3a7faf7ca808 100644
+index b740c7bb8101..d3a7faf7ca80 100644
 --- a/drivers/platform/x86/ideapad-laptop.c
 +++ b/drivers/platform/x86/ideapad-laptop.c
 @@ -15,6 +15,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
@@ -1,0 +1,41 @@
+From 7ba8c8def946ca59f3e6c7a78c3fdc6e977c0716 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:50 +0000
+Subject: [PATCH 329/330] BACKPORT: FROMLIST: platform/loongarch: laptop: Get
+ brightness setting from EC on probe
+
+Previously 1 is unconditionally taken as current brightness value. This
+causes problems since it's required to restore brightness settings on
+resumption, and a value that doesn't match EC's state before suspension
+will cause surprising changes of screen brightness.
+
+Let's get brightness from EC and take it as the current brightness on
+probe of the laptop driver to avoid the surprising behavior. Tested on
+TongFang L860-T2 3A5000 laptop.
+
+Cc: stable@vger.kernel.org
+Fixes: 6246ed09111f ("LoongArch: Add ACPI-based generic laptop driver")
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 99203584949d..828bd62e3596 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -392,7 +392,7 @@ static int laptop_backlight_register(void)
+ 	if (!acpi_evalf(hotkey_handle, &status, "ECLL", "d"))
+ 		return -EIO;
+ 
+-	props.brightness = 1;
++	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
@@ -1,0 +1,118 @@
+From f44f34a3104a2725300dc5a8237c111e524381e6 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:51 +0000
+Subject: [PATCH 330/330] BACKPORT: FROMLIST: platform/loongarch: laptop:
+ Support backlight power control
+
+loongson_laptop_turn_{on,off}_backlight() are designed for controlling
+power of the backlight, but they aren't really used in the driver
+previously.
+
+Unify these two functions since they only differ in arguments passed to
+ACPI method, and wire up loongson_laptop_backlight_update() to update
+power state of the backlight as well. Tested on TongFang L860-T2 3A5000
+laptop.
+
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 53 +++++++-------------
+ 1 file changed, 19 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 828bd62e3596..f01e53b1c84d 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -56,8 +56,6 @@ static struct input_dev *generic_inputdev;
+ static acpi_handle hotkey_handle;
+ static struct key_entry hotkey_keycode_map[GENERIC_HOTKEY_MAP_MAX];
+ 
+-int loongson_laptop_turn_on_backlight(void);
+-int loongson_laptop_turn_off_backlight(void);
+ static int loongson_laptop_backlight_update(struct backlight_device *bd);
+ 
+ /* 2. ACPI Helpers and device model */
+@@ -354,6 +352,22 @@ static int ec_backlight_level(u8 level)
+ 	return level;
+ }
+ 
++static int ec_backlight_set_power(bool state)
++{
++	int status;
++	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
++	struct acpi_object_list args = { 1, &arg0 };
++
++	arg0.integer.value = state;
++	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
++	if (ACPI_FAILURE(status)) {
++		pr_info("Loongson lvds error: 0x%x\n", status);
++		return -EIO;
++	}
++
++	return 0;
++}
++
+ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ {
+ 	int lvl = ec_backlight_level(bd->props.brightness);
+@@ -363,6 +377,8 @@ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ 	if (ec_set_brightness(lvl))
+ 		return -EIO;
+ 
++	ec_backlight_set_power(bd->props.power == BACKLIGHT_POWER_ON ? true : false);
++
+ 	return 0;
+ }
+ 
+@@ -394,6 +410,7 @@ static int laptop_backlight_register(void)
+ 
+ 	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
++	props.power = BACKLIGHT_POWER_ON;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+ 	backlight_device_register("loongson_laptop",
+@@ -402,38 +419,6 @@ static int laptop_backlight_register(void)
+ 	return 0;
+ }
+ 
+-int loongson_laptop_turn_on_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 1;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+-int loongson_laptop_turn_off_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 0;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+ static int __init event_init(struct generic_sub_driver *sub_driver)
+ {
+ 	int ret;
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.14.9
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=2
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 

--- a/topics/linux-kernel-6.14.9-loongarch-fixes.toml
+++ b/topics/linux-kernel-6.14.9-loongarch-fixes.toml
@@ -1,0 +1,12 @@
+security = false
+
+[name]
+default = "Linux Kernel, 6.14.9 (revision 2)"
+zh_CN = "Linux 内核，版本 6.14.9（修订 2）"
+
+[caution]
+default = "Fixes an issue where display brightness on Loongson 3A5000/6000-based laptops may be reset to the lowest upon wakeup from S3 suspend"
+zh_CN = "修复基于龙芯 3A5000/3A6000 的笔记本从 S3 睡眠唤醒时，屏幕背光亮度可能被复位为最低的问题"
+
+[packages]
+"linux-kernel-6.14.9" = "6.14.9-2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add linux-kernel-6.14.9-loongarch-fixes.toml
- linux-kernel: backport fixes for LoongArch
    - Introduce fixes for Loongson 3A5000/3A6000 laptop backlight.
    - Track patches at AOSC-Tracking/linux @ aosc/v6.14.9
    \(HEAD: f44f34a3104a2725300dc5a8237c111e524381e6\).

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.14.9-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
