### PR TITLE
jq: update to 1.8.0

### DIFF
--- a/app-devel/jq/autobuild/defines
+++ b/app-devel/jq/autobuild/defines
@@ -2,3 +2,9 @@ PKGNAME=jq
 PKGSEC=devel
 PKGDEP="onig"
 PKGDES="Command-line JSON processor"
+
+ABTYPE=autotools
+# NOTE: As suggested by upstream, preventing version string being regenerated
+# (and resulting in a missing version string)
+# Link: https://github.com/jqlang/jq?tab=readme-ov-file#building-from-source.
+RECONF=0

--- a/app-devel/jq/autobuild/patch
+++ b/app-devel/jq/autobuild/patch
@@ -1,4 +1,0 @@
-for i in autobuild/patches/CVE*.patch; do
-    abinfo "Applying $i ..."
-    patch -Np2 -i $i
-done

--- a/app-devel/jq/spec
+++ b/app-devel/jq/spec
@@ -1,4 +1,4 @@
-VER=1.7.1
-SRCS="tbl::https://github.com/stedolan/jq/archive/jq-$VER.tar.gz"
-CHKSUMS="sha256::fc75b1824aba7a954ef0886371d951c3bf4b6e0a921d1aefc553f309702d6ed1"
+VER=1.8.0
+SRCS="tbl::https://github.com/jqlang/jq/releases/download/jq-$VER/jq-$VER.tar.gz"
+CHKSUMS="sha256::91811577f91d9a6195ff50c2bffec9b72c8429dc05ec3ea022fd95c06d2b319c"
 CHKUPDATE="anitya::id=13252"


### PR DESCRIPTION
Topic Description
-----------------

- jq: update to 1.8.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- jq: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit jq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
