### PR TITLE
samba: fix CVE-2025-0620

### DIFF
--- a/app-network/samba/01-samba/patches/0001-CVE-2025-0620.patch
+++ b/app-network/samba/01-samba/patches/0001-CVE-2025-0620.patch
@@ -1,0 +1,31 @@
+From 865961bc1c06a3a0d8e53a8b8fa7d65111c8b1da Mon Sep 17 00:00:00 2001
+From: Ralph Boehme <slow@samba.org>
+Date: Fri, 23 May 2025 08:47:06 +0200
+Subject: [PATCH] CVE-2025-0620: smbd: smbd doesn't pick up group membership
+ changes when re-authenticating an expired SMB session
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15707
+
+Signed-off-by: Ralph Boehme <slow@samba.org>
+---
+ source3/smbd/conn.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source3/smbd/conn.c b/source3/smbd/conn.c
+index 4e7e1ce01276..0e4d78237876 100644
+--- a/source3/smbd/conn.c
++++ b/source3/smbd/conn.c
+@@ -173,8 +173,8 @@ static void conn_clear_vuid_cache(connection_struct *conn, uint64_t vuid)
+ 
+ 	for (i=0; i<VUID_CACHE_SIZE; i++) {
+ 		ent = &conn->vuid_cache->array[i];
+-		if (ent->vuid != vuid) {
+-			continue;
++		if (ent->vuid == vuid) {
++			break;
+ 		}
+ 	}
+ 	if (i == VUID_CACHE_SIZE) {
+-- 
+2.49.0
+

--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,4 +1,5 @@
 VER=4.22.1
+REL=1
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
 CHKSUMS="sha256::6a1f89f1ab25916e255f1c2c3a4a88235a854af2eca40bb9d9bba7545b684a0a"
 CHKUPDATE="anitya::id=4758"

--- a/topics/samba-4.22.1-cve-2025-0620.toml
+++ b/topics/samba-4.22.1-cve-2025-0620.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Security Patch for Samba 4.22.1"
+zh_CN = "适用于 Samba 4.22.1 的安全补丁"
+
+[caution]
+default = "Fixes CVE-2025-0620: smbd (Samba Daemon) doesn't pick up Kerberos group membership changes when re-authenticating an expired SMB session (Severity: High)"
+zh_CN = "修复编号为 CVE-2025-0620 的安全漏洞：smbd（Samba 守护程序）在重新认证过期 SMB 会话时未识别 Kerberos 组成员身份变更（严重性：高）"
+
+[packages]
+"samba" = "4.22.1-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add samba-4.22.1-cve-2025-0620.toml
- samba: fix CVE-2025-0620
    Link: https://www.samba.org/samba/security/CVE-2025-0620.html
    Link: https://bugzilla.samba.org/show_bug.cgi?id=15707

Package(s) Affected
-------------------

- ldb: 2:4.22.1-1
- samba: 4.22.1-1

Security Update?
----------------

Yes, #11243 

Build Order
-----------

```
#buildit samba
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
