### PR TITLE
ttf-adf: update to 0.20190904

### DIFF
--- a/desktop-fonts/ttf-adf/autobuild/build
+++ b/desktop-fonts/ttf-adf/autobuild/build
@@ -1,4 +1,9 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/OTF
-for i in `find . -type f -name '*.otf' -o -name '*.OTF'`; do
-    cp -v $i "$PKGDIR"/usr/share/fonts/OTF/
-done
+# Note: Fonts matching glob may be found both 2nd, 3rd, or 4th level in,
+# using extglob.
+abinfo "Installing fonts (OTF) ..."
+install -Dvm644 "$SRCDIR"/**/*.otf \
+    -t "$PKGDIR"/usr/share/fonts/OTF/
+
+abinfo "Installing fonts (OTF) ..."
+install -Dvm644 "$SRCDIR"/**/*.{afm,pfb,pfm} \
+    -t "$PKGDIR"/usr/share/fonts/Type1/

--- a/desktop-fonts/ttf-adf/autobuild/defines
+++ b/desktop-fonts/ttf-adf/autobuild/defines
@@ -3,4 +3,39 @@ PKGSEC=fonts
 PKGDEP="fontconfig"
 PKGDES="Fonts from the Arkandis Digital Foundry"
 
+PKGEPOCH=1
+
 ABHOST=noarch
+
+# Note: Taken from Debian to help locating exact fonts.
+PKGPROV="""
+fonts-adf-accanthis
+fonts-adf-baskervald
+fonts-adf-berenis
+fonts-adf-gillius
+fonts-adf-ikarius
+fonts-adf-irianis
+fonts-adf-libris
+fonts-adf-mekanus
+fonts-adf-oldania
+fonts-adf-romande
+fonts-adf-solothurn
+fonts-adf-switzera
+fonts-adf-tribun
+fonts-adf-universalis
+fonts-adf-verana
+ttf-adf-accanthis
+ttf-adf-baskervald
+ttf-adf-berenis
+ttf-adf-gillius
+ttf-adf-ikarius
+ttf-adf-irianis
+ttf-adf-libris
+ttf-adf-mekanus
+ttf-adf-oldania
+ttf-adf-romande
+ttf-adf-switzera
+ttf-adf-tribun
+ttf-adf-universalis
+ttf-adf-verana
+"""

--- a/desktop-fonts/ttf-adf/spec
+++ b/desktop-fonts/ttf-adf/spec
@@ -1,5 +1,5 @@
-VER=20090423
-REL=4
-SRCS="tbl::http://http.debian.net/debian/pool/main/t/ttf-adf/ttf-adf_0.$VER.orig.tar.gz"
-CHKSUMS="sha256::7c70bd0e279be9573a850b6ff44bbbdadab7bd3c3efeab405518b5178a9e8df6"
-SUBDIR=.
+UPSTREAM_VER=0.20190904.orig
+VER=${UPSTREAM_VER/.orig/}
+SRCS="tbl::https://deb.debian.org/debian/pool/main/f/fonts-adf/fonts-adf_$VER.orig.tar.xz"
+CHKSUMS="sha256::0a5522b3be6fdd63bcef39958e36f6f59ade367adc49ad41230b6abdd4a6281c"
+CHKUPDATE="anitya::id=378543"


### PR DESCRIPTION
Topic Description
-----------------

- ttf-adf: update to 0.20190904
    - Add Debian package names as Provides to help with indexing.
    - Clean up build script.

Package(s) Affected
-------------------

- ttf-adf: 1:0.20190904

Security Update?
----------------

No

Build Order
-----------

```
#buildit ttf-adf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
