### PR TITLE
numpy: update to 2.0.1

### DIFF
--- a/app-multimedia/aubio/autobuild/build
+++ b/app-multimedia/aubio/autobuild/build
@@ -1,3 +1,8 @@
+# Together with 0008-waf-bump-to-2.0.26.patch
+abinfo "Updating WAF ..."
+make cleanwaf
+make getwaf
+
 # FIXME: Upstream pushed FFmpeg 7.0 support but did not update its unit tests.
 abinfo "Configuring aubio ..."
 python3 "$SRCDIR"/waf configure \

--- a/app-multimedia/aubio/autobuild/patches/0008-waf-bump-to-2.0.26.patch
+++ b/app-multimedia/aubio/autobuild/patches/0008-waf-bump-to-2.0.26.patch
@@ -1,0 +1,27 @@
+From 665561fbd1230093cddc56b2b07a3073a71b5256 Mon Sep 17 00:00:00 2001
+From: Paul Brossier <piem@piem.org>
+Date: Wed, 27 Dec 2023 18:12:54 +0100
+Subject: [PATCH] [waf] bump to 2.0.26
+
+---
+ scripts/get_waf.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/get_waf.sh b/scripts/get_waf.sh
+index c7d921710514..0a40e09aa127 100755
+--- a/scripts/get_waf.sh
++++ b/scripts/get_waf.sh
+@@ -3,7 +3,7 @@
+ set -e
+ #set -x
+ 
+-WAFVERSION=2.0.14
++WAFVERSION=2.0.26
+ WAFTARBALL=waf-$WAFVERSION.tar.bz2
+ WAFURL=https://waf.io/$WAFTARBALL
+ WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/master/utils/pubkey.asc
+
+base-commit: 90bd27a23123fcc524c31787c9c8fc0ae4c79378
+-- 
+2.46.0
+

--- a/app-multimedia/aubio/autobuild/patches/0009-fix-for-numpy.patch
+++ b/app-multimedia/aubio/autobuild/patches/0009-fix-for-numpy.patch
@@ -1,0 +1,37 @@
+From 95ff046c698156f21e2ca0d1d8a02c23ab76969f Mon Sep 17 00:00:00 2001
+From: Paul Brossier <piem@piem.org>
+Date: Thu, 2 Jul 2020 11:16:13 +0200
+Subject: [PATCH] [py] add const qualifiers to ufuncs prototypes for latest
+ numpy
+
+---
+ python/ext/ufuncs.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/python/ext/ufuncs.c b/python/ext/ufuncs.c
+index d373d7258..e5641342e 100644
+--- a/python/ext/ufuncs.c
++++ b/python/ext/ufuncs.c
+@@ -3,8 +3,8 @@
+ 
+ typedef smpl_t (*aubio_unary_func_t)(smpl_t input);
+ 
+-static void aubio_PyUFunc_d_d(char **args, npy_intp *dimensions,
+-                            npy_intp* steps, void* data)
++static void aubio_PyUFunc_d_d(char **args, const npy_intp *dimensions,
++                            const npy_intp* steps, void* data)
+ {
+     npy_intp i;
+     npy_intp n = dimensions[0];
+@@ -22,8 +22,8 @@ static void aubio_PyUFunc_d_d(char **args, npy_intp *dimensions,
+     }
+ }
+ 
+-static void aubio_PyUFunc_f_f_As_d_d(char **args, npy_intp *dimensions,
+-                            npy_intp* steps, void* data)
++static void aubio_PyUFunc_f_f_As_d_d(char **args, const npy_intp *dimensions,
++                            const npy_intp* steps, void* data)
+ {
+     npy_intp i;
+     npy_intp n = dimensions[0];
+

--- a/app-multimedia/aubio/spec
+++ b/app-multimedia/aubio/spec
@@ -1,5 +1,5 @@
 VER=0.4.9
-REL=4
+REL=5
 SRCS="tbl::https://aubio.org/pub/aubio-$VER.tar.bz2"
 CHKSUMS="sha256::d48282ae4dab83b3dc94c16cf011bcb63835c1c02b515490e1883049c3d1f3da"
 CHKUPDATE="anitya::id=10301"

--- a/lang-python/beniget/autobuild/defines
+++ b/lang-python/beniget/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=beniget
+PKGSEC=python
+PKGDEP="gast"
+BUILDDEP="setuptools"
+PKGDES="A library to extract semantic information about static Python code"
+
+NOPYTHON2=1
+ABTYPE=python
+ABHOST=noarch

--- a/lang-python/beniget/spec
+++ b/lang-python/beniget/spec
@@ -1,0 +1,4 @@
+VER=0.4.2.post1
+SRCS="git::commit=tags/$VER::https://github.com/serge-sans-paille/beniget"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=91782"

--- a/lang-python/gast/autobuild/defines
+++ b/lang-python/gast/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=gast
+PKGSEC=python
+BUILDDEP="setuptools"
+PKGDES="A library providing generic AST to represent Python2 and Python3's AST"
+
+ABTYPE=python
+ABSPLITDBG=0

--- a/lang-python/gast/autobuild/defines
+++ b/lang-python/gast/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=gast
 PKGSEC=python
+PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="A library providing generic AST to represent Python2 and Python3's AST"
 
 ABTYPE=python
-ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/gast/spec
+++ b/lang-python/gast/spec
@@ -1,0 +1,4 @@
+VER=0.6.0
+SRCS="git::commit=tags/$VER::https://github.com/serge-sans-paille/gast"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=65692"

--- a/lang-python/numpy/autobuild/defines
+++ b/lang-python/numpy/autobuild/defines
@@ -1,12 +1,10 @@
 PKGNAME=numpy
 PKGSEC=python
 PKGDEP="lapack python-3 openblas"
-BUILDDEP="setuptools cython meson llvm"
+BUILDDEP="setuptools cython meson-python llvm"
 PKGDES="Scientific tools for Python"
 
-USECLANG=1
-USECLANG__LOONGSON3=0
-ABTYPE=meson
+ABTYPE=pep517
 
 NOSTATIC=0
 NOPYTHON2=1

--- a/lang-python/numpy/spec
+++ b/lang-python/numpy/spec
@@ -1,5 +1,5 @@
-VER=1.26.4
+VER=2.0.1
 SRCS="tbl::https://pypi.org/packages/source/n/numpy/numpy-$VER.tar.gz"
-CHKSUMS="sha256::2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"
+CHKSUMS="sha256::485b87235796410c3519a699cfe1faab097e509e90ebb05dcd098db2ae87e7b3"
 CHKUPDATE="anitya::id=41556"
 REL=1

--- a/lang-python/pythran/autobuild/defines
+++ b/lang-python/pythran/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=pythran
+PKGSEC=python
+PKGDEP="ply numpy gast beniget python-3"
+BUILDDEP="setuptools"
+PKGDES="An AOT compiler for a subset of the Python language"
+
+ABTYPE=pep517
+NOPYTHON2=1
+ABSPLITDBG=0
+ABHOST=noarch

--- a/lang-python/pythran/autobuild/patches/0001-Bump-gast-requirement-to-0.6.0.patch
+++ b/lang-python/pythran/autobuild/patches/0001-Bump-gast-requirement-to-0.6.0.patch
@@ -1,0 +1,81 @@
+From 95ee3af2fec54baa5bbe9b0f9368f7a74edf5de6 Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <serge.guelton@telecom-bretagne.eu>
+Date: Sat, 29 Jun 2024 19:13:02 +0200
+Subject: [PATCH] Bump gast requirement to 0.6.0
+
+This mostly helps for harmonious behavior wrt. gast.dump
+---
+ docs/TUTORIAL.rst | 8 ++++----
+ pythran/utils.py  | 2 +-
+ requirements.txt  | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/docs/TUTORIAL.rst b/docs/TUTORIAL.rst
+index 09f6902f9def..7692547eb735 100644
+--- a/docs/TUTORIAL.rst
++++ b/docs/TUTORIAL.rst
+@@ -20,7 +20,7 @@ Python ships a standard module, ``ast`` to turn Python code into an AST. For ins
+   >>> code = "a=1"
+   >>> tree = ast.parse(code)  # turn the code into an AST
+   >>> print(ast.dump(tree))  # view it as a string
+-  Module(body=[Assign(targets=[Name(id='a', ctx=Store(), annotation=None, type_comment=None)], value=Constant(value=1, kind=None), type_comment=None)], type_ignores=[])
++  Module(body=[Assign(targets=[Name(id='a', ctx=Store())], value=Constant(value=1, kind=None))])
+ 
+ Deciphering the above line, one learns that the single assignment is parsed as
+ a module containing a single statement, which is an assignment to a single
+@@ -33,7 +33,7 @@ Eventually, one needs to parse more complex codes, and things get a bit more cry
+   ...     return n if n< 2 else fib(n-1) + fib(n-2)"""
+   >>> tree = ast.parse(fib_src)
+   >>> print(ast.dump(tree))
+-  Module(body=[FunctionDef(name='fib', args=arguments(args=[Name(id='n', ctx=Param(), annotation=None, type_comment=None)], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Return(value=IfExp(test=Compare(left=Name(id='n', ctx=Load(), annotation=None, type_comment=None), ops=[Lt()], comparators=[Constant(value=2, kind=None)]), body=Name(id='n', ctx=Load(), annotation=None, type_comment=None), orelse=BinOp(left=Call(func=Name(id='fib', ctx=Load(), annotation=None, type_comment=None), args=[BinOp(left=Name(id='n', ctx=Load(), annotation=None, type_comment=None), op=Sub(), right=Constant(value=1, kind=None))], keywords=[]), op=Add(), right=Call(func=Name(id='fib', ctx=Load(), annotation=None, type_comment=None), args=[BinOp(left=Name(id='n', ctx=Load(), annotation=None, type_comment=None), op=Sub(), right=Constant(value=2, kind=None))], keywords=[]))))], decorator_list=[], returns=None, type_comment=None)], type_ignores=[])
++  Module(body=[FunctionDef(name='fib', args=arguments(args=[Name(id='n', ctx=Param())]), body=[Return(value=IfExp(test=Compare(left=Name(id='n', ctx=Load()), ops=[Lt()], comparators=[Constant(value=2, kind=None)]), body=Name(id='n', ctx=Load()), orelse=BinOp(left=Call(func=Name(id='fib', ctx=Load()), args=[BinOp(left=Name(id='n', ctx=Load()), op=Sub(), right=Constant(value=1, kind=None))]), op=Add(), right=Call(func=Name(id='fib', ctx=Load()), args=[BinOp(left=Name(id='n', ctx=Load()), op=Sub(), right=Constant(value=2, kind=None))]))))])])
+ 
+ The idea remains the same. The whole Python syntax is described in
+ http://docs.python.org/2/library/ast.html and is worth a glance, otherwise
+@@ -199,7 +199,7 @@ constant expressions. In the previous code, there is only two constant
+ 
+   >>> ce = pm.gather(analyses.ConstantExpressions, tree)
+   >>> sorted(map(ast.dump, ce))
+-  ["Attribute(value=Name(id='math', ctx=Load(), annotation=None, type_comment=None), attr='cos', ctx=Load())", 'Constant(value=3, kind=None)']
++  ["Attribute(value=Name(id='math', ctx=Load()), attr='cos', ctx=Load())", 'Constant(value=3, kind=None)']
+ 
+ One of the most critical analyse of Pythran is the points-to analysis. There
+ are two flavors of this analyse, one that computes an over-set of the aliased
+@@ -210,7 +210,7 @@ variable, and one that computes an under set. ``Aliases`` computes an over-set::
+   >>> al = pm.gather(analyses.Aliases, tree)
+   >>> returned = tree.body[-1].body[-1].value
+   >>> print(ast.dump(returned))
+-  Name(id='b', ctx=Load(), annotation=None, type_comment=None)
++  Name(id='b', ctx=Load())
+   >>> sorted(a.id for a in al[returned])
+   ['c', 'd']
+ 
+diff --git a/pythran/utils.py b/pythran/utils.py
+index 2d7a67327403..55a7e8ad6f99 100644
+--- a/pythran/utils.py
++++ b/pythran/utils.py
+@@ -106,7 +106,7 @@ def get_variable(assignable):
+     ...     slice=ast.Name('j', ast.Load(), None, None),
+     ...     ctx=ast.Load())
+     >>> ast.dump(get_variable(ref))
+-    "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
++    "Name(id='a', ctx=Load())"
+     """
+     msg = "Only name and subscript can be assigned."
+     assert isinstance(assignable, (ast.Name, ast.Subscript)), msg
+diff --git a/requirements.txt b/requirements.txt
+index fd6a738e51da..c7a25c52a16e 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,5 +1,5 @@
+ ply>=3.4
+ setuptools
+-gast~=0.5.0
++gast~=0.6.0
+ numpy
+ beniget~=0.4.0
+
+base-commit: ab9f31aca68b42a69bd87e09a635f3630b051280
+-- 
+2.46.0
+

--- a/lang-python/pythran/spec
+++ b/lang-python/pythran/spec
@@ -1,0 +1,4 @@
+VER=0.16.1
+SRCS="git::commit=tags/$VER::https://github.com/serge-sans-paille/pythran"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=21140"

--- a/lang-python/scipy/autobuild/build
+++ b/lang-python/scipy/autobuild/build
@@ -1,5 +1,0 @@
-export NPY_NUM_BUILD_JOBS="$ABTHREADS"
-
-python3 setup.py config_fc --fcompiler=gnu95 build
-python3 setup.py config_fc --fcompiler=gnu95 install \
-    --prefix=/usr --root="$PKGDIR" --optimize=1

--- a/lang-python/scipy/autobuild/defines
+++ b/lang-python/scipy/autobuild/defines
@@ -1,8 +1,17 @@
 PKGNAME=scipy
 PKGSEC=python
-PKGDEP="numpy pillow pybind11"
-BUILDDEP="setuptools"
+PKGDEP="python-3 numpy pillow pybind11"
+BUILDDEP="python-build meson meson-python cython pythran llvm"
 PKGDES="Open-source software for mathematics, science, and engineering"
 
 AB_FLAGS_SPECS=0
+ABTYPE=pep517
+ABSPLITDBG=0
+NOPYTHON2=1
+
+# scipy has to be linked with numpy (which is built with LLVM + LTO)
+USECLANG=0
+NOSTATIC=1
+
+# FIXME: GCC ICE
 NOLTO=1

--- a/lang-python/scipy/autobuild/patches/0001-Revert-MAINT-version-pins-prep-for-1.15.0rc1-22024.patch
+++ b/lang-python/scipy/autobuild/patches/0001-Revert-MAINT-version-pins-prep-for-1.15.0rc1-22024.patch
@@ -1,0 +1,92 @@
+From d76a355fb1a138a223950e5dcdff72c0d595ebf5 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 17 May 2025 16:18:31 +0800
+Subject: [PATCH 1/2] Revert "MAINT: version pins/prep for 1.15.0rc1 (#22024)"
+
+This reverts commit 31d7497817ee9f1b9e4e5efca4dd98d1cfd63075.
+---
+ ci/cirrus_wheels.yml |  2 +-
+ pyproject.toml       | 24 ++++++------------------
+ scipy/__init__.py    |  2 +-
+ 3 files changed, 8 insertions(+), 20 deletions(-)
+
+diff --git a/ci/cirrus_wheels.yml b/ci/cirrus_wheels.yml
+index 13c47373a341..f3fd39669bbe 100644
+--- a/ci/cirrus_wheels.yml
++++ b/ci/cirrus_wheels.yml
+@@ -29,7 +29,7 @@ cirrus_wheels_linux_aarch64_task:
+     - env:
+         CIBW_BUILD: cp311-manylinux* cp312-manylinux*
+   env:
+-    CIBW_PRERELEASE_PYTHONS: False
++    CIBW_PRERELEASE_PYTHONS: True
+     # The following settings are useful when targetting an unreleased Python version.
+     #CIBW_BEFORE_BUILD_LINUX: "pip install numpy>=2.0.0.dev0 meson-python cython pythran pybind11 ninja;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+     #CIBW_ENVIRONMENT: >
+diff --git a/pyproject.toml b/pyproject.toml
+index 0cf5122d8545..1f5f21724ce4 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -17,19 +17,10 @@
+ [build-system]
+ build-backend = 'mesonpy'
+ requires = [
+-    # The upper bound on meson-python is pre-emptive only (looser
+-    # on purpose, since chance of breakage in 0.18/0.19 is low with
+-    # 0.17.1 working at time of writing)
+-    "meson-python>=0.15.0,<0.20.0",
+-    # we need at least Cython 3.1.0a1 for free-threaded CPython;
+-    # for other CPython versions, the regular pre-emptive
+-    # Cython version bounds policy applies
+-    "Cython>=3.0.8,<3.1.0",
+-    # The upper bound on pybind11 is pre-emptive only
+-    "pybind11>=2.13.2,<2.14.0",     # when updating version, also update check in scipy/meson.build
+-    # The upper bound on pythran is pre-emptive only; 0.17.0
+-    # is released/working at time of writing
+-    "pythran>=0.14.0,<0.18.0",
++    "meson-python>=0.15.0",
++    "Cython>=3.0.8",        # when updating version, also update check in meson.build
++    "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
++    "pythran>=0.14.0",
+ 
+     # numpy requirement for wheel builds for distribution on PyPI - building
+     # against 2.x yields wheels that are also compatible with numpy 1.x at
+@@ -37,8 +28,7 @@ requires = [
+     # Note that building against numpy 1.x works fine too - users and
+     # redistributors can do this by installing the numpy version they like and
+     # disabling build isolation.
+-    # NOTE: need numpy>=2.1.3 for free-threaded CPython 3.13 support
+-    "numpy>=2.0.0,<2.5",
++    "numpy>=2.0.0rc1",
+ ]
+ 
+ [project]
+@@ -56,9 +46,7 @@ maintainers = [
+ #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
+ requires-python = ">=3.10"
+ dependencies = [
+-    # free-threaded CPython 3.13 support requires more
+-    # recent NumPy release at runtime (>=2.1.3)
+-    "numpy>=1.23.5,<2.5",
++    "numpy>=1.23.5",
+ ] # keep in sync with `min_numpy_version` in meson.build
+ readme = "README.rst"
+ classifiers = [
+diff --git a/scipy/__init__.py b/scipy/__init__.py
+index d17c59d80a8e..2e001cfc1359 100644
+--- a/scipy/__init__.py
++++ b/scipy/__init__.py
+@@ -67,7 +67,7 @@ del _distributor_init
+ from scipy._lib import _pep440
+ # In maintenance branch, change to np_maxversion N+3 if numpy is at N
+ np_minversion = '1.23.5'
+-np_maxversion = '2.5.0'
++np_maxversion = '9.9.99'
+ if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
+         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
+     import warnings
+
+base-commit: e29dcb65a2040f04819b426a04b60d44a8f69c04
+-- 
+2.49.0
+

--- a/lang-python/scipy/autobuild/patches/0002-AOSCOS-Replace-I-with-_Complex_I.patch
+++ b/lang-python/scipy/autobuild/patches/0002-AOSCOS-Replace-I-with-_Complex_I.patch
@@ -1,0 +1,28 @@
+From ed8032c0f1c13b349c4918e7835c5bc42db40369 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 17 May 2025 16:31:20 +0800
+Subject: [PATCH 2/2] AOSCOS: Replace I with _Complex_I
+
+idk why it fixed the build
+---
+ scipy/linalg/_matfuncs_expm.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scipy/linalg/_matfuncs_expm.c b/scipy/linalg/_matfuncs_expm.c
+index 9e9b004758be..960f06dee915 100644
+--- a/scipy/linalg/_matfuncs_expm.c
++++ b/scipy/linalg/_matfuncs_expm.c
+@@ -13,8 +13,8 @@
+     #include <complex.h>
+     #define EXPM_Z double complex
+     #define EXPM_C float complex
+-    #define CPLX_Z(real, imag) (real + imag*I)
+-    #define CPLX_C(real, imag) (real + imag*I)
++    #define CPLX_Z(real, imag) (real + imag * _Complex_I)
++    #define CPLX_C(real, imag) (real + imag * _Complex_I)
+ #endif
+ 
+ 
+-- 
+2.49.0
+

--- a/lang-python/scipy/autobuild/prepare
+++ b/lang-python/scipy/autobuild/prepare
@@ -1,7 +1,7 @@
 unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
 export CFLAGS="-fPIC"
 export CXXFLAGS="-fPIC"
-export LDFLAGS="-Wall -shared -fno-lto -fPIC"
+export LDFLAGS="-Wall -fno-lto -fPIC"
 export FFLAGS="-fPIC"
 
 ln -sv /usr/bin/ld.bfd "$SRCDIR"/ld

--- a/lang-python/scipy/spec
+++ b/lang-python/scipy/spec
@@ -1,5 +1,4 @@
-VER=1.6.3
-SRCS="tbl::https://github.com/scipy/scipy/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::6cdb9d3aabe46c1602d9fd2f34812700068eddfe3ffd1dafcbd7e7960a874e1c"
+VER=1.15.3
+SRCS="git::commit=tags/v${VER}::https://github.com/scipy/scipy"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4768"
-REL=1

--- a/runtime-common/boost/autobuild/patches/0004-Support-numpy-2.0.0b1.patch
+++ b/runtime-common/boost/autobuild/patches/0004-Support-numpy-2.0.0b1.patch
@@ -1,0 +1,28 @@
+From 0474de0f6cc9c6e7230aeb7164af2f7e4ccf74bf Mon Sep 17 00:00:00 2001
+From: Alexis DUBURCQ <alexis.duburcq@gmail.com>
+Date: Fri, 15 Mar 2024 14:10:16 +0100
+Subject: [PATCH] Support numpy 2.0.0b1
+
+---
+ src/numpy/dtype.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libs/python/src/numpy/dtype.cpp b/libs/python/src/numpy/dtype.cpp
+index 88a20a27b5..da30d1927b 100644
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -98,7 +98,13 @@ python::detail::new_reference dtype::convert(object const & arg, bool align)
+   return python::detail::new_reference(reinterpret_cast<PyObject*>(obj));
+ }
+ 
+-int dtype::get_itemsize() const { return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;}
++int dtype::get_itemsize() const {
++#if NPY_ABI_VERSION < 0x02000000
++  return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;
++#else
++  return PyDataType_ELSIZE(reinterpret_cast<PyArray_Descr*>(ptr()));
++#endif
++}
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+     // On Windows x64, the behaviour described on 


### PR DESCRIPTION
Topic Description
-----------------

- beniget: new, 0.4.2.post1
- gast: add missing setuptools-python2 build dependency
- gast: new, 0.6.0
- pythran: new, 0.16.1
- aubio: fix for latest numpy
- boost: support numpy 2.0.0b1
- scipy: update to 1.15.3
- numpy: update to 2.0.1
    - Update to 2.0.1.
    - Ship debuginfo.
- libuser: drop again, orphaned
    The previous drop commit was cherry-picked from
    the python-3.14 branch. There was a peroid when
    I was rebasing that branch, a improper merge method
    was used, which led to some drop commits didn't
    clear spec files.
    Apologize for my mistake.
    Fixes: 15a5cfdbc1f8 \("libuser: drop, orphaned"\)

Package(s) Affected
-------------------

- aubio: 0.4.9-5
- beniget: 0.4.2.post1
- boost: 1:1.83.0-6
- gast: 0.6.0
- numpy: 2.0.1-1
- pythran: 0.16.1
- scipy: 1.15.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gast beniget pythran numpy scipy aubio boost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
