### PR TITLE
Orphans Cleanup (June 1st, 2025, part 2)

### DIFF
--- a/app-network/scapy/autobuild/defines
+++ b/app-network/scapy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=scapy
 PKGSEC=net
 PKGDEP="tcpdump python-3"
-PKGSUG="pycryptodome pyx python-gnuplot graphviz sox"
+PKGSUG="pycryptodome pyx python-matplotlib graphviz sox"
 BUILDDEP="python-build python-installer wheel"
 PKGDES="An interactive packet manipulation program"
 

--- a/app-network/scapy/autobuild/defines
+++ b/app-network/scapy/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=scapy
 PKGSEC=net
-PKGDEP="tcpdump python-2"
+PKGDEP="tcpdump python-3"
 PKGSUG="pycryptodome pyx python-gnuplot graphviz sox"
 BUILDDEP="python-build python-installer wheel"
 PKGDES="An interactive packet manipulation program"

--- a/app-network/scapy/spec
+++ b/app-network/scapy/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
-SRCS="tbl::https://github.com/secdev/scapy/archive/v$VER.tar.gz"
-CHKSUMS="sha256::5669fdf6a11b6ef7400716690016ffb9dcb6d984d560a63b87c7fad082ff6c3c"
+VER=2.6.1
+SRCS="git::commit=tags/v${VER}::https://github.com/secdev/scapy.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=115624"

--- a/app-utils/udiskie/autobuild/defines
+++ b/app-utils/udiskie/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=udiskie
 PKGSEC=utils
 PKGDES="A GUI frontend for UDisks-2"
-PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd python-keyutils"
+PKGDEP="python-3 docopt libappindicator pyyaml pygobject-3 libnotify udisks-2 polkit systemd"
 BUILDDEP="asciidoc"
 
 NOPYTHON2=1

--- a/app-utils/udiskie/spec
+++ b/app-utils/udiskie/spec
@@ -1,4 +1,4 @@
-VER=2.5.3
+VER=2.5.7
 SRCS="git::commit=tags/v$VER::https://github.com/coldfix/udiskie"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7187"

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -530,7 +530,6 @@ lang-python/python-dbusmock
 lang-python/python-djvulibre
 lang-python/python-gflags
 lang-python/python-hglib
-lang-python/python-keyutils
 lang-python/python-lz4
 lang-python/python-pam
 lang-python/python-systemd

--- a/lang-python/python-gnuplot/autobuild/defines
+++ b/lang-python/python-gnuplot/autobuild/defines
@@ -1,9 +1,0 @@
-ABTYPE=python
-PKGNAME=python-gnuplot
-PKGSEC=python
-PKGDEP="python-2 numpy gnuplot"
-PKGDES="Plot graphs with Gnuplot"
-
-NOPYTHON3=1
-ABTYPE=python
-ABHOST=noarch

--- a/lang-python/python-gnuplot/spec
+++ b/lang-python/python-gnuplot/spec
@@ -1,5 +1,0 @@
-VER=1.8
-REL=4
-SRCS="tbl::https://sourceforge.net/projects/gnuplot-py/files/Gnuplot-py/$VER/gnuplot-py-$VER.tar.gz"
-CHKSUMS="sha256::ab339be7847d30a8acfd616f27b5021bfde0999b7bf2d68400fbe62c53106e21"
-CHKUPDATE="anitya::id=15158"

--- a/lang-python/python-keyutils/autobuild/defines
+++ b/lang-python/python-keyutils/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=python-keyutils
-PKGSEC=python
-PKGDEP="python-3 keyutils"
-PKGDES="A python binding library of keyutils"
-
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/python-keyutils/spec
+++ b/lang-python/python-keyutils/spec
@@ -1,5 +1,0 @@
-VER=0.6
-SRCS="tbl::https://github.com/sassoftware/python-keyutils/archive/${VER}.tar.gz"
-CHKSUMS="sha256::f69e6cadc50525dcb117714e440ee6579b0e5b7f12910b2bb2e910b236a2b18b"
-CHKUPDATE="anitya::id=15167"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- python-gnuplot: drop, orphaned
- scapy: update to 2.6.1
- scapy: fix python3 dependency
- python-keyutils: drop, orphaned
- udiskie: update to 2.5.7
- udiskie: remove unused python-keyutils dependency

Package(s) Affected
-------------------

- scapy: 2.6.1
- udiskie: 2.5.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit scapy udiskie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
