### PR TITLE
mesa: update to 25.1.1

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
-From 719ef1e00489bb8291d462cca4a29328b8b2728f Mon Sep 17 00:00:00 2001
+From 99e281a9d34038b2ea30a3468d7b3391c30767fe Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 1/3] AOSCOS: r600: disable buggy VC-1 hardware decoding
+Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding
 
 Per commit 6cd30f5d730c ("radeon/uvd: disable VC-1 simple/main on UVD
 2.x"), VC-1 simple/main decoding was broken on at least UVD-1. According

--- a/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,7 +1,7 @@
-From 151c748be17ddbdd693686a9d5141502e0946e9c Mon Sep 17 00:00:00 2001
+From 4224e69ff4ead6b15479e5ea8b2aab06fd9a39af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 2/3] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
+Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
  LoongArch (LP64)
 
 16KiB is the most commonly found kernel page size on LoongArch

--- a/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,4 +1,4 @@
-From 0160cc0d0b7450b05cb7ea38c6b13080dfd4368e Mon Sep 17 00:00:00 2001
+From d255a59654e39c3cc04cf1285e1044066f2f0623 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
 Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs

--- a/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,4 +1,4 @@
-From cae31848a9256105b716766353d771ea21b67782 Mon Sep 17 00:00:00 2001
+From ab4fe57b31696f0dd7b434721a0736880e8b1301 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 30 Nov 2024 17:11:09 +0800
 Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG

--- a/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,4 +1,4 @@
-From ed470d0533fac87c6a56034a46197629e5082cae Mon Sep 17 00:00:00 2001
+From fad00a643412f3bea7e43ead1f044bc3b5b421ab Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 09:00:21 +0800
 Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting

--- a/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,4 +1,4 @@
-From 82152389e5e0dbf0c42d1c990e1e11cea6c7c528 Mon Sep 17 00:00:00 2001
+From da54f142b26757566ed40ce7bc4eca9bf474e1e6 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 20:49:58 +0800
 Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for

--- a/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,4 +1,4 @@
-From 9268c902578e5dc3540b31b7c04bdc43a445ce1f Mon Sep 17 00:00:00 2001
+From 9f56af714748cf49a8821fff95eb326297cf8b0f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 29 Nov 2024 16:10:29 +0800
 Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary

--- a/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,4 +1,4 @@
-From 2019daf7a1c133fac390070878313bc0b54e2961 Mon Sep 17 00:00:00 2001
+From 850c85abdd33b0aca5b999172cf55bed0eeb40f3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 26 Apr 2025 22:13:35 +0800
 Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=25.1.0
-DXHEADERS_VER=1.615.0
+UPSTREAM_VER=25.1.1
+DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::b1c45888969ee5df997e2542654f735ab1b772924b442f3016d2293414c99c14 \
+CHKSUMS="sha256::cf942a18b7b9e9b88524dcbf0b31fed3cde18e6d52b3375b0ab6587a14415bce \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,7 +1,7 @@
-From 719ef1e00489bb8291d462cca4a29328b8b2728f Mon Sep 17 00:00:00 2001
+From 99e281a9d34038b2ea30a3468d7b3391c30767fe Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
-Subject: [PATCH 1/3] AOSCOS: r600: disable buggy VC-1 hardware decoding
+Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding
 
 Per commit 6cd30f5d730c ("radeon/uvd: disable VC-1 simple/main on UVD
 2.x"), VC-1 simple/main decoding was broken on at least UVD-1. According

--- a/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,7 +1,7 @@
-From 151c748be17ddbdd693686a9d5141502e0946e9c Mon Sep 17 00:00:00 2001
+From 4224e69ff4ead6b15479e5ea8b2aab06fd9a39af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
-Subject: [PATCH 2/3] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
+Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
  LoongArch (LP64)
 
 16KiB is the most commonly found kernel page size on LoongArch

--- a/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,7 +1,7 @@
-From a763eba20b683c4f89f1a4ac6884112333133c86 Mon Sep 17 00:00:00 2001
+From d255a59654e39c3cc04cf1285e1044066f2f0623 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
-Subject: [PATCH 3/3] FROMLIST: zink: Do not use demote on IMG blobs
+Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
 
 The implementation of demote in IMG blobs seems to be a piece of hack,
 and the current use of it in Zink leads to assertion failure with
@@ -10,13 +10,8 @@ shader".
 
 Disable usage of demote for IMG blobs.
 
-[Mingcong Bai: Resolved minor merge conflict in
-src/gallium/drivers/zink/zink_screen.c, as
-PIPE_CAP_DEMOTE_TO_HELPER_INVOCATION in zink_get_param() was refactored
-as src->demote_to_helper_invocation in zink_init_screen_caps().]
-
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33051>
 ---
  src/gallium/drivers/zink/zink_compiler.c |  3 ++-
  src/gallium/drivers/zink/zink_screen.c   | 15 +++++++++++++--

--- a/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,0 +1,36 @@
+From ab4fe57b31696f0dd7b434721a0736880e8b1301 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 30 Nov 2024 17:11:09 +0800
+Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
+ proprietary driver
+
+The proprietary driver for Imagination Rogue-architecture GPUs does not
+come with geometryShader support.
+
+Change the assert for it to another if condition.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 26254397268..75b60dfd5b9 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2844,10 +2844,9 @@ init_driver_workarounds(struct zink_screen *screen)
+    }
+ 
+    if (zink_driverid(screen) ==
+-       VK_DRIVER_ID_IMAGINATION_PROPRIETARY) {
+-      assert(screen->info.feats.features.geometryShader);
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+-   }
+ 
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,0 +1,34 @@
+From fad00a643412f3bea7e43ead1f044bc3b5b421ab Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 09:00:21 +0800
+Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting
+
+The closed blob from Imagination for their Rogue GPUs cannot accept
+empty VkSubmitInfo, skip them.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index c7e746829ed..c861587538e 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -674,6 +674,13 @@ submit_queue(void *data, void *gdata, int thread_index)
+       }
+    }
+ 
++   if (si[ZINK_SUBMIT_WAIT_ACQUIRE].waitSemaphoreCount != 0 &&
++       si[ZINK_SUBMIT_WAIT_FD].waitSemaphoreCount == 0) {
++      si[ZINK_SUBMIT_WAIT_FD] = si[ZINK_SUBMIT_WAIT_ACQUIRE];
++      num_si--;
++      submit++;
++   }
++
+    /* then the real submit */
+    si[ZINK_SUBMIT_CMDBUF].waitSemaphoreCount = util_dynarray_num_elements(&bs->wait_semaphores, VkSemaphore);
+    si[ZINK_SUBMIT_CMDBUF].pWaitSemaphores = bs->wait_semaphores.data;
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,0 +1,73 @@
+From da54f142b26757566ed40ce7bc4eca9bf474e1e6 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 19 Jan 2025 20:49:58 +0800
+Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
+ Imagination Rogue
+
+The proprietary Vulkan driver for Imagination Rogue architecture GPUs
+has a broken VkQueueSubmit which cannot handle semaphore signaling w/o
+command buffers.
+
+Try to merge semaphores signaling submit to command processing one in
+this case.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_batch.c  | 9 ++++++++-
+ src/gallium/drivers/zink/zink_screen.c | 6 ++++++
+ src/gallium/drivers/zink/zink_types.h  | 1 +
+ 3 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/zink/zink_batch.c b/src/gallium/drivers/zink/zink_batch.c
+index c861587538e..e621da37cef 100644
+--- a/src/gallium/drivers/zink/zink_batch.c
++++ b/src/gallium/drivers/zink/zink_batch.c
+@@ -763,8 +763,15 @@ submit_queue(void *data, void *gdata, int thread_index)
+       );
+    }
+ 
+-   if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount)
++   if (!si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount &&
++       screen->driver_workarounds.broken_submit) {
++      si[ZINK_SUBMIT_CMDBUF].signalSemaphoreCount = si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount;
++      si[ZINK_SUBMIT_CMDBUF].pSignalSemaphores = si[ZINK_SUBMIT_SIGNAL].pSignalSemaphores;
++      si[ZINK_SUBMIT_CMDBUF].pNext = si[ZINK_SUBMIT_SIGNAL].pNext;
+       num_si--;
++   } else if (!si[ZINK_SUBMIT_SIGNAL].signalSemaphoreCount) {
++      num_si--;
++   }
+ 
+    simple_mtx_lock(&screen->queue_lock);
+    VRAM_ALLOC_LOOP(result,
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 75b60dfd5b9..9e2a29ccfd5 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -2848,6 +2848,12 @@ init_driver_workarounds(struct zink_screen *screen)
+        screen->info.feats.features.geometryShader)
+       screen->driver_workarounds.no_linesmooth = true;
+ 
++   /* Assume Rogue when no geometryShader is available */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       !screen->info.feats.features.geometryShader)
++      screen->driver_workarounds.broken_submit = true;
++
+    /* This is a workarround for the lack of
+     * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
+     * proprietary driver.
+diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
+index 66a3fc1200f..da6e92a8df9 100644
+--- a/src/gallium/drivers/zink/zink_types.h
++++ b/src/gallium/drivers/zink/zink_types.h
+@@ -1565,6 +1565,7 @@ struct zink_screen {
+       bool inconsistent_interpolation;
+       bool can_2d_view_sparse;
+       bool general_depth_layout;
++      bool broken_submit;
+       unsigned z16_unscaled_bias;
+       unsigned z24_unscaled_bias;
+    } driver_workarounds;
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,0 +1,36 @@
+From 9f56af714748cf49a8821fff95eb326297cf8b0f Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 29 Nov 2024 16:10:29 +0800
+Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
+ driver w/o geometryShader"
+
+This reverts commit ca087e202766872085d6d02363fd7f4961feba48.
+
+As running Zink on Rogue proprietary driver is somehow fixed now, revert
+this commit to reallow it.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 9e2a29ccfd5..44e6b6a8cbd 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3414,12 +3414,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
+-   if (zink_driverid(screen) == VK_DRIVER_ID_IMAGINATION_PROPRIETARY && !screen->info.feats.features.geometryShader) {
+-      if (!screen->driver_name_is_inferred)
+-         mesa_loge("zink: Imagination proprietary driver w/o geometryShader is unsupported");
+-      goto fail;
+-   }
+-
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,0 +1,39 @@
+From 850c85abdd33b0aca5b999172cf55bed0eeb40f3 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 26 Apr 2025 22:13:35 +0800
+Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
+ enforced
+
+Imagination closed driver 1.17@6210866 is known to be very glitchy with
+Zink.
+
+Reject it unless zink is enforced.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/gallium/drivers/zink/zink_screen.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
+index 44e6b6a8cbd..ec0117db081 100644
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3414,6 +3414,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+       goto fail;
+    }
+ 
++   /* Reject IMG blobs with DDK below 1.17@6210866 if not forced */
++   if (zink_driverid(screen) ==
++       VK_DRIVER_ID_IMAGINATION_PROPRIETARY &&
++       screen->info.props.driverVersion <= 6210866) {
++      debug_printf("zink: Imagination proprietary driver is too old to be supported\n");
++      if (screen->driver_name_is_inferred)
++         goto fail;
++   }
++
+    if (zink_debug & ZINK_DEBUG_MEM) {
+       simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
+       screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
+-- 
+2.49.0
+

--- a/runtime-optenv32/mesa+32/spec
+++ b/runtime-optenv32/mesa+32/spec
@@ -1,9 +1,10 @@
-UPSTREAM_VER=25.1.0
-DXHEADERS_VER=1.615.0
+UPSTREAM_VER=25.1.1
+DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
+REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::b1c45888969ee5df997e2542654f735ab1b772924b442f3016d2293414c99c14 \
+CHKSUMS="sha256::cf942a18b7b9e9b88524dcbf0b31fed3cde18e6d52b3375b0ab6587a14415bce \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.1.1+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.1
    \(HEAD: 850c85abdd33b0aca5b999172cf55bed0eeb40f3\).
- mesa: update to 25.1.1+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.1
    \(HEAD: 850c85abdd33b0aca5b999172cf55bed0eeb40f3\).

Package(s) Affected
-------------------

- mesa: 1:25.1.1+dxheaders1.616.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
