### PR TITLE
sing-box: update to 1.11.13

### DIFF
--- a/app-network/sing-box/autobuild/beyond
+++ b/app-network/sing-box/autobuild/beyond
@@ -3,6 +3,8 @@ install -Dvm644 "$SRCDIR"/release/config/sing-box.service \
     -t "$PKGDIR"/usr/lib/systemd/system
 install -Dvm644 "$SRCDIR"/release/config/sing-box@.service \
     -t "$PKGDIR"/usr/lib/systemd/system
+
+abinfo "Installing the sample configuration ..."
 install -Dvm644 "$SRCDIR"/release/config/config.json \
     -t "$PKGDIR"/etc/sing-box
 

--- a/app-network/sing-box/autobuild/overrides/usr/lib/sysusers.d/sing-box.conf
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/sysusers.d/sing-box.conf
@@ -1,0 +1,1 @@
+u sing-box - "sing-box Service" /var/lib/sing-box

--- a/app-network/sing-box/autobuild/overrides/usr/lib/tmpfiles.d/sing-box.conf
+++ b/app-network/sing-box/autobuild/overrides/usr/lib/tmpfiles.d/sing-box.conf
@@ -1,0 +1,1 @@
+d /var/lib/sing-box 0750 sing-box sing-box

--- a/app-network/sing-box/autobuild/patches/0001-backport-to-run-systemd-service-with-sing-box-user.patch
+++ b/app-network/sing-box/autobuild/patches/0001-backport-to-run-systemd-service-with-sing-box-user.patch
@@ -1,0 +1,39 @@
+From 170292e9b6b0ae89d60bfc91e5535398b449df26 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Thu, 5 Jun 2025 12:47:31 +0800
+Subject: [PATCH] backport to run systemd service with `sing-box` user
+
+---
+ release/config/sing-box.service  | 2 ++
+ release/config/sing-box@.service | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/release/config/sing-box.service b/release/config/sing-box.service
+index 388d7250..f003f844 100644
+--- a/release/config/sing-box.service
++++ b/release/config/sing-box.service
+@@ -4,6 +4,8 @@ Documentation=https://sing-box.sagernet.org
+ After=network.target nss-lookup.target network-online.target
+ 
+ [Service]
++User=sing-box
++StateDirectory=sing-box
+ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ ExecStart=/usr/bin/sing-box -D /var/lib/sing-box -C /etc/sing-box run
+diff --git a/release/config/sing-box@.service b/release/config/sing-box@.service
+index 38866457..74567429 100644
+--- a/release/config/sing-box@.service
++++ b/release/config/sing-box@.service
+@@ -4,6 +4,8 @@ Documentation=https://sing-box.sagernet.org
+ After=network.target nss-lookup.target network-online.target
+ 
+ [Service]
++User=sing-box
++StateDirectory=sing-box
+ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+ ExecStart=/usr/bin/sing-box -D /var/lib/sing-box-%i -c /etc/sing-box/%i.json run
+-- 
+2.49.0
+

--- a/app-network/sing-box/autobuild/postinst
+++ b/app-network/sing-box/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers sing-box.conf
+systemd-tmpfiles --create sing-box.conf

--- a/app-network/sing-box/spec
+++ b/app-network/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.11.11
+VER=1.11.13
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.11.13
    - Improve systemd service.
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- sing-box: 1.11.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
