### PR TITLE
dust: update to 1.2.1

### DIFF
--- a/app-utils/dust/spec
+++ b/app-utils/dust/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.2.1
 SRCS="git::commit=tags/v$VER::https://github.com/bootandy/dust"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141344"


### PR DESCRIPTION
Topic Description
-----------------

- dust: update to 1.2.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- dust: 1.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
