### PR TITLE
shh: update to 2025.6.4

### DIFF
--- a/app-utils/shh/autobuild/beyond
+++ b/app-utils/shh/autobuild/beyond
@@ -2,9 +2,26 @@ abinfo "Building manpages ..."
 install -dvm755 "$SRCDIR"/target/man
 cargo run \
     --locked \
-    --features gen-man-pages \
-    -- "$SRCDIR"/target/man/
+    --features generate-extra \
+    -- gen-man-pages \
+    "$SRCDIR"/target/man/
 
 abinfo "Installing manpages ..."
 install -Dvm644 "$SRCDIR"/target/man/* \
     -t "$PKGDIR"/usr/share/man/man1
+
+abinfo "Building completion files ..."
+install -dvm755 "$SRCDIR"/target/shellcompletions
+cargo run \
+    --locked \
+    --features generate-extra \
+    -- gen-shell-complete \
+    "$SRCDIR"/target/shellcompletions/
+
+abinfo "Installing completion files ..."
+install -Dvm644 "$SRCDIR"/target/shellcompletions/shh.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/shh
+install -Dvm644 "$SRCDIR"/target/shellcompletions/_shh \
+    "$PKGDIR"/usr/share/zsh/site-functions/_shh
+install -Dvm644 "$SRCDIR"/target/shellcompletions/shh.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/shh.fish

--- a/app-utils/shh/spec
+++ b/app-utils/shh/spec
@@ -1,4 +1,4 @@
-VER=2025.4.12
+VER=2025.6.4
 SRCS="git::commit=tags/v$VER::https://github.com/desbma/shh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377910"


### PR DESCRIPTION
Topic Description
-----------------

- shh: update to 2025.6.4
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- shh: 2025.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit shh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
