### PR TITLE
wput: fix build and improve scripting

### DIFF
--- a/app-web/wput/autobuild/build
+++ b/app-web/wput/autobuild/build
@@ -1,3 +1,0 @@
-./configure --prefix=/usr
-make
-make prefix="$PKGDIR"/usr install

--- a/app-web/wput/autobuild/defines
+++ b/app-web/wput/autobuild/defines
@@ -1,4 +1,28 @@
 PKGNAME=wput
-PKGDES="A command line tool to upload files to FTP site, the opposite to wget"
-PKGDEP="gnutls"
 PKGSEC=web
+PKGDEP="gnutls"
+PKGDES="Command-line to upload files to FTP sites"
+
+# Note: Incomplete but genuine Autotools source tree.
+ABTYPE=autotools
+
+# FIXME: Re-generation fails.
+#
+# autoheader: warning: missing template: HAVE_IOCTL
+# autoheader: warning: Use AC_DEFINE([HAVE_IOCTL], [], [Description])
+# autoheader: warning: missing template: HAVE_SSL
+# autoheader: warning: missing template: HAVE_SYSTERMIO
+# autoheader: warning: missing template: HAVE_TERMIO
+# autoheader: warning: missing template: HAVE_WINSIZE
+# autoreconf: error: /usr/bin/autoheader failed with exit status: 1
+RECONF=0
+
+# FIXME: make[1]: *** No rule to make target 'wput.h', needed by 'wput.o'.  Stop.
+ABSHADOW=0
+
+# Note: Not all installation paths follow DESTDIR=.
+MAKE_AFTER=(
+    "prefix=$PKGDIR/usr"
+    "bindir=$PKGDIR/usr/bin"
+    "mandir=$PKGDIR/usr/share/man"
+)

--- a/app-web/wput/autobuild/patches/0001-DEBIAN-Enable-POSIX-strdup-and-strptime-definition-v.patch
+++ b/app-web/wput/autobuild/patches/0001-DEBIAN-Enable-POSIX-strdup-and-strptime-definition-v.patch
@@ -1,0 +1,28 @@
+From 7ff325903f022163786ab694ada3fb227c478f32 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 4 Jun 2025 23:12:43 +0800
+Subject: [PATCH 1/2] DEBIAN: Enable POSIX strdup() and strptime() definition
+ via _XOPEN_SOURCE
+
+Link: https://salsa.debian.org/paulo.nunes/wput/-/blob/e7469f930b32822734e26a8ab8205a182e3f2b41/debian/patches/11-src--ftp-ls.c-compiling-fixes.patch
+Link: https://salsa.debian.org/paulo.nunes/wput/-/blob/bc0c787b6921c7ebc99463e8ea77c9fe8a5d8aaa/debian/patches/forward-declarations.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/ftp-ls.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/ftp-ls.c b/src/ftp-ls.c
+index 80c6649..40e8778 100644
+--- a/src/ftp-ls.c
++++ b/src/ftp-ls.c
+@@ -29,6 +29,7 @@ file, but you are not obligated to do so.  If you do not wish to do
+ so, delete this exception statement from your version.  */
+ 
+ #include "config.h"
++#define _XOPEN_SOURCE 500
+ #include <stdio.h>
+ #include <stdlib.h>
+ #ifdef HAVE_STRING_H
+-- 
+2.49.0
+

--- a/app-web/wput/autobuild/patches/0002-DEBIAN-Ensure-variables-are-only-declared-once.patch
+++ b/app-web/wput/autobuild/patches/0002-DEBIAN-Ensure-variables-are-only-declared-once.patch
@@ -1,0 +1,42 @@
+From aa4d827784001a514742bc767bce8a277444f3ae Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@debian.org>
+Date: Wed, 4 Jun 2025 23:20:15 +0800
+Subject: [PATCH 2/2] DEBIAN: Ensure variables are only declared once
+
+Link: https://salsa.debian.org/paulo.nunes/wput/-/blob/856a79cebc5cd4bf51f9cd53e5689be8a5e50022/debian/patches/single-declaration.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/wput.c | 1 +
+ src/wput.h | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/wput.c b/src/wput.c
+index 3a40370..6287875 100644
+--- a/src/wput.c
++++ b/src/wput.c
+@@ -55,6 +55,7 @@
+ #include "utils.h"
+ 
+ extern char *optarg;
++struct global_options opt;
+ 
+ #ifdef WIN32
+ const static char * version = "0.6.2-w32";
+diff --git a/src/wput.h b/src/wput.h
+index 3d162f3..4bd1c01 100644
+--- a/src/wput.h
++++ b/src/wput.h
+@@ -140,7 +140,9 @@ struct global_options {
+ 
+   unsigned short int retry_interval;
+   unsigned       int speed_limit;
+-} opt;
++};
++
++extern struct global_options opt;
+ 
+ extern _fsession * fsession_queue_entry_point;
+ extern char * email_address;
+-- 
+2.49.0
+

--- a/app-web/wput/autobuild/prepare
+++ b/app-web/wput/autobuild/prepare
@@ -1,1 +1,0 @@
-mkdir -p "$PKGDIR"/usr/{bin,share/man/man1}


### PR DESCRIPTION
Topic Description
-----------------

- wput: fix build and improve scripting

Package(s) Affected
-------------------

- wput: 0.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit wput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
