### PR TITLE
libieee1284: fix build with Python 3

### DIFF
--- a/runtime-devices/libieee1284/autobuild/defines
+++ b/runtime-devices/libieee1284/autobuild/defines
@@ -1,6 +1,4 @@
 PKGNAME=libieee1284
 PKGSEC=libs
-PKGDEP="python-2"
-PKGDES="A library to query devices connected in parallel port"
-
-RECONF=0
+PKGDEP="python-3"
+PKGDES="Library to handle devices connected in parallel port"

--- a/runtime-devices/libieee1284/autobuild/patches/0001-2009-11-13-Tim-Waugh-twaugh-redhat.com.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0001-2009-11-13-Tim-Waugh-twaugh-redhat.com.patch
@@ -1,0 +1,205 @@
+From 93458c2ccdc989f017c967842e988ab0f3b4d0d0 Mon Sep 17 00:00:00 2001
+From: Tim Waugh <twaugh@redhat.com>
+Date: Fri, 13 Nov 2009 13:23:34 +0000
+Subject: [PATCH 1/6] 2009-11-13  Tim Waugh  <twaugh@redhat.com>
+
+* Applied NetBSD support patch from Jacques Pelletier.
+---
+ ChangeLog       |  4 ++++
+ configure.in    |  3 +++
+ src/access.h    |  4 ++++
+ src/access_io.c | 27 +++++++++++++++++++++++++--
+ src/detect.c    | 11 +++++++++++
+ src/ports.c     | 14 +++++++++++++-
+ 6 files changed, 60 insertions(+), 3 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 6c65c5f..af430ae 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,7 @@
++2009-11-13  Tim Waugh  <twaugh@redhat.com>
++
++	* Applied NetBSD support patch from Jacques Pelletier.
++
+ 2007-09-18  Tim Waugh  <twaugh@redhat.com>
+ 
+ 	* configure.in: Version 0.2.11 (stable).
+diff --git a/configure.in b/configure.in
+index a22fe97..a67542a 100644
+--- a/configure.in
++++ b/configure.in
+@@ -33,6 +33,9 @@ case "{$host}" in
+ *86-*-freebsd* | *86-*-kfreebsd*)
+         AC_DEFINE(HAVE_FBSD_I386,1,enable FreeBSD /dev/io access)
+ ;;
++*86-*-netbsd*)
++        AC_DEFINE(HAVE_NBSD_I386,1,enable NetBSD i386 ioperm access)
++;;
+ *86-*-solaris*)
+         AC_DEFINE(HAVE_SOLARIS,1,enable solaris iop access)
+ 	solaris_io=true
+diff --git a/src/access.h b/src/access.h
+index e61a6a4..c62da03 100644
+--- a/src/access.h
++++ b/src/access.h
+@@ -61,6 +61,10 @@ delay (int which)
+ #endif
+ }
+ 
++#if defined(HAVE_NBSD_I386)
++void netbsd_ioport(int port);
++#endif
++
+ /*
+  * Local Variables:
+  * eval: (c-set-style "gnu")
+diff --git a/src/access_io.c b/src/access_io.c
+index 43d75f2..974e68e 100644
+--- a/src/access_io.c
++++ b/src/access_io.c
+@@ -120,6 +120,25 @@ set_bitmap(unsigned long *bitmap, short base, short extent, int new_value)
+   }
+ }
+ 
++#elif defined(HAVE_NBSD_I386)
++#include <sys/syscall.h>
++#include <machine/sysarch.h>
++#include <machine/pio.h>
++
++/* netbsd_ioport(port)  permit access to an I/O port.
++ * port                 I/O address to enable
++ */
++void
++netbsd_ioport(int port) {
++  u_long iomap[32];
++  struct i386_set_ioperm_args ioperm;
++
++  ioperm.iomap = iomap;
++  syscall(SYS_sysarch, I386_GET_IOPERM, (char *) &ioperm);
++  iomap[port >> 5] &= ~(1 << (port & 0x1f));
++  syscall(SYS_sysarch, I386_SET_IOPERM, (char *) &ioperm);
++}
++
+ #endif
+ 
+ 
+@@ -127,7 +146,7 @@ static unsigned char
+ raw_inb (struct parport_internal *port, unsigned long addr)
+ {
+ #if (defined(HAVE_LINUX) && defined(HAVE_SYS_IO_H)) || defined(HAVE_CYGWIN_9X) \
+-	|| defined(HAVE_OBSD_I386) || defined(HAVE_FBSD_I386)
++	|| defined(HAVE_OBSD_I386) || defined(HAVE_FBSD_I386) || defined(HAVE_NBSD_i386)
+   return inb ((unsigned short)addr);
+ 
+ #elif defined(HAVE_SOLARIS)
+@@ -146,7 +165,7 @@ static void
+ raw_outb (struct parport_internal *port, unsigned char val, unsigned long addr)
+ {
+ #if (defined(HAVE_LINUX) && defined(HAVE_SYS_IO_H)) || defined(HAVE_CYGWIN_9X) \
+-	|| defined(HAVE_OBSD_I386) || defined(HAVE_FBSD_I386)
++	|| defined(HAVE_OBSD_I386) || defined(HAVE_FBSD_I386) || defined(HAVE_NBSD_i386)
+ #if defined(__i386__) || defined(__x86_64__) || defined(_MSC_VER)
+   outb_p (val, (unsigned short)addr);
+ #else
+@@ -234,6 +253,10 @@ init (struct parport *pport, int flags, int *capabilities)
+ 	}
+ 
+       free(iomap);
++#elif defined(HAVE_NBSD_I386)
++      netbsd_ioport(port->base);
++      netbsd_ioport(port->base +1);
++      netbsd_ioport(port->base +2);
+ #elif defined(HAVE_SOLARIS)
+       if((port->fd=open("/devices/pseudo/iop@0:iop", O_RDWR)) < 0)
+       {
+diff --git a/src/detect.c b/src/detect.c
+index a53ef19..5881754 100644
+--- a/src/detect.c
++++ b/src/detect.c
+@@ -46,6 +46,8 @@
+ #elif defined(HAVE_OBSD_I386)
+ /* for i386_get_ioperm and i386_set_ioperm */
+ #include <machine/sysarch.h>
++#elif defined(HAVE_NBSD_I386)
++#include "access.h"
+ #elif defined(HAVE_SOLARIS)
+ #include <sys/ddi.h>
+ #include <sys/sunddi.h>
+@@ -169,6 +171,15 @@ check_io (void)
+     close(fd);
+     return 1;
+   }
++
++  #elif defined(HAVE_NBSD_I386)
++/*
++    FIXME: how to test
++*/     
++    capabilities |= IO_CAPABLE;
++    debugprintf ("We can use I386_GET_IOPERM\n");
++    return 1;
++
+   #elif defined(HAVE_LINUX)
+   #ifdef HAVE_SYS_IO_H
+   if (ioperm (0x378 /* say */, 3, 1) == 0) {
+diff --git a/src/ports.c b/src/ports.c
+index f3c38f1..e1065c8 100644
+--- a/src/ports.c
++++ b/src/ports.c
+@@ -154,6 +154,7 @@ add_port (struct parport_list *list, int flags,
+   return 0;
+ }
+ 
++#ifdef __linux
+ static int
+ populate_from_parport (struct parport_list *list, int flags)
+ {
+@@ -229,7 +230,9 @@ populate_from_parport (struct parport_list *list, int flags)
+   return 0;
+ #endif
+ }
++#endif /* __linux */
+ 
++#ifdef __linux
+ static int
+ populate_from_sys_dev_parport (struct parport_list *list, int flags)
+ {
+@@ -319,6 +322,7 @@ populate_from_sys_dev_parport (struct parport_list *list, int flags)
+   return 0;
+ #endif
+ }
++#endif /* __linux */
+ 
+ static int
+ populate_nt_ports (struct parport_list *list, int flags)
+@@ -356,6 +360,11 @@ populate_by_guessing (struct parport_list *list, int flags)
+   add_port (list, flags, "0x378", "/dev/io", NULL, 0x378, 0, -1);
+   add_port (list, flags, "0x278", "/dev/io", NULL, 0x278, 0, -1);
+   add_port (list, flags, "0x3bc", "/dev/io", NULL, 0x3bc, 0, -1);
++#elif defined(HAVE_NBSD_I386)
++  /* FIXME Get the right names for NetBSD */
++  add_port (list, flags, "0x378", "/dev/port", NULL, 0x378, 0, -1);
++  add_port (list, flags, "0x278", "/dev/port", NULL, 0x278, 0, -1);
++  add_port (list, flags, "0x3bc", "/dev/port", NULL, 0x3bc, 0, -1);
+ #elif defined(HAVE_SOLARIS)
+   add_port (list, flags, "0x378", "/devices/pseudo/iop@0:iop", NULL, 0x378, 0, -1);
+   add_port (list, flags, "0x278", "/devices/pseudo/iop@0:iop", NULL, 0x278, 0, -1);
+@@ -376,11 +385,14 @@ ieee1284_find_ports (struct parport_list *list, int flags)
+     return E1284_NOMEM;
+ 
+   detect_environment (0);
++#ifdef __linux
+   if (capabilities & PROC_SYS_DEV_PARPORT_CAPABLE)
+     populate_from_sys_dev_parport (list, flags);
+   else if (capabilities & PROC_PARPORT_CAPABLE)
+     populate_from_parport (list, flags);
+-  else if (capabilities & LPT_CAPABLE)
++#else /* __linux */
++  if (capabilities & LPT_CAPABLE)
++#endif /* __linux */
+     populate_nt_ports (list, flags);
+   else 
+     populate_by_guessing (list, flags);
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/autobuild/patches/0002-2010-06-23-Tim-Waugh-twaugh-redhat.com.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0002-2010-06-23-Tim-Waugh-twaugh-redhat.com.patch
@@ -1,0 +1,79 @@
+From ddc3e02aec08f14fa2aedf1ea18b14116d2dd56e Mon Sep 17 00:00:00 2001
+From: Tim Waugh <twaugh@redhat.com>
+Date: Wed, 23 Jun 2010 11:54:51 +0000
+Subject: [PATCH 2/6] 2010-06-23  Tim Waugh  <twaugh@redhat.com>
+
+* src/ports.c: Fixed build.
+---
+ ChangeLog   |  4 ++++
+ src/ports.c | 14 +++++++-------
+ 2 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index af430ae..037e9c4 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,7 @@
++2010-06-23  Tim Waugh  <twaugh@redhat.com>
++
++	* src/ports.c: Fixed build.
++
+ 2009-11-13  Tim Waugh  <twaugh@redhat.com>
+ 
+ 	* Applied NetBSD support patch from Jacques Pelletier.
+diff --git a/src/ports.c b/src/ports.c
+index e1065c8..458d4f8 100644
+--- a/src/ports.c
++++ b/src/ports.c
+@@ -154,7 +154,7 @@ add_port (struct parport_list *list, int flags,
+   return 0;
+ }
+ 
+-#ifdef __linux
++#ifdef HAVE_LINUX
+ static int
+ populate_from_parport (struct parport_list *list, int flags)
+ {
+@@ -230,9 +230,9 @@ populate_from_parport (struct parport_list *list, int flags)
+   return 0;
+ #endif
+ }
+-#endif /* __linux */
++#endif /* HAVE_LINUX */
+ 
+-#ifdef __linux
++#ifdef HAVE_LINUX
+ static int
+ populate_from_sys_dev_parport (struct parport_list *list, int flags)
+ {
+@@ -322,7 +322,7 @@ populate_from_sys_dev_parport (struct parport_list *list, int flags)
+   return 0;
+ #endif
+ }
+-#endif /* __linux */
++#endif /* HAVE_LINUX */
+ 
+ static int
+ populate_nt_ports (struct parport_list *list, int flags)
+@@ -385,15 +385,15 @@ ieee1284_find_ports (struct parport_list *list, int flags)
+     return E1284_NOMEM;
+ 
+   detect_environment (0);
+-#ifdef __linux
++#ifdef HAVE_LINUX
+   if (capabilities & PROC_SYS_DEV_PARPORT_CAPABLE)
+     populate_from_sys_dev_parport (list, flags);
+   else if (capabilities & PROC_PARPORT_CAPABLE)
+     populate_from_parport (list, flags);
+-#else /* __linux */
++#else /* HAVE_LINUX */
+   if (capabilities & LPT_CAPABLE)
+-#endif /* __linux */
+     populate_nt_ports (list, flags);
++#endif /* HAVE_LINUX */
+   else 
+     populate_by_guessing (list, flags);
+ 
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/autobuild/patches/0003-2010-06-23-Tim-Waugh-twaugh-redhat.com.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0003-2010-06-23-Tim-Waugh-twaugh-redhat.com.patch
@@ -1,0 +1,118 @@
+From 1d04e0683dd6c199e66233cd1d260992ed9d455b Mon Sep 17 00:00:00 2001
+From: Tim Waugh <twaugh@redhat.com>
+Date: Wed, 23 Jun 2010 11:58:04 +0000
+Subject: [PATCH 3/6] 2010-06-23  Tim Waugh  <twaugh@redhat.com>
+
+* src/ieee1284module.c: Fixed warnings.
+---
+ ChangeLog            |  1 +
+ src/ieee1284module.c | 37 ++++++++++++++++++++++++++++---------
+ 2 files changed, 29 insertions(+), 9 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 037e9c4..6f4dde0 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,5 +1,6 @@
+ 2010-06-23  Tim Waugh  <twaugh@redhat.com>
+ 
++	* src/ieee1284module.c: Fixed warnings.
+ 	* src/ports.c: Fixed build.
+ 
+ 2009-11-13  Tim Waugh  <twaugh@redhat.com>
+diff --git a/src/ieee1284module.c b/src/ieee1284module.c
+index 30972f8..0093d6f 100644
+--- a/src/ieee1284module.c
++++ b/src/ieee1284module.c
+@@ -28,6 +28,17 @@ typedef struct {
+ 	struct parport *port;
+ } ParportObject;
+ 
++static PyObject *
++Parport_new (PyTypeObject *type, PyObject *args, PyObject *kwds)
++{
++  ParportObject *self;
++  self = (ParportObject *) type->tp_alloc (type, 0);
++  if (self != NULL)
++    self->port = NULL;
++
++  return (PyObject *) self;
++}
++
+ static int
+ Parport_init (ParportObject *self, PyObject *args, PyObject *kwds)
+ {
+@@ -215,7 +226,6 @@ Parport_release (ParportObject *self)
+ static PyObject *
+ Parport_read_data (ParportObject *self)
+ {
+-	unsigned char b[2];
+ 	int r = ieee1284_read_data (self->port);
+ 	if (r < 0) {
+ 		handle_error (r);
+@@ -258,7 +268,6 @@ Parport_data_dir (ParportObject *self, PyObject *args)
+ static PyObject *
+ Parport_read_status (ParportObject *self)
+ {
+-	unsigned char b[2];
+ 	int r = ieee1284_read_status (self->port);
+ 	if (r < 0) {
+ 		handle_error (r);
+@@ -293,7 +302,6 @@ Parport_wait_status (ParportObject *self, PyObject *args)
+ static PyObject *
+ Parport_read_control (ParportObject *self)
+ {
+-	unsigned char b[2];
+ 	int r = ieee1284_read_control (self->port);
+ 	if (r < 0) {
+ 		handle_error (r);
+@@ -435,7 +443,6 @@ Parport_##x (ParportObject *self, PyObject *args)			\
+ 	int len;							\
+ 	char *buffer;							\
+ 	ssize_t wrote;							\
+-	PyObject *ret;							\
+ 									\
+ 	if (!PyArg_ParseTuple (args, "s#|i", &buffer, &len, &flags))	\
+ 		return NULL;						\
+@@ -562,6 +569,23 @@ static PyTypeObject ParportType = {
+ 	0,					/* tp_as_buffer */
+ 	Py_TPFLAGS_DEFAULT,			/* tp_flags */
+ 	"parallel port object",			/* tp_doc */
++	0,					/* tp_traverse */
++	0,					/* tp_clear */
++	0,					/* tp_richcompare */
++	0,					/* tp_weaklistoffset */
++	0,					/* tp_iter */
++	0,					/* tp_iternext */
++	Parport_methods,			/* tp_methods */
++	0,					/* tp_members */
++	Parport_getseters,			/* tp_getset */
++	0,					/* tp_base */
++	0,					/* tp_dict */
++	0,					/* tp_descr_get */
++	0,					/* tp_descr_set */
++	0,					/* tp_dictoffset */
++	(initproc)Parport_init,			/* tp_init */
++	0,					/* tp_alloc */
++	Parport_new,		                /* tp_new */
+ };
+ 
+ static PyObject *
+@@ -625,14 +649,9 @@ initieee1284 (void)
+ 	PyObject *d = PyModule_GetDict (m);
+ 	PyObject *c;
+ 
+-	ParportType.tp_new = PyType_GenericNew;
+-	ParportType.tp_init = (initproc) Parport_init;
+-	ParportType.tp_getset = Parport_getseters;
+-	ParportType.tp_methods = Parport_methods;
+ 	if (PyType_Ready (&ParportType) < 0)
+ 		return;
+ 
+-	Py_INCREF (&ParportType);
+ 	PyModule_AddObject (m, "Parport", (PyObject *) &ParportType);
+ 
+ 	pyieee1284_error = PyErr_NewException("ieee1284.error", NULL, NULL);
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/autobuild/patches/0004-2011-03-08-Tim-Waugh-twaugh-redhat.com.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0004-2011-03-08-Tim-Waugh-twaugh-redhat.com.patch
@@ -1,0 +1,79 @@
+From 02079925bf5843f190e44b8a736cd7e5dd48f738 Mon Sep 17 00:00:00 2001
+From: Tim Waugh <twaugh@redhat.com>
+Date: Tue, 8 Mar 2011 15:07:04 +0000
+Subject: [PATCH 4/6] 2011-03-08  Tim Waugh  <twaugh@redhat.com>
+
+* src/ieee1284module.c: Added bindings for get_irq_fd and
+clear_irq.  Patch by Sergey Temerkhanov.
+---
+ ChangeLog            |  5 +++++
+ src/ieee1284module.c | 33 +++++++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/ChangeLog b/ChangeLog
+index 6f4dde0..58f3ed7 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,8 @@
++2011-03-08  Tim Waugh  <twaugh@redhat.com>
++
++	* src/ieee1284module.c: Added bindings for get_irq_fd and
++	clear_irq.  Patch by Sergey Temerkhanov.
++
+ 2010-06-23  Tim Waugh  <twaugh@redhat.com>
+ 
+ 	* src/ieee1284module.c: Fixed warnings.
+diff --git a/src/ieee1284module.c b/src/ieee1284module.c
+index 0093d6f..23c1f29 100644
+--- a/src/ieee1284module.c
++++ b/src/ieee1284module.c
+@@ -189,6 +189,33 @@ Parport_open (ParportObject *self, PyObject *args)
+ 	return PyInt_FromLong (capabilities);
+ }
+ 
++static PyObject *
++Parport_get_irq_fd (ParportObject *self)
++{
++	int fd = ieee1284_get_irq_fd (self->port);
++	if (fd < 0) {
++		handle_error (fd);
++		return NULL;
++	}
++
++	return PyInt_FromLong (fd);
++}
++
++static PyObject *
++Parport_clear_irq (ParportObject *self)
++{
++	int portcount = 0;
++	int r;
++
++	int fd = ieee1284_clear_irq (self->port, &portcount);
++	if (r < 0) {
++		handle_error (r);
++		return NULL;
++	}
++
++	return PyInt_FromLong (portcount);
++}
++
+ static PyObject *
+ Parport_close (ParportObject *self)
+ {
+@@ -484,6 +511,12 @@ PyMethodDef Parport_methods[] = {
+ 	{ "close", (PyCFunction) Parport_close, METH_NOARGS,
+ 	  "close() -> None\n"
+ 	  "Closes a port." },
++	{ "get_irq_fd", (PyCFunction) Parport_get_irq_fd, METH_VARARGS,
++	  "get_irq_fd() -> int\n"
++	  "Returns a pollable IRQ file descriptor." },
++	{ "clear_irq", (PyCFunction) Parport_clear_irq, METH_NOARGS,
++	  "clear_irq(portcount) -> int\n"
++	  "Clears IRQ and returns number of IRQs raised." },
+ 	{ "claim", (PyCFunction) Parport_claim, METH_NOARGS,
+ 	  "claim() -> None\n"
+ 	  "Claims a port." },
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/autobuild/patches/0005-Fix-Python-3-compatibility.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0005-Fix-Python-3-compatibility.patch
@@ -1,0 +1,278 @@
+From 725a65b10f3cc58997edde6c3daed61a24db1cfa Mon Sep 17 00:00:00 2001
+From: Anatol Pomozov <anatol.pomozov@gmail.com>
+Date: Sun, 17 Nov 2024 11:10:11 +0100
+Subject: [PATCH 5/6] Fix Python 3 compatibility
+
+---
+ src/ieee1284module.c | 136 +++++++++++++++++++++++++------------------
+ 1 file changed, 79 insertions(+), 57 deletions(-)
+
+diff --git a/src/ieee1284module.c b/src/ieee1284module.c
+index 23c1f29..c6d6928 100644
+--- a/src/ieee1284module.c
++++ b/src/ieee1284module.c
+@@ -52,33 +52,32 @@ Parport_dealloc (ParportObject *self)
+ {
+ 	if (self->port)
+ 		ieee1284_unref (self->port);
+-
+-	self->ob_type->tp_free ((PyObject *) self);
++	Py_TYPE(self)->tp_free((PyObject *) self);
+ }
+ 
+ static PyObject *
+ Parport_getname (ParportObject *self, void *closure)
+ {
+-	return PyString_FromString (self->port->name);
++	return PyBytes_FromString (self->port->name);
+ }
+ 
+ static PyObject *
+ Parport_getbase_addr (ParportObject *self, void *closure)
+ {
+-	return PyInt_FromLong (self->port->base_addr);
++	return PyLong_FromLong (self->port->base_addr);
+ }
+ 
+ static PyObject *
+ Parport_gethibase_addr (ParportObject *self, void *closure)
+ {
+-	return PyInt_FromLong (self->port->hibase_addr);
++	return PyLong_FromLong (self->port->hibase_addr);
+ }
+ 
+ static PyObject *
+ Parport_getfilename (ParportObject *self, void *closure)
+ {
+ 	if (self->port->filename)
+-		return PyString_FromString (self->port->filename);
++		return PyBytes_FromString (self->port->filename);
+ 
+ 	Py_INCREF (Py_None);
+ 	return Py_None;
+@@ -168,7 +167,7 @@ Parport_get_deviceid (ParportObject *self, PyObject *args)
+ 		return NULL;
+ 	}
+ 
+-	return PyString_FromStringAndSize (buffer, r);
++	return PyBytes_FromStringAndSize (buffer, r);
+ }
+ 
+ static PyObject *
+@@ -186,7 +185,7 @@ Parport_open (ParportObject *self, PyObject *args)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (capabilities);
++	return PyLong_FromLong (capabilities);
+ }
+ 
+ static PyObject *
+@@ -198,7 +197,7 @@ Parport_get_irq_fd (ParportObject *self)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (fd);
++	return PyLong_FromLong (fd);
+ }
+ 
+ static PyObject *
+@@ -213,7 +212,7 @@ Parport_clear_irq (ParportObject *self)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (portcount);
++	return PyLong_FromLong (portcount);
+ }
+ 
+ static PyObject *
+@@ -259,7 +258,7 @@ Parport_read_data (ParportObject *self)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (r);
++	return PyLong_FromLong (r);
+ }
+ 
+ static PyObject *
+@@ -301,7 +300,7 @@ Parport_read_status (ParportObject *self)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (r);
++	return PyLong_FromLong (r);
+ }
+ 
+ static PyObject *
+@@ -335,7 +334,7 @@ Parport_read_control (ParportObject *self)
+ 		return NULL;
+ 	}
+ 
+-	return PyInt_FromLong (r);
++	return PyLong_FromLong (r);
+ }
+ 
+ static PyObject *
+@@ -452,7 +451,7 @@ Parport_##x (ParportObject *self, PyObject *args)		\
+ 		return NULL;					\
+ 	}							\
+ 								\
+-	ret = PyString_FromStringAndSize (buffer, got);		\
++	ret = PyBytes_FromStringAndSize (buffer, got);		\
+ 	free (buffer);						\
+ 	return ret;						\
+ }
+@@ -480,7 +479,7 @@ Parport_##x (ParportObject *self, PyObject *args)			\
+ 		return NULL;						\
+ 	}								\
+ 									\
+-	return PyInt_FromLong (wrote);					\
++	return PyLong_FromLong (wrote);					\
+ }
+ 
+ #define WRITE_METHOD(x)						\
+@@ -581,44 +580,53 @@ WRITE_METHOD(ecp_write_addr)
+ 
+ static PyTypeObject ParportType = {
+ 	PyObject_HEAD_INIT(NULL)
+-	0,					/* ob_size */
+-	"ieee1284.Parport",			/* tp_name */
+-	sizeof (ParportObject),			/* tp_basicsize */
+-	0,					/* tp_itemsize */
+-	(destructor)Parport_dealloc,		/* tp_dealloc */
+-	0,					/* tp_print */
+-	0,					/* tp_getattr */
+-	0,					/* tp_setattr */
+-	0,					/* tp_compare */
+-	0,					/* tp_repr */
+-	0,					/* tp_as_number */
+-	0,					/* tp_as_sequence */
+-	0,					/* tp_as_mapping */
+-	0,					/* tp_hash */
+-	0,					/* tp_call */
+-	0,					/* tp_str */
+-	0,					/* tp_getattro */
+-	0,					/* tp_setattro */
+-	0,					/* tp_as_buffer */
+-	Py_TPFLAGS_DEFAULT,			/* tp_flags */
+-	"parallel port object",			/* tp_doc */
+-	0,					/* tp_traverse */
+-	0,					/* tp_clear */
+-	0,					/* tp_richcompare */
+-	0,					/* tp_weaklistoffset */
+-	0,					/* tp_iter */
+-	0,					/* tp_iternext */
+-	Parport_methods,			/* tp_methods */
+-	0,					/* tp_members */
+-	Parport_getseters,			/* tp_getset */
+-	0,					/* tp_base */
+-	0,					/* tp_dict */
+-	0,					/* tp_descr_get */
+-	0,					/* tp_descr_set */
+-	0,					/* tp_dictoffset */
+-	(initproc)Parport_init,			/* tp_init */
+-	0,					/* tp_alloc */
+-	Parport_new,		                /* tp_new */
++	"ieee1284.Parport",	/* const char *tp_name; */
++	sizeof (ParportObject),	/* Py_ssize_t tp_basicsize */
++	0,		/* Py_ssize_t tp_itemsize; */
++	(destructor)Parport_dealloc,	/* destructor tp_dealloc; */
++	0,	/* printfunc tp_print; */
++	0,	/* getattrfunc tp_getattr; */
++	0,	/* setattrfunc tp_setattr; */
++	0,	/* PyAsyncMethods *tp_as_async; */
++	0,	/* reprfunc tp_repr; */
++	0,	/* PyNumberMethods *tp_as_number; */
++	0,	/* PySequenceMethods *tp_as_sequence; */
++	0,	/* PyMappingMethods *tp_as_mapping; */
++	0,	/* hashfunc tp_hash; */
++	0,	/* ternaryfunc tp_call; */
++	0,	/* reprfunc tp_str; */
++	0,	/* getattrofunc tp_getattro; */
++	0,	/* setattrofunc tp_setattro; */
++	0,	/* PyBufferProcs *tp_as_buffer; */
++	Py_TPFLAGS_DEFAULT,	/* unsigned long tp_flags; */
++	"parallel port object",	/* const char *tp_doc; */
++	0,	/* traverseproc tp_traverse; */
++	0,	/* inquiry tp_clear; */
++	0,	/* richcmpfunc tp_richcompare; */
++	0,	/* Py_ssize_t tp_weaklistoffset; */
++	0,	/* getiterfunc tp_iter; */
++	0,	/* iternextfunc tp_iternext; */
++	Parport_methods,	/* struct PyMethodDef *tp_methods; */
++	0,	/* struct PyMemberDef *tp_members; */
++	Parport_getseters,	/* struct PyGetSetDef *tp_getset; */
++	0,	/* struct _typeobject *tp_base; */
++	0,	/* PyObject *tp_dict; */
++	0,	/* descrgetfunc tp_descr_get; */
++	0,	/* descrsetfunc tp_descr_set; */
++	0,	/* Py_ssize_t tp_dictoffset; */
++	(initproc)Parport_init,	/* initproc tp_init; */
++	0,	/* allocfunc tp_alloc; */
++	Parport_new,	/* newfunc tp_new; */
++	0,	/* freefunc tp_free; */
++	0,	/* inquiry tp_is_gc; */
++	0,	/* PyObject *tp_bases; */
++	0,	/* PyObject *tp_mro; */
++	0,	/* PyObject *tp_cache; */
++	0,	/* PyObject *tp_subclasses; */
++	0,	/* PyObject *tp_weaklist; */
++	0,	/* destructor tp_del; */
++	0,	/* unsigned int tp_version_tag; */
++	0	/* destructor tp_finalize; */
+ };
+ 
+ static PyObject *
+@@ -672,18 +680,30 @@ static PyMethodDef Ieee1284Methods[] = {
+ 	{NULL, NULL, 0, NULL}
+ };
+ 
++static struct PyModuleDef Ieee1284Module = {
++	PyModuleDef_HEAD_INIT,
++	"ieee1284",
++	NULL, /* documentation */
++	-1,
++	Ieee1284Methods,
++	NULL,
++	NULL,
++	NULL,
++	NULL
++};
++
+ #ifndef PyMODINIT_FUNC
+ #define PyMODINIT_FUNC void
+ #endif
+ PyMODINIT_FUNC
+-initieee1284 (void)
++PyInit_ieee1284module (void)
+ {
+-	PyObject *m = Py_InitModule ("ieee1284", Ieee1284Methods);
++	PyObject *m = PyModule_Create (&Ieee1284Module);
+ 	PyObject *d = PyModule_GetDict (m);
+ 	PyObject *c;
+ 
+ 	if (PyType_Ready (&ParportType) < 0)
+-		return;
++		return NULL;
+ 
+ 	PyModule_AddObject (m, "Parport", (PyObject *) &ParportType);
+ 
+@@ -693,7 +713,7 @@ initieee1284 (void)
+ 
+ #define CONSTANT(x)					\
+         do {						\
+-		c = PyInt_FromLong (x);			\
++		c = PyLong_FromLong (x);			\
+ 		PyDict_SetItemString (d, #x, c);	\
+ 		Py_DECREF (c);				\
+ 	} while (0)
+@@ -740,4 +760,6 @@ initieee1284 (void)
+ 	CONSTANT (F1284_SWE);
+ 	CONSTANT (F1284_RLE);
+ 	CONSTANT (F1284_FASTEPP);
++	
++	return m;
+ }
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/autobuild/patches/0006-Fix-Python-3.12-compatibility.patch
+++ b/runtime-devices/libieee1284/autobuild/patches/0006-Fix-Python-3.12-compatibility.patch
@@ -1,0 +1,25 @@
+From c645e67d9bdbcc469a9fe0ca21f8defc886df8c1 Mon Sep 17 00:00:00 2001
+From: Carl Smedstad <carl.smedstad@protonmail.com>
+Date: Sun, 17 Nov 2024 11:11:37 +0100
+Subject: [PATCH 6/6] Fix Python 3.12 compatibility
+
+---
+ src/ieee1284module.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ieee1284module.c b/src/ieee1284module.c
+index c6d6928..23a4426 100644
+--- a/src/ieee1284module.c
++++ b/src/ieee1284module.c
+@@ -579,7 +579,7 @@ WRITE_METHOD(ecp_write_addr)
+ /***/
+ 
+ static PyTypeObject ParportType = {
+-	PyObject_HEAD_INIT(NULL)
++	PyVarObject_HEAD_INIT(NULL, 0)
+ 	"ieee1284.Parport",	/* const char *tp_name; */
+ 	sizeof (ParportObject),	/* Py_ssize_t tp_basicsize */
+ 	0,		/* Py_ssize_t tp_itemsize; */
+-- 
+2.49.0
+

--- a/runtime-devices/libieee1284/prepare
+++ b/runtime-devices/libieee1284/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-devices/libieee1284/spec
+++ b/runtime-devices/libieee1284/spec
@@ -1,5 +1,5 @@
 VER=0.2.11
-REL=2
+REL=3
 SRCS="tbl::https://sourceforge.net/projects/libieee1284/files/libieee1284/${VER}/libieee1284-${VER}.tar.bz2"
 CHKSUMS="sha256::7730de107782e5d2b071bdcb5b06a44da74856f00ef4a9be85d1ba4806a38f1a"
 CHKUPDATE="anitya::id=229574"


### PR DESCRIPTION
Topic Description
-----------------

- libieee1284: fix build with Python 3
    - Backport patches from alternative upstream
    https://github.com/twaugh/libieee1284/tags to fix build with Python 3.
    - Track patches at AOSC-Tracking/libieee1284 @ aosc/V0_2_11
    \(HEAD: c645e67d9bdbcc469a9fe0ca21f8defc886df8c1\).

Package(s) Affected
-------------------

- libieee1284: 0.2.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libieee1284
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
