### PR TITLE
libcamera: update to 0.5.1

### DIFF
--- a/runtime-devices/libcamera/autobuild/defines.stage2
+++ b/runtime-devices/libcamera/autobuild/defines.stage2
@@ -2,9 +2,9 @@ PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
-        elfutils libunwind gstreamer glib gnutls qt-6 openssl"
-PKGDEP__ARM64="${PKGDEP} libpisp"
+        elfutils libunwind gstreamer glib gnutls openssl"
 BUILDDEP="doxygen jinja2 ply pyyaml sphinx texlive graphviz gtest"
+
 PKGBREAK="pipewire<=1.4.1"
 
 # Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
@@ -20,7 +20,7 @@ MESON_AFTER=(
     '-Dlc-compliance=enabled'
     '-Dpipelines=auto'
     '-Dpycamera=disabled'
-    '-Dqcam=enabled'
+    '-Dqcam=disabled'
     '-Dtest=false'
     '-Dtracing=enabled'
     '-Dudev=enabled'

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.5.0
+VER=0.5.1
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"

--- a/runtime-devices/libpisp/autobuild/defines
+++ b/runtime-devices/libpisp/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=libpisp
+PKGSEC=libs
+PKGDES="Library to generate runtime configuration for the Raspberry Pi ISP (PiSP)"
+PKGDEP="boost nlohmann-json"
+BUILDDEP="cxxopts"
+
+MESON_AFTER=(
+    '-Dlogging=enabled'
+    '-Dexamples=true'
+)

--- a/runtime-devices/libpisp/spec
+++ b/runtime-devices/libpisp/spec
@@ -1,0 +1,4 @@
+VER=1.2.1
+SRCS="git::commit=tags/v${VER}::https://github.com/raspberrypi/libpisp.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378526"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.5.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libcamera: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpisp libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
