### PR TITLE
plymouth: add missing libxkbcommon dependency

### DIFF
--- a/app-admin/plymouth/autobuild/beyond
+++ b/app-admin/plymouth/autobuild/beyond
@@ -1,4 +1,0 @@
-abinfo "Glow isn't quite ready for prime time..."
-rm -rfv "$PKGDIR"/usr/share/plymouth/glow/
-rm -fv "$PKGDIR"/usr/lib/plymouth/glow.so
-rm -rfv "$PKGDIR"/usr/share/plymouth/themes/glow

--- a/app-admin/plymouth/autobuild/defines
+++ b/app-admin/plymouth/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=plymouth
 PKGSEC=kernel
-PKGDEP="dracut libdrm pango systemd libevdev"
+PKGDEP="dracut libdrm libevdev libxkbcommon pango systemd"
 PKGRECOM="plymouth-semaphore"
 BUILDDEP="docbook-xsl intltool"
 PKGDES="Graphical boot animation and logger"

--- a/app-admin/plymouth/spec
+++ b/app-admin/plymouth/spec
@@ -1,5 +1,5 @@
 VER=24.004.60
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/plymouth/plymouth.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3669"


### PR DESCRIPTION
Topic Description
-----------------

- plymouth: add missing libxkbcommon dep

Package(s) Affected
-------------------

- plymouth: 2:24.004.60-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit plymouth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
