### PR TITLE
sdl2: fix wayland support

### DIFF
--- a/runtime-multimedia/sdl2/autobuild/defines
+++ b/runtime-multimedia/sdl2/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=sdl2
 PKGSEC=x11
 PKGDEP="glibc x11-lib mesa libibus tslib"
-BUILDDEP="alsa-lib pulseaudio wayland"
+BUILDDEP="alsa-lib pulseaudio wayland libxkbcommon"
 PKGDES="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Version 2)"
 
 CMAKE_AFTER="-DARTS=OFF \

--- a/runtime-multimedia/sdl2/spec
+++ b/runtime-multimedia/sdl2/spec
@@ -2,4 +2,4 @@ VER=2.30.4
 SRCS="tbl::https://www.libsdl.org/release/SDL2-$VER.tar.gz"
 CHKSUMS="sha256::59c89d0ed40d4efb23b7318aa29fe7039dbbc098334b14f17f1e7e561da31a26"
 CHKUPDATE="anitya::id=4779"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- sdl2: fix wayland support
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- sdl2: 2.30.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
