### PR TITLE
mercurial: update to 7.0.2

### DIFF
--- a/app-vcs/mercurial/autobuild/defines
+++ b/app-vcs/mercurial/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=mercurial
 PKGSEC=vcs
-PKGDEP="python-3"
-BUILDDEP="docutils"
+PKGDEP="python-3 pygments"
+BUILDDEP="setuptools setuptools-scm docutils"
 PKGDES="A scalable distributed SCM tool"
 
 PKGPROV="hg"

--- a/app-vcs/mercurial/autobuild/patches/0001-fix-python-3.14.patch
+++ b/app-vcs/mercurial/autobuild/patches/0001-fix-python-3.14.patch
@@ -1,0 +1,28 @@
+# HG changeset patch
+# User Miro HronÄ¨ok <miro@hroncok.cz>
+# Date 1747130687 -7200
+#      Tue May 13 12:04:47 2025 +0200
+# Branch stable
+# Node ID 177a6a3abf138d6b7077f9cb4c612c864460256e
+# Parent  be4be016b6272b3566d66959069334527bbfe992
+# EXP-Topic hgdemandimport-_contextvars
+hgdemandimport: exclude _contextvars (newly imported from threading)
+
+This is needed for Python 3.14.0b1 compatibility.
+
+threading now imports _contextvars:
+https://github.com/python/cpython/commit/d687900f98114bb5910daad9553ae381d7daf94b
+
+Originally reported in Fedora: https://bugzilla.redhat.com/2365820
+
+diff --git a/hgdemandimport/__init__.py b/hgdemandimport/__init__.py
+--- a/hgdemandimport/__init__.py
++++ b/hgdemandimport/__init__.py
+@@ -60,6 +60,7 @@
+     'setuptools',
+     '_distutils_hack.override',
+     # threading is locally imported by importlib.util.LazyLoader.exec_module
++    '_contextvars',
+     '_weakrefset',
+     'warnings',
+     'threading',

--- a/app-vcs/mercurial/spec
+++ b/app-vcs/mercurial/spec
@@ -1,4 +1,4 @@
-VER=6.9.4
+VER=7.0.2
 SRCS="tbl::https://www.mercurial-scm.org/release/mercurial-$VER.tar.gz"
-CHKSUMS="sha256::7ea0e839ec8345277dd19d07250b4426134dc5d6682ff880a86a2b09b4e38ecd"
+CHKSUMS="sha256::f7731f1b42acaeaacb8cf7e41c0a472a7aa31a8f47e518baea735f1cb2987e0c"
 CHKUPDATE="anitya::id=1969"


### PR DESCRIPTION
Topic Description
-----------------

- mercurial: update to 7.0.2
    - Adjust run-time and build-time dependencies.
    - Preemptively backport a patch for Python >= 3.14.
    Co-authored-by: Mingcong Bai <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mercurial: 7.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mercurial
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
