### PR TITLE
coreutils: fix CVE-2025-5278

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.11.1
+VER=4.12.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-utils/coreutils/autobuild/defines
+++ b/app-utils/coreutils/autobuild/defines
@@ -1,42 +1,33 @@
 PKGNAME=coreutils
 PKGSEC=utils
 PKGDEP="acl glibc gmp libcap linux-pam openssl"
-PKGDES="A collection of basic file, shell and text manipulation utilities"
+PKGDES="Collection of basic system utilities"
 
-AUTOTOOLS_AFTER="--enable-largefile \
-                 --enable-year2038 \
-                 --enable-threads=posix \
-                 --enable-acl \
-                 --enable-assert \
-                 --disable-rpath \
-                 --disable-libsmack \
-                 --enable-xattr \
-                 --enable-libcap \
-                 --disable-single-binary \
-                 --enable-bold-man-page-references \
-                 --enable-install-program=arch \
-                 --enable-no-install-program=hostname,kill,uptime \
-                 --enable-nls \
-                 --with-linux-crypto \
-                 --with-openssl=yes \
-                 --with-libgmp \
-                 --without-included-regex \
-                 --without-selinux \
-                 --without-tty-group"
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--enable-year2038'
+    '--enable-threads=posix'
+    '--enable-acl'
+    '--enable-assert'
+    '--disable-rpath'
+    '--disable-libsmack'
+    '--enable-xattr'
+    '--enable-libcap'
+    '--disable-single-binary'
+    '--enable-bold-man-page-references'
+    '--enable-install-program=arch'
+    '--enable-no-install-program=hostname,kill,uptime'
+    '--enable-nls'
+    '--with-linux-crypto'
+    '--with-openssl=yes'
+    '--with-libgmp'
+    '--without-included-regex'
+    '--without-selinux'
+    '--without-tty-group'
+)
 
 PKGESS=1
 
-# FIXME: reconf failed because it extracts threadlib.m4 "serial 10" from
-# /usr/share/gettext/archive.dir.tar.xz (because
-# AM_GNU_GETTEXT_VERSION([0.19.2]) in configure.ac), overwriting the
-# shipped threadlib.m4 "serial 42".  Fedora uses a workaround:
-#
-#    sed -i 's/0.19.2/0.22.5/' bootstrap.conf configure.ac
-#
-# and LFS uses a different workaround (avoiding -i for autoreconf):
-#
-#    autoreconf -fv && automake -af
-#
-# But as we don't apply the Fedora i18n patch like them, we can simply
-# skip reconf here.
-RECONF=0
+# Note: The bootstrap script only works with checked-out sources.
+ABNOBOOTSTRAP=1
+ABNOAUTOGEN=1

--- a/app-utils/coreutils/autobuild/defines
+++ b/app-utils/coreutils/autobuild/defines
@@ -28,6 +28,9 @@ AUTOTOOLS_AFTER=(
 
 PKGESS=1
 
-# Note: The bootstrap script only works with checked-out sources.
-ABNOBOOTSTRAP=1
-ABNOAUTOGEN=1
+# FIXME: we cannot run autoreconf with "-i" because doing so would cause
+# autoconf to extract threadlib.m4 "serial 10" from
+# /usr/share/gettext/archive.dir.tar.xz (due to
+# AM_GNU_GETTEXT_VERSION([0.19.2]) in configure.ac), overwriting the
+# shipped threadlib.m4 "serial 42".
+RECONF=0

--- a/app-utils/coreutils/autobuild/patches/0001-sort-fix-buffer-under-read-CWE-127.patch
+++ b/app-utils/coreutils/autobuild/patches/0001-sort-fix-buffer-under-read-CWE-127.patch
@@ -1,0 +1,106 @@
+From 2907d4abe6e6b032c4bf47ce139b54ba3dea4646 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Tue, 20 May 2025 16:03:44 +0100
+Subject: [PATCH] sort: fix buffer under-read (CWE-127)
+
+* src/sort.c (begfield): Check pointer adjustment
+to avoid Out-of-range pointer offset (CWE-823).
+(limfield): Likewise.
+* tests/sort/sort-field-limit.sh: Add a new test,
+which triggers with ASAN or Valgrind.
+* tests/local.mk: Reference the new test.
+* NEWS: Mention bug fix introduced in v7.2 (2009).
+Fixes https://bugs.gnu.org/78507
+---
+ src/sort.c                     | 12 ++++++++++--
+ tests/local.mk                 |  1 +
+ tests/sort/sort-field-limit.sh | 35 ++++++++++++++++++++++++++++++++++
+ 3 files changed, 46 insertions(+), 2 deletions(-)
+ create mode 100755 tests/sort/sort-field-limit.sh
+
+diff --git a/src/sort.c b/src/sort.c
+index b10183b6f..7af1a2512 100644
+--- a/src/sort.c
++++ b/src/sort.c
+@@ -1644,7 +1644,11 @@ begfield (struct line const *line, struct keyfield const *key)
+       ++ptr;
+ 
+   /* Advance PTR by SCHAR (if possible), but no further than LIM.  */
+-  ptr = MIN (lim, ptr + schar);
++  size_t remaining_bytes = lim - ptr;
++  if (schar < remaining_bytes)
++    ptr += schar;
++  else
++    ptr = lim;
+ 
+   return ptr;
+ }
+@@ -1746,7 +1750,11 @@ limfield (struct line const *line, struct keyfield const *key)
+           ++ptr;
+ 
+       /* Advance PTR by ECHAR (if possible), but no further than LIM.  */
+-      ptr = MIN (lim, ptr + echar);
++      size_t remaining_bytes = lim - ptr;
++      if (echar < remaining_bytes)
++        ptr += echar;
++      else
++        ptr = lim;
+     }
+ 
+   return ptr;
+diff --git a/tests/local.mk b/tests/local.mk
+index 4da6756ac..642d225fa 100644
+--- a/tests/local.mk
++++ b/tests/local.mk
+@@ -388,6 +388,7 @@ all_tests =					\
+   tests/sort/sort-debug-keys.sh			\
+   tests/sort/sort-debug-warn.sh			\
+   tests/sort/sort-discrim.sh			\
++  tests/sort/sort-field-limit.sh		\
+   tests/sort/sort-files0-from.pl		\
+   tests/sort/sort-float.sh			\
+   tests/sort/sort-h-thousands-sep.sh		\
+diff --git a/tests/sort/sort-field-limit.sh b/tests/sort/sort-field-limit.sh
+new file mode 100755
+index 000000000..52d8e1d17
+--- /dev/null
++++ b/tests/sort/sort-field-limit.sh
+@@ -0,0 +1,35 @@
++#!/bin/sh
++# From 7.2-9.7, this would trigger an out of bounds mem read
++
++# Copyright (C) 2025 Free Software Foundation, Inc.
++
++# This program is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <https://www.gnu.org/licenses/>.
++
++. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
++print_ver_ sort
++getlimits_
++
++# This issue triggers with valgrind or ASAN
++valgrind --error-exitcode=1 sort --version 2>/dev/null &&
++  VALGRIND='valgrind --error-exitcode=1'
++
++{ printf '%s\n' aa bb; } > in || framework_failure_
++
++_POSIX2_VERSION=200809 $VALGRIND sort +0.${SIZE_MAX}R in > out || fail=1
++compare in out || fail=1
++
++_POSIX2_VERSION=200809 $VALGRIND sort +1 -1.${SIZE_MAX}R in > out || fail=1
++compare in out || fail=1
++
++Exit $fail
+-- 
+2.49.0
+

--- a/app-utils/coreutils/autobuild/prepare
+++ b/app-utils/coreutils/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Kill the noisy bootstrap script that only allows checked-out distribution."
-rm -v "$SRCDIR"/bootstrap

--- a/app-utils/coreutils/autobuild/prepare
+++ b/app-utils/coreutils/autobuild/prepare
@@ -1,0 +1,7 @@
+# We had to set RECONF=0 (see defines) but then we applied a patch which
+# modifies the build system, thus we need to regenerate the build system
+# but still avoid passing "-i" to autoreconf.  Only use "-f" here.
+autoreconf -f
+
+# Note: if running the test suite this would be needed.
+# automake -af

--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,4 +1,5 @@
 VER=9.7
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
 CHKSUMS="sha256::e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf"
 CHKUPDATE="anitya::id=343"

--- a/topics/coreutils-9.7-fix-cve-2025-5278.toml
+++ b/topics/coreutils-9.7-fix-cve-2025-5278.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Security Patch for Coreutils 9.7"
+zh_CN = "适用于 Coreutils 9.7 的安全补丁"
+
+[caution]
+default = "Fixes a heap buffer under-read vulnerability - CVE-2025-5278 (Severity: Medium)"
+zh_CN = "修复一处堆缓冲区读下溢 (heap buffer under-read) 漏洞，漏洞编号 CVE-2025-5278（严重性：中）"
+
+[packages]
+"coreutils" = "9.7-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add coreutils-9.7-fix-cve-2025-5278.toml
- coreutils: fix CVE-2025-5278
- autobuild4: update to 4.12.0

Package(s) Affected
-------------------

- autobuild4: 4.12.0
- coreutils: 9.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
