### PR TITLE
python-3: update to 3.10.8

### DIFF
--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,5 +1,4 @@
-VER=3.10.13
-REL=7
+VER=3.10.8
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
-CHKSUMS="sha256::5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
+CHKSUMS="sha256::6a30ecde59c47048013eb5a658c9b5dec277203d2793667f578df7671f7f03f3"
 CHKUPDATE="anitya::id=13254"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: update to 3.10.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-3: 3.10.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
