### PR TITLE
kiwisolver: update to 1.4.8

### DIFF
--- a/lang-python/cppy/autobuild/defines
+++ b/lang-python/cppy/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=cppy
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="C++ header library for Python extension modules"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/cppy/spec
+++ b/lang-python/cppy/spec
@@ -1,0 +1,4 @@
+VER=1.3.1
+SRCS="pypi::version=${VER}::cppy"
+CHKSUMS="sha256::55b5307c11874f242ea135396f398cb67a5bbde4fab3e3c3294ea5fce43a6d68"
+CHKUPDATE="anitya::id=89055"

--- a/lang-python/kiwisolver/autobuild/defines
+++ b/lang-python/kiwisolver/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kiwisolver
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
-PKGDES="A fast implementation of the Cassowary constraint solver"
+PKGDEP="python-3"
+BUILDDEP="setuptools setuptools-scm cppy"
+PKGDES="Python implementation of the Cassowary constraint solver"

--- a/lang-python/kiwisolver/spec
+++ b/lang-python/kiwisolver/spec
@@ -1,5 +1,4 @@
-VER=1.0.1
-REL=6
+VER=1.4.8
 SRCS="tbl::https://pypi.io/packages/source/k/kiwisolver/kiwisolver-$VER.tar.gz"
-CHKSUMS="sha256::ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278"
+CHKSUMS="sha256::23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e"
 CHKUPDATE="anitya::id=16910"


### PR DESCRIPTION
Topic Description
-----------------

- cppy: new, 1.3.1
- kiwisolver: update to 1.4.8
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- cppy: 1.3.1
- kiwisolver: 1.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit cppy kiwisolver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
