### PR TITLE
libcamera: add gtest build dep and introduce stage2 recipe

### DIFF
--- a/runtime-devices/libcamera/autobuild/defines.stage2
+++ b/runtime-devices/libcamera/autobuild/defines.stage2
@@ -2,7 +2,7 @@ PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
-        elfutils libunwind gstreamer glib gnutls qt-6 openssl"
+        elfutils libunwind gstreamer glib gnutls openssl"
 BUILDDEP="doxygen jinja2 ply pyyaml sphinx texlive graphviz gtest"
 
 PKGBREAK="pipewire<=1.4.1"
@@ -20,7 +20,7 @@ MESON_AFTER=(
     '-Dlc-compliance=enabled'
     '-Dpipelines=auto'
     '-Dpycamera=disabled'
-    '-Dqcam=enabled'
+    '-Dqcam=disabled'
     '-Dtest=false'
     '-Dtracing=enabled'
     '-Dudev=enabled'

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,5 @@
 VER=0.5.0
+REL=1
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: add gtest build dep and introduce stage2 recipe
    libcamera and qt-6 forms a dependency loop, introduce a stage2 recipe to
    work around this.

Package(s) Affected
-------------------

- libcamera: 0.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
