### PR TITLE
[NO BUILD] wqy-microhei: workaround ACBS failure as it treats ~ as a literal

### DIFF
--- a/desktop-fonts/wqy-microhei/spec
+++ b/desktop-fonts/wqy-microhei/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=0.2.0-beta
 # Note: 0.2.0-beta => 0.2.0~beta
-VER=${UPSTREAM_VER/\-/~}
+VER=${UPSTREAM_VER/\-/\~}
 SRCS="tbl::https://sourceforge.net/projects/wqy/files/wqy-microhei/${UPSTREAM_VER}/wqy-microhei-${UPSTREAM_VER}.tar.gz"
 CHKSUMS="sha256::2802ac8023aa36a66ea6e7445854e3a078d377ffff42169341bd237871f7213e"
 CHKUPDATE="anitya::id=5324"


### PR DESCRIPTION
Topic Description
-----------------

- wqy-microhei: workaround ACBS failure as it treats \~ as a literal
    \[ERROR\]: \[Errno 2\] No such file or directory: '/var/cache/acbs/tarballs/d0b03097022427ea3f1ff7c8d346c41a60a35a826250cf3bdff3166b7b989087' -> '/var/cache/acbs/build/acbs.py0zcdvc/wqy-microhei-0.2.0/rootbeta.tar.gz'

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
