### PR TITLE
vscode: allow users to modify electron flags

### DIFF
--- a/app-editors/vscode/autobuild/overrides/usr/bin/vscode
+++ b/app-editors/vscode/autobuild/overrides/usr/bin/vscode
@@ -1,4 +1,12 @@
 #!/bin/sh -e
 
 nanny -n vscode -a VSCodium -k vscodium -d "Visual Studio Code" -l "https://code.visualstudio.com/license"
-/usr/lib/vscode/bin/code "$@"
+
+VSCODE_USER_FLAGS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/Code/user-flags.conf"
+
+# Allow users to override command-line options
+if [[ -f "${VSCODE_USER_FLAGS_FILE}" ]]; then
+   VSCODE_USER_FLAGS=$(grep -v '^#' "$VSCODE_USER_FLAGS_FILE")
+fi
+
+/usr/lib/vscode/bin/code $VSCODE_USER_FLAGS "$@"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: allow users to modify electron flags

Package(s) Affected
-------------------

- vscode: 1.100.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
