### PR TITLE
easytier: update to 2.3.1

### DIFF
--- a/app-network/easytier/autobuild/patches/0001-optimize-easytier-web-features.patch
+++ b/app-network/easytier/autobuild/patches/0001-optimize-easytier-web-features.patch
@@ -1,4 +1,4 @@
-From 6fe5e190c5a46d7c44c160e96bbe2ed945dc4718 Mon Sep 17 00:00:00 2001
+From 1771b5c478043f2661ace79b1d37acea402fef16 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Wed, 23 Apr 2025 14:13:24 +0800
 Subject: [PATCH 1/2] optimize easytier-web features
@@ -9,7 +9,7 @@ This commit makes --no-default-features in virtual manifest take effect.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/easytier-web/Cargo.toml b/easytier-web/Cargo.toml
-index 12bbcee..8deb47c 100644
+index 90de5c8..477b92f 100644
 --- a/easytier-web/Cargo.toml
 +++ b/easytier-web/Cargo.toml
 @@ -5,7 +5,7 @@ edition = "2021"

--- a/app-network/easytier/autobuild/patches/0002-build-remove-linker-configuration-for-aarch64-unknow.patch
+++ b/app-network/easytier/autobuild/patches/0002-build-remove-linker-configuration-for-aarch64-unknow.patch
@@ -1,4 +1,4 @@
-From 92b569628b60d1e58f8a7af10b023d9388d333d1 Mon Sep 17 00:00:00 2001
+From 7af74755c3e2432065c7ea1fd8c616d668248d77 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Tue, 22 Apr 2025 15:34:56 +0800
 Subject: [PATCH 2/2] build: remove linker configuration for
@@ -14,7 +14,7 @@ Signed-off-by: Qing Yun <kf@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/.cargo/config.toml b/.cargo/config.toml
-index c6749ca..b505e54 100644
+index a92f80e..0797b06 100644
 --- a/.cargo/config.toml
 +++ b/.cargo/config.toml
 @@ -2,9 +2,6 @@
@@ -25,7 +25,7 @@ index c6749ca..b505e54 100644
 -linker = "aarch64-linux-gnu-gcc"
 -
  [target.aarch64-unknown-linux-musl]
- linker = "aarch64-linux-musl-gcc"
+ linker = "aarch64-unknown-linux-musl-gcc"
  rustflags = ["-C", "target-feature=+crt-static"]
 -- 
 2.49.0

--- a/app-network/easytier/spec
+++ b/app-network/easytier/spec
@@ -1,4 +1,4 @@
-VER=2.3.0
+VER=2.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/EasyTier/EasyTier"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377832"


### PR DESCRIPTION
Topic Description
-----------------

- easytier: update to 2.3.1
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- easytier: 2.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit easytier
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
