### PR TITLE
linux-kernel: update to 6.14.10

### DIFF
--- a/app-admin/kernel-tools/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
@@ -1,7 +1,7 @@
-From 8fcd4b7cbe8866e88bada4c97edbae359f4ebbe3 Mon Sep 17 00:00:00 2001
+From ec53bd43ad84f47ccc718f1c9d8a2cc801a84b82 Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:29 +0800
-Subject: [PATCH 001/328] FROMGIT: dt-bindings: display: rockchip: Fix label
+Subject: [PATCH 001/331] FROMGIT: dt-bindings: display: rockchip: Fix label
  name of hdptxphy for RK3588 HDMI TX Controller
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/app-admin/kernel-tools/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
@@ -1,7 +1,7 @@
-From 1b451052fd86e80e103159bf7f21bf074cca7089 Mon Sep 17 00:00:00 2001
+From e8e3878db2b594b1b0973953b503f6bffd384adc Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:04 +0200
-Subject: [PATCH 002/328] FROMGIT: dt-bindings: display: vop2: Add optional PLL
+Subject: [PATCH 002/331] FROMGIT: dt-bindings: display: vop2: Add optional PLL
  clock properties
 
 On RK3588, HDMI PHY PLL can be used as an alternative and more accurate

--- a/app-admin/kernel-tools/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
@@ -1,7 +1,7 @@
-From 868d3187541cc8106871d39917ed172c85b8ab0c Mon Sep 17 00:00:00 2001
+From 53aa3b2ab1d82b5cbd8e2659de25a4ff24fa51eb Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:05 +0200
-Subject: [PATCH 003/328] FROMGIT: drm/rockchip: vop2: Drop unnecessary
+Subject: [PATCH 003/331] FROMGIT: drm/rockchip: vop2: Drop unnecessary
  if_pixclk_rate computation
 
 The if_pixclk_rate variable is not being used outside of the if-block in

--- a/app-admin/kernel-tools/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
@@ -1,7 +1,7 @@
-From 1b054568395be506c296fdbdf7f8d28e26a805fc Mon Sep 17 00:00:00 2001
+From 4811b4a70f488ae49a5f5c0edff9f1d1efee10ce Mon Sep 17 00:00:00 2001
 From: Jianfeng Liu <liujianfeng1994@gmail.com>
 Date: Wed, 15 Jan 2025 10:33:21 +0800
-Subject: [PATCH 004/328] FROMGIT: arm64: dts: rockchip: Enable HDMI on
+Subject: [PATCH 004/331] FROMGIT: arm64: dts: rockchip: Enable HDMI on
  armsom-sige7
 
 Add the necessary DT changes to enable HDMI on ArmSoM Sige7.

--- a/app-admin/kernel-tools/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
@@ -1,7 +1,7 @@
-From d2c5ea748f66f91c30b5830e6bfd75dddfb45794 Mon Sep 17 00:00:00 2001
+From 57eade1b859e57f0f9d6bc5d26a19ad5203fece2 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:07 +0200
-Subject: [PATCH 005/328] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
+Subject: [PATCH 005/331] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
  provider on RK3588
 
 Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock

--- a/app-admin/kernel-tools/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
@@ -1,7 +1,7 @@
-From 66182a5c54910afa4b4a288ec66907113fbcd262 Mon Sep 17 00:00:00 2001
+From 3edf269fabf4f124db163b9b9c59d8f8efa70823 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:08 +0200
-Subject: [PATCH 006/328] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
+Subject: [PATCH 006/331] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
  clock source to VOP2 on RK3588
 
 VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and

--- a/app-admin/kernel-tools/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
@@ -1,7 +1,7 @@
-From 797ef753c3fcdc7ecfb8b04ad7f8e0266734ef5a Mon Sep 17 00:00:00 2001
+From 76d4a9497a147f24f61da35b13201bdb8a84365c Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:30 +0800
-Subject: [PATCH 007/328] FROMGIT: arm64: dts: rockchip: Fix label name of
+Subject: [PATCH 007/331] FROMGIT: arm64: dts: rockchip: Fix label name of
  hdptxphy for RK3588
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/app-admin/kernel-tools/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
@@ -1,7 +1,7 @@
-From ea11e5a778962fc56d6c3d0fd2435939f5372aae Mon Sep 17 00:00:00 2001
+From 0077008f9cde60ac1d4bef5f86e29a1d9cbbeac6 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:15 +0200
-Subject: [PATCH 008/328] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
+Subject: [PATCH 008/331] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
  for HDMI1 TX port on RK3588
 
 In preparation to enable the second HDMI output port found on RK3588

--- a/app-admin/kernel-tools/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
@@ -1,7 +1,7 @@
-From 786d7c9c8cd05e0ea628aa8f71f3729eddc0b2b1 Mon Sep 17 00:00:00 2001
+From d09d53af73ff5d5c2bd626c553ff8e80779075b6 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:16 +0200
-Subject: [PATCH 009/328] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
+Subject: [PATCH 009/331] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
  RK3588
 
 Add support for the second HDMI TX port found on RK3588 SoC.

--- a/app-admin/kernel-tools/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
@@ -1,7 +1,7 @@
-From 0add2ed34644c5ff7d7c3a86549f63e48de28971 Mon Sep 17 00:00:00 2001
+From 1a0e074eff63ca0336e264a31fd9368958d8bb8b Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:17 +0200
-Subject: [PATCH 010/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
+Subject: [PATCH 010/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
  rock-5b
 
 Add the necessary DT changes to enable the second HDMI output port on

--- a/app-admin/kernel-tools/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
@@ -1,7 +1,7 @@
-From aa6d5b0ac787bd9c875053115455d99ba195caee Mon Sep 17 00:00:00 2001
+From 78815af669f897599dd41b34f01cb4ef2a22f446 Mon Sep 17 00:00:00 2001
 From: Jagan Teki <jagan@edgeble.ai>
 Date: Fri, 27 Dec 2024 18:59:36 +0530
-Subject: [PATCH 011/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
+Subject: [PATCH 011/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
  Edgeble-6TOPS Modules
 
 Edgeble-6TOPS modules configure HDMI1 for HDMI Out from RK3588.

--- a/app-admin/kernel-tools/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
@@ -1,7 +1,7 @@
-From ac29fecaedf881a74ae6acdb8cf61d3e8762be7f Mon Sep 17 00:00:00 2001
+From 1cbd0e0890404d66b57755ec4cbfc1f1e6ddfcd6 Mon Sep 17 00:00:00 2001
 From: Jimmy Hon <honyuenkwun@gmail.com>
 Date: Wed, 8 Jan 2025 23:16:18 -0600
-Subject: [PATCH 012/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
+Subject: [PATCH 012/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
  Pi 5 Max
 
 Enable the second HDMI output port on the Orange Pi 5 Max

--- a/app-admin/kernel-tools/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
@@ -1,7 +1,7 @@
-From 581b45fe3b084963d7d3cda32265a284ae8f8968 Mon Sep 17 00:00:00 2001
+From 0d2ae04125f161a2b4f9dc941ea5b6b73c3f050e Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko.stuebner@cherry.de>
 Date: Fri, 6 Dec 2024 11:34:00 +0100
-Subject: [PATCH 013/328] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
+Subject: [PATCH 013/331] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
  regmap register-callback
 
 The variant of the driver in the vendor-tree contained those handy
@@ -22,10 +22,10 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-index 920abf6fa9bdd..dfcc37b1c8a6d 100644
+index 28a4235bfd5fb..6c51f764b1a5c 100644
 --- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
 +++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-@@ -571,13 +571,13 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {
+@@ -573,13 +573,13 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {
  static bool rk_hdptx_phy_is_rw_reg(struct device *dev, unsigned int reg)
  {
  	switch (reg) {

--- a/app-admin/kernel-tools/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
@@ -1,7 +1,7 @@
-From c0d8cbaf6628d412c7749e9a154a2d150005090f Mon Sep 17 00:00:00 2001
+From 907c377b0a40ce8adaf27cc80469efb69b233213 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:40 -0800
-Subject: [PATCH 014/328] FROMGIT: perf trace: Allocate syscall stats only if
+Subject: [PATCH 014/331] FROMGIT: perf trace: Allocate syscall stats only if
  summary is on
 
 The syscall stats are used only when summary is requested.  Let's avoid

--- a/app-admin/kernel-tools/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
@@ -1,7 +1,7 @@
-From d917c799a7a7becf247d865185ca33cefb95cf1a Mon Sep 17 00:00:00 2001
+From 67fe91e4cf3916ca623cc23244d086d4849dd176 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:41 -0800
-Subject: [PATCH 015/328] FROMGIT: perf trace: Convert syscall_stats to hashmap
+Subject: [PATCH 015/331] FROMGIT: perf trace: Convert syscall_stats to hashmap
 
 It was using a RBtree-based int-list as a hash and a custom resort
 logic for that.  As we have hashmap, let's convert to it and add a

--- a/app-admin/kernel-tools/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
@@ -1,7 +1,7 @@
-From 7f4e137d64d80ead8e7a3a5eac662300d8a002ca Mon Sep 17 00:00:00 2001
+From 1a1255ff95df253ade38c0788b4162a424349435 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:42 -0800
-Subject: [PATCH 016/328] FROMGIT: perf tools: Get rid of now-unused
+Subject: [PATCH 016/331] FROMGIT: perf tools: Get rid of now-unused
  rb_resort.h
 
 It was only used in perf trace and it switched to use hashmap instead.

--- a/app-admin/kernel-tools/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
@@ -1,7 +1,7 @@
-From f36d4a64986abd44d97531f4d17ecc0633e81445 Mon Sep 17 00:00:00 2001
+From 60afae4fbf77c98cd3ab687cf8ef968d7bbe5151 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:43 -0800
-Subject: [PATCH 017/328] FROMGIT: perf trace: Add --summary-mode option
+Subject: [PATCH 017/331] FROMGIT: perf trace: Add --summary-mode option
 
 The --summary-mode option will select how to show the syscall summary at
 the end.  By default, it'll show the summary for each thread and it's

--- a/app-admin/kernel-tools/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
@@ -1,7 +1,7 @@
-From f5a6161e2add63abacf9860c2ffd1782f43c129a Mon Sep 17 00:00:00 2001
+From 04d805e672bfa3a5d56482bced16b9fc86f4f826 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:01 -0800
-Subject: [PATCH 018/328] FROMGIT: perf tools: Add dummy functions for
+Subject: [PATCH 018/331] FROMGIT: perf tools: Add dummy functions for
  !HAVE_LZMA_SUPPORT
 
 This allows us to use them without needing to ifdef the calling code.

--- a/app-admin/kernel-tools/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
@@ -1,7 +1,7 @@
-From 877b2f3363c9ebcfdb099a854aa96e26047e8e37 Mon Sep 17 00:00:00 2001
+From 7d3a7ecdfea66670f99e33612c4519c8bd0650b2 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:02 -0800
-Subject: [PATCH 019/328] FROMGIT: perf tools: Add LZMA decompression from FILE
+Subject: [PATCH 019/331] FROMGIT: perf tools: Add LZMA decompression from FILE
 
 Internally lzma_decompress_to_file() creates a FILE from the filename.
 Add an API that takes an existing FILE directly. This allows

--- a/app-admin/kernel-tools/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
@@ -1,7 +1,7 @@
-From 3325115148e50fa9b234b961235c98bc7a274ae6 Mon Sep 17 00:00:00 2001
+From 6641b0a51945ba20c7505d876eea5b352e51cd52 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:03 -0800
-Subject: [PATCH 020/328] FROMGIT: perf symbol: Support .gnu_debugdata for
+Subject: [PATCH 020/331] FROMGIT: perf symbol: Support .gnu_debugdata for
  symbols
 
 Fedora introduced a "MiniDebuginfo" feature, in which an LZMA-compressed

--- a/app-admin/kernel-tools/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
@@ -1,7 +1,7 @@
-From 238fc8603ac8dcbf0705c862ce151011f67c00aa Mon Sep 17 00:00:00 2001
+From 9e68cc2cccb9ee4c6c84b7d3a53e70dd61154ef1 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:49 -0700
-Subject: [PATCH 021/328] FROMGIT: perf mutex: Add annotations for
+Subject: [PATCH 021/331] FROMGIT: perf mutex: Add annotations for
  LOCKS_EXCLUDED and LOCKS_RETURNED
 
 Used to annotate when locks shouldn't be held for a function or if a

--- a/app-admin/kernel-tools/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
@@ -1,7 +1,7 @@
-From 7b84d1a1dd128fb43a62dc7823c3e89c7ce7a3b7 Mon Sep 17 00:00:00 2001
+From 09d2a47f30a74aa9fbcdc4061d5fb59187a75609 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:50 -0700
-Subject: [PATCH 022/328] FROMGIT: perf dso: Use lock annotations to fix asan
+Subject: [PATCH 022/331] FROMGIT: perf dso: Use lock annotations to fix asan
  deadlock
 
 dso__list_del with address sanitizer and/or reference count checking

--- a/app-admin/kernel-tools/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
@@ -1,7 +1,7 @@
-From c0a9a75a28e6debf27f4ca6e457b81002e10dd6e Mon Sep 17 00:00:00 2001
+From c0e197435e1741bc7f76892c12987ee46456d44f Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:51 -0700
-Subject: [PATCH 023/328] FROMGIT: perf test dso-data: Correctly free test file
+Subject: [PATCH 023/331] FROMGIT: perf test dso-data: Correctly free test file
  in read test
 
 The DSO data read test opens a file but as dsos__exit is used the test

--- a/app-admin/kernel-tools/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
@@ -1,7 +1,7 @@
-From 34af1bb3fb157b9a4101b44bf8ecd756122afb2e Mon Sep 17 00:00:00 2001
+From 57d67b58f0dabaff9114c3942525aca75b9f09f2 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:28 -0700
-Subject: [PATCH 024/328] FROMGIT: perf dso: Move libunwind dso_data variables
+Subject: [PATCH 024/331] FROMGIT: perf dso: Move libunwind dso_data variables
  into ifdef
 
 The variables elf_base_addr, debug_frame_offset, eh_frame_hdr_addr and

--- a/app-admin/kernel-tools/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
@@ -1,7 +1,7 @@
-From be3b23514c2a0f78ed81abd38191e85566fe76f9 Mon Sep 17 00:00:00 2001
+From 0733c3117e94d4fdfee08486ebef77481d1e7217 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:29 -0700
-Subject: [PATCH 025/328] FROMGIT: perf dso: kernel-doc for enum
+Subject: [PATCH 025/331] FROMGIT: perf dso: kernel-doc for enum
  dso_binary_type
 
 There are many and non-obvious meanings to the dso_binary_type enum

--- a/app-admin/kernel-tools/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
@@ -1,7 +1,7 @@
-From bb0632fea64565c34abd34a2f0e69f09f53a52da Mon Sep 17 00:00:00 2001
+From 13d666fbe7e3ef5dfea33dcd0eb7cd3e7aa4fbe0 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:30 -0700
-Subject: [PATCH 026/328] FROMGIT: perf syscalltbl: Remove syscall_table.h
+Subject: [PATCH 026/331] FROMGIT: perf syscalltbl: Remove syscall_table.h
 
 The definition of "static const char *const syscalltbl[] = {" is done
 in a generated syscalls_32.h or syscalls_64.h that is architecture

--- a/app-admin/kernel-tools/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
@@ -1,7 +1,7 @@
-From ae8c5e80f44bda2cc78f910c2602c0259be58a5d Mon Sep 17 00:00:00 2001
+From 86da6429d452dda2f278cd495bc72b7d889afdd1 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:31 -0700
-Subject: [PATCH 027/328] FROMGIT: perf trace: Reorganize syscalls
+Subject: [PATCH 027/331] FROMGIT: perf trace: Reorganize syscalls
 
 Identify struct syscall information in the syscalls table by a machine
 type and syscall number, not just system call number. Having the

--- a/app-admin/kernel-tools/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
@@ -1,7 +1,7 @@
-From 815e28f683840f22c9243fb9c162cac135811741 Mon Sep 17 00:00:00 2001
+From 485f26ef9b2be4921a35471681e104e153b0d150 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:32 -0700
-Subject: [PATCH 028/328] FROMGIT: perf syscalltbl: Remove struct syscalltbl
+Subject: [PATCH 028/331] FROMGIT: perf syscalltbl: Remove struct syscalltbl
 
 The syscalltbl held entries of system call name and number pairs,
 generated from a native syscalltbl at start up. As there are gaps in

--- a/app-admin/kernel-tools/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
@@ -1,7 +1,7 @@
-From af9980704e3f6482da4c6e30f55a7888dcf78f4c Mon Sep 17 00:00:00 2001
+From 1e1371c4a8e260d119191dee0a0acb6bf124de16 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:33 -0700
-Subject: [PATCH 029/328] FROMGIT: perf dso: Add support for reading the
+Subject: [PATCH 029/331] FROMGIT: perf dso: Add support for reading the
  e_machine type for a dso
 
 For ELF file dsos read the e_machine from the ELF header. For kernel

--- a/app-admin/kernel-tools/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
@@ -1,7 +1,7 @@
-From 1ae77fcb27026a80af228d99c57e4e8ba1ebd703 Mon Sep 17 00:00:00 2001
+From 8297fe8e1959d8f5436dcab1d275248d3d55fe19 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:34 -0700
-Subject: [PATCH 030/328] FROMGIT: perf thread: Add support for reading the
+Subject: [PATCH 030/331] FROMGIT: perf thread: Add support for reading the
  e_machine type for a thread
 
 First try to read the e_machine from the dsos associated with the

--- a/app-admin/kernel-tools/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
@@ -1,7 +1,7 @@
-From ecdb06f1fb94dd17179385484a38e23866e89802 Mon Sep 17 00:00:00 2001
+From 1d6e0f13ad08f26c47c0fd030764311de901351c Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:35 -0700
-Subject: [PATCH 031/328] FROMGIT: perf trace beauty: Add syscalltbl.sh
+Subject: [PATCH 031/331] FROMGIT: perf trace beauty: Add syscalltbl.sh
  generating all system call tables
 
 Rather than generating individual syscall header files generate a

--- a/app-admin/kernel-tools/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
@@ -1,7 +1,7 @@
-From 803a93ba3fde51a74acd472dadd8bfe902a6cec5 Mon Sep 17 00:00:00 2001
+From d2dd5cf536a321f1d400fd19e05df8eb8945b140 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:36 -0700
-Subject: [PATCH 032/328] FROMGIT: perf syscalltbl: Use lookup table containing
+Subject: [PATCH 032/331] FROMGIT: perf syscalltbl: Use lookup table containing
  multiple architectures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
@@ -1,7 +1,7 @@
-From fd36ce5789a798c393227895e222af0490dc5a0b Mon Sep 17 00:00:00 2001
+From 8b9ec838a3c55c68b3d4259fd6c3eb49298c814b Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:37 -0700
-Subject: [PATCH 033/328] FROMGIT: perf build: Remove Makefile.syscalls
+Subject: [PATCH 033/331] FROMGIT: perf build: Remove Makefile.syscalls
 
 Now a single beauty file is generated and used by all architectures,
 remove the per-architecture Makefiles, Kbuild files and previous

--- a/app-admin/kernel-tools/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
@@ -1,7 +1,7 @@
-From f6e485ed21931c3360f32fe4ad105ff8ac337d03 Mon Sep 17 00:00:00 2001
+From ccf1ab939373138a0e585936a61631fdca02ec52 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:38 -0700
-Subject: [PATCH 034/328] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
+Subject: [PATCH 034/331] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
  system calls
 
 Arnd Bergmann described that MIPS system calls don't necessarily start

--- a/app-admin/kernel-tools/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
@@ -1,7 +1,7 @@
-From 40c899db72974af5d57460c9652b021705c77404 Mon Sep 17 00:00:00 2001
+From 24dd8d1178da80a225a990aed3cdf1a442e8b3c4 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:39 -0700
-Subject: [PATCH 035/328] FROMGIT: perf trace: Make syscall table stable
+Subject: [PATCH 035/331] FROMGIT: perf trace: Make syscall table stable
 
 Namhyung fixed the syscall table being reallocated and moving by
 reloading the system call pointer after a move:

--- a/app-admin/kernel-tools/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
@@ -1,7 +1,7 @@
-From 4a6293322d121d4e81c67251f2c258e8db3f2f89 Mon Sep 17 00:00:00 2001
+From c5c4fb7700543d93301bb7b5971f53f5680fbb85 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:40 -0700
-Subject: [PATCH 036/328] FROMGIT: perf trace: Fix BTF memory leak
+Subject: [PATCH 036/331] FROMGIT: perf trace: Fix BTF memory leak
 
 Add missing btf__free in trace__exit.
 

--- a/app-admin/kernel-tools/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
@@ -1,7 +1,7 @@
-From 98f64cada9826d286aa7750566dff7602b17e256 Mon Sep 17 00:00:00 2001
+From 0dd157f6d7ace77f9891d23ca5d212fe1793666a Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:41 -0700
-Subject: [PATCH 037/328] FROMGIT: perf trace: Fix evlist memory leak
+Subject: [PATCH 037/331] FROMGIT: perf trace: Fix evlist memory leak
 
 Leak sanitizer was reporting a memory leak in the "perf record and
 replay" test. Add evlist__delete to trace__exit, also ensure

--- a/app-admin/kernel-tools/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
@@ -1,7 +1,7 @@
-From ab74f8bf801d004e1de289f9e8df03f6136791c8 Mon Sep 17 00:00:00 2001
+From 7381a8f76b72781ac6352718577de6eead58691a Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Sat, 22 Feb 2025 19:45:31 +0800
-Subject: [PATCH 038/328] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
+Subject: [PATCH 038/331] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
  Support for mic and audio mute LEDs
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
@@ -1,7 +1,7 @@
-From 949411326f0197250d454c43547aa4d458578a8f Mon Sep 17 00:00:00 2001
+From 1162e8a6e2777ef773110320c3f2d81251b20b78 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:51 +0800
-Subject: [PATCH 039/328] FROMGIT: dt-bindings: gpio: loongson: Add new
+Subject: [PATCH 039/331] FROMGIT: dt-bindings: gpio: loongson: Add new
  loongson gpio chip compatible
 
 Add the devicetree compatibles for Loongson-7A2000 and Loongson-3A6000

--- a/app-admin/kernel-tools/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
@@ -1,7 +1,7 @@
-From bc7f0a2f09a32d47f78dbda9ecb17e27281e8fb0 Mon Sep 17 00:00:00 2001
+From e71c9025fbab1f5ab1fc813a715e81d7d8198567 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:52 +0800
-Subject: [PATCH 040/328] FROMGIT: gpio: loongson-64bit: Add more gpio chip
+Subject: [PATCH 040/331] FROMGIT: gpio: loongson-64bit: Add more gpio chip
  support
 
 The Loongson-7A2000 and Loongson-3A6000 share the same gpio chip model.

--- a/app-admin/kernel-tools/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
@@ -1,7 +1,7 @@
-From 590bed431f42bc23d5fc2feda2463bec5c0a6e69 Mon Sep 17 00:00:00 2001
+From 793923cec759fc7da08a6c3619e15b2ba756bce0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 12 Mar 2025 21:39:54 +0800
-Subject: [PATCH 041/328] FROMGIT: ata: libata: Improve return value of
+Subject: [PATCH 041/331] FROMGIT: ata: libata: Improve return value of
  atapi_check_dma()
 
 atapi_check_dma() allows a LLD to filter ATAPI commands, returning a

--- a/app-admin/kernel-tools/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
@@ -1,7 +1,7 @@
-From c5889146b51c397f3c151d1e7aceb144adef948d Mon Sep 17 00:00:00 2001
+From 01873e36de91f1770b3415723cfc42abcf0d2558 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:13 +0800
-Subject: [PATCH 042/328] FROMGIT: objtool/LoongArch: Add support for switch
+Subject: [PATCH 042/331] FROMGIT: objtool/LoongArch: Add support for switch
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/app-admin/kernel-tools/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
@@ -1,7 +1,7 @@
-From 3116cf7478b090712f23223c5135971fe5d90882 Mon Sep 17 00:00:00 2001
+From 646ea41aa04a4b6ac68e0efbf20219fad6486366 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:14 +0800
-Subject: [PATCH 043/328] FROMGIT: objtool/LoongArch: Add support for goto
+Subject: [PATCH 043/331] FROMGIT: objtool/LoongArch: Add support for goto
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/app-admin/kernel-tools/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
@@ -1,7 +1,7 @@
-From c23b1b0fbec8855e4480b70a990d21d1cb3d038b Mon Sep 17 00:00:00 2001
+From f93a438cfd7f3d01f806cc916f9cc527750e91d4 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 17 Dec 2024 09:09:03 +0800
-Subject: [PATCH 044/328] FROMGIT: LoongArch: Enable jump table for objtool
+Subject: [PATCH 044/331] FROMGIT: LoongArch: Enable jump table for objtool
 
 For now, it is time to remove -fno-jump-tables to enable jump table for
 objtool if the compiler has -mannotate-tablejump, otherwise it is better

--- a/app-admin/kernel-tools/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
@@ -1,7 +1,7 @@
-From 32910cab64d753061e57730d20c82a7dbcf1dfd7 Mon Sep 17 00:00:00 2001
+From 1430a2b048ff03133225a3a6e228ccbf2a770fa3 Mon Sep 17 00:00:00 2001
 From: Masahiro Yamada <masahiroy@kernel.org>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 045/328] FROMGIT: LoongArch: KVM: Remove unnecessary header
+Subject: [PATCH 045/331] FROMGIT: LoongArch: KVM: Remove unnecessary header
  include path
 
 arch/loongarch/kvm/ includes local headers with the double-quote form

--- a/app-admin/kernel-tools/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
@@ -1,7 +1,7 @@
-From efb23e50c8233592edb1c75e7495e57d6f73c534 Mon Sep 17 00:00:00 2001
+From a541c08dd066706f4ba00634e67fc0169a6cdd6c Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 046/328] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
+Subject: [PATCH 046/331] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
  context switch
 
 PGD table for primary mmu keeps unchanged once VM is created, it is not

--- a/app-admin/kernel-tools/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
@@ -1,7 +1,7 @@
-From f3961bd241bd6ffdf3e89b9a7295b8b10b3f3c6a Mon Sep 17 00:00:00 2001
+From 9c9d9bf602dbd3b02bc80968f24f63deaa9ecd9a Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 047/328] FROMGIT: LoongArch: KVM: Add stub for
+Subject: [PATCH 047/331] FROMGIT: LoongArch: KVM: Add stub for
  kvm_arch_vcpu_preempted_in_kernel()
 
 Pause-Loop Exiting is not supported by LoongArch hardware, nor is pv

--- a/app-admin/kernel-tools/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
@@ -1,7 +1,7 @@
-From 12101c3210fe0f7b1c9e7e4a29c35cf0cd59fbfe Mon Sep 17 00:00:00 2001
+From 239e7e2b4014f434eeeb1055401709a3f034947d Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 048/328] FROMGIT: LoongArch: KVM: Implement arch-specific
+Subject: [PATCH 048/331] FROMGIT: LoongArch: KVM: Implement arch-specific
  functions for guest perf
 
 Three architecture specific functions are added for the guest perf

--- a/app-admin/kernel-tools/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
@@ -1,7 +1,7 @@
-From 608f8c1b9ff41f38f09e6cd424a9d4a9d828a186 Mon Sep 17 00:00:00 2001
+From f3b922731c73da304fdbc2a6891ae3b74dba2668 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 049/328] FROMGIT: LoongArch: KVM: Register perf callbacks for
+Subject: [PATCH 049/331] FROMGIT: LoongArch: KVM: Register perf callbacks for
  guest
 
 Add selection for GUEST_PERF_EVENTS if KVM is enabled, also add perf

--- a/app-admin/kernel-tools/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
-From cd5cf771823cfadc54b5e9a27a2d8077f6487640 Mon Sep 17 00:00:00 2001
+From bb837aba6421ef9e2fab756f26653614296ee8d5 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 050/328] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 050/331] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/app-admin/kernel-tools/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
@@ -1,7 +1,7 @@
-From 3ca32eac062835adfbdebb8a860e675dd3232641 Mon Sep 17 00:00:00 2001
+From dd69cce1e865724c165c1d469b442a0754be8f2c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 051/328] FROMLIST: drm/Makefile: Move tiny drivers before
+Subject: [PATCH 051/331] FROMLIST: drm/Makefile: Move tiny drivers before
  native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/app-admin/kernel-tools/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
-From 20a98995be888ef1bf783b6c6fc18317804cab06 Mon Sep 17 00:00:00 2001
+From be9dcfd20910e5a4bfb3e12de330e0ec5b048769 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 052/328] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 052/331] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/app-admin/kernel-tools/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
-From 9af5d2ec27f17f6aba245ffc4947031a2d373a7d Mon Sep 17 00:00:00 2001
+From b1c6491ffa9882f40bac5721e80cf5f75e74e3fc Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 053/328] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 053/331] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/app-admin/kernel-tools/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
@@ -1,7 +1,7 @@
-From 976d54041ddda288626dfe4b3926e33f66c7dc23 Mon Sep 17 00:00:00 2001
+From c1925a4a798132e7f2f45c7a39de22d7be61bbc3 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
-Subject: [PATCH 054/328] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
+Subject: [PATCH 054/331] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
  when selected cpu is offline
 
 Call work_on_cpu(cpu, fn, arg) in pci_call_probe() while the argument

--- a/app-admin/kernel-tools/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
-From 5a484027f837d692ffb77ee89838fa83583adfba Mon Sep 17 00:00:00 2001
+From c85d79ff599c971fa2f495c06e3d4c5b368b2fe2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 4 Aug 2024 09:24:18 +0800
-Subject: [PATCH 055/328] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 055/331] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/app-admin/kernel-tools/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
-From 161ab385e26e8981c671245f3b9318986532053b Mon Sep 17 00:00:00 2001
+From 020557a395b5f89164b6eb1a576403980aa2793d Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 056/328] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 056/331] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using

--- a/app-admin/kernel-tools/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
-From 64bd6acbc9c7afdd1c5ff359defd6c1e2f9f7b2e Mon Sep 17 00:00:00 2001
+From 5ca583e1e34063750cc1af2d079eca200b293389 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 057/328] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 057/331] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to

--- a/app-admin/kernel-tools/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
-From 9278f571a1758e30643e3ba3f6bd020cf732c167 Mon Sep 17 00:00:00 2001
+From eb216884f1cdc9d82639a6609c5108d40cbd3fc0 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 058/328] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 058/331] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,

--- a/app-admin/kernel-tools/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
-From 69cdb23ae551752d5aa0809795613cce4a82af42 Mon Sep 17 00:00:00 2001
+From 378c72755854c2ba01885c0d5d5afed5b7a2d464 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 059/328] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 059/331] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/app-admin/kernel-tools/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
@@ -1,7 +1,7 @@
-From b3679a8b3021a7764acfd41cde62a2dc8e327929 Mon Sep 17 00:00:00 2001
+From f2823b5676185743339a37ec345051d041a6580e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 11 Nov 2024 21:21:49 +0800
-Subject: [PATCH 060/328] FROMLIST: drm: Remove redundant statement in
+Subject: [PATCH 060/331] FROMLIST: drm: Remove redundant statement in
  drm_crtc_helper_set_mode()
 
 Commit dbbfaf5f2641a ("drm: Remove bridge support from legacy helpers")

--- a/app-admin/kernel-tools/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
-From b29ddb57ec77e93484f8d748247ff315c4fee8d5 Mon Sep 17 00:00:00 2001
+From d107e80bcb513c3862b223ed170cc467a0d3717c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 061/328] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 061/331] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/app-admin/kernel-tools/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
-From 32b1785a66dd54f9259a50ab91f68a5e51f152e6 Mon Sep 17 00:00:00 2001
+From cc701a8de3b08ee37c0e7e4dfd194a92a6fd4d28 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:08 +0800
-Subject: [PATCH 062/328] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 062/331] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC MFD Core driver
 
 The Loongson-2K Board Management Controller provides an PCIe

--- a/app-admin/kernel-tools/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
-From 3b242681579fe88b4cfb850f71503259e184fe76 Mon Sep 17 00:00:00 2001
+From adb3bf13af5a124f2d1f4f44093d2b0221471870 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:09 +0800
-Subject: [PATCH 063/328] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 063/331] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 

--- a/app-admin/kernel-tools/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
@@ -1,7 +1,7 @@
-From bff94d0d2b8cdf36f04a41579aa2ea3943d91656 Mon Sep 17 00:00:00 2001
+From 2674a97266b33ed4ecc08fc293fdb443d7b9ebf6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:10 +0800
-Subject: [PATCH 064/328] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
+Subject: [PATCH 064/331] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
  BMC display
 
 Adds a driver for the Loongson-2K BMC display as a sub-function of

--- a/app-admin/kernel-tools/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
-From 623e622fe31d3db9a54cd9351a7c2cadb496fe42 Mon Sep 17 00:00:00 2001
+From 3e1c6457658e05a3a0d869467647e02ee3d9475b Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:36 +0800
-Subject: [PATCH 065/328] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 065/331] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the

--- a/app-admin/kernel-tools/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
-From 4f08061cc57c7495875fd042d73c7a7189b8ab16 Mon Sep 17 00:00:00 2001
+From 2c0c0727fb43922cea93487043dbb946e16f2ee5 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 066/328] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 066/331] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/app-admin/kernel-tools/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
@@ -1,7 +1,7 @@
-From 68ddfd15d3c6beb99c2d394d9388626fe71a236e Mon Sep 17 00:00:00 2001
+From 6a21a8f3acebe645e02c0195473fd98d47cbda4c Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:29:56 +0800
-Subject: [PATCH 067/328] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
+Subject: [PATCH 067/331] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/app-admin/kernel-tools/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
@@ -1,7 +1,7 @@
-From 1133f1e2eee4fd905748aa5bd7d58207fb6fdf28 Mon Sep 17 00:00:00 2001
+From e9c7ac5f4d27d8f060d1f5f018e4e214bd80b967 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:15 +0800
-Subject: [PATCH 068/328] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
+Subject: [PATCH 068/331] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/app-admin/kernel-tools/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
@@ -1,7 +1,7 @@
-From c8f26fc4543302aea2a503865888af8046efd0b1 Mon Sep 17 00:00:00 2001
+From dbba1560b24c0b1ed6364252e6e19b526d33b05e Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:35 +0800
-Subject: [PATCH 069/328] FROMLIST: drm/amd/display: Harden callers of division
+Subject: [PATCH 069/331] FROMLIST: drm/amd/display: Harden callers of division
  functions
 
 There are objtool warnings compiled with the latest mainline LLVM:

--- a/app-admin/kernel-tools/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
@@ -1,7 +1,7 @@
-From d299415caa9d91295a9d96a1c9c6a089e63bfbfa Mon Sep 17 00:00:00 2001
+From ef311aa20727721402e3bd2b8b9e73b7625d2764 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 21 Jan 2025 19:42:25 +0800
-Subject: [PATCH 070/328] FROMLIST: PCI: loongson: Add quirk for OHCI device
+Subject: [PATCH 070/331] FROMLIST: PCI: loongson: Add quirk for OHCI device
  rev 0x02
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.

--- a/app-admin/kernel-tools/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
-From 072a260e27b38c2bc143c41745ba28a9a1b9b170 Mon Sep 17 00:00:00 2001
+From 4cb9f43f9c64365c2ca4a16ede5f4bb06c390c5f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 071/328] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 071/331] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/app-admin/kernel-tools/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
@@ -1,7 +1,7 @@
-From bae74d74f63177be90f55653c7bb2efe18a02842 Mon Sep 17 00:00:00 2001
+From f504a70b24798cbef96d139a5450051e495cfdfb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:24 +0800
-Subject: [PATCH 072/328] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
+Subject: [PATCH 072/331] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
  PWM controller
 
 Add Loongson PWM controller binding with DT schema format using

--- a/app-admin/kernel-tools/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,7 +1,7 @@
-From 9e0d8ec32791a7378c08dc569f79ee5fb8719030 Mon Sep 17 00:00:00 2001
+From aef12d4f8f638ee8ff1034a5f5f7ce80131c96f5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:25 +0800
-Subject: [PATCH 073/328] FROMLIST: pwm: Add Loongson PWM controller support
+Subject: [PATCH 073/331] FROMLIST: pwm: Add Loongson PWM controller support
 
 This commit adds a generic PWM framework driver for the PWM controller
 found on Loongson family chips.

--- a/app-admin/kernel-tools/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
-From b1a4b53f1a2765731339b4792196b6998c4d8460 Mon Sep 17 00:00:00 2001
+From f6c2655717205b2409d0c86857bb3579d05f4c88 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:40 +0800
-Subject: [PATCH 074/328] FROMLIST: riscv: vDSO: Remove --hash-style=both
+Subject: [PATCH 074/331] FROMLIST: riscv: vDSO: Remove --hash-style=both
 
 When RISC-V borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/app-admin/kernel-tools/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
-From 28cde97236a093b7b2fb87659c13ce38b75b404c Mon Sep 17 00:00:00 2001
+From 562764f854f8ea48d8eab4f2986505fd881f7d5a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:41 +0800
-Subject: [PATCH 075/328] FROMLIST: csky: vDSO: Remove --hash-style=both
+Subject: [PATCH 075/331] FROMLIST: csky: vDSO: Remove --hash-style=both
 
 When CSKY borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/app-admin/kernel-tools/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
@@ -1,7 +1,7 @@
-From 4a38af30d15e57236693ee15f326c0b09637ae0a Mon Sep 17 00:00:00 2001
+From 838a65f2ee111b706bc4060ab9d0ee06ae1996c1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:42 +0800
-Subject: [PATCH 076/328] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
+Subject: [PATCH 076/331] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
 
 glibc added support for .gnu.hash in 2006 and .hash has been obsoleted
 far before the first LoongArch CPU was taped.  Using

--- a/app-admin/kernel-tools/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
@@ -1,7 +1,7 @@
-From 780d966f54f66518f852c6693f875fd1a3a6ecf6 Mon Sep 17 00:00:00 2001
+From 12d0fd3afbbffcb48fda0aec571a0e05589d646f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 077/328] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
+Subject: [PATCH 077/331] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
  page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/app-admin/kernel-tools/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
-From fba5146cef00ca1de0fe08608ac48199182510b2 Mon Sep 17 00:00:00 2001
+From 3bfa2952f12decc1219130a4c83d58e431f1f4ca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 078/328] FROMLIST: drm/xe/guc: use SZ_4K for alignment
+Subject: [PATCH 078/331] FROMLIST: drm/xe/guc: use SZ_4K for alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/app-admin/kernel-tools/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
-From b462b49cb7f3d57618221e0662df6b3d9880be7f Mon Sep 17 00:00:00 2001
+From 77a153ec1efe42c39b2285af4f1faa6f6aded565 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 079/328] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 079/331] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/app-admin/kernel-tools/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
-From c50b45c7da20c201f5b3d7f1d68e88ce4f1c77c6 Mon Sep 17 00:00:00 2001
+From bccb3c1e65e510a3e0bfde8bb1e8aa67bedaa13e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 080/328] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 080/331] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 

--- a/app-admin/kernel-tools/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
-From 7e5c8c1a1a4cad7dd7aeca4036c82d95ff30c316 Mon Sep 17 00:00:00 2001
+From d2ed0560fea2ac32275d1150ad83ed2fc531951c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 081/328] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 081/331] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/app-admin/kernel-tools/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
-From 09609e1200abc5763921b9707a633ae53d9c1699 Mon Sep 17 00:00:00 2001
+From 842926242d0dc1b8652734e39ed24a1346c250a8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 4 Mar 2025 14:33:51 +0800
-Subject: [PATCH 082/328] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 082/331] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/app-admin/kernel-tools/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From 0b51b6246a93d25badb82ba0f70b7565737ac14b Mon Sep 17 00:00:00 2001
+From e6c2d15969da83e7e1d098334c4d41ad2cdc4827 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 083/328] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 083/331] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/app-admin/kernel-tools/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
-From 7779d1fa57b01a02166fa9b3eb41da6493f88b24 Mon Sep 17 00:00:00 2001
+From 29953fd70506e98e188059a45e0fcdbd4d51576a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 084/328] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 084/331] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
-From 920161c121203bf37d0d08913f18264408bc2479 Mon Sep 17 00:00:00 2001
+From ed9bc84d8de37c648f7d06679b07639a70c6188d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 085/328] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 085/331] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/app-admin/kernel-tools/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
-From 85ccdb322ffa04c7b1376f4d916e59ef88132994 Mon Sep 17 00:00:00 2001
+From 49c8a5d33b90a5445bae5c4c2dbf0331659b7c7e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 086/328] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 086/331] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/app-admin/kernel-tools/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
-From 0ea7d5ad8e67fe1deff2ef5d4e80acdacd0f6e89 Mon Sep 17 00:00:00 2001
+From e042ad2afe52168ab07e23c42e070cce73eed44f Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 087/328] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 087/331] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/app-admin/kernel-tools/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
-From 30c70df6c0c313e7ef732025d37164a5bdcdce32 Mon Sep 17 00:00:00 2001
+From 991b9b6d7cf392620d62292f7878083536bd7a79 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 088/328] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 088/331] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/app-admin/kernel-tools/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
-From 473a23bff9fad27611aed78e637d313447234879 Mon Sep 17 00:00:00 2001
+From 6644c5e3d23bd69bee0f515f3cc87c5e2601a637 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 089/328] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 089/331] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/app-admin/kernel-tools/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
-From cc887d23fb203ad6e5628dc89eba10e84fc657cc Mon Sep 17 00:00:00 2001
+From 6eab28ab154ea8ecfe9356be42dba39066eb5907 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 090/328] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 090/331] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/app-admin/kernel-tools/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
-From 71069e72e4c867dea22d764f24d602f1efcf3310 Mon Sep 17 00:00:00 2001
+From bf3912d73761e0e20d6e9b243f80686ed76f5a0b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 091/328] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 091/331] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/app-admin/kernel-tools/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
-From a1277952666cea3f7c06432f46ee428e1cfb854e Mon Sep 17 00:00:00 2001
+From 2b8d29f8cdbd86a1e7f18b514d33c970dc2a12d4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 092/328] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 092/331] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/app-admin/kernel-tools/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
-From 45074a17ce8cfbc686649e54607945f6fec866f0 Mon Sep 17 00:00:00 2001
+From bf0ef5ecde60e4653e1ca21da40cc10cec159d37 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 093/328] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 093/331] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/app-admin/kernel-tools/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From 41eb7c563dfb674c5696c160003227ef6e7364f4 Mon Sep 17 00:00:00 2001
+From db921f2a7ba93aedc06b9f9c58302b696c80bffb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 094/328] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 094/331] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/app-admin/kernel-tools/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
-From 7a779c3fffbbb478a61829ff2fca6845bafb47d3 Mon Sep 17 00:00:00 2001
+From 0eb961f1e530ac161b6e1bc0ca8c3415c1a93db0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 095/328] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 095/331] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/app-admin/kernel-tools/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
@@ -1,7 +1,7 @@
-From b98c9351cd8de32fb08da96d96d03a73d8f40cfd Mon Sep 17 00:00:00 2001
+From 9fe3e33d565839d4f8e27d9ff32f97c7ce189214 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 25 Feb 2025 17:24:20 +0800
-Subject: [PATCH 096/328] LOONGSON: LoongArch: Always select
+Subject: [PATCH 096/331] LOONGSON: LoongArch: Always select
  HAVE_VIRT_CPU_ACCOUNTING_GEN
 
 Option HAVE_VIRT_CPU_ACCOUNTING_GEN is selected by default for 64bit

--- a/app-admin/kernel-tools/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
@@ -1,7 +1,7 @@
-From 81ba88b864ad5e44bacb9ff09444b24a835503f4 Mon Sep 17 00:00:00 2001
+From 698193fd40246bb36140be3dc6243b0377a9f7c9 Mon Sep 17 00:00:00 2001
 From: Yuli Wang <wangyuli@uniontech.com>
 Date: Thu, 6 Feb 2025 14:38:20 +0800
-Subject: [PATCH 097/328] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
+Subject: [PATCH 097/331] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
  Sanitizer)
 
 Select ARCH_HAS_UBSAN in order to allow the user to enable CONFIG_UBSAN

--- a/app-admin/kernel-tools/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
@@ -1,7 +1,7 @@
-From 85502d9c3c1b156f7b8d7cbdd51e71846325098e Mon Sep 17 00:00:00 2001
+From 2b9bd33f17fcbdf5f401a23d4999c1303a0b7fd3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 21 Feb 2025 19:32:43 +0800
-Subject: [PATCH 098/328] LOONGSON: LoongArch: vDSO: Make use of the t8
+Subject: [PATCH 098/331] LOONGSON: LoongArch: vDSO: Make use of the t8
  register for vgetrandom-chacha
 
 Make use of the t8 register for vgetrandom-chacha, so we don't need to

--- a/app-admin/kernel-tools/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
-From 3f316724bf9ff8d788067e53ac49fe441411d877 Mon Sep 17 00:00:00 2001
+From 564d2380ee671ceebc08897191289b55fd66b4a8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 099/328] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 099/331] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/app-admin/kernel-tools/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
-From fce05dadaf1eb2da874f595460b7d05244bed38d Mon Sep 17 00:00:00 2001
+From 468b67b2d92d3aa435a75481874f6b4a50ddecae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 100/328] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 100/331] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/app-admin/kernel-tools/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
-From 42b873752b46a99d2ac8f32a94cf329fa0daac55 Mon Sep 17 00:00:00 2001
+From 7f65d340697dd4e47ee854b2b3b7b7fde0dd4f17 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 101/328] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 101/331] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/app-admin/kernel-tools/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
-From 3d268637c6d5bf6c3b8a5aac8a75daba66d4b008 Mon Sep 17 00:00:00 2001
+From 4ff003d8273019459b562eeb72c18ca373c92065 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 102/328] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 102/331] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/app-admin/kernel-tools/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
-From abb78678f10717910e819a42e8faaee67f49662c Mon Sep 17 00:00:00 2001
+From a50720881ce311388b29e1b8748b6f564e06dc06 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 103/328] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 103/331] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/app-admin/kernel-tools/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
-From 3665718c82db1920ed4c84dba1d48efae6938552 Mon Sep 17 00:00:00 2001
+From 215a65618814d407695482cfe8c734490985b25b Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 104/328] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 104/331] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/app-admin/kernel-tools/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
-From e9afc183ebbc8e89d1bd5cfee498aa493dff1528 Mon Sep 17 00:00:00 2001
+From 4a55652e80d66f6adc4f930a76c3d013ee6f9871 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 105/328] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 105/331] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/app-admin/kernel-tools/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
-From 99284bc9d1cc7ab74b4ed02e63195fb4fe46d94b Mon Sep 17 00:00:00 2001
+From 6cbc2448d1ae05de242e1f7c839b262aca5d2ebd Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 106/328] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 106/331] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/app-admin/kernel-tools/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
-From fd340327ff81e795395f739d4a6cd67c0cc74df1 Mon Sep 17 00:00:00 2001
+From de8a18009d40db3619576045062e3028679f5d0a Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 107/328] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 107/331] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/app-admin/kernel-tools/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
-From 30971b1b763140de3d1018a66ea4459778664d60 Mon Sep 17 00:00:00 2001
+From 80a76c0f25cfb1ee2dea5f4503ff54549af134ed Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 108/328] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 108/331] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/app-admin/kernel-tools/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
-From eb68fcd0133c1c71c27e63d74cd0061c15d347b8 Mon Sep 17 00:00:00 2001
+From 22559eacbf2ae381254ecfe837a568094a94b7b3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 109/328] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 109/331] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/app-admin/kernel-tools/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
-From e295d41e4fb4169212df7c1478de759320cb561e Mon Sep 17 00:00:00 2001
+From f60c64d0246cbbba98291f97b9bfdfb144eb0353 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 110/328] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 110/331] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/app-admin/kernel-tools/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
-From 1a43e9be228843fc2686d8a076cf143d80e85b6b Mon Sep 17 00:00:00 2001
+From f40b8d998c82fad893653365a68f01e56d9143fd Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 111/328] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 111/331] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/app-admin/kernel-tools/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
-From 101839f08f3c59a301622ebab9ea351e67a931c1 Mon Sep 17 00:00:00 2001
+From 104f253474a260e96c9838b51165272ef498eba0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 112/328] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 112/331] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/app-admin/kernel-tools/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
-From d029c0c4c0548e8570fc5053f0cfa6d2e5207c28 Mon Sep 17 00:00:00 2001
+From 4530812feac7c66b66a9a971d82acbb2aff08ccc Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 113/328] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 113/331] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/app-admin/kernel-tools/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
-From adfd9c9d82e151efe4fde9917247bfd652a401e2 Mon Sep 17 00:00:00 2001
+From d1a7c549193a147f238a20b113f81caa254cd230 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 114/328] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 114/331] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/app-admin/kernel-tools/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
-From 0c9bbe29772deaccd94451b20bbf499dfd3edc6f Mon Sep 17 00:00:00 2001
+From 14daef10ec4901fe4153c864197802dd37ba5a3c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 115/328] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 115/331] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/app-admin/kernel-tools/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
-From 3e5931425d6463f4c3d5ed1238e25bc1faee926e Mon Sep 17 00:00:00 2001
+From f66b3d3c23dd8359f3d27b7e4893ce1b5cc7201e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 116/328] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 116/331] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/app-admin/kernel-tools/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
-From 2f8bfc0405a75f4e73bd69f70f30e5a50affb524 Mon Sep 17 00:00:00 2001
+From 3377e3d88b12d8cf9ddaa723f8792cc464567b5a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 117/328] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 117/331] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/app-admin/kernel-tools/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
-From 8f476d1831f9a5a18ffe111141292278f5ced8e9 Mon Sep 17 00:00:00 2001
+From cfea24be954f2a302b63022a8dc47b9535e9c72e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 118/328] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 118/331] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/app-admin/kernel-tools/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
-From bb81253cfd3d3855b86198babeddabf1a842b087 Mon Sep 17 00:00:00 2001
+From b59ca15944a9dc8230e68e561822ffd80be08632 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 119/328] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 119/331] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/app-admin/kernel-tools/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
-From caa41f9a3ca929efd3b1210b37761f81c1619d60 Mon Sep 17 00:00:00 2001
+From df138def196489dcb4867f0723059213a0218bbb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 120/328] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 120/331] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/app-admin/kernel-tools/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
-From 9adfee3d0dc19140218de2a7cd5e71469a9d7279 Mon Sep 17 00:00:00 2001
+From 2c530649852b5d3dc917c37fca2eb8d7ba39b93f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 121/328] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 121/331] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/app-admin/kernel-tools/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
-From a283b2c09605bc512b9bd56b44d3bb1f60b66226 Mon Sep 17 00:00:00 2001
+From 202b47e5b3c498cb0d5943725dfbbbda299a7e4d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 122/328] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 122/331] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/app-admin/kernel-tools/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
-From 93f38035d8aad24e0fa006f61f215917c3ed8a1d Mon Sep 17 00:00:00 2001
+From 864a597f9a47e877070096de1e13d97d2ddf4664 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 123/328] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 123/331] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/app-admin/kernel-tools/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
-From d7fc96e6fca8765ea219d304fa90e41b279212fc Mon Sep 17 00:00:00 2001
+From 37ec5d5897312ef0fe4cb1773801c3a642dd12ef Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 124/328] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 124/331] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/app-admin/kernel-tools/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
-From 98c60fe8a7ecb040844f089b62a17da573f9700e Mon Sep 17 00:00:00 2001
+From 3dc5aa0becedec06ea4ec4f3620a9acc999f8754 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 125/328] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 125/331] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/app-admin/kernel-tools/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
-From 46425ae808654a7dbd5db5860fad39a8f55ea8f9 Mon Sep 17 00:00:00 2001
+From 0e73bff591d093a58587a984fc090427a5cba8ba Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 126/328] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 126/331] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/app-admin/kernel-tools/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
-From 808e1cab566feca68f95f2ff70f2fe531843e24c Mon Sep 17 00:00:00 2001
+From 653213b85470dcc224793745c24294b9bf33844a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 127/328] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 127/331] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/app-admin/kernel-tools/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
-From 8acac7a55e6b3eb9eedc533dce6337d67fba7431 Mon Sep 17 00:00:00 2001
+From f03c3682c1b9dc1b0bf37652cb31533e2ce45d7e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 128/328] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 128/331] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/app-admin/kernel-tools/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
-From cd227e288caeea667da01a63b9291aaa798cbbc0 Mon Sep 17 00:00:00 2001
+From b57b84a5dd1dd24bfb3e04f81d233c4c4f99801a Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 129/328] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 129/331] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/app-admin/kernel-tools/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
-From f8550ec3dd7f4c5f490487f4bfc1de1b6177d701 Mon Sep 17 00:00:00 2001
+From 6e5a2aa15dc219f43470e91a32912f50363fcefd Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 130/328] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 130/331] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/app-admin/kernel-tools/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
-From cee58bd142ba90da8a94faca9660d3b1bcba4183 Mon Sep 17 00:00:00 2001
+From d469b363004b11b2b0e612f86dc2aa6d038a14ae Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 131/328] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 131/331] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/app-admin/kernel-tools/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 168948244cdf0973129d9181026258c258fa6f9d Mon Sep 17 00:00:00 2001
+From 07abf999c1f595cbb5f3301b61159bfdbb2e5b48 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 132/328] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 132/331] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/app-admin/kernel-tools/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 6f6dd127608f1d5c74cbaf5bd47693c9d57fc32b Mon Sep 17 00:00:00 2001
+From c684713f10249d87cd87410a170324790dcddfa8 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 133/328] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 133/331] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/app-admin/kernel-tools/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 077ff3d5dfa8db788cb680e84d037b4ab67f2e0e Mon Sep 17 00:00:00 2001
+From 338e431cdeeddfca2ac833c3e53c6846c505a4b9 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 134/328] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 134/331] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/app-admin/kernel-tools/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
-From b5e7ed1dd64122c82284bd1cb95f5d008152838e Mon Sep 17 00:00:00 2001
+From 05294f2b08729f0ae96868126de50df9a8988fbe Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 135/328] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 135/331] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/app-admin/kernel-tools/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
-From 40d024d402d898ca44f92230e8e54cd2311aceb7 Mon Sep 17 00:00:00 2001
+From 118ebc6899e172fe754cfef6e727a4aeb7460761 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 136/328] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 136/331] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/app-admin/kernel-tools/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
-From a13ff5fea24b19d907fead019e9fc791fae0006e Mon Sep 17 00:00:00 2001
+From 1f8683975a0ae04eb1eb5d6cfe6073d28f891d38 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 137/328] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 137/331] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/app-admin/kernel-tools/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
@@ -1,7 +1,7 @@
-From 71951cfd1924bf32de8af948f9963553030fc6ec Mon Sep 17 00:00:00 2001
+From 068a11012025d6223530216d639786d02ec9b2f3 Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:31 +0800
-Subject: [PATCH 138/328] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
+Subject: [PATCH 138/331] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
  support for MPAM
 
 maillist inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
@@ -1,7 +1,7 @@
-From 6b5840472214a1e4d24d74a374f295267a84e7ff Mon Sep 17 00:00:00 2001
+From 09541a47d3e6db3f4f194e9d4578825bce41169e Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:32 +0800
-Subject: [PATCH 139/328] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
+Subject: [PATCH 139/331] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
  guest accesses to the MPAM registers
 
 maillist inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
@@ -1,7 +1,7 @@
-From cf423f8ca305420e0034f10f5bb96bbff14b5c94 Mon Sep 17 00:00:00 2001
+From 7df1b9c8fa34ec13f15804ed2bc6261ee4ff67ff Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Sat, 1 Jun 2024 14:38:28 +0800
-Subject: [PATCH 140/328] BACKPORT: OPENEULER: arm64: cpufeature: Both the
+Subject: [PATCH 140/331] BACKPORT: OPENEULER: arm64: cpufeature: Both the
  major and the minor version numbers need to be checked
 
 hulk inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
@@ -1,7 +1,7 @@
-From 8a130bd3bebd8a92948f36129b2f1f517083da6c Mon Sep 17 00:00:00 2001
+From 2494b3f8408b4d44df159edec99267601d044a9d Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:52 +0800
-Subject: [PATCH 141/328] BACKPORT: OPENEULER: Revert "arm64: head.S:
+Subject: [PATCH 141/331] BACKPORT: OPENEULER: Revert "arm64: head.S:
  Initialise MPAM EL2 registers and disable traps"
 
 hulk inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
@@ -1,7 +1,7 @@
-From f19a40a584b555954c20d66cf08bb85a47cc5c0d Mon Sep 17 00:00:00 2001
+From d41643f11d78ca5dda0e255ffdfa3a7de30736c8 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:53 +0800
-Subject: [PATCH 142/328] BACKPORT: OPENEULER: arm64/mpam: Check
+Subject: [PATCH 142/331] BACKPORT: OPENEULER: arm64/mpam: Check
  mpam_detect_is_enabled() before accessing MPAM registers
 
 hulk inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
@@ -1,7 +1,7 @@
-From 05a50e582a73d7d69d67f28d3757ff6801945fd9 Mon Sep 17 00:00:00 2001
+From a43876ff66674420c8a10e0524649cfadd39e711 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Thu, 26 Sep 2024 17:28:18 +0800
-Subject: [PATCH 143/328] OPENEULER: arm64/mpam: Fix redefined reference of
+Subject: [PATCH 143/331] OPENEULER: arm64/mpam: Fix redefined reference of
  'mpam_detect_is_enabled'
 
 hulk inclusion

--- a/app-admin/kernel-tools/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
-From e2fb4ba2f76865beb127d15b1ca762ef55c201c7 Mon Sep 17 00:00:00 2001
+From 625f50b31afa5da8c44aa0b70a98731c3e1ecdaf Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 144/328] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 144/331] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/app-admin/kernel-tools/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
-From ca348c19a878853ce1f81692f946050ff2dee33e Mon Sep 17 00:00:00 2001
+From afa32fa41b82cc2d848d9ed190eb9781413b4c56 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 145/328] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 145/331] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/app-admin/kernel-tools/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
-From ebc38b82cd3fcd0296aceb48f73b0c5a7dc752df Mon Sep 17 00:00:00 2001
+From 8f4627200fe0bf0f7dfd6d7d4f3bb15392ca27bb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 146/328] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 146/331] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/app-admin/kernel-tools/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
-From a763675674a043c0e1dfd8a80b3cbab20ec7b4d4 Mon Sep 17 00:00:00 2001
+From 37f88f995927a36912010000b50bcc9df836f852 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 147/328] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 147/331] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses

--- a/app-admin/kernel-tools/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
@@ -1,7 +1,7 @@
-From 2dcc89ca969cb25d48e19e22597bfde888e78c9a Mon Sep 17 00:00:00 2001
+From febae37d9aff333f461590586826e5d1e199fdb4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:51:08 +0800
-Subject: [PATCH 148/328] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
+Subject: [PATCH 148/331] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
  of the number of packages
 
 Signed-off-by: wanghongliang <wanghongliang@loongson.cn>

--- a/app-admin/kernel-tools/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
@@ -1,7 +1,7 @@
-From 9784e806980106c96afff9372d920434625236be Mon Sep 17 00:00:00 2001
+From 069f212c5c0af3ab919585b7aa62e4d6d634c6ae Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 149/328] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
+Subject: [PATCH 149/331] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
  devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/app-admin/kernel-tools/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
-From 9013e5d6dabeb2c56536a15d09a5999edf7a20b8 Mon Sep 17 00:00:00 2001
+From e2e2e787382f6d90b754743b270f286bf07461a2 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 150/328] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 150/331] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 

--- a/app-admin/kernel-tools/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
-From fc44fe6aac194b5854be87d00deaf758edaae460 Mon Sep 17 00:00:00 2001
+From 6bb5a3e9e24b0214e3d05a2af321b51128927235 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 151/328] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 151/331] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/app-admin/kernel-tools/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
-From ab6f83bc3debb13ac92bfcb0024a74ec36b1a981 Mon Sep 17 00:00:00 2001
+From 45bcac767b16fd4a6cdf32efba7354355e368598 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 152/328] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 152/331] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/app-admin/kernel-tools/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
-From 53d182d3be5f88721eaa6db1b9b643b0fbe3b414 Mon Sep 17 00:00:00 2001
+From 1d781bcb9db1d84a99bace6865d25011339c0da8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 153/328] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 153/331] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/app-admin/kernel-tools/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
-From 9a5d19c3a34673e2ecdd277cbbe71aa1d37b0a68 Mon Sep 17 00:00:00 2001
+From 4aa8d98ca60bf9677caf3e4f1d98594880a4e1f3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 154/328] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 154/331] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
-From 685d70d27d4b6a862e91dcc7e74094347fde11b8 Mon Sep 17 00:00:00 2001
+From fd75b2ecf6cb99e0975e2eb64e7ac5615e5a261a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 155/328] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 155/331] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/app-admin/kernel-tools/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
-From 6f2b3a07c787d6b07cf46a29986d67fcc852d0d5 Mon Sep 17 00:00:00 2001
+From d575d36f9e5bb55b93178d165e8024432c444b6d Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 156/328] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 156/331] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/app-admin/kernel-tools/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
-From 13da2583cd07a7e43ad05f5b46bf350b2aec0f2c Mon Sep 17 00:00:00 2001
+From ca5509eb9d1928d253ee2764e703cbf1d4f6420c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 157/328] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 157/331] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
-From cfe49cf9f25128b3c5e4cf4fefe9113f424b0165 Mon Sep 17 00:00:00 2001
+From 897db67c9fc099d5536a80360f4890ce3c9bd183 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 158/328] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 158/331] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/app-admin/kernel-tools/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
-From 356d6d007e6efa5917fedeb156cd2df3c81e55f8 Mon Sep 17 00:00:00 2001
+From bcb91347da6d2a49f8a4f88d2ee66d9a2d9deeb9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 159/328] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 159/331] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
-From 22f9eda5983ec390719b63dc384ecf2e998390b1 Mon Sep 17 00:00:00 2001
+From 72b4edc64fc7d64ca03bb2cc9ba91950a6e6c00f Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 160/328] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 160/331] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/app-admin/kernel-tools/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
@@ -1,7 +1,7 @@
-From 06723144dea3c8113dbf17cf04674fe0fa1ffe82 Mon Sep 17 00:00:00 2001
+From e49698bf6f4e253f9085835d6ef56c7106793a4d Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 161/328] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
+Subject: [PATCH 161/331] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
 Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:

--- a/app-admin/kernel-tools/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
@@ -1,7 +1,7 @@
-From bbf3a842012e288fb965ac49f01f746e8fba6372 Mon Sep 17 00:00:00 2001
+From 085a38d0b3d3f2c4ce21aa1517168ca86747100b Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 162/328] BACKPORT: SURFACE: hid: Add support for Intel Precise
+Subject: [PATCH 162/331] BACKPORT: SURFACE: hid: Add support for Intel Precise
  Touch and Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/app-admin/kernel-tools/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
-From c3ef21e91e5d96e2003463b893b72721ddf8dcd5 Mon Sep 17 00:00:00 2001
+From 34d630a83c1d83ade04db228b862fda1c39bff85 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 163/328] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 163/331] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
-From 0b58ee13b0d93de2da2f9e68ddbffd1b7375096d Mon Sep 17 00:00:00 2001
+From 85b02a4838598d78f3b3735cc0a597dfa0e7b364 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 164/328] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 164/331] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/app-admin/kernel-tools/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
-From 9030cec67f107596b725eb0b230cd0c88c3240b3 Mon Sep 17 00:00:00 2001
+From d122101d5620358ad8c39e9919e0fce455897943 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 165/328] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 165/331] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/app-admin/kernel-tools/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
@@ -1,7 +1,7 @@
-From 4e88dab36bf6a544f9d3bc9cfe6cb4895efb5e05 Mon Sep 17 00:00:00 2001
+From 8817b683ca829263a5966b29d46bac6647b24440 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 166/328] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
+Subject: [PATCH 166/331] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
  for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/app-admin/kernel-tools/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
-From 8db60838d17327798f02760bddd72c427e7d8031 Mon Sep 17 00:00:00 2001
+From c9354aa824d4c66842ec2d9095b33892252915e4 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 167/328] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 167/331] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/app-admin/kernel-tools/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
-From 958394e7d4f1048ec13bfe516bb7b5ae3f655daa Mon Sep 17 00:00:00 2001
+From fb2d25685a9420cd96c30419d1b19387957efa42 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 168/328] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 168/331] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/app-admin/kernel-tools/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
-From 43c31271c01945cf7cdf561f9611d284d62f9268 Mon Sep 17 00:00:00 2001
+From 1c5ca2ad6022b188099d725634b6b44f57a99496 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 169/328] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 169/331] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/app-admin/kernel-tools/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
-From 94ae8441e5ddb1c6bd6a237e0c61de081db22006 Mon Sep 17 00:00:00 2001
+From 4c27b11ce456cb25125ce481b4b72f2ce83ef946 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 170/328] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 170/331] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/app-admin/kernel-tools/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
-From 90ab9ce2ddb644248283f924a175ccac0582c644 Mon Sep 17 00:00:00 2001
+From 8e51dd57a82e5d0d343228b65f5d5e5ff96dd4c2 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 171/328] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 171/331] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/app-admin/kernel-tools/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
-From c7ab17c3f14bee6886225816bcba06af6ed6f96c Mon Sep 17 00:00:00 2001
+From f4e992f228bff532ce49ba61527adbcb1ed85860 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 172/328] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 172/331] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/app-admin/kernel-tools/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
-From f32ccd3a5993fe8a8c9e82237296b2ff16ca0369 Mon Sep 17 00:00:00 2001
+From c6f5bc672ff00c2f8ec49ba3b007a502f6693af9 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 173/328] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 173/331] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/app-admin/kernel-tools/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
@@ -1,7 +1,7 @@
-From d97849d79f0a62183972f0a16fd647ad36072384 Mon Sep 17 00:00:00 2001
+From 296d2a48e97715ff33262f10054495a8892a33b4 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Mon, 16 Sep 2024 05:55:58 -0400
-Subject: [PATCH 174/328] FROMEXT:
+Subject: [PATCH 174/331] FROMEXT:
  more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
@@ -1,7 +1,7 @@
-From c33f22b5dcd11d97f2da51242f110e5cbeb63df4 Mon Sep 17 00:00:00 2001
+From eea5a2fe27a2534f7ed4a6f262e3ef7ddc727da3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 18 Dec 2024 12:31:33 +0800
-Subject: [PATCH 175/328] FROMEXT: cjktty-6.9.patch
+Subject: [PATCH 175/331] FROMEXT: cjktty-6.9.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/app-admin/kernel-tools/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
@@ -1,7 +1,7 @@
-From 87f84446b5d7d6da3729e692a149466e3ce3b916 Mon Sep 17 00:00:00 2001
+From b6a0e33a544e856bbde4f87883a38feae795ec5b Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 13 Sep 2024 17:30:35 +0300
-Subject: [PATCH 176/328] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
+Subject: [PATCH 176/331] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
  clock ratio and scrambling support
 
 Enable use of HDMI 2.0 display modes, e.g. 4K@60Hz, by permitting TMDS

--- a/app-admin/kernel-tools/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
-From f5f19fc3e5504b7f23b92158f8566e1c4dbf159b Mon Sep 17 00:00:00 2001
+From a4242accbae9e3e3d101b7dc680489200806be2b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 177/328] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 177/331] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/app-admin/kernel-tools/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
-From c7ec140e0dfa07f284cb20e7df30ce9c50209709 Mon Sep 17 00:00:00 2001
+From d9b7100fa084e19bae73683846424770f4b615d8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 178/328] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 178/331] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/app-admin/kernel-tools/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
-From 2e13e81ad47a5e4c98083411c5ab76dcd173a0e4 Mon Sep 17 00:00:00 2001
+From 44aa71c9af86a87c300ebe63bf10a435987f6b0c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 179/328] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 179/331] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/app-admin/kernel-tools/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
-From 6e00d4698cff537e482d1d4d2737914a94233cd4 Mon Sep 17 00:00:00 2001
+From b843211b742c06a38b0472047746e9ff866b01aa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 180/328] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 180/331] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/app-admin/kernel-tools/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
-From b9a6c81a1e96324d6ef389b50853dcfa429e68cb Mon Sep 17 00:00:00 2001
+From 1c83f2c6b01b79e023d4d7bca5efb17d367af4e5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 181/328] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 181/331] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/app-admin/kernel-tools/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
-From 41214eedc7567556bd33532ffbbcf540e6d32166 Mon Sep 17 00:00:00 2001
+From 0d2fd17ef8d7439955410de718916751ea70f8fd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 182/328] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 182/331] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/app-admin/kernel-tools/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
-From 97e46141d4793f7ee67ddb3a852181a148c294a2 Mon Sep 17 00:00:00 2001
+From 2a19da5a2414240a54f2c3ed30cd09ce98f495dd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 183/328] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 183/331] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/app-admin/kernel-tools/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
-From 787985c7978fec8443b9ed4c373e38e34928f7ed Mon Sep 17 00:00:00 2001
+From 799650fa7c9bc46acff43a389b523fd454898fe3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 184/328] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 184/331] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/app-admin/kernel-tools/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
-From 8dbac38f55108d71a181ca11f37dc44ad5f154a1 Mon Sep 17 00:00:00 2001
+From 7082a360be91bfc25cbf689da6296884be63f924 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 185/328] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 185/331] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/app-admin/kernel-tools/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
-From d964087fa24f4f1590b9ec91b79240a7214b3b2f Mon Sep 17 00:00:00 2001
+From c0a8a3b7278e32b1ce149be73af6860a889530b7 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 186/328] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 186/331] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/app-admin/kernel-tools/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
-From 99eaab192f2473b56f07a8c55e0759a9d1afc924 Mon Sep 17 00:00:00 2001
+From edf9bcf8e740996f07a08c28559d8dc1785cb74d Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 187/328] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 187/331] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/app-admin/kernel-tools/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
-From 4a75506a1346b9ec024bd60002700e05a72be554 Mon Sep 17 00:00:00 2001
+From 91b71e6d3ee7f63222ebcfe048f1d84fb67033a3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 188/328] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 188/331] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/app-admin/kernel-tools/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
-From 00d6e427636adeffd8f3a1b481113eaf788b64c6 Mon Sep 17 00:00:00 2001
+From d2a3a6eab563f5e364e1ca3de91c247ad5ae6dc8 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 189/328] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 189/331] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/app-admin/kernel-tools/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
-From 15c0a3ee7a0ba280b36e41f69818455259d58118 Mon Sep 17 00:00:00 2001
+From 30ff51e4529ce995695f72fe0885d30d31d56dec Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 190/328] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 190/331] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/app-admin/kernel-tools/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
-From f66c0e09b6bb9486f578462fd84e2dc65f5a7c78 Mon Sep 17 00:00:00 2001
+From 80ac88479de1ec2b0bf99e11b9cf008816b57158 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 191/328] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 191/331] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/app-admin/kernel-tools/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
-From 8839cc120c3c41f6521861542be89da5d17eff4d Mon Sep 17 00:00:00 2001
+From fe7be048448966b64e64ab1abc1d02196b5ceac1 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 192/328] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 192/331] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/app-admin/kernel-tools/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
-From f5592ac9965186505743ddaf0e6bb99cb31af03b Mon Sep 17 00:00:00 2001
+From fd25f66fe8ccc0f082478ed1701af1b77938dd1e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 193/328] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 193/331] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/app-admin/kernel-tools/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
-From 906599fa4a4dd2cd4dc73a17cd2153c245dc46b2 Mon Sep 17 00:00:00 2001
+From c247f6b776148a85f076f4e0d771914ccdb1e91a Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 194/328] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 194/331] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/app-admin/kernel-tools/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
-From 89a178731a0e6f716b51bda65bfb895c46478514 Mon Sep 17 00:00:00 2001
+From e27b5e875602083b9de991d5dae03f3452a08d74 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 195/328] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 195/331] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/app-admin/kernel-tools/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
-From 79d56a8e49d82a692c5a86255af0f0d97c5dbf5d Mon Sep 17 00:00:00 2001
+From dad596710256e8fbd704a8f47ab58a2e9e5fb025 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 196/328] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 196/331] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/app-admin/kernel-tools/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
-From b42235dc7f2cb2a953dbd7144cded329f1df806d Mon Sep 17 00:00:00 2001
+From 32393fba0189144cf7bfb3da5660638249c818a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 197/328] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 197/331] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/app-admin/kernel-tools/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
-From ce2edd6ea8d153633ff92c1d8360f569fc7fe085 Mon Sep 17 00:00:00 2001
+From b7e5b584dce31390096bcb07d66e41c6b68b3308 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 198/328] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 198/331] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/app-admin/kernel-tools/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
-From db6e31f0a6bfa2e5236971a84e757416fa390eee Mon Sep 17 00:00:00 2001
+From 2266ed388f0807c474360173e81cb7904e272c16 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 199/328] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 199/331] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/app-admin/kernel-tools/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
@@ -1,7 +1,7 @@
-From 752c0d9bfc65240aeae223ed8451616484d5cb7d Mon Sep 17 00:00:00 2001
+From 2eb027cbc61d260a901d430a75214a6c214790d4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 31 Dec 2024 15:56:52 +0800
-Subject: [PATCH 200/328] AOSCOS: drm/ls2kbmc: Add id_table for
+Subject: [PATCH 200/331] AOSCOS: drm/ls2kbmc: Add id_table for
  ls2kbmc_platform_driver
 
 Try to fix device binding for the driver.

--- a/app-admin/kernel-tools/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
-From 9a33e02849c6c73e3a1eaa94d0972e8a6a5cdf98 Mon Sep 17 00:00:00 2001
+From 95df4f1c42093190be1a5c72a5effa7f24d236f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 201/328] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 201/331] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/app-admin/kernel-tools/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
-From 4788e2e6377086b9b6f034adcbf56c4b21a75eca Mon Sep 17 00:00:00 2001
+From 551efbdf25020112f8f80bbc5596098dbe76a3f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 202/328] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 202/331] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/app-admin/kernel-tools/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
-From 36578d5d86df38df85d86288ba5b17451340da1a Mon Sep 17 00:00:00 2001
+From 47080bcd109d33bade24e4cc973b4840b5c00cda Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 203/328] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 203/331] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/app-admin/kernel-tools/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
-From b2f912a9183f71ed7c66e206a9350c0b11191f9d Mon Sep 17 00:00:00 2001
+From 84d7fdbbab5e720c334b3fa6aa3f62a790c9a33f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 204/328] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 204/331] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/kernel-tools/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
@@ -1,7 +1,7 @@
-From ee325e1fc0d830edc20ab59b81222c509051fe9f Mon Sep 17 00:00:00 2001
+From bdfb42dcff1281ff50a2e885f7bcced236b684d0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:06:44 +0800
-Subject: [PATCH 205/328] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
+Subject: [PATCH 205/331] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
 
 Following upstream name changes.
 

--- a/app-admin/kernel-tools/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
@@ -1,7 +1,7 @@
-From 44d51a300b3c020a2d2840f25d856130d1e9dc16 Mon Sep 17 00:00:00 2001
+From 2e24ec1874bfb4788d8f3ea5326a7d796b45f6ad Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:41:10 +0800
-Subject: [PATCH 206/328] AOSCOS: drm/ls2kbmc: remove driver date
+Subject: [PATCH 206/331] AOSCOS: drm/ls2kbmc: remove driver date
 
 Following upstream changes.
 

--- a/app-admin/kernel-tools/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
-From f709c2ee34720af833db69163d0a8feb36def2f7 Mon Sep 17 00:00:00 2001
+From cfd029e38cddba0424dd59371cad76362da778ad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 207/328] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 207/331] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/app-admin/kernel-tools/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
-From 416a8c94733dab0736ea7eabe50b8dc38bc248a1 Mon Sep 17 00:00:00 2001
+From 42842d19ce14b619c520a45ea2bf5318b875afc6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 208/328] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 208/331] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/app-admin/kernel-tools/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
-From fb6479a7c014f32a9469b632d856f77a0c679ad9 Mon Sep 17 00:00:00 2001
+From ebda65cc9099a61bf83071b17af55cee09c44671 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 209/328] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 209/331] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/app-admin/kernel-tools/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
-From 9cfbb269682585c0872bc5d95aa434752a8f8a44 Mon Sep 17 00:00:00 2001
+From 8d32bd293b288ba93e9e50015c1a95bc45e4becb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 210/328] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 210/331] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/app-admin/kernel-tools/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From a8d379b70015ae322342644bbef27373ba7b0485 Mon Sep 17 00:00:00 2001
+From 0bd74c1a90486d06de130e8b7dc7b9a6ae31fc5c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 211/328] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 211/331] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/app-admin/kernel-tools/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
-From 93db20eafd54b24125e59ca699fcc84b92556b59 Mon Sep 17 00:00:00 2001
+From 3ce4bb6899f4d0d4d8988ff9b98c7fa4bbde74a2 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 212/328] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 212/331] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/app-admin/kernel-tools/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
-From 10aa992197927dcaa1b348cd668c5d54f8fd5f89 Mon Sep 17 00:00:00 2001
+From 3061b7faa1465d51e4b442be7c5717871e629b02 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 213/328] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 213/331] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/app-admin/kernel-tools/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
-From af173838578c7e4ed35576311114aac9535b9383 Mon Sep 17 00:00:00 2001
+From 29a4172fd2734233650c8dcd2e6f9cfeb006a8ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 214/328] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 214/331] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/app-admin/kernel-tools/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
-From 8ef7834586d6a500235382a00a6cb2c2b11b3e7f Mon Sep 17 00:00:00 2001
+From a5ad18c3663630c7adeee49da50f20d89048c1bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 215/328] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 215/331] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/app-admin/kernel-tools/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
-From 6c22ae7b86d4794f5e7e1ee991d0fd9ba97f4d62 Mon Sep 17 00:00:00 2001
+From 431504dd7c9451dac404f884fab3e202ada608db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 216/328] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 216/331] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/app-admin/kernel-tools/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
-From 627b35c23383d364ade801dd500958b310df4ac6 Mon Sep 17 00:00:00 2001
+From 3f99f049eba0d19ddd312d01fb9c0bc441af7bea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 217/328] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 217/331] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/app-admin/kernel-tools/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
-From f25936ce1117b7b4874315f49160ab1fcdad7f11 Mon Sep 17 00:00:00 2001
+From 6c6dee64125103dca3242b115116d53eeabdb3ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 218/328] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 218/331] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/app-admin/kernel-tools/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
-From 947981323ee1237a568d5f19ce40f789c1b95812 Mon Sep 17 00:00:00 2001
+From 313f7dd1b7a0d5ea6faeb284ecd101184ebdb1c2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 219/328] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 219/331] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/app-admin/kernel-tools/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
-From 1812270f0dda73454a5b0ca33debd742a7460310 Mon Sep 17 00:00:00 2001
+From b5f4f40098062802ceb4e04789254bdbd1b27c62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 220/328] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 220/331] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/app-admin/kernel-tools/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
-From a1bdb04860fffd69066fb97595f1c007fd37d4de Mon Sep 17 00:00:00 2001
+From 866116c01cc44fed5619ae5400fa71b95dc80145 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 221/328] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 221/331] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/app-admin/kernel-tools/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
-From 71412268842ebe3c625ff093d35dc65aa9ed4fd3 Mon Sep 17 00:00:00 2001
+From e76287124d4e2af40b1cd7a7efc2ce5c38c15139 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 222/328] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 222/331] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/app-admin/kernel-tools/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
-From 84a5756639bd716bf7802123651792f79eb96f3c Mon Sep 17 00:00:00 2001
+From 13d17ce43754fb86a0dfbe515a155de4435c7cfa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 223/328] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 223/331] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/app-admin/kernel-tools/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
-From 9193e04ba31fcbbe6b39706c538ce0dbd077d0b5 Mon Sep 17 00:00:00 2001
+From 2f266141fbd90f626fa4c68a7963fb3c1d04f02a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 224/328] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 224/331] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/app-admin/kernel-tools/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
-From b8b56314474fb8f6a6a4ea68d70f05959ab49e75 Mon Sep 17 00:00:00 2001
+From e80d9945e279f972b25b3d03b5564fa887a49194 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 225/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 225/331] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/app-admin/kernel-tools/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
-From fbf191befdd7ac91e4e6ff60673506985930763a Mon Sep 17 00:00:00 2001
+From 96b8cc4c513ecc1d4c15d6232b2f92b9c00c78cb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 226/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 226/331] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/app-admin/kernel-tools/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
-From b5a97a1fe0cfe1ec037c0d4e8a3cd898ba523b24 Mon Sep 17 00:00:00 2001
+From 85296d6ec9c66b915098958fb16407cb1e3598f7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 227/328] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 227/331] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/app-admin/kernel-tools/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
-From bd23f4d14766609544224b9847442e6dd4912cc1 Mon Sep 17 00:00:00 2001
+From b5c49e43f7a0cbef0c514b1c1865f8565b0b52ee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 228/328] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 228/331] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/app-admin/kernel-tools/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
-From 1950d4db09bda92997efc876656e8a5807bd4082 Mon Sep 17 00:00:00 2001
+From 9b5b14d46036df621102d640e74c75a6e9b031bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 229/328] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 229/331] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/app-admin/kernel-tools/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
-From ce95e391a5e82cc1ca6bdbda46a865f653db84ec Mon Sep 17 00:00:00 2001
+From df3d4dc97a9eb2b3a42e067e4602bec6440831ca Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 230/328] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 230/331] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/app-admin/kernel-tools/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
-From 37d048f60e36c78e1508e69caf6b0d735fb545f1 Mon Sep 17 00:00:00 2001
+From 80f263b05c3657449242ea4ce1ef92f10fa1dd25 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 231/328] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 231/331] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/app-admin/kernel-tools/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
-From 9bfa19e968f0fc4bedf73d6d478b92bf15ab1ac9 Mon Sep 17 00:00:00 2001
+From 8e6c737d585f9bd50d88aad0ccd5f494c09b195a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 232/328] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 232/331] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/app-admin/kernel-tools/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
-From e70b4573423ef7adf949eb2a3bebaf66ade1e107 Mon Sep 17 00:00:00 2001
+From 5e8864fe1a7bf227e33968326d0f4e21545757e0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 233/328] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 233/331] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/app-admin/kernel-tools/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
-From a623408c62e80b04ad30256c7f246d1933b22252 Mon Sep 17 00:00:00 2001
+From ebaebc4dd96a2dfa30024bc4c71de594681b6183 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 234/328] AOSCOS: input: atkbd: disable
+Subject: [PATCH 234/331] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/app-admin/kernel-tools/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
-From 72893cf1da4b4f8bd4e2ca08f4e345f840e63a77 Mon Sep 17 00:00:00 2001
+From 71458513ac0dab31eec8214e63ed15e50c39c164 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 235/328] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 235/331] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
-From 8fb43c20673808828831f8d42ae5df5a0665d90a Mon Sep 17 00:00:00 2001
+From c4d3df0c406aa56a5cb0dc92ac7b5b0d0726db63 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 236/328] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 236/331] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/app-admin/kernel-tools/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
-From 418a1dbb40b1c8efbbed661805c488de9e42be03 Mon Sep 17 00:00:00 2001
+From 9467f767a24ba50941c405aad72313f231e756c3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 237/328] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 237/331] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/app-admin/kernel-tools/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
-From 2ef3bcdbcaa1cbdc2de36a476f20af87c0e197ec Mon Sep 17 00:00:00 2001
+From 0a356a17a9178304ca6ac841eaeb11b021a67ec7 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 238/328] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 238/331] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
-From 5f92a10ceb4e691ebd1402aeed8f36ded998e6a5 Mon Sep 17 00:00:00 2001
+From 2620baa9c82703c94f8a8b6e6be82c9bbc3976eb Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 239/328] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 239/331] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/app-admin/kernel-tools/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
-From 28791d3c644891ea37560d14e740f94eb3d87a38 Mon Sep 17 00:00:00 2001
+From 0ada807a011c78d372271924d8742c33842abaae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 240/328] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 240/331] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
-From 68139fd3dfd28a34dfe95fe84b2463fc50748ff4 Mon Sep 17 00:00:00 2001
+From 93cfd417a9a85308103490c9855016db85bb96c0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 241/328] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 241/331] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/app-admin/kernel-tools/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
-From 7b617ebeabd292cc47224ca264a7ad9a0f2176aa Mon Sep 17 00:00:00 2001
+From c988f2fc2fe5e9dd6f8c3cb0cedbc106d7233beb Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 242/328] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 242/331] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/app-admin/kernel-tools/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
-From f2f28f060713d98681e1e636bc003fbb68b0aa29 Mon Sep 17 00:00:00 2001
+From 54a5d694da2febf2dc51347fb484756eb92e8014 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 243/328] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 243/331] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/app-admin/kernel-tools/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
-From 57702ca889552e8cd30be6ccc8e653b60e262e46 Mon Sep 17 00:00:00 2001
+From ddc2d3e7eb0b6196079ce6b518fb1b98770fb73b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 244/328] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 244/331] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/app-admin/kernel-tools/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
-From 80876e51d884a3047e4443938b8818508cf45542 Mon Sep 17 00:00:00 2001
+From bfe19559a4f5ae742ecdef9d810c161238347e66 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 245/328] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 245/331] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/app-admin/kernel-tools/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
-From 998ccc492d0f9571d1fe71c035611230f25bd627 Mon Sep 17 00:00:00 2001
+From 263b69d2f9f645ad1501e0decf3082d67e0959f6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 246/328] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 246/331] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/app-admin/kernel-tools/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
-From 6db473d29fbd0f2a3b5f4314b667ed6a7bd1a38e Mon Sep 17 00:00:00 2001
+From 0f9a9bba137cfc60dcc24614fc82d777c5d0bec1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 247/328] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 247/331] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/app-admin/kernel-tools/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
-From 1ec360c53fabc943c3d879141958145bd05c9b0f Mon Sep 17 00:00:00 2001
+From ec404e03bb2f52551c5718c21844f4a238b23ebc Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 248/328] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 248/331] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/app-admin/kernel-tools/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
-From f67f9939f501c9900548923597f8ebc39a52af0f Mon Sep 17 00:00:00 2001
+From fbd45483d1eb18032955feb516b6fd64f71bf8eb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 249/328] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 249/331] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/app-admin/kernel-tools/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
-From 0e9bfd68b0d1d7d70160d8fabb0b9da4dbb2384c Mon Sep 17 00:00:00 2001
+From f3b5dd651c44324ea83b2e9de440282aa5a1b6be Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 250/328] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 250/331] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/app-admin/kernel-tools/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
-From 9647734f1170bbc7d61e9f7003db8c5e7a634c4f Mon Sep 17 00:00:00 2001
+From ef055618092d8782e2954f6626635a74d9293db4 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 251/328] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 251/331] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/app-admin/kernel-tools/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
-From cb9875debdc63aef0472d928da45e55a9d15ce1b Mon Sep 17 00:00:00 2001
+From a2408534faf616eb200cb0bf948a165107e3059d Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 252/328] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 252/331] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/app-admin/kernel-tools/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
-From 0ce573843cb52cf5d7319dbff4221831fb3ad8e1 Mon Sep 17 00:00:00 2001
+From dc67297198041f2af7fd03aa9f26f8736ca3d65c Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 253/328] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 253/331] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/app-admin/kernel-tools/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
-From 877aac55ca4d0c71badd2dafc4341c45faf28f01 Mon Sep 17 00:00:00 2001
+From 8bc454f81ed7f6db347c44eace627f335f191350 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 254/328] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 254/331] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/app-admin/kernel-tools/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
-From 5095a38b7b5aa446c394aa502d599192a32d2be2 Mon Sep 17 00:00:00 2001
+From cd31a68b0f05298e871ad47f8c7a92ca83c02e46 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 255/328] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 255/331] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
-From 9aa413406f8e697413f558540782037efcac69d4 Mon Sep 17 00:00:00 2001
+From 12e14243eef65f125ccd5a78842238d09ce627e1 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 256/328] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 256/331] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/app-admin/kernel-tools/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
-From 4c9409eeb132945ddd9bae339830d2039336a175 Mon Sep 17 00:00:00 2001
+From 9436739ec8101a2ea023ece85b51f6b5bb84dc21 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 257/328] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 257/331] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/app-admin/kernel-tools/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
-From cd639f23cbd79fedeff9be1c9acdc81426c53c0a Mon Sep 17 00:00:00 2001
+From b0b6f748cc8d8363bca30f13c8d266e729697628 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 258/328] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 258/331] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/app-admin/kernel-tools/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
-From bc25b387f567fb45c68b5e8543439c6443b009e6 Mon Sep 17 00:00:00 2001
+From c07c3b9444e8433691102350e81dcfb55043c602 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 259/328] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 259/331] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/app-admin/kernel-tools/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
-From 8b44f129418988956b3307ebf40ca1abf457fe43 Mon Sep 17 00:00:00 2001
+From 2451a59452d2bbd57d3f19e7bfc0b8c8a8ed31da Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 260/328] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 260/331] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/app-admin/kernel-tools/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
-From 15d29362f490a2c432fb3dd24910d6889f99fed4 Mon Sep 17 00:00:00 2001
+From dc3d98d38cf4a096a13de242d7fb191c62d38f20 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 261/328] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 261/331] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
-From 119602bcc540671604f6ab136b88943299d333df Mon Sep 17 00:00:00 2001
+From 232bc42d588fe3e3ed9c7bbbb09973b641c24472 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 262/328] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 262/331] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/app-admin/kernel-tools/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
-From 56e74fce01675982a95779f93782eb956be59c40 Mon Sep 17 00:00:00 2001
+From 436e3417a6000ee4618a88aff7bead936bf5cfff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 263/328] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 263/331] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/app-admin/kernel-tools/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
-From 7e3480ba542527caf3633838d564931edaed6847 Mon Sep 17 00:00:00 2001
+From 598d599f3a3ea0a15a7fbfdd96fcfe782d8b4a97 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 264/328] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 264/331] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/app-admin/kernel-tools/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
-From 539a89f0ee96ccbc97fc50235bccb3ebd933b7f5 Mon Sep 17 00:00:00 2001
+From a5295d5e48ff390fe1b0a1cd42aba0d30efc49ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 265/328] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 265/331] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/app-admin/kernel-tools/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
-From b10fdcd2cc2dc51cc39d15a1c966532b3c5f8b5c Mon Sep 17 00:00:00 2001
+From dfa8b51dad1838664471c1801404cf9af8e44052 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 266/328] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 266/331] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/app-admin/kernel-tools/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
-From 46fa0e93010bd3e049aa0ce902900fcd0aae831b Mon Sep 17 00:00:00 2001
+From 6a3445b83c324737daf3a41004b9055138d71489 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 267/328] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 267/331] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/app-admin/kernel-tools/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
-From 9ff1140ca4a0476ec28ec8c607252a7b6b35b717 Mon Sep 17 00:00:00 2001
+From 4ffcc25388fe75464e7b96ee838a07821625b5b2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 268/328] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 268/331] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/app-admin/kernel-tools/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
-From 6a2ce88b7b4074a6b8c58577688eda3b5c23732d Mon Sep 17 00:00:00 2001
+From b1b62273d4158391cf543af5e9df0489978fb80b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 269/328] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 269/331] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/app-admin/kernel-tools/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
-From 69225c17de204642b6db14ffda80bc7ca4263d3e Mon Sep 17 00:00:00 2001
+From fa86e311952407386c395d1a256993f94b1c1849 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 270/328] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 270/331] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
-From 737ba971bcd62d0acce289a967fb8c5470077a40 Mon Sep 17 00:00:00 2001
+From a798fb4847a786b05aa95429fc706771dee42059 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 271/328] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 271/331] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/app-admin/kernel-tools/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
-From 8c0d68f692a12f2ee4782f7cb10e557ea309bb45 Mon Sep 17 00:00:00 2001
+From ad01f69d940601f52ec17ae776ab98c7c129b1f3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 272/328] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 272/331] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
-From d86457697d8f9059e0cddd378be3a3fa01c43772 Mon Sep 17 00:00:00 2001
+From 692c4231179d793b8d3b8cce32638a12058e38bf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 273/328] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 273/331] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/app-admin/kernel-tools/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
-From 418bb743459b9703543153acc75d3608267326cb Mon Sep 17 00:00:00 2001
+From b2b6d72b666cbaa3eb3c25efaa79f4290205a5c0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 274/328] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 274/331] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/app-admin/kernel-tools/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
-From 7fa1ad0465b83112fdf32f4b1874745bd5cd6fb2 Mon Sep 17 00:00:00 2001
+From 594199d74c43a4bf2e52d65d0ee4c0cf8afecabc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 275/328] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 275/331] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/app-admin/kernel-tools/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
-From ccc3f796da6099b7471039c2fbafcda2862ec4d2 Mon Sep 17 00:00:00 2001
+From d3bf090812f78ec6be2fd91b00f4b77413bd4305 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 276/328] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 276/331] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
-From 957f1c0df5202dc98dd0d76cf973f584dee71a1a Mon Sep 17 00:00:00 2001
+From f028e51007eb13c641d2fa014efce61eafd0cb53 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 277/328] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 277/331] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/app-admin/kernel-tools/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
-From eb1307c4743abde83c431db1a7ca231b9e99893f Mon Sep 17 00:00:00 2001
+From 94eb7d00374e5d258628ce748d0abc4141c1a651 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 278/328] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 278/331] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/app-admin/kernel-tools/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
-From 75c5f1b9ec6029e074c8cc3551e44db295979eac Mon Sep 17 00:00:00 2001
+From bd6084f52d7547c5593466aa379394e2d44962ac Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 279/328] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 279/331] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/app-admin/kernel-tools/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
-From 2f046c664812aafdab4684c5790da8e73f901543 Mon Sep 17 00:00:00 2001
+From e3affdb8057f6392ce3c1725a0da28ff4881cc3c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 280/328] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 280/331] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/app-admin/kernel-tools/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
-From be612a60997b16695d65c05acccbe9d81cc65613 Mon Sep 17 00:00:00 2001
+From 0c5a4ffd580f157d2470c2140c5ae8c78f15983d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 281/328] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 281/331] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/app-admin/kernel-tools/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
-From b2e7d6da193ad239bd7b5c417cb442d78f5b8ed0 Mon Sep 17 00:00:00 2001
+From 2d4beaea9c4aaf084de56612000960cbba08c8b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 282/328] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 282/331] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/app-admin/kernel-tools/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
-From a6428164a6f6219d62317921c934198f4167a476 Mon Sep 17 00:00:00 2001
+From 90a1a0c58d514b94a39377895b1260790b3d96de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 283/328] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 283/331] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/app-admin/kernel-tools/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
-From 9f83d3e0a763e9282c10bb64d55031b1217d0fb1 Mon Sep 17 00:00:00 2001
+From bf9f7856c0dcecc420280d70e7dae11f8c298466 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 284/328] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 284/331] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/app-admin/kernel-tools/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
-From 7b7332900bc2208b178a9f0903e7cf07a22dd536 Mon Sep 17 00:00:00 2001
+From 4c4997059bba83bbaf342c3ae1c893b31fe06076 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 285/328] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 285/331] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/app-admin/kernel-tools/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
-From cdc77eda85cecb36789e992e91421129d82b1766 Mon Sep 17 00:00:00 2001
+From 2aae3a6869a1a0218b503256b48c0472ccb2e7b8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 286/328] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 286/331] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/app-admin/kernel-tools/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
-From 25307fd0b8569b3947b7a48cd72df69913acdd11 Mon Sep 17 00:00:00 2001
+From 662d0655b6a6d04cdc123a1d5183f2c867b05ce8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 287/328] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 287/331] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/app-admin/kernel-tools/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
-From 3596a3dd0f5aaa3a90fd7d499e9789b54bbb6346 Mon Sep 17 00:00:00 2001
+From a193de9a51854ad6f53860523de5690a8677c31d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 288/328] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 288/331] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/app-admin/kernel-tools/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
-From 45fcb0239b8345bf303530acf7814865dd63c4a3 Mon Sep 17 00:00:00 2001
+From 95f560ac8c355216791dfdd037a760d101e61341 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 289/328] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 289/331] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/app-admin/kernel-tools/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
-From c03f3edb2671e29b6000b454568815baf6fb99d5 Mon Sep 17 00:00:00 2001
+From dfe6dac454e20e566083167d4c5e8b4128535686 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 290/328] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 290/331] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/app-admin/kernel-tools/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
-From 23a1cfa6b1083ad861c80b4afd8f13fc0c51dfd8 Mon Sep 17 00:00:00 2001
+From 1034b47f4ccf605440edd873818cdc95d558517d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 291/328] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 291/331] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/app-admin/kernel-tools/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
-From f9d832f868ba3a0a018dbc18930ca47231051189 Mon Sep 17 00:00:00 2001
+From 2fd6b7699261b040da878326e26f06787e07090c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 292/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 292/331] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/app-admin/kernel-tools/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
-From 5bce332afab8c0d4981a65ffdc70c7c0dc0e1cb2 Mon Sep 17 00:00:00 2001
+From bde78b223eff4096339988c88d7a53b6c997efff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 293/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 293/331] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/app-admin/kernel-tools/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
-From 3e9fd5735de2c7b0ea08956ef3916261d0059261 Mon Sep 17 00:00:00 2001
+From 8b93cbc2b7958bb16156bac498e016536415dd45 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 294/328] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 294/331] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/app-admin/kernel-tools/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
-From 2bf8cbfa04e8f2e4414d3e1e408af88493113d4e Mon Sep 17 00:00:00 2001
+From ff8c1625dd8182ddf1fa4b4d32f64a04be4ebc2e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 295/328] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 295/331] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/app-admin/kernel-tools/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
-From 507a7e1a14cc01d7a0b7d3b915543a2180d6cd6c Mon Sep 17 00:00:00 2001
+From 8ab3bb4f4cd71504d15a0119da9e0fcf9512292d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 296/328] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 296/331] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/app-admin/kernel-tools/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
-From 7b6c9d184b9a48a1d979fb185beebce69d932c8b Mon Sep 17 00:00:00 2001
+From 956f56937dbb5e8148bf6d7cd19329495706425c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 297/328] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 297/331] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,10 +13,10 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 288a2b864cc41..8c564389812ce 100644
+index 1062731315a2a..c2089273b1fac 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -659,7 +659,17 @@
+@@ -663,7 +663,17 @@
  #define USB_DEVICE_ID_IDEACOM_IDC6680	0x6680
  
  #define USB_VENDOR_ID_ILITEK		0x222a

--- a/app-admin/kernel-tools/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
-From 2065e8a1e79dc4d3969c676d529ebdcecd40eecd Mon Sep 17 00:00:00 2001
+From 121734ae659dee3b9de02dd9b21812914220bb9d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 298/328] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 298/331] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/app-admin/kernel-tools/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
-From 2dbb1cc362d04d0ad87b57b871f00a1a0123a6d5 Mon Sep 17 00:00:00 2001
+From f4848e78cb750301474e958438f3a8c6853a0356 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 299/328] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 299/331] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/app-admin/kernel-tools/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
-From 882f5584ba7fcf93dc291d0f06f49c145b9d5fda Mon Sep 17 00:00:00 2001
+From 43a3149a5d51df3c50eebb01164995e59d672758 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 300/328] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 300/331] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/app-admin/kernel-tools/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
-From 36fe24b20be1fae41b22dc2448fc15cadacf28b5 Mon Sep 17 00:00:00 2001
+From 2a5a29fc313266e9414e950998a27113ba7721b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 301/328] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 301/331] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/app-admin/kernel-tools/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
-From 6dd0341b812c802d49e1ce504f230cd42469f17c Mon Sep 17 00:00:00 2001
+From ac74944111972748b4f7b09283b2e4e5b9a22527 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 302/328] AOSCOS: Optimize clear_page
+Subject: [PATCH 302/331] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/app-admin/kernel-tools/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
-From 8a7bb8bf849d64224a52ed790eb2935c0c063572 Mon Sep 17 00:00:00 2001
+From 7eca3a05e71156d8fcacc9e29bbffcc1bfd27742 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 303/328] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 303/331] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/app-admin/kernel-tools/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
-From 4fbd2d172917f0c2f3ed408569f4c52f2597d99a Mon Sep 17 00:00:00 2001
+From b56607e71ed6dcafc0b19bca0353f4a4f748e3d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 304/328] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 304/331] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/app-admin/kernel-tools/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
-From d857acfedacc301355ca16efce7d046a06417c2d Mon Sep 17 00:00:00 2001
+From 878a53b453ece9f832c559563f45dbfc55c182ad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 305/328] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 305/331] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/app-admin/kernel-tools/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
-From 1c6b252eb87211418a57a6316b2516bfd11175f3 Mon Sep 17 00:00:00 2001
+From 86bb91a3b199c7eabe3f8332b6cb4a7319980931 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 306/328] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 306/331] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/app-admin/kernel-tools/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
-From ad8a023cb718524f682dbdf4233a05fcafad2c1f Mon Sep 17 00:00:00 2001
+From 24afda1df39a825dc2cc6613fb8002532ecc8144 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 307/328] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 307/331] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/app-admin/kernel-tools/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
-From 9adc2d7a27a71578e81bafb655427123c6a358db Mon Sep 17 00:00:00 2001
+From 062c70954c3ee95b3170e11331001d3fa02384c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 308/328] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 308/331] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/app-admin/kernel-tools/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
-From 78293e0db8f8414f0f0cf760722ad71aca3e4a28 Mon Sep 17 00:00:00 2001
+From df7f1a93eec36067442a945ef5bdfa27cec5b765 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 309/328] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 309/331] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/app-admin/kernel-tools/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
-From 84e3f7a196ebd2e275f0416bf27d9ff8d1bf2597 Mon Sep 17 00:00:00 2001
+From d5a1d2b36a8ebebb0d6aefdfa59b31331c8f3f5b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 310/328] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 310/331] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/app-admin/kernel-tools/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
-From 2741110a2b05f81d91ef45a296821afcd0e4b4db Mon Sep 17 00:00:00 2001
+From 7432c274385db4571bb6cc369794bd814d0cac50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 311/328] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 311/331] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/app-admin/kernel-tools/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
-From 84f8832360609bacc39daabc1eca198250e76210 Mon Sep 17 00:00:00 2001
+From ccf6103cdb907813cc2f81bac11bb3bbfa923c04 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 312/328] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 312/331] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/app-admin/kernel-tools/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
-From 0fcffd3a159e36b608726a5549e2038b54c3fa69 Mon Sep 17 00:00:00 2001
+From 172cee309f65daba78e13384e7e9e8b1fe2f6043 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 313/328] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 313/331] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/app-admin/kernel-tools/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
-From c80b237a3c588fb8e1cbdcd60dd23e0f2e88e52b Mon Sep 17 00:00:00 2001
+From 9241cfdb6d8ddd9f216f4cdbfe558a42eefbd63e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 314/328] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 314/331] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/app-admin/kernel-tools/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
-From 1f01b884845bb0513e31af62a90b57f895abd92f Mon Sep 17 00:00:00 2001
+From 0e8e9e023d8d35b27a761095ec78462e04e520df Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 315/328] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 315/331] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/app-admin/kernel-tools/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
-From e9ecd3a14aa8df32f6e3ae5b4308cff2e6ac8b1b Mon Sep 17 00:00:00 2001
+From 919c33637892910e495ba8de7f10aa7965ef1efa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 316/328] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 316/331] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/app-admin/kernel-tools/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
-From 1557f9b332e6d57d6186aca06e3125ba0b0b90a8 Mon Sep 17 00:00:00 2001
+From a9f19320c12926b9d46557076d2f6b4cd6888359 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 317/328] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 317/331] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/app-admin/kernel-tools/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
-From f95bad568a3f6c5c27d9e21a1e101341ac044ce6 Mon Sep 17 00:00:00 2001
+From 4421d06bd6d34505709cf29e942136adf873bbc5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 318/328] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 318/331] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/app-admin/kernel-tools/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
-From 6b7af4f888aaf14e8d5d5c2704b38f83079c910d Mon Sep 17 00:00:00 2001
+From 843012b9241bbf140ad1a9e13e3e1b23a2277dab Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 319/328] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 319/331] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/app-admin/kernel-tools/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
-From c378d8360e61ebca9584226d019fffa6b05f5078 Mon Sep 17 00:00:00 2001
+From e0ff0746b6a04e394e08811a6af2e66f709a339c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 320/328] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 320/331] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes.

--- a/app-admin/kernel-tools/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
-From 4412038bfc50163904d66c8bb64493b9089c7550 Mon Sep 17 00:00:00 2001
+From 9a234e63d068874235e3e108af786c8567909e8a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 321/328] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 321/331] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/app-admin/kernel-tools/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From e8a2530598552e6681ce1f8a8710ff4ab8cb657a Mon Sep 17 00:00:00 2001
+From 7f92154b8992bf6547ae6ffb4584fe73fa3bc44f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 322/328] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 322/331] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/app-admin/kernel-tools/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
-From f331f74145dff0c6cecf7bc485e83119771222ef Mon Sep 17 00:00:00 2001
+From 89bd55c7e595d23e0ebd892552db6f101b8cfb46 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 323/328] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 323/331] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global

--- a/app-admin/kernel-tools/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
-From 82e1818c080d564c2612bcd3a51f1076b4fc7247 Mon Sep 17 00:00:00 2001
+From bd950bfa65e41b277679a01fc1449f229ae52010 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 324/328] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 324/331] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages

--- a/app-admin/kernel-tools/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
@@ -1,7 +1,7 @@
-From 38fd36b3a5161c47a8fa2d3e4c09ff7e78e5a66d Mon Sep 17 00:00:00 2001
+From 8260095c2172b05dcb9a8b30055e29dc15763e7b Mon Sep 17 00:00:00 2001
 From: Qunqin Zhao <zhaoqunqin@loongson.cn>
 Date: Tue, 1 Apr 2025 17:41:54 +0800
-Subject: [PATCH 325/328] LOONGSON: input: atkbd: do not init atkbd_reset
+Subject: [PATCH 325/331] LOONGSON: input: atkbd: do not init atkbd_reset
  variable to true on Loongson
 
 The keyboard will not be confused on Loongson platform, so do not need a

--- a/app-admin/kernel-tools/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
@@ -1,7 +1,7 @@
-From 1c595ceb69ffdc5760fe4a0c3a6399fb1905b371 Mon Sep 17 00:00:00 2001
+From 7afc15e52fe36ea0b31c7310c716c13e3149b5a0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 22 Apr 2025 14:17:54 +0800
-Subject: [PATCH 326/328] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
+Subject: [PATCH 326/331] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
  RTL8723BE with subsystem ID 11ad:1723
 
 RTL8723BE found on some ASUSTek laptops, such as F441U and X555UQ with

--- a/app-admin/kernel-tools/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
@@ -1,7 +1,7 @@
-From 2c1a091965b3d3517a773d4d6668ff9c27615620 Mon Sep 17 00:00:00 2001
+From e640a87897061619f75c792deaacc2120b1ba897 Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Mon, 26 May 2025 04:18:07 +0800
-Subject: [PATCH 328/328] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
+Subject: [PATCH 328/331] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
  usleep_range() for EC polling
 
 It was reported that ideapad-laptop sometimes causes some recent (since

--- a/app-admin/kernel-tools/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
@@ -1,0 +1,41 @@
+From 41e03a821fc7fc011664399bf64ad68c6064f028 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:50 +0000
+Subject: [PATCH 329/331] BACKPORT: FROMLIST: platform/loongarch: laptop: Get
+ brightness setting from EC on probe
+
+Previously 1 is unconditionally taken as current brightness value. This
+causes problems since it's required to restore brightness settings on
+resumption, and a value that doesn't match EC's state before suspension
+will cause surprising changes of screen brightness.
+
+Let's get brightness from EC and take it as the current brightness on
+probe of the laptop driver to avoid the surprising behavior. Tested on
+TongFang L860-T2 3A5000 laptop.
+
+Cc: stable@vger.kernel.org
+Fixes: 6246ed09111f ("LoongArch: Add ACPI-based generic laptop driver")
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 99203584949da..828bd62e3596c 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -392,7 +392,7 @@ static int laptop_backlight_register(void)
+ 	if (!acpi_evalf(hotkey_handle, &status, "ECLL", "d"))
+ 		return -EIO;
+ 
+-	props.brightness = 1;
++	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+-- 
+2.49.0
+

--- a/app-admin/kernel-tools/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
@@ -1,0 +1,118 @@
+From f77acc69752d5d92f67c147463a0b156389a9bf7 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:51 +0000
+Subject: [PATCH 330/331] BACKPORT: FROMLIST: platform/loongarch: laptop:
+ Support backlight power control
+
+loongson_laptop_turn_{on,off}_backlight() are designed for controlling
+power of the backlight, but they aren't really used in the driver
+previously.
+
+Unify these two functions since they only differ in arguments passed to
+ACPI method, and wire up loongson_laptop_backlight_update() to update
+power state of the backlight as well. Tested on TongFang L860-T2 3A5000
+laptop.
+
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 53 +++++++-------------
+ 1 file changed, 19 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 828bd62e3596c..f01e53b1c84d1 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -56,8 +56,6 @@ static struct input_dev *generic_inputdev;
+ static acpi_handle hotkey_handle;
+ static struct key_entry hotkey_keycode_map[GENERIC_HOTKEY_MAP_MAX];
+ 
+-int loongson_laptop_turn_on_backlight(void);
+-int loongson_laptop_turn_off_backlight(void);
+ static int loongson_laptop_backlight_update(struct backlight_device *bd);
+ 
+ /* 2. ACPI Helpers and device model */
+@@ -354,6 +352,22 @@ static int ec_backlight_level(u8 level)
+ 	return level;
+ }
+ 
++static int ec_backlight_set_power(bool state)
++{
++	int status;
++	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
++	struct acpi_object_list args = { 1, &arg0 };
++
++	arg0.integer.value = state;
++	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
++	if (ACPI_FAILURE(status)) {
++		pr_info("Loongson lvds error: 0x%x\n", status);
++		return -EIO;
++	}
++
++	return 0;
++}
++
+ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ {
+ 	int lvl = ec_backlight_level(bd->props.brightness);
+@@ -363,6 +377,8 @@ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ 	if (ec_set_brightness(lvl))
+ 		return -EIO;
+ 
++	ec_backlight_set_power(bd->props.power == BACKLIGHT_POWER_ON ? true : false);
++
+ 	return 0;
+ }
+ 
+@@ -394,6 +410,7 @@ static int laptop_backlight_register(void)
+ 
+ 	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
++	props.power = BACKLIGHT_POWER_ON;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+ 	backlight_device_register("loongson_laptop",
+@@ -402,38 +419,6 @@ static int laptop_backlight_register(void)
+ 	return 0;
+ }
+ 
+-int loongson_laptop_turn_on_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 1;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+-int loongson_laptop_turn_off_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 0;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+ static int __init event_init(struct generic_sub_driver *sub_driver)
+ {
+ 	int ret;
+-- 
+2.49.0
+

--- a/app-admin/kernel-tools/autobuild/patches/0331-AOSCOS-PCI-Override-PCIe-bridge-supported-speeds-for.patch
+++ b/app-admin/kernel-tools/autobuild/patches/0331-AOSCOS-PCI-Override-PCIe-bridge-supported-speeds-for.patch
@@ -1,0 +1,67 @@
+From 60db49226ea76fd5350be0966b170a9cabcbfb76 Mon Sep 17 00:00:00 2001
+From: Ayden Meng <aydenmeng@yeah.net>
+Date: Wed, 4 Jun 2025 10:01:45 +0800
+Subject: [PATCH 331/331] AOSCOS: PCI: Override PCIe bridge supported speeds
+ for older Loongson 3C6000 series steppings
+
+Older steppings of the Loongson 3C6000 series incorrectly report the
+supported link speeds on their PCIe bridges (device IDs 3c19, 3c29) as
+only 2.5 GT/s, despite the upstream bus supporting speeds from 2.5 GT/s
+up to 16 GT/s.
+
+As a result, certain PCIe devices would be incorrectly probed as a Gen1-
+only, even if higher link speeds are supported, harming performance and
+prevents dynamic link speed functionality from being enabled in drivers
+such as amdgpu.
+
+Manually override the `supported_speeds` field for affected PCIe bridges
+with those found on the upstream bus to correctly reflect the supported
+link speeds.
+
+Tested-by: Lain "Fearyncess" Yang <fsf@live.com>
+Reviewed-by: Mingcong Bai <baimingcong@aosc.io>
+Signed-off-by: Ayden Meng <aydenmeng@yeah.net>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ drivers/pci/quirks.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 1c22112e71bf8..d3e89ebea3d49 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -1988,6 +1988,30 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL,	PCI_DEVICE_ID_INTEL_E7525_MCH,	quir
+ 
+ DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_VENDOR_ID_HUAWEI, 0x1610, PCI_CLASS_BRIDGE_PCI, 8, quirk_pcie_mch);
+ 
++/*
++ * Older steppings of the Loongson 3C6000 series incorrectly report the
++ * supported link speeds on their PCIe bridges (device IDs 3c19, 3c29) as
++ * only 2.5 GT/s, despite the upstream bus supporting speeds from 2.5 GT/s
++ * up to 16 GT/s.
++ */
++static void quirk_loongson_pci_bridge_supported_speeds(struct pci_dev *pdev)
++{
++	switch (pdev->bus->max_bus_speed) {
++	case PCIE_SPEED_16_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_16_0GB;
++	case PCIE_SPEED_8_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_8_0GB;
++	case PCIE_SPEED_5_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_5_0GB;
++	case PCIE_SPEED_2_5GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_2_5GB;
++	default:
++		break;
++	}
++}
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c19, quirk_loongson_pci_bridge_supported_speeds);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c29, quirk_loongson_pci_bridge_supported_speeds);
++
+ /*
+  * HiSilicon KunPeng920 and KunPeng930 have devices appear as PCI but are
+  * actually on the AMBA bus. These fake PCI devices can support SVA via
+-- 
+2.49.0
+

--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,4 +1,4 @@
-VER=6.14.9
+VER=6.14.10
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
@@ -12,7 +12,7 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #RC=1
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
 #REL=0.${RC}
-#COMMIT="10804dbee7fa8cfb895bbffcc7be97d8221748b6"
+#COMMIT="d9764ae2492695b2e87e4cd07bf1c61426d3693d"
 #SRCS="tbl::https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/snapshot/linux-stable-rc-${COMMIT}.tar.gz"
 
 # Use this for mainline RC releases.
@@ -28,7 +28,7 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #TAG="next-20250124"
 #SRCS="tbl::https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/linux-next-${TAG}.tar.gz"
 
-CHKSUMS="sha256::390cdde032719925a08427270197ef55db4e90c09d454e9c3554157292c9f361"
+CHKSUMS="sha256::de8b97cfeae74c22f832ee4ca2333c157cc978d98baa122f0ee9c01796a2fe43"
 CHKUPDATE="anitya::id=6501"
 
 ENVREQ__LOONGARCH64="core=128"

--- a/runtime-kernel/linux+kernel/autobuild/defines
+++ b/runtime-kernel/linux+kernel/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=linux+kernel
 PKGSEC=kernel
-PKGDEP="linux-kernel-6.14.9"
+PKGDEP="linux-kernel-6.14.10"
 PKGDES="Generic Linux Kernel for AOSC OS (Mainline)"
 
 PKGREP="linux+image+new linux+header+new linux+image linux+header linux+image+old linux+header+old"

--- a/runtime-kernel/linux+kernel/spec
+++ b/runtime-kernel/linux+kernel/spec
@@ -1,3 +1,3 @@
-VER=6.14.9
+VER=6.14.10
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"

--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-FROMGIT-dt-bindings-display-rockchip-Fix-label-name-.patch
@@ -1,7 +1,7 @@
-From 8fcd4b7cbe8866e88bada4c97edbae359f4ebbe3 Mon Sep 17 00:00:00 2001
+From ec53bd43ad84f47ccc718f1c9d8a2cc801a84b82 Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:29 +0800
-Subject: [PATCH 001/328] FROMGIT: dt-bindings: display: rockchip: Fix label
+Subject: [PATCH 001/331] FROMGIT: dt-bindings: display: rockchip: Fix label
  name of hdptxphy for RK3588 HDMI TX Controller
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-FROMGIT-dt-bindings-display-vop2-Add-optional-PLL-cl.patch
@@ -1,7 +1,7 @@
-From 1b451052fd86e80e103159bf7f21bf074cca7089 Mon Sep 17 00:00:00 2001
+From e8e3878db2b594b1b0973953b503f6bffd384adc Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:04 +0200
-Subject: [PATCH 002/328] FROMGIT: dt-bindings: display: vop2: Add optional PLL
+Subject: [PATCH 002/331] FROMGIT: dt-bindings: display: vop2: Add optional PLL
  clock properties
 
 On RK3588, HDMI PHY PLL can be used as an alternative and more accurate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-FROMGIT-drm-rockchip-vop2-Drop-unnecessary-if_pixclk.patch
@@ -1,7 +1,7 @@
-From 868d3187541cc8106871d39917ed172c85b8ab0c Mon Sep 17 00:00:00 2001
+From 53aa3b2ab1d82b5cbd8e2659de25a4ff24fa51eb Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:05 +0200
-Subject: [PATCH 003/328] FROMGIT: drm/rockchip: vop2: Drop unnecessary
+Subject: [PATCH 003/331] FROMGIT: drm/rockchip: vop2: Drop unnecessary
  if_pixclk_rate computation
 
 The if_pixclk_rate variable is not being used outside of the if-block in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-FROMGIT-arm64-dts-rockchip-Enable-HDMI-on-armsom-sig.patch
@@ -1,7 +1,7 @@
-From 1b054568395be506c296fdbdf7f8d28e26a805fc Mon Sep 17 00:00:00 2001
+From 4811b4a70f488ae49a5f5c0edff9f1d1efee10ce Mon Sep 17 00:00:00 2001
 From: Jianfeng Liu <liujianfeng1994@gmail.com>
 Date: Wed, 15 Jan 2025 10:33:21 +0800
-Subject: [PATCH 004/328] FROMGIT: arm64: dts: rockchip: Enable HDMI on
+Subject: [PATCH 004/331] FROMGIT: arm64: dts: rockchip: Enable HDMI on
  armsom-sige7
 
 Add the necessary DT changes to enable HDMI on ArmSoM Sige7.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-FROMGIT-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-prov.patch
@@ -1,7 +1,7 @@
-From d2c5ea748f66f91c30b5830e6bfd75dddfb45794 Mon Sep 17 00:00:00 2001
+From 57eade1b859e57f0f9d6bc5d26a19ad5203fece2 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:07 +0200
-Subject: [PATCH 005/328] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
+Subject: [PATCH 005/331] FROMGIT: arm64: dts: rockchip: Enable HDMI0 PHY clk
  provider on RK3588
 
 Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-FROMGIT-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-s.patch
@@ -1,7 +1,7 @@
-From 66182a5c54910afa4b4a288ec66907113fbcd262 Mon Sep 17 00:00:00 2001
+From 3edf269fabf4f124db163b9b9c59d8f8efa70823 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Tue, 4 Feb 2025 14:40:08 +0200
-Subject: [PATCH 006/328] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
+Subject: [PATCH 006/331] FROMGIT: arm64: dts: rockchip: Add HDMI0 PHY PLL
  clock source to VOP2 on RK3588
 
 VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-FROMGIT-arm64-dts-rockchip-Fix-label-name-of-hdptxph.patch
@@ -1,7 +1,7 @@
-From 797ef753c3fcdc7ecfb8b04ad7f8e0266734ef5a Mon Sep 17 00:00:00 2001
+From 76d4a9497a147f24f61da35b13201bdb8a84365c Mon Sep 17 00:00:00 2001
 From: Damon Ding <damon.ding@rock-chips.com>
 Date: Thu, 6 Feb 2025 11:03:30 +0800
-Subject: [PATCH 007/328] FROMGIT: arm64: dts: rockchip: Fix label name of
+Subject: [PATCH 007/331] FROMGIT: arm64: dts: rockchip: Fix label name of
  hdptxphy for RK3588
 
 The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-BACKPORT-FROMGIT-arm64-dts-rockchip-Add-PHY-node-for.patch
@@ -1,7 +1,7 @@
-From ea11e5a778962fc56d6c3d0fd2435939f5372aae Mon Sep 17 00:00:00 2001
+From 0077008f9cde60ac1d4bef5f86e29a1d9cbbeac6 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:15 +0200
-Subject: [PATCH 008/328] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
+Subject: [PATCH 008/331] BACKPORT: FROMGIT: arm64: dts: rockchip: Add PHY node
  for HDMI1 TX port on RK3588
 
 In preparation to enable the second HDMI output port found on RK3588

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-FROMGIT-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
@@ -1,7 +1,7 @@
-From 786d7c9c8cd05e0ea628aa8f71f3729eddc0b2b1 Mon Sep 17 00:00:00 2001
+From d09d53af73ff5d5c2bd626c553ff8e80779075b6 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:16 +0200
-Subject: [PATCH 009/328] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
+Subject: [PATCH 009/331] FROMGIT: arm64: dts: rockchip: Add HDMI1 node on
  RK3588
 
 Add support for the second HDMI TX port found on RK3588 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
@@ -1,7 +1,7 @@
-From 0add2ed34644c5ff7d7c3a86549f63e48de28971 Mon Sep 17 00:00:00 2001
+From 1a0e074eff63ca0336e264a31fd9368958d8bb8b Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 11 Dec 2024 01:06:17 +0200
-Subject: [PATCH 010/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
+Subject: [PATCH 010/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on
  rock-5b
 
 Add the necessary DT changes to enable the second HDMI output port on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-out-for-Edge.patch
@@ -1,7 +1,7 @@
-From aa6d5b0ac787bd9c875053115455d99ba195caee Mon Sep 17 00:00:00 2001
+From 78815af669f897599dd41b34f01cb4ef2a22f446 Mon Sep 17 00:00:00 2001
 From: Jagan Teki <jagan@edgeble.ai>
 Date: Fri, 27 Dec 2024 18:59:36 +0530
-Subject: [PATCH 011/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
+Subject: [PATCH 011/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 out for
  Edgeble-6TOPS Modules
 
 Edgeble-6TOPS modules configure HDMI1 for HDMI Out from RK3588.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-FROMGIT-arm64-dts-rockchip-Enable-HDMI1-on-Orange-Pi.patch
@@ -1,7 +1,7 @@
-From ac29fecaedf881a74ae6acdb8cf61d3e8762be7f Mon Sep 17 00:00:00 2001
+From 1cbd0e0890404d66b57755ec4cbfc1f1e6ddfcd6 Mon Sep 17 00:00:00 2001
 From: Jimmy Hon <honyuenkwun@gmail.com>
 Date: Wed, 8 Jan 2025 23:16:18 -0600
-Subject: [PATCH 012/328] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
+Subject: [PATCH 012/331] FROMGIT: arm64: dts: rockchip: Enable HDMI1 on Orange
  Pi 5 Max
 
 Enable the second HDMI output port on the Orange Pi 5 Max

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-FROMGIT-phy-phy-rockchip-samsung-hdptx-annotate-regm.patch
@@ -1,7 +1,7 @@
-From 581b45fe3b084963d7d3cda32265a284ae8f8968 Mon Sep 17 00:00:00 2001
+From 0d2ae04125f161a2b4f9dc941ea5b6b73c3f050e Mon Sep 17 00:00:00 2001
 From: Heiko Stuebner <heiko.stuebner@cherry.de>
 Date: Fri, 6 Dec 2024 11:34:00 +0100
-Subject: [PATCH 013/328] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
+Subject: [PATCH 013/331] FROMGIT: phy: phy-rockchip-samsung-hdptx: annotate
  regmap register-callback
 
 The variant of the driver in the vendor-tree contained those handy
@@ -22,10 +22,10 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-index 920abf6fa9bdd..dfcc37b1c8a6d 100644
+index 28a4235bfd5fb..6c51f764b1a5c 100644
 --- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
 +++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
-@@ -571,13 +571,13 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {
+@@ -573,13 +573,13 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {
  static bool rk_hdptx_phy_is_rw_reg(struct device *dev, unsigned int reg)
  {
  	switch (reg) {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMGIT-perf-trace-Allocate-syscall-stats-only-if-su.patch
@@ -1,7 +1,7 @@
-From c0d8cbaf6628d412c7749e9a154a2d150005090f Mon Sep 17 00:00:00 2001
+From 907c377b0a40ce8adaf27cc80469efb69b233213 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:40 -0800
-Subject: [PATCH 014/328] FROMGIT: perf trace: Allocate syscall stats only if
+Subject: [PATCH 014/331] FROMGIT: perf trace: Allocate syscall stats only if
  summary is on
 
 The syscall stats are used only when summary is requested.  Let's avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-FROMGIT-perf-trace-Convert-syscall_stats-to-hashmap.patch
@@ -1,7 +1,7 @@
-From d917c799a7a7becf247d865185ca33cefb95cf1a Mon Sep 17 00:00:00 2001
+From 67fe91e4cf3916ca623cc23244d086d4849dd176 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:41 -0800
-Subject: [PATCH 015/328] FROMGIT: perf trace: Convert syscall_stats to hashmap
+Subject: [PATCH 015/331] FROMGIT: perf trace: Convert syscall_stats to hashmap
 
 It was using a RBtree-based int-list as a hash and a custom resort
 logic for that.  As we have hashmap, let's convert to it and add a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMGIT-perf-tools-Get-rid-of-now-unused-rb_resort.h.patch
@@ -1,7 +1,7 @@
-From 7f4e137d64d80ead8e7a3a5eac662300d8a002ca Mon Sep 17 00:00:00 2001
+From 1a1255ff95df253ade38c0788b4162a424349435 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:42 -0800
-Subject: [PATCH 016/328] FROMGIT: perf tools: Get rid of now-unused
+Subject: [PATCH 016/331] FROMGIT: perf tools: Get rid of now-unused
  rb_resort.h
 
 It was only used in perf trace and it switched to use hashmap instead.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMGIT-perf-trace-Add-summary-mode-option.patch
@@ -1,7 +1,7 @@
-From f36d4a64986abd44d97531f4d17ecc0633e81445 Mon Sep 17 00:00:00 2001
+From 60afae4fbf77c98cd3ab687cf8ef968d7bbe5151 Mon Sep 17 00:00:00 2001
 From: Namhyung Kim <namhyung@kernel.org>
 Date: Wed, 5 Feb 2025 12:54:43 -0800
-Subject: [PATCH 017/328] FROMGIT: perf trace: Add --summary-mode option
+Subject: [PATCH 017/331] FROMGIT: perf trace: Add --summary-mode option
 
 The --summary-mode option will select how to show the syscall summary at
 the end.  By default, it'll show the summary for each thread and it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMGIT-perf-tools-Add-dummy-functions-for-HAVE_LZMA.patch
@@ -1,7 +1,7 @@
-From f5a6161e2add63abacf9860c2ffd1782f43c129a Mon Sep 17 00:00:00 2001
+From 04d805e672bfa3a5d56482bced16b9fc86f4f826 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:01 -0800
-Subject: [PATCH 018/328] FROMGIT: perf tools: Add dummy functions for
+Subject: [PATCH 018/331] FROMGIT: perf tools: Add dummy functions for
  !HAVE_LZMA_SUPPORT
 
 This allows us to use them without needing to ifdef the calling code.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMGIT-perf-tools-Add-LZMA-decompression-from-FILE.patch
@@ -1,7 +1,7 @@
-From 877b2f3363c9ebcfdb099a854aa96e26047e8e37 Mon Sep 17 00:00:00 2001
+From 7d3a7ecdfea66670f99e33612c4519c8bd0650b2 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:02 -0800
-Subject: [PATCH 019/328] FROMGIT: perf tools: Add LZMA decompression from FILE
+Subject: [PATCH 019/331] FROMGIT: perf tools: Add LZMA decompression from FILE
 
 Internally lzma_decompress_to_file() creates a FILE from the filename.
 Add an API that takes an existing FILE directly. This allows

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMGIT-perf-symbol-Support-.gnu_debugdata-for-symbo.patch
@@ -1,7 +1,7 @@
-From 3325115148e50fa9b234b961235c98bc7a274ae6 Mon Sep 17 00:00:00 2001
+From 6641b0a51945ba20c7505d876eea5b352e51cd52 Mon Sep 17 00:00:00 2001
 From: Stephen Brennan <stephen.s.brennan@oracle.com>
 Date: Fri, 7 Mar 2025 15:22:03 -0800
-Subject: [PATCH 020/328] FROMGIT: perf symbol: Support .gnu_debugdata for
+Subject: [PATCH 020/331] FROMGIT: perf symbol: Support .gnu_debugdata for
  symbols
 
 Fedora introduced a "MiniDebuginfo" feature, in which an LZMA-compressed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMGIT-perf-mutex-Add-annotations-for-LOCKS_EXCLUDE.patch
@@ -1,7 +1,7 @@
-From 238fc8603ac8dcbf0705c862ce151011f67c00aa Mon Sep 17 00:00:00 2001
+From 9e68cc2cccb9ee4c6c84b7d3a53e70dd61154ef1 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:49 -0700
-Subject: [PATCH 021/328] FROMGIT: perf mutex: Add annotations for
+Subject: [PATCH 021/331] FROMGIT: perf mutex: Add annotations for
  LOCKS_EXCLUDED and LOCKS_RETURNED
 
 Used to annotate when locks shouldn't be held for a function or if a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMGIT-perf-dso-Use-lock-annotations-to-fix-asan-de.patch
@@ -1,7 +1,7 @@
-From 7b84d1a1dd128fb43a62dc7823c3e89c7ce7a3b7 Mon Sep 17 00:00:00 2001
+From 09d2a47f30a74aa9fbcdc4061d5fb59187a75609 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:50 -0700
-Subject: [PATCH 022/328] FROMGIT: perf dso: Use lock annotations to fix asan
+Subject: [PATCH 022/331] FROMGIT: perf dso: Use lock annotations to fix asan
  deadlock
 
 dso__list_del with address sanitizer and/or reference count checking

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMGIT-perf-test-dso-data-Correctly-free-test-file-.patch
@@ -1,7 +1,7 @@
-From c0a9a75a28e6debf27f4ca6e457b81002e10dd6e Mon Sep 17 00:00:00 2001
+From c0e197435e1741bc7f76892c12987ee46456d44f Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Mon, 17 Mar 2025 21:31:51 -0700
-Subject: [PATCH 023/328] FROMGIT: perf test dso-data: Correctly free test file
+Subject: [PATCH 023/331] FROMGIT: perf test dso-data: Correctly free test file
  in read test
 
 The DSO data read test opens a file but as dsos__exit is used the test

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMGIT-perf-dso-Move-libunwind-dso_data-variables-i.patch
@@ -1,7 +1,7 @@
-From 34af1bb3fb157b9a4101b44bf8ecd756122afb2e Mon Sep 17 00:00:00 2001
+From 57d67b58f0dabaff9114c3942525aca75b9f09f2 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:28 -0700
-Subject: [PATCH 024/328] FROMGIT: perf dso: Move libunwind dso_data variables
+Subject: [PATCH 024/331] FROMGIT: perf dso: Move libunwind dso_data variables
  into ifdef
 
 The variables elf_base_addr, debug_frame_offset, eh_frame_hdr_addr and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMGIT-perf-dso-kernel-doc-for-enum-dso_binary_type.patch
@@ -1,7 +1,7 @@
-From be3b23514c2a0f78ed81abd38191e85566fe76f9 Mon Sep 17 00:00:00 2001
+From 0733c3117e94d4fdfee08486ebef77481d1e7217 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:29 -0700
-Subject: [PATCH 025/328] FROMGIT: perf dso: kernel-doc for enum
+Subject: [PATCH 025/331] FROMGIT: perf dso: kernel-doc for enum
  dso_binary_type
 
 There are many and non-obvious meanings to the dso_binary_type enum

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMGIT-perf-syscalltbl-Remove-syscall_table.h.patch
@@ -1,7 +1,7 @@
-From bb0632fea64565c34abd34a2f0e69f09f53a52da Mon Sep 17 00:00:00 2001
+From 13d666fbe7e3ef5dfea33dcd0eb7cd3e7aa4fbe0 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:30 -0700
-Subject: [PATCH 026/328] FROMGIT: perf syscalltbl: Remove syscall_table.h
+Subject: [PATCH 026/331] FROMGIT: perf syscalltbl: Remove syscall_table.h
 
 The definition of "static const char *const syscalltbl[] = {" is done
 in a generated syscalls_32.h or syscalls_64.h that is architecture

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMGIT-perf-trace-Reorganize-syscalls.patch
@@ -1,7 +1,7 @@
-From ae8c5e80f44bda2cc78f910c2602c0259be58a5d Mon Sep 17 00:00:00 2001
+From 86da6429d452dda2f278cd495bc72b7d889afdd1 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:31 -0700
-Subject: [PATCH 027/328] FROMGIT: perf trace: Reorganize syscalls
+Subject: [PATCH 027/331] FROMGIT: perf trace: Reorganize syscalls
 
 Identify struct syscall information in the syscalls table by a machine
 type and syscall number, not just system call number. Having the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-FROMGIT-perf-syscalltbl-Remove-struct-syscalltbl.patch
@@ -1,7 +1,7 @@
-From 815e28f683840f22c9243fb9c162cac135811741 Mon Sep 17 00:00:00 2001
+From 485f26ef9b2be4921a35471681e104e153b0d150 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:32 -0700
-Subject: [PATCH 028/328] FROMGIT: perf syscalltbl: Remove struct syscalltbl
+Subject: [PATCH 028/331] FROMGIT: perf syscalltbl: Remove struct syscalltbl
 
 The syscalltbl held entries of system call name and number pairs,
 generated from a native syscalltbl at start up. As there are gaps in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-FROMGIT-perf-dso-Add-support-for-reading-the-e_machi.patch
@@ -1,7 +1,7 @@
-From af9980704e3f6482da4c6e30f55a7888dcf78f4c Mon Sep 17 00:00:00 2001
+From 1e1371c4a8e260d119191dee0a0acb6bf124de16 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:33 -0700
-Subject: [PATCH 029/328] FROMGIT: perf dso: Add support for reading the
+Subject: [PATCH 029/331] FROMGIT: perf dso: Add support for reading the
  e_machine type for a dso
 
 For ELF file dsos read the e_machine from the ELF header. For kernel

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-FROMGIT-perf-thread-Add-support-for-reading-the-e_ma.patch
@@ -1,7 +1,7 @@
-From 1ae77fcb27026a80af228d99c57e4e8ba1ebd703 Mon Sep 17 00:00:00 2001
+From 8297fe8e1959d8f5436dcab1d275248d3d55fe19 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:34 -0700
-Subject: [PATCH 030/328] FROMGIT: perf thread: Add support for reading the
+Subject: [PATCH 030/331] FROMGIT: perf thread: Add support for reading the
  e_machine type for a thread
 
 First try to read the e_machine from the dsos associated with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-FROMGIT-perf-trace-beauty-Add-syscalltbl.sh-generati.patch
@@ -1,7 +1,7 @@
-From ecdb06f1fb94dd17179385484a38e23866e89802 Mon Sep 17 00:00:00 2001
+From 1d6e0f13ad08f26c47c0fd030764311de901351c Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:35 -0700
-Subject: [PATCH 031/328] FROMGIT: perf trace beauty: Add syscalltbl.sh
+Subject: [PATCH 031/331] FROMGIT: perf trace beauty: Add syscalltbl.sh
  generating all system call tables
 
 Rather than generating individual syscall header files generate a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMGIT-perf-syscalltbl-Use-lookup-table-containing-.patch
@@ -1,7 +1,7 @@
-From 803a93ba3fde51a74acd472dadd8bfe902a6cec5 Mon Sep 17 00:00:00 2001
+From d2dd5cf536a321f1d400fd19e05df8eb8945b140 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:36 -0700
-Subject: [PATCH 032/328] FROMGIT: perf syscalltbl: Use lookup table containing
+Subject: [PATCH 032/331] FROMGIT: perf syscalltbl: Use lookup table containing
  multiple architectures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMGIT-perf-build-Remove-Makefile.syscalls.patch
@@ -1,7 +1,7 @@
-From fd36ce5789a798c393227895e222af0490dc5a0b Mon Sep 17 00:00:00 2001
+From 8b9ec838a3c55c68b3d4259fd6c3eb49298c814b Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:37 -0700
-Subject: [PATCH 033/328] FROMGIT: perf build: Remove Makefile.syscalls
+Subject: [PATCH 033/331] FROMGIT: perf build: Remove Makefile.syscalls
 
 Now a single beauty file is generated and used by all architectures,
 remove the per-architecture Makefiles, Kbuild files and previous

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-perf-syscalltbl-Mask-off-ABI-type-for-MIPS-s.patch
@@ -1,7 +1,7 @@
-From f6e485ed21931c3360f32fe4ad105ff8ac337d03 Mon Sep 17 00:00:00 2001
+From ccf1ab939373138a0e585936a61631fdca02ec52 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:38 -0700
-Subject: [PATCH 034/328] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
+Subject: [PATCH 034/331] FROMGIT: perf syscalltbl: Mask off ABI type for MIPS
  system calls
 
 Arnd Bergmann described that MIPS system calls don't necessarily start

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMGIT-perf-trace-Make-syscall-table-stable.patch
@@ -1,7 +1,7 @@
-From 40c899db72974af5d57460c9652b021705c77404 Mon Sep 17 00:00:00 2001
+From 24dd8d1178da80a225a990aed3cdf1a442e8b3c4 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:39 -0700
-Subject: [PATCH 035/328] FROMGIT: perf trace: Make syscall table stable
+Subject: [PATCH 035/331] FROMGIT: perf trace: Make syscall table stable
 
 Namhyung fixed the syscall table being reallocated and moving by
 reloading the system call pointer after a move:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMGIT-perf-trace-Fix-BTF-memory-leak.patch
@@ -1,7 +1,7 @@
-From 4a6293322d121d4e81c67251f2c258e8db3f2f89 Mon Sep 17 00:00:00 2001
+From c5c4fb7700543d93301bb7b5971f53f5680fbb85 Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:40 -0700
-Subject: [PATCH 036/328] FROMGIT: perf trace: Fix BTF memory leak
+Subject: [PATCH 036/331] FROMGIT: perf trace: Fix BTF memory leak
 
 Add missing btf__free in trace__exit.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMGIT-perf-trace-Fix-evlist-memory-leak.patch
@@ -1,7 +1,7 @@
-From 98f64cada9826d286aa7750566dff7602b17e256 Mon Sep 17 00:00:00 2001
+From 0dd157f6d7ace77f9891d23ca5d212fe1793666a Mon Sep 17 00:00:00 2001
 From: Ian Rogers <irogers@google.com>
 Date: Tue, 18 Mar 2025 22:07:41 -0700
-Subject: [PATCH 037/328] FROMGIT: perf trace: Fix evlist memory leak
+Subject: [PATCH 037/331] FROMGIT: perf trace: Fix evlist memory leak
 
 Leak sanitizer was reporting a memory leak in the "perf record and
 replay" test. Add evlist__delete to trace__exit, also ensure

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMGIT-platform-x86-lenovo-wmi-hotkey-utilities.c-S.patch
@@ -1,7 +1,7 @@
-From ab74f8bf801d004e1de289f9e8df03f6136791c8 Mon Sep 17 00:00:00 2001
+From 7381a8f76b72781ac6352718577de6eead58691a Mon Sep 17 00:00:00 2001
 From: Jackie Dong <xy-jackie@139.com>
 Date: Sat, 22 Feb 2025 19:45:31 +0800
-Subject: [PATCH 038/328] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
+Subject: [PATCH 038/331] FROMGIT: platform/x86:lenovo-wmi-hotkey-utilities.c:
  Support for mic and audio mute LEDs
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMGIT-dt-bindings-gpio-loongson-Add-new-loongson-g.patch
@@ -1,7 +1,7 @@
-From 949411326f0197250d454c43547aa4d458578a8f Mon Sep 17 00:00:00 2001
+From 1162e8a6e2777ef773110320c3f2d81251b20b78 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:51 +0800
-Subject: [PATCH 039/328] FROMGIT: dt-bindings: gpio: loongson: Add new
+Subject: [PATCH 039/331] FROMGIT: dt-bindings: gpio: loongson: Add new
  loongson gpio chip compatible
 
 Add the devicetree compatibles for Loongson-7A2000 and Loongson-3A6000

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMGIT-gpio-loongson-64bit-Add-more-gpio-chip-suppo.patch
@@ -1,7 +1,7 @@
-From bc7f0a2f09a32d47f78dbda9ecb17e27281e8fb0 Mon Sep 17 00:00:00 2001
+From e71c9025fbab1f5ab1fc813a715e81d7d8198567 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 3 Mar 2025 15:45:52 +0800
-Subject: [PATCH 040/328] FROMGIT: gpio: loongson-64bit: Add more gpio chip
+Subject: [PATCH 040/331] FROMGIT: gpio: loongson-64bit: Add more gpio chip
  support
 
 The Loongson-7A2000 and Loongson-3A6000 share the same gpio chip model.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMGIT-ata-libata-Improve-return-value-of-atapi_che.patch
@@ -1,7 +1,7 @@
-From 590bed431f42bc23d5fc2feda2463bec5c0a6e69 Mon Sep 17 00:00:00 2001
+From 793923cec759fc7da08a6c3619e15b2ba756bce0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 12 Mar 2025 21:39:54 +0800
-Subject: [PATCH 041/328] FROMGIT: ata: libata: Improve return value of
+Subject: [PATCH 041/331] FROMGIT: ata: libata: Improve return value of
  atapi_check_dma()
 
 atapi_check_dma() allows a LLD to filter ATAPI commands, returning a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMGIT-objtool-LoongArch-Add-support-for-switch-tab.patch
@@ -1,7 +1,7 @@
-From c5889146b51c397f3c151d1e7aceb144adef948d Mon Sep 17 00:00:00 2001
+From 01873e36de91f1770b3415723cfc42abcf0d2558 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:13 +0800
-Subject: [PATCH 042/328] FROMGIT: objtool/LoongArch: Add support for switch
+Subject: [PATCH 042/331] FROMGIT: objtool/LoongArch: Add support for switch
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMGIT-objtool-LoongArch-Add-support-for-goto-table.patch
@@ -1,7 +1,7 @@
-From 3116cf7478b090712f23223c5135971fe5d90882 Mon Sep 17 00:00:00 2001
+From 646ea41aa04a4b6ac68e0efbf20219fad6486366 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 11 Feb 2025 19:50:14 +0800
-Subject: [PATCH 043/328] FROMGIT: objtool/LoongArch: Add support for goto
+Subject: [PATCH 043/331] FROMGIT: objtool/LoongArch: Add support for goto
  table
 
 The objtool program need to analysis the control flow of each object file

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMGIT-LoongArch-Enable-jump-table-for-objtool.patch
@@ -1,7 +1,7 @@
-From c23b1b0fbec8855e4480b70a990d21d1cb3d038b Mon Sep 17 00:00:00 2001
+From f93a438cfd7f3d01f806cc916f9cc527750e91d4 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 17 Dec 2024 09:09:03 +0800
-Subject: [PATCH 044/328] FROMGIT: LoongArch: Enable jump table for objtool
+Subject: [PATCH 044/331] FROMGIT: LoongArch: Enable jump table for objtool
 
 For now, it is time to remove -fno-jump-tables to enable jump table for
 objtool if the compiler has -mannotate-tablejump, otherwise it is better

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMGIT-LoongArch-KVM-Remove-unnecessary-header-incl.patch
@@ -1,7 +1,7 @@
-From 32910cab64d753061e57730d20c82a7dbcf1dfd7 Mon Sep 17 00:00:00 2001
+From 1430a2b048ff03133225a3a6e228ccbf2a770fa3 Mon Sep 17 00:00:00 2001
 From: Masahiro Yamada <masahiroy@kernel.org>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 045/328] FROMGIT: LoongArch: KVM: Remove unnecessary header
+Subject: [PATCH 045/331] FROMGIT: LoongArch: KVM: Remove unnecessary header
  include path
 
 arch/loongarch/kvm/ includes local headers with the double-quote form

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMGIT-LoongArch-KVM-Remove-PGD-saving-during-VM-co.patch
@@ -1,7 +1,7 @@
-From efb23e50c8233592edb1c75e7495e57d6f73c534 Mon Sep 17 00:00:00 2001
+From a541c08dd066706f4ba00634e67fc0169a6cdd6c Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 046/328] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
+Subject: [PATCH 046/331] FROMGIT: LoongArch: KVM: Remove PGD saving during VM
  context switch
 
 PGD table for primary mmu keeps unchanged once VM is created, it is not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMGIT-LoongArch-KVM-Add-stub-for-kvm_arch_vcpu_pre.patch
@@ -1,7 +1,7 @@
-From f3961bd241bd6ffdf3e89b9a7295b8b10b3f3c6a Mon Sep 17 00:00:00 2001
+From 9c9d9bf602dbd3b02bc80968f24f63deaa9ecd9a Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 047/328] FROMGIT: LoongArch: KVM: Add stub for
+Subject: [PATCH 047/331] FROMGIT: LoongArch: KVM: Add stub for
  kvm_arch_vcpu_preempted_in_kernel()
 
 Pause-Loop Exiting is not supported by LoongArch hardware, nor is pv

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMGIT-LoongArch-KVM-Implement-arch-specific-functi.patch
@@ -1,7 +1,7 @@
-From 12101c3210fe0f7b1c9e7e4a29c35cf0cd59fbfe Mon Sep 17 00:00:00 2001
+From 239e7e2b4014f434eeeb1055401709a3f034947d Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 048/328] FROMGIT: LoongArch: KVM: Implement arch-specific
+Subject: [PATCH 048/331] FROMGIT: LoongArch: KVM: Implement arch-specific
  functions for guest perf
 
 Three architecture specific functions are added for the guest perf

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMGIT-LoongArch-KVM-Register-perf-callbacks-for-gu.patch
@@ -1,7 +1,7 @@
-From 608f8c1b9ff41f38f09e6cd424a9d4a9d828a186 Mon Sep 17 00:00:00 2001
+From f3b922731c73da304fdbc2a6891ae3b74dba2668 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 18 Mar 2025 16:48:08 +0800
-Subject: [PATCH 049/328] FROMGIT: LoongArch: KVM: Register perf callbacks for
+Subject: [PATCH 049/331] FROMGIT: LoongArch: KVM: Register perf callbacks for
  guest
 
 Add selection for GUEST_PERF_EVENTS if KVM is enabled, also add perf

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
-From cd5cf771823cfadc54b5e9a27a2d8077f6487640 Mon Sep 17 00:00:00 2001
+From bb837aba6421ef9e2fab756f26653614296ee8d5 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 050/328] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 050/331] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-Makefile-Move-tiny-drivers-before-nativ.patch
@@ -1,7 +1,7 @@
-From 3ca32eac062835adfbdebb8a860e675dd3232641 Mon Sep 17 00:00:00 2001
+From dd69cce1e865724c165c1d469b442a0754be8f2c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 051/328] FROMLIST: drm/Makefile: Move tiny drivers before
+Subject: [PATCH 051/331] FROMLIST: drm/Makefile: Move tiny drivers before
  native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
-From 20a98995be888ef1bf783b6c6fc18317804cab06 Mon Sep 17 00:00:00 2001
+From be9dcfd20910e5a4bfb3e12de330e0ec5b048769 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 052/328] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 052/331] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
-From 9af5d2ec27f17f6aba245ffc4947031a2d373a7d Mon Sep 17 00:00:00 2001
+From b1c6491ffa9882f40bac5721e80cf5f75e74e3fc Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 053/328] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 053/331] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-PCI-pci_call_probe-call-local_pci_probe-whe.patch
@@ -1,7 +1,7 @@
-From 976d54041ddda288626dfe4b3926e33f66c7dc23 Mon Sep 17 00:00:00 2001
+From c1925a4a798132e7f2f45c7a39de22d7be61bbc3 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Thu, 13 Jun 2024 15:42:58 +0800
-Subject: [PATCH 054/328] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
+Subject: [PATCH 054/331] FROMLIST: PCI: pci_call_probe: call local_pci_probe()
  when selected cpu is offline
 
 Call work_on_cpu(cpu, fn, arg) in pci_call_probe() while the argument

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
-From 5a484027f837d692ffb77ee89838fa83583adfba Mon Sep 17 00:00:00 2001
+From c85d79ff599c971fa2f495c06e3d4c5b368b2fe2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 4 Aug 2024 09:24:18 +0800
-Subject: [PATCH 055/328] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 055/331] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
-From 161ab385e26e8981c671245f3b9318986532053b Mon Sep 17 00:00:00 2001
+From 020557a395b5f89164b6eb1a576403980aa2793d Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 056/328] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 056/331] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
-From 64bd6acbc9c7afdd1c5ff359defd6c1e2f9f7b2e Mon Sep 17 00:00:00 2001
+From 5ca583e1e34063750cc1af2d079eca200b293389 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 057/328] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 057/331] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
-From 9278f571a1758e30643e3ba3f6bd020cf732c167 Mon Sep 17 00:00:00 2001
+From eb216884f1cdc9d82639a6609c5108d40cbd3fc0 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 058/328] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 058/331] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
-From 69cdb23ae551752d5aa0809795613cce4a82af42 Mon Sep 17 00:00:00 2001
+From 378c72755854c2ba01885c0d5d5afed5b7a2d464 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 059/328] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 059/331] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-drm-Remove-redundant-statement-in-drm_crtc_.patch
@@ -1,7 +1,7 @@
-From b3679a8b3021a7764acfd41cde62a2dc8e327929 Mon Sep 17 00:00:00 2001
+From f2823b5676185743339a37ec345051d041a6580e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 11 Nov 2024 21:21:49 +0800
-Subject: [PATCH 060/328] FROMLIST: drm: Remove redundant statement in
+Subject: [PATCH 060/331] FROMLIST: drm: Remove redundant statement in
  drm_crtc_helper_set_mode()
 
 Commit dbbfaf5f2641a ("drm: Remove bridge support from legacy helpers")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
-From b29ddb57ec77e93484f8d748247ff315c4fee8d5 Mon Sep 17 00:00:00 2001
+From d107e80bcb513c3862b223ed170cc467a0d3717c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 061/328] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 061/331] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
-From 32b1785a66dd54f9259a50ab91f68a5e51f152e6 Mon Sep 17 00:00:00 2001
+From cc701a8de3b08ee37c0e7e4dfd194a92a6fd4d28 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:08 +0800
-Subject: [PATCH 062/328] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 062/331] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC MFD Core driver
 
 The Loongson-2K Board Management Controller provides an PCIe

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
-From 3b242681579fe88b4cfb850f71503259e184fe76 Mon Sep 17 00:00:00 2001
+From adb3bf13af5a124f2d1f4f44093d2b0221471870 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:09 +0800
-Subject: [PATCH 063/328] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 063/331] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ls2kbmc-Add-support-for-Loongson-2K-BMC.patch
@@ -1,7 +1,7 @@
-From bff94d0d2b8cdf36f04a41579aa2ea3943d91656 Mon Sep 17 00:00:00 2001
+From 2674a97266b33ed4ecc08fc293fdb443d7b9ebf6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:10 +0800
-Subject: [PATCH 064/328] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
+Subject: [PATCH 064/331] FROMLIST: drm/ls2kbmc: Add support for Loongson-2K
  BMC display
 
 Adds a driver for the Loongson-2K BMC display as a sub-function of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-drm-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
-From 623e622fe31d3db9a54cd9351a7c2cadb496fe42 Mon Sep 17 00:00:00 2001
+From 3e1c6457658e05a3a0d869467647e02ee3d9475b Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 30 Dec 2024 17:31:36 +0800
-Subject: [PATCH 065/328] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 065/331] FROMLIST: drm/ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
-From 4f08061cc57c7495875fd042d73c7a7189b8ab16 Mon Sep 17 00:00:00 2001
+From 2c0c0727fb43922cea93487043dbb946e16f2ee5 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 066/328] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 066/331] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-drm-amd-display-Add-ASSERT_BUG-macro-defini.patch
@@ -1,7 +1,7 @@
-From 68ddfd15d3c6beb99c2d394d9388626fe71a236e Mon Sep 17 00:00:00 2001
+From 6a21a8f3acebe645e02c0195473fd98d47cbda4c Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:29:56 +0800
-Subject: [PATCH 067/328] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
+Subject: [PATCH 067/331] FROMLIST: drm/amd/display: Add ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-drm-amd-display-Add-SPL_ASSERT_BUG-macro-de.patch
@@ -1,7 +1,7 @@
-From 1133f1e2eee4fd905748aa5bd7d58207fb6fdf28 Mon Sep 17 00:00:00 2001
+From e9c7ac5f4d27d8f060d1f5f018e4e214bd80b967 Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:15 +0800
-Subject: [PATCH 068/328] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
+Subject: [PATCH 068/331] FROMLIST: drm/amd/display: Add SPL_ASSERT_BUG() macro
  definition
 
 In order to keep the current ability for the aim of debugging and avoid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-drm-amd-display-Harden-callers-of-division-.patch
@@ -1,7 +1,7 @@
-From c8f26fc4543302aea2a503865888af8046efd0b1 Mon Sep 17 00:00:00 2001
+From dbba1560b24c0b1ed6364252e6e19b526d33b05e Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 14 Jan 2025 21:30:35 +0800
-Subject: [PATCH 069/328] FROMLIST: drm/amd/display: Harden callers of division
+Subject: [PATCH 069/331] FROMLIST: drm/amd/display: Harden callers of division
  functions
 
 There are objtool warnings compiled with the latest mainline LLVM:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-PCI-loongson-Add-quirk-for-OHCI-device-rev-.patch
@@ -1,7 +1,7 @@
-From d299415caa9d91295a9d96a1c9c6a089e63bfbfa Mon Sep 17 00:00:00 2001
+From ef311aa20727721402e3bd2b8b9e73b7625d2764 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 21 Jan 2025 19:42:25 +0800
-Subject: [PATCH 070/328] FROMLIST: PCI: loongson: Add quirk for OHCI device
+Subject: [PATCH 070/331] FROMLIST: PCI: loongson: Add quirk for OHCI device
  rev 0x02
 
 The OHCI controller (rev 0x02) under LS7A PCI host has a hardware flaw.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
-From 072a260e27b38c2bc143c41745ba28a9a1b9b170 Mon Sep 17 00:00:00 2001
+From 4cb9f43f9c64365c2ca4a16ede5f4bb06c390c5f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 071/328] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 071/331] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-BACKPORT-FROMLIST-dt-bindings-pwm-Add-Loongson-PWM-c.patch
@@ -1,7 +1,7 @@
-From bae74d74f63177be90f55653c7bb2efe18a02842 Mon Sep 17 00:00:00 2001
+From f504a70b24798cbef96d139a5450051e495cfdfb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:24 +0800
-Subject: [PATCH 072/328] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
+Subject: [PATCH 072/331] BACKPORT: FROMLIST: dt-bindings: pwm: Add Loongson
  PWM controller
 
 Add Loongson PWM controller binding with DT schema format using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-FROMLIST-pwm-Add-Loongson-PWM-controller-support.patch
@@ -1,7 +1,7 @@
-From 9e0d8ec32791a7378c08dc569f79ee5fb8719030 Mon Sep 17 00:00:00 2001
+From aef12d4f8f638ee8ff1034a5f5f7ce80131c96f5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Mon, 17 Feb 2025 17:30:25 +0800
-Subject: [PATCH 073/328] FROMLIST: pwm: Add Loongson PWM controller support
+Subject: [PATCH 073/331] FROMLIST: pwm: Add Loongson PWM controller support
 
 This commit adds a generic PWM framework driver for the PWM controller
 found on Loongson family chips.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-riscv-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
-From b1a4b53f1a2765731339b4792196b6998c4d8460 Mon Sep 17 00:00:00 2001
+From f6c2655717205b2409d0c86857bb3579d05f4c88 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:40 +0800
-Subject: [PATCH 074/328] FROMLIST: riscv: vDSO: Remove --hash-style=both
+Subject: [PATCH 074/331] FROMLIST: riscv: vDSO: Remove --hash-style=both
 
 When RISC-V borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-csky-vDSO-Remove-hash-style-both.patch
@@ -1,7 +1,7 @@
-From 28cde97236a093b7b2fb87659c13ce38b75b404c Mon Sep 17 00:00:00 2001
+From 562764f854f8ea48d8eab4f2986505fd881f7d5a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:41 +0800
-Subject: [PATCH 075/328] FROMLIST: csky: vDSO: Remove --hash-style=both
+Subject: [PATCH 075/331] FROMLIST: csky: vDSO: Remove --hash-style=both
 
 When CSKY borned, DT_GNU_HASH had already became the de-facto
 standard so DT_HASH is just wasting storage space.  Remove the explicit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-LoongArch-vDSO-Remove-hash-style-sysv.patch
@@ -1,7 +1,7 @@
-From 4a38af30d15e57236693ee15f326c0b09637ae0a Mon Sep 17 00:00:00 2001
+From 838a65f2ee111b706bc4060ab9d0ee06ae1996c1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 24 Feb 2025 19:20:42 +0800
-Subject: [PATCH 076/328] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
+Subject: [PATCH 076/331] FROMLIST: LoongArch: vDSO: Remove --hash-style=sysv
 
 glibc added support for .gnu.hash in 2006 and .hash has been obsoleted
 far before the first LoongArch CPU was taped.  Using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-drm-xe-bo-fix-alignment-with-non-4K-kernel-.patch
@@ -1,7 +1,7 @@
-From 780d966f54f66518f852c6693f875fd1a3a6ecf6 Mon Sep 17 00:00:00 2001
+From 12d0fd3afbbffcb48fda0aec571a0e05589d646f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 077/328] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
+Subject: [PATCH 077/331] FROMLIST: drm/xe/bo: fix alignment with non-4K kernel
  page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
-From fba5146cef00ca1de0fe08608ac48199182510b2 Mon Sep 17 00:00:00 2001
+From 3bfa2952f12decc1219130a4c83d58e431f1f4ca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 078/328] FROMLIST: drm/xe/guc: use SZ_4K for alignment
+Subject: [PATCH 078/331] FROMLIST: drm/xe/guc: use SZ_4K for alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
-From b462b49cb7f3d57618221e0662df6b3d9880be7f Mon Sep 17 00:00:00 2001
+From 77a153ec1efe42c39b2285af4f1faa6f6aded565 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 079/328] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 079/331] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
-From c50b45c7da20c201f5b3d7f1d68e88ce4f1c77c6 Mon Sep 17 00:00:00 2001
+From bccb3c1e65e510a3e0bfde8bb1e8aa67bedaa13e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 080/328] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 080/331] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
-From 7e5c8c1a1a4cad7dd7aeca4036c82d95ff30c316 Mon Sep 17 00:00:00 2001
+From d2ed0560fea2ac32275d1150ad83ed2fc531951c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 081/328] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 081/331] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
-From 09609e1200abc5763921b9707a633ae53d9c1699 Mon Sep 17 00:00:00 2001
+From 842926242d0dc1b8652734e39ed24a1346c250a8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 4 Mar 2025 14:33:51 +0800
-Subject: [PATCH 082/328] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 082/331] FROMLIST: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From 0b51b6246a93d25badb82ba0f70b7565737ac14b Mon Sep 17 00:00:00 2001
+From e6c2d15969da83e7e1d098334c4d41ad2cdc4827 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 083/328] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 083/331] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
-From 7779d1fa57b01a02166fa9b3eb41da6493f88b24 Mon Sep 17 00:00:00 2001
+From 29953fd70506e98e188059a45e0fcdbd4d51576a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 084/328] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 084/331] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
-From 920161c121203bf37d0d08913f18264408bc2479 Mon Sep 17 00:00:00 2001
+From ed9bc84d8de37c648f7d06679b07639a70c6188d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 085/328] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 085/331] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
-From 85ccdb322ffa04c7b1376f4d916e59ef88132994 Mon Sep 17 00:00:00 2001
+From 49c8a5d33b90a5445bae5c4c2dbf0331659b7c7e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 086/328] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 086/331] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
-From 0ea7d5ad8e67fe1deff2ef5d4e80acdacd0f6e89 Mon Sep 17 00:00:00 2001
+From e042ad2afe52168ab07e23c42e070cce73eed44f Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 087/328] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 087/331] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
-From 30c70df6c0c313e7ef732025d37164a5bdcdce32 Mon Sep 17 00:00:00 2001
+From 991b9b6d7cf392620d62292f7878083536bd7a79 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 088/328] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 088/331] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
-From 473a23bff9fad27611aed78e637d313447234879 Mon Sep 17 00:00:00 2001
+From 6644c5e3d23bd69bee0f515f3cc87c5e2601a637 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 089/328] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 089/331] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
-From cc887d23fb203ad6e5628dc89eba10e84fc657cc Mon Sep 17 00:00:00 2001
+From 6eab28ab154ea8ecfe9356be42dba39066eb5907 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 090/328] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 090/331] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
-From 71069e72e4c867dea22d764f24d602f1efcf3310 Mon Sep 17 00:00:00 2001
+From bf3912d73761e0e20d6e9b243f80686ed76f5a0b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 091/328] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 091/331] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
-From a1277952666cea3f7c06432f46ee428e1cfb854e Mon Sep 17 00:00:00 2001
+From 2b8d29f8cdbd86a1e7f18b514d33c970dc2a12d4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 092/328] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 092/331] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
-From 45074a17ce8cfbc686649e54607945f6fec866f0 Mon Sep 17 00:00:00 2001
+From bf0ef5ecde60e4653e1ca21da40cc10cec159d37 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 093/328] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 093/331] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From 41eb7c563dfb674c5696c160003227ef6e7364f4 Mon Sep 17 00:00:00 2001
+From db921f2a7ba93aedc06b9f9c58302b696c80bffb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 094/328] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 094/331] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
-From 7a779c3fffbbb478a61829ff2fca6845bafb47d3 Mon Sep 17 00:00:00 2001
+From 0eb961f1e530ac161b6e1bc0ca8c3415c1a93db0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 095/328] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 095/331] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-LOONGSON-LoongArch-Always-select-HAVE_VIRT_CPU_ACCOU.patch
@@ -1,7 +1,7 @@
-From b98c9351cd8de32fb08da96d96d03a73d8f40cfd Mon Sep 17 00:00:00 2001
+From 9fe3e33d565839d4f8e27d9ff32f97c7ce189214 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 25 Feb 2025 17:24:20 +0800
-Subject: [PATCH 096/328] LOONGSON: LoongArch: Always select
+Subject: [PATCH 096/331] LOONGSON: LoongArch: Always select
  HAVE_VIRT_CPU_ACCOUNTING_GEN
 
 Option HAVE_VIRT_CPU_ACCOUNTING_GEN is selected by default for 64bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-LOONGSON-LoongArch-Enable-UBSAN-Undefined-Behavior-S.patch
@@ -1,7 +1,7 @@
-From 81ba88b864ad5e44bacb9ff09444b24a835503f4 Mon Sep 17 00:00:00 2001
+From 698193fd40246bb36140be3dc6243b0377a9f7c9 Mon Sep 17 00:00:00 2001
 From: Yuli Wang <wangyuli@uniontech.com>
 Date: Thu, 6 Feb 2025 14:38:20 +0800
-Subject: [PATCH 097/328] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
+Subject: [PATCH 097/331] LOONGSON: LoongArch: Enable UBSAN (Undefined Behavior
  Sanitizer)
 
 Select ARCH_HAS_UBSAN in order to allow the user to enable CONFIG_UBSAN

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-LOONGSON-LoongArch-vDSO-Make-use-of-the-t8-register-.patch
@@ -1,7 +1,7 @@
-From 85502d9c3c1b156f7b8d7cbdd51e71846325098e Mon Sep 17 00:00:00 2001
+From 2b9bd33f17fcbdf5f401a23d4999c1303a0b7fd3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 21 Feb 2025 19:32:43 +0800
-Subject: [PATCH 098/328] LOONGSON: LoongArch: vDSO: Make use of the t8
+Subject: [PATCH 098/331] LOONGSON: LoongArch: vDSO: Make use of the t8
  register for vgetrandom-chacha
 
 Make use of the t8 register for vgetrandom-chacha, so we don't need to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
-From 3f316724bf9ff8d788067e53ac49fe441411d877 Mon Sep 17 00:00:00 2001
+From 564d2380ee671ceebc08897191289b55fd66b4a8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 099/328] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 099/331] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
-From fce05dadaf1eb2da874f595460b7d05244bed38d Mon Sep 17 00:00:00 2001
+From 468b67b2d92d3aa435a75481874f6b4a50ddecae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 100/328] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 100/331] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
-From 42b873752b46a99d2ac8f32a94cf329fa0daac55 Mon Sep 17 00:00:00 2001
+From 7f65d340697dd4e47ee854b2b3b7b7fde0dd4f17 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 101/328] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 101/331] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
-From 3d268637c6d5bf6c3b8a5aac8a75daba66d4b008 Mon Sep 17 00:00:00 2001
+From 4ff003d8273019459b562eeb72c18ca373c92065 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 102/328] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 102/331] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
-From abb78678f10717910e819a42e8faaee67f49662c Mon Sep 17 00:00:00 2001
+From a50720881ce311388b29e1b8748b6f564e06dc06 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 103/328] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 103/331] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
-From 3665718c82db1920ed4c84dba1d48efae6938552 Mon Sep 17 00:00:00 2001
+From 215a65618814d407695482cfe8c734490985b25b Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 104/328] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 104/331] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
-From e9afc183ebbc8e89d1bd5cfee498aa493dff1528 Mon Sep 17 00:00:00 2001
+From 4a55652e80d66f6adc4f930a76c3d013ee6f9871 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 105/328] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 105/331] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
-From 99284bc9d1cc7ab74b4ed02e63195fb4fe46d94b Mon Sep 17 00:00:00 2001
+From 6cbc2448d1ae05de242e1f7c839b262aca5d2ebd Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 106/328] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 106/331] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
-From fd340327ff81e795395f739d4a6cd67c0cc74df1 Mon Sep 17 00:00:00 2001
+From de8a18009d40db3619576045062e3028679f5d0a Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 107/328] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 107/331] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
-From 30971b1b763140de3d1018a66ea4459778664d60 Mon Sep 17 00:00:00 2001
+From 80a76c0f25cfb1ee2dea5f4503ff54549af134ed Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 108/328] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 108/331] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
-From eb68fcd0133c1c71c27e63d74cd0061c15d347b8 Mon Sep 17 00:00:00 2001
+From 22559eacbf2ae381254ecfe837a568094a94b7b3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 109/328] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 109/331] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
-From e295d41e4fb4169212df7c1478de759320cb561e Mon Sep 17 00:00:00 2001
+From f60c64d0246cbbba98291f97b9bfdfb144eb0353 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 110/328] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 110/331] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
-From 1a43e9be228843fc2686d8a076cf143d80e85b6b Mon Sep 17 00:00:00 2001
+From f40b8d998c82fad893653365a68f01e56d9143fd Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 111/328] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 111/331] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
-From 101839f08f3c59a301622ebab9ea351e67a931c1 Mon Sep 17 00:00:00 2001
+From 104f253474a260e96c9838b51165272ef498eba0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 112/328] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 112/331] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
-From d029c0c4c0548e8570fc5053f0cfa6d2e5207c28 Mon Sep 17 00:00:00 2001
+From 4530812feac7c66b66a9a971d82acbb2aff08ccc Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 113/328] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 113/331] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
-From adfd9c9d82e151efe4fde9917247bfd652a401e2 Mon Sep 17 00:00:00 2001
+From d1a7c549193a147f238a20b113f81caa254cd230 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 114/328] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 114/331] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
-From 0c9bbe29772deaccd94451b20bbf499dfd3edc6f Mon Sep 17 00:00:00 2001
+From 14daef10ec4901fe4153c864197802dd37ba5a3c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 115/328] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 115/331] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
-From 3e5931425d6463f4c3d5ed1238e25bc1faee926e Mon Sep 17 00:00:00 2001
+From f66b3d3c23dd8359f3d27b7e4893ce1b5cc7201e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 116/328] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 116/331] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
-From 2f8bfc0405a75f4e73bd69f70f30e5a50affb524 Mon Sep 17 00:00:00 2001
+From 3377e3d88b12d8cf9ddaa723f8792cc464567b5a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 117/328] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 117/331] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
-From 8f476d1831f9a5a18ffe111141292278f5ced8e9 Mon Sep 17 00:00:00 2001
+From cfea24be954f2a302b63022a8dc47b9535e9c72e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 118/328] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 118/331] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
-From bb81253cfd3d3855b86198babeddabf1a842b087 Mon Sep 17 00:00:00 2001
+From b59ca15944a9dc8230e68e561822ffd80be08632 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 119/328] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 119/331] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
-From caa41f9a3ca929efd3b1210b37761f81c1619d60 Mon Sep 17 00:00:00 2001
+From df138def196489dcb4867f0723059213a0218bbb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 120/328] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 120/331] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
-From 9adfee3d0dc19140218de2a7cd5e71469a9d7279 Mon Sep 17 00:00:00 2001
+From 2c530649852b5d3dc917c37fca2eb8d7ba39b93f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 121/328] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 121/331] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
-From a283b2c09605bc512b9bd56b44d3bb1f60b66226 Mon Sep 17 00:00:00 2001
+From 202b47e5b3c498cb0d5943725dfbbbda299a7e4d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 122/328] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 122/331] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
-From 93f38035d8aad24e0fa006f61f215917c3ed8a1d Mon Sep 17 00:00:00 2001
+From 864a597f9a47e877070096de1e13d97d2ddf4664 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 123/328] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 123/331] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
-From d7fc96e6fca8765ea219d304fa90e41b279212fc Mon Sep 17 00:00:00 2001
+From 37ec5d5897312ef0fe4cb1773801c3a642dd12ef Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 124/328] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 124/331] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
-From 98c60fe8a7ecb040844f089b62a17da573f9700e Mon Sep 17 00:00:00 2001
+From 3dc5aa0becedec06ea4ec4f3620a9acc999f8754 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 125/328] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 125/331] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
-From 46425ae808654a7dbd5db5860fad39a8f55ea8f9 Mon Sep 17 00:00:00 2001
+From 0e73bff591d093a58587a984fc090427a5cba8ba Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 126/328] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 126/331] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
-From 808e1cab566feca68f95f2ff70f2fe531843e24c Mon Sep 17 00:00:00 2001
+From 653213b85470dcc224793745c24294b9bf33844a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 127/328] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 127/331] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
-From 8acac7a55e6b3eb9eedc533dce6337d67fba7431 Mon Sep 17 00:00:00 2001
+From f03c3682c1b9dc1b0bf37652cb31533e2ce45d7e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 128/328] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 128/331] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
-From cd227e288caeea667da01a63b9291aaa798cbbc0 Mon Sep 17 00:00:00 2001
+From b57b84a5dd1dd24bfb3e04f81d233c4c4f99801a Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 129/328] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 129/331] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
-From f8550ec3dd7f4c5f490487f4bfc1de1b6177d701 Mon Sep 17 00:00:00 2001
+From 6e5a2aa15dc219f43470e91a32912f50363fcefd Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 130/328] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 130/331] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
-From cee58bd142ba90da8a94faca9660d3b1bcba4183 Mon Sep 17 00:00:00 2001
+From d469b363004b11b2b0e612f86dc2aa6d038a14ae Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 131/328] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 131/331] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 168948244cdf0973129d9181026258c258fa6f9d Mon Sep 17 00:00:00 2001
+From 07abf999c1f595cbb5f3301b61159bfdbb2e5b48 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 132/328] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 132/331] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 6f6dd127608f1d5c74cbaf5bd47693c9d57fc32b Mon Sep 17 00:00:00 2001
+From c684713f10249d87cd87410a170324790dcddfa8 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 133/328] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 133/331] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
-From 077ff3d5dfa8db788cb680e84d037b4ab67f2e0e Mon Sep 17 00:00:00 2001
+From 338e431cdeeddfca2ac833c3e53c6846c505a4b9 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 134/328] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 134/331] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
-From b5e7ed1dd64122c82284bd1cb95f5d008152838e Mon Sep 17 00:00:00 2001
+From 05294f2b08729f0ae96868126de50df9a8988fbe Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 135/328] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 135/331] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
-From 40d024d402d898ca44f92230e8e54cd2311aceb7 Mon Sep 17 00:00:00 2001
+From 118ebc6899e172fe754cfef6e727a4aeb7460761 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 136/328] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 136/331] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
-From a13ff5fea24b19d907fead019e9fc791fae0006e Mon Sep 17 00:00:00 2001
+From 1f8683975a0ae04eb1eb5d6cfe6073d28f891d38 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 137/328] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 137/331] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-BACKPORT-OPENEULER-arm64-cpufeature-discover-CPU-sup.patch
@@ -1,7 +1,7 @@
-From 71951cfd1924bf32de8af948f9963553030fc6ec Mon Sep 17 00:00:00 2001
+From 068a11012025d6223530216d639786d02ec9b2f3 Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:31 +0800
-Subject: [PATCH 138/328] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
+Subject: [PATCH 138/331] BACKPORT: OPENEULER: arm64: cpufeature: discover CPU
  support for MPAM
 
 maillist inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-BACKPORT-OPENEULER-KVM-arm64-Fix-missing-traps-of-gu.patch
@@ -1,7 +1,7 @@
-From 6b5840472214a1e4d24d74a374f295267a84e7ff Mon Sep 17 00:00:00 2001
+From 09541a47d3e6db3f4f194e9d4578825bce41169e Mon Sep 17 00:00:00 2001
 From: James Morse <james.morse@arm.com>
 Date: Mon, 22 Jan 2024 14:57:32 +0800
-Subject: [PATCH 139/328] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
+Subject: [PATCH 139/331] BACKPORT: OPENEULER: KVM: arm64: Fix missing traps of
  guest accesses to the MPAM registers
 
 maillist inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-BACKPORT-OPENEULER-arm64-cpufeature-Both-the-major-a.patch
@@ -1,7 +1,7 @@
-From cf423f8ca305420e0034f10f5bb96bbff14b5c94 Mon Sep 17 00:00:00 2001
+From 7df1b9c8fa34ec13f15804ed2bc6261ee4ff67ff Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Sat, 1 Jun 2024 14:38:28 +0800
-Subject: [PATCH 140/328] BACKPORT: OPENEULER: arm64: cpufeature: Both the
+Subject: [PATCH 140/331] BACKPORT: OPENEULER: arm64: cpufeature: Both the
  major and the minor version numbers need to be checked
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-OPENEULER-Revert-arm64-head.S-Initialise-MP.patch
@@ -1,7 +1,7 @@
-From 8a130bd3bebd8a92948f36129b2f1f517083da6c Mon Sep 17 00:00:00 2001
+From 2494b3f8408b4d44df159edec99267601d044a9d Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:52 +0800
-Subject: [PATCH 141/328] BACKPORT: OPENEULER: Revert "arm64: head.S:
+Subject: [PATCH 141/331] BACKPORT: OPENEULER: Revert "arm64: head.S:
  Initialise MPAM EL2 registers and disable traps"
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-OPENEULER-arm64-mpam-Check-mpam_detect_is_e.patch
@@ -1,7 +1,7 @@
-From f19a40a584b555954c20d66cf08bb85a47cc5c0d Mon Sep 17 00:00:00 2001
+From d41643f11d78ca5dda0e255ffdfa3a7de30736c8 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Tue, 24 Sep 2024 21:47:53 +0800
-Subject: [PATCH 142/328] BACKPORT: OPENEULER: arm64/mpam: Check
+Subject: [PATCH 142/331] BACKPORT: OPENEULER: arm64/mpam: Check
  mpam_detect_is_enabled() before accessing MPAM registers
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-OPENEULER-arm64-mpam-Fix-redefined-reference-of-mpam.patch
@@ -1,7 +1,7 @@
-From 05a50e582a73d7d69d67f28d3757ff6801945fd9 Mon Sep 17 00:00:00 2001
+From a43876ff66674420c8a10e0524649cfadd39e711 Mon Sep 17 00:00:00 2001
 From: Zeng Heng <zengheng4@huawei.com>
 Date: Thu, 26 Sep 2024 17:28:18 +0800
-Subject: [PATCH 143/328] OPENEULER: arm64/mpam: Fix redefined reference of
+Subject: [PATCH 143/331] OPENEULER: arm64/mpam: Fix redefined reference of
  'mpam_detect_is_enabled'
 
 hulk inclusion

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
-From e2fb4ba2f76865beb127d15b1ca762ef55c201c7 Mon Sep 17 00:00:00 2001
+From 625f50b31afa5da8c44aa0b70a98731c3e1ecdaf Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 144/328] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 144/331] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
-From ca348c19a878853ce1f81692f946050ff2dee33e Mon Sep 17 00:00:00 2001
+From afa32fa41b82cc2d848d9ed190eb9781413b4c56 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 145/328] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 145/331] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
-From ebc38b82cd3fcd0296aceb48f73b0c5a7dc752df Mon Sep 17 00:00:00 2001
+From 8f4627200fe0bf0f7dfd6d7d4f3bb15392ca27bb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 146/328] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 146/331] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
-From a763675674a043c0e1dfd8a80b3cbab20ec7b4d4 Mon Sep 17 00:00:00 2001
+From 37f88f995927a36912010000b50bcc9df836f852 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 147/328] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 147/331] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-LoongArch-Adjust-the-calculation-of-.patch
@@ -1,7 +1,7 @@
-From 2dcc89ca969cb25d48e19e22597bfde888e78c9a Mon Sep 17 00:00:00 2001
+From febae37d9aff333f461590586826e5d1e199fdb4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:51:08 +0800
-Subject: [PATCH 148/328] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
+Subject: [PATCH 148/331] BACKPORT: DEEPIN: LoongArch: Adjust the calculation
  of the number of packages
 
 Signed-off-by: wanghongliang <wanghongliang@loongson.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transition-of-devi.patch
@@ -1,7 +1,7 @@
-From 9784e806980106c96afff9372d920434625236be Mon Sep 17 00:00:00 2001
+From 069f212c5c0af3ab919585b7aa62e4d6d634c6ae Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 149/328] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
+Subject: [PATCH 149/331] DEEPIN: pci/quirks: LS7A2000: Fix pm transition of
  devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
-From 9013e5d6dabeb2c56536a15d09a5999edf7a20b8 Mon Sep 17 00:00:00 2001
+From e2e2e787382f6d90b754743b270f286bf07461a2 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 150/328] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 150/331] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
-From fc44fe6aac194b5854be87d00deaf758edaae460 Mon Sep 17 00:00:00 2001
+From 6bb5a3e9e24b0214e3d05a2af321b51128927235 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 151/328] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 151/331] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
-From ab6f83bc3debb13ac92bfcb0024a74ec36b1a981 Mon Sep 17 00:00:00 2001
+From 45bcac767b16fd4a6cdf32efba7354355e368598 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 152/328] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 152/331] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
-From 53d182d3be5f88721eaa6db1b9b643b0fbe3b414 Mon Sep 17 00:00:00 2001
+From 1d781bcb9db1d84a99bace6865d25011339c0da8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 153/328] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 153/331] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
-From 9a5d19c3a34673e2ecdd277cbbe71aa1d37b0a68 Mon Sep 17 00:00:00 2001
+From 4aa8d98ca60bf9677caf3e4f1d98594880a4e1f3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 154/328] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 154/331] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
-From 685d70d27d4b6a862e91dcc7e74094347fde11b8 Mon Sep 17 00:00:00 2001
+From fd75b2ecf6cb99e0975e2eb64e7ac5615e5a261a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 155/328] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 155/331] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
-From 6f2b3a07c787d6b07cf46a29986d67fcc852d0d5 Mon Sep 17 00:00:00 2001
+From d575d36f9e5bb55b93178d165e8024432c444b6d Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 156/328] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 156/331] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
-From 13da2583cd07a7e43ad05f5b46bf350b2aec0f2c Mon Sep 17 00:00:00 2001
+From ca5509eb9d1928d253ee2764e703cbf1d4f6420c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 157/328] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 157/331] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
-From cfe49cf9f25128b3c5e4cf4fefe9113f424b0165 Mon Sep 17 00:00:00 2001
+From 897db67c9fc099d5536a80360f4890ce3c9bd183 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 158/328] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 158/331] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
-From 356d6d007e6efa5917fedeb156cd2df3c81e55f8 Mon Sep 17 00:00:00 2001
+From bcb91347da6d2a49f8a4f88d2ee66d9a2d9deeb9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 159/328] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 159/331] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
-From 22f9eda5983ec390719b63dc384ecf2e998390b1 Mon Sep 17 00:00:00 2001
+From 72b4edc64fc7d64ca03bb2cc9ba91950a6e6c00f Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 160/328] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 160/331] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-iommu-Use-IOMMU-passthrough-mode-for-IPTS.patch
@@ -1,7 +1,7 @@
-From 06723144dea3c8113dbf17cf04674fe0fa1ffe82 Mon Sep 17 00:00:00 2001
+From e49698bf6f4e253f9085835d6ef56c7106793a4d Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 161/328] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
+Subject: [PATCH 161/331] SURFACE: iommu: Use IOMMU passthrough mode for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
 Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-BACKPORT-SURFACE-hid-Add-support-for-Intel-Precise-T.patch
@@ -1,7 +1,7 @@
-From bbf3a842012e288fb965ac49f01f746e8fba6372 Mon Sep 17 00:00:00 2001
+From 085a38d0b3d3f2c4ce21aa1517168ca86747100b Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 162/328] BACKPORT: SURFACE: hid: Add support for Intel Precise
+Subject: [PATCH 162/331] BACKPORT: SURFACE: hid: Add support for Intel Precise
  Touch and Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
-From c3ef21e91e5d96e2003463b893b72721ddf8dcd5 Mon Sep 17 00:00:00 2001
+From 34d630a83c1d83ade04db228b862fda1c39bff85 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 163/328] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 163/331] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
-From 0b58ee13b0d93de2da2f9e68ddbffd1b7375096d Mon Sep 17 00:00:00 2001
+From 85b02a4838598d78f3b3735cc0a597dfa0e7b364 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 164/328] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 164/331] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
-From 9030cec67f107596b725eb0b230cd0c88c3240b3 Mon Sep 17 00:00:00 2001
+From d122101d5620358ad8c39e9919e0fce455897943 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 165/328] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 165/331] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-iommu-intel-ipu-use-IOMMU-passthrough-mode-f.patch
@@ -1,7 +1,7 @@
-From 4e88dab36bf6a544f9d3bc9cfe6cb4895efb5e05 Mon Sep 17 00:00:00 2001
+From 8817b683ca829263a5966b29d46bac6647b24440 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 166/328] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
+Subject: [PATCH 166/331] SURFACE: iommu: intel-ipu: use IOMMU passthrough mode
  for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
-From 8db60838d17327798f02760bddd72c427e7d8031 Mon Sep 17 00:00:00 2001
+From c9354aa824d4c66842ec2d9095b33892252915e4 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 167/328] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 167/331] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
-From 958394e7d4f1048ec13bfe516bb7b5ae3f655daa Mon Sep 17 00:00:00 2001
+From fb2d25685a9420cd96c30419d1b19387957efa42 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 168/328] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 168/331] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
-From 43c31271c01945cf7cdf561f9611d284d62f9268 Mon Sep 17 00:00:00 2001
+From 1c5ca2ad6022b188099d725634b6b44f57a99496 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 169/328] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 169/331] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
-From 94ae8441e5ddb1c6bd6a237e0c61de081db22006 Mon Sep 17 00:00:00 2001
+From 4c27b11ce456cb25125ce481b4b72f2ce83ef946 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 170/328] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 170/331] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
-From 90ab9ce2ddb644248283f924a175ccac0582c644 Mon Sep 17 00:00:00 2001
+From 8e51dd57a82e5d0d343228b65f5d5e5ff96dd4c2 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 171/328] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 171/331] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
-From c7ab17c3f14bee6886225816bcba06af6ed6f96c Mon Sep 17 00:00:00 2001
+From f4e992f228bff532ce49ba61527adbcb1ed85860 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 172/328] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 172/331] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
-From f32ccd3a5993fe8a8c9e82237296b2ff16ca0369 Mon Sep 17 00:00:00 2001
+From c6f5bc672ff00c2f8ec49ba3b007a502f6693af9 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 173/328] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 173/331] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-FROMEXT-more-ISA-levels-and-uarches-for-kernel-6.1.7.patch
@@ -1,7 +1,7 @@
-From d97849d79f0a62183972f0a16fd647ad36072384 Mon Sep 17 00:00:00 2001
+From 296d2a48e97715ff33262f10054495a8892a33b4 Mon Sep 17 00:00:00 2001
 From: graysky <therealgraysky AT proton DOT me>
 Date: Mon, 16 Sep 2024 05:55:58 -0400
-Subject: [PATCH 174/328] FROMEXT:
+Subject: [PATCH 174/331] FROMEXT:
  more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-FROMEXT-cjktty-6.9.patch.patch
@@ -1,7 +1,7 @@
-From c33f22b5dcd11d97f2da51242f110e5cbeb63df4 Mon Sep 17 00:00:00 2001
+From eea5a2fe27a2534f7ed4a6f262e3ef7ddc727da3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 18 Dec 2024 12:31:33 +0800
-Subject: [PATCH 175/328] FROMEXT: cjktty-6.9.patch
+Subject: [PATCH 175/331] FROMEXT: cjktty-6.9.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-FROMEXT-WIP-dw-hdmi-qp-Add-high-TMDS-clock-.patch
@@ -1,7 +1,7 @@
-From 87f84446b5d7d6da3729e692a149466e3ce3b916 Mon Sep 17 00:00:00 2001
+From b6a0e33a544e856bbde4f87883a38feae795ec5b Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 13 Sep 2024 17:30:35 +0300
-Subject: [PATCH 176/328] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
+Subject: [PATCH 176/331] BACKPORT: FROMEXT: [WIP] dw-hdmi-qp: Add high TMDS
  clock ratio and scrambling support
 
 Enable use of HDMI 2.0 display modes, e.g. 4K@60Hz, by permitting TMDS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
-From f5f19fc3e5504b7f23b92158f8566e1c4dbf159b Mon Sep 17 00:00:00 2001
+From a4242accbae9e3e3d101b7dc680489200806be2b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 177/328] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 177/331] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
-From c7ec140e0dfa07f284cb20e7df30ce9c50209709 Mon Sep 17 00:00:00 2001
+From d9b7100fa084e19bae73683846424770f4b615d8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 178/328] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 178/331] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
-From 2e13e81ad47a5e4c98083411c5ab76dcd173a0e4 Mon Sep 17 00:00:00 2001
+From 44aa71c9af86a87c300ebe63bf10a435987f6b0c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 179/328] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 179/331] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
-From 6e00d4698cff537e482d1d4d2737914a94233cd4 Mon Sep 17 00:00:00 2001
+From b843211b742c06a38b0472047746e9ff866b01aa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 180/328] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 180/331] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
-From b9a6c81a1e96324d6ef389b50853dcfa429e68cb Mon Sep 17 00:00:00 2001
+From 1c83f2c6b01b79e023d4d7bca5efb17d367af4e5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 181/328] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 181/331] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
-From 41214eedc7567556bd33532ffbbcf540e6d32166 Mon Sep 17 00:00:00 2001
+From 0d2fd17ef8d7439955410de718916751ea70f8fd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 182/328] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 182/331] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
-From 97e46141d4793f7ee67ddb3a852181a148c294a2 Mon Sep 17 00:00:00 2001
+From 2a19da5a2414240a54f2c3ed30cd09ce98f495dd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 183/328] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 183/331] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
-From 787985c7978fec8443b9ed4c373e38e34928f7ed Mon Sep 17 00:00:00 2001
+From 799650fa7c9bc46acff43a389b523fd454898fe3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 184/328] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 184/331] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
-From 8dbac38f55108d71a181ca11f37dc44ad5f154a1 Mon Sep 17 00:00:00 2001
+From 7082a360be91bfc25cbf689da6296884be63f924 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 185/328] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 185/331] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
-From d964087fa24f4f1590b9ec91b79240a7214b3b2f Mon Sep 17 00:00:00 2001
+From c0a8a3b7278e32b1ce149be73af6860a889530b7 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 186/328] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 186/331] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
-From 99eaab192f2473b56f07a8c55e0759a9d1afc924 Mon Sep 17 00:00:00 2001
+From edf9bcf8e740996f07a08c28559d8dc1785cb74d Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 187/328] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 187/331] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
-From 4a75506a1346b9ec024bd60002700e05a72be554 Mon Sep 17 00:00:00 2001
+From 91b71e6d3ee7f63222ebcfe048f1d84fb67033a3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 188/328] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 188/331] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
-From 00d6e427636adeffd8f3a1b481113eaf788b64c6 Mon Sep 17 00:00:00 2001
+From d2a3a6eab563f5e364e1ca3de91c247ad5ae6dc8 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 189/328] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 189/331] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
-From 15c0a3ee7a0ba280b36e41f69818455259d58118 Mon Sep 17 00:00:00 2001
+From 30ff51e4529ce995695f72fe0885d30d31d56dec Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 190/328] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 190/331] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
-From f66c0e09b6bb9486f578462fd84e2dc65f5a7c78 Mon Sep 17 00:00:00 2001
+From 80ac88479de1ec2b0bf99e11b9cf008816b57158 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 191/328] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 191/331] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
-From 8839cc120c3c41f6521861542be89da5d17eff4d Mon Sep 17 00:00:00 2001
+From fe7be048448966b64e64ab1abc1d02196b5ceac1 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 192/328] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 192/331] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
-From f5592ac9965186505743ddaf0e6bb99cb31af03b Mon Sep 17 00:00:00 2001
+From fd25f66fe8ccc0f082478ed1701af1b77938dd1e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 193/328] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 193/331] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
-From 906599fa4a4dd2cd4dc73a17cd2153c245dc46b2 Mon Sep 17 00:00:00 2001
+From c247f6b776148a85f076f4e0d771914ccdb1e91a Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 194/328] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 194/331] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
-From 89a178731a0e6f716b51bda65bfb895c46478514 Mon Sep 17 00:00:00 2001
+From e27b5e875602083b9de991d5dae03f3452a08d74 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 195/328] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 195/331] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
-From 79d56a8e49d82a692c5a86255af0f0d97c5dbf5d Mon Sep 17 00:00:00 2001
+From dad596710256e8fbd704a8f47ab58a2e9e5fb025 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 196/328] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 196/331] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
-From b42235dc7f2cb2a953dbd7144cded329f1df806d Mon Sep 17 00:00:00 2001
+From 32393fba0189144cf7bfb3da5660638249c818a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 197/328] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 197/331] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
-From ce2edd6ea8d153633ff92c1d8360f569fc7fe085 Mon Sep 17 00:00:00 2001
+From b7e5b584dce31390096bcb07d66e41c6b68b3308 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 198/328] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 198/331] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
-From db6e31f0a6bfa2e5236971a84e757416fa390eee Mon Sep 17 00:00:00 2001
+From 2266ed388f0807c474360173e81cb7904e272c16 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 199/328] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 199/331] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-drm-ls2kbmc-Add-id_table-for-ls2kbmc_platform.patch
@@ -1,7 +1,7 @@
-From 752c0d9bfc65240aeae223ed8451616484d5cb7d Mon Sep 17 00:00:00 2001
+From 2eb027cbc61d260a901d430a75214a6c214790d4 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 31 Dec 2024 15:56:52 +0800
-Subject: [PATCH 200/328] AOSCOS: drm/ls2kbmc: Add id_table for
+Subject: [PATCH 200/331] AOSCOS: drm/ls2kbmc: Add id_table for
  ls2kbmc_platform_driver
 
 Try to fix device binding for the driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
-From 9a33e02849c6c73e3a1eaa94d0972e8a6a5cdf98 Mon Sep 17 00:00:00 2001
+From 95df4f1c42093190be1a5c72a5effa7f24d236f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 201/328] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 201/331] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
-From 4788e2e6377086b9b6f034adcbf56c4b21a75eca Mon Sep 17 00:00:00 2001
+From 551efbdf25020112f8f80bbc5596098dbe76a3f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 202/328] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 202/331] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
-From 36578d5d86df38df85d86288ba5b17451340da1a Mon Sep 17 00:00:00 2001
+From 47080bcd109d33bade24e4cc973b4840b5c00cda Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 203/328] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 203/331] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
-From b2f912a9183f71ed7c66e206a9350c0b11191f9d Mon Sep 17 00:00:00 2001
+From 84d7fdbbab5e720c334b3fa6aa3f62a790c9a33f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 204/328] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 204/331] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-drm-ls2kbmc-fix-drm_client_setup.h-inclusion.patch
@@ -1,7 +1,7 @@
-From ee325e1fc0d830edc20ab59b81222c509051fe9f Mon Sep 17 00:00:00 2001
+From bdfb42dcff1281ff50a2e885f7bcced236b684d0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:06:44 +0800
-Subject: [PATCH 205/328] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
+Subject: [PATCH 205/331] AOSCOS: drm/ls2kbmc: fix drm_client_setup.h inclusion
 
 Following upstream name changes.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-ls2kbmc-remove-driver-date.patch
@@ -1,7 +1,7 @@
-From 44d51a300b3c020a2d2840f25d856130d1e9dc16 Mon Sep 17 00:00:00 2001
+From 2e24ec1874bfb4788d8f3ea5326a7d796b45f6ad Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:41:10 +0800
-Subject: [PATCH 206/328] AOSCOS: drm/ls2kbmc: remove driver date
+Subject: [PATCH 206/331] AOSCOS: drm/ls2kbmc: remove driver date
 
 Following upstream changes.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
-From f709c2ee34720af833db69163d0a8feb36def2f7 Mon Sep 17 00:00:00 2001
+From cfd029e38cddba0424dd59371cad76362da778ad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 207/328] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 207/331] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
-From 416a8c94733dab0736ea7eabe50b8dc38bc248a1 Mon Sep 17 00:00:00 2001
+From 42842d19ce14b619c520a45ea2bf5318b875afc6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 208/328] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 208/331] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
-From fb6479a7c014f32a9469b632d856f77a0c679ad9 Mon Sep 17 00:00:00 2001
+From ebda65cc9099a61bf83071b17af55cee09c44671 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 209/328] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 209/331] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
-From 9cfbb269682585c0872bc5d95aa434752a8f8a44 Mon Sep 17 00:00:00 2001
+From 8d32bd293b288ba93e9e50015c1a95bc45e4becb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 210/328] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 210/331] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From a8d379b70015ae322342644bbef27373ba7b0485 Mon Sep 17 00:00:00 2001
+From 0bd74c1a90486d06de130e8b7dc7b9a6ae31fc5c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 211/328] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 211/331] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
-From 93db20eafd54b24125e59ca699fcc84b92556b59 Mon Sep 17 00:00:00 2001
+From 3ce4bb6899f4d0d4d8988ff9b98c7fa4bbde74a2 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 212/328] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 212/331] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
-From 10aa992197927dcaa1b348cd668c5d54f8fd5f89 Mon Sep 17 00:00:00 2001
+From 3061b7faa1465d51e4b442be7c5717871e629b02 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 213/328] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 213/331] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
-From af173838578c7e4ed35576311114aac9535b9383 Mon Sep 17 00:00:00 2001
+From 29a4172fd2734233650c8dcd2e6f9cfeb006a8ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 214/328] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 214/331] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
-From 8ef7834586d6a500235382a00a6cb2c2b11b3e7f Mon Sep 17 00:00:00 2001
+From a5ad18c3663630c7adeee49da50f20d89048c1bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 215/328] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 215/331] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
-From 6c22ae7b86d4794f5e7e1ee991d0fd9ba97f4d62 Mon Sep 17 00:00:00 2001
+From 431504dd7c9451dac404f884fab3e202ada608db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 216/328] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 216/331] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
-From 627b35c23383d364ade801dd500958b310df4ac6 Mon Sep 17 00:00:00 2001
+From 3f99f049eba0d19ddd312d01fb9c0bc441af7bea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 217/328] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 217/331] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
-From f25936ce1117b7b4874315f49160ab1fcdad7f11 Mon Sep 17 00:00:00 2001
+From 6c6dee64125103dca3242b115116d53eeabdb3ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 218/328] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 218/331] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
-From 947981323ee1237a568d5f19ce40f789c1b95812 Mon Sep 17 00:00:00 2001
+From 313f7dd1b7a0d5ea6faeb284ecd101184ebdb1c2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 219/328] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 219/331] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
-From 1812270f0dda73454a5b0ca33debd742a7460310 Mon Sep 17 00:00:00 2001
+From b5f4f40098062802ceb4e04789254bdbd1b27c62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 220/328] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 220/331] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
-From a1bdb04860fffd69066fb97595f1c007fd37d4de Mon Sep 17 00:00:00 2001
+From 866116c01cc44fed5619ae5400fa71b95dc80145 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 221/328] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 221/331] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
-From 71412268842ebe3c625ff093d35dc65aa9ed4fd3 Mon Sep 17 00:00:00 2001
+From e76287124d4e2af40b1cd7a7efc2ce5c38c15139 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 222/328] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 222/331] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
-From 84a5756639bd716bf7802123651792f79eb96f3c Mon Sep 17 00:00:00 2001
+From 13d17ce43754fb86a0dfbe515a155de4435c7cfa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 223/328] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 223/331] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
-From 9193e04ba31fcbbe6b39706c538ce0dbd077d0b5 Mon Sep 17 00:00:00 2001
+From 2f266141fbd90f626fa4c68a7963fb3c1d04f02a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 224/328] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 224/331] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
-From b8b56314474fb8f6a6a4ea68d70f05959ab49e75 Mon Sep 17 00:00:00 2001
+From e80d9945e279f972b25b3d03b5564fa887a49194 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 225/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 225/331] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
-From fbf191befdd7ac91e4e6ff60673506985930763a Mon Sep 17 00:00:00 2001
+From 96b8cc4c513ecc1d4c15d6232b2f92b9c00c78cb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 226/328] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 226/331] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
-From b5a97a1fe0cfe1ec037c0d4e8a3cd898ba523b24 Mon Sep 17 00:00:00 2001
+From 85296d6ec9c66b915098958fb16407cb1e3598f7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 227/328] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 227/331] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
-From bd23f4d14766609544224b9847442e6dd4912cc1 Mon Sep 17 00:00:00 2001
+From b5c49e43f7a0cbef0c514b1c1865f8565b0b52ee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 228/328] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 228/331] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
-From 1950d4db09bda92997efc876656e8a5807bd4082 Mon Sep 17 00:00:00 2001
+From 9b5b14d46036df621102d640e74c75a6e9b031bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 229/328] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 229/331] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
-From ce95e391a5e82cc1ca6bdbda46a865f653db84ec Mon Sep 17 00:00:00 2001
+From df3d4dc97a9eb2b3a42e067e4602bec6440831ca Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 230/328] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 230/331] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
-From 37d048f60e36c78e1508e69caf6b0d735fb545f1 Mon Sep 17 00:00:00 2001
+From 80f263b05c3657449242ea4ce1ef92f10fa1dd25 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 231/328] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 231/331] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
-From 9bfa19e968f0fc4bedf73d6d478b92bf15ab1ac9 Mon Sep 17 00:00:00 2001
+From 8e6c737d585f9bd50d88aad0ccd5f494c09b195a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 232/328] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 232/331] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
-From e70b4573423ef7adf949eb2a3bebaf66ade1e107 Mon Sep 17 00:00:00 2001
+From 5e8864fe1a7bf227e33968326d0f4e21545757e0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 233/328] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 233/331] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
-From a623408c62e80b04ad30256c7f246d1933b22252 Mon Sep 17 00:00:00 2001
+From ebaebc4dd96a2dfa30024bc4c71de594681b6183 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 234/328] AOSCOS: input: atkbd: disable
+Subject: [PATCH 234/331] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
-From 72893cf1da4b4f8bd4e2ca08f4e345f840e63a77 Mon Sep 17 00:00:00 2001
+From 71458513ac0dab31eec8214e63ed15e50c39c164 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 235/328] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 235/331] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
-From 8fb43c20673808828831f8d42ae5df5a0665d90a Mon Sep 17 00:00:00 2001
+From c4d3df0c406aa56a5cb0dc92ac7b5b0d0726db63 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 236/328] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 236/331] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
-From 418a1dbb40b1c8efbbed661805c488de9e42be03 Mon Sep 17 00:00:00 2001
+From 9467f767a24ba50941c405aad72313f231e756c3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 237/328] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 237/331] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
-From 2ef3bcdbcaa1cbdc2de36a476f20af87c0e197ec Mon Sep 17 00:00:00 2001
+From 0a356a17a9178304ca6ac841eaeb11b021a67ec7 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 238/328] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 238/331] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
-From 5f92a10ceb4e691ebd1402aeed8f36ded998e6a5 Mon Sep 17 00:00:00 2001
+From 2620baa9c82703c94f8a8b6e6be82c9bbc3976eb Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 239/328] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 239/331] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
-From 28791d3c644891ea37560d14e740f94eb3d87a38 Mon Sep 17 00:00:00 2001
+From 0ada807a011c78d372271924d8742c33842abaae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 240/328] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 240/331] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
-From 68139fd3dfd28a34dfe95fe84b2463fc50748ff4 Mon Sep 17 00:00:00 2001
+From 93cfd417a9a85308103490c9855016db85bb96c0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 241/328] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 241/331] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
-From 7b617ebeabd292cc47224ca264a7ad9a0f2176aa Mon Sep 17 00:00:00 2001
+From c988f2fc2fe5e9dd6f8c3cb0cedbc106d7233beb Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 242/328] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 242/331] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
-From f2f28f060713d98681e1e636bc003fbb68b0aa29 Mon Sep 17 00:00:00 2001
+From 54a5d694da2febf2dc51347fb484756eb92e8014 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 243/328] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 243/331] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
-From 57702ca889552e8cd30be6ccc8e653b60e262e46 Mon Sep 17 00:00:00 2001
+From ddc2d3e7eb0b6196079ce6b518fb1b98770fb73b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 244/328] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 244/331] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
-From 80876e51d884a3047e4443938b8818508cf45542 Mon Sep 17 00:00:00 2001
+From bfe19559a4f5ae742ecdef9d810c161238347e66 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 245/328] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 245/331] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
-From 998ccc492d0f9571d1fe71c035611230f25bd627 Mon Sep 17 00:00:00 2001
+From 263b69d2f9f645ad1501e0decf3082d67e0959f6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 246/328] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 246/331] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
-From 6db473d29fbd0f2a3b5f4314b667ed6a7bd1a38e Mon Sep 17 00:00:00 2001
+From 0f9a9bba137cfc60dcc24614fc82d777c5d0bec1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 247/328] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 247/331] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
-From 1ec360c53fabc943c3d879141958145bd05c9b0f Mon Sep 17 00:00:00 2001
+From ec404e03bb2f52551c5718c21844f4a238b23ebc Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 248/328] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 248/331] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
-From f67f9939f501c9900548923597f8ebc39a52af0f Mon Sep 17 00:00:00 2001
+From fbd45483d1eb18032955feb516b6fd64f71bf8eb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 249/328] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 249/331] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
-From 0e9bfd68b0d1d7d70160d8fabb0b9da4dbb2384c Mon Sep 17 00:00:00 2001
+From f3b5dd651c44324ea83b2e9de440282aa5a1b6be Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 250/328] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 250/331] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
-From 9647734f1170bbc7d61e9f7003db8c5e7a634c4f Mon Sep 17 00:00:00 2001
+From ef055618092d8782e2954f6626635a74d9293db4 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 251/328] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 251/331] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
-From cb9875debdc63aef0472d928da45e55a9d15ce1b Mon Sep 17 00:00:00 2001
+From a2408534faf616eb200cb0bf948a165107e3059d Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 252/328] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 252/331] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
-From 0ce573843cb52cf5d7319dbff4221831fb3ad8e1 Mon Sep 17 00:00:00 2001
+From dc67297198041f2af7fd03aa9f26f8736ca3d65c Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 253/328] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 253/331] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
-From 877aac55ca4d0c71badd2dafc4341c45faf28f01 Mon Sep 17 00:00:00 2001
+From 8bc454f81ed7f6db347c44eace627f335f191350 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 254/328] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 254/331] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
-From 5095a38b7b5aa446c394aa502d599192a32d2be2 Mon Sep 17 00:00:00 2001
+From cd31a68b0f05298e871ad47f8c7a92ca83c02e46 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 255/328] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 255/331] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
-From 9aa413406f8e697413f558540782037efcac69d4 Mon Sep 17 00:00:00 2001
+From 12e14243eef65f125ccd5a78842238d09ce627e1 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 256/328] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 256/331] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
-From 4c9409eeb132945ddd9bae339830d2039336a175 Mon Sep 17 00:00:00 2001
+From 9436739ec8101a2ea023ece85b51f6b5bb84dc21 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 257/328] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 257/331] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
-From cd639f23cbd79fedeff9be1c9acdc81426c53c0a Mon Sep 17 00:00:00 2001
+From b0b6f748cc8d8363bca30f13c8d266e729697628 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 258/328] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 258/331] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
-From bc25b387f567fb45c68b5e8543439c6443b009e6 Mon Sep 17 00:00:00 2001
+From c07c3b9444e8433691102350e81dcfb55043c602 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 259/328] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 259/331] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
-From 8b44f129418988956b3307ebf40ca1abf457fe43 Mon Sep 17 00:00:00 2001
+From 2451a59452d2bbd57d3f19e7bfc0b8c8a8ed31da Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 260/328] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 260/331] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
-From 15d29362f490a2c432fb3dd24910d6889f99fed4 Mon Sep 17 00:00:00 2001
+From dc3d98d38cf4a096a13de242d7fb191c62d38f20 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 261/328] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 261/331] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
-From 119602bcc540671604f6ab136b88943299d333df Mon Sep 17 00:00:00 2001
+From 232bc42d588fe3e3ed9c7bbbb09973b641c24472 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 262/328] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 262/331] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
-From 56e74fce01675982a95779f93782eb956be59c40 Mon Sep 17 00:00:00 2001
+From 436e3417a6000ee4618a88aff7bead936bf5cfff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 263/328] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 263/331] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
-From 7e3480ba542527caf3633838d564931edaed6847 Mon Sep 17 00:00:00 2001
+From 598d599f3a3ea0a15a7fbfdd96fcfe782d8b4a97 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 264/328] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 264/331] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
-From 539a89f0ee96ccbc97fc50235bccb3ebd933b7f5 Mon Sep 17 00:00:00 2001
+From a5295d5e48ff390fe1b0a1cd42aba0d30efc49ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 265/328] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 265/331] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
-From b10fdcd2cc2dc51cc39d15a1c966532b3c5f8b5c Mon Sep 17 00:00:00 2001
+From dfa8b51dad1838664471c1801404cf9af8e44052 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 266/328] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 266/331] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
-From 46fa0e93010bd3e049aa0ce902900fcd0aae831b Mon Sep 17 00:00:00 2001
+From 6a3445b83c324737daf3a41004b9055138d71489 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 267/328] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 267/331] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
-From 9ff1140ca4a0476ec28ec8c607252a7b6b35b717 Mon Sep 17 00:00:00 2001
+From 4ffcc25388fe75464e7b96ee838a07821625b5b2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 268/328] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 268/331] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
-From 6a2ce88b7b4074a6b8c58577688eda3b5c23732d Mon Sep 17 00:00:00 2001
+From b1b62273d4158391cf543af5e9df0489978fb80b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 269/328] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 269/331] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
-From 69225c17de204642b6db14ffda80bc7ca4263d3e Mon Sep 17 00:00:00 2001
+From fa86e311952407386c395d1a256993f94b1c1849 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 270/328] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 270/331] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
-From 737ba971bcd62d0acce289a967fb8c5470077a40 Mon Sep 17 00:00:00 2001
+From a798fb4847a786b05aa95429fc706771dee42059 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 271/328] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 271/331] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
-From 8c0d68f692a12f2ee4782f7cb10e557ea309bb45 Mon Sep 17 00:00:00 2001
+From ad01f69d940601f52ec17ae776ab98c7c129b1f3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 272/328] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 272/331] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
-From d86457697d8f9059e0cddd378be3a3fa01c43772 Mon Sep 17 00:00:00 2001
+From 692c4231179d793b8d3b8cce32638a12058e38bf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 273/328] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 273/331] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
-From 418bb743459b9703543153acc75d3608267326cb Mon Sep 17 00:00:00 2001
+From b2b6d72b666cbaa3eb3c25efaa79f4290205a5c0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 274/328] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 274/331] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
-From 7fa1ad0465b83112fdf32f4b1874745bd5cd6fb2 Mon Sep 17 00:00:00 2001
+From 594199d74c43a4bf2e52d65d0ee4c0cf8afecabc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 275/328] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 275/331] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
-From ccc3f796da6099b7471039c2fbafcda2862ec4d2 Mon Sep 17 00:00:00 2001
+From d3bf090812f78ec6be2fd91b00f4b77413bd4305 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 276/328] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 276/331] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
-From 957f1c0df5202dc98dd0d76cf973f584dee71a1a Mon Sep 17 00:00:00 2001
+From f028e51007eb13c641d2fa014efce61eafd0cb53 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 277/328] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 277/331] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
-From eb1307c4743abde83c431db1a7ca231b9e99893f Mon Sep 17 00:00:00 2001
+From 94eb7d00374e5d258628ce748d0abc4141c1a651 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 278/328] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 278/331] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
-From 75c5f1b9ec6029e074c8cc3551e44db295979eac Mon Sep 17 00:00:00 2001
+From bd6084f52d7547c5593466aa379394e2d44962ac Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 279/328] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 279/331] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
-From 2f046c664812aafdab4684c5790da8e73f901543 Mon Sep 17 00:00:00 2001
+From e3affdb8057f6392ce3c1725a0da28ff4881cc3c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 280/328] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 280/331] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
-From be612a60997b16695d65c05acccbe9d81cc65613 Mon Sep 17 00:00:00 2001
+From 0c5a4ffd580f157d2470c2140c5ae8c78f15983d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 281/328] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 281/331] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
-From b2e7d6da193ad239bd7b5c417cb442d78f5b8ed0 Mon Sep 17 00:00:00 2001
+From 2d4beaea9c4aaf084de56612000960cbba08c8b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 282/328] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 282/331] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
-From a6428164a6f6219d62317921c934198f4167a476 Mon Sep 17 00:00:00 2001
+From 90a1a0c58d514b94a39377895b1260790b3d96de Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 283/328] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 283/331] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
-From 9f83d3e0a763e9282c10bb64d55031b1217d0fb1 Mon Sep 17 00:00:00 2001
+From bf9f7856c0dcecc420280d70e7dae11f8c298466 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 284/328] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 284/331] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
-From 7b7332900bc2208b178a9f0903e7cf07a22dd536 Mon Sep 17 00:00:00 2001
+From 4c4997059bba83bbaf342c3ae1c893b31fe06076 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 285/328] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 285/331] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
-From cdc77eda85cecb36789e992e91421129d82b1766 Mon Sep 17 00:00:00 2001
+From 2aae3a6869a1a0218b503256b48c0472ccb2e7b8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 286/328] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 286/331] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
-From 25307fd0b8569b3947b7a48cd72df69913acdd11 Mon Sep 17 00:00:00 2001
+From 662d0655b6a6d04cdc123a1d5183f2c867b05ce8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 287/328] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 287/331] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
-From 3596a3dd0f5aaa3a90fd7d499e9789b54bbb6346 Mon Sep 17 00:00:00 2001
+From a193de9a51854ad6f53860523de5690a8677c31d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 288/328] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 288/331] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
-From 45fcb0239b8345bf303530acf7814865dd63c4a3 Mon Sep 17 00:00:00 2001
+From 95f560ac8c355216791dfdd037a760d101e61341 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 289/328] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 289/331] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
-From c03f3edb2671e29b6000b454568815baf6fb99d5 Mon Sep 17 00:00:00 2001
+From dfe6dac454e20e566083167d4c5e8b4128535686 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 290/328] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 290/331] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
-From 23a1cfa6b1083ad861c80b4afd8f13fc0c51dfd8 Mon Sep 17 00:00:00 2001
+From 1034b47f4ccf605440edd873818cdc95d558517d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 291/328] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 291/331] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
-From f9d832f868ba3a0a018dbc18930ca47231051189 Mon Sep 17 00:00:00 2001
+From 2fd6b7699261b040da878326e26f06787e07090c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 292/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 292/331] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
-From 5bce332afab8c0d4981a65ffdc70c7c0dc0e1cb2 Mon Sep 17 00:00:00 2001
+From bde78b223eff4096339988c88d7a53b6c997efff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 293/328] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 293/331] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
-From 3e9fd5735de2c7b0ea08956ef3916261d0059261 Mon Sep 17 00:00:00 2001
+From 8b93cbc2b7958bb16156bac498e016536415dd45 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 294/328] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 294/331] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
-From 2bf8cbfa04e8f2e4414d3e1e408af88493113d4e Mon Sep 17 00:00:00 2001
+From ff8c1625dd8182ddf1fa4b4d32f64a04be4ebc2e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 295/328] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 295/331] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
-From 507a7e1a14cc01d7a0b7d3b915543a2180d6cd6c Mon Sep 17 00:00:00 2001
+From 8ab3bb4f4cd71504d15a0119da9e0fcf9512292d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 296/328] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 296/331] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
-From 7b6c9d184b9a48a1d979fb185beebce69d932c8b Mon Sep 17 00:00:00 2001
+From 956f56937dbb5e8148bf6d7cd19329495706425c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 297/328] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 297/331] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,10 +13,10 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 288a2b864cc41..8c564389812ce 100644
+index 1062731315a2a..c2089273b1fac 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -659,7 +659,17 @@
+@@ -663,7 +663,17 @@
  #define USB_DEVICE_ID_IDEACOM_IDC6680	0x6680
  
  #define USB_VENDOR_ID_ILITEK		0x222a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
-From 2065e8a1e79dc4d3969c676d529ebdcecd40eecd Mon Sep 17 00:00:00 2001
+From 121734ae659dee3b9de02dd9b21812914220bb9d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 298/328] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 298/331] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
-From 2dbb1cc362d04d0ad87b57b871f00a1a0123a6d5 Mon Sep 17 00:00:00 2001
+From f4848e78cb750301474e958438f3a8c6853a0356 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 299/328] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 299/331] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
-From 882f5584ba7fcf93dc291d0f06f49c145b9d5fda Mon Sep 17 00:00:00 2001
+From 43a3149a5d51df3c50eebb01164995e59d672758 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 300/328] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 300/331] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
-From 36fe24b20be1fae41b22dc2448fc15cadacf28b5 Mon Sep 17 00:00:00 2001
+From 2a5a29fc313266e9414e950998a27113ba7721b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 301/328] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 301/331] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
-From 6dd0341b812c802d49e1ce504f230cd42469f17c Mon Sep 17 00:00:00 2001
+From ac74944111972748b4f7b09283b2e4e5b9a22527 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 302/328] AOSCOS: Optimize clear_page
+Subject: [PATCH 302/331] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
-From 8a7bb8bf849d64224a52ed790eb2935c0c063572 Mon Sep 17 00:00:00 2001
+From 7eca3a05e71156d8fcacc9e29bbffcc1bfd27742 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 303/328] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 303/331] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
-From 4fbd2d172917f0c2f3ed408569f4c52f2597d99a Mon Sep 17 00:00:00 2001
+From b56607e71ed6dcafc0b19bca0353f4a4f748e3d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 304/328] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 304/331] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
-From d857acfedacc301355ca16efce7d046a06417c2d Mon Sep 17 00:00:00 2001
+From 878a53b453ece9f832c559563f45dbfc55c182ad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 305/328] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 305/331] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
-From 1c6b252eb87211418a57a6316b2516bfd11175f3 Mon Sep 17 00:00:00 2001
+From 86bb91a3b199c7eabe3f8332b6cb4a7319980931 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 306/328] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 306/331] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
-From ad8a023cb718524f682dbdf4233a05fcafad2c1f Mon Sep 17 00:00:00 2001
+From 24afda1df39a825dc2cc6613fb8002532ecc8144 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 307/328] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 307/331] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
-From 9adc2d7a27a71578e81bafb655427123c6a358db Mon Sep 17 00:00:00 2001
+From 062c70954c3ee95b3170e11331001d3fa02384c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 308/328] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 308/331] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
-From 78293e0db8f8414f0f0cf760722ad71aca3e4a28 Mon Sep 17 00:00:00 2001
+From df7f1a93eec36067442a945ef5bdfa27cec5b765 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 309/328] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 309/331] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
-From 84e3f7a196ebd2e275f0416bf27d9ff8d1bf2597 Mon Sep 17 00:00:00 2001
+From d5a1d2b36a8ebebb0d6aefdfa59b31331c8f3f5b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 310/328] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 310/331] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
-From 2741110a2b05f81d91ef45a296821afcd0e4b4db Mon Sep 17 00:00:00 2001
+From 7432c274385db4571bb6cc369794bd814d0cac50 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 311/328] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 311/331] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
-From 84f8832360609bacc39daabc1eca198250e76210 Mon Sep 17 00:00:00 2001
+From ccf6103cdb907813cc2f81bac11bb3bbfa923c04 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 312/328] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 312/331] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
-From 0fcffd3a159e36b608726a5549e2038b54c3fa69 Mon Sep 17 00:00:00 2001
+From 172cee309f65daba78e13384e7e9e8b1fe2f6043 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 313/328] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 313/331] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
-From c80b237a3c588fb8e1cbdcd60dd23e0f2e88e52b Mon Sep 17 00:00:00 2001
+From 9241cfdb6d8ddd9f216f4cdbfe558a42eefbd63e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 314/328] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 314/331] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
-From 1f01b884845bb0513e31af62a90b57f895abd92f Mon Sep 17 00:00:00 2001
+From 0e8e9e023d8d35b27a761095ec78462e04e520df Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 315/328] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 315/331] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
-From e9ecd3a14aa8df32f6e3ae5b4308cff2e6ac8b1b Mon Sep 17 00:00:00 2001
+From 919c33637892910e495ba8de7f10aa7965ef1efa Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 316/328] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 316/331] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
-From 1557f9b332e6d57d6186aca06e3125ba0b0b90a8 Mon Sep 17 00:00:00 2001
+From a9f19320c12926b9d46557076d2f6b4cd6888359 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 317/328] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 317/331] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
-From f95bad568a3f6c5c27d9e21a1e101341ac044ce6 Mon Sep 17 00:00:00 2001
+From 4421d06bd6d34505709cf29e942136adf873bbc5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 318/328] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 318/331] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
-From 6b7af4f888aaf14e8d5d5c2704b38f83079c910d Mon Sep 17 00:00:00 2001
+From 843012b9241bbf140ad1a9e13e3e1b23a2277dab Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 319/328] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 319/331] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
-From c378d8360e61ebca9584226d019fffa6b05f5078 Mon Sep 17 00:00:00 2001
+From e0ff0746b6a04e394e08811a6af2e66f709a339c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 320/328] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 320/331] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
-From 4412038bfc50163904d66c8bb64493b9089c7550 Mon Sep 17 00:00:00 2001
+From 9a234e63d068874235e3e108af786c8567909e8a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 321/328] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 321/331] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
-From e8a2530598552e6681ce1f8a8710ff4ab8cb657a Mon Sep 17 00:00:00 2001
+From 7f92154b8992bf6547ae6ffb4584fe73fa3bc44f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 322/328] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 322/331] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
-From f331f74145dff0c6cecf7bc485e83119771222ef Mon Sep 17 00:00:00 2001
+From 89bd55c7e595d23e0ebd892552db6f101b8cfb46 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 323/328] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 323/331] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
-From 82e1818c080d564c2612bcd3a51f1076b4fc7247 Mon Sep 17 00:00:00 2001
+From bd950bfa65e41b277679a01fc1449f229ae52010 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 324/328] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 324/331] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-LOONGSON-input-atkbd-do-not-init-atkbd_reset-variabl.patch
@@ -1,7 +1,7 @@
-From 38fd36b3a5161c47a8fa2d3e4c09ff7e78e5a66d Mon Sep 17 00:00:00 2001
+From 8260095c2172b05dcb9a8b30055e29dc15763e7b Mon Sep 17 00:00:00 2001
 From: Qunqin Zhao <zhaoqunqin@loongson.cn>
 Date: Tue, 1 Apr 2025 17:41:54 +0800
-Subject: [PATCH 325/328] LOONGSON: input: atkbd: do not init atkbd_reset
+Subject: [PATCH 325/331] LOONGSON: input: atkbd: do not init atkbd_reset
  variable to true on Loongson
 
 The keyboard will not be confused on Loongson platform, so do not need a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-BACKPORT-FROMLIST-wifi-rtlwifi-disable-ASPM-for-RTL8.patch
@@ -1,7 +1,7 @@
-From 1c595ceb69ffdc5760fe4a0c3a6399fb1905b371 Mon Sep 17 00:00:00 2001
+From 7afc15e52fe36ea0b31c7310c716c13e3149b5a0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 22 Apr 2025 14:17:54 +0800
-Subject: [PATCH 326/328] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
+Subject: [PATCH 326/331] BACKPORT: FROMLIST: wifi: rtlwifi: disable ASPM for
  RTL8723BE with subsystem ID 11ad:1723
 
 RTL8723BE found on some ASUSTek laptops, such as F441U and X555UQ with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-BACKPORT-FROMLIST-platform-x86-ideapad-laptop-use-us.patch
@@ -1,7 +1,7 @@
-From 2c1a091965b3d3517a773d4d6668ff9c27615620 Mon Sep 17 00:00:00 2001
+From e640a87897061619f75c792deaacc2120b1ba897 Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Mon, 26 May 2025 04:18:07 +0800
-Subject: [PATCH 328/328] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
+Subject: [PATCH 328/331] BACKPORT: FROMLIST: platform/x86: ideapad-laptop: use
  usleep_range() for EC polling
 
 It was reported that ideapad-laptop sometimes causes some recent (since

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-BACKPORT-FROMLIST-platform-loongarch-laptop-Get-brig.patch
@@ -1,0 +1,41 @@
+From 41e03a821fc7fc011664399bf64ad68c6064f028 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:50 +0000
+Subject: [PATCH 329/331] BACKPORT: FROMLIST: platform/loongarch: laptop: Get
+ brightness setting from EC on probe
+
+Previously 1 is unconditionally taken as current brightness value. This
+causes problems since it's required to restore brightness settings on
+resumption, and a value that doesn't match EC's state before suspension
+will cause surprising changes of screen brightness.
+
+Let's get brightness from EC and take it as the current brightness on
+probe of the laptop driver to avoid the surprising behavior. Tested on
+TongFang L860-T2 3A5000 laptop.
+
+Cc: stable@vger.kernel.org
+Fixes: 6246ed09111f ("LoongArch: Add ACPI-based generic laptop driver")
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 99203584949da..828bd62e3596c 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -392,7 +392,7 @@ static int laptop_backlight_register(void)
+ 	if (!acpi_evalf(hotkey_handle, &status, "ECLL", "d"))
+ 		return -EIO;
+ 
+-	props.brightness = 1;
++	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-BACKPORT-FROMLIST-platform-loongarch-laptop-Support-.patch
@@ -1,0 +1,118 @@
+From f77acc69752d5d92f67c147463a0b156389a9bf7 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 31 May 2025 11:38:51 +0000
+Subject: [PATCH 330/331] BACKPORT: FROMLIST: platform/loongarch: laptop:
+ Support backlight power control
+
+loongson_laptop_turn_{on,off}_backlight() are designed for controlling
+power of the backlight, but they aren't really used in the driver
+previously.
+
+Unify these two functions since they only differ in arguments passed to
+ACPI method, and wire up loongson_laptop_backlight_update() to update
+power state of the backlight as well. Tested on TongFang L860-T2 3A5000
+laptop.
+
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+
+Link: https://lore.kernel.org/loongarch/20250531113851.21426-3-ziyao@disroot.org/
+Signed-off-by: Mingcong Bai <jeffbai@asoc.io>
+---
+ drivers/platform/loongarch/loongson-laptop.c | 53 +++++++-------------
+ 1 file changed, 19 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/platform/loongarch/loongson-laptop.c b/drivers/platform/loongarch/loongson-laptop.c
+index 828bd62e3596c..f01e53b1c84d1 100644
+--- a/drivers/platform/loongarch/loongson-laptop.c
++++ b/drivers/platform/loongarch/loongson-laptop.c
+@@ -56,8 +56,6 @@ static struct input_dev *generic_inputdev;
+ static acpi_handle hotkey_handle;
+ static struct key_entry hotkey_keycode_map[GENERIC_HOTKEY_MAP_MAX];
+ 
+-int loongson_laptop_turn_on_backlight(void);
+-int loongson_laptop_turn_off_backlight(void);
+ static int loongson_laptop_backlight_update(struct backlight_device *bd);
+ 
+ /* 2. ACPI Helpers and device model */
+@@ -354,6 +352,22 @@ static int ec_backlight_level(u8 level)
+ 	return level;
+ }
+ 
++static int ec_backlight_set_power(bool state)
++{
++	int status;
++	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
++	struct acpi_object_list args = { 1, &arg0 };
++
++	arg0.integer.value = state;
++	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
++	if (ACPI_FAILURE(status)) {
++		pr_info("Loongson lvds error: 0x%x\n", status);
++		return -EIO;
++	}
++
++	return 0;
++}
++
+ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ {
+ 	int lvl = ec_backlight_level(bd->props.brightness);
+@@ -363,6 +377,8 @@ static int loongson_laptop_backlight_update(struct backlight_device *bd)
+ 	if (ec_set_brightness(lvl))
+ 		return -EIO;
+ 
++	ec_backlight_set_power(bd->props.power == BACKLIGHT_POWER_ON ? true : false);
++
+ 	return 0;
+ }
+ 
+@@ -394,6 +410,7 @@ static int laptop_backlight_register(void)
+ 
+ 	props.brightness = ec_get_brightness();
+ 	props.max_brightness = status;
++	props.power = BACKLIGHT_POWER_ON;
+ 	props.type = BACKLIGHT_PLATFORM;
+ 
+ 	backlight_device_register("loongson_laptop",
+@@ -402,38 +419,6 @@ static int laptop_backlight_register(void)
+ 	return 0;
+ }
+ 
+-int loongson_laptop_turn_on_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 1;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+-int loongson_laptop_turn_off_backlight(void)
+-{
+-	int status;
+-	union acpi_object arg0 = { ACPI_TYPE_INTEGER };
+-	struct acpi_object_list args = { 1, &arg0 };
+-
+-	arg0.integer.value = 0;
+-	status = acpi_evaluate_object(NULL, "\\BLSW", &args, NULL);
+-	if (ACPI_FAILURE(status)) {
+-		pr_info("Loongson lvds error: 0x%x\n", status);
+-		return -ENODEV;
+-	}
+-
+-	return 0;
+-}
+-
+ static int __init event_init(struct generic_sub_driver *sub_driver)
+ {
+ 	int ret;
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-PCI-Override-PCIe-bridge-supported-speeds-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-PCI-Override-PCIe-bridge-supported-speeds-for.patch
@@ -1,0 +1,67 @@
+From 60db49226ea76fd5350be0966b170a9cabcbfb76 Mon Sep 17 00:00:00 2001
+From: Ayden Meng <aydenmeng@yeah.net>
+Date: Wed, 4 Jun 2025 10:01:45 +0800
+Subject: [PATCH 331/331] AOSCOS: PCI: Override PCIe bridge supported speeds
+ for older Loongson 3C6000 series steppings
+
+Older steppings of the Loongson 3C6000 series incorrectly report the
+supported link speeds on their PCIe bridges (device IDs 3c19, 3c29) as
+only 2.5 GT/s, despite the upstream bus supporting speeds from 2.5 GT/s
+up to 16 GT/s.
+
+As a result, certain PCIe devices would be incorrectly probed as a Gen1-
+only, even if higher link speeds are supported, harming performance and
+prevents dynamic link speed functionality from being enabled in drivers
+such as amdgpu.
+
+Manually override the `supported_speeds` field for affected PCIe bridges
+with those found on the upstream bus to correctly reflect the supported
+link speeds.
+
+Tested-by: Lain "Fearyncess" Yang <fsf@live.com>
+Reviewed-by: Mingcong Bai <baimingcong@aosc.io>
+Signed-off-by: Ayden Meng <aydenmeng@yeah.net>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ drivers/pci/quirks.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 1c22112e71bf8..d3e89ebea3d49 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -1988,6 +1988,30 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL,	PCI_DEVICE_ID_INTEL_E7525_MCH,	quir
+ 
+ DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_VENDOR_ID_HUAWEI, 0x1610, PCI_CLASS_BRIDGE_PCI, 8, quirk_pcie_mch);
+ 
++/*
++ * Older steppings of the Loongson 3C6000 series incorrectly report the
++ * supported link speeds on their PCIe bridges (device IDs 3c19, 3c29) as
++ * only 2.5 GT/s, despite the upstream bus supporting speeds from 2.5 GT/s
++ * up to 16 GT/s.
++ */
++static void quirk_loongson_pci_bridge_supported_speeds(struct pci_dev *pdev)
++{
++	switch (pdev->bus->max_bus_speed) {
++	case PCIE_SPEED_16_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_16_0GB;
++	case PCIE_SPEED_8_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_8_0GB;
++	case PCIE_SPEED_5_0GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_5_0GB;
++	case PCIE_SPEED_2_5GT:
++		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_2_5GB;
++	default:
++		break;
++	}
++}
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c19, quirk_loongson_pci_bridge_supported_speeds);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c29, quirk_loongson_pci_bridge_supported_speeds);
++
+ /*
+  * HiSilicon KunPeng920 and KunPeng930 have devices appear as PCI but are
+  * actually on the AMBA bus. These fake PCI devices can support SVA via
+-- 
+2.49.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -1,10 +1,10 @@
-VER=6.14.9
+VER=6.14.10
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=2
+REL=1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 
@@ -12,7 +12,7 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #RC=1
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
 #REL=0.${RC}
-#COMMIT="10804dbee7fa8cfb895bbffcc7be97d8221748b6"
+#COMMIT="d9764ae2492695b2e87e4cd07bf1c61426d3693d"
 #SRCS="tbl::https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/snapshot/linux-stable-rc-${COMMIT}.tar.gz"
 
 # Use this for mainline RC releases.
@@ -28,7 +28,7 @@ SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 #TAG="next-20250124"
 #SRCS="tbl::https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/linux-next-${TAG}.tar.gz"
 
-CHKSUMS="sha256::390cdde032719925a08427270197ef55db4e90c09d454e9c3554157292c9f361"
+CHKSUMS="sha256::de8b97cfeae74c22f832ee4ca2333c157cc978d98baa122f0ee9c01796a2fe43"
 CHKUPDATE="anitya::id=6501"
 
 ENVREQ__LOONGARCH64="core=128"

--- a/topics/linux-kernel-6.14.10.toml
+++ b/topics/linux-kernel-6.14.10.toml
@@ -1,0 +1,12 @@
+security = false
+
+[name]
+default = "Linux Kernel, 6.14.10"
+zh_CN = "Linux 内核，版本 6.14.10"
+
+[caution]
+default = "Fixes an issue where display brightness on Loongson 3A5000/6000-based laptops may be reset to the lowest upon wakeup from S3 suspend, also works around incorrectly configured supported link speed on PCIe bridges found on older Loongson 3C6000 series steppings, causing degraded performance or functionalities on certain peripherals"
+zh_CN = "修复基于龙芯 3A5000/3A6000 的笔记本从 S3 睡眠唤醒时，屏幕背光亮度可能被复位为最低的问题，并规避较老的龙芯 3C6000 系列处理器步进上 PCIe 桥未正确设置支持链路速率而导致部分设备性能和功能受限的问题"
+
+[packages]
+"linux+kernel" = "3:6.14.10"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add linux-kernel-6.14.10.toml
- kernel-tools: update to 6.14.10
- linux+kernel: update to 6.14.10
- linux-kernel: update to 6.14.10
    - Backport fixes for Loongson 3A5000/3A6000 laptop backlight.
    - Add a home-grown patch to override PCIe bridge supported speeds for
    older Loongson 3C6000 series steppings:
    Older steppings of the Loongson 3C6000 series incorrectly report the
    supported link speeds on their PCIe bridges \(device IDs 3c19, 3c29\) as
    only 2.5GT/s, despite the upstream bus supporting speeds from 2.5GT/s
    up to 16GT/s.
    - Track patches at AOSC-Tracking/linux @ aosc/v6.14.10
    \(HEAD: 60db49226ea76fd5350be0966b170a9cabcbfb76\).

Package(s) Affected
-------------------

- kernel-tools: 6.14.10-1
- linux+kernel: 3:6.14.10
- linux-kernel-${__VER}: 6.14.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel linux+kernel kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
