### PR TITLE
enchant: update to 1.6.1

### DIFF
--- a/app-i18n/enchant/autobuild/defines
+++ b/app-i18n/enchant/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=enchant
-PKGDES="A generic interface into various existing spell checking libraries"
+PKGDES="Generic interface into various existing spell checking libraries"
 PKGSEC=libs
 PKGDEP="aspell dbus-glib hunspell hspell"
 
-AUTOTOOLS_AFTER="--disable-ispell --with-myspell-dir=/usr/share/myspell"
-ABSHADOW=no
+# FIXME: configure: error: source directory already configured; run "make distclean" there first
+ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--disable-ispell'
+    '--with-myspell-dir=/usr/share/myspell'
+)

--- a/app-i18n/enchant/autobuild/prepare
+++ b/app-i18n/enchant/autobuild/prepare
@@ -1,1 +1,2 @@
-cp /usr/share/automake-1.16/config.* .
+abinfo "Passing -std=gnu89 to work around build failures ..."
+export CFLAGS="${CFLAGS} -std=gnu89"

--- a/app-i18n/enchant/spec
+++ b/app-i18n/enchant/spec
@@ -1,5 +1,5 @@
-VER=1.6.0
-REL=9
-SRCS="tbl::https://repo.aosc.io/aosc-repacks/enchant-$VER.tar.gz"
-CHKSUMS="sha256::2fac9e7be7e9424b2c5570d8affe568db39f7572c10ed48d4e13cddf03f7097f"
+UPSTREAM_VER=1-6-1
+VER=${UPSTREAM_VER//\-/.}
+SRCS="git::commit=tags/enchant-${UPSTREAM_VER}::https://github.com/rrthomas/enchant"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228866"


### PR DESCRIPTION
Topic Description
-----------------

- enchant: update to 1.6.1
    - Pass -std=gnu89 as a workaround for build failure with GCC >= 14
    \(legacy runtime with no known patch, anyone is welcome to pick this up
    or port the remainder of the enchant-1.x dependees over\).
    - Drop unused prepare script.
    - Improve PKGDES.
    - Add a comment about why shadow build was disabled.
    - Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- enchant: 1.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit enchant
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
