### PR TITLE
linux-kernel-lts: backport fixes for LoongArch

### DIFF
--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-UPSTREAM-cpufreq-amd-pstate-Use-amd_pstate_update_mi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0001-UPSTREAM-cpufreq-amd-pstate-Use-amd_pstate_update_mi.patch
@@ -1,7 +1,7 @@
 From a576014cb58c86a020957d392d90db14de80487f Mon Sep 17 00:00:00 2001
 From: Mario Limonciello <mario.limonciello@amd.com>
 Date: Sat, 12 Oct 2024 12:45:18 -0500
-Subject: [PATCH 001/303] UPSTREAM: cpufreq/amd-pstate: Use
+Subject: [PATCH 001/305] UPSTREAM: cpufreq/amd-pstate: Use
  amd_pstate_update_min_max_limit() for EPP limits
 
 When the EPP updates are set the maximum capable frequency for the
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index 7a16d19322286..6040d4eeec09f 100644
+index 7a16d1932228..6040d4eeec09 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -1481,26 +1481,13 @@ static void amd_pstate_epp_cpu_exit(struct cpufreq_policy *policy)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-UPSTREAM-cpufreq-amd-pstate-Drop-needless-EPP-initia.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0002-UPSTREAM-cpufreq-amd-pstate-Drop-needless-EPP-initia.patch
@@ -1,7 +1,7 @@
 From 5303afb7d77cc093b0f755d270602e9ac6dd28a3 Mon Sep 17 00:00:00 2001
 From: Mario Limonciello <mario.limonciello@amd.com>
 Date: Sat, 12 Oct 2024 12:45:19 -0500
-Subject: [PATCH 002/303] UPSTREAM: cpufreq/amd-pstate: Drop needless EPP
+Subject: [PATCH 002/305] UPSTREAM: cpufreq/amd-pstate: Drop needless EPP
  initialization
 
 The EPP value doesn't need to be cached to the CPPC request in
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index 6040d4eeec09f..1bf45b5317ca1 100644
+index 6040d4eeec09..1bf45b5317ca 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -1524,12 +1524,6 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-BACKPORT-platform-x86-amd-amd_3d_vcache-Add-AMD-3D-V.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0003-BACKPORT-platform-x86-amd-amd_3d_vcache-Add-AMD-3D-V.patch
@@ -1,7 +1,7 @@
 From c9936bd4401b1c1b3f0966402afee656885b793e Mon Sep 17 00:00:00 2001
 From: Basavaraj Natikar <Basavaraj.Natikar@amd.com>
 Date: Tue, 12 Nov 2024 22:33:06 +0530
-Subject: [PATCH 003/303] BACKPORT: platform/x86/amd: amd_3d_vcache: Add AMD 3D
+Subject: [PATCH 003/305] BACKPORT: platform/x86/amd: amd_3d_vcache: Add AMD 3D
  V-Cache optimizer driver
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/x86/amd/x3d_vcache.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d0f18fdba068b..57b61123a8b16 100644
+index d0f18fdba068..57b61123a8b1 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -965,6 +965,13 @@ Q:	https://patchwork.kernel.org/project/linux-rdma/list/
@@ -59,7 +59,7 @@ index d0f18fdba068b..57b61123a8b16 100644
  M:	Yazen Ghannam <Yazen.Ghannam@amd.com>
  L:	linux-edac@vger.kernel.org
 diff --git a/drivers/platform/x86/amd/Kconfig b/drivers/platform/x86/amd/Kconfig
-index f88682d36447c..d73f691020d0f 100644
+index f88682d36447..d73f691020d0 100644
 --- a/drivers/platform/x86/amd/Kconfig
 +++ b/drivers/platform/x86/amd/Kconfig
 @@ -6,6 +6,18 @@
@@ -82,7 +82,7 @@ index f88682d36447c..d73f691020d0f 100644
  	tristate "AMD HSMP Driver"
  	depends on AMD_NB && X86_64 && ACPI
 diff --git a/drivers/platform/x86/amd/Makefile b/drivers/platform/x86/amd/Makefile
-index dcec0a46f8af1..86d73f3bd1760 100644
+index dcec0a46f8af..86d73f3bd176 100644
 --- a/drivers/platform/x86/amd/Makefile
 +++ b/drivers/platform/x86/amd/Makefile
 @@ -4,6 +4,8 @@
@@ -96,7 +96,7 @@ index dcec0a46f8af1..86d73f3bd1760 100644
  obj-$(CONFIG_AMD_HSMP)		+= amd_hsmp.o
 diff --git a/drivers/platform/x86/amd/x3d_vcache.c b/drivers/platform/x86/amd/x3d_vcache.c
 new file mode 100644
-index 0000000000000..0f6d3c54d8795
+index 000000000000..0f6d3c54d879
 --- /dev/null
 +++ b/drivers/platform/x86/amd/x3d_vcache.c
 @@ -0,0 +1,176 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-UPSTREAM-platform-x86-amd-amd_3d_vcache-Add-sysfs-AB.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0004-UPSTREAM-platform-x86-amd-amd_3d_vcache-Add-sysfs-AB.patch
@@ -1,7 +1,7 @@
 From 3b53edbdcd56786eea957837290098e777415e1b Mon Sep 17 00:00:00 2001
 From: Basavaraj Natikar <Basavaraj.Natikar@amd.com>
 Date: Tue, 12 Nov 2024 22:33:07 +0530
-Subject: [PATCH 004/303] UPSTREAM: platform/x86/amd: amd_3d_vcache: Add sysfs
+Subject: [PATCH 004/305] UPSTREAM: platform/x86/amd: amd_3d_vcache: Add sysfs
  ABI documentation
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -32,7 +32,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/ABI/testing/sysfs-bus-platform-drivers-amd_x3d_vcache b/Documentation/ABI/testing/sysfs-bus-platform-drivers-amd_x3d_vcache
 new file mode 100644
-index 0000000000000..ac3431736f5ca
+index 000000000000..ac3431736f5c
 --- /dev/null
 +++ b/Documentation/ABI/testing/sysfs-bus-platform-drivers-amd_x3d_vcache
 @@ -0,0 +1,12 @@
@@ -49,7 +49,7 @@ index 0000000000000..ac3431736f5ca
 +		- "cache" cores within the larger L3 CCD are prioritized before
 +		those in the smaller L3 CCD.
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 57b61123a8b16..879f598ca34e6 100644
+index 57b61123a8b1..879f598ca34e 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -970,6 +970,7 @@ M:	Basavaraj Natikar <Basavaraj.Natikar@amd.com>

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-UPSTREAM-ASoC-dt-bindings-Add-Everest-ES8323-Codec.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0005-UPSTREAM-ASoC-dt-bindings-Add-Everest-ES8323-Codec.patch
@@ -1,7 +1,7 @@
 From cbf7a77097b137f2f65530b1dc9d3a4136548b97 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:51:43 +0800
-Subject: [PATCH 005/303] UPSTREAM: ASoC: dt-bindings: Add Everest ES8323 Codec
+Subject: [PATCH 005/305] UPSTREAM: ASoC: dt-bindings: Add Everest ES8323 Codec
 
 Add DT bindings documentation for the Everest-semi ES8323 codec.
 
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/devicetree/bindings/sound/everest,es8316.yaml b/Documentation/devicetree/bindings/sound/everest,es8316.yaml
-index 214f135b7777f..e4b2eb5fae2fc 100644
+index 214f135b7777..e4b2eb5fae2f 100644
 --- a/Documentation/devicetree/bindings/sound/everest,es8316.yaml
 +++ b/Documentation/devicetree/bindings/sound/everest,es8316.yaml
 @@ -4,12 +4,13 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-UPSTREAM-ASoC-codecs-Add-support-for-ES8323.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0006-UPSTREAM-ASoC-codecs-Add-support-for-ES8323.patch
@@ -1,7 +1,7 @@
 From 082cffbd7ae19609aae3084c6b513ee06b9be0bd Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:52:10 +0800
-Subject: [PATCH 006/303] UPSTREAM: ASoC: codecs: Add support for ES8323
+Subject: [PATCH 006/305] UPSTREAM: ASoC: codecs: Add support for ES8323
 
 Add a codec driver for the Everest ES8323. It supports two separate
 audio outputs and two separate audio inputs.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 sound/soc/codecs/es8323.h
 
 diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
-index 6a72561c4189b..1dd87d566e032 100644
+index 6a72561c4189..1dd87d566e03 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
 @@ -112,6 +112,7 @@ config SND_SOC_ALL_CODECS
@@ -45,7 +45,7 @@ index 6a72561c4189b..1dd87d566e032 100644
  	tristate "Everest Semi ES8326 CODEC"
  	depends on I2C
 diff --git a/sound/soc/codecs/Makefile b/sound/soc/codecs/Makefile
-index 69cb0b39f2200..436719b241632 100644
+index 69cb0b39f220..436719b24163 100644
 --- a/sound/soc/codecs/Makefile
 +++ b/sound/soc/codecs/Makefile
 @@ -125,6 +125,7 @@ snd-soc-es7241-y := es7241.o
@@ -66,7 +66,7 @@ index 69cb0b39f2200..436719b241632 100644
  obj-$(CONFIG_SND_SOC_ES8328_I2C)+= snd-soc-es8328-i2c.o
 diff --git a/sound/soc/codecs/es8323.c b/sound/soc/codecs/es8323.c
 new file mode 100644
-index 0000000000000..c09bd92b2ed31
+index 000000000000..c09bd92b2ed3
 --- /dev/null
 +++ b/sound/soc/codecs/es8323.c
 @@ -0,0 +1,792 @@
@@ -864,7 +864,7 @@ index 0000000000000..c09bd92b2ed31
 +MODULE_LICENSE("GPL");
 diff --git a/sound/soc/codecs/es8323.h b/sound/soc/codecs/es8323.h
 new file mode 100644
-index 0000000000000..f986c9301dc62
+index 000000000000..f986c9301dc6
 --- /dev/null
 +++ b/sound/soc/codecs/es8323.h
 @@ -0,0 +1,78 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-UPSTREAM-ASoC-dt-bindings-Add-NXP-uda1342-Codec.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0007-UPSTREAM-ASoC-dt-bindings-Add-NXP-uda1342-Codec.patch
@@ -1,7 +1,7 @@
 From 6751092c051cb09c4c3bdf75053836a0cc4d3aa9 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:52:11 +0800
-Subject: [PATCH 007/303] UPSTREAM: ASoC: dt-bindings: Add NXP uda1342 Codec
+Subject: [PATCH 007/305] UPSTREAM: ASoC: dt-bindings: Add NXP uda1342 Codec
 
 Add NXP uda1342 CODEC binding with DT schema format using json-schema.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/sound/nxp,uda1342.yaml b/Documentation/devicetree/bindings/sound/nxp,uda1342.yaml
 new file mode 100644
-index 0000000000000..71c6a5a2f5bc0
+index 000000000000..71c6a5a2f5bc
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/sound/nxp,uda1342.yaml
 @@ -0,0 +1,42 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-UPSTREAM-ASoC-codecs-Add-uda1342-codec-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0008-UPSTREAM-ASoC-codecs-Add-uda1342-codec-driver.patch
@@ -1,7 +1,7 @@
 From 230ad1e131c09188093ec5ff670bc0fb9f20c641 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:52:26 +0800
-Subject: [PATCH 008/303] UPSTREAM: ASoC: codecs: Add uda1342 codec driver
+Subject: [PATCH 008/305] UPSTREAM: ASoC: codecs: Add uda1342 codec driver
 
 The UDA1342 is an NXP audio codec, support 2x Stereo audio ADC (4x PGA
 mic inputs), stereo audio DAC, with basic audio processing.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 sound/soc/codecs/uda1342.h
 
 diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
-index 1dd87d566e032..40299c2b2793b 100644
+index 1dd87d566e03..40299c2b2793 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
 @@ -282,6 +282,7 @@ config SND_SOC_ALL_CODECS
@@ -48,7 +48,7 @@ index 1dd87d566e032..40299c2b2793b 100644
  	tristate
  	depends on I2C
 diff --git a/sound/soc/codecs/Makefile b/sound/soc/codecs/Makefile
-index 436719b241632..2d97a82c74c69 100644
+index 436719b24163..2d97a82c74c6 100644
 --- a/sound/soc/codecs/Makefile
 +++ b/sound/soc/codecs/Makefile
 @@ -320,6 +320,7 @@ snd-soc-ts3a227e-y := ts3a227e.o
@@ -69,7 +69,7 @@ index 436719b241632..2d97a82c74c69 100644
  obj-$(CONFIG_SND_SOC_WCD_MBHC)	+= snd-soc-wcd-mbhc.o
 diff --git a/sound/soc/codecs/uda1342.c b/sound/soc/codecs/uda1342.c
 new file mode 100644
-index 0000000000000..3d49a78699485
+index 000000000000..3d49a7869948
 --- /dev/null
 +++ b/sound/soc/codecs/uda1342.c
 @@ -0,0 +1,347 @@
@@ -422,7 +422,7 @@ index 0000000000000..3d49a78699485
 +MODULE_LICENSE("GPL");
 diff --git a/sound/soc/codecs/uda1342.h b/sound/soc/codecs/uda1342.h
 new file mode 100644
-index 0000000000000..ff6aea0a8b016
+index 000000000000..ff6aea0a8b01
 --- /dev/null
 +++ b/sound/soc/codecs/uda1342.h
 @@ -0,0 +1,78 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-UPSTREAM-ASoC-dt-bindings-Add-Loongson-I2S-controlle.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0009-UPSTREAM-ASoC-dt-bindings-Add-Loongson-I2S-controlle.patch
@@ -1,7 +1,7 @@
 From f197a98190f73013e8a057aa545db0225b355d96 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:52:37 +0800
-Subject: [PATCH 009/303] UPSTREAM: ASoC: dt-bindings: Add Loongson I2S
+Subject: [PATCH 009/305] UPSTREAM: ASoC: dt-bindings: Add Loongson I2S
  controller
 
 Add Loongson I2S controller binding with DT schema format using
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/sound/loongson,ls2k1000-i2s.yaml b/Documentation/devicetree/bindings/sound/loongson,ls2k1000-i2s.yaml
 new file mode 100644
-index 0000000000000..da79510bb2d91
+index 000000000000..da79510bb2d9
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/sound/loongson,ls2k1000-i2s.yaml
 @@ -0,0 +1,68 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-UPSTREAM-ASoC-loongson-Add-I2S-controller-driver-as-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0010-UPSTREAM-ASoC-loongson-Add-I2S-controller-driver-as-.patch
@@ -1,7 +1,7 @@
 From 18ed2fdb5557359451e251d7e0ff3c7c546ff3c0 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 9 Oct 2024 15:52:38 +0800
-Subject: [PATCH 010/303] UPSTREAM: ASoC: loongson: Add I2S controller driver
+Subject: [PATCH 010/305] UPSTREAM: ASoC: loongson: Add I2S controller driver
  as platform device
 
 The Loongson I2S controller exists not only in PCI form (LS7A bridge
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 sound/soc/loongson/loongson_i2s_plat.c
 
 diff --git a/sound/soc/loongson/Kconfig b/sound/soc/loongson/Kconfig
-index b8d7e2bade246..e641ae4156d9a 100644
+index b8d7e2bade24..e641ae4156d9 100644
 --- a/sound/soc/loongson/Kconfig
 +++ b/sound/soc/loongson/Kconfig
 @@ -1,11 +1,22 @@
@@ -76,7 +76,7 @@ index b8d7e2bade246..e641ae4156d9a 100644
 +	  Loongson-2K1000 SoCs.
  endmenu
 diff --git a/sound/soc/loongson/Makefile b/sound/soc/loongson/Makefile
-index 578030ad6563c..f396259244a32 100644
+index 578030ad6563..f396259244a3 100644
 --- a/sound/soc/loongson/Makefile
 +++ b/sound/soc/loongson/Makefile
 @@ -3,6 +3,9 @@
@@ -91,7 +91,7 @@ index 578030ad6563c..f396259244a32 100644
  obj-$(CONFIG_SND_SOC_LOONGSON_CARD) += snd-soc-loongson-card.o
 diff --git a/sound/soc/loongson/loongson_i2s_plat.c b/sound/soc/loongson/loongson_i2s_plat.c
 new file mode 100644
-index 0000000000000..fa2e450ff618d
+index 000000000000..fa2e450ff618
 --- /dev/null
 +++ b/sound/soc/loongson/loongson_i2s_plat.c
 @@ -0,0 +1,185 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-UPSTREAM-ASoC-codecs-Fix-error-check-in-es8323_i2c_p.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0011-UPSTREAM-ASoC-codecs-Fix-error-check-in-es8323_i2c_p.patch
@@ -1,7 +1,7 @@
 From ff295409ffdca0635495289e6388a3ab8a50b1a9 Mon Sep 17 00:00:00 2001
 From: Tang Bin <tangbin@cmss.chinamobile.com>
 Date: Fri, 11 Oct 2024 15:31:15 +0800
-Subject: [PATCH 011/303] UPSTREAM: ASoC: codecs: Fix error check in
+Subject: [PATCH 011/305] UPSTREAM: ASoC: codecs: Fix error check in
  es8323_i2c_probe
 
 In the function es8323_i2c_probe(), devm_kzalloc() could
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/sound/soc/codecs/es8323.c b/sound/soc/codecs/es8323.c
-index c09bd92b2ed31..6f4fa36ea34d6 100644
+index c09bd92b2ed3..6f4fa36ea34d 100644
 --- a/sound/soc/codecs/es8323.c
 +++ b/sound/soc/codecs/es8323.c
 @@ -743,7 +743,7 @@ static int es8323_i2c_probe(struct i2c_client *i2c_client)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-UPSTREAM-ASoC-loongson-Fix-build-warning-when-CONFIG.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0012-UPSTREAM-ASoC-loongson-Fix-build-warning-when-CONFIG.patch
@@ -1,7 +1,7 @@
 From 28b0dcd82fb88ec9cc329043037741c340437950 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 12 Oct 2024 17:58:40 +0800
-Subject: [PATCH 012/303] UPSTREAM: ASoC: loongson: Fix build warning when
+Subject: [PATCH 012/305] UPSTREAM: ASoC: loongson: Fix build warning when
  !CONFIG_PCI
 
 Fixes the below if kernel config disable PCI support:
@@ -32,7 +32,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/sound/soc/loongson/Kconfig b/sound/soc/loongson/Kconfig
-index e641ae4156d9a..2d8291c1443cc 100644
+index e641ae4156d9..2d8291c1443c 100644
 --- a/sound/soc/loongson/Kconfig
 +++ b/sound/soc/loongson/Kconfig
 @@ -16,6 +16,7 @@ config SND_SOC_LOONGSON_CARD

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-UPSTREAM-ASoC-loongson-make-loongson-i2s.o-a-separat.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0013-UPSTREAM-ASoC-loongson-make-loongson-i2s.o-a-separat.patch
@@ -1,7 +1,7 @@
 From f5671c69e916d1e2fc1512247d19ef9c3cfb14a1 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Tue, 15 Oct 2024 15:09:54 +0000
-Subject: [PATCH 013/303] UPSTREAM: ASoC: loongson: make loongson-i2s.o a
+Subject: [PATCH 013/305] UPSTREAM: ASoC: loongson: make loongson-i2s.o a
  separate module
 
 An object file should not be linked into multiple modules and/or
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 11 insertions(+), 4 deletions(-)
 
 diff --git a/sound/soc/loongson/Makefile b/sound/soc/loongson/Makefile
-index f396259244a32..c0cb1acb36e34 100644
+index f396259244a3..c0cb1acb36e3 100644
 --- a/sound/soc/loongson/Makefile
 +++ b/sound/soc/loongson/Makefile
 @@ -1,10 +1,12 @@
@@ -46,7 +46,7 @@ index f396259244a32..c0cb1acb36e34 100644
  #Machine Support
  snd-soc-loongson-card-y := loongson_card.o
 diff --git a/sound/soc/loongson/loongson_i2s.c b/sound/soc/loongson/loongson_i2s.c
-index 40bbf32053918..e8852a30f213f 100644
+index 40bbf3205391..e8852a30f213 100644
 --- a/sound/soc/loongson/loongson_i2s.c
 +++ b/sound/soc/loongson/loongson_i2s.c
 @@ -246,6 +246,7 @@ struct snd_soc_dai_driver loongson_i2s_dai = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-UPSTREAM-ALSA-hda-Poll-jack-events-for-LS7A-HD-Audio.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0014-UPSTREAM-ALSA-hda-Poll-jack-events-for-LS7A-HD-Audio.patch
@@ -1,7 +1,7 @@
 From dcd0765ace6a8399f971ab0c335c8ccdf73d006d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 15 Nov 2024 23:06:53 +0800
-Subject: [PATCH 014/303] UPSTREAM: ALSA: hda: Poll jack events for LS7A
+Subject: [PATCH 014/305] UPSTREAM: ALSA: hda: Poll jack events for LS7A
  HD-Audio
 
 LS7A HD-Audio disable interrupts and use polling mode due to hardware
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/sound/pci/hda/hda_intel.c b/sound/pci/hda/hda_intel.c
-index 25b1984898ab2..7815aa5eb42f7 100644
+index 25b1984898ab..7815aa5eb42f 100644
 --- a/sound/pci/hda/hda_intel.c
 +++ b/sound/pci/hda/hda_intel.c
 @@ -1881,6 +1881,8 @@ static int azx_first_init(struct azx *chip)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-UPSTREAM-drm-nouveau-disp-Move-tiling-functions-to-d.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0015-UPSTREAM-drm-nouveau-disp-Move-tiling-functions-to-d.patch
@@ -1,7 +1,7 @@
 From 270b95873de675d84b4fb57ff5413b66f66f1f72 Mon Sep 17 00:00:00 2001
 From: Jocelyn Falempe <jfalempe@redhat.com>
 Date: Tue, 22 Oct 2024 20:39:48 +0200
-Subject: [PATCH 015/303] UPSTREAM: drm/nouveau/disp: Move tiling functions to
+Subject: [PATCH 015/305] UPSTREAM: drm/nouveau/disp: Move tiling functions to
  dispnv50/tile.h
 
 Refactor, and move the tiling geometry functions to dispnv50/tile.h,
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/drivers/gpu/drm/nouveau/dispnv50/tile.h b/drivers/gpu/drm/nouveau/dispnv50/tile.h
 new file mode 100644
-index 0000000000000..e2be82830cf75
+index 000000000000..e2be82830cf7
 --- /dev/null
 +++ b/drivers/gpu/drm/nouveau/dispnv50/tile.h
 @@ -0,0 +1,63 @@
@@ -90,7 +90,7 @@ index 0000000000000..e2be82830cf75
 +
 +#endif
 diff --git a/drivers/gpu/drm/nouveau/nouveau_display.c b/drivers/gpu/drm/nouveau/nouveau_display.c
-index e2fd561cd23f4..faf9308f88c04 100644
+index e2fd561cd23f..faf9308f88c0 100644
 --- a/drivers/gpu/drm/nouveau/nouveau_display.c
 +++ b/drivers/gpu/drm/nouveau/nouveau_display.c
 @@ -44,6 +44,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-UPSTREAM-drm-nouveau-Add-drm_panic-support-for-nv50.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0016-UPSTREAM-drm-nouveau-Add-drm_panic-support-for-nv50.patch
@@ -1,7 +1,7 @@
 From 6b6b5c71b77aaee3bb0fee4fe7b7e828a0df266f Mon Sep 17 00:00:00 2001
 From: Jocelyn Falempe <jfalempe@redhat.com>
 Date: Tue, 22 Oct 2024 20:39:49 +0200
-Subject: [PATCH 016/303] UPSTREAM: drm/nouveau: Add drm_panic support for
+Subject: [PATCH 016/305] UPSTREAM: drm/nouveau: Add drm_panic support for
  nv50+
 
 Add drm_panic support for nv50+ cards.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 127 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/nouveau/dispnv50/wndw.c b/drivers/gpu/drm/nouveau/dispnv50/wndw.c
-index 7a2cceaee6e97..f6be426dd5253 100644
+index 7a2cceaee6e9..f6be426dd525 100644
 --- a/drivers/gpu/drm/nouveau/dispnv50/wndw.c
 +++ b/drivers/gpu/drm/nouveau/dispnv50/wndw.c
 @@ -30,14 +30,20 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-UPSTREAM-drm-amdgpu-fix-comment-about-amdgpu.abmleve.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0017-UPSTREAM-drm-amdgpu-fix-comment-about-amdgpu.abmleve.patch
@@ -1,7 +1,7 @@
 From d5f07d0ca20c3d85386f7b2f758536a56b5bbe8d Mon Sep 17 00:00:00 2001
 From: "jeffbai@aosc.io" <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 21:07:18 +0800
-Subject: [PATCH 017/303] UPSTREAM: drm/amdgpu: fix comment about
+Subject: [PATCH 017/305] UPSTREAM: drm/amdgpu: fix comment about
  amdgpu.abmlevel defaults
 
 Since 040fdcde288a ("drm/amdgpu: respect the abmlevel module parameter value
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 93c3de2d27d3a..564ba40b1dcd0 100644
+index 93c3de2d27d3..564ba40b1dcd 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -895,7 +895,7 @@ module_param_named(visualconfirm, amdgpu_dc_visual_confirm, uint, 0444);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-UPSTREAM-LoongArch-KVM-Add-iocsr-and-mmio-bus-simula.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0018-UPSTREAM-LoongArch-KVM-Add-iocsr-and-mmio-bus-simula.patch
@@ -1,7 +1,7 @@
 From 70823e70da31d6887a002b5aefce996c38a8168e Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:26 +0800
-Subject: [PATCH 018/303] UPSTREAM: LoongArch: KVM: Add iocsr and mmio bus
+Subject: [PATCH 018/305] UPSTREAM: LoongArch: KVM: Add iocsr and mmio bus
  simulation in kernel
 
 Add iocsr and mmio memory read and write simulation to the kernel. When
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 94 insertions(+), 24 deletions(-)
 
 diff --git a/arch/loongarch/kvm/exit.c b/arch/loongarch/kvm/exit.c
-index add52e927f153..501f225b357f7 100644
+index add52e927f15..501f225b357f 100644
 --- a/arch/loongarch/kvm/exit.c
 +++ b/arch/loongarch/kvm/exit.c
 @@ -157,7 +157,7 @@ static int kvm_handle_csr(struct kvm_vcpu *vcpu, larch_inst inst)
@@ -156,7 +156,7 @@ index add52e927f153..501f225b357f7 100644
  }
  
 diff --git a/include/linux/kvm_host.h b/include/linux/kvm_host.h
-index 2e836d44f7386..fd20fc85dc402 100644
+index 2e836d44f738..fd20fc85dc40 100644
 --- a/include/linux/kvm_host.h
 +++ b/include/linux/kvm_host.h
 @@ -219,6 +219,7 @@ enum kvm_bus {
@@ -168,7 +168,7 @@ index 2e836d44f7386..fd20fc85dc402 100644
  };
  
 diff --git a/include/trace/events/kvm.h b/include/trace/events/kvm.h
-index 74e40d5d4af42..fc7d0f8ff0788 100644
+index 74e40d5d4af4..fc7d0f8ff078 100644
 --- a/include/trace/events/kvm.h
 +++ b/include/trace/events/kvm.h
 @@ -236,6 +236,41 @@ TRACE_EVENT(kvm_mmio,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-UPSTREAM-LoongArch-KVM-Add-IPI-device-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0019-UPSTREAM-LoongArch-KVM-Add-IPI-device-support.patch
@@ -1,7 +1,7 @@
 From d476984325910e1260304e5d2b25a2a333db76a7 Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 019/303] UPSTREAM: LoongArch: KVM: Add IPI device support
+Subject: [PATCH 019/305] UPSTREAM: LoongArch: KVM: Add IPI device support
 
 Add device model for IPI interrupt controller, implement basic create &
 destroy interfaces, and register device model to kvm device table.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kvm/intc/ipi.c
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index d6bb72424027a..8e5393d21fcbe 100644
+index d6bb72424027..8e5393d21fcb 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -18,6 +18,7 @@
@@ -55,7 +55,7 @@ index d6bb72424027a..8e5393d21fcbe 100644
  
 diff --git a/arch/loongarch/include/asm/kvm_ipi.h b/arch/loongarch/include/asm/kvm_ipi.h
 new file mode 100644
-index 0000000000000..baaa6253e4dcf
+index 000000000000..baaa6253e4dc
 --- /dev/null
 +++ b/arch/loongarch/include/asm/kvm_ipi.h
 @@ -0,0 +1,33 @@
@@ -93,7 +93,7 @@ index 0000000000000..baaa6253e4dcf
 +
 +#endif
 diff --git a/arch/loongarch/kvm/Makefile b/arch/loongarch/kvm/Makefile
-index 2e188e8f14687..10ebf7e91b58d 100644
+index 2e188e8f1468..10ebf7e91b58 100644
 --- a/arch/loongarch/kvm/Makefile
 +++ b/arch/loongarch/kvm/Makefile
 @@ -18,5 +18,6 @@ kvm-y += timer.o
@@ -105,7 +105,7 @@ index 2e188e8f14687..10ebf7e91b58d 100644
  CFLAGS_exit.o	+= $(call cc-disable-warning, override-init)
 diff --git a/arch/loongarch/kvm/intc/ipi.c b/arch/loongarch/kvm/intc/ipi.c
 new file mode 100644
-index 0000000000000..9e45571ad76e0
+index 000000000000..9e45571ad76e
 --- /dev/null
 +++ b/arch/loongarch/kvm/intc/ipi.c
 @@ -0,0 +1,112 @@
@@ -222,7 +222,7 @@ index 0000000000000..9e45571ad76e0
 +	return kvm_register_device_ops(&kvm_ipi_dev_ops, KVM_DEV_TYPE_LOONGARCH_IPI);
 +}
 diff --git a/arch/loongarch/kvm/main.c b/arch/loongarch/kvm/main.c
-index 34fad2c29ee69..99369ea3bcbe3 100644
+index 34fad2c29ee6..99369ea3bcbe 100644
 --- a/arch/loongarch/kvm/main.c
 +++ b/arch/loongarch/kvm/main.c
 @@ -320,7 +320,7 @@ void kvm_arch_disable_virtualization_cpu(void)
@@ -247,7 +247,7 @@ index 34fad2c29ee69..99369ea3bcbe3 100644
  
  static void kvm_loongarch_env_exit(void)
 diff --git a/arch/loongarch/kvm/vcpu.c b/arch/loongarch/kvm/vcpu.c
-index 4b0ae29b8acab..7462faaec9666 100644
+index 4b0ae29b8aca..7462faaec966 100644
 --- a/arch/loongarch/kvm/vcpu.c
 +++ b/arch/loongarch/kvm/vcpu.c
 @@ -1485,6 +1485,9 @@ int kvm_arch_vcpu_create(struct kvm_vcpu *vcpu)
@@ -261,7 +261,7 @@ index 4b0ae29b8acab..7462faaec9666 100644
  	 * Initialize guest register state to valid architectural reset state.
  	 */
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index 637efc0551453..9fff439c30ea7 100644
+index 637efc055145..9fff439c30ea 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
 @@ -1158,7 +1158,11 @@ enum kvm_device_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-UPSTREAM-LoongArch-KVM-Add-IPI-read-and-write-functi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0020-UPSTREAM-LoongArch-KVM-Add-IPI-read-and-write-functi.patch
@@ -1,7 +1,7 @@
 From faf1f61a19047172e6a410c05bf70e4bafbe40be Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 020/303] UPSTREAM: LoongArch: KVM: Add IPI read and write
+Subject: [PATCH 020/305] UPSTREAM: LoongArch: KVM: Add IPI read and write
  function
 
 Add implementation of IPI interrupt controller's address space read and
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 291 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index 8e5393d21fcbe..a1de884ebb44f 100644
+index 8e5393d21fcb..a1de884ebb44 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -45,6 +45,8 @@ struct kvm_vm_stat {
@@ -34,7 +34,7 @@ index 8e5393d21fcbe..a1de884ebb44f 100644
  
  struct kvm_vcpu_stat {
 diff --git a/arch/loongarch/include/asm/kvm_ipi.h b/arch/loongarch/include/asm/kvm_ipi.h
-index baaa6253e4dcf..060163dfb4a38 100644
+index baaa6253e4dc..060163dfb4a3 100644
 --- a/arch/loongarch/include/asm/kvm_ipi.h
 +++ b/arch/loongarch/include/asm/kvm_ipi.h
 @@ -28,6 +28,18 @@ struct ipi_state {
@@ -57,7 +57,7 @@ index baaa6253e4dcf..060163dfb4a38 100644
  
  #endif
 diff --git a/arch/loongarch/kvm/intc/ipi.c b/arch/loongarch/kvm/intc/ipi.c
-index 9e45571ad76e0..462d6ac084d38 100644
+index 9e45571ad76e..462d6ac084d3 100644
 --- a/arch/loongarch/kvm/intc/ipi.c
 +++ b/arch/loongarch/kvm/intc/ipi.c
 @@ -7,18 +7,293 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-UPSTREAM-LoongArch-KVM-Add-IPI-user-mode-read-and-wr.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0021-UPSTREAM-LoongArch-KVM-Add-IPI-user-mode-read-and-wr.patch
@@ -1,7 +1,7 @@
 From 0adbf2cdc212ea75888546d7a64b4985793fe2fc Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 021/303] UPSTREAM: LoongArch: KVM: Add IPI user mode read and
+Subject: [PATCH 021/305] UPSTREAM: LoongArch: KVM: Add IPI user mode read and
  write function
 
 Implement the communication interface between the user mode programs
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 92 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index 70d89070bfeb4..c6bbbb34cef4e 100644
+index 70d89070bfeb..c6bbbb34cef4 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -132,4 +132,6 @@ struct kvm_iocsr_entry {
@@ -34,7 +34,7 @@ index 70d89070bfeb4..c6bbbb34cef4e 100644
 +
  #endif /* __UAPI_ASM_LOONGARCH_KVM_H */
 diff --git a/arch/loongarch/kvm/intc/ipi.c b/arch/loongarch/kvm/intc/ipi.c
-index 462d6ac084d38..a233a323e2957 100644
+index 462d6ac084d3..a233a323e295 100644
 --- a/arch/loongarch/kvm/intc/ipi.c
 +++ b/arch/loongarch/kvm/intc/ipi.c
 @@ -301,16 +301,104 @@ static const struct kvm_io_device_ops kvm_ipi_ops = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-UPSTREAM-LoongArch-KVM-Add-EIOINTC-device-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0022-UPSTREAM-LoongArch-KVM-Add-EIOINTC-device-support.patch
@@ -1,7 +1,7 @@
 From e8fd4745a273fdaba1526d2ad765344dd119842a Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 022/303] UPSTREAM: LoongArch: KVM: Add EIOINTC device support
+Subject: [PATCH 022/305] UPSTREAM: LoongArch: KVM: Add EIOINTC device support
 
 Add device model for EIOINTC interrupt controller, implement basic
 create & destroy interfaces, and register device model to kvm device
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/loongarch/include/asm/kvm_eiointc.h b/arch/loongarch/include/asm/kvm_eiointc.h
 new file mode 100644
-index 0000000000000..ed65de5a8168a
+index 000000000000..ed65de5a8168
 --- /dev/null
 +++ b/arch/loongarch/include/asm/kvm_eiointc.h
 @@ -0,0 +1,93 @@
@@ -124,7 +124,7 @@ index 0000000000000..ed65de5a8168a
 +
 +#endif /* __ASM_KVM_EIOINTC_H */
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index a1de884ebb44f..2d0476f05148a 100644
+index a1de884ebb44..2d0476f05148 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -19,6 +19,7 @@
@@ -153,7 +153,7 @@ index a1de884ebb44f..2d0476f05148a 100644
  
  #define CSR_MAX_NUMS		0x800
 diff --git a/arch/loongarch/kvm/Makefile b/arch/loongarch/kvm/Makefile
-index 10ebf7e91b58d..34a638570d10f 100644
+index 10ebf7e91b58..34a638570d10 100644
 --- a/arch/loongarch/kvm/Makefile
 +++ b/arch/loongarch/kvm/Makefile
 @@ -19,5 +19,6 @@ kvm-y += tlb.o
@@ -165,7 +165,7 @@ index 10ebf7e91b58d..34a638570d10f 100644
  CFLAGS_exit.o	+= $(call cc-disable-warning, override-init)
 diff --git a/arch/loongarch/kvm/intc/eiointc.c b/arch/loongarch/kvm/intc/eiointc.c
 new file mode 100644
-index 0000000000000..10afa61636432
+index 000000000000..10afa6163643
 --- /dev/null
 +++ b/arch/loongarch/kvm/intc/eiointc.c
 @@ -0,0 +1,132 @@
@@ -302,7 +302,7 @@ index 0000000000000..10afa61636432
 +	return kvm_register_device_ops(&kvm_eiointc_dev_ops, KVM_DEV_TYPE_LOONGARCH_EIOINTC);
 +}
 diff --git a/arch/loongarch/kvm/main.c b/arch/loongarch/kvm/main.c
-index 99369ea3bcbe3..96268753cc4b0 100644
+index 99369ea3bcbe..96268753cc4b 100644
 --- a/arch/loongarch/kvm/main.c
 +++ b/arch/loongarch/kvm/main.c
 @@ -9,6 +9,7 @@
@@ -326,7 +326,7 @@ index 99369ea3bcbe3..96268753cc4b0 100644
  	return ret;
  }
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index 9fff439c30ea7..0ec5c631d9e92 100644
+index 9fff439c30ea..0ec5c631d9e9 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
 @@ -1160,6 +1160,8 @@ enum kvm_device_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-UPSTREAM-LoongArch-KVM-Add-EIOINTC-read-and-write-fu.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0023-UPSTREAM-LoongArch-KVM-Add-EIOINTC-read-and-write-fu.patch
@@ -1,7 +1,7 @@
 From c1a7f648df05fbc7e4dd5cfccb8ce34723e5f38e Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 023/303] UPSTREAM: LoongArch: KVM: Add EIOINTC read and write
+Subject: [PATCH 023/305] UPSTREAM: LoongArch: KVM: Add EIOINTC read and write
  functions
 
 Add implementation of EIOINTC interrupt controller's address space read
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 771 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_eiointc.h b/arch/loongarch/include/asm/kvm_eiointc.h
-index ed65de5a8168a..a3a40aba8acf2 100644
+index ed65de5a8168..a3a40aba8acf 100644
 --- a/arch/loongarch/include/asm/kvm_eiointc.h
 +++ b/arch/loongarch/include/asm/kvm_eiointc.h
 @@ -20,9 +20,38 @@
@@ -70,7 +70,7 @@ index ed65de5a8168a..a3a40aba8acf2 100644
  
  #endif /* __ASM_KVM_EIOINTC_H */
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index 2d0476f05148a..a63c2bf6fae0c 100644
+index 2d0476f05148..a63c2bf6fae0 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -48,6 +48,8 @@ struct kvm_vm_stat {
@@ -83,7 +83,7 @@ index 2d0476f05148a..a63c2bf6fae0c 100644
  
  struct kvm_vcpu_stat {
 diff --git a/arch/loongarch/kvm/intc/eiointc.c b/arch/loongarch/kvm/intc/eiointc.c
-index 10afa61636432..7369c23be036a 100644
+index 10afa6163643..7369c23be036 100644
 --- a/arch/loongarch/kvm/intc/eiointc.c
 +++ b/arch/loongarch/kvm/intc/eiointc.c
 @@ -7,18 +7,700 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-UPSTREAM-LoongArch-KVM-Add-EIOINTC-user-mode-read-an.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0024-UPSTREAM-LoongArch-KVM-Add-EIOINTC-user-mode-read-an.patch
@@ -1,7 +1,7 @@
 From 8bd5ce766c296efefa30c2d81c7e76d7ee46fe3e Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 024/303] UPSTREAM: LoongArch: KVM: Add EIOINTC user mode read
+Subject: [PATCH 024/305] UPSTREAM: LoongArch: KVM: Add EIOINTC user mode read
  and write functions
 
 Implement the communication interface between the user mode programs
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 173 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index c6bbbb34cef4e..98126c034eb80 100644
+index c6bbbb34cef4..98126c034eb8 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -134,4 +134,16 @@ struct kvm_iocsr_entry {
@@ -42,7 +42,7 @@ index c6bbbb34cef4e..98126c034eb80 100644
 +
  #endif /* __UAPI_ASM_LOONGARCH_KVM_H */
 diff --git a/arch/loongarch/kvm/intc/eiointc.c b/arch/loongarch/kvm/intc/eiointc.c
-index 7369c23be036a..f39929d7bf8a2 100644
+index 7369c23be036..f39929d7bf8a 100644
 --- a/arch/loongarch/kvm/intc/eiointc.c
 +++ b/arch/loongarch/kvm/intc/eiointc.c
 @@ -781,16 +781,175 @@ static const struct kvm_io_device_ops kvm_eiointc_virt_ops = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-UPSTREAM-LoongArch-KVM-Add-PCHPIC-device-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0025-UPSTREAM-LoongArch-KVM-Add-PCHPIC-device-support.patch
@@ -1,7 +1,7 @@
 From 187d92372bc352a68ed9dc6f7600fc82e6e63fd9 Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 025/303] UPSTREAM: LoongArch: KVM: Add PCHPIC device support
+Subject: [PATCH 025/305] UPSTREAM: LoongArch: KVM: Add PCHPIC device support
 
 Add device model for PCHPIC interrupt controller, implemente basic
 create & destroy interface, and register device model to kvm device
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kvm/intc/pch_pic.c
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index a63c2bf6fae0c..a6b82c8ab7bc9 100644
+index a63c2bf6fae0..a6b82c8ab7bc 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -20,6 +20,7 @@
@@ -46,7 +46,7 @@ index a63c2bf6fae0c..a6b82c8ab7bc9 100644
  #define CSR_MAX_NUMS		0x800
 diff --git a/arch/loongarch/include/asm/kvm_pch_pic.h b/arch/loongarch/include/asm/kvm_pch_pic.h
 new file mode 100644
-index 0000000000000..914be4fd35e97
+index 000000000000..914be4fd35e9
 --- /dev/null
 +++ b/arch/loongarch/include/asm/kvm_pch_pic.h
 @@ -0,0 +1,31 @@
@@ -82,7 +82,7 @@ index 0000000000000..914be4fd35e97
 +
 +#endif /* __ASM_KVM_PCH_PIC_H */
 diff --git a/arch/loongarch/kvm/Makefile b/arch/loongarch/kvm/Makefile
-index 34a638570d10f..3888e89bff3b5 100644
+index 34a638570d10..3888e89bff3b 100644
 --- a/arch/loongarch/kvm/Makefile
 +++ b/arch/loongarch/kvm/Makefile
 @@ -20,5 +20,6 @@ kvm-y += vcpu.o
@@ -94,7 +94,7 @@ index 34a638570d10f..3888e89bff3b5 100644
  CFLAGS_exit.o	+= $(call cc-disable-warning, override-init)
 diff --git a/arch/loongarch/kvm/intc/pch_pic.c b/arch/loongarch/kvm/intc/pch_pic.c
 new file mode 100644
-index 0000000000000..564b7dcbbbed6
+index 000000000000..564b7dcbbbed
 --- /dev/null
 +++ b/arch/loongarch/kvm/intc/pch_pic.c
 @@ -0,0 +1,88 @@
@@ -187,7 +187,7 @@ index 0000000000000..564b7dcbbbed6
 +	return kvm_register_device_ops(&kvm_pch_pic_dev_ops, KVM_DEV_TYPE_LOONGARCH_PCHPIC);
 +}
 diff --git a/arch/loongarch/kvm/main.c b/arch/loongarch/kvm/main.c
-index 96268753cc4b0..d0b941459a6ba 100644
+index 96268753cc4b..d0b941459a6b 100644
 --- a/arch/loongarch/kvm/main.c
 +++ b/arch/loongarch/kvm/main.c
 @@ -10,6 +10,7 @@
@@ -211,7 +211,7 @@ index 96268753cc4b0..d0b941459a6ba 100644
  	return ret;
  }
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index 0ec5c631d9e92..502ea63b5d2e7 100644
+index 0ec5c631d9e9..502ea63b5d2e 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
 @@ -1162,6 +1162,8 @@ enum kvm_device_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-UPSTREAM-LoongArch-KVM-Add-PCHPIC-read-and-write-fun.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0026-UPSTREAM-LoongArch-KVM-Add-PCHPIC-read-and-write-fun.patch
@@ -1,7 +1,7 @@
 From bfdeaee7ae1acb662718c6df3f698a86c45fd776 Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 026/303] UPSTREAM: LoongArch: KVM: Add PCHPIC read and write
+Subject: [PATCH 026/305] UPSTREAM: LoongArch: KVM: Add PCHPIC read and write
  functions
 
 Add implementation of IPI interrupt controller's address space read and
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 322 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index a6b82c8ab7bc9..d1f75b8541074 100644
+index a6b82c8ab7bc..d1f75b854107 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -51,6 +51,8 @@ struct kvm_vm_stat {
@@ -35,7 +35,7 @@ index a6b82c8ab7bc9..d1f75b8541074 100644
  
  struct kvm_vcpu_stat {
 diff --git a/arch/loongarch/include/asm/kvm_pch_pic.h b/arch/loongarch/include/asm/kvm_pch_pic.h
-index 914be4fd35e97..e6df6a4c1c705 100644
+index 914be4fd35e9..e6df6a4c1c70 100644
 --- a/arch/loongarch/include/asm/kvm_pch_pic.h
 +++ b/arch/loongarch/include/asm/kvm_pch_pic.h
 @@ -8,6 +8,35 @@
@@ -83,7 +83,7 @@ index 914be4fd35e97..e6df6a4c1c705 100644
  
  #endif /* __ASM_KVM_PCH_PIC_H */
 diff --git a/arch/loongarch/kvm/intc/pch_pic.c b/arch/loongarch/kvm/intc/pch_pic.c
-index 564b7dcbbbed6..1269ab264ac27 100644
+index 564b7dcbbbed..1269ab264ac2 100644
 --- a/arch/loongarch/kvm/intc/pch_pic.c
 +++ b/arch/loongarch/kvm/intc/pch_pic.c
 @@ -8,18 +8,305 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-UPSTREAM-LoongArch-KVM-Add-PCHPIC-user-mode-read-and.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0027-UPSTREAM-LoongArch-KVM-Add-PCHPIC-user-mode-read-and.patch
@@ -1,7 +1,7 @@
 From c85e4e3d307c427b81f9cfa3c76935662f8ec714 Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 027/303] UPSTREAM: LoongArch: KVM: Add PCHPIC user mode read
+Subject: [PATCH 027/305] UPSTREAM: LoongArch: KVM: Add PCHPIC user mode read
  and write functions
 
 Implement the communication interface between the user mode programs
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 123 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index 98126c034eb80..72af0e854a50a 100644
+index 98126c034eb8..72af0e854a50 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -146,4 +146,8 @@ struct kvm_iocsr_entry {
@@ -35,7 +35,7 @@ index 98126c034eb80..72af0e854a50a 100644
 +
  #endif /* __UAPI_ASM_LOONGARCH_KVM_H */
 diff --git a/arch/loongarch/kvm/intc/pch_pic.c b/arch/loongarch/kvm/intc/pch_pic.c
-index 1269ab264ac27..fe1f966d6c8ad 100644
+index 1269ab264ac2..fe1f966d6c8a 100644
 --- a/arch/loongarch/kvm/intc/pch_pic.c
 +++ b/arch/loongarch/kvm/intc/pch_pic.c
 @@ -314,16 +314,133 @@ static const struct kvm_io_device_ops kvm_pch_pic_ops = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-UPSTREAM-LoongArch-KVM-Add-irqfd-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0028-UPSTREAM-LoongArch-KVM-Add-irqfd-support.patch
@@ -1,7 +1,7 @@
 From 63180e256da86a3e485694941606c712f1a52d9c Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 028/303] UPSTREAM: LoongArch: KVM: Add irqfd support
+Subject: [PATCH 028/305] UPSTREAM: LoongArch: KVM: Add irqfd support
 
 Enable the KVM_IRQ_ROUTING/KVM_IRQCHIP/KVM_MSI configuration items,
 add the KVM_CAP_IRQCHIP capability, and implement the query interface
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kvm/irqfd.c
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index d1f75b8541074..7b8367c39da85 100644
+index d1f75b854107..7b8367c39da8 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -23,6 +23,8 @@
@@ -37,7 +37,7 @@ index d1f75b8541074..7b8367c39da85 100644
  #define KVM_GET_IOC_CSR_IDX(id)		((id & KVM_CSR_IDX_MASK) >> LOONGARCH_REG_SHIFT)
  #define KVM_GET_IOC_CPUCFG_IDX(id)	((id & KVM_CPUCFG_IDX_MASK) >> LOONGARCH_REG_SHIFT)
 diff --git a/arch/loongarch/include/uapi/asm/kvm.h b/arch/loongarch/include/uapi/asm/kvm.h
-index 72af0e854a50a..5f354f5c68470 100644
+index 72af0e854a50..5f354f5c6847 100644
 --- a/arch/loongarch/include/uapi/asm/kvm.h
 +++ b/arch/loongarch/include/uapi/asm/kvm.h
 @@ -8,6 +8,8 @@
@@ -50,7 +50,7 @@ index 72af0e854a50a..5f354f5c68470 100644
   * KVM LoongArch specific structures and definitions.
   *
 diff --git a/arch/loongarch/kvm/Kconfig b/arch/loongarch/kvm/Kconfig
-index 248744b4d086d..97a811077ac3a 100644
+index 248744b4d086..97a811077ac3 100644
 --- a/arch/loongarch/kvm/Kconfig
 +++ b/arch/loongarch/kvm/Kconfig
 @@ -21,13 +21,16 @@ config KVM
@@ -72,7 +72,7 @@ index 248744b4d086d..97a811077ac3a 100644
  	select SCHED_INFO
  	help
 diff --git a/arch/loongarch/kvm/Makefile b/arch/loongarch/kvm/Makefile
-index 3888e89bff3b5..8e8f6bc87f89c 100644
+index 3888e89bff3b..8e8f6bc87f89 100644
 --- a/arch/loongarch/kvm/Makefile
 +++ b/arch/loongarch/kvm/Makefile
 @@ -21,5 +21,6 @@ kvm-y += vm.o
@@ -83,7 +83,7 @@ index 3888e89bff3b5..8e8f6bc87f89c 100644
  
  CFLAGS_exit.o	+= $(call cc-disable-warning, override-init)
 diff --git a/arch/loongarch/kvm/intc/pch_pic.c b/arch/loongarch/kvm/intc/pch_pic.c
-index fe1f966d6c8ad..08fce845f6680 100644
+index fe1f966d6c8a..08fce845f668 100644
 --- a/arch/loongarch/kvm/intc/pch_pic.c
 +++ b/arch/loongarch/kvm/intc/pch_pic.c
 @@ -443,8 +443,31 @@ static int kvm_pch_pic_set_attr(struct kvm_device *dev,
@@ -131,7 +131,7 @@ index fe1f966d6c8ad..08fce845f6680 100644
  		return -ENOMEM;
 diff --git a/arch/loongarch/kvm/irqfd.c b/arch/loongarch/kvm/irqfd.c
 new file mode 100644
-index 0000000000000..9a39627aecf07
+index 000000000000..9a39627aecf0
 --- /dev/null
 +++ b/arch/loongarch/kvm/irqfd.c
 @@ -0,0 +1,89 @@
@@ -225,7 +225,7 @@ index 0000000000000..9a39627aecf07
 +	return kvm_arch_irqchip_in_kernel(kvm);
 +}
 diff --git a/arch/loongarch/kvm/vm.c b/arch/loongarch/kvm/vm.c
-index fe9e973912d44..edccfc8c9cd80 100644
+index fe9e973912d4..edccfc8c9cd8 100644
 --- a/arch/loongarch/kvm/vm.c
 +++ b/arch/loongarch/kvm/vm.c
 @@ -6,6 +6,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-UPSTREAM-irqchip-loongson-eiointc-Add-virt-extension.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0029-UPSTREAM-irqchip-loongson-eiointc-Add-virt-extension.patch
@@ -1,7 +1,7 @@
 From 98e78b9ac9b5574ca4c2808223251bb3a523a896 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Wed, 13 Nov 2024 16:18:27 +0800
-Subject: [PATCH 029/303] UPSTREAM: irqchip/loongson-eiointc: Add virt
+Subject: [PATCH 029/305] UPSTREAM: irqchip/loongson-eiointc: Add virt
  extension support
 
 Interrupts can be routed to maximal four virtual CPUs with real HW
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 207 insertions(+), 21 deletions(-)
 
 diff --git a/Documentation/arch/loongarch/irq-chip-model.rst b/Documentation/arch/loongarch/irq-chip-model.rst
-index 6dd48256e39f7..a7ecce11e445c 100644
+index 6dd48256e39f..a7ecce11e445 100644
 --- a/Documentation/arch/loongarch/irq-chip-model.rst
 +++ b/Documentation/arch/loongarch/irq-chip-model.rst
 @@ -85,6 +85,70 @@ to CPUINTC directly::
@@ -103,7 +103,7 @@ index 6dd48256e39f7..a7ecce11e445c 100644
  ===========================
  
 diff --git a/Documentation/translations/zh_CN/arch/loongarch/irq-chip-model.rst b/Documentation/translations/zh_CN/arch/loongarch/irq-chip-model.rst
-index 472761938682c..d4ff80de47b63 100644
+index 472761938682..d4ff80de47b6 100644
 --- a/Documentation/translations/zh_CN/arch/loongarch/irq-chip-model.rst
 +++ b/Documentation/translations/zh_CN/arch/loongarch/irq-chip-model.rst
 @@ -87,6 +87,61 @@ PCH-LPC/PCH-MSI，然后被EIOINTC统一收集，再直接到达CPUINTC::
@@ -169,7 +169,7 @@ index 472761938682c..d4ff80de47b63 100644
  ===============
  
 diff --git a/arch/loongarch/include/asm/irq.h b/arch/loongarch/include/asm/irq.h
-index b2915fd538620..12bd15578c336 100644
+index b2915fd53862..12bd15578c33 100644
 --- a/arch/loongarch/include/asm/irq.h
 +++ b/arch/loongarch/include/asm/irq.h
 @@ -65,6 +65,7 @@ extern struct acpi_vector_group pch_group[MAX_IO_PICS];
@@ -181,7 +181,7 @@ index b2915fd538620..12bd15578c336 100644
  #define LOONGSON_CPU_UART0_VEC		10 /* CPU UART0 */
  #define LOONGSON_CPU_THSENS_VEC		14 /* CPU Thsens */
 diff --git a/drivers/irqchip/irq-loongson-eiointc.c b/drivers/irqchip/irq-loongson-eiointc.c
-index e24db71a8783c..bb79e19dfb590 100644
+index e24db71a8783..bb79e19dfb59 100644
 --- a/drivers/irqchip/irq-loongson-eiointc.c
 +++ b/drivers/irqchip/irq-loongson-eiointc.c
 @@ -14,6 +14,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-UPSTREAM-EDAC-Add-an-EDAC-driver-for-the-Loongson-me.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0030-UPSTREAM-EDAC-Add-an-EDAC-driver-for-the-Loongson-me.patch
@@ -1,7 +1,7 @@
 From 2400edaa78f473e089c3cb5d747183722dfd05f6 Mon Sep 17 00:00:00 2001
 From: Zhao Qunqin <zhaoqunqin@loongson.cn>
 Date: Thu, 19 Dec 2024 20:48:46 +0800
-Subject: [PATCH 030/303] UPSTREAM: EDAC: Add an EDAC driver for the Loongson
+Subject: [PATCH 030/305] UPSTREAM: EDAC: Add an EDAC driver for the Loongson
  memory controller
 
 Add ECC support for Loongson SoC DDR controller. This driver reports single
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/edac/loongson_edac.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 879f598ca34e6..66699597d76ec 100644
+index 879f598ca34e..66699597d76e 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13408,6 +13408,12 @@ S:	Maintained
@@ -46,7 +46,7 @@ index 879f598ca34e6..66699597d76ec 100644
  M:	Sathya Prakash <sathya.prakash@broadcom.com>
  M:	Sreekanth Reddy <sreekanth.reddy@broadcom.com>
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index a7a1f15bcc672..1027f1c3e6027 100644
+index a7a1f15bcc67..1027f1c3e602 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -80,6 +80,7 @@ config LOONGARCH
@@ -58,7 +58,7 @@ index a7a1f15bcc672..1027f1c3e6027 100644
  	select GENERIC_CLOCKEVENTS
  	select GENERIC_CMOS_UPDATE
 diff --git a/drivers/edac/Kconfig b/drivers/edac/Kconfig
-index 81af6c344d6ba..a59e7502f527d 100644
+index 81af6c344d6b..a59e7502f527 100644
 --- a/drivers/edac/Kconfig
 +++ b/drivers/edac/Kconfig
 @@ -564,5 +564,13 @@ config EDAC_VERSAL
@@ -76,7 +76,7 @@ index 81af6c344d6ba..a59e7502f527d 100644
  
  endif # EDAC
 diff --git a/drivers/edac/Makefile b/drivers/edac/Makefile
-index faf310eec4a67..f8bdbc8951df0 100644
+index faf310eec4a6..f8bdbc8951df 100644
 --- a/drivers/edac/Makefile
 +++ b/drivers/edac/Makefile
 @@ -88,3 +88,4 @@ obj-$(CONFIG_EDAC_DMC520)		+= dmc520_edac.o
@@ -86,7 +86,7 @@ index faf310eec4a67..f8bdbc8951df0 100644
 +obj-$(CONFIG_EDAC_LOONGSON)		+= loongson_edac.o
 diff --git a/drivers/edac/loongson_edac.c b/drivers/edac/loongson_edac.c
 new file mode 100644
-index 0000000000000..38745800ed01d
+index 000000000000..38745800ed01
 --- /dev/null
 +++ b/drivers/edac/loongson_edac.c
 @@ -0,0 +1,157 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-UPSTREAM-drm-amdgpu-add-generic-display-panic-helper.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0031-UPSTREAM-drm-amdgpu-add-generic-display-panic-helper.patch
@@ -1,7 +1,7 @@
 From 9e104ed60c53b13965369ed532a3e4c42de01818 Mon Sep 17 00:00:00 2001
 From: Alex Deucher <alexander.deucher@amd.com>
 Date: Wed, 30 Oct 2024 17:27:23 -0400
-Subject: [PATCH 031/303] UPSTREAM: drm/amdgpu: add generic display panic
+Subject: [PATCH 031/305] UPSTREAM: drm/amdgpu: add generic display panic
  helper code
 
 Pull this out of Jocelyn's patch and make it generic.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 85 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
-index b119d27271c1a..35c778426a7c7 100644
+index b119d27271c1..35c778426a7c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
 @@ -33,6 +33,7 @@
@@ -115,7 +115,7 @@ index b119d27271c1a..35c778426a7c7 100644
 +	return 0;
 +}
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.h b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.h
-index 9d19940f73c8f..dfa0d642ac161 100644
+index 9d19940f73c8..dfa0d642ac16 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.h
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.h
 @@ -23,6 +23,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-BACKPORT-drm-amd-display-add-clear_tiling-hubp-callb.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0032-BACKPORT-drm-amd-display-add-clear_tiling-hubp-callb.patch
@@ -1,7 +1,7 @@
 From a836965a01529cbf022635f15c7433f68d755e18 Mon Sep 17 00:00:00 2001
 From: Alex Deucher <alexander.deucher@amd.com>
 Date: Thu, 31 Oct 2024 13:17:06 -0400
-Subject: [PATCH 032/303] BACKPORT: drm/amd/display: add clear_tiling hubp
+Subject: [PATCH 032/305] BACKPORT: drm/amd/display: add clear_tiling hubp
  callbacks
 
 This adds clear_tiling callbacks to the hubp structure that
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  14 files changed, 76 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.c
-index da963f73829f6..874892e754887 100644
+index da963f73829f..874892e75488 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.c
 @@ -518,6 +518,20 @@ bool hubp1_program_surface_flip_and_addr(
@@ -70,7 +70,7 @@ index da963f73829f6..874892e754887 100644
  	.dmdata_set_attributes = NULL,
  	.dmdata_load = NULL,
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.h b/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.h
-index 193e48b440ef1..3a07845d55ae1 100644
+index 193e48b440ef..3a07845d55ae 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.h
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn10/dcn10_hubp.h
 @@ -796,4 +796,6 @@ void hubp1_soft_reset(struct hubp *hubp, bool reset);
@@ -81,7 +81,7 @@ index 193e48b440ef1..3a07845d55ae1 100644
 +
  #endif
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.c
-index c74ee2d50a699..ed334b728f237 100644
+index c74ee2d50a69..ed334b728f23 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.c
 @@ -406,6 +406,20 @@ void hubp2_program_rotation(
@@ -114,7 +114,7 @@ index c74ee2d50a699..ed334b728f237 100644
  
  
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.h b/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.h
-index 18e194507e36d..7fd9240868c34 100644
+index 18e194507e36..7fd9240868c3 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.h
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn20/dcn20_hubp.h
 @@ -409,6 +409,8 @@ void hubp2_read_state_common(struct hubp *hubp);
@@ -127,7 +127,7 @@ index 18e194507e36d..7fd9240868c34 100644
  
  
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn201/dcn201_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn201/dcn201_hubp.c
-index 6efcb10abf3de..d50bdcaa52f8d 100644
+index 6efcb10abf3d..d50bdcaa52f8 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn201/dcn201_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn201/dcn201_hubp.c
 @@ -132,6 +132,7 @@ static struct hubp_funcs dcn201_hubp_funcs = {
@@ -139,7 +139,7 @@ index 6efcb10abf3de..d50bdcaa52f8d 100644
  
  bool dcn201_hubp_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn21/dcn21_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn21/dcn21_hubp.c
-index 4e2d9d381db39..e2740482e1cfb 100644
+index 4e2d9d381db3..e2740482e1cf 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn21/dcn21_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn21/dcn21_hubp.c
 @@ -840,6 +840,7 @@ static struct hubp_funcs dcn21_hubp_funcs = {
@@ -151,7 +151,7 @@ index 4e2d9d381db39..e2740482e1cfb 100644
  
  bool hubp21_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.c
-index 5cf7e6771cb49..e335d20879692 100644
+index 5cf7e6771cb4..e335d2087969 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.c
 @@ -334,6 +334,22 @@ void hubp3_program_tiling(
@@ -186,7 +186,7 @@ index 5cf7e6771cb49..e335d20879692 100644
  
  bool hubp3_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.h b/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.h
-index b010531a7fe88..cfb01bf340a1a 100644
+index b010531a7fe8..cfb01bf340a1 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.h
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn30/dcn30_hubp.h
 @@ -297,6 +297,8 @@ void hubp3_read_state(struct hubp *hubp);
@@ -199,7 +199,7 @@ index b010531a7fe88..cfb01bf340a1a 100644
  
  
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn31/dcn31_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn31/dcn31_hubp.c
-index c671908ba7d06..7fd582a8a4ba9 100644
+index c671908ba7d0..7fd582a8a4ba 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn31/dcn31_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn31/dcn31_hubp.c
 @@ -97,6 +97,7 @@ static struct hubp_funcs dcn31_hubp_funcs = {
@@ -211,7 +211,7 @@ index c671908ba7d06..7fd582a8a4ba9 100644
  
  bool hubp31_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn32/dcn32_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn32/dcn32_hubp.c
-index c4f41350d1b3c..f3a21c623f441 100644
+index c4f41350d1b3..f3a21c623f44 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn32/dcn32_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn32/dcn32_hubp.c
 @@ -204,7 +204,8 @@ static struct hubp_funcs dcn32_hubp_funcs = {
@@ -225,7 +225,7 @@ index c4f41350d1b3c..f3a21c623f441 100644
  
  bool hubp32_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn35/dcn35_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn35/dcn35_hubp.c
-index e7625290c0e46..3173be5336e39 100644
+index e7625290c0e4..3173be5336e3 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn35/dcn35_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn35/dcn35_hubp.c
 @@ -217,6 +217,7 @@ static struct hubp_funcs dcn35_hubp_funcs = {
@@ -237,7 +237,7 @@ index e7625290c0e46..3173be5336e39 100644
  
  bool hubp35_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.c b/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.c
-index 7013c124efcff..7eaa1bc9dc090 100644
+index 7013c124efcf..7eaa1bc9dc09 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.c
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.c
 @@ -508,6 +508,18 @@ bool hubp401_program_surface_flip_and_addr(
@@ -270,7 +270,7 @@ index 7013c124efcff..7eaa1bc9dc090 100644
  
  bool hubp401_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.h b/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.h
-index e52fdb5b0cd02..92041d7e0569e 100644
+index e52fdb5b0cd0..92041d7e0569 100644
 --- a/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.h
 +++ b/drivers/gpu/drm/amd/display/dc/hubp/dcn401/dcn401_hubp.h
 @@ -340,4 +340,6 @@ int hubp401_get_3dlut_fl_done(struct hubp *hubp);
@@ -281,7 +281,7 @@ index e52fdb5b0cd02..92041d7e0569e 100644
 +
  #endif /* __DC_HUBP_DCN401_H__ */
 diff --git a/drivers/gpu/drm/amd/display/dc/inc/hw/hubp.h b/drivers/gpu/drm/amd/display/dc/inc/hw/hubp.h
-index eec16b0a199dd..d4230e28338b4 100644
+index eec16b0a199d..d4230e28338b 100644
 --- a/drivers/gpu/drm/amd/display/dc/inc/hw/hubp.h
 +++ b/drivers/gpu/drm/amd/display/dc/inc/hw/hubp.h
 @@ -277,6 +277,7 @@ struct hubp_funcs {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-UPSTREAM-drm-amd-display-add-clear_tiling-mi-callbac.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0033-UPSTREAM-drm-amd-display-add-clear_tiling-mi-callbac.patch
@@ -1,7 +1,7 @@
 From 6b3b1b8410dbbb717b015f99b4f4c097a115a03b Mon Sep 17 00:00:00 2001
 From: Alex Deucher <alexander.deucher@amd.com>
 Date: Thu, 31 Oct 2024 13:20:19 -0400
-Subject: [PATCH 033/303] UPSTREAM: drm/amd/display: add clear_tiling mi
+Subject: [PATCH 033/305] UPSTREAM: drm/amd/display: add clear_tiling mi
  callbacks
 
 This adds clear_tiling callbacks to the mi structure that
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 31 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/dce/dce_mem_input.c b/drivers/gpu/drm/amd/display/dc/dce/dce_mem_input.c
-index f5e1d9caee4c8..ebd174be5786b 100644
+index f5e1d9caee4c..ebd174be5786 100644
 --- a/drivers/gpu/drm/amd/display/dc/dce/dce_mem_input.c
 +++ b/drivers/gpu/drm/amd/display/dc/dce/dce_mem_input.c
 @@ -481,7 +481,6 @@ static void program_tiling(
@@ -103,7 +103,7 @@ index f5e1d9caee4c8..ebd174be5786b 100644
  
  void dce_mem_input_construct(
 diff --git a/drivers/gpu/drm/amd/display/dc/inc/hw/mem_input.h b/drivers/gpu/drm/amd/display/dc/inc/hw/mem_input.h
-index a8b44f398ce68..4f5d102455cac 100644
+index a8b44f398ce6..4f5d102455ca 100644
 --- a/drivers/gpu/drm/amd/display/dc/inc/hw/mem_input.h
 +++ b/drivers/gpu/drm/amd/display/dc/inc/hw/mem_input.h
 @@ -187,6 +187,8 @@ struct mem_input_funcs {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-UPSTREAM-drm-amd-display-dc-add-helper-for-panic-upd.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0034-UPSTREAM-drm-amd-display-dc-add-helper-for-panic-upd.patch
@@ -1,7 +1,7 @@
 From 37fa43f583af73cefb1907fd3cbaba36330fd629 Mon Sep 17 00:00:00 2001
 From: Alex Deucher <alexander.deucher@amd.com>
 Date: Tue, 12 Nov 2024 16:19:18 -0500
-Subject: [PATCH 034/303] UPSTREAM: drm/amd/display/dc: add helper for panic
+Subject: [PATCH 034/305] UPSTREAM: drm/amd/display/dc: add helper for panic
  updates
 
 Add a DC helper for panic updates.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 49 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/core/dc_surface.c b/drivers/gpu/drm/amd/display/dc/core/dc_surface.c
-index ccbb15f1638c8..50faeba498c67 100644
+index ccbb15f1638c..50faeba498c6 100644
 --- a/drivers/gpu/drm/amd/display/dc/core/dc_surface.c
 +++ b/drivers/gpu/drm/amd/display/dc/core/dc_surface.c
 @@ -277,4 +277,50 @@ void dc_3dlut_func_retain(struct dc_3dlut *lut)
@@ -75,7 +75,7 @@ index ccbb15f1638c8..50faeba498c67 100644
 +	}
 +}
 diff --git a/drivers/gpu/drm/amd/display/dc/dc_plane.h b/drivers/gpu/drm/amd/display/dc/dc_plane.h
-index 44afcd9892248..7c89d962eb685 100644
+index 44afcd989224..7c89d962eb68 100644
 --- a/drivers/gpu/drm/amd/display/dc/dc_plane.h
 +++ b/drivers/gpu/drm/amd/display/dc/dc_plane.h
 @@ -35,4 +35,7 @@ const struct dc_plane_status *dc_plane_get_status(

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0035-UPSTREAM-drm-amd-display-add-DC-drm_panic-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0035-UPSTREAM-drm-amd-display-add-DC-drm_panic-support.patch
@@ -1,7 +1,7 @@
 From 76e3ecbac8fc2a68e66da5793415284a20e60130 Mon Sep 17 00:00:00 2001
 From: Jocelyn Falempe <jfalempe@redhat.com>
 Date: Thu, 31 Oct 2024 13:27:03 -0400
-Subject: [PATCH 035/303] UPSTREAM: drm/amd/display: add DC drm_panic support
+Subject: [PATCH 035/305] UPSTREAM: drm/amd/display: add DC drm_panic support
 
 Add support for the drm_panic module, which displays a pretty user
 friendly message on the screen when a Linux kernel panic occurs.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
-index 62e30942f735d..19d0fbb63d7ca 100644
+index 62e30942f735..19d0fbb63d7c 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 @@ -26,6 +26,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0036-UPSTREAM-drm-amd-display-add-non-DC-drm_panic-suppor.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0036-UPSTREAM-drm-amd-display-add-non-DC-drm_panic-suppor.patch
@@ -1,7 +1,7 @@
 From 59844c227e3437b449aa47156f3812c3a266518a Mon Sep 17 00:00:00 2001
 From: Alex Deucher <alexander.deucher@amd.com>
 Date: Thu, 31 Oct 2024 13:51:35 -0400
-Subject: [PATCH 036/303] UPSTREAM: drm/amd/display: add non-DC drm_panic
+Subject: [PATCH 036/305] UPSTREAM: drm/amd/display: add non-DC drm_panic
  support
 
 Add support for the drm_panic module, which displays a pretty user
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 107 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
-index 70c1399f738de..cf526b3ca1a60 100644
+index 70c1399f738d..cf526b3ca1a6 100644
 --- a/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
 @@ -2687,6 +2687,32 @@ static const struct drm_crtc_helper_funcs dce_v10_0_crtc_helper_funcs = {
@@ -73,7 +73,7 @@ index 70c1399f738de..cf526b3ca1a60 100644
  	return 0;
  }
 diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
-index f154c24499c8a..21c98368815e7 100644
+index f154c24499c8..21c98368815e 100644
 --- a/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
 @@ -2800,6 +2800,32 @@ static const struct drm_crtc_helper_funcs dce_v11_0_crtc_helper_funcs = {
@@ -118,7 +118,7 @@ index f154c24499c8a..21c98368815e7 100644
  	return 0;
  }
 diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
-index a7fcb135827f8..a20f2e2007d84 100644
+index a7fcb135827f..a20f2e2007d8 100644
 --- a/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
 @@ -2602,6 +2602,32 @@ static const struct drm_crtc_helper_funcs dce_v6_0_crtc_helper_funcs = {
@@ -163,7 +163,7 @@ index a7fcb135827f8..a20f2e2007d84 100644
  	return 0;
  }
 diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
-index 77ac3f114d241..9eafe98368cc4 100644
+index 77ac3f114d24..9eafe98368cc 100644
 --- a/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
 @@ -2613,6 +2613,31 @@ static const struct drm_crtc_helper_funcs dce_v8_0_crtc_helper_funcs = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0037-UPSTREAM-ALSA-hda-Support-for-Ideapad-hotkey-mute-LE.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0037-UPSTREAM-ALSA-hda-Support-for-Ideapad-hotkey-mute-LE.patch
@@ -1,7 +1,7 @@
 From 33151c3fb19ad7cb015e8fd85acbc2bc42f24d3c Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Thu, 16 Jan 2025 00:25:15 +0800
-Subject: [PATCH 037/303] UPSTREAM: ALSA: hda: Support for Ideapad hotkey mute
+Subject: [PATCH 037/305] UPSTREAM: ALSA: hda: Support for Ideapad hotkey mute
  LEDs
 
 New ideapad helper file with support for handling FN key mute LEDs.
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/sound/pci/hda/ideapad_hotkey_led_helper.c b/sound/pci/hda/ideapad_hotkey_led_helper.c
 new file mode 100644
-index 0000000000000..c10d97964d49b
+index 000000000000..c10d97964d49
 --- /dev/null
 +++ b/sound/pci/hda/ideapad_hotkey_led_helper.c
 @@ -0,0 +1,36 @@
@@ -64,7 +64,7 @@ index 0000000000000..c10d97964d49b
 +
 +#endif /* CONFIG_IDEAPAD_LAPTOP */
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 84ab357b840d6..34874039ad453 100644
+index 84ab357b840d..34874039ad45 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -291,6 +291,7 @@ enum {
@@ -116,7 +116,7 @@ index 84ab357b840d6..34874039ad453 100644
  	{ .id = CXT_PINCFG_LEMOTE_A1205, .name = "lemote-a1205" },
  	{ .id = CXT_FIXUP_OLPC_XO, .name = "olpc-xo" },
 diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
-index 13ffc9a6555f6..bc0ac15bb72be 100644
+index 13ffc9a6555f..bc0ac15bb72b 100644
 --- a/sound/pci/hda/patch_realtek.c
 +++ b/sound/pci/hda/patch_realtek.c
 @@ -7106,6 +7106,15 @@ static void alc_fixup_thinkpad_acpi(struct hda_codec *codec,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0038-UPSTREAM-MIPS-Loongson-Add-comments-for-interface_in.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0038-UPSTREAM-MIPS-Loongson-Add-comments-for-interface_in.patch
@@ -1,7 +1,7 @@
 From 9f31e14c7483123986d134eb465137d812c19e30 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 11 Jan 2025 01:22:09 +0800
-Subject: [PATCH 038/303] UPSTREAM: MIPS: Loongson: Add comments for
+Subject: [PATCH 038/305] UPSTREAM: MIPS: Loongson: Add comments for
  interface_info
 
 Clarify meanings of members of interface_info, especially for .size,
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/boot_param.h b/arch/mips/include/asm/mach-loongson64/boot_param.h
-index 9218b3ae33832..3a11ce85762be 100644
+index 9218b3ae3383..3a11ce85762b 100644
 --- a/arch/mips/include/asm/mach-loongson64/boot_param.h
 +++ b/arch/mips/include/asm/mach-loongson64/boot_param.h
 @@ -128,10 +128,10 @@ struct irq_source_routing_table {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0039-UPSTREAM-ntsync-Return-the-fd-from-NTSYNC_IOC_CREATE.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0039-UPSTREAM-ntsync-Return-the-fd-from-NTSYNC_IOC_CREATE.patch
@@ -1,7 +1,7 @@
 From 88f70b86c59dc8a920b24fdbdb7389d8231c3016 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:42 -0600
-Subject: [PATCH 039/303] UPSTREAM: ntsync: Return the fd from
+Subject: [PATCH 039/305] UPSTREAM: ntsync: Return the fd from
  NTSYNC_IOC_CREATE_SEM.
 
 Simplify the user API a bit by returning the fd as return value from the ioctl
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 4954553b7baa6..2e7f698268c1f 100644
+index 4954553b7baa..2e7f698268c1 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -165,7 +165,6 @@ static int ntsync_obj_get_fd(struct ntsync_obj *obj)
@@ -46,7 +46,7 @@ index 4954553b7baa6..2e7f698268c1f 100644
  
  static int ntsync_char_open(struct inode *inode, struct file *file)
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index dcfa38fdc93c6..27d8cb3dd5b7c 100644
+index dcfa38fdc93c..27d8cb3dd5b7 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -11,12 +11,11 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0040-UPSTREAM-ntsync-Rename-NTSYNC_IOC_SEM_POST-to-NTSYNC.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0040-UPSTREAM-ntsync-Rename-NTSYNC_IOC_SEM_POST-to-NTSYNC.patch
@@ -1,7 +1,7 @@
 From ebfe516c7021e96e007b4eab783b2727aba43007 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:43 -0600
-Subject: [PATCH 040/303] UPSTREAM: ntsync: Rename NTSYNC_IOC_SEM_POST to
+Subject: [PATCH 040/305] UPSTREAM: ntsync: Rename NTSYNC_IOC_SEM_POST to
  NTSYNC_IOC_SEM_RELEASE.
 
 Use the more common "release" terminology, which is also the term used by NT,
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 2e7f698268c1f..cb3a3bd97ba0c 100644
+index 2e7f698268c1..cb3a3bd97ba0 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -57,7 +57,7 @@ struct ntsync_device {
@@ -61,7 +61,7 @@ index 2e7f698268c1f..cb3a3bd97ba0c 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 27d8cb3dd5b7c..9af9d8125553d 100644
+index 27d8cb3dd5b7..9af9d8125553 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -17,6 +17,6 @@ struct ntsync_sem_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0041-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0041-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_WAIT_ANY.patch
@@ -1,7 +1,7 @@
 From eebd0866ecca30a1e875584b2bdf9353716f272b Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:44 -0600
-Subject: [PATCH 041/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_WAIT_ANY.
+Subject: [PATCH 041/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_WAIT_ANY.
 
 This corresponds to part of the functionality of the NT syscall
 NtWaitForMultipleObjects(). Specifically, it implements the behaviour where
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 260 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index cb3a3bd97ba0c..900cc5ce5761f 100644
+index cb3a3bd97ba0..900cc5ce5761 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -6,11 +6,16 @@
@@ -359,7 +359,7 @@ index cb3a3bd97ba0c..900cc5ce5761f 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 9af9d8125553d..40ffdc41d5bb3 100644
+index 9af9d8125553..40ffdc41d5bb 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -15,7 +15,21 @@ struct ntsync_sem_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0042-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0042-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_WAIT_ALL.patch
@@ -1,7 +1,7 @@
 From d90e5a4b29d3a0d2097ac02dece49c5bde08eef4 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:45 -0600
-Subject: [PATCH 042/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_WAIT_ALL.
+Subject: [PATCH 042/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_WAIT_ALL.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 323 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 900cc5ce5761f..c8beb5504bccb 100644
+index 900cc5ce5761..c8beb5504bcc 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -13,6 +13,7 @@
@@ -529,7 +529,7 @@ index 900cc5ce5761f..c8beb5504bccb 100644
  		return ntsync_wait_any(dev, argp);
  	default:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 40ffdc41d5bb3..d64420ffbcd71 100644
+index 40ffdc41d5bb..d64420ffbcd7 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -30,6 +30,7 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0043-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0043-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_CREATE_MUTEX.patch
@@ -1,7 +1,7 @@
 From a905391bbf5a0b8f7c056e15b333e644699f833a Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:46 -0600
-Subject: [PATCH 043/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.
+Subject: [PATCH 043/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_CREATE_MUTEX.
 
 This corresponds to the NT syscall NtCreateMutant().
 
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 79 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index c8beb5504bccb..a2826dbff2f46 100644
+index c8beb5504bcc..a2826dbff2f4 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -25,6 +25,7 @@
@@ -196,7 +196,7 @@ index c8beb5504bccb..a2826dbff2f46 100644
  		return ntsync_create_sem(dev, argp);
  	case NTSYNC_IOC_WAIT_ALL:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index d64420ffbcd71..bb7fb94f58561 100644
+index d64420ffbcd7..bb7fb94f5856 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -15,6 +15,11 @@ struct ntsync_sem_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0044-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0044-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_UNLOCK.patch
@@ -1,7 +1,7 @@
 From 391e08cac92249a0427bf8d643d58acb974f7acd Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:47 -0600
-Subject: [PATCH 044/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.
+Subject: [PATCH 044/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_UNLOCK.
 
 This corresponds to the NT syscall NtReleaseMutant().
 
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 54 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index a2826dbff2f46..33e26240d9e7c 100644
+index a2826dbff2f4..33e26240d9e7 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -396,6 +396,57 @@ static int ntsync_sem_release(struct ntsync_obj *sem, void __user *argp)
@@ -92,7 +92,7 @@ index a2826dbff2f46..33e26240d9e7c 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index bb7fb94f58561..9186304b253c6 100644
+index bb7fb94f5856..9186304b253c 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -40,5 +40,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0045-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0045-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_KILL.patch
@@ -1,7 +1,7 @@
 From 4aa40ac141a9467b2ae192f062991d20359affba Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:48 -0600
-Subject: [PATCH 045/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.
+Subject: [PATCH 045/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_KILL.
 
 This does not correspond to any NT syscall. Rather, when a thread dies, it
 should be called by the NT emulator for each mutex, with the TID of the dying
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 60 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 33e26240d9e7c..03768ac254256 100644
+index 33e26240d9e7..03768ac25425 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -59,6 +59,7 @@ struct ntsync_obj {
@@ -153,7 +153,7 @@ index 33e26240d9e7c..03768ac254256 100644
  		if (put_user(signaled, &user_args->index))
  			ret = -EFAULT;
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 9186304b253c6..633958d90be31 100644
+index 9186304b253c..633958d90be3 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -41,5 +41,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0046-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0046-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_CREATE_EVENT.patch
@@ -1,7 +1,7 @@
 From f23fe3ce2c1d285061d8eafb3e0d2758fe2693be Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:49 -0600
-Subject: [PATCH 046/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.
+Subject: [PATCH 046/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_CREATE_EVENT.
 
 This correspond to the NT syscall NtCreateEvent().
 
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 65 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 03768ac254256..3e8827b6f4804 100644
+index 03768ac25425..3e8827b6f480 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -26,6 +26,7 @@
@@ -146,7 +146,7 @@ index 03768ac254256..3e8827b6f4804 100644
  		return ntsync_create_mutex(dev, argp);
  	case NTSYNC_IOC_CREATE_SEM:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 633958d90be31..e08aa02f4dcca 100644
+index 633958d90be3..e08aa02f4dcc 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -20,6 +20,11 @@ struct ntsync_mutex_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0047-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0047-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_SET.patch
@@ -1,7 +1,7 @@
 From 6908d6e56ed1f4478bf7e124b98110f611a8b7b3 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:50 -0600
-Subject: [PATCH 047/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_SET.
+Subject: [PATCH 047/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_SET.
 
 This corresponds to the NT syscall NtSetEvent().
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 28 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 3e8827b6f4804..0a87f8ad59932 100644
+index 3e8827b6f480..0a87f8ad5993 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -534,6 +534,31 @@ static int ntsync_mutex_kill(struct ntsync_obj *mutex, void __user *argp)
@@ -64,7 +64,7 @@ index 3e8827b6f4804..0a87f8ad59932 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index e08aa02f4dcca..db2512f6e3f42 100644
+index e08aa02f4dcc..db2512f6e3f4 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -48,5 +48,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0048-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0048-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_RESET.patch
@@ -1,7 +1,7 @@
 From 9bbfd6269813d9034b9178847778a9f6ed8a7829 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:51 -0600
-Subject: [PATCH 048/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_RESET.
+Subject: [PATCH 048/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_RESET.
 
 This corresponds to the NT syscall NtResetEvent().
 
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 0a87f8ad59932..b31443aa9692b 100644
+index 0a87f8ad5993..b31443aa9692 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -559,6 +559,28 @@ static int ntsync_event_set(struct ntsync_obj *event, void __user *argp)
@@ -63,7 +63,7 @@ index 0a87f8ad59932..b31443aa9692b 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index db2512f6e3f42..d74c4e4f93d81 100644
+index db2512f6e3f4..d74c4e4f93d8 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -49,5 +49,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0049-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0049-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_PULSE.patch
@@ -1,7 +1,7 @@
 From 883b98bb0da9e3baaea853a3e7ad63a0ad787bdf Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:52 -0600
-Subject: [PATCH 049/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.
+Subject: [PATCH 049/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_PULSE.
 
 This corresponds to the NT syscall NtPulseEvent().
 
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index b31443aa9692b..141ebe8a7d4f0 100644
+index b31443aa9692..141ebe8a7d4f 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -534,7 +534,7 @@ static int ntsync_mutex_kill(struct ntsync_obj *mutex, void __user *argp)
@@ -59,7 +59,7 @@ index b31443aa9692b..141ebe8a7d4f0 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index d74c4e4f93d81..9eab7666b8b99 100644
+index d74c4e4f93d8..9eab7666b8b9 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -50,5 +50,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0050-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0050-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_SEM_READ.patch
@@ -1,7 +1,7 @@
 From c4edda08a587161a44fd30240f5b772cd76dfc75 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:53 -0600
-Subject: [PATCH 050/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_SEM_READ.
+Subject: [PATCH 050/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_SEM_READ.
 
 This corresponds to the NT syscall NtQuerySemaphore().
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 141ebe8a7d4f0..b2043412c5cd3 100644
+index 141ebe8a7d4f..b2043412c5cd 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -583,6 +583,28 @@ static int ntsync_event_reset(struct ntsync_obj *event, void __user *argp)
@@ -61,7 +61,7 @@ index 141ebe8a7d4f0..b2043412c5cd3 100644
  		return ntsync_mutex_unlock(obj, argp);
  	case NTSYNC_IOC_MUTEX_KILL:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 9eab7666b8b99..e36b4cfb7d346 100644
+index 9eab7666b8b9..e36b4cfb7d34 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -51,5 +51,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0051-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0051-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_MUTEX_READ.patch
@@ -1,7 +1,7 @@
 From 3e9d05ed086115ce2f85853b514c11e42814d034 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:54 -0600
-Subject: [PATCH 051/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_READ.
+Subject: [PATCH 051/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_MUTEX_READ.
 
 This corresponds to the NT syscall NtQueryMutant().
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 27 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index b2043412c5cd3..0047b13b6ebd4 100644
+index b2043412c5cd..0047b13b6ebd 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -605,6 +605,30 @@ static int ntsync_sem_read(struct ntsync_obj *sem, void __user *argp)
@@ -63,7 +63,7 @@ index b2043412c5cd3..0047b13b6ebd4 100644
  		return ntsync_event_set(obj, argp, false);
  	case NTSYNC_IOC_EVENT_RESET:
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index e36b4cfb7d346..207646e63ef3b 100644
+index e36b4cfb7d34..207646e63ef3 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -52,5 +52,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0052-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0052-UPSTREAM-ntsync-Introduce-NTSYNC_IOC_EVENT_READ.patch
@@ -1,7 +1,7 @@
 From 53d36d4714b596f114a659b408fbd0689edfcc7b Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:55 -0600
-Subject: [PATCH 052/303] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_READ.
+Subject: [PATCH 052/305] UPSTREAM: ntsync: Introduce NTSYNC_IOC_EVENT_READ.
 
 This corresponds to the NT syscall NtQueryEvent().
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 0047b13b6ebd4..78dc405bb7590 100644
+index 0047b13b6ebd..78dc405bb759 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -629,6 +629,28 @@ static int ntsync_mutex_read(struct ntsync_obj *mutex, void __user *argp)
@@ -61,7 +61,7 @@ index 0047b13b6ebd4..78dc405bb7590 100644
  		return -ENOIOCTLCMD;
  	}
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index 207646e63ef3b..b9d208a8c00fe 100644
+index 207646e63ef3..b9d208a8c00f 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -53,5 +53,6 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0053-UPSTREAM-ntsync-Introduce-alertable-waits.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0053-UPSTREAM-ntsync-Introduce-alertable-waits.patch
@@ -1,7 +1,7 @@
 From deb91211cc73e9ced3a8f53ff38fdddda702e86e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:56 -0600
-Subject: [PATCH 053/303] UPSTREAM: ntsync: Introduce alertable waits.
+Subject: [PATCH 053/305] UPSTREAM: ntsync: Introduce alertable waits.
 
 NT waits can optionally be made "alertable". This is a special channel for
 thread wakeup that is mildly similar to SIGIO. A thread has an internal single
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 63 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
-index 78dc405bb7590..457ff28b789f7 100644
+index 78dc405bb759..457ff28b789f 100644
 --- a/drivers/misc/ntsync.c
 +++ b/drivers/misc/ntsync.c
 @@ -869,22 +869,29 @@ static int setup_wait(struct ntsync_device *dev,
@@ -183,7 +183,7 @@ index 78dc405bb7590..457ff28b789f7 100644
  	if (signaled != -1) {
  		struct ntsync_wait_args __user *user_args = argp;
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
-index b9d208a8c00fe..6d06793512b15 100644
+index b9d208a8c00f..6d06793512b1 100644
 --- a/include/uapi/linux/ntsync.h
 +++ b/include/uapi/linux/ntsync.h
 @@ -34,7 +34,8 @@ struct ntsync_wait_args {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0054-UPSTREAM-selftests-ntsync-Add-some-tests-for-semapho.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0054-UPSTREAM-selftests-ntsync-Add-some-tests-for-semapho.patch
@@ -1,7 +1,7 @@
 From 9f7f519ca754186afef374625b2ed106829a53ce Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:57 -0600
-Subject: [PATCH 054/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 054/305] UPSTREAM: selftests: ntsync: Add some tests for
  semaphore state.
 
 Wine has tests for its synchronization primitives, but these are more accessible
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 tools/testing/selftests/drivers/ntsync/ntsync.c
 
 diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
-index 9cf769d415687..d2ae8d2db3c6b 100644
+index 9cf769d41568..d2ae8d2db3c6 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
 @@ -18,6 +18,7 @@ TARGETS += devices/error_logs
@@ -43,14 +43,14 @@ index 9cf769d415687..d2ae8d2db3c6b 100644
  TARGETS += drivers/net/bonding
 diff --git a/tools/testing/selftests/drivers/ntsync/.gitignore b/tools/testing/selftests/drivers/ntsync/.gitignore
 new file mode 100644
-index 0000000000000..848573a3d3eaf
+index 000000000000..848573a3d3ea
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/.gitignore
 @@ -0,0 +1 @@
 +ntsync
 diff --git a/tools/testing/selftests/drivers/ntsync/Makefile b/tools/testing/selftests/drivers/ntsync/Makefile
 new file mode 100644
-index 0000000000000..dbf2b055c0b28
+index 000000000000..dbf2b055c0b2
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/Makefile
 @@ -0,0 +1,7 @@
@@ -63,14 +63,14 @@ index 0000000000000..dbf2b055c0b28
 +include ../../lib.mk
 diff --git a/tools/testing/selftests/drivers/ntsync/config b/tools/testing/selftests/drivers/ntsync/config
 new file mode 100644
-index 0000000000000..60539c826d062
+index 000000000000..60539c826d06
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/config
 @@ -0,0 +1 @@
 +CONFIG_WINESYNC=y
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
 new file mode 100644
-index 0000000000000..cc72da0a91de5
+index 000000000000..cc72da0a91de
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -0,0 +1,145 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0055-UPSTREAM-selftests-ntsync-Add-some-tests-for-mutex-s.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0055-UPSTREAM-selftests-ntsync-Add-some-tests-for-mutex-s.patch
@@ -1,7 +1,7 @@
 From 7aeb7599c6bfa243f4e1435639f427d4ab1a3633 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:58 -0600
-Subject: [PATCH 055/303] UPSTREAM: selftests: ntsync: Add some tests for mutex
+Subject: [PATCH 055/305] UPSTREAM: selftests: ntsync: Add some tests for mutex
  state.
 
 Test mutex-specific ioctls NTSYNC_IOC_MUTEX_UNLOCK and NTSYNC_IOC_MUTEX_READ,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 187 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index cc72da0a91de5..4db65490b6a12 100644
+index cc72da0a91de..4db65490b6a1 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -40,6 +40,39 @@ static int release_sem(int sem, __u32 *count)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0056-UPSTREAM-selftests-ntsync-Add-some-tests-for-NTSYNC_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0056-UPSTREAM-selftests-ntsync-Add-some-tests-for-NTSYNC_.patch
@@ -1,7 +1,7 @@
 From acf2342b45963a47ce44f8b566a6a8b650fd9e9e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:34:59 -0600
-Subject: [PATCH 056/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 056/305] UPSTREAM: selftests: ntsync: Add some tests for
  NTSYNC_IOC_WAIT_ANY.
 
 Test basic synchronous functionality of NTSYNC_IOC_WAIT_ANY, when objects are
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 114 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 4db65490b6a12..9781a74253eeb 100644
+index 4db65490b6a1..9781a74253ee 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -329,4 +329,118 @@ TEST(mutex_state)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0057-UPSTREAM-selftests-ntsync-Add-some-tests-for-NTSYNC_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0057-UPSTREAM-selftests-ntsync-Add-some-tests-for-NTSYNC_.patch
@@ -1,7 +1,7 @@
 From 2c2ed40ef9a836fa25839faf8d883f1827cbfbd7 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:00 -0600
-Subject: [PATCH 057/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 057/305] UPSTREAM: selftests: ntsync: Add some tests for
  NTSYNC_IOC_WAIT_ALL.
 
 Test basic synchronous functionality of NTSYNC_IOC_WAIT_ALL, and when objects
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 91 insertions(+), 2 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 9781a74253eeb..aba11eaf9a7cb 100644
+index 9781a74253ee..aba11eaf9a7c 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -73,7 +73,8 @@ static int unlock_mutex(int mutex, __u32 owner, __u32 *count)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0058-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0058-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
@@ -1,7 +1,7 @@
 From 5e5f64ef1ab76ebe94a1e1a9f36fafed1c4cc120 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:01 -0600
-Subject: [PATCH 058/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 058/305] UPSTREAM: selftests: ntsync: Add some tests for
  wakeup signaling with WINESYNC_IOC_WAIT_ANY.
 
 Test contended "wait-for-any" waits, to make sure that scheduling and wakeup
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 143 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index aba11eaf9a7cb..ad3f031c0b926 100644
+index aba11eaf9a7c..ad3f031c0b92 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -532,4 +532,147 @@ TEST(test_wait_all)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0059-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0059-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
@@ -1,7 +1,7 @@
 From 37c99bb2638eadac8b0610aeed6ab0c81e612323 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:02 -0600
-Subject: [PATCH 059/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 059/305] UPSTREAM: selftests: ntsync: Add some tests for
  wakeup signaling with WINESYNC_IOC_WAIT_ALL.
 
 Test contended "wait-for-all" waits, to make sure that scheduling and wakeup
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 91 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index ad3f031c0b926..6bf0f10679d8a 100644
+index ad3f031c0b92..6bf0f10679d8 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -675,4 +675,95 @@ TEST(wake_any)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0060-UPSTREAM-selftests-ntsync-Add-some-tests-for-manual-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0060-UPSTREAM-selftests-ntsync-Add-some-tests-for-manual-.patch
@@ -1,7 +1,7 @@
 From b54646a978fccdfd86d783838fde2de2524e616e Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:03 -0600
-Subject: [PATCH 060/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 060/305] UPSTREAM: selftests: ntsync: Add some tests for
  manual-reset event state.
 
 Test event-specific ioctls NTSYNC_IOC_EVENT_SET, NTSYNC_IOC_EVENT_RESET,
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 86 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 6bf0f10679d8a..4024a5c48bbb6 100644
+index 6bf0f10679d8..4024a5c48bbb 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -73,6 +73,27 @@ static int unlock_mutex(int mutex, __u32 owner, __u32 *count)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0061-UPSTREAM-selftests-ntsync-Add-some-tests-for-auto-re.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0061-UPSTREAM-selftests-ntsync-Add-some-tests-for-auto-re.patch
@@ -1,7 +1,7 @@
 From 2c9fb54a7eeadbc4aa0b358ed53a48a0db4fdaf7 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:04 -0600
-Subject: [PATCH 061/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 061/305] UPSTREAM: selftests: ntsync: Add some tests for
  auto-reset event state.
 
 Test event-specific ioctls NTSYNC_IOC_EVENT_SET, NTSYNC_IOC_EVENT_RESET,
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 56 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 4024a5c48bbb6..66a096cb20456 100644
+index 4024a5c48bbb..66a096cb2045 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -426,6 +426,62 @@ TEST(manual_event_state)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0062-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0062-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
@@ -1,7 +1,7 @@
 From 3128b8cdef19ff573d391b97650c3b543eb32cbe Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:05 -0600
-Subject: [PATCH 062/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 062/305] UPSTREAM: selftests: ntsync: Add some tests for
  wakeup signaling with events.
 
 Expand the contended wait tests, which previously only covered events and
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 141 insertions(+), 4 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 66a096cb20456..33348f0b621f2 100644
+index 66a096cb2045..33348f0b621f 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -598,6 +598,7 @@ TEST(test_wait_any)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0063-UPSTREAM-selftests-ntsync-Add-tests-for-alertable-wa.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0063-UPSTREAM-selftests-ntsync-Add-tests-for-alertable-wa.patch
@@ -1,7 +1,7 @@
 From c7c44281c88a5b21340f50558916fba504cb3033 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:06 -0600
-Subject: [PATCH 063/303] UPSTREAM: selftests: ntsync: Add tests for alertable
+Subject: [PATCH 063/305] UPSTREAM: selftests: ntsync: Add tests for alertable
  waits.
 
 Test the "alert" functionality of NTSYNC_IOC_WAIT_ALL and NTSYNC_IOC_WAIT_ANY,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 164 insertions(+), 3 deletions(-)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 33348f0b621f2..72f078dde444b 100644
+index 33348f0b621f..72f078dde444 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -95,7 +95,7 @@ static int read_event_state(int event, __u32 *signaled, __u32 *manual)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0064-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0064-UPSTREAM-selftests-ntsync-Add-some-tests-for-wakeup-.patch
@@ -1,7 +1,7 @@
 From 0d260001f4ea4ef12ca59b7db1f41860b3d8779d Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:07 -0600
-Subject: [PATCH 064/303] UPSTREAM: selftests: ntsync: Add some tests for
+Subject: [PATCH 064/305] UPSTREAM: selftests: ntsync: Add some tests for
  wakeup signaling via alerts.
 
 Expand the alert tests to cover alerting a thread mid-wait, to test that the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 62 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 72f078dde444b..298b279729aa8 100644
+index 72f078dde444..298b279729aa 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -1063,9 +1063,12 @@ TEST(wake_all)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0065-UPSTREAM-selftests-ntsync-Add-a-stress-test-for-cont.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0065-UPSTREAM-selftests-ntsync-Add-a-stress-test-for-cont.patch
@@ -1,7 +1,7 @@
 From 98e6352f312922439d3e1c804f74851838729553 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:08 -0600
-Subject: [PATCH 065/303] UPSTREAM: selftests: ntsync: Add a stress test for
+Subject: [PATCH 065/305] UPSTREAM: selftests: ntsync: Add a stress test for
  contended waits.
 
 Test a more realistic usage pattern, and one with heavy contention, in order to
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 72 insertions(+)
 
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
-index 298b279729aa8..3aad311574c44 100644
+index 298b279729aa..3aad311574c4 100644
 --- a/tools/testing/selftests/drivers/ntsync/ntsync.c
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -1268,4 +1268,76 @@ TEST(alert_all)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0066-UPSTREAM-maintainers-Add-an-entry-for-ntsync.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0066-UPSTREAM-maintainers-Add-an-entry-for-ntsync.patch
@@ -1,7 +1,7 @@
 From 7bfb446c55785694f967fd5ad81c865db346f886 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:09 -0600
-Subject: [PATCH 066/303] UPSTREAM: maintainers: Add an entry for ntsync.
+Subject: [PATCH 066/305] UPSTREAM: maintainers: Add an entry for ntsync.
 
 Add myself as maintainer, supported by CodeWeavers.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 66699597d76ec..0741e350ce76f 100644
+index 66699597d76e..0741e350ce76 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -16500,6 +16500,15 @@ T:	git https://github.com/Paragon-Software-Group/linux-ntfs3.git

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0067-UPSTREAM-docs-ntsync-Add-documentation-for-the-ntsyn.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0067-UPSTREAM-docs-ntsync-Add-documentation-for-the-ntsyn.patch
@@ -1,7 +1,7 @@
 From 87b825f8b8f86138d2d6283b2c91213408eed2f4 Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:10 -0600
-Subject: [PATCH 067/303] UPSTREAM: docs: ntsync: Add documentation for the
+Subject: [PATCH 067/305] UPSTREAM: docs: ntsync: Add documentation for the
  ntsync uAPI.
 
 Add an overall explanation of the driver architecture, and complete and precise
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 Documentation/userspace-api/ntsync.rst
 
 diff --git a/Documentation/userspace-api/index.rst b/Documentation/userspace-api/index.rst
-index 274cc7546efc2..9c1b15cd89ab0 100644
+index 274cc7546efc..9c1b15cd89ab 100644
 --- a/Documentation/userspace-api/index.rst
 +++ b/Documentation/userspace-api/index.rst
 @@ -63,6 +63,7 @@ Everything else
@@ -33,7 +33,7 @@ index 274cc7546efc2..9c1b15cd89ab0 100644
  
 diff --git a/Documentation/userspace-api/ntsync.rst b/Documentation/userspace-api/ntsync.rst
 new file mode 100644
-index 0000000000000..25e7c4aef9681
+index 000000000000..25e7c4aef968
 --- /dev/null
 +++ b/Documentation/userspace-api/ntsync.rst
 @@ -0,0 +1,385 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0068-UPSTREAM-ntsync-No-longer-depend-on-BROKEN.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0068-UPSTREAM-ntsync-No-longer-depend-on-BROKEN.patch
@@ -1,7 +1,7 @@
 From cae5b6e118c1e5118114d80b34444676d31818fb Mon Sep 17 00:00:00 2001
 From: Elizabeth Figura <zfigura@codeweavers.com>
 Date: Fri, 13 Dec 2024 13:35:11 -0600
-Subject: [PATCH 068/303] UPSTREAM: ntsync: No longer depend on BROKEN.
+Subject: [PATCH 068/305] UPSTREAM: ntsync: No longer depend on BROKEN.
 
 f5b335dc025cfee90957efa90dc72fada0d5abb4 ("misc: ntsync: mark driver as "broken"
 to prevent from building") was committed to avoid the driver being used while
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index 3fe7e2a9bd294..6c8b999a5e085 100644
+index 3fe7e2a9bd29..6c8b999a5e08 100644
 --- a/drivers/misc/Kconfig
 +++ b/drivers/misc/Kconfig
 @@ -517,7 +517,6 @@ config OPEN_DICE

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0069-UPSTREAM-net-stmmac-Apply-new-page-pool-parameters-w.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0069-UPSTREAM-net-stmmac-Apply-new-page-pool-parameters-w.patch
@@ -1,7 +1,7 @@
 From 16f50dd6dfe6adc1d2b4157eadb7c0b767bbeb8f Mon Sep 17 00:00:00 2001
 From: Furong Xu <0x1207@gmail.com>
 Date: Fri, 7 Feb 2025 16:56:39 +0800
-Subject: [PATCH 069/303] UPSTREAM: net: stmmac: Apply new page pool parameters
+Subject: [PATCH 069/305] UPSTREAM: net: stmmac: Apply new page pool parameters
  when SPH is enabled
 
 Commit df542f669307 ("net: stmmac: Switch to zero-copy in
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 918d7f2e8ba99..3f3c84147dd79 100644
+index 918d7f2e8ba9..3f3c84147dd7 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -2048,6 +2048,11 @@ static int __alloc_dma_rx_desc_resources(struct stmmac_priv *priv,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0070-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0070-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 4a2df6e18ed21f3d3b6b925c85ecc995cc740538 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 070/303] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 070/305] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index 4ea47e6f835bf..12f6a2bb4057d 100644
+index 4ea47e6f835b..12f6a2bb4057 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0071-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0071-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
@@ -1,7 +1,7 @@
 From af5b1d8d4842e6a0d4fa8a67e308a827b0ab3189 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 071/303] FROMLIST: drm/Makefile: Move tiny drivers before
+Subject: [PATCH 071/305] FROMLIST: drm/Makefile: Move tiny drivers before
  native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
@@ -38,7 +38,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index 1ec44529447a7..89da8f62e32c3 100644
+index 1ec44529447a..89da8f62e32c 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -164,6 +164,7 @@ obj-y			+= arm/

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0072-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0072-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From 8ece090a351e36915d265a76254cc622447cbbcf Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 072/303] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 072/305] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/mm/cache.c b/arch/loongarch/mm/cache.c
-index 6be04d36ca076..89eeb9a97dd5d 100644
+index 6be04d36ca07..89eeb9a97dd5 100644
 --- a/arch/loongarch/mm/cache.c
 +++ b/arch/loongarch/mm/cache.c
 @@ -63,6 +63,27 @@ static void flush_cache_leaf(unsigned int leaf)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0073-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0073-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
@@ -1,7 +1,7 @@
 From ad45b0c063275ef541fff6acb829e7cca7bbdad5 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
-Subject: [PATCH 073/303] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
+Subject: [PATCH 073/305] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
  when selected cpu is offline
 
 Call work_on_cpu(cpu, fn, arg) in pci_call_probe() while the argument
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 35270172c8331..fcfc40a7785dd 100644
+index 35270172c833..fcfc40a7785d 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -386,7 +386,7 @@ static int pci_call_probe(struct pci_driver *drv, struct pci_dev *dev,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0074-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0074-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
 From fdaad67d90474f28a34882f1a3799edeab77c0c6 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 074/303] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 074/305] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/serial/loongson,uart.yaml b/Documentation/devicetree/bindings/serial/loongson,uart.yaml
 new file mode 100644
-index 0000000000000..19a65dd5be9f8
+index 000000000000..19a65dd5be9f
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/serial/loongson,uart.yaml
 @@ -0,0 +1,63 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0075-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0075-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
 From b2f2a87f512cb900ef5a53e0be86f6bd7b80fce2 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 075/303] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 075/305] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/tty/serial/8250/8250_loongson.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 0741e350ce76f..6c431431e9e9e 100644
+index 0741e350ce76..6c431431e9e9 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13360,6 +13360,13 @@ S:	Maintained
@@ -41,7 +41,7 @@ index 0741e350ce76f..6c431431e9e9e 100644
  L:	linux-clk@vger.kernel.org
 diff --git a/drivers/tty/serial/8250/8250_loongson.c b/drivers/tty/serial/8250/8250_loongson.c
 new file mode 100644
-index 0000000000000..88205fed4fd30
+index 000000000000..88205fed4fd3
 --- /dev/null
 +++ b/drivers/tty/serial/8250/8250_loongson.c
 @@ -0,0 +1,228 @@
@@ -274,7 +274,7 @@ index 0000000000000..88205fed4fd30
 +MODULE_AUTHOR("Haowei Zheng <zhenghaowei@loongson.cn>");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
-index 0519679929652..1d92585d4976e 100644
+index 051967992965..1d92585d4976 100644
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
 @@ -319,6 +319,14 @@ static const struct serial8250_config uart_config[] = {
@@ -293,7 +293,7 @@ index 0519679929652..1d92585d4976e 100644
  
  /* Uart divisor latch read */
 diff --git a/drivers/tty/serial/8250/Kconfig b/drivers/tty/serial/8250/Kconfig
-index 47ff50763c048..ca828e94719ae 100644
+index 47ff50763c04..ca828e94719a 100644
 --- a/drivers/tty/serial/8250/Kconfig
 +++ b/drivers/tty/serial/8250/Kconfig
 @@ -568,6 +568,15 @@ config SERIAL_8250_BCM7271
@@ -313,7 +313,7 @@ index 47ff50763c048..ca828e94719ae 100644
  	tristate "Devicetree based probing for 8250 ports"
  	depends on SERIAL_8250 && OF
 diff --git a/drivers/tty/serial/8250/Makefile b/drivers/tty/serial/8250/Makefile
-index 1516de629b617..e9587bf69f655 100644
+index 1516de629b61..e9587bf69f65 100644
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
 @@ -51,5 +51,6 @@ obj-$(CONFIG_SERIAL_8250_RT288X)	+= 8250_rt288x.o
@@ -324,7 +324,7 @@ index 1516de629b617..e9587bf69f655 100644
  
  CFLAGS_8250_ingenic.o += -I$(srctree)/scripts/dtc/libfdt
 diff --git a/include/uapi/linux/serial_core.h b/include/uapi/linux/serial_core.h
-index 9c007a106330b..9e316b9295e52 100644
+index 9c007a106330..9e316b9295e5 100644
 --- a/include/uapi/linux/serial_core.h
 +++ b/include/uapi/linux/serial_core.h
 @@ -31,6 +31,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0076-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0076-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
 From aa305c5ed2071cd6aa1af75c4df119da25747abf Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 076/303] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 076/305] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/boot/dts/loongson-2k0500.dtsi b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
-index 3b38ff8853a7d..63c77d70639c2 100644
+index 3b38ff8853a7..63c77d70639c 100644
 --- a/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 @@ -220,7 +220,7 @@ tsensor: thermal-sensor@1fe11500 {
@@ -31,7 +31,7 @@ index 3b38ff8853a7d..63c77d70639c2 100644
  			clock-frequency = <100000000>;
  			interrupt-parent = <&eiointc>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k1000.dtsi b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
-index 92180140eb56e..cafb8d13c065e 100644
+index 92180140eb56..cafb8d13c065 100644
 --- a/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 @@ -297,7 +297,7 @@ dma-controller@1fe00c40 {
@@ -44,7 +44,7 @@ index 92180140eb56e..cafb8d13c065e 100644
  			clock-frequency = <125000000>;
  			interrupt-parent = <&liointc0>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k2000.dtsi b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
-index 0953c57078256..d4fe91af8c077 100644
+index 0953c5707825..d4fe91af8c07 100644
 --- a/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 @@ -174,7 +174,7 @@ rtc0: rtc@100d0100 {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0077-FROMLIST-ahci-Marvell-controllers-prefer-DMA-for-ATA.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0077-FROMLIST-ahci-Marvell-controllers-prefer-DMA-for-ATA.patch
@@ -1,7 +1,7 @@
 From 168cb2ad938b425ced8f6df0dc50ec4ff8ebe728 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 8 Sep 2024 17:46:04 +0800
-Subject: [PATCH 077/303] FROMLIST: ahci: Marvell controllers prefer DMA for
+Subject: [PATCH 077/305] FROMLIST: ahci: Marvell controllers prefer DMA for
  ATAPI
 
 We use Marvell CD/DVD controllers on many Loongson-based machines. We
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/ata/ahci.c b/drivers/ata/ahci.c
-index 650122deb480d..561383a10d6a7 100644
+index 650122deb480..561383a10d6a 100644
 --- a/drivers/ata/ahci.c
 +++ b/drivers/ata/ahci.c
 @@ -1950,6 +1950,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
@@ -40,7 +40,7 @@ index 650122deb480d..561383a10d6a7 100644
  
  	if (ahci_broken_system_poweroff(pdev)) {
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index 0cb97181d10a9..d47f5bf13b93e 100644
+index 0cb97181d10a..d47f5bf13b93 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
 @@ -3064,6 +3064,10 @@ int ata_dev_configure(struct ata_device *dev)
@@ -64,7 +64,7 @@ index 0cb97181d10a9..d47f5bf13b93e 100644
  	if (ap->ops->check_atapi_dma)
  		return ap->ops->check_atapi_dma(qc);
 diff --git a/include/linux/libata.h b/include/linux/libata.h
-index 79974a99265fc..006a664591f78 100644
+index 79974a99265f..006a664591f7 100644
 --- a/include/linux/libata.h
 +++ b/include/linux/libata.h
 @@ -195,6 +195,7 @@ enum {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0078-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0078-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From c104e43bcbc21ae48accc54bb2db55e31c647e6f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 078/303] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 078/305] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/mouse/pixart_ps2.h
 
 diff --git a/drivers/input/mouse/Kconfig b/drivers/input/mouse/Kconfig
-index 833b643f06164..8a27a20d04b01 100644
+index 833b643f0616..8a27a20d04b0 100644
 --- a/drivers/input/mouse/Kconfig
 +++ b/drivers/input/mouse/Kconfig
 @@ -69,6 +69,18 @@ config MOUSE_PS2_LOGIPS2PP
@@ -54,7 +54,7 @@ index 833b643f06164..8a27a20d04b01 100644
  	bool "Synaptics PS/2 mouse protocol extension" if EXPERT
  	default y
 diff --git a/drivers/input/mouse/Makefile b/drivers/input/mouse/Makefile
-index a1336d5bee6f3..5630295515291 100644
+index a1336d5bee6f..563029551529 100644
 --- a/drivers/input/mouse/Makefile
 +++ b/drivers/input/mouse/Makefile
 @@ -32,6 +32,7 @@ psmouse-$(CONFIG_MOUSE_PS2_ELANTECH)	+= elantech.o
@@ -67,7 +67,7 @@ index a1336d5bee6f3..5630295515291 100644
  psmouse-$(CONFIG_MOUSE_PS2_TOUCHKIT)	+= touchkit_ps2.o
 diff --git a/drivers/input/mouse/pixart_ps2.c b/drivers/input/mouse/pixart_ps2.c
 new file mode 100644
-index 0000000000000..d5cd009361716
+index 000000000000..d5cd00936171
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.c
 @@ -0,0 +1,310 @@
@@ -383,7 +383,7 @@ index 0000000000000..d5cd009361716
 +}
 diff --git a/drivers/input/mouse/pixart_ps2.h b/drivers/input/mouse/pixart_ps2.h
 new file mode 100644
-index 0000000000000..47a1d040f2d10
+index 000000000000..47a1d040f2d1
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.h
 @@ -0,0 +1,36 @@
@@ -424,7 +424,7 @@ index 0000000000000..47a1d040f2d10
 +
 +#endif  /* _PIXART_PS2_H */
 diff --git a/drivers/input/mouse/psmouse-base.c b/drivers/input/mouse/psmouse-base.c
-index a2c9f7144864e..5a4defe9cf325 100644
+index a2c9f7144864..5a4defe9cf32 100644
 --- a/drivers/input/mouse/psmouse-base.c
 +++ b/drivers/input/mouse/psmouse-base.c
 @@ -36,6 +36,7 @@
@@ -466,7 +466,7 @@ index a2c9f7144864e..5a4defe9cf325 100644
  		if (psmouse_try_protocol(psmouse, PSMOUSE_GENPS,
  					 &max_proto, set_properties, true))
 diff --git a/drivers/input/mouse/psmouse.h b/drivers/input/mouse/psmouse.h
-index 4d8acfe0d82aa..23f7fa7243cb5 100644
+index 4d8acfe0d82a..23f7fa7243cb 100644
 --- a/drivers/input/mouse/psmouse.h
 +++ b/drivers/input/mouse/psmouse.h
 @@ -69,6 +69,7 @@ enum psmouse_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0079-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0079-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From 533ee0bd2ec018b4dacbef5f357ecca0c6ecf145 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 079/303] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 079/305] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 5078ebf071ec0..efcaca5f4820f 100644
+index 5078ebf071ec..efcaca5f4820 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2875,9 +2875,6 @@ config ARCH_SUPPORTS_KEXEC

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0080-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0080-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 81d291529abef66bddb312f7d644459fe7ab898a Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 080/303] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 080/305] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/fpu/xstate.h b/arch/x86/kernel/fpu/xstate.h
-index aa16f1a1bbcf1..4d966c6c794ad 100644
+index aa16f1a1bbcf..4d966c6c794a 100644
 --- a/arch/x86/kernel/fpu/xstate.h
 +++ b/arch/x86/kernel/fpu/xstate.h
 @@ -80,6 +80,9 @@ static inline int update_pkru_in_sigframe(struct xregs_state __user *buf, u64 ma

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0081-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0081-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
@@ -1,7 +1,7 @@
 From 58ec499fc529abe6033b79d5fdb30b4df8bd830d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 21 Jan 2025 19:42:25 +0800
-Subject: [PATCH 081/303] FROMLIST: PCI: loongson: Add quirk for OHCI device
+Subject: [PATCH 081/305] FROMLIST: PCI: loongson: Add quirk for OHCI device
  rev 0x02
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/pci/controller/pci-loongson.c b/drivers/pci/controller/pci-loongson.c
-index bc630ab8a2831..977f7b15f3a73 100644
+index bc630ab8a283..977f7b15f3a7 100644
 --- a/drivers/pci/controller/pci-loongson.c
 +++ b/drivers/pci/controller/pci-loongson.c
 @@ -32,6 +32,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0082-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0082-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From 66cb33c0d3c05c8f14b008210e594acdf29767c7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 082/303] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 082/305] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 145787c424e0c..afa89f7aada60 100644
+index 145787c424e0..afa89f7aada6 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3490,6 +3490,7 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0083-FROMLIST-mm-slab-Initialise-random_kmalloc_seed-afte.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0083-FROMLIST-mm-slab-Initialise-random_kmalloc_seed-afte.patch
@@ -1,7 +1,7 @@
 From f3971a0d2d3a0df705fbf30ab17c194c1cf2007e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 12 Feb 2025 22:16:48 +0800
-Subject: [PATCH 083/303] FROMLIST: mm/slab: Initialise random_kmalloc_seed
+Subject: [PATCH 083/305] FROMLIST: mm/slab: Initialise random_kmalloc_seed
  after initcalls
 
 Hibernation assumes the memory layout after resume be the same as that
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/init/main.c b/init/main.c
-index c4778edae7972..905e2277aa2f2 100644
+index c4778edae797..905e2277aa2f 100644
 --- a/init/main.c
 +++ b/init/main.c
 @@ -1470,6 +1470,9 @@ static int __ref kernel_init(void *unused)
@@ -41,7 +41,7 @@ index c4778edae7972..905e2277aa2f2 100644
  	kprobe_free_init_mem();
  	ftrace_free_init_mem();
 diff --git a/mm/slab_common.c b/mm/slab_common.c
-index 477fa471da185..3982bde96d2cd 100644
+index 477fa471da18..3982bde96d2c 100644
 --- a/mm/slab_common.c
 +++ b/mm/slab_common.c
 @@ -960,9 +960,6 @@ void __init create_kmalloc_caches(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0084-FROMLIST-platform-x86-lenovo-wmi-hotkey-utilities.c-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0084-FROMLIST-platform-x86-lenovo-wmi-hotkey-utilities.c-.patch
@@ -1,7 +1,7 @@
 From 80767a4fee0c2a63782d4f4b238a829b6268d854 Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Mon, 17 Feb 2025 11:57:33 +0800
-Subject: [PATCH 084/303] FROMLIST: platform/x86:lenovo-wmi-hotkey-utilities.c:
+Subject: [PATCH 084/305] FROMLIST: platform/x86:lenovo-wmi-hotkey-utilities.c:
  Support for mic and audio mute LEDs
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 6c431431e9e9e..96354853c7051 100644
+index 6c431431e9e9..96354853c705 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -12898,6 +12898,12 @@ S:	Maintained
@@ -52,7 +52,7 @@ index 6c431431e9e9e..96354853c7051 100644
  M:	Hans de Goede <hdegoede@redhat.com>
  L:	linux-input@vger.kernel.org
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 3875abba5a790..59a14b43ad47c 100644
+index 3875abba5a79..59a14b43ad47 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -473,6 +473,17 @@ config IDEAPAD_LAPTOP
@@ -74,7 +74,7 @@ index 3875abba5a790..59a14b43ad47c 100644
  	tristate "Lenovo Yoga Tablet Mode Control"
  	depends on ACPI_WMI
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index e1b1429470674..131fcf9744779 100644
+index e1b142947067..131fcf974477 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
 @@ -61,6 +61,7 @@ obj-$(CONFIG_UV_SYSFS)       += uv_sysfs.o
@@ -87,7 +87,7 @@ index e1b1429470674..131fcf9744779 100644
  obj-$(CONFIG_THINKPAD_ACPI)	+= thinkpad_acpi.o
 diff --git a/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c b/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 new file mode 100644
-index 0000000000000..a8fedc8ed7a6e
+index 000000000000..a8fedc8ed7a6
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-hotkey-utilities.c
 @@ -0,0 +1,216 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0085-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0085-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
@@ -1,7 +1,7 @@
 From f792c510784b7d51e67bfe464e76c88ab7f7bdb5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:24 +0800
-Subject: [PATCH 085/303] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
+Subject: [PATCH 085/305] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
  PWM controller
 
 Add Loongson PWM controller binding with DT schema format using
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 new file mode 100644
-index 0000000000000..46814773e0cc8
+index 000000000000..46814773e0cc
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pwm/loongson,ls7a-pwm.yaml
 @@ -0,0 +1,66 @@
@@ -93,7 +93,7 @@ index 0000000000000..46814773e0cc8
 +        #pwm-cells = <3>;
 +    };
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 96354853c7051..e3a690adc2a25 100644
+index 96354853c705..e3a690adc2a2 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13366,6 +13366,12 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0086-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0086-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,7 +1,7 @@
 From de95bbba4bba097c7a945555f616d44d3a2fe4e7 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:25 +0800
-Subject: [PATCH 086/303] FROMLIST: pwm: Add Loongson PWM controller support
+Subject: [PATCH 086/305] FROMLIST: pwm: Add Loongson PWM controller support
 
 This commit adds a generic PWM framework driver for the PWM controller
 found on Loongson family chips.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/pwm/pwm-loongson.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index e3a690adc2a25..64630175f8efd 100644
+index e3a690adc2a2..64630175f8ef 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13371,6 +13371,7 @@ M:	Binbin Zhou <zhoubinbin@loongson.cn>
@@ -34,7 +34,7 @@ index e3a690adc2a25..64630175f8efd 100644
  LOONGSON UART DRIVER
  M:	Haowei Zheng <zhenghaowei@loongson.cn>
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index 0915c1e7df16d..ef02a44d83a77 100644
+index 0915c1e7df16..ef02a44d83a7 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -351,6 +351,18 @@ config PWM_KEEMBAY
@@ -57,7 +57,7 @@ index 0915c1e7df16d..ef02a44d83a77 100644
  	tristate "TI/National Semiconductor LP3943 PWM support"
  	depends on MFD_LP3943
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index 9081e0c0e9e09..7c18c9be419ff 100644
+index 9081e0c0e9e0..7c18c9be419f 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -30,6 +30,7 @@ obj-$(CONFIG_PWM_INTEL_LGM)	+= pwm-intel-lgm.o
@@ -70,7 +70,7 @@ index 9081e0c0e9e09..7c18c9be419ff 100644
  obj-$(CONFIG_PWM_LPC32XX)	+= pwm-lpc32xx.o
 diff --git a/drivers/pwm/pwm-loongson.c b/drivers/pwm/pwm-loongson.c
 new file mode 100644
-index 0000000000000..e34a450e38382
+index 000000000000..e34a450e3838
 --- /dev/null
 +++ b/drivers/pwm/pwm-loongson.c
 @@ -0,0 +1,278 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0087-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0087-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 0a29afab016d9e1a91e3cfde6ef2281a978c3f55 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 087/303] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 087/305] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/scsi/lpfc/lpfc_compat.h b/drivers/scsi/lpfc/lpfc_compat.h
-index 43cf46a3a71fe..0cd1e3c82d875 100644
+index 43cf46a3a71f..0cd1e3c82d87 100644
 --- a/drivers/scsi/lpfc/lpfc_compat.h
 +++ b/drivers/scsi/lpfc/lpfc_compat.h
 @@ -91,8 +91,8 @@ lpfc_memcpy_to_slim( void __iomem *dest, void *src, unsigned int bytes)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0088-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0088-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From 571460b7bc1c722116003f393b40980d5cedb748 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 088/303] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 088/305] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 32 insertions(+)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index c89e70df43d82..cc0360e8dd62c 100644
+index c89e70df43d8..cc0360e8dd62 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,6 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0089-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0089-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 8b30eabc6abb15ff061d1778fc59416e30cd8d22 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 089/303] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 089/305] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  9 files changed, 51 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/include/asm/cpu-info.h b/arch/mips/include/asm/cpu-info.h
-index a600670d00e97..d2ea1476aaae8 100644
+index a600670d00e9..d2ea1476aaae 100644
 --- a/arch/mips/include/asm/cpu-info.h
 +++ b/arch/mips/include/asm/cpu-info.h
 @@ -125,7 +125,9 @@ extern void cpu_probe(void);
@@ -62,7 +62,7 @@ index a600670d00e97..d2ea1476aaae8 100644
  struct seq_file;
  struct notifier_block;
 diff --git a/arch/mips/include/asm/mach-loongson64/boot_param.h b/arch/mips/include/asm/mach-loongson64/boot_param.h
-index 3a11ce85762be..943c576220732 100644
+index 3a11ce85762b..943c57622073 100644
 --- a/arch/mips/include/asm/mach-loongson64/boot_param.h
 +++ b/arch/mips/include/asm/mach-loongson64/boot_param.h
 @@ -66,6 +66,7 @@ struct efi_cpuinfo_loongson {
@@ -74,7 +74,7 @@ index 3a11ce85762be..943c576220732 100644
  
  #define MAX_UARTS 64
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index e855a3611d922..3ba2bc06ae778 100644
+index e855a3611d92..3ba2bc06ae77 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -22,6 +22,8 @@ extern spinlock_t rtc_lock;
@@ -87,7 +87,7 @@ index e855a3611d922..3ba2bc06ae778 100644
   * mips_hpt_frequency - must be set if you intend to use an R4k-compatible
   * counter as a timer interrupt source.
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index af7412549e6ea..6934ee44852b4 100644
+index af7412549e6e..6934ee44852b 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1248,32 +1248,44 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)
@@ -180,7 +180,7 @@ index af7412549e6ea..6934ee44852b4 100644
  const char *__elf_base_platform;
  
 diff --git a/arch/mips/kernel/proc.c b/arch/mips/kernel/proc.c
-index 8eba5a1ed664c..23fe62a3cdde4 100644
+index 8eba5a1ed664..23fe62a3cdde 100644
 --- a/arch/mips/kernel/proc.c
 +++ b/arch/mips/kernel/proc.c
 @@ -15,6 +15,7 @@
@@ -204,7 +204,7 @@ index 8eba5a1ed664c..23fe62a3cdde4 100644
  		      cpu_data[n].udelay_val / (500000/HZ),
  		      (cpu_data[n].udelay_val / (5000/HZ)) % 100);
 diff --git a/arch/mips/kernel/time.c b/arch/mips/kernel/time.c
-index ed339d7979f3f..849c6be53b296 100644
+index ed339d7979f3..849c6be53b29 100644
 --- a/arch/mips/kernel/time.c
 +++ b/arch/mips/kernel/time.c
 @@ -120,6 +120,8 @@ EXPORT_SYMBOL(perf_irq);
@@ -217,7 +217,7 @@ index ed339d7979f3f..849c6be53b296 100644
  EXPORT_SYMBOL_GPL(mips_hpt_frequency);
  
 diff --git a/arch/mips/loongson64/env.c b/arch/mips/loongson64/env.c
-index 09ff052698614..d526d1b14d3ac 100644
+index 09ff05269861..d526d1b14d3a 100644
 --- a/arch/mips/loongson64/env.c
 +++ b/arch/mips/loongson64/env.c
 @@ -17,6 +17,7 @@
@@ -271,7 +271,7 @@ index 09ff052698614..d526d1b14d3ac 100644
  	id = readl(HOST_BRIDGE_CONFIG_ADDR);
  	vendor = id & 0xffff;
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 147acd972a07b..69c1e77e6bfc7 100644
+index 147acd972a07..69c1e77e6bfc 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -418,6 +418,7 @@ static void loongson3_init_secondary(void)
@@ -283,7 +283,7 @@ index 147acd972a07b..69c1e77e6bfc7 100644
  
  static void loongson3_smp_finish(void)
 diff --git a/arch/mips/loongson64/smp.h b/arch/mips/loongson64/smp.h
-index 957bde81e0e4e..6112d9d7dd226 100644
+index 957bde81e0e4..6112d9d7dd22 100644
 --- a/arch/mips/loongson64/smp.h
 +++ b/arch/mips/loongson64/smp.h
 @@ -3,6 +3,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 9432394759efa6fbcd0cf67278ef773b2b6efae6 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 090/303] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 090/305] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six
@@ -54,7 +54,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.c
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index efcaca5f4820f..1db8a8a0c8913 100644
+index efcaca5f4820..1db8a8a0c891 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -28,6 +28,7 @@ config MIPS
@@ -106,7 +106,7 @@ index efcaca5f4820f..1db8a8a0c8913 100644
  	  Select this option if you want to run n32 binaries.  These are
  	  64-bit binaries using 32-bit quantities for addressing and certain
 diff --git a/arch/mips/include/asm/abi.h b/arch/mips/include/asm/abi.h
-index dba7f4b6bebfa..6e717a4a13ceb 100644
+index dba7f4b6bebf..6e717a4a13ce 100644
 --- a/arch/mips/include/asm/abi.h
 +++ b/arch/mips/include/asm/abi.h
 @@ -21,6 +21,7 @@ struct mips_abi {
@@ -118,7 +118,7 @@ index dba7f4b6bebfa..6e717a4a13ceb 100644
  	unsigned	off_sc_fpregs;
  	unsigned	off_sc_fpc_csr;
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index ba83d3fb0a848..1c054e3096db8 100644
+index ba83d3fb0a84..1c054e3096db 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,4 +64,14 @@
@@ -137,7 +137,7 @@ index ba83d3fb0a848..1c054e3096db8 100644
 +
  #endif /* _ASM_UNISTD_H */
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index 4abe387549ad2..b501ea16ccd40 100644
+index 4abe387549ad..b501ea16ccd4 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,34 +6,37 @@
@@ -188,7 +188,7 @@ index 4abe387549ad2..b501ea16ccd40 100644
  
  #endif /* _UAPI_ASM_UNISTD_H */
 diff --git a/arch/mips/kernel/Makefile b/arch/mips/kernel/Makefile
-index ecf3278a32f70..5e56641a4e3e0 100644
+index ecf3278a32f7..5e56641a4e3e 100644
 --- a/arch/mips/kernel/Makefile
 +++ b/arch/mips/kernel/Makefile
 @@ -105,6 +105,10 @@ obj-$(CONFIG_HW_PERF_EVENTS)	+= perf_event_mipsxx.o
@@ -204,7 +204,7 @@ index ecf3278a32f70..5e56641a4e3e0 100644
  
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
 new file mode 100644
-index 0000000000000..2248badc3acb6
+index 000000000000..2248badc3acb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -0,0 +1,58 @@
@@ -268,7 +268,7 @@ index 0000000000000..2248badc3acb6
 +__initcall(audit_classes_n32_init);
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
 new file mode 100644
-index 0000000000000..09ae3dbcfecbc
+index 000000000000..09ae3dbcfecb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-native.c
 @@ -0,0 +1,97 @@
@@ -371,7 +371,7 @@ index 0000000000000..09ae3dbcfecbc
 +__initcall(audit_classes_init);
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
 new file mode 100644
-index 0000000000000..e8b9b50f7d267
+index 000000000000..e8b9b50f7d26
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -0,0 +1,60 @@
@@ -436,7 +436,7 @@ index 0000000000000..e8b9b50f7d267
 +
 +__initcall(audit_classes_o32_init);
 diff --git a/arch/mips/kernel/signal.c b/arch/mips/kernel/signal.c
-index 4a10f18a88060..c803c39f5cbe5 100644
+index 4a10f18a8806..c803c39f5cbe 100644
 --- a/arch/mips/kernel/signal.c
 +++ b/arch/mips/kernel/signal.c
 @@ -8,6 +8,7 @@
@@ -472,7 +472,7 @@ index 4a10f18a88060..c803c39f5cbe5 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_n32.c b/arch/mips/kernel/signal_n32.c
-index 139d2596b0d40..fb9ddefae9648 100644
+index 139d2596b0d4..fb9ddefae964 100644
 --- a/arch/mips/kernel/signal_n32.c
 +++ b/arch/mips/kernel/signal_n32.c
 @@ -2,6 +2,7 @@
@@ -498,7 +498,7 @@ index 139d2596b0d40..fb9ddefae9648 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_o32.c b/arch/mips/kernel/signal_o32.c
-index 4f04584596507..ea3f280a18aa0 100644
+index 4f0458459650..ea3f280a18aa 100644
 --- a/arch/mips/kernel/signal_o32.c
 +++ b/arch/mips/kernel/signal_o32.c
 @@ -8,6 +8,7 @@
@@ -524,7 +524,7 @@ index 4f04584596507..ea3f280a18aa0 100644
  	.off_sc_fpregs = offsetof(struct sigcontext32, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext32, sc_fpc_csr),
 diff --git a/include/uapi/linux/audit.h b/include/uapi/linux/audit.h
-index 75e21a1354838..29a0848137342 100644
+index 75e21a135483..29a084813734 100644
 --- a/include/uapi/linux/audit.h
 +++ b/include/uapi/linux/audit.h
 @@ -188,7 +188,11 @@
@@ -553,7 +553,7 @@ index 75e21a1354838..29a0848137342 100644
   * are currently used in an audit field constant understood by the kernel.
   * If you are adding a new #define AUDIT_<whatever>, please ensure that
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index cd57053b4a699..5aa09586d17fb 100644
+index cd57053b4a69..5aa09586d17f 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -189,6 +189,19 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0091-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0091-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 8750f9b8972405d94d789c89eab742b547853c6c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 091/303] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 091/305] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index a35dd73117958..95602736a74f5 100644
+index a35dd7311795..95602736a74f 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -22,6 +22,16 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0092-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0092-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From f820587d2f086a7c1a5ce7456129435a41527053 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 092/303] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 092/305] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 12a1a4ffb6021..50264d9ca2697 100644
+index 12a1a4ffb602..50264d9ca269 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -357,8 +357,10 @@ static int __init early_parse_mem(char *p)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From e10672a979ad1b02ce9f52ce07eac343966f2224 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 093/303] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 093/305] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 62 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 50264d9ca2697..553ca3b363a8b 100644
+index 50264d9ca269..553ca3b363a8 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -54,6 +54,10 @@ struct cpuinfo_mips cpu_data[NR_CPUS] __read_mostly;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0094-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0094-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 92390ad4891d446cde0558cdef7deb047cde6143 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 094/303] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 094/305] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 1db8a8a0c8913..8043e1892ca5f 100644
+index 1db8a8a0c891..8043e1892ca5 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -18,6 +18,7 @@ config MIPS
@@ -36,7 +36,7 @@ index 1db8a8a0c8913..8043e1892ca5f 100644
  	select ARCH_USE_BUILTIN_BSWAP
  	select ARCH_USE_CMPXCHG_LOCKREF if 64BIT
 diff --git a/arch/mips/include/asm/pgtable-64.h b/arch/mips/include/asm/pgtable-64.h
-index 401c1d9e4409a..b688c68bd3f46 100644
+index 401c1d9e4409..b688c68bd3f4 100644
 --- a/arch/mips/include/asm/pgtable-64.h
 +++ b/arch/mips/include/asm/pgtable-64.h
 @@ -260,7 +260,7 @@ static inline int pmd_present(pmd_t pmd)
@@ -49,7 +49,7 @@ index 401c1d9e4409a..b688c68bd3f46 100644
  
  	return pmd_val(pmd) != (unsigned long) invalid_pte_table;
 diff --git a/arch/mips/include/asm/pgtable-bits.h b/arch/mips/include/asm/pgtable-bits.h
-index 088623ba7b8b1..9ee6e189d329f 100644
+index 088623ba7b8b..9ee6e189d329 100644
 --- a/arch/mips/include/asm/pgtable-bits.h
 +++ b/arch/mips/include/asm/pgtable-bits.h
 @@ -52,6 +52,9 @@ enum pgtable_bits {
@@ -105,7 +105,7 @@ index 088623ba7b8b1..9ee6e189d329f 100644
  # define _PAGE_SPECIAL		(1 << _PAGE_SPECIAL_SHIFT)
  #else
 diff --git a/arch/mips/include/asm/pgtable.h b/arch/mips/include/asm/pgtable.h
-index c29a551eb0ca8..24d0c4b6b17ad 100644
+index c29a551eb0ca..24d0c4b6b17a 100644
 --- a/arch/mips/include/asm/pgtable.h
 +++ b/arch/mips/include/asm/pgtable.h
 @@ -160,7 +160,7 @@ static inline void pte_clear(struct mm_struct *mm, unsigned long addr, pte_t *pt

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0095-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0095-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From 6cd6194406dbdb360b0936a96ca4bebca8de5d40 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 095/303] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 095/305] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/numa.c b/arch/mips/loongson64/numa.c
-index 8388400d052fe..4efe3d50f1f8f 100644
+index 8388400d052f..4efe3d50f1f8 100644
 --- a/arch/mips/loongson64/numa.c
 +++ b/arch/mips/loongson64/numa.c
 @@ -60,7 +60,7 @@ static int __init compute_node_distance(int row, int col)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0096-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0096-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From 1088c4ceb9e572c46f62d7fdec1f70cf0ebd1c9c Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 096/303] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 096/305] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+), 15 deletions(-)
 
 diff --git a/arch/mips/mm/tlbex.c b/arch/mips/mm/tlbex.c
-index 69ea54bdc0c36..33f613d6665b8 100644
+index 69ea54bdc0c3..33f613d6665b 100644
 --- a/arch/mips/mm/tlbex.c
 +++ b/arch/mips/mm/tlbex.c
 @@ -676,13 +676,12 @@ static void build_huge_tlb_write_entry(u32 **p, struct uasm_label **l,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0097-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0097-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 6ca5a005b4018adad1234acdf2a9627d0ca442a7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 097/303] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 097/305] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/loongarch/cpu_hwmon.c
 
 diff --git a/drivers/platform/loongarch/Kconfig b/drivers/platform/loongarch/Kconfig
-index 5633e4d73991a..9ec1a86ef7fae 100644
+index 5633e4d73991..9ec1a86ef7fa 100644
 --- a/drivers/platform/loongarch/Kconfig
 +++ b/drivers/platform/loongarch/Kconfig
 @@ -16,6 +16,14 @@ menuconfig LOONGARCH_PLATFORM_DEVICES
@@ -37,7 +37,7 @@ index 5633e4d73991a..9ec1a86ef7fae 100644
  	tristate "Generic Loongson-3 Laptop Driver"
  	depends on ACPI
 diff --git a/drivers/platform/loongarch/Makefile b/drivers/platform/loongarch/Makefile
-index f43ab03db1a2d..8038291bae3aa 100644
+index f43ab03db1a2..8038291bae3a 100644
 --- a/drivers/platform/loongarch/Makefile
 +++ b/drivers/platform/loongarch/Makefile
 @@ -1 +1,2 @@
@@ -45,7 +45,7 @@ index f43ab03db1a2d..8038291bae3aa 100644
  obj-$(CONFIG_LOONGSON_LAPTOP) += loongson-laptop.o
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
 new file mode 100644
-index 0000000000000..93a05993745aa
+index 000000000000..93a05993745a
 --- /dev/null
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -0,0 +1,194 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0098-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0098-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 55daa1dbb0c170e17b95114f53189ba1643d1af8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 098/303] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 098/305] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:
@@ -43,7 +43,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index a3df782fa687b..ed843153aa5af 100644
+index a3df782fa687..ed843153aa5a 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -192,4 +192,4 @@ static __init int sysfb_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0099-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0099-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 9f953cb600100fbe168602110d66187167080501 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 099/303] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 099/305] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 11a492f21157f..b1e4155ef31b6 100644
+index 11a492f21157..b1e4155ef31b 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8093,6 +8093,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -33,7 +33,7 @@ index 11a492f21157f..b1e4155ef31b6 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index bc4ab71613a55..1ce165c627a6c 100644
+index bc4ab71613a5..1ce165c627a6 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4919,6 +4919,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -45,7 +45,7 @@ index bc4ab71613a55..1ce165c627a6c 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 8b62f7faa5b99..88e38fb3f3476 100644
+index 8b62f7faa5b9..88e38fb3f347 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -57,7 +57,7 @@ index 8b62f7faa5b99..88e38fb3f3476 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 6c95575ce109f..465859e2fcff9 100644
+index 6c95575ce109..465859e2fcff 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6423,6 +6423,7 @@ int si_irq_process(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0100-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0100-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From d93fa280278ed122ef045b3be4c4aca7c79e6fc9 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 100/303] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 100/305] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index 6c6d11536b42e..54fc8ab89ee78 100644
+index 6c6d11536b42..54fc8ab89ee7 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -262,6 +262,14 @@ config ARCH_PENSANDO

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0101-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0101-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From f0a16457fa1e7bd6ba9b6dc655698a05ca1c031a Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 101/303] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 101/305] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index c395b3c5c05cf..8284f7744d1bc 100644
+index c395b3c5c05c..8284f7744d1b 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -3247,4 +3247,6 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0102-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0102-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From 55b92e35f8cc5a4c5a2b14999c05df0a1dbe9bf4 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 102/303] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 102/305] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 64630175f8efd..561e4aa32d15b 100644
+index 64630175f8ef..561e4aa32d15 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -2806,6 +2806,12 @@ S:	Maintained
@@ -42,7 +42,7 @@ index 64630175f8efd..561e4aa32d15b 100644
  R:	cros-qcom-dts-watchers@chromium.org
  F:	arch/arm64/boot/dts/qcom/sc7180*
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 05cc07b8f48c0..0a30d9b406a16 100644
+index 05cc07b8f48c..0a30d9b406a1 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -121,6 +121,16 @@ config DWMAC_MESON
@@ -63,7 +63,7 @@ index 05cc07b8f48c0..0a30d9b406a16 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index c2f0e91f6bf83..9ad873b60920e 100644
+index c2f0e91f6bf8..9ad873b60920 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -76,7 +76,7 @@ index c2f0e91f6bf83..9ad873b60920e 100644
  obj-$(CONFIG_DWMAC_RZN1)	+= dwmac-rzn1.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 0000000000000..db1672deae824
+index 000000000000..db1672deae82
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,229 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0103-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0103-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From 0a46161d131a7cd009025e69f873c8587e04f43f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 103/303] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 103/305] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 684489156dcee..59af8728ecae0 100644
+index 684489156dce..59af8728ecae 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -51,10 +51,10 @@
@@ -38,7 +38,7 @@ index 684489156dcee..59af8728ecae0 100644
  
  #undef FRAME_FILTER_DEBUG
 diff --git a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
-index 68a7cfcb1d8f3..40088a390f7b3 100644
+index 68a7cfcb1d8f..40088a390f7b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 @@ -200,6 +200,10 @@ static void ndesc_prepare_tx_desc(struct dma_desc *p, int is_fs, int len,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0104-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0104-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From e98ef3df853be821c369801f2d84efc427ff8ea9 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 104/303] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 104/305] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index db1672deae824..86f491ea569e6 100644
+index db1672deae82..86f491ea569e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -73,14 +73,14 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0105-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0105-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 230cb812ca06db848e5c8eedbd00a73456ffcc09 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 105/303] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 105/305] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
@@ -113,7 +113,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 86f491ea569e6..a930cea6280b6 100644
+index 86f491ea569e..a930cea6280b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -2,7 +2,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0106-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0106-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From e38eaa47084e2fc28440bc594e8cb1c0e0a65718 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 106/303] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 106/305] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 561e4aa32d15b..a571aa60ec00c 100644
+index 561e4aa32d15..a571aa60ec00 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -2806,12 +2806,6 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0107-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0107-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From 00ff0f5d3a18c236c5853ceeaea9501b8b1e66a0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 107/303] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 107/305] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 16 insertions(+), 22 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index a571aa60ec00c..40038370f8bdc 100644
+index a571aa60ec00..40038370f8bd 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -18777,6 +18777,7 @@ ARM/PHYTIUM SOC SUPPORT
@@ -32,7 +32,7 @@ index a571aa60ec00c..40038370f8bdc 100644
  QAT DRIVER
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index a930cea6280b6..d31b8e870f647 100644
+index a930cea6280b..d31b8e870f64 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -37,8 +37,7 @@ static int phytium_get_mac_mode(struct fwnode_handle *fwnode)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0108-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0108-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 15f982a18fea063fb7a2d93db7d2893a8b749607 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 108/303] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 108/305] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d31b8e870f647..6e8e44730bec6 100644
+index d31b8e870f64..6e8e44730bec 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -209,6 +209,7 @@ static struct platform_driver phytium_dwmac_driver = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0109-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0109-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From b1319698461ca838f073e0e85f4338cb425cc5c4 Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 109/303] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 109/305] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/phytium/phytmac_v2.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 40038370f8bdc..060b697321728 100644
+index 40038370f8bd..060b69732172 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -18777,6 +18777,9 @@ ARM/PHYTIUM SOC SUPPORT
@@ -61,7 +61,7 @@ index 40038370f8bdc..060b697321728 100644
  
  QAT DRIVER
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 9a542e3c9b05d..74fa135810e8e 100644
+index 9a542e3c9b05..74fa135810e8 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -172,6 +172,7 @@ config OA_TC6
@@ -73,7 +73,7 @@ index 9a542e3c9b05d..74fa135810e8e 100644
  source "drivers/net/ethernet/brocade/Kconfig"
  source "drivers/net/ethernet/qualcomm/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 99fa180dedb80..d29f86067c486 100644
+index 99fa180dedb8..d29f86067c48 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -76,6 +76,7 @@ obj-$(CONFIG_NET_VENDOR_OKI) += oki-semi/
@@ -86,7 +86,7 @@ index 99fa180dedb80..d29f86067c486 100644
  obj-$(CONFIG_NET_VENDOR_REALTEK) += realtek/
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
 new file mode 100644
-index 0000000000000..14a77adbfdc12
+index 000000000000..14a77adbfdc1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -0,0 +1,58 @@
@@ -150,7 +150,7 @@ index 0000000000000..14a77adbfdc12
 +endif # NET_VENDOR_PHYTIUM
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
 new file mode 100644
-index 0000000000000..6e710d4d54b66
+index 000000000000..6e710d4d54b6
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -0,0 +1,17 @@
@@ -173,7 +173,7 @@ index 0000000000000..6e710d4d54b66
 +phytmac-pci-objs := phytmac_pci.o
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
 new file mode 100644
-index 0000000000000..b90e1551499ef
+index 000000000000..b90e1551499e
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -0,0 +1,591 @@
@@ -770,7 +770,7 @@ index 0000000000000..b90e1551499ef
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 new file mode 100644
-index 0000000000000..592d2d9dc6d4b
+index 000000000000..592d2d9dc6d4
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -0,0 +1,544 @@
@@ -1320,7 +1320,7 @@ index 0000000000000..592d2d9dc6d4b
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
 new file mode 100644
-index 0000000000000..b0977f5cae755
+index 000000000000..b0977f5cae75
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -0,0 +1,2236 @@
@@ -3562,7 +3562,7 @@ index 0000000000000..b0977f5cae755
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
 new file mode 100644
-index 0000000000000..fd21bf80f1388
+index 000000000000..fd21bf80f138
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -0,0 +1,318 @@
@@ -3886,7 +3886,7 @@ index 0000000000000..fd21bf80f1388
 +MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
 new file mode 100644
-index 0000000000000..305ff5866e2fe
+index 000000000000..305ff5866e2f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -0,0 +1,255 @@
@@ -4147,7 +4147,7 @@ index 0000000000000..305ff5866e2fe
 +MODULE_ALIAS("platform:phytmac");
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
 new file mode 100644
-index 0000000000000..26b1b75edbde1
+index 000000000000..26b1b75edbde
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -0,0 +1,304 @@
@@ -4457,7 +4457,7 @@ index 0000000000000..26b1b75edbde1
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
 new file mode 100644
-index 0000000000000..72c8b7c674137
+index 000000000000..72c8b7c67413
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -0,0 +1,55 @@
@@ -4518,7 +4518,7 @@ index 0000000000000..72c8b7c674137
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
 new file mode 100644
-index 0000000000000..2d9f67c82050c
+index 000000000000..2d9f67c82050
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -0,0 +1,1370 @@
@@ -5894,7 +5894,7 @@ index 0000000000000..2d9f67c82050c
 +EXPORT_SYMBOL_GPL(phytmac_1p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
 new file mode 100644
-index 0000000000000..6f2b521aaebdb
+index 000000000000..6f2b521aaebd
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -0,0 +1,453 @@
@@ -6353,7 +6353,7 @@ index 0000000000000..6f2b521aaebdb
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
 new file mode 100644
-index 0000000000000..df142aa6797f6
+index 000000000000..df142aa6797f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -0,0 +1,1254 @@
@@ -7613,7 +7613,7 @@ index 0000000000000..df142aa6797f6
 +EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
 new file mode 100644
-index 0000000000000..92e4806ac2c1f
+index 000000000000..92e4806ac2c1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -0,0 +1,362 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0110-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0110-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From 1df425cc107ef57d58ec1a3bbf621d2c0b8ce2e2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 110/303] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 110/305] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 19 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index b0977f5cae755..da4e067362803 100644
+index b0977f5cae75..da4e06736280 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1508,7 +1508,7 @@ int phytmac_mdio_register(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0111-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0111-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From 8f151289585e285be7650698a7d66dd6db283393 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 111/303] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 111/305] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 2d9f67c82050c..79df9a7f981f1 100644
+index 2d9f67c82050..79df9a7f981f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -357,8 +357,11 @@ static int phytmac_init_hw(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0112-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0112-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From 1fd913f6ee7a6b1e91430cbd19a01024043b32a3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 112/303] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 112/305] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index da4e067362803..c172103a97362 100644
+index da4e06736280..c172103a9736 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1560,6 +1560,7 @@ static void phytmac_validate(struct phylink_config *config,
@@ -30,7 +30,7 @@ index da4e067362803..c172103a97362 100644
  	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
  	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 79df9a7f981f1..ec95c6c79b066 100644
+index 79df9a7f981f..ec95c6c79b06 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -161,6 +161,20 @@ static int phytmac_enable_autoneg(struct phytmac *pdata, int enable)
@@ -105,7 +105,7 @@ index 79df9a7f981f1..ec95c6c79b066 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NSTATUS, PCS_LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 6f2b521aaebdb..d8de2c26cab4b 100644
+index 6f2b521aaebd..d8de2c26cab4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -228,6 +228,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0113-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0113-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From 7324880332c4f92c8b572660d95f3207e3a3ae58 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 113/303] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 113/305] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/fpu-probe.c b/arch/mips/kernel/fpu-probe.c
-index 6bf3f19b1c335..404d753120582 100644
+index 6bf3f19b1c33..404d75312058 100644
 --- a/arch/mips/kernel/fpu-probe.c
 +++ b/arch/mips/kernel/fpu-probe.c
 @@ -144,7 +144,12 @@ static void cpu_set_fpu_2008(struct cpuinfo_mips *c)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0114-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0114-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 5601e0459ae756b2b659739627ac8c51167817d7 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 114/303] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 114/305] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/hwmon-aaeon.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 58480a3f4683f..d67bdf871528d 100644
+index 58480a3f4683..d67bdf871528 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -38,6 +38,18 @@ config HWMON_DEBUG_CHIP
@@ -49,7 +49,7 @@ index 58480a3f4683f..d67bdf871528d 100644
  	tristate "Abit uGuru (rev 1 & 2)"
  	depends on (X86 && DMI) || COMPILE_TEST && HAS_IOPORT
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 9554d2fdcf7bb..74f84764992f9 100644
+index 9554d2fdcf7b..74f84764992f 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -15,6 +15,7 @@ obj-$(CONFIG_SENSORS_HP_WMI)	+= hp-wmi-sensors.o
@@ -62,7 +62,7 @@ index 9554d2fdcf7bb..74f84764992f9 100644
  obj-$(CONFIG_SENSORS_W83773G)	+= w83773g.o
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
 new file mode 100644
-index 0000000000000..146da10309bbb
+index 000000000000..146da10309bb
 --- /dev/null
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -0,0 +1,568 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0115-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0115-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 40a0f3079efcfd90959c371bf51c54ae5b0edd5e Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 115/303] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 115/305] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/leds/leds-aaeon.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index b784bb74a8378..0a663f0231f82 100644
+index b784bb74a837..0a663f0231f8 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -65,6 +65,18 @@ config LEDS_88PM860X
@@ -49,7 +49,7 @@ index b784bb74a8378..0a663f0231f82 100644
  	tristate "LED support for Panasonic AN30259A"
  	depends on LEDS_CLASS && I2C && OF
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 18afbb5a23ee5..3edf875503903 100644
+index 18afbb5a23ee..3edf87550390 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -9,6 +9,7 @@ obj-$(CONFIG_LEDS_TRIGGERS)		+= led-triggers.o
@@ -62,7 +62,7 @@ index 18afbb5a23ee5..3edf875503903 100644
  obj-$(CONFIG_LEDS_AN30259A)		+= leds-an30259a.o
 diff --git a/drivers/leds/leds-aaeon.c b/drivers/leds/leds-aaeon.c
 new file mode 100644
-index 0000000000000..10090a4bff654
+index 000000000000..10090a4bff65
 --- /dev/null
 +++ b/drivers/leds/leds-aaeon.c
 @@ -0,0 +1,142 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0116-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0116-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From d31262c890afe282d7e7f657fcd099c49a074105 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 116/303] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 116/305] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-aaeon.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index d93cd4f722b40..253661449adaa 100644
+index d93cd4f722b4..253661449ada 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1643,6 +1643,18 @@ endmenu
@@ -49,7 +49,7 @@ index d93cd4f722b40..253661449adaa 100644
  	tristate "AMD 8111 GPIO driver"
  	depends on X86 || COMPILE_TEST
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index 1429e8c0229b9..c1a4fd033b94d 100644
+index 1429e8c0229b..c1a4fd033b94 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -24,6 +24,7 @@ obj-$(CONFIG_GPIO_104_IDI_48)		+= gpio-104-idi-48.o
@@ -62,7 +62,7 @@ index 1429e8c0229b9..c1a4fd033b94d 100644
  obj-$(CONFIG_GPIO_ADP5585)		+= gpio-adp5585.o
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
 new file mode 100644
-index 0000000000000..3183c45dd1946
+index 000000000000..3183c45dd194
 --- /dev/null
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -0,0 +1,205 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0117-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0117-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From ac2e46111fd67513448329dfaa268e66df463e84 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 117/303] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 117/305] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/mfd/mfd-aaeon.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 060b697321728..1ee873cba1e1f 100644
+index 060b69732172..1ee873cba1e1 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -190,6 +190,18 @@ M:	Linus Walleij <linus.walleij@linaro.org>
@@ -60,7 +60,7 @@ index 060b697321728..1ee873cba1e1f 100644
  L:	linux-api@vger.kernel.org
  F:	include/linux/syscalls.h
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index f9325bcce1b94..7687025c7e3b5 100644
+index f9325bcce1b9..7687025c7e3b 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2257,6 +2257,18 @@ config MFD_QCOM_PM8008
@@ -83,7 +83,7 @@ index f9325bcce1b94..7687025c7e3b5 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 2a9f91e81af83..877fb90ab5816 100644
+index 2a9f91e81af8..877fb90ab581 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -286,6 +286,7 @@ obj-$(CONFIG_MFD_INTEL_M10_BMC_PMCI)   += intel-m10-bmc-pmci.o
@@ -96,7 +96,7 @@ index 2a9f91e81af83..877fb90ab5816 100644
  obj-$(CONFIG_MFD_RSMU_SPI)	+= rsmu_spi.o rsmu_core.o
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
 new file mode 100644
-index 0000000000000..9d2efde53cad3
+index 000000000000..9d2efde53cad
 --- /dev/null
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -0,0 +1,77 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0118-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0118-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From a9964edc12cc30c63ec0c4515ca95532e1fa9eca Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 118/303] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 118/305] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
-index 9d2efde53cad3..74211d01ce656 100644
+index 9d2efde53cad..74211d01ce65 100644
 --- a/drivers/mfd/mfd-aaeon.c
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -16,12 +16,17 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0119-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0119-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 96e1487c3eff32a8f19822a5e4731316ee74d096 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 119/303] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 119/305] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
-index 146da10309bbb..80bf4d1224f3f 100644
+index 146da10309bb..80bf4d1224f3 100644
 --- a/drivers/hwmon/hwmon-aaeon.c
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -49,7 +49,7 @@ static ssize_t name_show(struct device *dev, struct device_attribute *devattr,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0120-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0120-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From 5c8ef6b9c5ce69bce0335d2d39068b892aecf308 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 120/303] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 120/305] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6e8e44730bec6..078e3ee52bdcb 100644
+index 6e8e44730bec..078e3ee52bdc 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -198,6 +198,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0121-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0121-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From ad1d2c4b993626fe442543f889b02da16f9242fb Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 121/303] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 121/305] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 3f3c84147dd79..2c7ee01e17ae6 100644
+index 3f3c84147dd7..2c7ee01e17ae 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1946,13 +1946,18 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0122-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0122-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From aa7aea877139578f7e3921457fc89f11221e0831 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 122/303] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 122/305] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 078e3ee52bdcb..ba86b6bb047dc 100644
+index 078e3ee52bdc..ba86b6bb047d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -68,6 +68,21 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0123-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0123-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
 From 59028cefd570da56557945ae9a51d9781718f36e Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 123/303] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 123/305] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses
@@ -69,7 +69,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 
 diff --git a/arch/loongarch/configs/loongson3_defconfig b/arch/loongarch/configs/loongson3_defconfig
-index 75b366407a60a..1864ad18f325a 100644
+index 75b366407a60..1864ad18f325 100644
 --- a/arch/loongarch/configs/loongson3_defconfig
 +++ b/arch/loongarch/configs/loongson3_defconfig
 @@ -549,6 +549,7 @@ CONFIG_IXGBE=y
@@ -81,7 +81,7 @@ index 75b366407a60a..1864ad18f325a 100644
  # CONFIG_NET_VENDOR_ROCKER is not set
  # CONFIG_NET_VENDOR_SAMSUNG is not set
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 74fa135810e8e..32b345495d6c6 100644
+index 74fa135810e8..32b345495d6c 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -125,6 +125,7 @@ source "drivers/net/ethernet/mellanox/Kconfig"
@@ -93,7 +93,7 @@ index 74fa135810e8e..32b345495d6c6 100644
  source "drivers/net/ethernet/microsoft/Kconfig"
  source "drivers/net/ethernet/moxa/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index d29f86067c486..302bca5c5f858 100644
+index d29f86067c48..302bca5c5f85 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -62,6 +62,7 @@ obj-$(CONFIG_NET_VENDOR_MELLANOX) += mellanox/
@@ -106,7 +106,7 @@ index d29f86067c486..302bca5c5f858 100644
  obj-$(CONFIG_NET_VENDOR_MYRI) += myricom/
 diff --git a/drivers/net/ethernet/motorcomm/Kconfig b/drivers/net/ethernet/motorcomm/Kconfig
 new file mode 100644
-index 0000000000000..2d058928936f0
+index 000000000000..2d058928936f
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Kconfig
 @@ -0,0 +1,27 @@
@@ -139,7 +139,7 @@ index 0000000000000..2d058928936f0
 +endif # NET_VENDOR_MOTORCOMM
 diff --git a/drivers/net/ethernet/motorcomm/Makefile b/drivers/net/ethernet/motorcomm/Makefile
 new file mode 100644
-index 0000000000000..af0a439d54a16
+index 000000000000..af0a439d54a1
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Makefile
 @@ -0,0 +1,4 @@
@@ -149,7 +149,7 @@ index 0000000000000..af0a439d54a16
 +obj-$(CONFIG_YT6801) += yt6801/
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/Makefile b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 new file mode 100644
-index 0000000000000..93b5c4510eb05
+index 000000000000..93b5c4510eb0
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 @@ -0,0 +1,15 @@
@@ -170,7 +170,7 @@ index 0000000000000..93b5c4510eb05
 +	fuxi-gmac-debugfs.o
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 new file mode 100644
-index 0000000000000..24282f8e22303
+index 000000000000..24282f8e2230
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 @@ -0,0 +1,15 @@
@@ -192,7 +192,7 @@ index 0000000000000..24282f8e22303
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 new file mode 100644
-index 0000000000000..ae4ca3d59ac4c
+index 000000000000..ae4ca3d59ac4
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 @@ -0,0 +1,1344 @@
@@ -1543,7 +1543,7 @@ index 0000000000000..ae4ca3d59ac4c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 new file mode 100644
-index 0000000000000..fa0446958719c
+index 000000000000..fa0446958719
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 @@ -0,0 +1,25 @@
@@ -1575,7 +1575,7 @@ index 0000000000000..fa0446958719c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 new file mode 100644
-index 0000000000000..63cbf948cbfa2
+index 000000000000..63cbf948cbfa
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 @@ -0,0 +1,939 @@
@@ -2520,7 +2520,7 @@ index 0000000000000..63cbf948cbfa2
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 new file mode 100644
-index 0000000000000..4596d91b6e282
+index 000000000000..4596d91b6e28
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 @@ -0,0 +1,787 @@
@@ -3313,7 +3313,7 @@ index 0000000000000..4596d91b6e282
 +#endif /* HAVE_XLGMAC_DEBUG_FS */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 new file mode 100644
-index 0000000000000..969d84eb44e2a
+index 000000000000..969d84eb44e2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 @@ -0,0 +1,601 @@
@@ -3920,7 +3920,7 @@ index 0000000000000..969d84eb44e2a
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 new file mode 100644
-index 0000000000000..05aa42f90ad83
+index 000000000000..05aa42f90ad8
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -0,0 +1,1114 @@
@@ -5040,7 +5040,7 @@ index 0000000000000..05aa42f90ad83
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 new file mode 100644
-index 0000000000000..0517968365d74
+index 000000000000..0517968365d7
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 @@ -0,0 +1,6256 @@
@@ -11302,7 +11302,7 @@ index 0000000000000..0517968365d74
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 new file mode 100644
-index 0000000000000..b8734efb36426
+index 000000000000..b8734efb3642
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 @@ -0,0 +1,2329 @@
@@ -13637,7 +13637,7 @@ index 0000000000000..b8734efb36426
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 new file mode 100644
-index 0000000000000..f6f8f4f6a5e9b
+index 000000000000..f6f8f4f6a5e9
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 @@ -0,0 +1,250 @@
@@ -13893,7 +13893,7 @@ index 0000000000000..f6f8f4f6a5e9b
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 new file mode 100644
-index 0000000000000..88066a110f410
+index 000000000000..88066a110f41
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 @@ -0,0 +1,256 @@
@@ -14155,7 +14155,7 @@ index 0000000000000..88066a110f410
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 new file mode 100644
-index 0000000000000..65d6288e6869a
+index 000000000000..65d6288e6869
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 @@ -0,0 +1,1894 @@
@@ -16055,7 +16055,7 @@ index 0000000000000..65d6288e6869a
 +#endif /* __FUXI_GMAC_REG_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 new file mode 100644
-index 0000000000000..ea01ebdadc4e3
+index 000000000000..ea01ebdadc4e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 @@ -0,0 +1,934 @@
@@ -16995,7 +16995,7 @@ index 0000000000000..ea01ebdadc4e3
 +#endif /* __FUXI_GMAC_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 new file mode 100644
-index 0000000000000..1a40267e1fa2e
+index 000000000000..1a40267e1fa2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 @@ -0,0 +1,515 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0124-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0124-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
@@ -1,7 +1,7 @@
 From 95987768d2f0ffd2ef6582950c2d46ffcf98d7c1 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:51:08 +0800
-Subject: [PATCH 124/303] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
+Subject: [PATCH 124/305] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
  of the number of packages
 
 Signed-off-by: wanghongliang <wanghongliang@loongson.cn>
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/topology.h b/arch/loongarch/include/asm/topology.h
-index 50273c9187d02..f36bb0e7074e5 100644
+index 50273c9187d0..f36bb0e7074e 100644
 --- a/arch/loongarch/include/asm/topology.h
 +++ b/arch/loongarch/include/asm/topology.h
 @@ -30,10 +30,14 @@ void numa_set_distance(int from, int to, int distance);
@@ -37,7 +37,7 @@ index 50273c9187d02..f36bb0e7074e5 100644
  
  #include <asm-generic/topology.h>
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 1fa6a604734ef..e1ed45b19949b 100644
+index 1fa6a604734e..e1ed45b19949 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -127,6 +127,7 @@ static void __init parse_cpu_table(const struct dmi_header *dm)
@@ -49,7 +49,7 @@ index 1fa6a604734ef..e1ed45b19949b 100644
  	pr_info("CpuClock = %llu\n", cpu_clock_freq);
  }
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index d96065dbe779b..3363e753ea249 100644
+index d96065dbe779..3363e753ea24 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -76,6 +76,9 @@ static const char *ipi_types[NR_IPI] __tracepoint_string = {
@@ -63,7 +63,7 @@ index d96065dbe779b..3363e753ea249 100644
  {
  	unsigned int cpu, i;
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
-index 93a05993745aa..57e771f39781e 100644
+index 93a05993745a..57e771f39781 100644
 --- a/drivers/platform/loongarch/cpu_hwmon.c
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -154,8 +154,7 @@ static int __init loongson_hwmon_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0125-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0125-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
@@ -1,7 +1,7 @@
 From 00f2880c5f214e7fcf31e5b831b3891912a01e30 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 125/303] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
+Subject: [PATCH 125/305] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
  devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 31 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 064067d9c8b52..6bbb3ed08cd42 100644
+index 064067d9c8b5..6bbb3ed08cd4 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -396,6 +396,36 @@ static void quirk_tigerpoint_bm_sts(struct pci_dev *dev)
@@ -65,7 +65,7 @@ index 064067d9c8b52..6bbb3ed08cd42 100644
  static void quirk_nopcipci(struct pci_dev *dev)
  {
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index ade889ded4e1e..2562650f2af1f 100644
+index ade889ded4e1..2562650f2af1 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -247,6 +247,7 @@ enum pci_dev_flags {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0126-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0126-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
 From 702b5fb31e158f71eafad10ea3610fb950bde1f7 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 126/303] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 126/305] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 18 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
-index 05aa42f90ad83..d0989eac966ac 100644
+index 05aa42f90ad8..d0989eac966a 100644
 --- a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -262,8 +262,8 @@ static void fxgmac_get_reta(struct fxgmac_pdata *pdata, u32 *indir)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0127-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0127-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From 1f2c19da8f5c9a04da5a6bb1d255c00f0611058f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 127/303] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 127/305] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index ba86b6bb047dc..eea8421955134 100644
+index ba86b6bb047d..eea842195513 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0128-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0128-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 61cbcd11caf0ff5565bd29cebe2f68f16aa40f66 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 128/303] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 128/305] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 305ff5866e2fe..b72e728a924b1 100644
+index 305ff5866e2f..b72e728a924b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -14,6 +14,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0129-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0129-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From 8d304e8aa71d4013e49aa9e3354ccb9f653cb48b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 129/303] DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 129/305] DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c172103a97362..d329aded10f0a 100644
+index c172103a9736..d329aded10f0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -293,7 +293,7 @@ inline struct phytmac_dma_desc *phytmac_get_rx_desc(struct phytmac_queue *queue,
@@ -66,7 +66,7 @@ index c172103a97362..d329aded10f0a 100644
  	struct net_device *ndev = pdata->ndev;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index b72e728a924b1..797909211fed1 100644
+index b72e728a924b..797909211fed 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,7 +77,6 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)
@@ -78,7 +78,7 @@ index b72e728a924b1..797909211fed1 100644
  	struct phytmac *pdata;
  	int ret, i;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index df142aa6797f6..77fde5c5e2915 100644
+index df142aa6797f..77fde5c5e291 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -60,7 +60,7 @@ static int phytmac_msg_send(struct phytmac *pdata, u16 cmd_id,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0130-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0130-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From eae264239baa08c141c95f96deb862450c23a323 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 130/303] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 130/305] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 797909211fed1..343e1a5ce564a 100644
+index 797909211fed..343e1a5ce564 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -77,6 +77,7 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0131-DEEPIN-net-phytium-convert-and-remove-validate-refer.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0131-DEEPIN-net-phytium-convert-and-remove-validate-refer.patch
@@ -1,7 +1,7 @@
 From a58ad525aaed885f5edb5f70766d1f2d863f4e21 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 131/303] DEEPIN: net: phytium: convert and remove validate()
+Subject: [PATCH 131/305] DEEPIN: net: phytium: convert and remove validate()
  references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 64 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index d329aded10f0a..696b491750ae5 100644
+index d329aded10f0..696b491750ae 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1551,71 +1551,7 @@ static void phytmac_pcs_get_state(struct phylink_config *config,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0132-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0132-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 5b0669d533c0aedeca50b497510a7f72d345a2ea Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 132/303] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 132/305] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 11d99d8b34a2b..084ad7e070dfd 100644
+index 11d99d8b34a2..084ad7e070df 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -307,7 +307,7 @@ &gmac {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0133-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0133-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From a637b868649f4f38e75af6bdee0355c61a92ae53 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 133/303] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 133/305] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 31 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index 5f997becdbaa2..9a9929424513a 100644
+index 5f997becdbaa..9a9929424513 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -1702,9 +1702,21 @@ mwifiex_pcie_send_boot_cmd(struct mwifiex_adapter *adapter, struct sk_buff *skb)
@@ -65,7 +65,7 @@ index 5f997becdbaa2..9a9929424513a 100644
  	mwifiex_write_reg(adapter, reg->rx_rdptr, card->rxbd_rdptr | tx_wrap);
  }
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index dd6d21f1dbfd7..f46b06f8d6435 100644
+index dd6d21f1dbfd..f46b06f8d643 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -13,7 +13,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -158,7 +158,7 @@ index dd6d21f1dbfd7..f46b06f8d6435 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index d6ff964aec5bf..5d30ae39d65ec 100644
+index d6ff964aec5b..5d30ae39d65e 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -4,6 +4,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0134-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0134-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From afa3e830b06d93c431fc6ac8181d608149327428 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 134/303] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 134/305] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 27 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index 9a9929424513a..2273e30297766 100644
+index 9a9929424513..2273e3029776 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -377,6 +377,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
@@ -49,7 +49,7 @@ index 9a9929424513a..2273e30297766 100644
  }
  
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index f46b06f8d6435..99b024ecbadea 100644
+index f46b06f8d643..99b024ecbade 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -14,7 +14,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -143,7 +143,7 @@ index f46b06f8d6435..99b024ecbadea 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index 5d30ae39d65ec..c14eb56eb9118 100644
+index 5d30ae39d65e..c14eb56eb911 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -5,6 +5,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0135-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0135-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
 From 7318be4d1fa2ed9cf1eae089ac7931f7bb297f5c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 135/303] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 135/305] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index af2be0271806f..1af20f692fdc0 100644
+index af2be0271806..1af20f692fdc 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -65,6 +65,7 @@ static struct usb_driver btusb_driver;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0136-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0136-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 12e5c440333cde7138e3223e8531a11ef6cd2f84 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 136/303] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 136/305] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 2 insertions(+)
 
 diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
-index bc40b940ae214..45fbd856d4162 100644
+index bc40b940ae21..45fbd856d416 100644
 --- a/drivers/misc/mei/hw-me-regs.h
 +++ b/drivers/misc/mei/hw-me-regs.h
 @@ -92,6 +92,7 @@
@@ -26,7 +26,7 @@ index bc40b940ae214..45fbd856d4162 100644
  
  #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
 diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
-index 3f9c60b579ae4..853a677533333 100644
+index 3f9c60b579ae..853a67753333 100644
 --- a/drivers/misc/mei/pci-me.c
 +++ b/drivers/misc/mei/pci-me.c
 @@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0137-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0137-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
@@ -1,7 +1,7 @@
 From 43f54c184cb42b3655edcd9336dc34ed165a7ac5 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 137/303] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
+Subject: [PATCH 137/305] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
 Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 157542c07aaaf..8af999747f1e5 100644
+index 157542c07aaa..8af999747f1e 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -40,6 +40,11 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0138-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0138-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From b2c12b1b24a523704e4eee1693a2436d3af7a608 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 138/303] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 138/305] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268
@@ -69,7 +69,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hid/ipts/thread.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 95a4ede270991..777d4619d06d3 100644
+index 95a4ede27099..777d4619d06d 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1388,4 +1388,6 @@ source "drivers/hid/amd-sfh-hid/Kconfig"
@@ -80,7 +80,7 @@ index 95a4ede270991..777d4619d06d3 100644
 +
  endif # HID_SUPPORT
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 27ee02bf6f26d..15a67dc834a69 100644
+index 27ee02bf6f26..15a67dc834a6 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -170,3 +170,5 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
@@ -91,7 +91,7 @@ index 27ee02bf6f26d..15a67dc834a69 100644
 +obj-$(CONFIG_HID_IPTS)          += ipts/
 diff --git a/drivers/hid/ipts/Kconfig b/drivers/hid/ipts/Kconfig
 new file mode 100644
-index 0000000000000..297401bd388dd
+index 000000000000..297401bd388d
 --- /dev/null
 +++ b/drivers/hid/ipts/Kconfig
 @@ -0,0 +1,14 @@
@@ -111,7 +111,7 @@ index 0000000000000..297401bd388dd
 +	  module will be called ipts.
 diff --git a/drivers/hid/ipts/Makefile b/drivers/hid/ipts/Makefile
 new file mode 100644
-index 0000000000000..883896f68e6ad
+index 000000000000..883896f68e6a
 --- /dev/null
 +++ b/drivers/hid/ipts/Makefile
 @@ -0,0 +1,16 @@
@@ -133,7 +133,7 @@ index 0000000000000..883896f68e6ad
 +ipts-objs += thread.o
 diff --git a/drivers/hid/ipts/cmd.c b/drivers/hid/ipts/cmd.c
 new file mode 100644
-index 0000000000000..63a4934bbc5fa
+index 000000000000..63a4934bbc5f
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.c
 @@ -0,0 +1,61 @@
@@ -200,7 +200,7 @@ index 0000000000000..63a4934bbc5fa
 +}
 diff --git a/drivers/hid/ipts/cmd.h b/drivers/hid/ipts/cmd.h
 new file mode 100644
-index 0000000000000..2b4079075b642
+index 000000000000..2b4079075b64
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.h
 @@ -0,0 +1,60 @@
@@ -266,7 +266,7 @@ index 0000000000000..2b4079075b642
 +#endif /* IPTS_CMD_H */
 diff --git a/drivers/hid/ipts/context.h b/drivers/hid/ipts/context.h
 new file mode 100644
-index 0000000000000..ba33259f1f7c5
+index 000000000000..ba33259f1f7c
 --- /dev/null
 +++ b/drivers/hid/ipts/context.h
 @@ -0,0 +1,52 @@
@@ -324,7 +324,7 @@ index 0000000000000..ba33259f1f7c5
 +#endif /* IPTS_CONTEXT_H */
 diff --git a/drivers/hid/ipts/control.c b/drivers/hid/ipts/control.c
 new file mode 100644
-index 0000000000000..5360842d260ba
+index 000000000000..5360842d260b
 --- /dev/null
 +++ b/drivers/hid/ipts/control.c
 @@ -0,0 +1,486 @@
@@ -816,7 +816,7 @@ index 0000000000000..5360842d260ba
 +}
 diff --git a/drivers/hid/ipts/control.h b/drivers/hid/ipts/control.h
 new file mode 100644
-index 0000000000000..26629c5144edb
+index 000000000000..26629c5144ed
 --- /dev/null
 +++ b/drivers/hid/ipts/control.h
 @@ -0,0 +1,126 @@
@@ -948,7 +948,7 @@ index 0000000000000..26629c5144edb
 +#endif /* IPTS_CONTROL_H */
 diff --git a/drivers/hid/ipts/desc.h b/drivers/hid/ipts/desc.h
 new file mode 100644
-index 0000000000000..307438c7c80cd
+index 000000000000..307438c7c80c
 --- /dev/null
 +++ b/drivers/hid/ipts/desc.h
 @@ -0,0 +1,80 @@
@@ -1034,7 +1034,7 @@ index 0000000000000..307438c7c80cd
 +#endif /* IPTS_DESC_H */
 diff --git a/drivers/hid/ipts/eds1.c b/drivers/hid/ipts/eds1.c
 new file mode 100644
-index 0000000000000..7b9f54388a9f6
+index 000000000000..7b9f54388a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.c
 @@ -0,0 +1,104 @@
@@ -1144,7 +1144,7 @@ index 0000000000000..7b9f54388a9f6
 +}
 diff --git a/drivers/hid/ipts/eds1.h b/drivers/hid/ipts/eds1.h
 new file mode 100644
-index 0000000000000..eeeb6575e3e89
+index 000000000000..eeeb6575e3e8
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.h
 @@ -0,0 +1,35 @@
@@ -1185,7 +1185,7 @@ index 0000000000000..eeeb6575e3e89
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/eds2.c b/drivers/hid/ipts/eds2.c
 new file mode 100644
-index 0000000000000..639940794615d
+index 000000000000..639940794615
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.c
 @@ -0,0 +1,145 @@
@@ -1336,7 +1336,7 @@ index 0000000000000..639940794615d
 +}
 diff --git a/drivers/hid/ipts/eds2.h b/drivers/hid/ipts/eds2.h
 new file mode 100644
-index 0000000000000..064e3716907ab
+index 000000000000..064e3716907a
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.h
 @@ -0,0 +1,35 @@
@@ -1377,7 +1377,7 @@ index 0000000000000..064e3716907ab
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/hid.c b/drivers/hid/ipts/hid.c
 new file mode 100644
-index 0000000000000..e34a1a4f9fa77
+index 000000000000..e34a1a4f9fa7
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.c
 @@ -0,0 +1,225 @@
@@ -1608,7 +1608,7 @@ index 0000000000000..e34a1a4f9fa77
 +}
 diff --git a/drivers/hid/ipts/hid.h b/drivers/hid/ipts/hid.h
 new file mode 100644
-index 0000000000000..1ebe77447903a
+index 000000000000..1ebe77447903
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.h
 @@ -0,0 +1,24 @@
@@ -1638,7 +1638,7 @@ index 0000000000000..1ebe77447903a
 +#endif /* IPTS_HID_H */
 diff --git a/drivers/hid/ipts/main.c b/drivers/hid/ipts/main.c
 new file mode 100644
-index 0000000000000..fb5b5c13ee3ea
+index 000000000000..fb5b5c13ee3e
 --- /dev/null
 +++ b/drivers/hid/ipts/main.c
 @@ -0,0 +1,126 @@
@@ -1770,7 +1770,7 @@ index 0000000000000..fb5b5c13ee3ea
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/ipts/mei.c b/drivers/hid/ipts/mei.c
 new file mode 100644
-index 0000000000000..1e0395ceae4a4
+index 000000000000..1e0395ceae4a
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.c
 @@ -0,0 +1,188 @@
@@ -1964,7 +1964,7 @@ index 0000000000000..1e0395ceae4a4
 +}
 diff --git a/drivers/hid/ipts/mei.h b/drivers/hid/ipts/mei.h
 new file mode 100644
-index 0000000000000..973bade6b0fdd
+index 000000000000..973bade6b0fd
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.h
 @@ -0,0 +1,66 @@
@@ -2036,7 +2036,7 @@ index 0000000000000..973bade6b0fdd
 +#endif /* IPTS_MEI_H */
 diff --git a/drivers/hid/ipts/receiver.c b/drivers/hid/ipts/receiver.c
 new file mode 100644
-index 0000000000000..977724c728c3e
+index 000000000000..977724c728c3
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.c
 @@ -0,0 +1,251 @@
@@ -2293,7 +2293,7 @@ index 0000000000000..977724c728c3e
 +}
 diff --git a/drivers/hid/ipts/receiver.h b/drivers/hid/ipts/receiver.h
 new file mode 100644
-index 0000000000000..3de7da62d40c1
+index 000000000000..3de7da62d40c
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.h
 @@ -0,0 +1,16 @@
@@ -2315,7 +2315,7 @@ index 0000000000000..3de7da62d40c1
 +#endif /* IPTS_RECEIVER_H */
 diff --git a/drivers/hid/ipts/resources.c b/drivers/hid/ipts/resources.c
 new file mode 100644
-index 0000000000000..cc14653b2a9f5
+index 000000000000..cc14653b2a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.c
 @@ -0,0 +1,131 @@
@@ -2452,7 +2452,7 @@ index 0000000000000..cc14653b2a9f5
 +}
 diff --git a/drivers/hid/ipts/resources.h b/drivers/hid/ipts/resources.h
 new file mode 100644
-index 0000000000000..2068e13285f0e
+index 000000000000..2068e13285f0
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.h
 @@ -0,0 +1,41 @@
@@ -2499,7 +2499,7 @@ index 0000000000000..2068e13285f0e
 +#endif /* IPTS_RESOURCES_H */
 diff --git a/drivers/hid/ipts/spec-data.h b/drivers/hid/ipts/spec-data.h
 new file mode 100644
-index 0000000000000..e8dd98895a7ee
+index 000000000000..e8dd98895a7e
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-data.h
 @@ -0,0 +1,100 @@
@@ -2605,7 +2605,7 @@ index 0000000000000..e8dd98895a7ee
 +#endif /* IPTS_SPEC_DATA_H */
 diff --git a/drivers/hid/ipts/spec-device.h b/drivers/hid/ipts/spec-device.h
 new file mode 100644
-index 0000000000000..41845f9d90257
+index 000000000000..41845f9d9025
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-device.h
 @@ -0,0 +1,290 @@
@@ -2901,7 +2901,7 @@ index 0000000000000..41845f9d90257
 +#endif /* IPTS_SPEC_DEVICE_H */
 diff --git a/drivers/hid/ipts/spec-hid.h b/drivers/hid/ipts/spec-hid.h
 new file mode 100644
-index 0000000000000..5a58d4a0a610f
+index 000000000000..5a58d4a0a610
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-hid.h
 @@ -0,0 +1,34 @@
@@ -2941,7 +2941,7 @@ index 0000000000000..5a58d4a0a610f
 +#endif /* IPTS_SPEC_HID_H */
 diff --git a/drivers/hid/ipts/thread.c b/drivers/hid/ipts/thread.c
 new file mode 100644
-index 0000000000000..355e92bea26f8
+index 000000000000..355e92bea26f
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.c
 @@ -0,0 +1,84 @@
@@ -3031,7 +3031,7 @@ index 0000000000000..355e92bea26f8
 +}
 diff --git a/drivers/hid/ipts/thread.h b/drivers/hid/ipts/thread.h
 new file mode 100644
-index 0000000000000..1f966b8b32c45
+index 000000000000..1f966b8b32c4
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.h
 @@ -0,0 +1,59 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0139-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0139-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From de7662fa179cde629f1ab9113659cf956508c1c3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 139/303] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 139/305] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 93b5c648ef82c..72d3020b237e6 100644
+index 93b5c648ef82..72d3020b237e 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -34,7 +34,10 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0140-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0140-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From a43df58348d4defe646f4c6ec1a6b9d09851cfaa Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 140/303] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 140/305] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 72d3020b237e6..546e15a2a0fd6 100644
+index 72d3020b237e..546e15a2a0fd 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -77,6 +77,7 @@ MODULE_LICENSE("GPL");

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0141-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0141-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 4268e044c2a6f00e6c3d18f39a5f71a5911f78d7 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 141/303] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 141/305] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices
@@ -61,7 +61,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index 7ecc401fb97f9..e35185de1902a 100644
+index 7ecc401fb97f..e35185de1902 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2205,6 +2205,9 @@ static acpi_status acpi_bus_check_add_2(acpi_handle handle, u32 lvl_not_used,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0142-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0142-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
@@ -1,7 +1,7 @@
 From c8f5a727dd24b44eba6271d481aa552c3ad524fb Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 142/303] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
+Subject: [PATCH 142/305] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
  for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 8af999747f1e5..6a4bc1b821bca 100644
+index 8af999747f1e..6a4bc1b821bc 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -45,6 +45,13 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0143-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0143-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From c3f1876d09091c0afdcbdc90955f6287ffb30329 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 143/303] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 143/305] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 81ac4c6919630..f453c90430429 100644
+index 81ac4c691963..f453c9043042 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -46,6 +46,13 @@ static int tps68470_chip_init(struct device *dev, struct regmap *regmap)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0144-SURFACE-platform-x86-int3472-Remap-reset-GPIO-for-IN.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0144-SURFACE-platform-x86-int3472-Remap-reset-GPIO-for-IN.patch
@@ -1,7 +1,7 @@
 From 8c866c3fcb8fe7b8013faa3e3d516e57ad92d6d4 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
-Subject: [PATCH 144/303] SURFACE: platform/x86: int3472: Remap reset GPIO for
+Subject: [PATCH 144/305] SURFACE: platform/x86: int3472: Remap reset GPIO for
  INT347E
 
 ACPI _HID INT347E represents the OmniVision 7251 camera sensor. The
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/platform/x86/intel/int3472/discrete.c b/drivers/platform/x86/intel/int3472/discrete.c
-index 9e69ac9cfb92c..d6003198aa12b 100644
+index 9e69ac9cfb92..d6003198aa12 100644
 --- a/drivers/platform/x86/intel/int3472/discrete.c
 +++ b/drivers/platform/x86/intel/int3472/discrete.c
 @@ -81,12 +81,27 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0145-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0145-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From ac1a11299f28f3b717524d96802f35a5ba789116 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 145/303] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 145/305] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/ov7251.c b/drivers/media/i2c/ov7251.c
-index 3226888d77e9c..3bfe45b764f7a 100644
+index 3226888d77e9..3bfe45b764f7 100644
 --- a/drivers/media/i2c/ov7251.c
 +++ b/drivers/media/i2c/ov7251.c
 @@ -1053,7 +1053,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0146-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0146-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From a7d4f255dac114a15a008dc0d54dad9b35b482a4 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 146/303] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 146/305] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
-index ee884a8221fbd..4f6bafd900eee 100644
+index ee884a8221fb..4f6bafd900ee 100644
 --- a/drivers/media/v4l2-core/v4l2-async.c
 +++ b/drivers/media/v4l2-core/v4l2-async.c
 @@ -799,6 +799,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
@@ -35,7 +35,7 @@ index ee884a8221fbd..4f6bafd900eee 100644
  	 * No reference taken. The reference is held by the device (struct
  	 * v4l2_subdev.dev), and async sub-device does not exist independently
 diff --git a/drivers/media/v4l2-core/v4l2-fwnode.c b/drivers/media/v4l2-core/v4l2-fwnode.c
-index f19c8adf2c61d..923ed1b5ab8b4 100644
+index f19c8adf2c61..923ed1b5ab8b 100644
 --- a/drivers/media/v4l2-core/v4l2-fwnode.c
 +++ b/drivers/media/v4l2-core/v4l2-fwnode.c
 @@ -1219,10 +1219,6 @@ int v4l2_async_register_subdev_sensor(struct v4l2_subdev *sd)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0147-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0147-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From b6ff28385fb8586a37aa14fc9ff596a25d45cf7b Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 147/303] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 147/305] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index f453c90430429..b8ad6b413e8b4 100644
+index f453c9043042..b8ad6b413e8b 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -17,7 +17,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0148-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0148-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From ceb69b193e2545ee8c76f5bba0533b8f796951e5 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 148/303] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 148/305] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/include/linux/mfd/tps68470.h b/include/linux/mfd/tps68470.h
-index 7807fa329db00..2d2abb25b944f 100644
+index 7807fa329db0..2d2abb25b944 100644
 --- a/include/linux/mfd/tps68470.h
 +++ b/include/linux/mfd/tps68470.h
 @@ -34,6 +34,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0149-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0149-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From 9d77ad189b973cc5758da0198cdedd6766a9efa8 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 149/303] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 149/305] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/leds/leds-tps68470.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 0a663f0231f82..20f982780e73f 100644
+index 0a663f0231f8..20f982780e73 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -953,6 +953,18 @@ config LEDS_TPS6105X
@@ -47,7 +47,7 @@ index 0a663f0231f82..20f982780e73f 100644
  	tristate "LED support for SGI Octane machines"
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 3edf875503903..12d78f82819ca 100644
+index 3edf87550390..12d78f82819c 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -89,6 +89,7 @@ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
@@ -60,7 +60,7 @@ index 3edf875503903..12d78f82819ca 100644
  obj-$(CONFIG_LEDS_WM8350)		+= leds-wm8350.o
 diff --git a/drivers/leds/leds-tps68470.c b/drivers/leds/leds-tps68470.c
 new file mode 100644
-index 0000000000000..35aeb5db89c8f
+index 000000000000..35aeb5db89c8
 --- /dev/null
 +++ b/drivers/leds/leds-tps68470.c
 @@ -0,0 +1,185 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0150-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0150-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From 476b4a6bbfc201fdc4e429e17215caf05916c633 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 150/303] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 150/305] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
-index c626ed845928c..0094cfda57ea8 100644
+index c626ed845928..0094cfda57ea 100644
 --- a/drivers/media/i2c/dw9719.c
 +++ b/drivers/media/i2c/dw9719.c
 @@ -82,6 +82,9 @@ static int dw9719_power_up(struct dw9719_device *dw9719)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0151-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0151-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
@@ -1,7 +1,7 @@
 From 6b973327194a426b530fcd8c25758f6d918d7835 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Mon, 16 Sep 2024 05:55:58 -0400
-Subject: [PATCH 151/303] FROMEXT:
+Subject: [PATCH 151/305] FROMEXT:
  more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -130,7 +130,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 511 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 42e6a40876ea4..ad838bf3082a3 100644
+index 42e6a40876ea..ad838bf3082a 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -155,9 +155,8 @@ config MPENTIUM4
@@ -576,7 +576,7 @@ index 42e6a40876ea4..ad838bf3082a3 100644
  #
  # P6_NOPs are a relatively minor optimization that require a family >=
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 5b773b34768d1..5f57fd8750c6c 100644
+index 5b773b34768d..5f57fd8750c6 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -182,15 +182,98 @@ else
@@ -682,7 +682,7 @@ index 5b773b34768d1..5f57fd8750c6c 100644
  
          KBUILD_CFLAGS += -mno-red-zone
 diff --git a/arch/x86/include/asm/vermagic.h b/arch/x86/include/asm/vermagic.h
-index 75884d2cdec37..2fdae271f47fe 100644
+index 75884d2cdec3..2fdae271f47f 100644
 --- a/arch/x86/include/asm/vermagic.h
 +++ b/arch/x86/include/asm/vermagic.h
 @@ -17,6 +17,56 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0152-FROMEXT-cjktty-6.9.patch.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0152-FROMEXT-cjktty-6.9.patch.patch
@@ -1,7 +1,7 @@
 From 1a4b4f45590c6bcd8ee185fd34e846e466005498 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 27 Dec 2024 14:32:25 +0800
-Subject: [PATCH 152/303] FROMEXT: cjktty-6.9.patch
+Subject: [PATCH 152/305] FROMEXT: cjktty-6.9.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 lib/fonts/font_cjk_32x32.h
 
 diff --git a/drivers/tty/vt/selection.c b/drivers/tty/vt/selection.c
-index 791e2f1f7c0b6..b615c568ba9d0 100644
+index 791e2f1f7c0b..b615c568ba9d 100644
 --- a/drivers/tty/vt/selection.c
 +++ b/drivers/tty/vt/selection.c
 @@ -243,6 +243,8 @@ static int vc_selection_store_chars(struct vc_data *vc, bool unicode)
@@ -48,7 +48,7 @@ index 791e2f1f7c0b6..b615c568ba9d0 100644
  	vc_sel.buf_len = bp - vc_sel.buffer;
  
 diff --git a/drivers/tty/vt/vt.c b/drivers/tty/vt/vt.c
-index be5564ed8c018..92282f43b6634 100644
+index be5564ed8c01..92282f43b663 100644
 --- a/drivers/tty/vt/vt.c
 +++ b/drivers/tty/vt/vt.c
 @@ -302,6 +302,14 @@ static void con_putc(struct vc_data *vc, u16 ca, unsigned int y, unsigned int x)
@@ -677,7 +677,7 @@ index be5564ed8c018..92282f43b6634 100644
  		c |= 0x100;
  	return c;
 diff --git a/drivers/video/fbdev/core/bitblit.c b/drivers/video/fbdev/core/bitblit.c
-index f9475c14f7339..5c039c47589cf 100644
+index f9475c14f733..5c039c47589c 100644
 --- a/drivers/video/fbdev/core/bitblit.c
 +++ b/drivers/video/fbdev/core/bitblit.c
 @@ -16,6 +16,7 @@
@@ -770,7 +770,7 @@ index f9475c14f7339..5c039c47589cf 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
-index 07d127110ca4c..bba58806f5d59 100644
+index 07d127110ca4..bba58806f5d5 100644
 --- a/drivers/video/fbdev/core/fbcon.c
 +++ b/drivers/video/fbdev/core/fbcon.c
 @@ -1070,7 +1070,7 @@ static void fbcon_init(struct vc_data *vc, bool init)
@@ -852,7 +852,7 @@ index 07d127110ca4c..bba58806f5d59 100644
  
  	updatescrollmode(p, info, vc);
 diff --git a/drivers/video/fbdev/core/fbcon.h b/drivers/video/fbdev/core/fbcon.h
-index 4d97e6d8a16a2..c53b83de80875 100644
+index 4d97e6d8a16a..c53b83de8087 100644
 --- a/drivers/video/fbdev/core/fbcon.h
 +++ b/drivers/video/fbdev/core/fbcon.h
 @@ -82,10 +82,12 @@ struct fbcon_ops {
@@ -869,7 +869,7 @@ index 4d97e6d8a16a2..c53b83de80875 100644
      /*
       *  Attribute Decoding
 diff --git a/drivers/video/fbdev/core/fbcon_ccw.c b/drivers/video/fbdev/core/fbcon_ccw.c
-index 89ef4ba7e8672..ba76f80617e12 100644
+index 89ef4ba7e867..ba76f80617e1 100644
 --- a/drivers/video/fbdev/core/fbcon_ccw.c
 +++ b/drivers/video/fbdev/core/fbcon_ccw.c
 @@ -18,6 +18,8 @@
@@ -900,7 +900,7 @@ index 89ef4ba7e8672..ba76f80617e12 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_cw.c b/drivers/video/fbdev/core/fbcon_cw.c
-index b9dac7940fb77..f2711c7faf059 100644
+index b9dac7940fb7..f2711c7faf05 100644
 --- a/drivers/video/fbdev/core/fbcon_cw.c
 +++ b/drivers/video/fbdev/core/fbcon_cw.c
 @@ -18,6 +18,8 @@
@@ -931,7 +931,7 @@ index b9dac7940fb77..f2711c7faf059 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_rotate.c b/drivers/video/fbdev/core/fbcon_rotate.c
-index ec3c883400f7b..d549b0880862e 100644
+index ec3c883400f7..d549b0880862 100644
 --- a/drivers/video/fbdev/core/fbcon_rotate.c
 +++ b/drivers/video/fbdev/core/fbcon_rotate.c
 @@ -14,10 +14,74 @@
@@ -1038,7 +1038,7 @@ index ec3c883400f7b..d549b0880862e 100644
  	return err;
  }
 diff --git a/drivers/video/fbdev/core/fbcon_ud.c b/drivers/video/fbdev/core/fbcon_ud.c
-index 0af7913a2abdc..e2da1f6340809 100644
+index 0af7913a2abd..e2da1f634080 100644
 --- a/drivers/video/fbdev/core/fbcon_ud.c
 +++ b/drivers/video/fbdev/core/fbcon_ud.c
 @@ -18,6 +18,8 @@
@@ -1078,7 +1078,7 @@ index 0af7913a2abdc..e2da1f6340809 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/include/linux/font.h b/include/linux/font.h
-index 81caffd51bb49..c073140557d74 100644
+index 81caffd51bb4..c073140557d7 100644
 --- a/include/linux/font.h
 +++ b/include/linux/font.h
 @@ -35,6 +35,8 @@ struct font_desc {
@@ -1102,7 +1102,7 @@ index 81caffd51bb49..c073140557d74 100644
  /* Find a font with a specific name */
  
 diff --git a/lib/fonts/Kconfig b/lib/fonts/Kconfig
-index 3ac26bdbc3ff0..6a426962ec3ed 100644
+index 3ac26bdbc3ff..6a426962ec3e 100644
 --- a/lib/fonts/Kconfig
 +++ b/lib/fonts/Kconfig
 @@ -128,6 +128,26 @@ config FONT_6x8
@@ -1142,7 +1142,7 @@ index 3ac26bdbc3ff0..6a426962ec3ed 100644
  
  endif # FONT_SUPPORT
 diff --git a/lib/fonts/Makefile b/lib/fonts/Makefile
-index e16f68492174a..3e1091d15bbb7 100644
+index e16f68492174..3e1091d15bbb 100644
 --- a/lib/fonts/Makefile
 +++ b/lib/fonts/Makefile
 @@ -16,6 +16,8 @@ font-objs-$(CONFIG_FONT_MINI_4x6)  += font_mini_4x6.o
@@ -1156,7 +1156,7 @@ index e16f68492174a..3e1091d15bbb7 100644
  
 diff --git a/lib/fonts/font_cjk_16x16.c b/lib/fonts/font_cjk_16x16.c
 new file mode 100644
-index 0000000000000..a0c56bd9f65b2
+index 000000000000..a0c56bd9f65b
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.c
 @@ -0,0 +1,27 @@
@@ -1189,7 +1189,7 @@ index 0000000000000..a0c56bd9f65b2
 +};
 diff --git a/lib/fonts/font_cjk_16x16.h b/lib/fonts/font_cjk_16x16.h
 new file mode 100644
-index 0000000000000..54e7e0db4a5e7
+index 000000000000..54e7e0db4a5e
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.h
 @@ -0,0 +1,196609 @@
@@ -197804,7 +197804,7 @@ index 0000000000000..54e7e0db4a5e7
 +0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 diff --git a/lib/fonts/font_cjk_32x32.c b/lib/fonts/font_cjk_32x32.c
 new file mode 100644
-index 0000000000000..88ba3f2783f54
+index 000000000000..88ba3f2783f5
 --- /dev/null
 +++ b/lib/fonts/font_cjk_32x32.c
 @@ -0,0 +1,27 @@
@@ -197837,9 +197837,9 @@ index 0000000000000..88ba3f2783f54
 +};
 diff --git a/lib/fonts/font_cjk_32x32.h b/lib/fonts/font_cjk_32x32.h
 new file mode 100644
-index 0000000000000..e69de29bb2d1d
+index 000000000000..e69de29bb2d1
 diff --git a/lib/fonts/fonts.c b/lib/fonts/fonts.c
-index 47e34950b665c..9e3ac0d00f49c 100644
+index 47e34950b665..9e3ac0d00f49 100644
 --- a/lib/fonts/fonts.c
 +++ b/lib/fonts/fonts.c
 @@ -60,6 +60,12 @@ static const struct font_desc *fonts[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0153-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0153-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From cba1f62f6a332d9c2b5db9550cc0847ee9abdbae Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 153/303] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 153/305] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 564ba40b1dcd0..8fd0c23f7c8c7 100644
+index 564ba40b1dcd..8fd0c23f7c8c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -621,13 +621,8 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
@@ -53,7 +53,7 @@ index 564ba40b1dcd0..8fd0c23f7c8c7 100644
  module_param_named(cik_support, amdgpu_cik_support, int, 0444);
  #endif
 diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
-index e5a6f3e7c75b6..6d87122cc9f6e 100644
+index e5a6f3e7c75b..6d87122cc9f6 100644
 --- a/drivers/gpu/drm/radeon/radeon_drv.c
 +++ b/drivers/gpu/drm/radeon/radeon_drv.c
 @@ -239,12 +239,12 @@ module_param_named(uvd, radeon_uvd, int, 0444);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0154-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0154-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 63160034ab0f2aa901df8aa3dcc9228c478b23a6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 154/303] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 154/305] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
-index f146806c4633b..3067333faae00 100644
+index f146806c4633..3067333faae0 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 @@ -2116,6 +2116,13 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -47,7 +47,7 @@ index f146806c4633b..3067333faae00 100644
  	/* Then send the real EOP event down the pipe. */
  	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
-index 9d741695ca07d..7398585053858 100644
+index 9d741695ca07..739858505385 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 @@ -6158,6 +6158,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -73,7 +73,7 @@ index 9d741695ca07d..7398585053858 100644
  	/* Then send the real EOP event down the pipe:
  	 * EVENT_WRITE_EOP - flush caches, send int */
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index b1e4155ef31b6..f20fd5ae6c45c 100644
+index b1e4155ef31b..f20fd5ae6c45 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0155-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0155-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From ee1cd68e4b692bafd2a37b4481c6ea9dc795366e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 155/303] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 155/305] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index eea8421955134..ea37d120113d1 100644
+index eea842195513..ea37d120113d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0156-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0156-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From db9bca38e0ec4279c0ddd3262bcc030b20f3d21f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 156/303] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 156/305] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 592d2d9dc6d4b..d212451cd682f 100644
+index 592d2d9dc6d4..d212451cd682 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -176,7 +176,7 @@ static int phytmac_set_ringparam(struct net_device *ndev,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0157-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0157-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From 5cbc87f9f19320a336d59d967d71b745fc98782b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 157/303] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 157/305] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 343e1a5ce564a..985ae83b3977e 100644
+index 343e1a5ce564..985ae83b3977 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -204,14 +204,12 @@ static int phytmac_plat_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0158-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0158-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 47495ca1e8496960ef314dfd1bada044a45dfc06 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 158/303] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 158/305] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index 37a1303d9a34f..dac1b96ec9744 100644
+index 37a1303d9a34..dac1b96ec974 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -790,6 +790,10 @@ &usb_host0_xhci {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0159-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0159-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From be18b2e608b1114b77ef99c55b7c15c6ab1ba6ac Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 159/303] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 159/305] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 48dcc8381ea75..a62ab2f0766f0 100644
+index 48dcc8381ea7..a62ab2f0766f 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0160-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0160-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From e9093fc41aa3124b2c78d83b0a9bae7a56a3d01f Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 160/303] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 160/305] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index de21e72759eeb..a4f0ea213d1d6 100644
+index de21e72759ee..a4f0ea213d1d 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -98,6 +98,23 @@ static void __init init_screen_info(void)
@@ -67,7 +67,7 @@ index de21e72759eeb..a4f0ea213d1d6 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index aed901c57fb43..86d37a447eec1 100644
+index aed901c57fb4..86d37a447eec 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -79,7 +79,7 @@ index aed901c57fb43..86d37a447eec1 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  		mem_end = mem_start + mem_size;
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index 3782d0a187d1f..8bea96492ef21 100644
+index 3782d0a187d1..8bea96492ef2 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0161-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0161-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From ed7657297dadf3d684c57055e9bcdb3e9f169b14 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 161/303] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 161/305] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 66132683f1ed5..44d02b3a170e4 100644
+index 66132683f1ed..44d02b3a170e 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -79,3 +79,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -45,7 +45,7 @@ index 66132683f1ed5..44d02b3a170e4 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index a4f0ea213d1d6..c5493c8a17ffe 100644
+index a4f0ea213d1d..c5493c8a17ff 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -67,7 +67,7 @@ index a4f0ea213d1d6..c5493c8a17ffe 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 0000000000000..30c01c8b22a0a
+index 000000000000..30c01c8b22a0
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -370,7 +370,7 @@ index 0000000000000..30c01c8b22a0a
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 0000000000000..6d3a36ebaab71
+index 000000000000..6d3a36ebaab7
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -393,7 +393,7 @@ index 0000000000000..6d3a36ebaab71
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 86d37a447eec1..b24b3db96018d 100644
+index 86d37a447eec..b24b3db96018 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -415,7 +415,7 @@ index 86d37a447eec1..b24b3db96018d 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 84fe7f8548209..2633620c1246a 100644
+index 84fe7f854820..2633620c1246 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -26,6 +26,8 @@
@@ -436,7 +436,7 @@ index 84fe7f8548209..2633620c1246a 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index e1ed45b19949b..f71b2c77dbd12 100644
+index e1ed45b19949..f71b2c77dbd1 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -457,7 +457,7 @@ index e1ed45b19949b..f71b2c77dbd12 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 3363e753ea249..d0b7fafc53b6e 100644
+index 3363e753ea24..d0b7fafc53b6 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -36,6 +36,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0162-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0162-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 02b3e5fbe92921f9d6742e169945a4fd503f93bb Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 162/303] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 162/305] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 313f66f7913af..ba78288a26e3f 100644
+index 313f66f7913a..ba78288a26e3 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -45,6 +45,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -37,7 +37,7 @@ index 313f66f7913af..ba78288a26e3f 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0a..841d8db85a3cb 100644
+index 30c01c8b22a0..841d8db85a3c 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -381,7 +381,7 @@ index 30c01c8b22a0a..841d8db85a3cb 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index 9e1b01c350702..564e5ca523cd4 100644
+index 9e1b01c35070..564e5ca523cd 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -693,6 +693,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -401,7 +401,7 @@ index 9e1b01c350702..564e5ca523cd4 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 4d5ee84c468ba..e043af2545748 100644
+index 4d5ee84c468b..e043af254574 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -773,6 +773,16 @@ int acpi_get_local_u64_address(acpi_handle handle, u64 *addr);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0163-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0163-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From 9a1a946e7ef652bd6202366f6ef5cec069f51c08 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 163/303] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 163/305] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index ba78288a26e3f..c954d15d0a47c 100644
+index ba78288a26e3..c954d15d0a47 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -49,6 +49,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -44,7 +44,7 @@ index ba78288a26e3f..c954d15d0a47c 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 841d8db85a3cb..7043bfd0399d6 100644
+index 841d8db85a3c..7043bfd0399d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -85,7 +85,7 @@ index 841d8db85a3cb..7043bfd0399d6 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index d0bfb37068019..cbb916be29764 100644
+index d0bfb3706801..cbb916be2976 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -909,6 +909,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -97,7 +97,7 @@ index d0bfb37068019..cbb916be29764 100644
  				acpi_pci_root_remap_iospace(&device->fwnode,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d48..1c22ca4ec794c 100644
+index 078225b514d4..1c22ca4ec794 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0164-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0164-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From 09db933a0d4252d012fe6878e027caac403a4995 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 164/303] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 164/305] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 54 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index c954d15d0a47c..8d8551c2b6c04 100644
+index c954d15d0a47..8d8551c2b6c0 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -51,6 +51,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -44,7 +44,7 @@ index c954d15d0a47c..8d8551c2b6c04 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 7043bfd0399d6..3ec69ffd8b942 100644
+index 7043bfd0399d..3ec69ffd8b94 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
@@ -102,7 +102,7 @@ index 7043bfd0399d6..3ec69ffd8b942 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/bus.c b/drivers/acpi/bus.c
-index 16917dc3ad604..976d1c4e6c714 100644
+index 16917dc3ad60..976d1c4e6c71 100644
 --- a/drivers/acpi/bus.c
 +++ b/drivers/acpi/bus.c
 @@ -1463,6 +1463,7 @@ static int __init acpi_init(void)
@@ -114,7 +114,7 @@ index 16917dc3ad604..976d1c4e6c714 100644
  	acpi_ec_init();
  	acpi_debugfs_init();
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index e043af2545748..1c691a6588b3b 100644
+index e043af254574..1c691a6588b3 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -1548,6 +1548,10 @@ void acpi_riscv_init(void);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0165-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0165-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From 598b719b06bdae1e1ff9d725a4d9347eea0b5fc7 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 165/303] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 165/305] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 3ec69ffd8b942..2888e2b9fb456 100644
+index 3ec69ffd8b94..2888e2b9fb45 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -46,6 +46,19 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0166-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0166-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From 2acb2105140451870811022c495b87ea1ab6eb99 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 166/303] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 166/305] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 2888e2b9fb456..204b33109f37d 100644
+index 2888e2b9fb45..204b33109f37 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -59,6 +59,16 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0167-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0167-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From fb79d20cecb23ed4fe4a88266f215d0f15b24632 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 167/303] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 167/305] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/systable.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index bfa21465d83af..52ddcb17537ce 100644
+index bfa21465d83a..52ddcb17537c 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -8,3 +8,5 @@ obj-$(CONFIG_BUILTIN_DTB) += boot/dts/
@@ -51,7 +51,7 @@ index bfa21465d83af..52ddcb17537ce 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..65cd78995176f
+index 000000000000..65cd78995176
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,38 @@
@@ -95,7 +95,7 @@ index 0000000000000..65cd78995176f
 +clean-files += kernel_feature.h feat_test.syms module_version.h
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 0000000000000..d159169d10508
+index 000000000000..d159169d1050
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -440,7 +440,7 @@ index 0000000000000..d159169d10508
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 0000000000000..e975aa1cdb7af
+index 000000000000..e975aa1cdb7a
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -483,7 +483,7 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..25c6757983896
+index 000000000000..25c675798389
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,77 @@
@@ -566,14 +566,14 @@ index 0000000000000..25c6757983896
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..17e51c385ea38
+index 000000000000..17e51c385ea3
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
 +0.1.1
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..ad9aec128e6f8
+index 000000000000..ad9aec128e6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,11 @@
@@ -590,7 +590,7 @@ index 0000000000000..ad9aec128e6f8
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/feat_test.c b/arch/loongarch/ow_syscall/feat_test.c
 new file mode 100644
-index 0000000000000..5fc3b8709364d
+index 000000000000..5fc3b8709364
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/feat_test.c
 @@ -0,0 +1,16 @@
@@ -612,7 +612,7 @@ index 0000000000000..5fc3b8709364d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..1f5c336f52ec1
+index 000000000000..1f5c336f52ec
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,87 @@
@@ -705,7 +705,7 @@ index 0000000000000..1f5c336f52ec1
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..fa40914afa414
+index 000000000000..fa40914afa41
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,4 @@
@@ -715,7 +715,7 @@ index 0000000000000..fa40914afa414
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..4ae3fc6d70785
+index 000000000000..4ae3fc6d7078
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,274 @@
@@ -995,7 +995,7 @@ index 0000000000000..4ae3fc6d70785
 +MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..90eb34727680d
+index 000000000000..90eb34727680
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,239 @@
@@ -1240,7 +1240,7 @@ index 0000000000000..90eb34727680d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..adcd53bedc662
+index 000000000000..adcd53bedc66
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,44 @@
@@ -1290,7 +1290,7 @@ index 0000000000000..adcd53bedc662
 +#endif
 diff --git a/arch/loongarch/ow_syscall/systable.c b/arch/loongarch/ow_syscall/systable.c
 new file mode 100644
-index 0000000000000..8b311954d62ef
+index 000000000000..8b311954d62e
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.c
 @@ -0,0 +1,65 @@
@@ -1361,7 +1361,7 @@ index 0000000000000..8b311954d62ef
 +};
 diff --git a/arch/loongarch/ow_syscall/systable.h b/arch/loongarch/ow_syscall/systable.h
 new file mode 100644
-index 0000000000000..f2b6602cc7ef4
+index 000000000000..f2b6602cc7ef
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.h
 @@ -0,0 +1,8 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0168-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0168-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 891e92e6f2c3c4fe073bd7557c00a21b553f8f8f Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 168/303] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 168/305] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 1027f1c3e6027..d467c22c1e0ab 100644
+index 1027f1c3e602..d467c22c1e0a 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -728,3 +728,5 @@ source "drivers/cpufreq/Kconfig"
@@ -23,7 +23,7 @@ index 1027f1c3e6027..d467c22c1e0ab 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 0000000000000..c28a37145b6f6
+index 000000000000..c28a37145b6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,15 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0169-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0169-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 96ee50c4a1574abb1247a8368dd12fb2f8490b4d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 169/303] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 169/305] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom
@@ -100,7 +100,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/kernel/rcu/tree.c b/kernel/rcu/tree.c
-index 4ed8632195217..d040ee6669c49 100644
+index 4ed863219521..d040ee6669c4 100644
 --- a/kernel/rcu/tree.c
 +++ b/kernel/rcu/tree.c
 @@ -5243,15 +5243,11 @@ void rcutree_migrate_callbacks(int cpu)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0170-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0170-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From c9942f559cd8b98feadbfbbb6ac0e16b7fba42de Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 170/303] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 170/305] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Makefile.postlink b/arch/mips/Makefile.postlink
-index 6cfdc149d3bcd..22b151c343b01 100644
+index 6cfdc149d3bc..22b151c343b0 100644
 --- a/arch/mips/Makefile.postlink
 +++ b/arch/mips/Makefile.postlink
 @@ -24,9 +24,6 @@ quiet_cmd_relocs = RELOCS  $@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0171-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0171-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 63b8d814bf78ae209e45d715fe2ceed6b0281583 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 171/303] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 171/305] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index d2a51bd395f6c..89915a33ec718 100644
+index d2a51bd395f6..89915a33ec71 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -17,6 +17,10 @@ int loongson_vblank = 1;
@@ -38,7 +38,7 @@ index d2a51bd395f6c..89915a33ec718 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 931c17521bf01..0dcc9646d2ff1 100644
+index 931c17521bf0..0dcc9646d2ff 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -7,6 +7,7 @@
@@ -50,7 +50,7 @@ index 931c17521bf01..0dcc9646d2ff1 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index adc7344d2f807..902e61058a16a 100644
+index adc7344d2f80..902e61058a16 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -265,6 +265,14 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0172-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0172-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From e2645fc3a83a03943b49da4f00a7a0ad4817eeb5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 172/303] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 172/305] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/hp/hp-wmi.c b/drivers/platform/x86/hp/hp-wmi.c
-index 3ba9c43d5516a..ccc2a0d341329 100644
+index 3ba9c43d5516..ccc2a0d34132 100644
 --- a/drivers/platform/x86/hp/hp-wmi.c
 +++ b/drivers/platform/x86/hp/hp-wmi.c
 @@ -64,7 +64,7 @@ static const char * const omen_thermal_profile_boards[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0173-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0173-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From dfc1a04a787b8625386af6062969bcd3bae85347 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 173/303] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 173/305] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 8fd0c23f7c8c7..37fe04f7947dc 100644
+index 8fd0c23f7c8c..37fe04f7947d 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -888,9 +888,9 @@ module_param_named(visualconfirm, amdgpu_dc_visual_confirm, uint, 0444);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0174-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0174-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From dd1f323a995683899380dd849fb04b0b27a12e5d Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 174/303] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 174/305] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/unaligned.c b/arch/mips/kernel/unaligned.c
-index db652c99b72e3..4f2055afbd7e8 100644
+index db652c99b72e..4f2055afbd7e 100644
 --- a/arch/mips/kernel/unaligned.c
 +++ b/arch/mips/kernel/unaligned.c
 @@ -1514,14 +1514,37 @@ static void emulate_load_store_MIPS16e(struct pt_regs *regs, void __user * addr)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0175-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0175-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From 3df001cf444c71d641d2bfa866c308684f0baaf8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 175/303] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 175/305] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 deletions(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 253661449adaa..ba17fea8be150 100644
+index 253661449ada..ba17fea8be15 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1646,7 +1646,6 @@ menu "PCI GPIO expanders"
@@ -28,7 +28,7 @@ index 253661449adaa..ba17fea8be150 100644
  	help
  	  Say yes here to support GPIO pins on Single Board Computers produced
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index d67bdf871528d..e4c69631ad355 100644
+index d67bdf871528..e4c69631ad35 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -41,7 +41,6 @@ comment "Native drivers"
@@ -40,7 +40,7 @@ index d67bdf871528d..e4c69631ad355 100644
  	help
  	  This hwmon driver adds support for reporting temperature or fan
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 20f982780e73f..a0f2832e49c69 100644
+index 20f982780e73..a0f2832e49c6 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -68,7 +68,6 @@ config LEDS_88PM860X
@@ -52,7 +52,7 @@ index 20f982780e73f..a0f2832e49c69 100644
  	help
  	  This led driver adds support for LED brightness control on Single
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 7687025c7e3b5..cc5a6f46408cb 100644
+index 7687025c7e3b..cc5a6f46408c 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2260,7 +2260,6 @@ config MFD_QCOM_PM8008

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0176-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0176-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From 9199ef270b25054c57f993b82c56e4cdefacc6db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 176/303] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 176/305] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling
@@ -34,7 +34,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index b99de3b5ffbc0..d69ce05481e99 100644
+index b99de3b5ffbc..d69ce05481e9 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -5577,7 +5577,7 @@ static struct miscdevice kvm_dev = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0177-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0177-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From f60fb8e90ad7d60cf51b8f10fbb17f2f96f4d2eb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 177/303] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 177/305] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index 89915a33ec718..99e5fef3f2d9d 100644
+index 89915a33ec71..99e5fef3f2d9 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -21,6 +21,10 @@ int loongson_ls7a1000_support = 0;
@@ -41,7 +41,7 @@ index 89915a33ec718..99e5fef3f2d9d 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 0dcc9646d2ff1..183a8a0586605 100644
+index 0dcc9646d2ff..183a8a058660 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -8,6 +8,7 @@
@@ -53,7 +53,7 @@ index 0dcc9646d2ff1..183a8a0586605 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index 902e61058a16a..ceaf400b1af03 100644
+index 902e61058a16..ceaf400b1af0 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -273,6 +273,13 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0178-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0178-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 18e641fab41c1e7ebc3e90ff04c6d883b099c0f2 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 178/303] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 178/305] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 8043e1892ca5f..af0cf50feefe4 100644
+index 8043e1892ca5..af0cf50feefe 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -25,7 +25,7 @@ config MIPS

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0179-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0179-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From 23026e07db941a8da85b06dd2d37ffef3a254b55 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 179/303] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 179/305] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/cpu_hwmon.c b/drivers/platform/mips/cpu_hwmon.c
-index 2ac2f31090f96..93619227f0396 100644
+index 2ac2f31090f9..93619227f039 100644
 --- a/drivers/platform/mips/cpu_hwmon.c
 +++ b/drivers/platform/mips/cpu_hwmon.c
 @@ -135,9 +135,22 @@ static int __init loongson_hwmon_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0180-AOSCOS-ata-libata-change-HORKAGE-to-QUIRK.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0180-AOSCOS-ata-libata-change-HORKAGE-to-QUIRK.patch
@@ -1,7 +1,7 @@
 From 498f0f243b80bea800d38254fe4d07c2b5a739f5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 19 Feb 2025 02:21:41 +0800
-Subject: [PATCH 180/303] AOSCOS: ata: libata: change HORKAGE to QUIRK
+Subject: [PATCH 180/305] AOSCOS: ata: libata: change HORKAGE to QUIRK
 
 Following upstream changes.
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index d47f5bf13b93e..ef0b334e262e6 100644
+index d47f5bf13b93..ef0b334e262e 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
 @@ -3066,7 +3066,7 @@ int ata_dev_configure(struct ata_device *dev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0181-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0181-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From 0cd2a9b1c3b3109f5a0a52ace86f9fe34d0330e0 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 181/303] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 181/305] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00.h b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
-index dfb4bb370f01b..9475fbf7a6657 100644
+index dfb4bb370f01..9475fbf7a665 100644
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 @@ -1167,23 +1167,27 @@ static inline bool rt2x00_intf(struct rt2x00_dev *rt2x00dev,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0182-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0182-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From e6f6cb43a339dbeb29ceb6ca41813cf3b590a8b4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 182/303] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 182/305] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index d94d73e45fb6d..54325a140f34d 100644
+index d94d73e45fb6..54325a140f34 100644
 --- a/drivers/tty/serial/serial_core.c
 +++ b/drivers/tty/serial/serial_core.c
 @@ -1988,6 +1988,8 @@ static int uart_open(struct tty_struct *tty, struct file *filp)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0183-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0183-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From 7f1f520a2aa97903f70f6aaf4f2dcd4f3b9941bc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 183/303] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 183/305] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/constant_timer.c
 
 diff --git a/arch/mips/include/asm/cpu-features.h b/arch/mips/include/asm/cpu-features.h
-index 404390bb87eaf..e522efa1b53d0 100644
+index 404390bb87ea..e522efa1b53d 100644
 --- a/arch/mips/include/asm/cpu-features.h
 +++ b/arch/mips/include/asm/cpu-features.h
 @@ -659,6 +659,10 @@
@@ -55,7 +55,7 @@ index 404390bb87eaf..e522efa1b53d0 100644
   * Guest capabilities
   */
 diff --git a/arch/mips/include/asm/cpu.h b/arch/mips/include/asm/cpu.h
-index ecb9854cb4324..3c1299b718e10 100644
+index ecb9854cb432..3c1299b718e1 100644
 --- a/arch/mips/include/asm/cpu.h
 +++ b/arch/mips/include/asm/cpu.h
 @@ -421,6 +421,7 @@ enum cpu_type_enum {
@@ -67,7 +67,7 @@ index ecb9854cb4324..3c1299b718e10 100644
  /*
   * CPU ASE encodings
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_regs.h b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
-index fec7675076049..47294ab78a2cd 100644
+index fec767507604..47294ab78a2c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 @@ -131,6 +131,9 @@ static inline u32 read_cpucfg(u32 reg)
@@ -120,7 +120,7 @@ index fec7675076049..47294ab78a2cd 100644
 +
  #endif
 diff --git a/arch/mips/include/asm/mipsregs.h b/arch/mips/include/asm/mipsregs.h
-index 3c6ddc0c2c7ac..4d8cc25828834 100644
+index 3c6ddc0c2c7a..4d8cc2582883 100644
 --- a/arch/mips/include/asm/mipsregs.h
 +++ b/arch/mips/include/asm/mipsregs.h
 @@ -838,6 +838,7 @@
@@ -132,7 +132,7 @@ index 3c6ddc0c2c7ac..4d8cc25828834 100644
  #define MTI_CONF6_FTLBEN	(_ULCAST_(1) << 15)
  /* Disable load/store bonding */
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 3ba2bc06ae778..8a91ad684fc87 100644
+index 3ba2bc06ae77..8a91ad684fc8 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -42,11 +42,19 @@ extern int __weak get_c0_perfcount_int(void);
@@ -178,7 +178,7 @@ index 3ba2bc06ae778..8a91ad684fc87 100644
  	return 0;
  #endif
 diff --git a/arch/mips/include/asm/vdso/clocksource.h b/arch/mips/include/asm/vdso/clocksource.h
-index 510e1671d8985..7fd43ca06eb11 100644
+index 510e1671d898..7fd43ca06eb1 100644
 --- a/arch/mips/include/asm/vdso/clocksource.h
 +++ b/arch/mips/include/asm/vdso/clocksource.h
 @@ -4,6 +4,7 @@
@@ -191,7 +191,7 @@ index 510e1671d8985..7fd43ca06eb11 100644
  
  #endif /* __ASM_VDSOCLOCKSOURCE_H */
 diff --git a/arch/mips/include/asm/vdso/gettimeofday.h b/arch/mips/include/asm/vdso/gettimeofday.h
-index 44a45f3fa4b01..c1b15b0f07689 100644
+index 44a45f3fa4b0..c1b15b0f0768 100644
 --- a/arch/mips/include/asm/vdso/gettimeofday.h
 +++ b/arch/mips/include/asm/vdso/gettimeofday.h
 @@ -183,6 +183,22 @@ static __always_inline u64 read_gic_count(const struct vdso_data *data)
@@ -229,7 +229,7 @@ index 44a45f3fa4b01..c1b15b0f07689 100644
  	/*
  	 * Core checks mode already. So this raced against a concurrent
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index 6934ee44852b4..782b41d14d4ea 100644
+index 6934ee44852b..782b41d14d4e 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -33,6 +33,10 @@
@@ -270,7 +270,7 @@ index 6934ee44852b4..782b41d14d4ea 100644
  				  LOONGSON_CONF6_INTIMER);
  		break;
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index cbba30dfddf5d..ba083beb6ca81 100644
+index cbba30dfddf5..ba083beb6ca8 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,6 +4,7 @@
@@ -283,7 +283,7 @@ index cbba30dfddf5d..ba083beb6ca81 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
 new file mode 100644
-index 0000000000000..b8bdbb2c47b51
+index 000000000000..b8bdbb2c47b5
 --- /dev/null
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -0,0 +1,256 @@
@@ -544,7 +544,7 @@ index 0000000000000..b8bdbb2c47b51
 +	return res;
 +}
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 69c1e77e6bfc7..f8e2fb4c7cd8c 100644
+index 69c1e77e6bfc..f8e2fb4c7cd8 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -425,7 +425,9 @@ static void loongson3_smp_finish(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0184-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0184-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 7feb07b3d84652332993c9b0bc1bf0cad983620b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 184/303] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 184/305] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index b8bdbb2c47b51..975fb93c4efa2 100644
+index b8bdbb2c47b5..975fb93c4efa 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -42,12 +42,6 @@ static irqreturn_t constant_timer_interrupt(int irq, void *data)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0185-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0185-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From aaaab8c4b50c7f277cf5f4dbc3bc46221d0ad31c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 185/303] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 185/305] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index 975fb93c4efa2..c1fda4a3ae165 100644
+index 975fb93c4efa..c1fda4a3ae16 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -252,7 +252,7 @@ int __init init_constant_clocksource(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0186-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0186-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 7b80652baf9b160d73395b0d6c10b3be7a295241 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 186/303] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 186/305] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 new file mode 100644
-index 0000000000000..3d2ca3245a3e2
+index 000000000000..3d2ca3245a3e
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -0,0 +1,381 @@
@@ -417,7 +417,7 @@ index 0000000000000..3d2ca3245a3e2
 +
 +#endif /* __EC_WPCE775L_H__ */
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index ba083beb6ca81..0cb1654f346ab 100644
+index ba083beb6ca8..0cb1654f346a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -431,7 +431,7 @@ index ba083beb6ca81..0cb1654f346ab 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/ec_wpce775l.c b/arch/mips/loongson64/ec_wpce775l.c
 new file mode 100644
-index 0000000000000..f407ddbe933a1
+index 000000000000..f407ddbe933a
 --- /dev/null
 +++ b/arch/mips/loongson64/ec_wpce775l.c
 @@ -0,0 +1,249 @@
@@ -685,7 +685,7 @@ index 0000000000000..f407ddbe933a1
 +}
 +EXPORT_SYMBOL(ec_query_get_event_num);
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index 8ec4872b44714..199e9f83a165c 100644
+index 8ec4872b4471..199e9f83a165 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -142,7 +142,7 @@ static struct fwnode_handle *i8042_kbd_fwnode;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0187-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0187-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From 7a125ac3f4ff2d0ad5e598b2f64c2dc96f07233a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 187/303] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 187/305] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index 3d2ca3245a3e2..fc60026bc6741 100644
+index 3d2ca3245a3e..fc60026bc674 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -374,6 +374,7 @@ extern int ec_write_noindex(unsigned char command, unsigned char data);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0188-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0188-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 7f3b7f02b6482b730335980c0c6f9bd59d382623 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 188/303] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 188/305] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/wpce_fan.c
 
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
-index 721eafc4644e5..071e8f445f5c9 100644
+index 721eafc4644e..071e8f445f5c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 @@ -36,7 +36,7 @@ struct temp_range {
@@ -66,7 +66,7 @@ index 721eafc4644e5..071e8f445f5c9 100644
 +
  #endif /* __LOONGSON_HWMON_H_*/
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 0cb1654f346ab..16b0c555b52ae 100644
+index 0cb1654f346a..16b0c555b52a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -80,7 +80,7 @@ index 0cb1654f346ab..16b0c555b52ae 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/platform.c b/arch/mips/loongson64/platform.c
 new file mode 100644
-index 0000000000000..a447eab0218d2
+index 000000000000..a447eab0218d
 --- /dev/null
 +++ b/arch/mips/loongson64/platform.c
 @@ -0,0 +1,67 @@
@@ -152,7 +152,7 @@ index 0000000000000..a447eab0218d2
 +	.type = CONSTANT_SPEED_POLICY,
 +};
 diff --git a/drivers/hwmon/lm93.c b/drivers/hwmon/lm93.c
-index be4853fad80fd..649c5e1cf8200 100644
+index be4853fad80f..649c5e1cf820 100644
 --- a/drivers/hwmon/lm93.c
 +++ b/drivers/hwmon/lm93.c
 @@ -2497,8 +2497,9 @@ ATTRIBUTE_GROUPS(lm93);
@@ -194,7 +194,7 @@ index be4853fad80fd..649c5e1cf8200 100644
  	for (i = 0; i < 20; i++) {
  		msleep(10);
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index fb4ac4b08e891..59b6027eeadf5 100644
+index fb4ac4b08e89..59b6027eeadf 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -37,4 +37,20 @@ config LS2K_RESET
@@ -219,7 +219,7 @@ index fb4ac4b08e891..59b6027eeadf5 100644
 +
  endif # MIPS_PLATFORM_DEVICES
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4c71444e453a6..4dcbbcfcf7a1e 100644
+index 4c71444e453a..4dcbbcfcf7a1 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -2,3 +2,6 @@
@@ -231,7 +231,7 @@ index 4c71444e453a6..4dcbbcfcf7a1e 100644
 +obj-$(CONFIG_LEMOTE3A_LAPTOP) += lemote3a-laptop.o
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
 new file mode 100644
-index 0000000000000..02f2284743ed3
+index 000000000000..02f2284743ed
 --- /dev/null
 +++ b/drivers/platform/mips/emc1412.c
 @@ -0,0 +1,454 @@
@@ -691,7 +691,7 @@ index 0000000000000..02f2284743ed3
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
 new file mode 100644
-index 0000000000000..b06e7b6ae97c7
+index 000000000000..b06e7b6ae97c
 --- /dev/null
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -0,0 +1,1179 @@
@@ -1876,7 +1876,7 @@ index 0000000000000..b06e7b6ae97c7
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
 new file mode 100644
-index 0000000000000..6331e09722a1f
+index 000000000000..6331e09722a1
 --- /dev/null
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -0,0 +1,767 @@
@@ -2649,7 +2649,7 @@ index 0000000000000..6331e09722a1f
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
 new file mode 100644
-index 0000000000000..be42c58822901
+index 000000000000..be42c5882290
 --- /dev/null
 +++ b/drivers/platform/mips/sd5075.c
 @@ -0,0 +1,211 @@
@@ -2866,7 +2866,7 @@ index 0000000000000..be42c58822901
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/tmp75.c b/drivers/platform/mips/tmp75.c
 new file mode 100644
-index 0000000000000..0582c8fa2e2b2
+index 000000000000..0582c8fa2e2b
 --- /dev/null
 +++ b/drivers/platform/mips/tmp75.c
 @@ -0,0 +1,24 @@
@@ -2896,7 +2896,7 @@ index 0000000000000..0582c8fa2e2b2
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/wpce_fan.c b/drivers/platform/mips/wpce_fan.c
 new file mode 100644
-index 0000000000000..ecef3158c59bc
+index 000000000000..ecef3158c59b
 --- /dev/null
 +++ b/drivers/platform/mips/wpce_fan.c
 @@ -0,0 +1,311 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0189-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0189-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 47be81b5c7dcf84690d55c2c2521dea0f4e2772f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 189/303] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 189/305] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 59b6027eeadf5..7ef9a47556d59 100644
+index 59b6027eeadf..7ef9a47556d5 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -39,7 +39,7 @@ config LS2K_RESET

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0190-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0190-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 0fe29fa2ecdeb71ced0448cfcc8c47ef76cb4b4d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 190/303] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 190/305] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index be42c58822901..02bb998210191 100644
+index be42c5882290..02bb99821019 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -93,7 +93,7 @@ static int sd5075_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0191-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0191-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From a724e6c8f2900f662243606fc08e5dfdfcd98023 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 191/303] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 191/305] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 02f2284743ed3..3fb2dcd600106 100644
+index 02f2284743ed..3fb2dcd60010 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -143,7 +143,7 @@ static int emc1412_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0192-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0192-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From f3a268720dd27f509885a5bb3bfb492e8c40c184 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 192/303] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 192/305] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index 02bb998210191..27e9fb359b9f6 100644
+index 02bb99821019..27e9fb359b9f 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -128,7 +128,7 @@ static ssize_t get_sd5075_label(struct device *dev,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0193-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0193-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From a2404027c34a5ba5dcad9a4d09c6765a100817d5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 193/303] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 193/305] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 3fb2dcd600106..bf2fa4b815c8f 100644
+index 3fb2dcd60010..bf2fa4b815c8 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -182,7 +182,7 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0194-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0194-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From 9c76113869029f05238583a0b8a5298055b1a934 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 194/303] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 194/305] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 60 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index bf2fa4b815c8f..6524baddd6ca2 100644
+index bf2fa4b815c8..6524baddd6ca 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -336,66 +336,6 @@ static void do_thermal_timer(struct work_struct *work)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0195-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0195-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 7e2c0566e56b47ea7bb52cb786de84c8fd5ca8f8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 195/303] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 195/305] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 6524baddd6ca2..fc1a26cd34fe0 100644
+index 6524baddd6ca..fc1a26cd34fe 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -174,30 +174,6 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0196-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0196-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 70aa2f86f0cfdc82240086f4cc44491017db3064 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 196/303] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 196/305] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b06e7b6ae97c7..6e6b0c46aca4c 100644
+index b06e7b6ae97c..6e6b0c46aca4 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -625,9 +625,8 @@ static int lemote3a_set_brightness(struct backlight_device * pdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0197-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0197-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From ec42e8cd02e7acff12e28204729efaa6b24ea65f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 197/303] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 197/305] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index 6e6b0c46aca4c..a8d339a3e30b7 100644
+index 6e6b0c46aca4..a8d339a3e30b 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -542,10 +542,16 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0198-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0198-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 366b5734e466c7f99e5b7d0ccb671390d5c08e7d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 198/303] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 198/305] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
-index 6331e09722a1f..51c2017ebe1d6 100644
+index 6331e09722a1..51c2017ebe1d 100644
 --- a/drivers/platform/mips/sbx00_fan.c
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -97,10 +97,44 @@ static struct loongson_fan_policy fan_policy[MAX_SBX00_FANS];

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0199-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0199-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 3910f8b7def389d71f044da9d8382c7779bab66d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 199/303] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 199/305] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 73 insertions(+)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 5b8f9cc325893..35d2be41a54c4 100644
+index 5b8f9cc32589..35d2be41a54c 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -1,10 +1,13 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0200-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0200-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From 0cb7acaa44ab0689ec1b9c3fbde52df638829e2a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 200/303] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 200/305] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 35d2be41a54c4..6e53355be9d9f 100644
+index 35d2be41a54c..6e53355be9d9 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -95,7 +95,7 @@ static int __init power_button_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0201-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0201-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From 9e612c14042a782f325bb7382348332817f00cab Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 201/303] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 201/305] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/keyboard/lmps2atkbd.h
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 721ab69e84ac6..2678b3132036a 100644
+index 721ab69e84ac..2678b3132036 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -156,6 +156,17 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -44,7 +44,7 @@ index 721ab69e84ac6..2678b3132036a 100644
  	tristate "Microchip AT42QT1050 Touch Sensor Chip"
  	depends on I2C
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index f7b08b359c9c6..174602f0b4d25 100644
+index f7b08b359c9c..174602f0b4d2 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -77,7 +77,13 @@ MODULE_PARM_DESC(terminal, "Enable break codes on an IBM Terminal keyboard conne
@@ -98,7 +98,7 @@ index f7b08b359c9c6..174602f0b4d25 100644
  
 diff --git a/drivers/input/keyboard/lmps2atkbd.h b/drivers/input/keyboard/lmps2atkbd.h
 new file mode 100644
-index 0000000000000..95d4ac5365c0d
+index 000000000000..95d4ac5365c0
 --- /dev/null
 +++ b/drivers/input/keyboard/lmps2atkbd.h
 @@ -0,0 +1,32 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0202-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0202-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From f07697ce9b0564884b50113143fcba8aba475b02 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 202/303] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 202/305] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 2678b3132036a..dd127dac0b783 100644
+index 2678b3132036..dd127dac0b78 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -158,7 +158,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0203-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0203-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From 742be826187166f166b3c7b2949232742269a992 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 203/303] AOSCOS: input: atkbd: disable
+Subject: [PATCH 203/305] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index dd127dac0b783..ac2612f2fa7d7 100644
+index dd127dac0b78..ac2612f2fa7d 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -159,7 +159,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0204-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0204-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 9cd17231208978cc2c48c0004e445cf6e3b4b7e8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 204/303] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 204/305] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ec_rom.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
+index 4dcbbcfcf7a1..5929b5ad7b6c 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,3 +5,4 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -27,7 +27,7 @@ index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
 +obj-m += ec_rom.o
 diff --git a/drivers/platform/mips/ec_rom.c b/drivers/platform/mips/ec_rom.c
 new file mode 100644
-index 0000000000000..b7b1624191f7a
+index 000000000000..b7b1624191f7
 --- /dev/null
 +++ b/drivers/platform/mips/ec_rom.c
 @@ -0,0 +1,179 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0205-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0205-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 935802a46cc4dbf309162b53087ac1e214712bd5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 205/303] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 205/305] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/pmon_flash.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 5929b5ad7b6cd..98eef2e092264 100644
+index 5929b5ad7b6c..98eef2e09226 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -6,3 +6,7 @@ obj-$(CONFIG_I2C_PIIX4) += emc1412.o sd5075.o tmp75.o
@@ -38,7 +38,7 @@ index 5929b5ad7b6cd..98eef2e092264 100644
 +endif
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
 new file mode 100644
-index 0000000000000..8fd5f4bf8b1bb
+index 000000000000..8fd5f4bf8b1b
 --- /dev/null
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -0,0 +1,100 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0206-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0206-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From d6bd126ec5b4e571b7d8e8d9c9116a3a06195af0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 206/303] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 206/305] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
-index 8fd5f4bf8b1bb..6c5a3c4342b29 100644
+index 8fd5f4bf8b1b..6c5a3c4342b2 100644
 --- a/drivers/platform/mips/pmon_flash.c
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -53,7 +53,7 @@ struct mtd_partition flash_parts[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0207-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0207-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 683e8b43d425c2cdc5a2d190a9baa62e9d0ef5eb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 207/303] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 207/305] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/at24c04.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 98eef2e092264..4dde0988fdadb 100644
+index 98eef2e09226..4dde0988fdad 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,7 +5,7 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -30,7 +30,7 @@ index 98eef2e092264..4dde0988fdadb 100644
  obj-m += pmon_flash.o
 diff --git a/drivers/platform/mips/at24c04.c b/drivers/platform/mips/at24c04.c
 new file mode 100644
-index 0000000000000..7ba3d1c8692e1
+index 000000000000..7ba3d1c8692e
 --- /dev/null
 +++ b/drivers/platform/mips/at24c04.c
 @@ -0,0 +1,26 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0208-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0208-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 9548dfec0b50fdfe5cb817ddb65d3c5365d990bb Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 208/303] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 208/305] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ioremap.h b/arch/mips/include/asm/mach-loongson64/ioremap.h
 new file mode 100644
-index 0000000000000..155dafe2ef346
+index 000000000000..155dafe2ef34
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ioremap.h
 @@ -0,0 +1,44 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0209-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0209-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 1baeabf7320a31b42cac098f9108514597748375 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 209/303] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 209/305] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/mouse/sentelic.c b/drivers/input/mouse/sentelic.c
-index 44b136fc29aaf..6ccdec46e1f44 100644
+index 44b136fc29aa..6ccdec46e1f4 100644
 --- a/drivers/input/mouse/sentelic.c
 +++ b/drivers/input/mouse/sentelic.c
 @@ -899,8 +899,8 @@ static int fsp_activate_protocol(struct psmouse *psmouse)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0210-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0210-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 1e74d98319f1b7218b2b09e32aa908dd3f5af660 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 210/303] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 210/305] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 42 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_64xx.c b/drivers/scsi/mvsas/mv_64xx.c
-index 1f2b61de8c632..855d8465b30f2 100644
+index 1f2b61de8c63..855d8465b30f 100644
 --- a/drivers/scsi/mvsas/mv_64xx.c
 +++ b/drivers/scsi/mvsas/mv_64xx.c
 @@ -376,10 +376,14 @@ static int mvs_64xx_init(struct mvs_info *mvi)
@@ -81,7 +81,7 @@ index 1f2b61de8c632..855d8465b30f2 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_94xx.c b/drivers/scsi/mvsas/mv_94xx.c
-index fc0b8eb682045..1d1042ab82c8c 100644
+index fc0b8eb68204..1d1042ab82c8 100644
 --- a/drivers/scsi/mvsas/mv_94xx.c
 +++ b/drivers/scsi/mvsas/mv_94xx.c
 @@ -515,10 +515,14 @@ static int mvs_94xx_init(struct mvs_info *mvi)
@@ -115,7 +115,7 @@ index fc0b8eb682045..1d1042ab82c8c 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 020037cbf0d91..7cdc0a7d7fa87 100644
+index 020037cbf0d9..7cdc0a7d7fa8 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -10,7 +10,11 @@
@@ -139,7 +139,7 @@ index 020037cbf0d91..7cdc0a7d7fa87 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index 1444b1f1c4c88..2b22f30e39a68 100644
+index 1444b1f1c4c8..2b22f30e39a6 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -265,6 +265,20 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -205,7 +205,7 @@ index 1444b1f1c4c88..2b22f30e39a68 100644
  
  	case SAS_PROTOCOL_SATA:
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index 19b01f7c47677..30c7d450fb9dd 100644
+index 19b01f7c4767..30c7d450fb9d 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -430,6 +430,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0211-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0211-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From 2229db132bdeb09ab4ff9882ab07846dc68fc98b Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 211/303] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 211/305] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-nct6102.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index ba17fea8be150..63d84ca8e2728 100644
+index ba17fea8be15..63d84ca8e272 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -524,6 +524,13 @@ config GPIO_NPCM_SGPIO
@@ -37,7 +37,7 @@ index ba17fea8be150..63d84ca8e2728 100644
  	tristate "Cavium OCTEON GPIO"
  	depends on CAVIUM_OCTEON_SOC
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index c1a4fd033b94d..4f951b2e30be6 100644
+index c1a4fd033b94..4f951b2e30be 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -122,6 +122,7 @@ obj-$(CONFIG_GPIO_MXC)			+= gpio-mxc.o
@@ -50,7 +50,7 @@ index c1a4fd033b94d..4f951b2e30be6 100644
  obj-$(CONFIG_GPIO_PALMAS)		+= gpio-palmas.o
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
 new file mode 100644
-index 0000000000000..25efc588c7612
+index 000000000000..25efc588c761
 --- /dev/null
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -0,0 +1,191 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0212-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0212-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From 2a8981bf40aed906aff9e763128998889e0d8fbe Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 212/303] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 212/305] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 63d84ca8e2728..432055865f788 100644
+index 63d84ca8e272..432055865f78 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -527,7 +527,7 @@ config GPIO_NPCM_SGPIO

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0213-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0213-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From c95be10460762855f73c845bf99b3e0318906425 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 213/303] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 213/305] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 25efc588c7612..547b61008390d 100644
+index 25efc588c761..547b61008390 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -6,6 +6,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0214-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0214-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From afa2f9660b1a64ca6bb35f8e75244545817ae0d8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 214/303] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 214/305] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 547b61008390d..c376f9fd6d076 100644
+index 547b61008390..c376f9fd6d07 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -47,15 +47,6 @@ static unsigned char read_gbl(u8 gbl_reg)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0215-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0215-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From ca3e3cf4c5f2ceadff2ee0491ef4ac9f8647099d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 215/303] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 215/305] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index c376f9fd6d076..1bb29ea5f5f2d 100644
+index c376f9fd6d07..1bb29ea5f5f2 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -170,7 +170,6 @@ static struct gpio_chip nct6102_chip = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0216-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0216-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From ebdd2ffd4b479620575d04e7768cec1bc285794f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 216/303] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 216/305] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 1bb29ea5f5f2d..143f0a139e212 100644
+index 1bb29ea5f5f2..143f0a139e21 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -177,6 +177,6 @@ static int __init nct6102_gpio_setup(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0217-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0217-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From ec1a4c65f092db7444508142a0ec5dba546b0f09 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 217/303] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 217/305] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/nct7511.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index e4c69631ad355..2610e4a41fe37 100644
+index e4c69631ad35..2610e4a41fe3 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -1681,6 +1681,17 @@ config SENSORS_NCT6775_I2C
@@ -44,7 +44,7 @@ index e4c69631ad355..2610e4a41fe37 100644
  	tristate "Nuvoton NCT7802Y"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 74f84764992f9..8faab7269f6a2 100644
+index 74f84764992f..8faab7269f6a 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -172,6 +172,7 @@ obj-$(CONFIG_SENSORS_NCT6775_CORE) += nct6775-core.o
@@ -57,7 +57,7 @@ index 74f84764992f9..8faab7269f6a2 100644
  obj-$(CONFIG_SENSORS_NPCM7XX)	+= npcm750-pwm-fan.o
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
 new file mode 100644
-index 0000000000000..a945ffc2ab3d5
+index 000000000000..a945ffc2ab3d
 --- /dev/null
 +++ b/drivers/hwmon/nct7511.c
 @@ -0,0 +1,801 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0218-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0218-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From 33c6c5e88abf3a02cd8bf974713df63e70b3b9ca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 218/303] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 218/305] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index a945ffc2ab3d5..e5006ecd83465 100644
+index a945ffc2ab3d..e5006ecd8346 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -709,7 +709,7 @@ static int nct7511_detect(struct i2c_client *client,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0219-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0219-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From 7534a4bc259c2cb96d8b85496439f2d675acf792 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 219/303] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 219/305] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index e5006ecd83465..808755e2c37d5 100644
+index e5006ecd8346..808755e2c37d 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -744,8 +744,7 @@ static int nct7511_init_chip(struct nct7511_data *data)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0220-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0220-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 9492960bbd0233dc40b8e3edf686bb0873ca59a7 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 220/303] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 220/305] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 74 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 34874039ad453..0df06250f5d42 100644
+index 34874039ad45..0df06250f5d4 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1178,6 +1178,78 @@ static void add_cx5051_fake_mutes(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0221-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0221-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 71b20e7b5862bcfca291346033286bc3ac73b617 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 221/303] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 221/305] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 20 insertions(+)
 
 diff --git a/include/sound/hda_codec.h b/include/sound/hda_codec.h
-index c1fe6290d04dc..1ef7175a7caed 100644
+index c1fe6290d04d..1ef7175a7cae 100644
 --- a/include/sound/hda_codec.h
 +++ b/include/sound/hda_codec.h
 @@ -369,6 +369,8 @@ struct hda_verb {
@@ -31,7 +31,7 @@ index c1fe6290d04dc..1ef7175a7caed 100644
  			    const struct hda_verb *seq);
  
 diff --git a/sound/pci/hda/hda_codec.c b/sound/pci/hda/hda_codec.c
-index 46a2204049993..51598637e9a21 100644
+index 46a220404999..51598637e9a2 100644
 --- a/sound/pci/hda/hda_codec.c
 +++ b/sound/pci/hda/hda_codec.c
 @@ -68,6 +68,24 @@ static int codec_exec_verb(struct hdac_device *dev, unsigned int cmd,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0222-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0222-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From b8ac67322f86fde261324eba7cd18fa7805eaefc Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 222/303] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 222/305] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 0df06250f5d42..716e882e0bcf4 100644
+index 0df06250f5d4..716e882e0bcf 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -43,6 +43,9 @@ struct conexant_spec {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0223-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0223-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From 6a581513ccb42fb22d11ebbab895f6ef197f311c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 223/303] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 223/305] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 716e882e0bcf4..203204378bdda 100644
+index 716e882e0bcf..203204378bdd 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -295,6 +295,7 @@ enum {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0224-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0224-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 5188c2f9b8e846afdb0b67a41b1b2b86064012d5 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 224/303] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 224/305] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index 27879cc575365..e0ab0481329fc 100644
+index 27879cc57536..e0ab0481329f 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
 @@ -2091,6 +2091,7 @@ static const struct usb_device_id option_ids[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0225-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0225-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From cddcf0d73ba41af851ee023d7711124d32c13d0f Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 225/303] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 225/305] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index 203204378bdda..a0e183107088c 100644
+index 203204378bdd..a0e183107088 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1334,6 +1334,13 @@ static int patch_conexant_auto(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0226-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0226-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 29135442bc11991be3fd8b22731d6ed35aa5f9cf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 226/303] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 226/305] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/sound/pci/hda/patch_conexant.c b/sound/pci/hda/patch_conexant.c
-index a0e183107088c..bc57b3092e598 100644
+index a0e183107088..bc57b3092e59 100644
 --- a/sound/pci/hda/patch_conexant.c
 +++ b/sound/pci/hda/patch_conexant.c
 @@ -1334,8 +1334,9 @@ static int patch_conexant_auto(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0227-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0227-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From c3dd6038e688af884cbee13cee32a02e452977a4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 227/303] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 227/305] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 82 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/e1000e/e1000.h b/drivers/net/ethernet/intel/e1000e/e1000.h
-index ba9c19e6994c9..0e56b992dd3c5 100644
+index ba9c19e6994c..0e56b992dd3c 100644
 --- a/drivers/net/ethernet/intel/e1000e/e1000.h
 +++ b/drivers/net/ethernet/intel/e1000e/e1000.h
 @@ -228,6 +228,7 @@ struct e1000_adapter {
@@ -43,7 +43,7 @@ index ba9c19e6994c9..0e56b992dd3c5 100644
  	u16 tx_ring_count;
  	u16 rx_ring_count;
 diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
-index 07e9033463582..a7661c0f009c9 100644
+index 07e903346358..a7661c0f009c 100644
 --- a/drivers/net/ethernet/intel/e1000e/netdev.c
 +++ b/drivers/net/ethernet/intel/e1000e/netdev.c
 @@ -637,6 +637,69 @@ static void e1000e_update_tdt_wa(struct e1000_ring *tx_ring, unsigned int i)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0228-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0228-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From e57ad4ff10073ee21759f1c7c83bd1f7382c90cc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 228/303] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 228/305] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/message.c b/drivers/usb/core/message.c
-index d2b2787be4092..8128bd0fc00b7 100644
+index d2b2787be409..8128bd0fc00b 100644
 --- a/drivers/usb/core/message.c
 +++ b/drivers/usb/core/message.c
 @@ -1999,7 +1999,7 @@ int usb_set_configuration(struct usb_device *dev, int configuration)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0229-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0229-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From f0abb87b89793a66c5016599327b782f804bf3b3 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 229/303] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 229/305] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 52 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index fc60026bc6741..f1c686ef7a54b 100644
+index fc60026bc674..f1c686ef7a54 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -127,6 +127,13 @@ enum
@@ -36,7 +36,7 @@ index fc60026bc6741..f1c686ef7a54b 100644
  /*
   * The reported battery die temperature.
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 7ef9a47556d59..a5a80e0a399ff 100644
+index 7ef9a47556d5..a5a80e0a399f 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -49,6 +49,7 @@ config LEMOTE3A_LAPTOP
@@ -48,7 +48,7 @@ index 7ef9a47556d59..a5a80e0a399ff 100644
  	help
  	  Lemote Loongson-3A/2Gq family laptops driver.
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index a8d339a3e30b7..b6f585b0f7d35 100644
+index a8d339a3e30b..b6f585b0f7d3 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -19,12 +19,14 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0230-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0230-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From ef7d8e175983ed73db545b6872b8ef3f91fc6350 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 230/303] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 230/305] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 61 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index f1c686ef7a54b..e1f8577a6ed61 100644
+index f1c686ef7a54..e1f8577a6ed6 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -320,6 +320,17 @@ enum
@@ -36,7 +36,7 @@ index f1c686ef7a54b..e1f8577a6ed61 100644
  /* EC Status query, by direct read 66h port. */
  #define EC_SMI_EVT		(1 << 6)	/* 1 = SMI event padding */
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b6f585b0f7d35..dbb37e376ee80 100644
+index b6f585b0f7d3..dbb37e376ee8 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -160,6 +160,7 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0231-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0231-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 058e4da63516e410fea9d9b1c34615320eff1276 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 231/303] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 231/305] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.h
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2248badc3acb6..2e9ac29588c81 100644
+index 2248badc3acb..2e9ac29588c8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -4,6 +4,7 @@
@@ -39,7 +39,7 @@ index 2248badc3acb6..2e9ac29588c81 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-n32.h b/arch/mips/kernel/audit-n32.h
 new file mode 100644
-index 0000000000000..781de2e9ad66b
+index 000000000000..781de2e9ad66
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.h
 @@ -0,0 +1,5 @@
@@ -49,7 +49,7 @@ index 0000000000000..781de2e9ad66b
 +int audit_classify_syscall_n32(int abi, unsigned syscall);
 +#endif /* CONFIG_AUDITSYSCALL_N32 */
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 09ae3dbcfecbc..88e283f8df385 100644
+index 09ae3dbcfecb..88e283f8df38 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -2,6 +2,8 @@
@@ -72,7 +72,7 @@ index 09ae3dbcfecbc..88e283f8df385 100644
  {
  	int res;
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index e8b9b50f7d267..6bf302c04e5d3 100644
+index e8b9b50f7d26..6bf302c04e5d 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -4,6 +4,7 @@
@@ -85,7 +85,7 @@ index e8b9b50f7d267..6bf302c04e5d3 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-o32.h b/arch/mips/kernel/audit-o32.h
 new file mode 100644
-index 0000000000000..8a782fdd1c6e7
+index 000000000000..8a782fdd1c6e
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.h
 @@ -0,0 +1,5 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0232-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0232-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From b352440fa9228291ee8af079bae606d00752c959 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 232/303] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 232/305] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 16 insertions(+), 13 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2e9ac29588c81..8d114bf854254 100644
+index 2e9ac29588c8..8d114bf85425 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -35,11 +35,11 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -38,7 +38,7 @@ index 2e9ac29588c81..8d114bf854254 100644
  		return 0;
  	}
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 88e283f8df385..4a0fecd0e4867 100644
+index 88e283f8df38..4a0fecd0e486 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -45,20 +45,20 @@ int audit_classify_syscall(int abi, unsigned syscall)
@@ -67,7 +67,7 @@ index 88e283f8df385..4a0fecd0e4867 100644
  	default:
  #ifdef CONFIG_AUDITSYSCALL_O32
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index 6bf302c04e5d3..818f91ce14acf 100644
+index 6bf302c04e5d..818f91ce14ac 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -35,15 +35,15 @@ int audit_classify_syscall_o32(int abi, unsigned syscall)
@@ -92,7 +92,7 @@ index 6bf302c04e5d3..818f91ce14acf 100644
  }
  
 diff --git a/include/linux/audit_arch.h b/include/linux/audit_arch.h
-index 0e34d673ef171..0436757bfc33e 100644
+index 0e34d673ef17..0436757bfc33 100644
 --- a/include/linux/audit_arch.h
 +++ b/include/linux/audit_arch.h
 @@ -17,6 +17,9 @@ enum auditsc_class_t {
@@ -106,7 +106,7 @@ index 0e34d673ef171..0436757bfc33e 100644
  	AUDITSC_NVALS /* count */
  };
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index 5aa09586d17fb..d81fb8050db4b 100644
+index 5aa09586d17f..d81fb8050db4 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -190,7 +190,7 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0233-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0233-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From b77d54b48a1fe7edfe62f1addf19a34fb85bc7ab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 233/303] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 233/305] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 27 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 8d114bf854254..76c95ff924f83 100644
+index 8d114bf85425..76c95ff924f8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -41,7 +41,7 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -29,7 +29,7 @@ index 8d114bf854254..76c95ff924f83 100644
  }
  
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 4a0fecd0e4867..763f0e6b3636a 100644
+index 4a0fecd0e486..763f0e6b3636 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -41,45 +41,26 @@ int audit_classify_arch(int arch)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0234-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0234-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From 741dadf7f469eb3262475b8556fc2f5ec6fd705c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 234/303] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 234/305] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index fd8a4513025fc..d2a26423be65d 100644
+index fd8a4513025f..d2a26423be65 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -2405,6 +2405,8 @@ struct radeon_device {
@@ -31,7 +31,7 @@ index fd8a4513025fc..d2a26423be65d 100644
  	struct mutex dc_hw_i2c_mutex; /* display controller hw i2c mutex */
  	bool has_uvd;
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 554b236c2328a..6706dd59a9023 100644
+index 554b236c2328..6706dd59a902 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1642,7 +1642,28 @@ int radeon_suspend_kms(struct drm_device *dev, bool suspend,
@@ -89,7 +89,7 @@ index 554b236c2328a..6706dd59a9023 100644
  }
  
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 9961251b44ba0..e5d5ea218579f 100644
+index 9961251b44ba..e5d5ea218579 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -307,6 +307,8 @@ static bool radeon_msi_ok(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0235-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0235-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 3d3eb5df0e188b61708d71ea3f616c4e6592e58d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 235/303] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 235/305] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.h b/drivers/gpu/drm/radeon/radeon_device.h
-index 31a0ae295cc8f..e7f6d468b5674 100644
+index 31a0ae295cc8..e7f6d468b567 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.h
 +++ b/drivers/gpu/drm/radeon/radeon_device.h
 @@ -29,4 +29,6 @@
@@ -28,7 +28,7 @@ index 31a0ae295cc8f..e7f6d468b5674 100644
 +
  #endif                         /* __RADEON_DEVICE_H__ */
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index e5d5ea218579f..d4ad1fa826454 100644
+index e5d5ea218579..d4ad1fa82645 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -40,6 +40,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0236-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0236-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 5850794720cf604eb7002edce5f943d143fc35d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 236/303] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 236/305] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 6706dd59a9023..965867c136fed 100644
+index 6706dd59a902..965867c136fe 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1798,6 +1798,7 @@ int radeon_gpu_reset(struct radeon_device *rdev)
@@ -55,7 +55,7 @@ index 6706dd59a9023..965867c136fed 100644
  	rdev->needs_reset = false;
  
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index b4fb7e70320b8..54b4b9b161f71 100644
+index b4fb7e70320b..54b4b9b161f7 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1854,10 +1854,11 @@ static bool radeon_pm_debug_check_in_vbl(struct radeon_device *rdev, bool finish
@@ -80,7 +80,7 @@ index b4fb7e70320b8..54b4b9b161f71 100644
  
  /*
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 320592435252e..76f03af89e8b1 100644
+index 320592435252..76f03af89e8b 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -328,6 +328,20 @@ void ttm_bo_put(struct ttm_buffer_object *bo)
@@ -105,7 +105,7 @@ index 320592435252e..76f03af89e8b1 100644
  				     struct ttm_operation_ctx *ctx,
  				     struct ttm_place *hop)
 diff --git a/include/drm/ttm/ttm_bo.h b/include/drm/ttm/ttm_bo.h
-index 7b56d1ca36d75..73a2d1d9a5f37 100644
+index 7b56d1ca36d7..73a2d1d9a5f3 100644
 --- a/include/drm/ttm/ttm_bo.h
 +++ b/include/drm/ttm/ttm_bo.h
 @@ -356,6 +356,22 @@ static inline void ttm_bo_move_null(struct ttm_buffer_object *bo,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0237-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0237-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From ae850dfa9d3783f0cb81b9996fe13f2096e67d55 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 237/303] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 237/305] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 965867c136fed..c3e045304dd19 100644
+index 965867c136fe..c3e045304dd1 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1658,7 +1658,7 @@ void radeon_recover_callback(struct work_struct *work)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0238-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0238-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From 03ff0fbcd861d52f13570c23894a4bc47dd78971 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 238/303] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 238/305] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 76f03af89e8b1..7c3cf93c81fbd 100644
+index 76f03af89e8b..7c3cf93c81fb 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -330,14 +330,14 @@ EXPORT_SYMBOL(ttm_bo_put);
@@ -47,7 +47,7 @@ index 76f03af89e8b1..7c3cf93c81fbd 100644
  }
  EXPORT_SYMBOL(ttm_bo_unlock_delayed_workqueue);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index c22f30535c848..1116429c20007 100644
+index c22f30535c84..1116429c2000 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -266,6 +266,11 @@ struct ttm_device {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0239-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0239-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 72bdd3a6593dc1f4a36d459ad754eb4550d35b7e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 239/303] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 239/305] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1ce165c627a6c..493022119c1a7 100644
+index 1ce165c627a6..493022119c1a 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,6 +1010,9 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -27,7 +27,7 @@ index 1ce165c627a6c..493022119c1a7 100644
  						 evergreen_golden_registers,
  						 (const u32)ARRAY_SIZE(evergreen_golden_registers));
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 54b4b9b161f71..c6c60f1b64cbf 100644
+index 54b4b9b161f7..c6c60f1b64cb 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,6 +1520,7 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0240-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0240-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From eec267fc948082fa3a78c16bb9cb8574dbf62001 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 240/303] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 240/305] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 493022119c1a7..1a15f9264ead0 100644
+index 493022119c1a..1a15f9264ead 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,8 +1010,10 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -31,7 +31,7 @@ index 493022119c1a7..1a15f9264ead0 100644
  		radeon_program_register_sequence(rdev,
  						 evergreen_golden_registers,
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index c6c60f1b64cbf..539065746db08 100644
+index c6c60f1b64cb..539065746db0 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,7 +1520,9 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0241-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0241-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From bce062fbd79577a407e78e4e741a6a120bceba24 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 241/303] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 241/305] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 539065746db08..f5ee0cc05c2d0 100644
+index 539065746db0..f5ee0cc05c2d 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1354,7 +1354,7 @@ static int radeon_pm_init_old(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0242-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0242-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 5317af3811f887a2ce35c172b289035490372dd3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 242/303] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 242/305] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  12 files changed, 35 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index f20fd5ae6c45c..61f254f270f0e 100644
+index f20fd5ae6c45..61f254f270f0 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -5435,6 +5435,7 @@ static int cik_pcie_gart_enable(struct radeon_device *rdev)
@@ -39,7 +39,7 @@ index f20fd5ae6c45c..61f254f270f0e 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1a15f9264ead0..4a7774c35e850 100644
+index 1a15f9264ead..4a7774c35e85 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -2414,6 +2414,7 @@ static int evergreen_pcie_gart_enable(struct radeon_device *rdev)
@@ -51,7 +51,7 @@ index 1a15f9264ead0..4a7774c35e850 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/ni.c b/drivers/gpu/drm/radeon/ni.c
-index 3890911fe693c..03335fa3367bb 100644
+index 3890911fe693..03335fa3367b 100644
 --- a/drivers/gpu/drm/radeon/ni.c
 +++ b/drivers/gpu/drm/radeon/ni.c
 @@ -1256,6 +1256,7 @@ static int cayman_pcie_gart_enable(struct radeon_device *rdev)
@@ -63,7 +63,7 @@ index 3890911fe693c..03335fa3367bb 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/r100.c b/drivers/gpu/drm/radeon/r100.c
-index 80703417d8a18..c926e3b27df89 100644
+index 80703417d8a1..c926e3b27df8 100644
 --- a/drivers/gpu/drm/radeon/r100.c
 +++ b/drivers/gpu/drm/radeon/r100.c
 @@ -672,6 +672,7 @@ int r100_pci_gart_enable(struct radeon_device *rdev)
@@ -75,7 +75,7 @@ index 80703417d8a18..c926e3b27df89 100644
  	tmp = RREG32(RADEON_AIC_CNTL) | RADEON_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32(RADEON_AIC_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r300.c b/drivers/gpu/drm/radeon/r300.c
-index d22889fbfa9c8..59404a4605727 100644
+index d22889fbfa9c..59404a460572 100644
 --- a/drivers/gpu/drm/radeon/r300.c
 +++ b/drivers/gpu/drm/radeon/r300.c
 @@ -161,6 +161,7 @@ int rv370_pcie_gart_enable(struct radeon_device *rdev)
@@ -87,7 +87,7 @@ index d22889fbfa9c8..59404a4605727 100644
  	tmp = RADEON_PCIE_TX_GART_UNMAPPED_ACCESS_DISCARD;
  	WREG32_PCIE(RADEON_PCIE_TX_GART_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 88e38fb3f3476..4c57b429af216 100644
+index 88e38fb3f347..4c57b429af21 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -1137,6 +1137,7 @@ static int r600_pcie_gart_enable(struct radeon_device *rdev)
@@ -99,7 +99,7 @@ index 88e38fb3f3476..4c57b429af216 100644
  	/* Setup L2 cache */
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index d2a26423be65d..6e9dea44a7f19 100644
+index d2a26423be65..6e9dea44a7f1 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -627,6 +627,7 @@ void radeon_gart_unbind(struct radeon_device *rdev, unsigned offset,
@@ -111,7 +111,7 @@ index d2a26423be65d..6e9dea44a7f19 100644
  
  /*
 diff --git a/drivers/gpu/drm/radeon/radeon_gart.c b/drivers/gpu/drm/radeon/radeon_gart.c
-index 4bb242437ff60..b34b8b9066947 100644
+index 4bb242437ff6..b34b8b906694 100644
 --- a/drivers/gpu/drm/radeon/radeon_gart.c
 +++ b/drivers/gpu/drm/radeon/radeon_gart.c
 @@ -317,6 +317,30 @@ int radeon_gart_bind(struct radeon_device *rdev, unsigned int offset,
@@ -146,7 +146,7 @@ index 4bb242437ff60..b34b8b9066947 100644
   * radeon_gart_init - init the driver info for managing the gart
   *
 diff --git a/drivers/gpu/drm/radeon/rs400.c b/drivers/gpu/drm/radeon/rs400.c
-index 13cd0a688a65c..6dad165e90fcc 100644
+index 13cd0a688a65..6dad165e90fc 100644
 --- a/drivers/gpu/drm/radeon/rs400.c
 +++ b/drivers/gpu/drm/radeon/rs400.c
 @@ -113,6 +113,7 @@ int rs400_gart_enable(struct radeon_device *rdev)
@@ -158,7 +158,7 @@ index 13cd0a688a65c..6dad165e90fcc 100644
  	tmp |= RS690_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32_MC(RS690_AIC_CTRL_SCRATCH, tmp);
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 88c8e91ea6512..7cfe137d7dcdd 100644
+index 88c8e91ea651..7cfe137d7dcd 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -571,6 +571,7 @@ static int rs600_gart_enable(struct radeon_device *rdev)
@@ -170,7 +170,7 @@ index 88c8e91ea6512..7cfe137d7dcdd 100644
  	tmp = RREG32(RADEON_BUS_CNTL) & ~RS600_BUS_MASTER_DIS;
  	WREG32(RADEON_BUS_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/rv770.c b/drivers/gpu/drm/radeon/rv770.c
-index 7d4b0bf591090..c7317aff4cd64 100644
+index 7d4b0bf59109..c7317aff4cd6 100644
 --- a/drivers/gpu/drm/radeon/rv770.c
 +++ b/drivers/gpu/drm/radeon/rv770.c
 @@ -903,6 +903,7 @@ static int rv770_pcie_gart_enable(struct radeon_device *rdev)
@@ -182,7 +182,7 @@ index 7d4b0bf591090..c7317aff4cd64 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 465859e2fcff9..361e6d7c25330 100644
+index 465859e2fcff..361e6d7c2533 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -4273,6 +4273,7 @@ static int si_pcie_gart_enable(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0243-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0243-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From d27492e1015e5c08328be4846609cd2bd4073750 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 243/303] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 243/305] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 7cfe137d7dcdd..8fb559af1a37f 100644
+index 7cfe137d7dcd..8fb559af1a37 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -654,6 +654,9 @@ uint64_t rs600_gart_get_page_entry(uint64_t addr, uint32_t flags)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0244-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0244-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From 2479a6f3eabe949e1f58112ba531653cd1887add Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 244/303] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 244/305] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 04c1b32a22c5e..9bdf3248556bd 100644
+index 04c1b32a22c5..9bdf3248556b 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -34,7 +34,7 @@ static int g_hwcursor = 1;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0245-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0245-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From b6061831011edf9828d72670ab140ada6205f3c6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 245/303] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 245/305] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 9bdf3248556bd..f6a2b00f7215b 100644
+index 9bdf3248556b..f6a2b00f7215 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -30,7 +30,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0246-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0246-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 0c69a089f9f899d74e63f9ca65cb11952e3326a6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 246/303] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 246/305] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index 199e9f83a165c..39175a94a7f34 100644
+index 199e9f83a165..39175a94a7f3 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -131,7 +131,9 @@ MODULE_PARM_DESC(unmask_kbd_data, "Unconditional enable (may reveal sensitive da

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0247-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0247-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 8b3e125fedd0076b485b814e24ed48cfcdb556b0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 247/303] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 247/305] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 76 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/igb/igb.h b/drivers/net/ethernet/intel/igb/igb.h
-index 3c2dc7bdebb50..2cf9762ca6f31 100644
+index 3c2dc7bdebb5..2cf9762ca6f3 100644
 --- a/drivers/net/ethernet/intel/igb/igb.h
 +++ b/drivers/net/ethernet/intel/igb/igb.h
 @@ -374,6 +374,13 @@ struct igb_q_vector {
@@ -30,7 +30,7 @@ index 3c2dc7bdebb50..2cf9762ca6f31 100644
  	struct igb_ring ring[] ____cacheline_internodealigned_in_smp;
  };
 diff --git a/drivers/net/ethernet/intel/igb/igb_main.c b/drivers/net/ethernet/intel/igb/igb_main.c
-index 18284a838e242..039775b4efc1e 100644
+index 18284a838e24..039775b4efc1 100644
 --- a/drivers/net/ethernet/intel/igb/igb_main.c
 +++ b/drivers/net/ethernet/intel/igb/igb_main.c
 @@ -4196,6 +4196,15 @@ static int __igb_open(struct net_device *netdev, bool resuming)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0248-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0248-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 979db94dad2820a08ef6bc6a54fc2797553140cb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 248/303] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 248/305] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/staging/sb105x/sb_ser_core.h
 
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 3fb68d60dfc1b..53e88bb04cb50 100644
+index 3fb68d60dfc1..53e88bb04cb5 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -50,6 +50,8 @@ source "drivers/staging/media/Kconfig"
@@ -44,7 +44,7 @@ index 3fb68d60dfc1b..53e88bb04cb50 100644
  
  source "drivers/staging/most/Kconfig"
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index c977aa13fad40..b7e9fc02623b4 100644
+index c977aa13fad4..b7e9fc02623b 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -15,6 +15,7 @@ obj-$(CONFIG_IIO)		+= iio/
@@ -57,7 +57,7 @@ index c977aa13fad40..b7e9fc02623b4 100644
  obj-$(CONFIG_GREYBUS)		+= greybus/
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
 new file mode 100644
-index 0000000000000..245e7847a3542
+index 000000000000..245e7847a354
 --- /dev/null
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -0,0 +1,9 @@
@@ -72,7 +72,7 @@ index 0000000000000..245e7847a3542
 +	  will be called "sb105x".
 diff --git a/drivers/staging/sb105x/Makefile b/drivers/staging/sb105x/Makefile
 new file mode 100644
-index 0000000000000..b1bf3779acaed
+index 000000000000..b1bf3779acae
 --- /dev/null
 +++ b/drivers/staging/sb105x/Makefile
 @@ -0,0 +1,3 @@
@@ -81,7 +81,7 @@ index 0000000000000..b1bf3779acaed
 +sb105x-y :=  sb_pci_mp.o
 diff --git a/drivers/staging/sb105x/sb_mp_register.h b/drivers/staging/sb105x/sb_mp_register.h
 new file mode 100644
-index 0000000000000..276c1bbcc18dd
+index 000000000000..276c1bbcc18d
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_mp_register.h
 @@ -0,0 +1,295 @@
@@ -382,7 +382,7 @@ index 0000000000000..276c1bbcc18dd
 +#endif 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
 new file mode 100644
-index 0000000000000..c9d6ee3903adc
+index 000000000000..c9d6ee3903ad
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -0,0 +1,3189 @@
@@ -3577,7 +3577,7 @@ index 0000000000000..c9d6ee3903adc
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
 new file mode 100644
-index 0000000000000..80ae4ab046031
+index 000000000000..80ae4ab04603
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -0,0 +1,291 @@
@@ -3874,7 +3874,7 @@ index 0000000000000..80ae4ab046031
 +
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
 new file mode 100644
-index 0000000000000..c8fb991732997
+index 000000000000..c8fb99173299
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -0,0 +1,368 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0249-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0249-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From 58aecd1e3666d5a17a9ca0a4d3b8e47499f181b0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 249/303] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 249/305] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
 new file mode 100644
-index 0000000000000..a780ee51a7188
+index 000000000000..a780ee51a718
 --- /dev/null
 +++ b/arch/mips/include/asm/serial.h
 @@ -0,0 +1,19 @@
@@ -45,7 +45,7 @@ index 0000000000000..a780ee51a7188
 +
 +#endif /* __ASM__SERIAL_H */
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
-index 245e7847a3542..c5f741e71c14b 100644
+index 245e7847a354..c5f741e71c14 100644
 --- a/drivers/staging/sb105x/Kconfig
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -1,7 +1,7 @@
@@ -58,7 +58,7 @@ index 245e7847a3542..c5f741e71c14b 100644
  	  A driver for the SystemBase Multi-2/PCI serial card
  
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c9d6ee3903adc..18e91bc61ba16 100644
+index c9d6ee3903ad..18e91bc61ba1 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1,6 +1,7 @@
@@ -314,7 +314,7 @@ index c9d6ee3903adc..18e91bc61ba16 100644
              
  	   		     	if (status != 0)
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
-index 80ae4ab046031..0920beb31c15e 100644
+index 80ae4ab04603..0920beb31c15 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.h
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -287,5 +287,4 @@ static const struct sb105x_uart_config uart_config[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0250-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0250-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From b50b96a64e88ebaf5df01e88d155d41a04b96f58 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 250/303] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 250/305] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index c8fb991732997..8835415e1d3df 100644
+index c8fb99173299..8835415e1d3d 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -196,13 +196,13 @@ struct uart_driver {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0251-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0251-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From a29d1a0e466458e7486b2f9c1402e5271172bfdf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 251/303] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 251/305] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 18e91bc61ba16..e333245ec9c5d 100644
+index 18e91bc61ba1..e333245ec9c5 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -480,7 +480,7 @@ static void __mp_start(struct tty_struct *tty)
@@ -41,7 +41,7 @@ index 18e91bc61ba16..e333245ec9c5d 100644
  
  	return put_user(result, value);
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index 8835415e1d3df..d8664e723b4a3 100644
+index 8835415e1d3d..d8664e723b4a 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -52,7 +52,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0252-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0252-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From aada1afb42f0a5ab42658fe6c4709e8d646b0dda Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 252/303] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 252/305] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index e333245ec9c5d..963f3091a5c95 100644
+index e333245ec9c5..963f3091a5c9 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1051,7 +1051,7 @@ static int mp_wait_modem_status(struct sb_uart_state *state, unsigned long arg)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0253-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0253-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 36aef78ef14437bdda2351d5f32597dbe8e73367 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 253/303] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 253/305] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 963f3091a5c95..cd98d3b0183da 100644
+index 963f3091a5c9..cd98d3b0183d 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1624,7 +1624,7 @@ static inline void mp_report_port(struct uart_driver *drv, struct sb_uart_port *

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0254-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0254-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From befc3938137f6faf6ef402a64b81803a3e68e592 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 254/303] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 254/305] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index cd98d3b0183da..ccf02cfeb2fcc 100644
+index cd98d3b0183d..ccf02cfeb2fc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1728,12 +1728,10 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0255-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0255-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From 6a9f2a43d6ad920ebf27b105cf0f268b9224817c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 255/303] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 255/305] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index ccf02cfeb2fcc..c5e1c39e7a7a2 100644
+index ccf02cfeb2fc..c5e1c39e7a7a 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1765,7 +1765,7 @@ for (i = 0; i < drv->nr; i++) {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0256-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0256-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From e3ca45de97d4b7656501d9d7e9fcc97b732bb5e1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 256/303] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 256/305] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
-index a780ee51a7188..2777148dbfc5a 100644
+index a780ee51a718..2777148dbfc5 100644
 --- a/arch/mips/include/asm/serial.h
 +++ b/arch/mips/include/asm/serial.h
 @@ -12,7 +12,6 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0257-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0257-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From c4a6288e103834e7ea879609d92165469f2c30de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 257/303] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 257/305] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c5e1c39e7a7a2..32f60de269ccb 100644
+index c5e1c39e7a7a..32f60de269cc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2808,7 +2808,7 @@ static void __init multi_init_ports(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0258-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0258-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 7ea8243407e812ec7526730510771f9e837ca5c0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 258/303] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 258/305] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 32f60de269ccb..841e9b15486b0 100644
+index 32f60de269cc..841e9b15486b 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1736,7 +1736,6 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0259-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0259-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From 7402f392f317d60d31430b58e74aa8e0053bb483 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 259/303] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 259/305] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 841e9b15486b0..0d7e216fad94a 100644
+index 841e9b15486b..0d7e216fad94 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -33,7 +33,7 @@ static void mp_tasklet_action(unsigned long data);
@@ -78,7 +78,7 @@ index 841e9b15486b0..0d7e216fad94a 100644
  	struct mp_port *mtpt = (struct mp_port *)port;
  	unsigned char cval, fcr = 0;
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index d8664e723b4a3..978b4b26ddbb1 100644
+index d8664e723b4a..978b4b26ddbb 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -77,7 +77,7 @@ struct sb_uart_ops {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0260-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0260-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From c5cb4638727ca405ab5365c03c8601af101b50ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 260/303] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 260/305] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 0d7e216fad94a..f61451fabdcd0 100644
+index 0d7e216fad94..f61451fabdcd 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -39,7 +39,7 @@ static inline int __mp_put_char(struct sb_uart_port *port, struct circ_buf *circ

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0261-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0261-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From 721dfcdbda28bbd9dc4d123bc6d6c8234073c269 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 261/303] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 261/305] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index f61451fabdcd0..593835f0ad11c 100644
+index f61451fabdcd..593835f0ad11 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -40,7 +40,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0262-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0262-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 7b51c0ece7175840be6791766d838d070d3d44eb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 262/303] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 262/305] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 593835f0ad11c..8712e74230648 100644
+index 593835f0ad11..8712e7423064 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -41,7 +41,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0263-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0263-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 2620aa242f01a8aa77ae62274d686a7ca57857de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 263/303] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 263/305] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 8712e74230648..19098bbfa113e 100644
+index 8712e7423064..19098bbfa113 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -43,7 +43,7 @@ static ssize_t mp_write(struct tty_struct *tty, const unsigned char *buf, long u

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0264-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0264-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 299c0cf26dade900db2f7bbc8739bf4867a6587f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 264/303] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 264/305] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 22 insertions(+)
 
 diff --git a/drivers/parport/parport_serial.c b/drivers/parport/parport_serial.c
-index 24d4f3a3ec3d0..9e1af7103d603 100644
+index 24d4f3a3ec3d..9e1af7103d60 100644
 --- a/drivers/parport/parport_serial.c
 +++ b/drivers/parport/parport_serial.c
 @@ -60,6 +60,7 @@ enum parport_pc_pci_cards {
@@ -63,7 +63,7 @@ index 24d4f3a3ec3d0..9e1af7103d603 100644
  		.flags		= FL_BASE2,
  		.num_ports	= 5,
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index b3c19ba777c68..d20f8fe3bf307 100644
+index b3c19ba777c6..d20f8fe3bf30 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,6 +74,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0265-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0265-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 2eca81368614f4b8c8ba5ad6ea611278726c955d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 265/303] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 265/305] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index d20f8fe3bf307..87900054a1136 100644
+index d20f8fe3bf30..87900054a113 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -332,6 +332,12 @@ static int pci_plx9050_init(struct pci_dev *dev)
@@ -63,7 +63,7 @@ index d20f8fe3bf307..87900054a1136 100644
  		PCI_VENDOR_ID_PLX,
  		PCI_SUBDEVICE_ID_UNKNOWN_0x1588, 0, 0,
 diff --git a/drivers/tty/serial/8250/8250_pcilib.c b/drivers/tty/serial/8250/8250_pcilib.c
-index ea906d721b2c3..f5696efb7feef 100644
+index ea906d721b2c..f5696efb7fee 100644
 --- a/drivers/tty/serial/8250/8250_pcilib.c
 +++ b/drivers/tty/serial/8250/8250_pcilib.c
 @@ -18,6 +18,12 @@ int serial8250_pci_setup_port(struct pci_dev *dev, struct uart_8250_port *port,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0266-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0266-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From 8cbb88a2469957b8eb541cbc7384e0898dba60b2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 266/303] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 266/305] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 92baa34f42f28..316ce8395ab21 100644
+index 92baa34f42f2..316ce8395ab2 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -659,7 +659,17 @@
@@ -36,7 +36,7 @@ index 92baa34f42f28..316ce8395ab21 100644
  #define USB_VENDOR_ID_INTEL_0		0x8086
  #define USB_VENDOR_ID_INTEL_1		0x8087
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 546e15a2a0fd6..b67d7d8a44c6d 100644
+index 546e15a2a0fd..b67d7d8a44c6 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -2293,7 +2293,47 @@ static const struct hid_device_id mt_devices[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0267-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0267-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From f519f47aa32b1daa380b409b350c11f08c486c5f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 267/303] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 267/305] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/host/ohci-hcd.c b/drivers/usb/host/ohci-hcd.c
-index 9b24181fee601..f9adf45938c58 100644
+index 9b24181fee60..f9adf45938c5 100644
 --- a/drivers/usb/host/ohci-hcd.c
 +++ b/drivers/usb/host/ohci-hcd.c
 @@ -1138,8 +1138,10 @@ int ohci_resume(struct usb_hcd *hcd, bool hibernated)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0268-AOSCOS-USB-XHCI-Fix-device-lost-problems-on-ETRON-co.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0268-AOSCOS-USB-XHCI-Fix-device-lost-problems-on-ETRON-co.patch
@@ -1,7 +1,7 @@
 From f2e1afa508b3a7ca69ed92f275c6d9fe6aa750a1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 3 Jun 2019 10:16:02 +0800
-Subject: [PATCH 268/303] AOSCOS: USB: XHCI: Fix device lost problems on ETRON
+Subject: [PATCH 268/305] AOSCOS: USB: XHCI: Fix device lost problems on ETRON
  controller
 
 [Mingcong Bai: Resolved merge conflicts in drivers/usb/host/xhci-ring.c
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 58 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/usb/host/xhci-hub.c b/drivers/usb/host/xhci-hub.c
-index 1952e05033407..169fb763d433e 100644
+index 1952e0503340..169fb763d433 100644
 --- a/drivers/usb/host/xhci-hub.c
 +++ b/drivers/usb/host/xhci-hub.c
 @@ -362,6 +362,9 @@ static void xhci_usb3_hub_descriptor(struct usb_hcd *hcd, struct xhci_hcd *xhci,
@@ -47,7 +47,7 @@ index 1952e05033407..169fb763d433e 100644
  
  	/* update status field */
 diff --git a/drivers/usb/host/xhci-mem.c b/drivers/usb/host/xhci-mem.c
-index f9c51e0f2e37c..f71128e70e708 100644
+index f9c51e0f2e37..f71128e70e70 100644
 --- a/drivers/usb/host/xhci-mem.c
 +++ b/drivers/usb/host/xhci-mem.c
 @@ -1404,9 +1404,15 @@ int xhci_endpoint_init(struct xhci_hcd *xhci,
@@ -87,7 +87,7 @@ index f9c51e0f2e37c..f71128e70e708 100644
  	virt_dev->eps[ep_index].new_ring =
  		xhci_ring_alloc(xhci, 2, 1, ring_type, max_packet, mem_flags);
 diff --git a/drivers/usb/host/xhci-ring.c b/drivers/usb/host/xhci-ring.c
-index fbc8419a54730..1b2ae77eca7ff 100644
+index fbc8419a5473..1b2ae77eca7f 100644
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
 @@ -2568,6 +2568,7 @@ static int process_bulk_intr_td(struct xhci_hcd *xhci, struct xhci_virt_ep *ep,
@@ -141,7 +141,7 @@ index fbc8419a54730..1b2ae77eca7ff 100644
  				lower_32_bits(send_addr),
  				upper_32_bits(send_addr),
 diff --git a/drivers/usb/host/xhci.c b/drivers/usb/host/xhci.c
-index 799941b6ad6c6..921743872885e 100644
+index 799941b6ad6c..921743872885 100644
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
 @@ -2940,6 +2940,8 @@ int xhci_check_bandwidth(struct usb_hcd *hcd, struct usb_device *udev)
@@ -172,7 +172,7 @@ index 799941b6ad6c6..921743872885e 100644
  	kfree(command);
  
 diff --git a/drivers/usb/host/xhci.h b/drivers/usb/host/xhci.h
-index c4d5b90ef90a8..cbc1aca2cb5c8 100644
+index c4d5b90ef90a..cbc1aca2cb5c 100644
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
 @@ -673,6 +673,7 @@ struct xhci_virt_ep {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0269-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0269-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 524ad19ebfd3f99b45f42cd9e6b06117a88c3b69 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 269/303] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 269/305] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ls7a_fan.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dde0988fdadb..a3e9e6b2f38fb 100644
+index 4dde0988fdad..a3e9e6b2f38f 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -3,7 +3,7 @@ obj-$(CONFIG_CPU_HWMON) += cpu_hwmon.o
@@ -28,7 +28,7 @@ index 4dde0988fdadb..a3e9e6b2f38fb 100644
  
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
 new file mode 100644
-index 0000000000000..cc188d4d05762
+index 000000000000..cc188d4d0576
 --- /dev/null
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -0,0 +1,598 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0270-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0270-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 71eb8a7b105fd25a6d87be80d837049a43fd2f5c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 270/303] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 270/305] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
-index cc188d4d05762..e9cf2dded39e4 100644
+index cc188d4d0576..e9cf2dded39e 100644
 --- a/drivers/platform/mips/ls7a_fan.c
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -9,10 +9,16 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0271-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0271-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From 4949a52e5e4655f81770e124b9a1d53cb2c406b8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 271/303] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 271/305] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index cc0360e8dd62c..fc1d0c83b554a 100644
+index cc0360e8dd62..fc1d0c83b554 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,7 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0272-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0272-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From 88f48d95573c3a0ab0964f16a30f146bff69d9a3 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 272/303] AOSCOS: Optimize clear_page
+Subject: [PATCH 272/305] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 56 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/uasm.h b/arch/mips/include/asm/uasm.h
-index b43bfd4452521..2573d559320e6 100644
+index b43bfd445252..2573d559320e 100644
 --- a/arch/mips/include/asm/uasm.h
 +++ b/arch/mips/include/asm/uasm.h
 @@ -42,6 +42,10 @@ void uasm_i##op(u32 **buf, unsigned int a, signed int b, unsigned int c)
@@ -37,7 +37,7 @@ index b43bfd4452521..2573d559320e6 100644
  Ip_u3u2u1(_sllv);
  Ip_s3s1s2(_slt);
 diff --git a/arch/mips/include/uapi/asm/inst.h b/arch/mips/include/uapi/asm/inst.h
-index c29dbc8c1d491..6d41c8bbbdec2 100644
+index c29dbc8c1d49..6d41c8bbbdec 100644
 --- a/arch/mips/include/uapi/asm/inst.h
 +++ b/arch/mips/include/uapi/asm/inst.h
 @@ -137,6 +137,13 @@ enum ddivu_op {
@@ -55,7 +55,7 @@ index c29dbc8c1d491..6d41c8bbbdec2 100644
   * rt field of bcond opcodes.
   */
 diff --git a/arch/mips/mm/page.c b/arch/mips/mm/page.c
-index 1df237bd4a72b..21c9d35ec25e8 100644
+index 1df237bd4a72..21c9d35ec25e 100644
 --- a/arch/mips/mm/page.c
 +++ b/arch/mips/mm/page.c
 @@ -206,6 +206,11 @@ static void set_prefetch_parameters(void)
@@ -87,7 +87,7 @@ index 1df237bd4a72b..21c9d35ec25e8 100644
  
  static inline void build_clear_pref(u32 **buf, int off)
 diff --git a/arch/mips/mm/uasm-mips.c b/arch/mips/mm/uasm-mips.c
-index e15c6700cd088..7e44ea365795b 100644
+index e15c6700cd08..7e44ea365795 100644
 --- a/arch/mips/mm/uasm-mips.c
 +++ b/arch/mips/mm/uasm-mips.c
 @@ -27,6 +27,10 @@
@@ -143,7 +143,7 @@ index e15c6700cd088..7e44ea365795b 100644
  		op |= build_simm(va_arg(ap, s32));
  	if (ip->fields & UIMM)
 diff --git a/arch/mips/mm/uasm.c b/arch/mips/mm/uasm.c
-index 125140979d62c..2a9ca7de43760 100644
+index 125140979d62..2a9ca7de4376 100644
 --- a/arch/mips/mm/uasm.c
 +++ b/arch/mips/mm/uasm.c
 @@ -26,6 +26,8 @@ enum fields {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0273-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0273-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 699664971ba5b5e57b33acecb975b211e380bf36 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 273/303] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 273/305] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memset.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 16b0c555b52ae..f6a1fd6cb736e 100644
+index 16b0c555b52a..f6a1fd6cb736 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,6 +5,7 @@
@@ -30,7 +30,7 @@ index 16b0c555b52ae..f6a1fd6cb736e 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
 new file mode 100644
-index 0000000000000..227b2d67082e3
+index 000000000000..227b2d67082e
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -0,0 +1,206 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0274-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0274-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From be9561d2e1f176c400ddcffb2b3d5fb533e0da42 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 274/303] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 274/305] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 227b2d67082e3..0a35c013f6df4 100644
+index 227b2d67082e..0a35c013f6df 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -8,9 +8,9 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0275-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0275-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 839d585114e00d922c1839cbc3322f0c3303da23 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 275/303] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 275/305] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 0a35c013f6df4..55c3b8d7bc458 100644
+index 0a35c013f6df..55c3b8d7bc45 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -22,7 +22,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0276-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0276-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From 28653ae81be1190eccaa955214047f4f66895aa7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 276/303] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 276/305] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/lib/Makefile b/arch/mips/lib/Makefile
-index 5d5b993cbc2bf..b5532bab9337b 100644
+index 5d5b993cbc2b..b5532bab9337 100644
 --- a/arch/mips/lib/Makefile
 +++ b/arch/mips/lib/Makefile
 @@ -10,6 +10,7 @@ lib-y	+= bitops.o csum_partial.o delay.o memcpy.o memset.o \

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0277-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0277-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From c9c6b901ef9b5455c6a5791c3a0db9e9214e5bcb Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 277/303] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 277/305] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memcpy.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index f6a1fd6cb736e..9783e54388902 100644
+index f6a1fd6cb736..9783e5438890 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,7 +5,7 @@
@@ -31,7 +31,7 @@ index f6a1fd6cb736e..9783e54388902 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
 new file mode 100644
-index 0000000000000..28b785363351c
+index 000000000000..28b785363351
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -0,0 +1,506 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0278-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0278-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 9d147f882915998a1da49a6bd4512753f9e76bff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 278/303] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 278/305] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 28b785363351c..4c0b6b8474f04 100644
+index 28b785363351..4c0b6b8474f0 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -37,13 +37,13 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0279-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0279-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 20b84e82bbdc4bd7abc8e18787f78673b982e325 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 279/303] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 279/305] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 4c0b6b8474f04..2021e75d5dd2e 100644
+index 4c0b6b8474f0..2021e75d5dd2 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -29,9 +29,9 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0280-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0280-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From cfa0e2f37278cf292988dbe3ff2c6cf53928b105 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 280/303] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 280/305] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index af0cf50feefe4..b90cdaf937572 100644
+index af0cf50feefe..b90cdaf93757 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -1338,6 +1338,7 @@ config CPU_LOONGSON64

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0281-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0281-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From c7d75f4219a2bedfbe03941110abba3bd506ec55 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 281/303] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 281/305] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 2021e75d5dd2e..c5dd2e2866c3c 100644
+index 2021e75d5dd2..c5dd2e2866c3 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -119,8 +119,10 @@ LEAF(memcpy)				/* a0=dst a1=src a2=len */

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0282-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0282-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From dc3aa049f6cf7641b81dc80670ffd2e13755cc10 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 282/303] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 282/305] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index 8237972174048..75c23e6df8309 100644
+index 823797217404..75c23e6df830 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -542,12 +542,12 @@ config SPI_LM70_LLP

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0283-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0283-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 440ddaf596e721068d7ab0cb1bdbb95c6ff32e3a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 283/303] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 283/305] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index b90cdaf937572..2b3abafaa2c28 100644
+index b90cdaf93757..2b3abafaa2c2 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2110,9 +2110,9 @@ config ZBOOT_LOAD_ADDRESS

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0284-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0284-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From f1d2dfc8744da3370f363099a158be80d5512471 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 284/303] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 284/305] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index d3755b2264bdf..387afe58c5dc5 100644
+index d3755b2264bd..387afe58c5dc 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -945,6 +945,7 @@ config NUMA_BALANCING

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0285-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0285-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From bb06de10a8264f6131517da73be44e32f393b800 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 285/303] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 285/305] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/lib/audit.c b/lib/audit.c
-index 738bda22dd39b..5f68998fdaf60 100644
+index 738bda22dd39..5f68998fdaf6 100644
 --- a/lib/audit.c
 +++ b/lib/audit.c
 @@ -29,6 +29,7 @@ static unsigned signal_class[] = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0286-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0286-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From 8a5a6a904e352e3ffd93626b1ef0fb63e1492814 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 286/303] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 286/305] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 10 deletions(-)
 
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index 1c054e3096db8..ba83d3fb0a848 100644
+index 1c054e3096db..ba83d3fb0a84 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,14 +64,4 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0287-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0287-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From aacc0cba9761a79d4e3571305f2d172a2cbd1afd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 287/303] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 287/305] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index b501ea16ccd40..63bfa241b3aa5 100644
+index b501ea16ccd4..63bfa241b3aa 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,6 +6,9 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0288-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0288-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From af923d197bab2c441351c4786b54f9f238dfba9c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 288/303] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 288/305] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 553ca3b363a8b..61242a9810e4f 100644
+index 553ca3b363a8..61242a9810e4 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -622,7 +622,9 @@ static void __init bootcmdline_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0289-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0289-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 8b4647b586a1c0ec87019dba47e6e5c9b8051320 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 289/303] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 289/305] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 9783e54388902..04eba1ce8ff54 100644
+index 9783e5438890..04eba1ce8ff5 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0290-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0290-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From bf592f6c72dfcb3caf290f375514840084213068 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 290/303] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 290/305] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 87900054a1136..613a501143edc 100644
+index 87900054a113..613a501143ed 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,7 +74,6 @@
@@ -27,7 +27,7 @@ index 87900054a1136..613a501143edc 100644
  
  #define PCI_DEVICE_ID_MOXA_CP102E	0x1024
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 8284f7744d1bc..81cf6593e3b7f 100644
+index 8284f7744d1b..81cf6593e3b7 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2593,6 +2593,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0291-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0291-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From 2d0be778b98bee0dc0195cdc09bc260d0deea733 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 291/303] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 291/305] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of
@@ -51,7 +51,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 581ae20c46e4b..346f0e49bb2ea 100644
+index 581ae20c46e4..346f0e49bb2e 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,6 +185,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0292-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0292-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From 5e4da4e5d450f215116159d9cea5d3d12ebb0576 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 292/303] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 292/305] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 346f0e49bb2ea..92aa8e1364c31 100644
+index 346f0e49bb2e..92aa8e1364c3 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,7 +185,9 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0293-LOONGARCH64-BACKPORT-FROMEXT-loongarch-debug.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0293-LOONGARCH64-BACKPORT-FROMEXT-loongarch-debug.patch.loongarch64
@@ -1,7 +1,7 @@
 From 9c7e74241e9938109ef828dd82542fb1f6c70652 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Mon, 11 Mar 2024 00:14:58 +0800
-Subject: [PATCH 293/303] LOONGARCH64: BACKPORT: FROMEXT: loongarch debug
+Subject: [PATCH 293/305] LOONGARCH64: BACKPORT: FROMEXT: loongarch debug
 
 Signed-off-by: shangyatsen <429839446@qq.com>
 Link: https://github.com/FanFansfan/loongson-linux/commit/22c55ab3931c32410a077b3ddb6dca3f28223360
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  11 files changed, 34 insertions(+), 30 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index 192e571348f6b..fe12e4b3d9cd4 100644
+index 192e571348f6..fe12e4b3d9cd 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -52,7 +52,7 @@
@@ -38,7 +38,7 @@ index 192e571348f6b..fe12e4b3d9cd4 100644
  #define RING_START_UDW(base)			XE_REG((base) + 0x48)
  
 diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
-index 8acc4640f0a28..b7e24fa9f4625 100644
+index 8acc4640f0a2..b7e24fa9f462 100644
 --- a/drivers/gpu/drm/xe/xe_bo.c
 +++ b/drivers/gpu/drm/xe/xe_bo.c
 @@ -1297,7 +1297,7 @@ struct xe_bo *___xe_bo_create_locked(struct xe_device *xe, struct xe_bo *bo,
@@ -88,7 +88,7 @@ index 8acc4640f0a28..b7e24fa9f4625 100644
  	if (resv) {
  		ctx.allow_res_evict = !(flags & XE_BO_FLAG_NO_RESV_EVICT);
 diff --git a/drivers/gpu/drm/xe/xe_ggtt.c b/drivers/gpu/drm/xe/xe_ggtt.c
-index ff19eca5d358b..938973e780557 100644
+index ff19eca5d358..938973e78055 100644
 --- a/drivers/gpu/drm/xe/xe_ggtt.c
 +++ b/drivers/gpu/drm/xe/xe_ggtt.c
 @@ -68,7 +68,7 @@ static u64 xelp_ggtt_pte_encode_bo(struct xe_bo *bo, u64 bo_offset,
@@ -101,7 +101,7 @@ index ff19eca5d358b..938973e780557 100644
  
  	if (xe_bo_is_vram(bo) || xe_bo_is_stolen_devmem(bo))
 diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
-index 52df28032a6ff..f9890a03ffb04 100644
+index 52df28032a6f..f9890a03ffb0 100644
 --- a/drivers/gpu/drm/xe/xe_guc.c
 +++ b/drivers/gpu/drm/xe/xe_guc.c
 @@ -78,7 +78,7 @@ static u32 guc_ctl_feature_flags(struct xe_guc *guc)
@@ -123,7 +123,7 @@ index 52df28032a6ff..f9890a03ffb04 100644
  
  	return flags;
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index e144fd41c0a76..83e95abfe80be 100644
+index e144fd41c0a7..83e95abfe80b 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -139,7 +139,7 @@ static size_t guc_ads_regset_size(struct xe_guc_ads *ads)
@@ -208,7 +208,7 @@ index e144fd41c0a76..83e95abfe80be 100644
  
  		xe_map_memcpy_to(xe, ads_to_map(ads), offset,
 diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
-index cd6a5f09d631e..afd2fca3f07ee 100644
+index cd6a5f09d631..afd2fca3f07e 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ct.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ct.c
 @@ -173,7 +173,7 @@ int xe_guc_ct_init(struct xe_guc_ct *ct)
@@ -221,7 +221,7 @@ index cd6a5f09d631e..afd2fca3f07ee 100644
  	ct->g2h_wq = alloc_ordered_workqueue("xe-g2h-wq", 0);
  	if (!ct->g2h_wq)
 diff --git a/drivers/gpu/drm/xe/xe_guc_log.c b/drivers/gpu/drm/xe/xe_guc_log.c
-index 50851638003b9..86414093c5a27 100644
+index 50851638003b..86414093c5a2 100644
 --- a/drivers/gpu/drm/xe/xe_guc_log.c
 +++ b/drivers/gpu/drm/xe/xe_guc_log.c
 @@ -48,7 +48,7 @@ static size_t guc_log_size(void)
@@ -234,7 +234,7 @@ index 50851638003b9..86414093c5a27 100644
  }
  
 diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
-index 034b29984d5ed..89ed21a074cd6 100644
+index 034b29984d5e..89ed21a074cd 100644
 --- a/drivers/gpu/drm/xe/xe_guc_pc.c
 +++ b/drivers/gpu/drm/xe/xe_guc_pc.c
 @@ -955,7 +955,7 @@ int xe_guc_pc_start(struct xe_guc_pc *pc)
@@ -256,7 +256,7 @@ index 034b29984d5ed..89ed21a074cd6 100644
  
  	if (xe->info.skip_guc_pc)
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index 6431697c61693..ce7c0d87f9a08 100644
+index 6431697c6169..ce7c0d87f9a0 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
 @@ -593,7 +593,7 @@ static void emit_pte(struct xe_migrate *m,
@@ -287,7 +287,7 @@ index 6431697c61693..ce7c0d87f9a08 100644
  
  	while (size) {
 diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
-index 6fec5d1a1eb44..3944529703a9b 100644
+index 6fec5d1a1eb4..3944529703a9 100644
 --- a/drivers/gpu/drm/xe/xe_query.c
 +++ b/drivers/gpu/drm/xe/xe_query.c
 @@ -344,7 +344,7 @@ static int query_config(struct xe_device *xe, struct drm_xe_device_query *query)
@@ -300,7 +300,7 @@ index 6fec5d1a1eb44..3944529703a9b 100644
  	config->info[DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY] =
  		xe_exec_queue_device_get_max_priority(xe);
 diff --git a/drivers/gpu/drm/xe/xe_vm.c b/drivers/gpu/drm/xe/xe_vm.c
-index de257a032225f..50a3f27b71d0f 100644
+index de257a032225..50a3f27b71d0 100644
 --- a/drivers/gpu/drm/xe/xe_vm.c
 +++ b/drivers/gpu/drm/xe/xe_vm.c
 @@ -19,6 +19,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0294-LOONGARCH64-AOSCOS-more-fixes-for-Xe-on-LoongArch.patch.loongarch64
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0294-LOONGARCH64-AOSCOS-more-fixes-for-Xe-on-LoongArch.patch.loongarch64
@@ -1,7 +1,7 @@
 From 156de5e3545207346cdd66705eddb7f5446ff6c8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 14 Oct 2024 06:58:21 +0800
-Subject: [PATCH 294/303] LOONGARCH64: AOSCOS: more fixes for Xe on LoongArch
+Subject: [PATCH 294/305] LOONGARCH64: AOSCOS: more fixes for Xe on LoongArch
 
 More fixes based on the previous patch.
 
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index 83e95abfe80be..a934bff07161b 100644
+index 83e95abfe80b..a934bff07161 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -144,7 +144,7 @@ static size_t guc_ads_golden_lrc_size(struct xe_guc_ads *ads)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0295-dt-bindings-gpio-loongson-Add-new-loongson-gpio-chip.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0295-dt-bindings-gpio-loongson-Add-new-loongson-gpio-chip.patch
@@ -1,7 +1,7 @@
 From 000b971660eb4860a664ae3f05c78dd83da24c89 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:51 +0800
-Subject: [PATCH 295/303] dt-bindings: gpio: loongson: Add new loongson gpio
+Subject: [PATCH 295/305] dt-bindings: gpio: loongson: Add new loongson gpio
  chip compatible
 
 Add the devicetree compatibles for Loongson-7A2000 and Loongson-3A6000
@@ -13,7 +13,7 @@ Signed-off-by: Binbin Zhou <zhoubinbin@loongson.cn>
  1 file changed, 3 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml b/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
-index cf3b1b270aa89..b68159600e2bd 100644
+index cf3b1b270aa8..b68159600e2b 100644
 --- a/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
 +++ b/Documentation/devicetree/bindings/gpio/loongson,ls-gpio.yaml
 @@ -20,7 +20,10 @@ properties:

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0296-gpio-loongson-64bit-Add-more-gpio-chip-support.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0296-gpio-loongson-64bit-Add-more-gpio-chip-support.patch
@@ -1,7 +1,7 @@
 From 393957edf3f5622d523bde5b936687de4094a810 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:52 +0800
-Subject: [PATCH 296/303] gpio: loongson-64bit: Add more gpio chip support
+Subject: [PATCH 296/305] gpio: loongson-64bit: Add more gpio chip support
 
 The Loongson-7A2000 and Loongson-3A6000 share the same gpio chip model.
 Just add them through driver_data.
@@ -12,7 +12,7 @@ Signed-off-by: Binbin Zhou <zhoubinbin@loongson.cn>
  1 file changed, 51 insertions(+)
 
 diff --git a/drivers/gpio/gpio-loongson-64bit.c b/drivers/gpio/gpio-loongson-64bit.c
-index 7f4d78fd800e7..7b0738fd4a24f 100644
+index 7f4d78fd800e..7b0738fd4a24 100644
 --- a/drivers/gpio/gpio-loongson-64bit.c
 +++ b/drivers/gpio/gpio-loongson-64bit.c
 @@ -258,6 +258,33 @@ static const struct loongson_gpio_chip_data loongson_gpio_ls7a_data = {

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0297-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0297-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 5df30e99dbe44d553e1d6a6b97f19f52fd8b30c8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 297/303] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 297/305] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index afa89f7aada60..830816cdab4f1 100644
+index afa89f7aada6..830816cdab4f 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3490,7 +3490,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0298-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0298-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
 From 58c478c079c72d367aa80f7aed6c4004121c8b05 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 298/303] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 298/305] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 10 insertions(+)
 
 diff --git a/drivers/acpi/acpica/evglock.c b/drivers/acpi/acpica/evglock.c
-index 989dc01af03fb..bc205b3309043 100644
+index 989dc01af03f..bc205b330904 100644
 --- a/drivers/acpi/acpica/evglock.c
 +++ b/drivers/acpi/acpica/evglock.c
 @@ -42,6 +42,10 @@ acpi_status acpi_ev_init_global_lock_handler(void)
@@ -36,7 +36,7 @@ index 989dc01af03fb..bc205b3309043 100644
  
  	status = acpi_install_fixed_event_handler(ACPI_EVENT_GLOBAL,
 diff --git a/include/acpi/acpixf.h b/include/acpi/acpixf.h
-index 78b24b0904888..a799bc8d25ff3 100644
+index 78b24b090488..a799bc8d25ff 100644
 --- a/include/acpi/acpixf.h
 +++ b/include/acpi/acpixf.h
 @@ -213,6 +213,12 @@ ACPI_INIT_GLOBAL(u8, acpi_gbl_osi_data, 0);

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0299-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0299-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
 From 2a5a130c6f96ea91406558f42a7976e917a7b302 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 299/303] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 299/305] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index f71b2c77dbd12..61f00ff77f9e5 100644
+index f71b2c77dbd1..61f00ff77f9e 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -357,6 +357,7 @@ void __init platform_init(void)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0300-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0300-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
@@ -1,7 +1,7 @@
 From 4002dd825dcd8da049c70db283488f24d33c2249 Mon Sep 17 00:00:00 2001
 From: Qunqin Zhao <zhaoqunqin@loongson.cn>
 Date: Tue, 1 Apr 2025 17:41:54 +0800
-Subject: [PATCH 300/303] LOONGSON: input: atkbd: do not init atkbd_reset
+Subject: [PATCH 300/305] LOONGSON: input: atkbd: do not init atkbd_reset
  variable to true on Loongson
 
 The keyboard will not be confused on Loongson platform, so do not need a
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 174602f0b4d25..fbca34028973e 100644
+index 174602f0b4d2..fbca34028973 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -37,7 +37,7 @@ static int atkbd_set = 2;

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0301-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0301-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
@@ -1,7 +1,7 @@
 From 3b2811cc4bbf65f4e7c518e3db87c05281e702f9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 22 Apr 2025 14:17:54 +0800
-Subject: [PATCH 301/303] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
+Subject: [PATCH 301/305] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
  RTL8723BE with subsystem ID 11ad:1723
 
 RTL8723BE found on some ASUSTek laptops, such as F441U and X555UQ with
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 insertions(+)
 
 diff --git a/drivers/net/wireless/realtek/rtlwifi/pci.c b/drivers/net/wireless/realtek/rtlwifi/pci.c
-index 0eafc4d125f91..898f597f70a96 100644
+index 0eafc4d125f9..898f597f70a9 100644
 --- a/drivers/net/wireless/realtek/rtlwifi/pci.c
 +++ b/drivers/net/wireless/realtek/rtlwifi/pci.c
 @@ -155,6 +155,16 @@ static void _rtl_pci_update_default_setting(struct ieee80211_hw *hw)

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0303-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0303-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
@@ -1,7 +1,7 @@
 From e6953035f85c184941b50c48e188535cf71c6929 Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Mon, 26 May 2025 04:18:07 +0800
-Subject: [PATCH 303/303] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
+Subject: [PATCH 303/305] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
  usleep_range() for EC polling
 
 It was reported that ideapad-laptop sometimes causes some recent (since
@@ -60,7 +60,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/ideapad-laptop.c b/drivers/platform/x86/ideapad-laptop.c
-index bdb4cbee42058..93aa72bff3f00 100644
+index bdb4cbee4205..93aa72bff3f0 100644
 --- a/drivers/platform/x86/ideapad-laptop.c
 +++ b/drivers/platform/x86/ideapad-laptop.c
 @@ -15,6 +15,7 @@

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0304-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0304-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
@@ -1,0 +1,41 @@
+From e9991d9451a9477c89f70593f6393ca628dc38f9 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:50 +0000
+Subject: [PATCH 304/305] BACKPORT: FROMLIST: platform/loongarch: laptop: Get
+ brightness setting from EC on probe
+
+Previously 1 is unconditionally taken as current brightness value. This
+causes problems since it's required to restore brightness settings on
+resumption, and a value that doesn't match EC's state before suspension
+will cause surprising changes of screen brightness.
+
+Let's get brightness from EC and take it as the current brightness on
+probe of the laptop driver to avoid the surprising behavior. Tested on
+TongFang L860-T2 3A5000 laptop.
+
+Cc: stable@vger.kernel.org
+Fixes: 6246ed09111f ("LoongArch: Add ACPI-based generic laptop driver")
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 99203584949d..828bd62e3596 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -392,7 +392,7 @@ static int laptop_backlight_register(void)
+ 	if (!acpi_evalf(hotkey_handle, &status, "ECLL", "d"))
+ 		return -EIO;
+ 
+-	props.brightness = 1;
++	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel-lts/autobuild/patches/0305-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
+++ b/runtime-kernel/linux-kernel-lts/autobuild/patches/0305-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
@@ -1,0 +1,118 @@
+From e3661a2104851ca495cbf06d21b2624785d6d307 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:51 +0000
+Subject: [PATCH 305/305] BACKPORT: FROMLIST: platform/loongarch: laptop:
+ Support backlight power control
+
+loongson_laptop_turn_{on,off}_backlight() are designed for controlling
+power of the backlight, but they aren't really used in the driver
+previously.
+
+Unify these two functions since they only differ in arguments passed to
+ACPI method, and wire up loongson_laptop_backlight_update() to update
+power state of the backlight as well. Tested on TongFang L860-T2 3A5000
+laptop.
+
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 53 +++++++-------------
+ 1 file changed, 19 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 828bd62e3596..f01e53b1c84d 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -56,8 +56,6 @@ static struct input_dev *generic_inputdev;
+ static acpi_handle hotkey_handle;
+ static struct key_entry hotkey_keycode_map[GENERIC_HOTKEY_MAP_MAX];
+ 
+-int loongson_laptop_turn_on_backlight(void);
+-int loongson_laptop_turn_off_backlight(void);
+ static int loongson_laptop_backlight_update(struct backlight_device *bd);
+ 
+ /* 2. ACPI Helpers and device model */
+@@ -354,6 +352,22 @@ static int ec_backlight_level(u8 level)
+ 	return level;
+ }
+ 
++static int ec_backlight_set_power(bool state)
++{
++	int status;
++	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
++	struct acpi_object_list args = { 1, &arg0 };
++
++	arg0.integer.value = state;
++	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
++	if (ACPI_FAILURE(status)) {
++		pr_info("Loongson lvds error: 0x%x\n", status);
++		return -EIO;
++	}
++
++	return 0;
++}
++
+ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ {
+ 	int lvl = ec_backlight_level(bd->props.brightness);
+@@ -363,6 +377,8 @@ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ 	if (ec_set_brightness(lvl))
+ 		return -EIO;
+ 
++	ec_backlight_set_power(bd->props.power == BACKLIGHT_POWER_ON ? true : false);
++
+ 	return 0;
+ }
+ 
+@@ -394,6 +410,7 @@ static int laptop_backlight_register(void)
+ 
+ 	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
++	props.power = BACKLIGHT_POWER_ON;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+ 	backlight_device_register("loongson_laptop",
+@@ -402,38 +419,6 @@ static int laptop_backlight_register(void)
+ 	return 0;
+ }
+ 
+-int loongson_laptop_turn_on_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 1;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+-int loongson_laptop_turn_off_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 0;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+ static int __init event_init(struct generic_sub_driver *sub_driver)
+ {
+ 	int ret;
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel-lts/spec
+++ b/runtime-kernel/linux-kernel-lts/spec
@@ -4,7 +4,7 @@ VER=6.12.31
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=2
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 

--- a/topics/linux-kernel-lts-6.12.31-loongarch-fixes.toml
+++ b/topics/linux-kernel-lts-6.12.31-loongarch-fixes.toml
@@ -1,0 +1,12 @@
+security = false
+
+[name]
+default = "Linux Kernel (Longterm Maintenance), 6.12.29 (revision 2)"
+zh_CN = "Linux 内核（长期维护版本），版本 6.12.29（修订 2）"
+
+[caution]
+default = "Fixes an issue where display brightness on Loongson 3A5000/6000-based laptops may be reset to the lowest upon wakeup from S3 suspend"
+zh_CN = "修复基于龙芯 3A5000/3A6000 的笔记本从 S3 睡眠唤醒时，屏幕背光亮度可能被复位为最低的问题"
+
+[packages]
+"linux-kernel-lts-6.12.31" = "6.12.31-2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add linux-kernel-lts-6.12.31-loongarch-fixes.toml
- linux-kernel-lts: backport fixes for LoongArch
    - Introduce fixes for Loongson 3A5000/3A6000 laptop backlight.
    - Track patches at AOSC-Tracking/linux @ aosc/v6.12.31
    \(HEAD: e3661a2104851ca495cbf06d21b2624785d6d307\).

Package(s) Affected
-------------------

- linux-kernel-lts-${__VER}: 6.12.31-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-lts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
