### PR TITLE
pip: update to 25.1.1

### DIFF
--- a/lang-python/pip/autobuild/defines
+++ b/lang-python/pip/autobuild/defines
@@ -2,9 +2,7 @@ PKGNAME=pip
 PKGDES="PyPA recommended tool to install Python packages"
 PKGSEC=python
 PKGDEP="setuptools"
-BUILDDEP="wheel"
+BUILDDEP="python-build"
 
 ABHOST=noarch
 NOPYTHON2=1
-
-ABTYPE=python

--- a/lang-python/pip/spec
+++ b/lang-python/pip/spec
@@ -1,4 +1,4 @@
-VER=22.3.1
-SRCS="tbl::https://github.com/pypa/pip/archive/${VER}.tar.gz"
-CHKSUMS="sha256::8d9f7cd8ad0d6f0c70e71704fd3f0f6538d70930454f1f21bbc2f8e94f6964ee"
+VER=25.1.1
+SRCS="git::commit=tags/$VER::https://github.com/pypa/pip"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6529"


### PR DESCRIPTION
Topic Description
-----------------

- pip: change build system to PEP-517
- pip: update to 25.1.1

Package(s) Affected
-------------------

- pip: 25.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
