### PR TITLE
inkscape: add missing tinycss2 dependency

### DIFF
--- a/app-creativity/inkscape/autobuild/defines
+++ b/app-creativity/inkscape/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=graphics
 PKGDEP="desktop-file-utils gc gnome-vfs gsl gtkmm gtkspell hicolor-icon-theme \
         imagemagick libcdr libxslt lxml murrine numpy poppler popt python-3 \
         libsoup libwpg libvisio openjpeg potrace scour double-conversion \
-        gtkmm-3 gdlmm"
+        gtkmm-3 gdlmm tinycss2"
 BUILDDEP="boost cmake intltool dos2unix"
 PKGSUG="texlive"
 PKGDES="Vector graphics editor using the SVG file format"

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=1_4_1
 VER=${UPSTREAM_VER//_/.}
-REL=3
+REL=4
 SRCS="git::commit=tags/INKSCAPE_${UPSTREAM_VER}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"


### PR DESCRIPTION
Topic Description
-----------------

- inkscape: add missing tinycss2 dependency
    Without tinycss2 installed, Inkscape would crash when attempting to create
    a new document from the "Seamless Pattern" template.

Package(s) Affected
-------------------

- inkscape: 1.4.1-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit inkscape
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
