### PR TITLE
squashfs-tools: update to 4.7

### DIFF
--- a/app-admin/squashfs-tools/autobuild/build
+++ b/app-admin/squashfs-tools/autobuild/build
@@ -30,5 +30,5 @@ make install \
 
 abinfo "Installing extra documentation ..."
 install -Dvm644 \
-    "$SRCDIR"/../{CHANGES,COPYING,README*,TECHNICAL-INFO,USAGE*} \
+    "$SRCDIR"/../{ACKNOWLEDGEMENTS,CHANGES,COPYING,README*,USAGE*} \
     -t "$PKGDIR"/usr/share/doc/squashfs-tools/

--- a/app-admin/squashfs-tools/spec
+++ b/app-admin/squashfs-tools/spec
@@ -1,4 +1,4 @@
-VER=4.6.1
+VER=4.7
 SRCS="git::commit=tags/$VER::https://github.com/plougher/squashfs-tools.git"
 CHKSUMS="SKIP"
 SUBDIR="squashfs-tools/squashfs-tools"


### PR DESCRIPTION
Topic Description
-----------------

- squashfs-tools: update to 4.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- squashfs-tools: 4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit squashfs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
