### PR TITLE
dovecot: update to 2.4.1

### DIFF
--- a/app-web/dovecot/autobuild/beyond
+++ b/app-web/dovecot/autobuild/beyond
@@ -1,4 +1,6 @@
-install -d -m755 "$PKGDIR"/etc/dovecot/conf.d
-rm -f "$PKGDIR"/etc/dovecot/README
+abinfo "Installing conf.d directory ..."
+mkdir -pv "$PKGDIR"/etc/dovecot/conf.d
 
-install -m 755  doc/mkcert.sh "$PKGDIR"/usr/lib/dovecot/mkcert.sh
+abinfo "Installing mkcert.sh ..."
+install -Dvm755 "$SRCDIR"/doc/mkcert.sh \
+    "$PKGDIR"/usr/lib/dovecot/mkcert.sh

--- a/app-web/dovecot/autobuild/defines
+++ b/app-web/dovecot/autobuild/defines
@@ -2,30 +2,20 @@ PKGNAME=dovecot
 PKGSEC=net
 PKGDEP="bzip2 curl clucene expat krb5 linux-pam lz4 mariadb openldap \
         openssl postgresql sqlite xz libnsl2"
-PKGDES="An open source IMAP and POP3 email server"
-BUILDDEP__AMD64="pandoc"
+PKGDES="IMAP and POP3 email server"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --with-moduledir=/usr/lib/dovecot/modules \
-                 --with-nss \
-                 --with-pam \
-                 --with-mysql \
-                 --with-pgsql \
-                 --with-sqlite \
-                 --with-ssl=openssl \
-                 --with-ssldir=/etc/ssl \
-                 --with-gssapi \
-                 --with-ldap=plugin \
-                 --with-zlib \
-                 --with-bzlib \
-                 --with-lzma \
-                 --with-lz4 \
-                 --with-libcap \
-                 --with-solr \
-                 --with-lucene \
-                 PANDOC=false"
-AUTOTOOLS_AFTER__AMD64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --with-docs PANDOC=/usr/bin/pandoc"
-
-NOLTO=1
+AUTOTOOLS_AFTER=(
+    '--libexecdir=/usr/lib'
+    '--with-moduledir=/usr/lib/dovecot/modules'
+    '--with-pam'
+    '--with-mysql'
+    '--with-pgsql'
+    '--with-sqlite'
+    '--with-ssldir=/etc/ssl'
+    '--with-gssapi'
+    '--with-ldap=plugin'
+    '--with-bzlib'
+    '--with-lz4'
+    '--with-libcap'
+    '--with-solr'
+)

--- a/app-web/dovecot/autobuild/overrides/usr/lib/sysusers.d/dovecot.conf
+++ b/app-web/dovecot/autobuild/overrides/usr/lib/sysusers.d/dovecot.conf
@@ -1,0 +1,6 @@
+g dovenull
+g dovecot
+u dovenull - "Dovecot daemon owner for completely untrustworthy processes" /var/empty /usr/bin/nologin
+u dovecot - "Dovecot daemon owner" /var/empty /usr/bin/nologin
+m dovenull dovenull
+m dovecot dovecot

--- a/app-web/dovecot/autobuild/patches/0001-global-Drop-support-for-old-iconv.patch
+++ b/app-web/dovecot/autobuild/patches/0001-global-Drop-support-for-old-iconv.patch
@@ -1,0 +1,200 @@
+From fd06bc86662b8afd85ae1dbe7dd7282d2a5000bc Mon Sep 17 00:00:00 2001
+From: Aki Tuomi <aki.tuomi@open-xchange.com>
+Date: Mon, 12 May 2025 11:20:18 +0300
+Subject: [PATCH 1/2] global: Drop support for old iconv()
+
+iconv() is part of POSIX.1-2001.
+---
+ Makefile.am                         |  1 -
+ autogen.sh                          | 12 -------
+ configure.ac                        |  3 +-
+ src/lib-charset/Makefile.am         |  4 +--
+ src/lib-charset/charset-iconv.c     |  8 ++---
+ src/lib-charset/charset-utf8-only.c | 51 -----------------------------
+ src/lib-charset/charset-utf8.c      |  4 ---
+ 7 files changed, 4 insertions(+), 79 deletions(-)
+ delete mode 100644 src/lib-charset/charset-utf8-only.c
+
+diff --git a/Makefile.am b/Makefile.am
+index ebf55dcd01..c8355b04b2 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -47,7 +47,6 @@ dovecot-config: dovecot-config.in Makefile
+ 	(echo "DOVECOT_INSTALLED=no"; cat dovecot-config.in | sed \
+ 	-e "s|\$$(top_builddir)|$$abs_builddir|g" \
+ 	-e "s|\$$(incdir)|$$abs_srcdir|g" \
+-	-e "s|\$$(LIBICONV)|$(LIBICONV)|g" \
+ 	-e "s|\$$(MODULE_LIBS)|$(MODULE_LIBS)|g" \
+ 	-e "s|^\(dovecot_pkgincludedir\)=|\1=$(pkgincludedir)|" \
+ 	-e "s|^\(dovecot_pkglibdir\)=|\1=$(pkglibdir)|" \
+diff --git a/autogen.sh b/autogen.sh
+index f6a57fc278..872167c61f 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -1,15 +1,3 @@
+ #!/bin/sh
+ 
+-# If you've non-standard directories, set these
+-#GETTEXT_DIR=
+-
+-if ! test -f build-aux/config.rpath; then
+-  for dir in $GETTEXT_DIR /usr/share/gettext /usr/local/share/gettext; do
+-    if test -f $dir/config.rpath; then
+-      /bin/cp -f $dir/config.rpath build-aux/
+-      break
+-    fi
+-  done
+-fi
+-
+ autoreconf -vif
+diff --git a/configure.ac b/configure.ac
+index 0537fb6f20..f48f21afcd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -251,7 +251,6 @@ AS_IF([test "$FLEX" = ":" && test ! -e "$srcdir/src/lib/event-filter-lexer.c"],
+ ])
+ AC_C_INLINE
+ LT_INIT
+-AM_ICONV
+ 
+ # SIZE_MAX is missing without this
+ CXXFLAGS="$CXXFLAGS -D__STDC_LIMIT_MACROS"
+@@ -596,7 +595,7 @@ if test "$want_shared_libs" = "yes"; then
+   fi
+ else
+   LIBDOVECOT_DEPS="$LIBDOVECOT_LA_LIBS"
+-  LIBDOVECOT="$LIBDOVECOT_DEPS \$(LIBICONV) \$(MODULE_LIBS)"
++  LIBDOVECOT="$LIBDOVECOT_DEPS \$(MODULE_LIBS)"
+   LIBDOVECOT_STORAGE_DEPS='$(top_builddir)/src/lib-storage/libstorage.la'
+   LIBDOVECOT_LOGIN='$(top_builddir)/src/login-common/liblogin.la'
+   LIBDOVECOT_LDA='$(top_builddir)/src/lib-lda/liblda.la'
+diff --git a/src/lib-charset/Makefile.am b/src/lib-charset/Makefile.am
+index 5c41f074c0..dd0b7b9283 100644
+--- a/src/lib-charset/Makefile.am
++++ b/src/lib-charset/Makefile.am
+@@ -4,11 +4,9 @@ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/src/lib \
+ 	-I$(top_srcdir)/src/lib-test
+ 
+-libcharset_la_LIBADD = $(LTLIBICONV)
+ libcharset_la_SOURCES = \
+ 	charset-iconv.c \
+-	charset-utf8.c \
+-	charset-utf8-only.c
++	charset-utf8.c
+ 
+ headers = \
+ 	charset-utf8.h \
+diff --git a/src/lib-charset/charset-iconv.c b/src/lib-charset/charset-iconv.c
+index 7b2921955f..8f5898fb1c 100644
+--- a/src/lib-charset/charset-iconv.c
++++ b/src/lib-charset/charset-iconv.c
+@@ -4,8 +4,6 @@
+ #include "buffer.h"
+ #include "charset-utf8-private.h"
+ 
+-#ifdef HAVE_ICONV
+-
+ #include <iconv.h>
+ #include <ctype.h>
+ 
+@@ -56,7 +54,7 @@ charset_to_utf8_try(struct charset_translation *t,
+ 		    const unsigned char *src, size_t *src_size, buffer_t *dest,
+ 		    enum charset_result *result)
+ {
+-	ICONV_CONST char *ic_srcbuf;
++	char *ic_srcbuf;
+ 	char tmpbuf[8192], *ic_destbuf;
+ 	size_t srcleft, destleft, tmpbuf_used;
+ 	bool ret = TRUE;
+@@ -69,7 +67,7 @@ charset_to_utf8_try(struct charset_translation *t,
+ 	destleft = sizeof(tmpbuf);
+ 	ic_destbuf = tmpbuf;
+ 	srcleft = *src_size;
+-	ic_srcbuf = (ICONV_CONST char *) src;
++	ic_srcbuf = (char *) src;
+ 
+ 	if (iconv(t->cd, &ic_srcbuf, &srcleft,
+ 		  &ic_destbuf, &destleft) != SIZE_MAX) {
+@@ -143,5 +141,3 @@ const struct charset_utf8_vfuncs charset_iconv = {
+ 	.to_utf8_reset = iconv_charset_to_utf8_reset,
+ 	.to_utf8 = iconv_charset_to_utf8,
+ };
+-
+-#endif
+diff --git a/src/lib-charset/charset-utf8-only.c b/src/lib-charset/charset-utf8-only.c
+deleted file mode 100644
+index e8ea810b8d..0000000000
+--- a/src/lib-charset/charset-utf8-only.c
++++ /dev/null
+@@ -1,51 +0,0 @@
+-/* Copyright (c) 2002-2018 Dovecot authors, see the included COPYING file */
+-
+-#include "lib.h"
+-#include "charset-utf8-private.h"
+-
+-struct charset_translation {
+-	normalizer_func_t *normalizer;
+-};
+-
+-static int
+-utf8only_charset_to_utf8_begin(const char *charset,
+-			       normalizer_func_t *normalizer,
+-			       struct charset_translation **t_r)
+-{
+-	struct charset_translation *t;
+-
+-	if (!charset_is_utf8(charset)) {
+-		/* no support for charsets that need translation */
+-		return -1;
+-	}
+-
+-	t = i_new(struct charset_translation, 1);
+-	t->normalizer = normalizer;
+-	*t_r = t;
+-	return 0;
+-}
+-
+-static void utf8only_charset_to_utf8_end(struct charset_translation *t)
+-{
+-	i_free(t);
+-}
+-
+-static void
+-utf8only_charset_to_utf8_reset(struct charset_translation *t ATTR_UNUSED)
+-{
+-}
+-
+-static enum charset_result
+-utf8only_charset_to_utf8(struct charset_translation *t,
+-			 const unsigned char *src, size_t *src_size,
+-			 buffer_t *dest)
+-{
+-	return charset_utf8_to_utf8(t->normalizer, src, src_size, dest);
+-}
+-
+-const struct charset_utf8_vfuncs charset_utf8only = {
+-	.to_utf8_begin = utf8only_charset_to_utf8_begin,
+-	.to_utf8_end = utf8only_charset_to_utf8_end,
+-	.to_utf8_reset = utf8only_charset_to_utf8_reset,
+-	.to_utf8 = utf8only_charset_to_utf8,
+-};
+diff --git a/src/lib-charset/charset-utf8.c b/src/lib-charset/charset-utf8.c
+index 22038e5592..1ccd535586 100644
+--- a/src/lib-charset/charset-utf8.c
++++ b/src/lib-charset/charset-utf8.c
+@@ -7,11 +7,7 @@
+ 
+ #include <ctype.h>
+ 
+-#ifdef HAVE_ICONV
+ const struct charset_utf8_vfuncs *charset_utf8_vfuncs = &charset_iconv;
+-#else
+-const struct charset_utf8_vfuncs *charset_utf8_vfuncs = &charset_utf8only;
+-#endif
+ 
+ bool charset_is_utf8(const char *charset)
+ {
+-- 
+2.49.0
+

--- a/app-web/dovecot/autobuild/patches/0002-AOSCOS-fix-doc-mkcert.sh-set-default-OPENSSLCONFIG-p.patch
+++ b/app-web/dovecot/autobuild/patches/0002-AOSCOS-fix-doc-mkcert.sh-set-default-OPENSSLCONFIG-p.patch
@@ -1,0 +1,27 @@
+From dd623c917f243590835ab6f9924ec667e7dbabc8 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 5 Jun 2025 15:23:36 +0800
+Subject: [PATCH 2/2] AOSCOS: fix(doc/mkcert.sh): set default OPENSSLCONFIG
+ path at /etc/ssl/dovecot-openssl.cnf
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ doc/mkcert.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/doc/mkcert.sh b/doc/mkcert.sh
+index a82c7e66bb..b47756bd96 100644
+--- a/doc/mkcert.sh
++++ b/doc/mkcert.sh
+@@ -6,7 +6,7 @@
+ umask 077
+ OPENSSL=${OPENSSL-openssl}
+ SSLDIR=${SSLDIR-/etc/ssl}
+-OPENSSLCONFIG=${OPENSSLCONFIG-dovecot-openssl.cnf}
++OPENSSLCONFIG=${OPENSSLCONFIG-/etc/ssl/dovecot-openssl.cnf}
+ 
+ CERTDIR=$SSLDIR/certs
+ KEYDIR=$SSLDIR/private
+-- 
+2.49.0
+

--- a/app-web/dovecot/autobuild/postinst
+++ b/app-web/dovecot/autobuild/postinst
@@ -1,13 +1,2 @@
-getent group dovenull &> /dev/null || \
-    groupadd -r dovenull &> /dev/null
-getent group dovecot &> /dev/null  || \
-    groupadd -r dovecot &> /dev/null
-getent passwd dovenull &> /dev/null || \
-    useradd -s /sbin/nologin \
-    -c "Dovecot user for completely untrustworthy processes" \
-    -d /var/empty -r -g dovenull -r dovenull &> /dev/null
-getent passwd dovecot &> /dev/null  || \
-    useradd -s /sbin/nologin -c "Dovecot user" \
-    -d /var/empty -r -g dovecot -r dovecot &> /dev/null
-
+systemd-sysusers dovecot.conf
 systemd-tmpfiles --create dovecot.conf

--- a/app-web/dovecot/autobuild/prepare
+++ b/app-web/dovecot/autobuild/prepare
@@ -1,3 +1,0 @@
-sed -i 's:OPENSSLCONFIG=${OPENSSLCONFIG-dovecot-openssl.cnf}:OPENSSLCONFIG=${OPENSSLCONFIG- /etc/ssl/dovecot-openssl.cnf}:' doc/mkcert.sh
-
-chmod a-s "$SRCDIR"

--- a/app-web/dovecot/spec
+++ b/app-web/dovecot/spec
@@ -1,5 +1,4 @@
-VER=2.3.21
-REL=1
-SRCS="tbl::https://dovecot.org/releases/${VER:0:3}/dovecot-$VER.tar.gz"
-CHKSUMS="sha256::05b11093a71c237c2ef309ad587510721cc93bbee6828251549fc1586c36502d"
+VER=2.4.1
+SRCS="git::commit=tags/$VER::https://github.com/dovecot/core"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=456"


### PR DESCRIPTION
Topic Description
-----------------

- dovecot: update to 2.4.1
    - Improve scripting, refactor AUTOTOOLS_AFTER as an array.
    - Backport a patch to fix RECONF.
    - Revise a sed call in prepare as a patch.
    - Refactor getent/useradd/groupadd as systemd-sysusers configuration.
    - Track patches at AOSC-Tracking/dovecot @ aosc/2.4.1
    \(HEAD: dd623c917f243590835ab6f9924ec667e7dbabc8\).

Package(s) Affected
-------------------

- dovecot: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dovecot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
