### PR TITLE
aosc-community-wallpapers: update to 2025.05.2

### DIFF
--- a/desktop-themes/aosc-community-wallpapers-extras-2024/spec
+++ b/desktop-themes/aosc-community-wallpapers-extras-2024/spec
@@ -1,4 +1,4 @@
-VER=2024.04.1
+VER=2024.04.4
 SRCS="git::commit=tags/extras-$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2025.05.1
+VER=2025.05.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-community-wallpapers-extras-2024: update to 2024.04.4
- aosc-community-wallpapers: update to 2025.05.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aosc-community-wallpapers: 1:2025.05.2
- aosc-community-wallpapers-extras-2024: 1:2024.04.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-community-wallpapers aosc-community-wallpapers-extras-2024
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
