### PR TITLE
cachy: drop installed tests

### DIFF
--- a/lang-python/cachy/autobuild/beyond
+++ b/lang-python/cachy/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing tests site-package ..."
+rm -rv "$PKGDIR"/usr/lib/python$ABPY3VER/site-packages/tests

--- a/lang-python/cachy/autobuild/defines
+++ b/lang-python/cachy/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=cachy
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools setuptools-python2"
 PKGDES="A simple yet effective caching library"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/cachy/spec
+++ b/lang-python/cachy/spec
@@ -1,5 +1,5 @@
 VER=0.3.0
-SRCS="tbl::https://pypi.io/packages/source/c/cachy/cachy-$VER.tar.gz"
+REL=3
+SRCS="pypi::version=$VER::cachy"
 CHKSUMS="sha256::186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1"
 CHKUPDATE="anitya::id=19560"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- cachy: drop installed tests
    Also use pypi:: source type.
    Co-authored-by: Mingcong Bai <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cachy: 0.3.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cachy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
