### PR TITLE
libuser: drop again, orphaned

### DIFF
--- a/groups/glib-rebuilds
+++ b/groups/glib-rebuilds
@@ -97,7 +97,6 @@ runtime-electronics/libsigrokdecode
 runtime-emulation/libslirp
 runtime-multimedia/libsmf
 runtime-devices/libtifiles2
-runtime-admin/libuser
 runtime-devices/libwacom
 desktop-xfce/libxfce4util
 runtime-display/libxklavier

--- a/runtime-admin/libuser/spec
+++ b/runtime-admin/libuser/spec
@@ -1,4 +1,0 @@
-VER=0.62
-REL=3
-SRCS="tbl::https://src.fedoraproject.org/repo/pkgs/libuser/libuser-0.62.tar.xz/63e5e5c551e99dc5302b40b80bd6d4f2/libuser-0.62.tar.xz"
-CHKSUMS="sha256::a58ff4fabb01a25043b142185a33eeea961109dd60d4b40b6a9df4fa3cace20b"


### PR DESCRIPTION
Topic Description
-----------------

- libuser: drop again, orphaned
    The previous drop commit was cherry-picked from
    the python-3.14 branch. There was a peroid when
    I was rebasing that branch, a improper merge method
    was used, which led to some drop commits didn't
    clear spec files.
    Apologize for my mistake.
    Fixes: 15a5cfdbc1f8 \("libuser: drop, orphaned"\)

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
