### PR TITLE
sqlmap: update to 1.9.5

### DIFF
--- a/app-penetration/sqlmap/autobuild/overrides/usr/bin/sqlmap
+++ b/app-penetration/sqlmap/autobuild/overrides/usr/bin/sqlmap
@@ -1,3 +1,4 @@
 #!/bin/sh
-cd /usr/share/sqlmap
-python sqlmap.py "$@"
+
+# Fix not using the cd command to fit relative paths
+python /usr/share/sqlmap/sqlmap.py "$@"

--- a/app-penetration/sqlmap/autobuild/overrides/usr/bin/sqlmapapi
+++ b/app-penetration/sqlmap/autobuild/overrides/usr/bin/sqlmapapi
@@ -1,3 +1,4 @@
 #!/bin/sh
-cd /usr/share/sqlmap
-python sqlmapapi.py "$@"
+
+# Fix not using the cd command to fit relative paths
+python /usr/share/sqlmap/sqlmapapi.py "$@"

--- a/app-penetration/sqlmap/spec
+++ b/app-penetration/sqlmap/spec
@@ -1,4 +1,4 @@
-VER=1.8.8
+VER=1.9.5
 SRCS="git::commit=tags/$VER::https://github.com/sqlmapproject/sqlmap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14901"


### PR DESCRIPTION
Topic Description
-----------------

- sqlmap: update to 1.9.5

Package(s) Affected
-------------------

- sqlmap: 1.9.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlmap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
