### PR TITLE
gcc-13: update to 13.4.0

### DIFF
--- a/app-devel/gcc-13/spec
+++ b/app-devel/gcc-13/spec
@@ -1,7 +1,6 @@
-VER=13.3.0
+VER=13.4.0
 SRCS="https://sourceware.org/pub/gcc/releases/gcc-${VER}/gcc-${VER}.tar.xz"
-CHKSUMS="sha256::0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083"
+CHKSUMS="sha256::9c4ce6dbb040568fdc545588ac03c5cbc95a8dbf0c7aa490170843afb59ca8f5"
 # NOTE: Pinning the major version number to 13. The non-capturing group
 #       is meant to strictly match the GCC release tags.
 CHKUPDATE="git::url=https://gcc.gnu.org/git/gcc.git;pattern=(?:releases/gcc-)(13\\.\\d+\\.\\d+)"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- gcc-13: update to 13.4.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gcc-13: 13.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc-13
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
