### PR TITLE
ttf-vlgothic: update to 20230918

### DIFF
--- a/desktop-fonts/ttf-vlgothic/autobuild/build
+++ b/desktop-fonts/ttf-vlgothic/autobuild/build
@@ -1,2 +1,3 @@
-install -dm755 "$PKGDIR"/usr/share/fonts/TTF
-install -vm644 *.ttf "$PKGDIR"/usr/share/fonts/TTF/
+abinfo "Installing fonts ..."
+install -Dvm644 "$SRCDIR"/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF/

--- a/desktop-fonts/ttf-vlgothic/autobuild/defines
+++ b/desktop-fonts/ttf-vlgothic/autobuild/defines
@@ -4,3 +4,5 @@ PKGDES="Japanese TrueType fonts from Vine Linux"
 PKGDEP="fontconfig"
 
 ABHOST=noarch
+
+PKGPROV="vlgothic"

--- a/desktop-fonts/ttf-vlgothic/spec
+++ b/desktop-fonts/ttf-vlgothic/spec
@@ -1,4 +1,4 @@
-VER=20200720
-SRCS="tbl::https://osdn.net/dl/vlgothic/VLGothic-$VER.tar.xz"
-CHKSUMS="sha256::297a3813675fbea12c5813b55a78091c9a5946515ecbf9fde8b8102e01c579f4"
+VER=20230918
+SRCS="tbl::https://github.com/daisukesuzuki/VLGothic/releases/download/$VER/VLGothic-$VER.tar.xz"
+CHKSUMS="sha256::c064b19e72da23a26ef18f336bcfed2cb2f5243cc055f1cfa0b35afc7e850e18"
 CHKUPDATE="anitya::id=5103"


### PR DESCRIPTION
Topic Description
-----------------

- ttf-vlgothic: update to 20230918

Package(s) Affected
-------------------

- ttf-vlgothic: 20230918

Security Update?
----------------

No

Build Order
-----------

```
#buildit ttf-vlgothic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
