### PR TITLE
zfs: do not build kernel module in containers

### DIFF
--- a/app-admin/zfs/autobuild/postinst
+++ b/app-admin/zfs/autobuild/postinst
@@ -1,10 +1,12 @@
 unset ARCH
 
-for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
-    if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then
-        echo -e "\033[36m**\033[0m\tBuilding zfs kernel modules for $i ..."
-        dkms install zfs/@ZFSVER@ -k $i > /dev/null
-    else
-        echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
-    fi
-done
+if systemd-detect-virt -q --container; then
+    for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+        if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then
+            echo -e "\033[36m**\033[0m\tBuilding zfs kernel modules for $i ..."
+            dkms install zfs/@ZFSVER@ -k $i > /dev/null
+        else
+            echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+        fi
+    done
+fi

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,5 @@
 VER=2.3.1
+REL=1
 SRCS="tbl::https://github.com/openzfs/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::053233799386920bdc636e22d0e19a8c2c3e642e8bd847ff87e108f8bb1f9006"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: do not build kernel module in containers

Package(s) Affected
-------------------

- zfs: 2.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
