### PR TITLE
python-3: update to 3.10.18

### DIFF
--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,5 +1,4 @@
-VER=3.10.13
-REL=7
+VER=3.10.18
 SRCS="tbl::https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz"
-CHKSUMS="sha256::5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
+CHKSUMS="sha256::ae665bc678abd9ab6a6e1573d2481625a53719bc517e9a634ed2b9fefae3817f"
 CHKUPDATE="anitya::id=13254"

--- a/topics/python-3-3.10.18.toml
+++ b/topics/python-3-3.10.18.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Python 3.10.18"
+zh_CN = "Python 3.10.18"
+
+[caution]
+default = "Fixes a use-after-free vulnerability - CVE-2025-4516 (Severity: Medium)"
+zh_CN = "修复一处释放后使用 (use-after-free) 漏洞，漏洞编号 CVE-2025-4516（严重性：中）"
+
+[packages]
+"python-3" = "3.10.18"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: update to 3.10.18
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- python-3: 3.10.18

Security Update?
----------------

Yes, #11247 

Build Order
-----------

```
#buildit python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
