### PR TITLE
msmtp: update to 1.8.29

### DIFF
--- a/app-web/msmtp/spec
+++ b/app-web/msmtp/spec
@@ -1,4 +1,4 @@
-VER=1.8.28
+VER=1.8.29
 SRCS="tbl::https://marlam.de/msmtp/releases/msmtp-${VER}.tar.xz"
-CHKSUMS="sha256::3a57f155f54e4860f7dd42138d9bea1af615b99dfab5ab4cd728fc8c09a647a4"
+CHKSUMS="sha256::13a78f3c6034b33008a7f2474fdddd0deaf7db6da89d0791d3d75eae721220d7"
 CHKUPDATE="anitya::id=2024"


### PR DESCRIPTION
Topic Description
-----------------

- msmtp: update to 1.8.29
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- msmtp: 1.8.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit msmtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
