### PR TITLE
libuser: drop, orphaned (virt-manager dep clean up)

### DIFF
--- a/app-virtualization/virt-manager/02-virt-manager/defines
+++ b/app-virtualization/virt-manager/02-virt-manager/defines
@@ -1,7 +1,7 @@
 PKGNAME=virt-manager
 PKGSEC=admin
 PKGDEP="dbus-python graphite gtk-vnc gtksourceview-4 ipy librsvg \
-        libspice-gtk libuser libvirt-glib libxml2 netcat \
+        libspice-gtk libvirt-glib libxml2 netcat \
         virt-install vte-gtk3 yajl"
 PKGDES="Desktop user interface for managing virtual machines"
 

--- a/app-virtualization/virt-manager/spec
+++ b/app-virtualization/virt-manager/spec
@@ -1,5 +1,5 @@
 VER=5.0.0
-REL=1
+REL=2
 SRCS="tbl::https://releases.pagure.org/virt-manager/virt-manager-$VER.tar.xz"
 CHKSUMS="sha256::bc89ae46e0c997bd754ed62a419ca39c6aadec27e3d8b850cea5282f0083f84a"
 CHKUPDATE="anitya::id=8183"

--- a/runtime-admin/libuser/autobuild/defines
+++ b/runtime-admin/libuser/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=libuser
-PKGSEC=libs
-PKGDEP="python-2 glib popt"
-BUILDDEP="gtk-doc"
-PKGDES="A standardized interface for manipulating and administering user and group accounts"
-
-ABSHADOW=0


### PR DESCRIPTION
Topic Description
-----------------

- libuser: drop, orphaned
- virt-manager: remove unused libuser dependency

Package(s) Affected
-------------------

- virt-install: 5.0.0-2
- virt-manager: 5.0.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit virt-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
