### PR TITLE
Revert "qownnotes: update to 25.6.0"

### DIFF
--- a/app-web/qownnotes/spec
+++ b/app-web/qownnotes/spec
@@ -1,4 +1,4 @@
-VER=25.6.0
-SRCS="tbl::https://github.com/pbek/QOwnNotes/releases/download/v$VER/qownnotes-$VER.tar.xz"
-CHKSUMS="sha256::4545bc7d63c9c53abb61afae67ac4683b5111dcfa88ee06cf60fbe517acaf48d"
+VER=22.6.1
+SRCS="tbl::https://download.tuxfamily.org/qownnotes/src/qownnotes-$VER.tar.xz"
+CHKSUMS="sha256::c5b2075d42298d28f901ad2df8eb65f5a61aa59727fae9eeb1f92dac1b63d8ba"
 CHKUPDATE="anitya::id=27552"


### PR DESCRIPTION
Topic Description
-----------------

- Revert "qownnotes: update to 25.6.0"
    This reverts commit 3384f55351f9b2abe8ae8660e27b53fa203e8be4, which was
    picked by mistake.

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
