### PR TITLE
syncthing: update to 1.29.7

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,5 @@
-VER=1.29.6
+VER=1.29.7
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::28e7f4984a6a34fb4697448141ce2611a6510f5a4369c1669d4e766eb75cd878"
+CHKSUMS="sha256::7b29b2bb1fb85adf6f3baf120ff725a19b06ed13b95011fe67dd952349e0e212"
 CHKUPDATE="anitya::id=11814"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 1.29.7
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- syncthing: 1.29.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
