### PR TITLE
sing-box: update to 1.11.12

### DIFF
--- a/app-network/sing-box/autobuild/beyond
+++ b/app-network/sing-box/autobuild/beyond
@@ -1,11 +1,3 @@
-abinfo "Installing systemd services..."
-install -Dvm644 "$SRCDIR"/release/config/sing-box.service \
-    -t "$PKGDIR"/usr/lib/systemd/system
-install -Dvm644 "$SRCDIR"/release/config/sing-box@.service \
-    -t "$PKGDIR"/usr/lib/systemd/system
-install -Dvm644 "$SRCDIR"/release/config/config.json \
-    -t "$PKGDIR"/etc/sing-box
-
 abinfo "Installing completion files ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
 "$PKGDIR"/usr/bin/sing-box completion bash \

--- a/app-network/sing-box/autobuild/overrides/usr/lib/systemd/system/sing-box.service
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/systemd/system/sing-box.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=sing-box service
+Documentation=https://sing-box.sagernet.org
+After=network.target nss-lookup.target network-online.target
+
+[Service]
+User=sing-box
+StateDirectory=sing-box
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ExecStart=/usr/bin/sing-box -D /var/lib/sing-box -C /etc/sing-box run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/sing-box/autobuild/overrides/usr/lib/systemd/system/sing-box@.service
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/systemd/system/sing-box@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=sing-box service
+Documentation=https://sing-box.sagernet.org
+After=network.target nss-lookup.target network-online.target
+
+[Service]
+User=sing-box
+StateDirectory=sing-box-%i
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ExecStart=/usr/bin/sing-box -D /var/lib/sing-box-%i -c /etc/sing-box/%i.json run
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/sing-box/autobuild/overrides/usr/lib/sysusers.d/sing-box.conf
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/sysusers.d/sing-box.conf
@@ -1,0 +1,1 @@
+u sing-box - "sing-box Service" /var/lib/sing-box

--- a/app-network/sing-box/autobuild/overrides/usr/lib/tmpfiles.d/sing-box.conf
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/tmpfiles.d/sing-box.conf
@@ -1,0 +1,1 @@
+d /var/lib/sing-box 0750 sing-box sing-box

--- a/app-network/sing-box/autobuild/postinst
+++ b/app-network/sing-box/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers sing-box.conf
+systemd-tmpfiles --create sing-box.conf

--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.11.11
+VER=1.11.12
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.11.12
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- sing-box: 1.11.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
