### PR TITLE
razergenie: update to 1.3.0

### DIFF
--- a/app-devices/libopenrazer/autobuild/defines
+++ b/app-devices/libopenrazer/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="libopenrazer"
+PKGDES="Qt wrapper around the D-Bus API from OpenRazer"
+PKGDEP="qt-6"
+BUILDDEP="extra-cmake-modules"
+PKGSEC="x11"
+ABTYPE="meson"

--- a/app-devices/libopenrazer/spec
+++ b/app-devices/libopenrazer/spec
@@ -1,0 +1,4 @@
+VER=0.4.0
+SRCS="git::commit=tags/v${VER}::https://github.com/z3ntu/libopenrazer"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369594"

--- a/app-devices/razergenie/autobuild/defines
+++ b/app-devices/razergenie/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME="razergenie"
 PKGDES="Qt application for configuring your Razer devices"
-PKGDEP="qt-5 openrazer"
+PKGDEP="qt-6 openrazer libopenrazer"
 BUILDDEP="extra-cmake-modules"
 PKGSEC="x11"
+ABTYPE="meson"

--- a/app-devices/razergenie/spec
+++ b/app-devices/razergenie/spec
@@ -1,4 +1,4 @@
-VER="0.9.0"
+VER=1.3.0
 SRCS="tbl::https://github.com/z3ntu/RazerGenie/releases/download/v$VER/RazerGenie-$VER.tar.xz"
-CHKSUMS="sha256::e4a35ce56f7a8bc102afaca121668831dab876a6f487849bce46b0c6613aa85e"
+CHKSUMS="sha256::20fbbdfb11c9b815e74a3b666362f3e680a830b6bc116950c7f45930e6b2b2f0"
 CHKUPDATE="anitya::id=21290"


### PR DESCRIPTION
Topic Description
-----------------

- razergenie: update to 1.3.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- libopenrazer: 0.4.0
- razergenie: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libopenrazer razergenie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
