### PR TITLE
zsh: fix module building

### DIFF
--- a/app-shells/zsh/autobuild/beyond
+++ b/app-shells/zsh/autobuild/beyond
@@ -1,4 +1,4 @@
 abinfo "Installing a symlink, /etc/zsh/zprofile => /etc/profile ..."
 mkdir -pv "$PKGDIR"/etc/zsh
-ln -sv /etc/profile \
+ln -sv ../profile \
     "$PKGDIR"/etc/zsh/zprofile

--- a/app-shells/zsh/autobuild/defines
+++ b/app-shells/zsh/autobuild/defines
@@ -1,11 +1,29 @@
 PKGNAME=zsh
-PKGDES="A very advanced and programmable command interpreter (shell) for UNIX"
-PKGDEP="groff ncurses texinfo pcre gdbm libcap"
 PKGSEC=shells
+PKGDEP="groff ncurses texinfo pcre gdbm libcap"
+PKGDES="Programmable command interpreter (shell)"
 
-AUTOTOOLS_AFTER="--docdir=/usr/share/doc/zsh --htmldir=/usr/share/doc/zsh/html --enable-etcdir=/etc/zsh \
-                 --enable-zshenv=/etc/zsh/zshenv --enable-zlogin=/etc/zsh/zlogin --enable-zlogout=/etc/zsh/zlogout \
-                 --enable-zprofile=/etc/zsh/zprofile --enable-zshrc=/etc/zsh/zshrc --enable-maildir-support --enable-multibyte \
-                 --enable-function-subdirs --enable-fndir=/usr/share/zsh/functions --enable-scriptdir=/usr/share/zsh/scripts \
-                 --with-tcsetpgrp --enable-pcre --enable-cap --enable-zsh-secure-free" 
-ABSHADOW=no
+AUTOTOOLS_AFTER=(
+    '--docdir=/usr/share/doc/zsh'
+    '--htmldir=/usr/share/doc/zsh/html'
+    '--enable-etcdir=/etc/zsh'
+    '--enable-zshenv=/etc/zsh/zshenv'
+    '--enable-zlogin=/etc/zsh/zlogin'
+    '--enable-zlogout=/etc/zsh/zlogout'
+    '--enable-zprofile=/etc/zsh/zprofile'
+    '--enable-zshrc=/etc/zsh/zshrc'
+    '--enable-maildir-support'
+    '--enable-multibyte'
+    '--enable-function-subdirs'
+    '--enable-fndir=/usr/share/zsh/functions'
+    '--enable-scriptdir=/usr/share/zsh/scripts'
+    '--with-tcsetpgrp'
+    '--enable-pcre'
+    '--enable-cap'
+    '--enable-zsh-secure-free'
+)
+
+# Note: Making sure that modules are bulit.
+MAKE_AFTER=(
+    'all'
+)

--- a/app-shells/zsh/autobuild/patches/0001-FROMLIST-C-compatiblity-fixes-for-the-configure-scri.patch
+++ b/app-shells/zsh/autobuild/patches/0001-FROMLIST-C-compatiblity-fixes-for-the-configure-scri.patch
@@ -1,7 +1,7 @@
 From d5dbe60eafe6bb72bb605a95ae51a5b55ee6b35e Mon Sep 17 00:00:00 2001
 From: Florian Weimer <fweimer@redhat.com>
 Date: Fri, 8 Dec 2023 21:58:07 +0100
-Subject: [PATCH 1/3] FROMLIST: C compatiblity fixes for the configure script
+Subject: [PATCH 1/5] FROMLIST: C compatiblity fixes for the configure script
  (incompatible-pointer-types)
 
 Avoid incompatible pointer types in terminfo global variable checks.

--- a/app-shells/zsh/autobuild/patches/0002-AOSCOS-fix-Completion-fix-paths-in-built-in-completi.patch
+++ b/app-shells/zsh/autobuild/patches/0002-AOSCOS-fix-Completion-fix-paths-in-built-in-completi.patch
@@ -1,7 +1,7 @@
 From 668ecc1ea70d747861e717144a867e4e176c11af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Jun 2025 22:42:40 +0800
-Subject: [PATCH 2/3] AOSCOS: fix(Completion): fix paths in built-in
+Subject: [PATCH 2/5] AOSCOS: fix(Completion): fix paths in built-in
  completions
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/app-shells/zsh/autobuild/patches/0003-AOSCOS-fix-Completion-disable-non-Linux-compatible-c.patch
+++ b/app-shells/zsh/autobuild/patches/0003-AOSCOS-fix-Completion-disable-non-Linux-compatible-c.patch
@@ -1,7 +1,7 @@
 From 16b5fa9690c21b181316183ed7f7e9dcbaee5906 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Jun 2025 22:43:54 +0800
-Subject: [PATCH 3/3] AOSCOS: fix(Completion): disable non-Linux-compatible
+Subject: [PATCH 3/5] AOSCOS: fix(Completion): disable non-Linux-compatible
  completions
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/app-shells/zsh/autobuild/patches/0004-FROMLIST-51889-fix-module-loading-problem-with-full-.patch
+++ b/app-shells/zsh/autobuild/patches/0004-FROMLIST-51889-fix-module-loading-problem-with-full-.patch
@@ -1,0 +1,73 @@
+From 433faee2b928b11bcd7e5f96c4ad16b50978a62d Mon Sep 17 00:00:00 2001
+From: Jun-ichi Takimoto <takimoto-j@kba.biglobe.ne.jp>
+Date: Mon, 26 Jun 2023 17:13:04 +0900
+Subject: [PATCH 4/5] FROMLIST: 51889: fix module loading problem with full
+ RELRO
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If full RELRO (relocation read-only, one of the security enhancement
+methods for ELF-based systems) is used when building zsh (as in binary
+packages of most Linuxes), loading a module (e.g. zsh/zftp) fails unless
+all the modules it depends on are already loaded. With this patch the
+necessary modules are automatically loaded.
+
+Upstream-commit: a84fdd7c8f77935ecce99ff2b0bdba738821ed79
+Signed-off-by: Lukáš Zaoral <lzaoral@redhat.com>
+---
+ Src/Modules/zftp.c |  2 +-
+ Src/mkbltnmlst.sh  | 24 ++++++++++++++++++++++++
+ 2 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/Src/Modules/zftp.c b/Src/Modules/zftp.c
+index e8e239e76..7c984c03a 100644
+--- a/Src/Modules/zftp.c
++++ b/Src/Modules/zftp.c
+@@ -3172,7 +3172,7 @@ static struct features module_features = {
+ int
+ setup_(UNUSED(Module m))
+ {
+-    return (require_module("zsh/net/tcp", NULL, 0) == 1);
++    return 0;
+ }
+ 
+ /**/
+diff --git a/Src/mkbltnmlst.sh b/Src/mkbltnmlst.sh
+index c4611d8b3..067ecdaf9 100644
+--- a/Src/mkbltnmlst.sh
++++ b/Src/mkbltnmlst.sh
+@@ -76,6 +76,30 @@ for x_mod in $x_mods; do
+     test "x$linked" = xno && echo "#endif"
+ done
+ 
++# if dynamic module 'mod' with load=no has moddeps in its .mdd,
++# then output add_dep(mod, dep) for each 'dep' in moddeps.
++dyn_mods="`grep ' link=dynamic .* load=no ' $CFMOD | \
++          sed -e '/^#/d' -e 's/ .*/ /' -e 's/^name=/ /'`"
++
++for mod in $dyn_mods; do
++    modfile="`grep '^name='$mod' ' $CFMOD | \
++              sed -e 's/^.* modfile=//' -e 's/ .*//'`"
++    if test "x$modfile" = x; then
++	echo >&2 "WARNING: no name for \`$mod' in $CFMOD (ignored)"
++	continue
++    fi
++    unset moddeps
++    . $srcdir/../$modfile
++    if test -n "$moddeps"; then
++        echo '#ifdef DYNAMIC'
++        echo "/* non-linked-in known module \`$mod' */"
++        for dep in $moddeps; do
++          echo "  add_dep(\"$mod\", \"$dep\");"
++        done
++        echo '#endif'
++    fi
++done
++
+ echo
+ done_mods=" "
+ for bin_mod in $bin_mods; do
+-- 
+2.49.0
+

--- a/app-shells/zsh/autobuild/patches/0005-AOSCOS-fix-fixup-pre-C99-syntax-in-m4-modules-and-co.patch
+++ b/app-shells/zsh/autobuild/patches/0005-AOSCOS-fix-fixup-pre-C99-syntax-in-m4-modules-and-co.patch
@@ -1,0 +1,462 @@
+From e9ea873f6f7273610f2ad8e3496798f3f642c393 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 5 Jun 2025 16:30:58 +0800
+Subject: [PATCH 5/5] AOSCOS: fix: fixup pre-C99 syntax in m4 modules and
+ configure.ac tests
+
+sed -e 's/^main/int &/'      \
+    -e 's/exit(/return(/'    \
+    -i aczsh.m4 configure.ac
+
+Link: https://www.linuxfromscratch.org/blfs/view/svn/postlfs/zsh.html (Version r12.3-809)
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ aczsh.m4     | 64 +++++++++++++++++++++----------------------
+ configure.ac | 76 ++++++++++++++++++++++++++--------------------------
+ 2 files changed, 70 insertions(+), 70 deletions(-)
+
+diff --git a/aczsh.m4 b/aczsh.m4
+index 1209ac614..e3fe76214 100644
+--- a/aczsh.m4
++++ b/aczsh.m4
+@@ -44,7 +44,7 @@ AC_DEFUN(zsh_64_BIT_TYPE,
+ #include <sys/types.h>
+ #endif
+ 
+-main()
++int main()
+ {
+   $1 foo = 0; 
+   int bar = (int) foo;
+@@ -146,29 +146,29 @@ char *zsh_gl_sym_addr ;
+ #define RTLD_GLOBAL 0
+ #endif
+ 
+-main()
++int main()
+ {
+     void *handle1, *handle2;
+     void *(*zsh_getaddr1)(), *(*zsh_getaddr2)();
+     void *sym1, *sym2;
+     handle1 = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle1) exit(1);
++    if(!handle1) return(1);
+     handle2 = dlopen("./conftest2.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle2) exit(1);
++    if(!handle2) return(1);
+     zsh_getaddr1 = (void *(*)()) dlsym(handle1, "${us}zsh_getaddr1");
+     zsh_getaddr2 = (void *(*)()) dlsym(handle2, "${us}zsh_getaddr2");
+     sym1 = zsh_getaddr1();
+     sym2 = zsh_getaddr2();
+-    if(!sym1 || !sym2) exit(1);
+-    if(sym1 != sym2) exit(1);
++    if(!sym1 || !sym2) return(1);
++    if(sym1 != sym2) return(1);
+     dlclose(handle1);
+     handle1 = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle1) exit(1);
++    if(!handle1) return(1);
+     zsh_getaddr1 = (void *(*)()) dlsym(handle1, "${us}zsh_getaddr1");
+     sym1 = zsh_getaddr1();
+-    if(!sym1) exit(1);
+-    if(sym1 != sym2) exit(1);
+-    exit(0);
++    if(!sym1) return(1);
++    if(sym1 != sym2) return(1);
++    return(0);
+ }
+ ]])],[zsh_cv_shared_$1=yes],
+ [zsh_cv_shared_$1=no],
+@@ -229,18 +229,18 @@ char *zsh_gl_sym_addr ;
+ #endif
+ 
+ 
+-main()
++int main()
+ {
+     void *handle1, *handle2;
+     int (*fred1)(), (*fred2)();
+     handle1 = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle1) exit(1);
++    if(!handle1) return(1);
+     handle2 = dlopen("./conftest2.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle2) exit(1);
++    if(!handle2) return(1);
+     fred1 = (int (*)()) dlsym(handle1, "${us}fred");
+     fred2 = (int (*)()) dlsym(handle2, "${us}fred");
+-    if(!fred1 || !fred2) exit(1);
+-    exit((*fred1)() != 42 || (*fred2)() != 69);
++    if(!fred1 || !fred2) return(1);
++    return((*fred1)() != 42 || (*fred2)() != 69);
+ }
+ ]])],[zsh_cv_sys_dynamic_clash_ok=yes],
+ [zsh_cv_sys_dynamic_clash_ok=no],
+@@ -304,17 +304,17 @@ char *zsh_gl_sym_addr ;
+ #define RTLD_GLOBAL 0
+ #endif
+ 
+-main()
++int main()
+ {
+     void *handle;
+     int (*barneysym)();
+     handle = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle) exit(1);
++    if(!handle) return(1);
+     handle = dlopen("./conftest2.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle) exit(1);
++    if(!handle) return(1);
+     barneysym = (int (*)()) dlsym(handle, "${us}barney");
+-    if(!barneysym) exit(1);
+-    exit((*barneysym)() != 69);
++    if(!barneysym) return(1);
++    return((*barneysym)() != 69);
+ }
+ ]])],[zsh_cv_sys_dynamic_rtld_global=yes],
+ [zsh_cv_sys_dynamic_rtld_global=no],
+@@ -374,15 +374,15 @@ char *zsh_gl_sym_addr ;
+ #define RTLD_GLOBAL 0
+ #endif
+ 
+-main()
++int main()
+ {
+     void *handle;
+     int (*barneysym)();
+     handle = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle) exit(1);
++    if(!handle) return(1);
+     barneysym = (int (*)()) dlsym(handle, "${us}barney");
+-    if(!barneysym) exit(1);
+-    exit((*barneysym)() != 69);
++    if(!barneysym) return(1);
++    return((*barneysym)() != 69);
+ }
+ 
+ int fred () { return 42; }
+@@ -448,15 +448,15 @@ char *zsh_gl_sym_addr ;
+ #define RTLD_GLOBAL 0
+ #endif
+ 
+-main()
++int main()
+ {
+     void *handle;
+     int (*barneysym)();
+     handle = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle) exit(1);
++    if(!handle) return(1);
+     barneysym = (int (*)()) dlsym(handle, "${us}barney");
+-    if(!barneysym) exit(1);
+-    exit((*barneysym)() != 69);
++    if(!barneysym) return(1);
++    return((*barneysym)() != 69);
+ }
+ 
+ int fred () { return 42; }
+@@ -516,15 +516,15 @@ char *zsh_gl_sym_addr ;
+ #define RTLD_GLOBAL 0
+ #endif
+ 
+-main()
++int main()
+ {
+     void *handle;
+     int (*fredsym)();
+     handle = dlopen("./conftest1.$DL_EXT", RTLD_LAZY | RTLD_GLOBAL);
+-    if(!handle) exit(1);
++    if(!handle) return(1);
+     fredsym = (int (*)()) dlsym(handle, "${us}fred");
+-    if(!fredsym) exit(1);
+-    exit((*fredsym)() != 42);
++    if(!fredsym) return(1);
++    return((*fredsym)() != 42);
+ }
+ ]])],[zsh_cv_sys_dynamic_strip_lib=yes],
+ [zsh_cv_sys_dynamic_strip_lib=no],
+diff --git a/configure.ac b/configure.ac
+index b4d3e1f96..cf1e925ef 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1046,7 +1046,7 @@ else
+   [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <sys/types.h>
+ 
+-main() { return sizeof(off_t) < 8; }
++int main() { return sizeof(off_t) < 8; }
+ ]])],[zsh_cv_off_t_is_64_bit=yes],[zsh_cv_off_t_is_64_bit=no],[zsh_cv_off_t_is_64_bit=no])])
+   if test x$zsh_cv_off_t_is_64_bit = xyes; then
+     AC_DEFINE(OFF_T_IS_64_BIT)
+@@ -1056,7 +1056,7 @@ main() { return sizeof(off_t) < 8; }
+   [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <sys/types.h>
+ 
+-main() { return sizeof(ino_t) < 8; }
++int main() { return sizeof(ino_t) < 8; }
+ ]])],[zsh_cv_ino_t_is_64_bit=yes],[zsh_cv_ino_t_is_64_bit=no],[zsh_cv_ino_t_is_64_bit=no])])
+   if test x$zsh_cv_ino_t_is_64_bit = xyes; then
+     AC_DEFINE(INO_T_IS_64_BIT)
+@@ -1369,7 +1369,7 @@ zsh_cv_func_realpath_accepts_null,
+ #include <stdlib.h>
+ #include <limits.h>
+ ],[
+-exit(!realpath("/", (char*)0));
++return(!realpath("/", (char*)0));
+ ])],
+ [zsh_cv_func_realpath_accepts_null=yes],
+ [zsh_cv_func_realpath_accepts_null=no],
+@@ -1396,7 +1396,7 @@ zsh_cv_func_tgetent_accepts_null,
+ #include <stdlib.h>
+ int tgetent(char *, char *);
+ char *tgetstr(char *, char **);
+-main()
++int main()
+ {
+     char buf[4096];
+     int r1 = tgetent(buf, "vt100");
+@@ -1407,7 +1407,7 @@ main()
+     	tgetstr("cl", &u);
+ 	creat("conftest.tgetent", 0640);
+     }
+-    exit((r1 != r2) || r2 == -1);
++    return((r1 != r2) || r2 == -1);
+ }
+ ]])],[if test -f conftest.tgetent; then
+     zsh_cv_func_tgetent_accepts_null=yes
+@@ -1424,7 +1424,7 @@ zsh_cv_func_tgetent_zero_success,
+ #include <stdlib.h>
+ int tgetent(char *, char*);
+ char *tgetstr(char *, char **);
+-main()
++int main()
+ {
+     char buf[4096];
+     int r1 = tgetent(buf, "!@#$%^&*");
+@@ -1435,7 +1435,7 @@ main()
+     	tgetstr("cl", &u);
+ 	creat("conftest.tgetent0", 0640);
+     }
+-    exit(r1 == r2);
++    return(r1 == r2);
+ }
+ ]])],[if test -f conftest.tgetent0; then
+     zsh_cv_func_tgetent_zero_success=yes
+@@ -1862,7 +1862,7 @@ zsh_cv_rlim_t_is_longer,
+ #endif
+ #include <sys/resource.h>
+ #include <stdlib.h>
+-main(){struct rlimit r;exit(sizeof(r.rlim_cur) <= sizeof(long));}]])],[zsh_cv_rlim_t_is_longer=yes],[zsh_cv_rlim_t_is_longer=no],[zsh_cv_rlim_t_is_longer=yes])])
++int main(){struct rlimit r;return(sizeof(r.rlim_cur) <= sizeof(long));}]])],[zsh_cv_rlim_t_is_longer=yes],[zsh_cv_rlim_t_is_longer=no],[zsh_cv_rlim_t_is_longer=yes])])
+ if test x$zsh_cv_rlim_t_is_longer = xyes; then
+   AC_CACHE_CHECK(if rlim_t is a quad,
+   zsh_cv_rlim_t_is_quad_t,
+@@ -1873,12 +1873,12 @@ if test x$zsh_cv_rlim_t_is_longer = xyes; then
+ #include <stdio.h>
+ #include <sys/resource.h>
+ #include <stdlib.h>
+-main() { 
++int main() { 
+   struct rlimit r;
+   char buf[20];
+   r.rlim_cur = 0;
+   sprintf(buf, "%qd", r.rlim_cur);
+-  exit(strcmp(buf, "0"));
++  return(strcmp(buf, "0"));
+ }]])],[zsh_cv_rlim_t_is_quad_t=yes],[zsh_cv_rlim_t_is_quad_t=no],[zsh_cv_rlim_t_is_quad_t=no])])
+   if test x$zsh_cv_rlim_t_is_quad_t = xyes; then
+     AC_DEFINE(RLIM_T_IS_QUAD_T)
+@@ -1896,7 +1896,7 @@ else
+ #endif
+ #include <sys/resource.h>
+ #include <stdlib.h>
+-  main(){struct rlimit r;r.rlim_cur=-1;exit(r.rlim_cur<0);}]])],[zsh_cv_type_rlim_t_is_unsigned=yes],[zsh_cv_type_rlim_t_is_unsigned=no],[zsh_cv_type_rlim_t_is_unsigned=no])])
++  main(){struct rlimit r;r.rlim_cur=-1;return(r.rlim_cur<0);}]])],[zsh_cv_type_rlim_t_is_unsigned=yes],[zsh_cv_type_rlim_t_is_unsigned=no],[zsh_cv_type_rlim_t_is_unsigned=no])])
+   if test x$zsh_cv_type_rlim_t_is_unsigned = xyes; then
+     AC_DEFINE(RLIM_T_IS_UNSIGNED)
+     DEFAULT_RLIM_T="unsigned $DEFAULT_RLIM_T"
+@@ -2177,7 +2177,7 @@ zsh_cv_sys_fifo,
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <sys/stat.h>
+-main()
++int main()
+ {
+     char c;
+     int fd;
+@@ -2188,18 +2188,18 @@ main()
+ #else
+     if(mknod("/tmp/fifo$$", 0010600, 0) < 0)
+ #endif
+-	exit(1);
++	return(1);
+     pid = fork();
+     if(pid < 0)
+-	exit(1);
++	return(1);
+     if(pid) {
+ 	fd = open("/tmp/fifo$$", O_RDONLY);
+-	exit(fd < 0 || read(fd, &c, 1) != 1 || c != 'x');
++	return(fd < 0 || read(fd, &c, 1) != 1 || c != 'x');
+     }
+     fd = open("/tmp/fifo$$", O_WRONLY);
+     ret = (fd < 0 || write(fd, "x", 1) < 1);
+     unlink("/tmp/fifo$$");
+-    exit(ret);
++    return(ret);
+ }
+ ]])],[zsh_cv_sys_fifo=yes],[zsh_cv_sys_fifo=no],[zsh_cv_sys_fifo=yes])
+ ])
+@@ -2278,7 +2278,7 @@ zsh_cv_sys_link,
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <stdlib.h>
+-main()
++int main()
+ {
+     int ret;
+     char *tmpfile, *newfile;
+@@ -2287,11 +2287,11 @@ main()
+     unlink(tmpfile);
+     unlink(newfile);
+     if(creat(tmpfile, 0644) < 0)
+-	exit(1);
++	return(1);
+     ret = link(tmpfile, newfile);
+     unlink(tmpfile);
+     unlink(newfile);
+-    exit(ret<0);
++    return(ret<0);
+ }
+ ]])],[zsh_cv_sys_link=yes],[zsh_cv_sys_link=no],[zsh_cv_sys_link=yes])])
+ AH_TEMPLATE([HAVE_LINK],
+@@ -2311,11 +2311,11 @@ zsh_cv_sys_killesrch,
+ #include <signal.h>
+ #include <errno.h>
+ #include <stdlib.h>
+-main()
++int main()
+ {
+     int pid = (getpid() + 10000) & 0xffffff;
+     while (pid && (kill(pid, 0) == 0 || errno != ESRCH)) pid >>= 1;
+-    exit(errno!=ESRCH);
++    return(errno!=ESRCH);
+ }
+ ]])],[zsh_cv_sys_killesrch=yes],[zsh_cv_sys_killesrch=no],[zsh_cv_sys_killesrch=yes])])
+ AH_TEMPLATE([BROKEN_KILL_ESRCH],
+@@ -2341,7 +2341,7 @@ int child=0;
+ void handler(sig)
+     int sig;
+ {if(sig==SIGCHLD) child=1;}
+-main() {
++int main() {
+     struct sigaction act;
+     sigset_t set;
+     int pid, ret;
+@@ -2356,7 +2356,7 @@ main() {
+     if(pid>0) {
+     sigemptyset(&set);
+         ret=sigsuspend(&set);
+-        exit(child==0);
++        return(child==0);
+     }
+ }
+ ]])],[zsh_cv_sys_sigsuspend=yes],[zsh_cv_sys_sigsuspend=no],[zsh_cv_sys_sigsuspend=yes])])
+@@ -2389,14 +2389,14 @@ case "x$zsh_working_tcsetpgrp" in
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <stdlib.h>
+-main() {
++int main() {
+     int fd;
+     int ret;
+     fd=open("/dev/tty", O_RDWR);
+-    if (fd < 0) exit(2);
++    if (fd < 0) return(2);
+     ret=tcsetpgrp(fd, tcgetpgrp(fd));
+-    if (ret < 0) exit(1);
+-    exit(0);
++    if (ret < 0) return(1);
++    return(0);
+ }
+ ]])],[zsh_cv_sys_tcsetpgrp=yes],[
+ case $? in
+@@ -2436,7 +2436,7 @@ if test x$ac_cv_func_getpwnam = xyes; then
+ #include <string.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+-main() {
++int main() {
+     struct passwd *pw1, *pw2;
+     char buf[1024], name[1024];
+     sprintf(buf, "%d:%d", getpid(), rand());
+@@ -2444,7 +2444,7 @@ main() {
+     if (pw1) strcpy(name, pw1->pw_name);
+     sprintf(buf, "%d:%d", rand(), getpid());
+     pw2=getpwnam(buf);
+-    exit(pw1!=0 && pw2!=0 && !strcmp(name, pw2->pw_name));
++    return(pw1!=0 && pw2!=0 && !strcmp(name, pw2->pw_name));
+ }
+ ]])],[zsh_cv_sys_getpwnam_faked=no],[zsh_cv_sys_getpwnam_faked=yes],[zsh_cv_sys_getpwnam_faked=no])])
+     if test x$zsh_cv_sys_getpwnam_faked = xyes; then
+@@ -2765,18 +2765,18 @@ elif test "x$dynamic" = xyes; then
+ #include <fcntl.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+-main(argc, argv)
++int main(argc, argv)
+ int argc;
+ char *argv[];
+ {
+ 	char b[4];
+ 	int i = open(argv[0],O_RDONLY);
+ 	if(i == -1) 
+-		exit(1); /* fail */
++		return(1); /* fail */
+ 	if(read(i,b,4)==4 && b[0]==127 && b[1]=='E' && b[2]=='L' && b[3]=='F')
+-		exit(0); /* succeed (yes, it's ELF) */
++		return(0); /* succeed (yes, it's ELF) */
+ 	else
+-		exit(1); /* fail */
++		return(1); /* fail */
+ }]])],[zsh_cv_sys_elf=yes],[zsh_cv_sys_elf=no],[zsh_cv_sys_elf=yes])])
+ 
+   # We use [0-9]* in case statements, so need to change quoting
+@@ -2945,16 +2945,16 @@ char *zsh_gl_sym_addr ;
+ 
+ extern int fred() ;
+ 
+-main()
++int main()
+ {
+     void * handle ;
+     void * symbol ;
+     FILE *f=fopen("conftestval", "w");
+-    if (!f) exit(1);
++    if (!f) return(1);
+     handle = dlopen("./conftest.$DL_EXT", RTLD_LAZY) ;
+     if (handle == NULL) {
+         fprintf (f, "dlopen failed") ;
+-            exit(1);
++            return(1);
+     }
+     symbol = dlsym(handle, "fred") ;
+     if (symbol == NULL) {
+@@ -2962,13 +2962,13 @@ main()
+         symbol = dlsym(handle, "_fred") ;
+         if (symbol == NULL) {
+             fprintf (f, "dlsym failed") ;
+-                exit(1);
++                return(1);
+                 }
+         fprintf (f, "yes") ;
+     }
+     else
+         fprintf (f, "no") ;
+-    exit(0);
++    return(0);
+ }]])],[zsh_cv_func_dlsym_needs_underscore=`cat conftestval`],[zsh_cv_func_dlsym_needs_underscore=failed
+     dynamic=no],[zsh_cv_func_dlsym_needs_underscore=no])])
+   if test "x$zsh_cv_func_dlsym_needs_underscore" = xyes; then
+-- 
+2.49.0
+

--- a/app-shells/zsh/spec
+++ b/app-shells/zsh/spec
@@ -1,5 +1,5 @@
 VER=5.9
-REL=1
+REL=2
 SRCS="tbl::https://www.zsh.org/pub/zsh-$VER.tar.xz"
 CHKSUMS="sha256::9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5"
 CHKUPDATE="anitya::id=5307"


### PR DESCRIPTION
Topic Description
-----------------

- zsh: fix module building
    - Add additional refactors for pre-C99 code.
    - Refactor AUTOTOOLS_AFTER as an array.
    - Improve PKGDES.
    - Backport a patch to fix module loading with RELRO.

Package(s) Affected
-------------------

- zsh: 5.9-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zsh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
