### PR TITLE
geoclue: drop, orphaned (fix qt-6: geoclue => geoclue2)

### DIFF
--- a/runtime-desktop/qt-6/01-runtime/defines
+++ b/runtime-desktop/qt-6/01-runtime/defines
@@ -5,7 +5,7 @@ PKGDES="Qt version 6"
 
 # FIXME: qdoc-qt6 needs to specify llvm dir, so using specific version of llvm
 PKGDEP="alsa-lib bluez cups dbus desktop-file-utils double-conversion ffmpeg \
-        fontconfig geoclue glib gst-plugins-base-1-0 harfbuzz llvm-runtime-18 \
+        fontconfig geoclue2 glib gst-plugins-base-1-0 harfbuzz llvm-runtime-18 \
         hicolor-icon-theme hyphen icu lcms2 libb2 libdrm libevent libinput \
         libglvnd libjpeg-turbo libmng libpng libproxy libvpx libwebp \
         libxkbcommon libxml2 libxslt mesa minizip opus pciutils pcre2 perl \

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=4
+REL=5
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::659d8bb5931afac9ed5d89a78e868e6bd00465a58ab566e2123db02d674be559"
 CHKUPDATE="anitya::id=7927"

--- a/runtime-gis/geoclue/autobuild/beyond
+++ b/runtime-gis/geoclue/autobuild/beyond
@@ -1,1 +1,0 @@
-rm -rfv "$PKGDIR"/usr/share/gtk-doc

--- a/runtime-gis/geoclue/autobuild/defines
+++ b/runtime-gis/geoclue/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=geoclue
-PKGDES="A modular geoinformation service built on top of the D-Bus messaging system"
-PKGDEP="dbus-glib dconf libxslt libsoup"
-BUILDDEP="gtk-doc"
-PKGSEC=libs
-
-AUTOTOOLS_AFTER="--enable-gpsd=no --disable-gtk-doc"
-ABSHADOW=0

--- a/runtime-gis/geoclue/autobuild/prepare
+++ b/runtime-gis/geoclue/autobuild/prepare
@@ -1,1 +1,0 @@
-cp /usr/share/automake-1.16/config.* .

--- a/runtime-gis/geoclue/spec
+++ b/runtime-gis/geoclue/spec
@@ -1,5 +1,0 @@
-VER=0.12.99
-REL=3
-SRCS="tbl::https://freedesktop.org/~hadess/geoclue-$VER.tar.gz"
-CHKSUMS="sha256::fe396c91cb52de4219281f4d9223156338fc03670d34700281e86d1399b80a72"
-CHKUPDATE="anitya::id=229511"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: fix dependency geoclue => geoclue2
- geoclue: drop, orphaned

Package(s) Affected
-------------------

- qt-6: 6.8.2-5
- qt-6-doc: 6.8.2-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
