### PR TITLE
linux-firmware: update to 20250604+debian20250410+2

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,19 +1,19 @@
-UPSTREAM_VER=20250425
-DEBIANVER=20241210-1~bpo12+1
+UPSTREAM_VER=20250604
+DEBIANVER=20250410-2
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 #SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=8d82acd29b5c115f0b75b17907ebce712c6f2e22::https://gitlab.com/kernel-firmware/linux-firmware.git \
-      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
-      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
+SRCS="git::commit=3b75d677f898fe2aacc7b11763bbcd4732e71ce7::https://gitlab.com/kernel-firmware/linux-firmware.git \
+      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
+      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
-      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/BCM4345C5.hcd \
+      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/6b6f053f6089e08dd2a675cda1ec813de2e842e2/brcm/BCM4345C5.hcd \
       tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free-firmware/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz"
 CHKSUMS="SKIP \
          sha256::ddf83f2100885b166be52d21c8966db164fdd4e1d816aca2acc67ee9cc28d726 \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::22187c54c6259e768e32c9ec97df2eb0121b75a4243b9e819c87fa07272f03f6"
+         sha256::a46a471de805cc6240209938c449e9ad8b018390dfd026727e397d2b2f424eac"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250604+debian20250410+2
    - Refresh Raspberry Pi-specific firmware blobs.
    - Notable changes from the main linux-firmware.git tree:
    AI:
    - Intel...
    - Update NPU firmware found on Meteor Lake, Arrow Lake, and Lunar Lake
    Audio:
    - Cirrus...
    - CS35L41...
    - Add firmware for HDA codec found on Acer and HP Agusta laptops
    - Fix firmware links for several ASUS laptops
    - CS35L56: Update firmware for "smart amplifiers" found on ASUS, Dell,
    Lenovo laptops, with additions for new Lenovo models
    - Intel...
    - Update topology file for Digital Microphone Array
    Graphics:
    - AMD...
    - DCN 3.2.0, 4.0.1: Update firmware to 0.1.10.0
    - DCN 3.2.0, 4.0.1: Update DMCUB firmware to 0.1.11.0
    - DCN 3.1.4, DCN 3.1.5, DCN 3.5, DCN 3.5.1, DCN 4.0.1, and Yellow Carp:
    Update DMCUB firmware to 0.1.13.0
    - Imagination...
    - Add firmware for Imagination Technologies BXS-4-64 GPU
    - Intel...
    - Battlemage, Lunar Lake: Update GuC firmware to v70.45.2
    - DG2: Update GuC firmware to v70.45.2
    - Lunar Lake: Update GSC firmware to v104.0.5.1429
    - NVIDIA...
    - Add GSP-RM version 570.144 firmware images
    Multimedia:
    - Amphion...
    - Update VPU decoder firmware to 1.10.0, encoder firmware to 1.4.5
    - Chips&Media...
    - K3: Update wave521c video IP firmware
    - NXP i.MX9: Add wave633c codec IP firmware
    - Intel...
    - Add firmware binary files for Intel IPU7 \(Lunar Lake\)
    - MediaTek...
    - MT8196: Add Video Companion Processor \(VCP\) firmware \(1.0.0\)
    Networking \(wired\):
    - Intel...
    - Intel\(R\) Ethernet Connection E800 Series...
    - Update firmware to 1.3.55.0, adding support for E825-C
    - Update wireless_edge package to 1.3.23, adding support for E825-C
    Platform:
    - AMD...
    - Platform Management Framework: Update Trusted Application \(PMF-TA\)
    firmware to v3.1
    - Qualcomm...
    - QCM6490: Add QUPv3 firmware
    - QCS8300: Add QUPv3 firmware
    - SC8280XP: Update firmware for Lenovo ThinkPad X13s
    Wi-Fi and Bluetooth:
    - Broadcom...
    - AP6212: Add Khadas VIM SDIO Wi-Fi configuration \(matching
    brcmfmac43455-sdio.AW-CM256SM.txt\)
    - AP6212, AP6356S: Add firmware for NanoPi devices
    - AP6254: Add NVRAM file for the Wi-Fi/Bluetooth module found on Radxa
    Rock Pi X Single Board Computer
    - Intel...
    - Gale Peak2 \(BE200\), Garfield Peak2 \(AX211\), Filmore Peak2 \(BE201\),
    Johnson Peak2 \(AX203\), Harrison Peak1 \(AX101\), Typhoon Peak2 \(AX210\),
    Thunder Peak2 \(9260\), Jefferson Peak2 \(9560\), Harrison Peak2 \(HrP2\),
    Cyclone Peak2 \(CcP2\): Update firmware to 23.140.0.5
    - 7265D: Update firmware to 29.9ef079ed.0
    - 8000C, 8265: Update firmware to 36.c8e8e144.0
    - Bz/gl: Update firmware for core96-76 release
    - cc/Qu/QuZ: Update firmware for core96-76 release
    - ty/So/Ma: Update firmware for core96-76 release
    - MediaTek...
    - MT7925...
    - Update Bluetooth firmware to 20250526153203
    - Update Wi-Fi firmware \(MCU: 20250526152947a, RAM: 20250526152808\)
    - Qualcomm...
    - WCN7850 hw2.0: Update firmware version to
    WLAN.HMT.1.1.c5-00284.1-QCAHMTSWPL_V1.0_V2.0_SILICONZ-3
    - Realtek...
    - RTL8127A: Add firmware
    - RTL8822C: Update Bluetooth controller firmware \(USB: 0x28D7_7C20,
    UART: 0x25D7_7C20\)
    - RTL8852C: Add tables for dynamic antenna TXPWR
    - RTL8922A: Update firmware to v0.35.71.0, which accepts "larger beacon
    loss count setting to prevent disconnection"

Package(s) Affected
-------------------

- firmware-free: 20250604+debian20250410+2
- firmware-nonfree: 20250604+debian20250410+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
