### PR TITLE
openexr: drop now discouraged Doxygen documentation

### DIFF
--- a/runtime-imaging/openexr/autobuild/defines
+++ b/runtime-imaging/openexr/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME=openexr
 PKGSEC=libs
-PKGDES="A high dynamic-range image file format library"
+PKGDES="Library to handle High Dynamic Range (HDR) images"
 PKGDEP="zlib imath"
-# Packages to build html documentations
-BUILDDEP="doxygen sphinx sphinx-press-theme breathe"
 
 PKGPROV="ilmbase openexr-viewers"
 
@@ -23,9 +21,9 @@ PKGBREAK="
 	openexr-viewers<=2.3.0-2
 "
 
-# Enable building of documentations
-CMAKE_AFTER="\
-	-DBUILD_DOCS=ON \
-"
+# Note: We do not encourage building Doxygen documentation.
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=OFF'
+)
 
 # ilmbase and openexr is replaced by openexr since version 2.4.0

--- a/runtime-imaging/openexr/spec
+++ b/runtime-imaging/openexr/spec
@@ -1,5 +1,5 @@
 VER=3.1.8
-REL=1
-SRCS="tbl::https://github.com/AcademySoftwareFoundation/openexr/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::3ff47111ef7e5da6f69330e66e1e90ae620b79df1cedf2512bb9bffe86c2c617"
+REL=2
+SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/openexr"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13289"


### PR DESCRIPTION
Topic Description
-----------------

- openexr: drop now discouraged Doxygen documentation
    Also revise SRCS as a Git tag per the Styling Manual.

Package(s) Affected
-------------------

- openexr: 3.1.8-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openexr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
