### PR TITLE
cython: update to 3.1.0

### DIFF
--- a/lang-python/cython/autobuild/defines
+++ b/lang-python/cython/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=cython
 PKGSEC=python
 PKGDES="C extensions for Python"
-PKGDEP="python-2 python-3 setuptools"
+PKGDEP="python-3 setuptools"
 
 PKGCONFL="cython-0.29"
 BUILDDEP="setuptools-python2"
+NOPYTHON2=1

--- a/lang-python/cython/spec
+++ b/lang-python/cython/spec
@@ -1,5 +1,5 @@
-VER=3.0.10
-SRCS="tbl::https://pypi.io/packages/source/C/Cython/Cython-$VER.tar.gz"
-CHKSUMS="sha256::dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99"
+VER=3.1.0
+SRCS="tbl::https://pypi.io/packages/source/C/Cython/cython-$VER.tar.gz"
+CHKSUMS="sha256::1097dd60d43ad0fff614a57524bfd531b35c13a907d13bee2cc2ec152e6bf4a1"
 CHKUPDATE="anitya::id=36699"
 REL=1

--- a/lang-python/pygame-sdl2/autobuild/patches/0001-AOSCOS-Support-Cython-3.1.0.patch
+++ b/lang-python/pygame-sdl2/autobuild/patches/0001-AOSCOS-Support-Cython-3.1.0.patch
@@ -1,0 +1,45 @@
+From a1f3514d13303573794432ee8ee60bb94af82623 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 31 May 2025 13:41:43 +0800
+Subject: [PATCH 1/2] AOSCOS: Support Cython 3.1.0
+
+---
+ src/pygame_sdl2/event.pyx | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/pygame_sdl2/event.pyx b/src/pygame_sdl2/event.pyx
+index 7b790eb53e47..4becb7370f4d 100644
+--- a/src/pygame_sdl2/event.pyx
++++ b/src/pygame_sdl2/event.pyx
+@@ -332,7 +332,7 @@ cdef object get_events(kinds):
+     The lock must be held when calling this function.
+     """
+ 
+-    if isinstance(kinds, (int, long)):
++    if isinstance(kinds, int):
+         kinds = [ kinds ]
+ 
+     global event_queue
+@@ -459,7 +459,7 @@ def set_blocked(t=None):
+     if t == None:
+         for et in event_names.keys():
+             SDL_EventState(et, SDL_ENABLE)
+-    elif isinstance(t, (int, long)):
++    elif isinstance(t, int):
+         SDL_EventState(t, SDL_IGNORE)
+     else:
+         for et in t:
+@@ -469,7 +469,7 @@ def set_allowed(t=None):
+     if t == None:
+         for et in event_names.keys():
+             SDL_EventState(et, SDL_IGNORE)
+-    elif isinstance(t, (int, long)):
++    elif isinstance(t, int):
+         SDL_EventState(t, SDL_ENABLE)
+     else:
+         for et in t:
+
+base-commit: 7e61ebdbf1fbc2cbff4994dd5c9bdd23411d8d37
+-- 
+2.49.0
+

--- a/lang-python/pygame-sdl2/autobuild/patches/0002-AOSCOS-Add-missing-import.patch
+++ b/lang-python/pygame-sdl2/autobuild/patches/0002-AOSCOS-Add-missing-import.patch
@@ -1,0 +1,24 @@
+From 1cd966ef14b35010ae4f1ea3fbc1d7e3dd09c818 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 31 May 2025 13:44:48 +0800
+Subject: [PATCH 2/2] AOSCOS: Add missing import
+
+---
+ setup.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/setup.py b/setup.py
+index 63bfaef9562f..abff6b0942a7 100755
+--- a/setup.py
++++ b/setup.py
+@@ -30,6 +30,7 @@ import os
+ import platform
+ import shutil
+ import sys
++import sysconfig
+ 
+ 
+ def setup_env(name):
+-- 
+2.49.0
+

--- a/lang-python/rencode/autobuild/patches/0001-GENTOO-Fix-cython-3.1.0.patch
+++ b/lang-python/rencode/autobuild/patches/0001-GENTOO-Fix-cython-3.1.0.patch
@@ -1,0 +1,26 @@
+From db3ad169c16e00e39ebc72dc2938828f24299d56 Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Sun, 11 May 2025 22:17:27 +0200
+Subject: [PATCH] rencode/rencode.pyx: Fix compilation for Cython 3.1.0
+
+https://github.com/aresch/rencode/issues/31
+---
+ rencode/rencode.pyx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rencode/rencode.pyx b/rencode/rencode.pyx
+index 3db1180..494919b 100644
+--- a/rencode/rencode.pyx
++++ b/rencode/rencode.pyx
+@@ -275,7 +275,7 @@ cdef object MIN_SIGNED_LONGLONG = -MAX_SIGNED_LONGLONG
+ 
+ cdef encode(char **buf, unsigned int *pos, data):
+     t = type(data)
+-    if t == int or t == long:
++    if t == int:
+         if -128 <= data < 128:
+             encode_char(buf, pos, data)
+         elif -32768 <= data < 32768:
+-- 
+2.49.0
+

--- a/runtime-devices/libimobiledevice/autobuild/patches/0001-Fix-Cython-3.1.patch
+++ b/runtime-devices/libimobiledevice/autobuild/patches/0001-Fix-Cython-3.1.patch
@@ -1,0 +1,19 @@
+https://github.com/libimobiledevice/libimobiledevice/issues/1666
+
+diff --git a/cython/debugserver.pxi b/cython/debugserver.pxi
+index a3b7d1e..0ec864c 100644
+--- a/cython/debugserver.pxi
++++ b/cython/debugserver.pxi
+@@ -45,11 +45,7 @@ cdef class DebugServerError(BaseError):
+
+ # from http://stackoverflow.com/a/17511714
+ # https://github.com/libimobiledevice/libimobiledevice/pull/198
+-from cpython cimport PY_MAJOR_VERSION
+-if PY_MAJOR_VERSION <= 2:
+-    from cpython.string cimport PyString_AsString
+-else:
+-    from cpython.bytes cimport PyBytes_AsString as PyString_AsString
++from cpython.bytes cimport PyBytes_AsString as PyString_AsString
+ cdef char ** to_cstring_array(list_str):
+     if not list_str:
+         return NULL


### PR DESCRIPTION
Topic Description
-----------------

- libimobiledevice: patch to fix Cython 3.1.0
- pygame-sdl2: patch to support Cython 3.1.0
- rencode: fix for Cython 3.1.0
- cython: update to 3.1.0, drop python2 support

Package(s) Affected
-------------------

- cython: 3.1.0-1
- libimobiledevice: 1.3.0+git20240725
- pygame-sdl2: 8.3.7.25031702-1
- rencode: 1.0.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cython rencode pygame-sdl2 libimobiledevice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
