### PR TITLE
liferea: update to 1.14.6

### DIFF
--- a/app-web/liferea/autobuild/defines
+++ b/app-web/liferea/autobuild/defines
@@ -4,6 +4,14 @@ PKGDEP="desktop-file-utils gnome-keyring json-glib libgnome-keyring \
         libayatana-indicator libnotify libpeas pygobject-3 webkit2gtk \
         libxslt"
 BUILDDEP="gobject-introspection intltool xorg-server"
-PKGDES="A desktop news aggregator for online news feeds and weblogs"
+PKGDES="Desktop news aggregator for online news feeds and weblogs"
 
-AUTOTOOLS_AFTER="--disable-schemas-compile"
+# FIXME: Re-generation fails.
+#
+# configure:13795: error: possibly undefined macro: AM_NLS
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+RECONF=0
+AUTOTOOLS_AFTER=(
+    '--disable-schemas-compile'
+)

--- a/app-web/liferea/autobuild/patches/0001-Add-Ayatana-AppIndicator-backend-to-trayicon-plugin.patch
+++ b/app-web/liferea/autobuild/patches/0001-Add-Ayatana-AppIndicator-backend-to-trayicon-plugin.patch
@@ -1,4 +1,4 @@
-From 3f724fc5bcc0221569efbf117329cb567d4532e2 Mon Sep 17 00:00:00 2001
+From baea1e43fef042213e30d1a4731eaf47f18a927e Mon Sep 17 00:00:00 2001
 From: Yuri Konotopov <ykonotopov@gnome.org>
 Date: Wed, 11 Oct 2023 22:21:30 +0400
 Subject: [PATCH] Add Ayatana AppIndicator backend to trayicon plugin
@@ -193,5 +193,5 @@ index 3461aa1f..53d39352 100644
   * icon_create_from_file:
   * @filename:	the name of the file
 -- 
-2.43.0
+2.49.0
 

--- a/app-web/liferea/spec
+++ b/app-web/liferea/spec
@@ -1,5 +1,4 @@
-VER=1.13.8
-SRCS="tbl::https://github.com/lwindolf/liferea/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3f57a8d568dd02048cc1fd788304a760085f66e4db889ccf5c25a2b6a6978c4b"
+VER=1.14.6
+SRCS="tbl::https://github.com/lwindolf/liferea/releases/download/v$VER/liferea-$VER.tar.bz2"
+CHKSUMS="sha256::36f28e51d26eebcbd3460c53eb5cb012855a5fc6cce6bca58103dfc06353cc72"
 CHKUPDATE="anitya::id=6357"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- liferea: update to 1.14.6
    Track patches at AOSC-Tracking/liferea @ aosc/v1.14.6
    \(HEAD: baea1e43fef042213e30d1a4731eaf47f18a927e\).

Package(s) Affected
-------------------

- liferea: 1.14.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit liferea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
