### PR TITLE
gdu: update to 5.31.0

### DIFF
--- a/app-utils/gdu/autobuild/build
+++ b/app-utils/gdu/autobuild/build
@@ -1,5 +1,0 @@
-# autobuild4's go template cannot specify a specific directory
-# to run `go get`
-abinfo "Building gdu ..."
-GOBIN="$PKGDIR/usr/bin/" \
-    ab_go_build "$SRCDIR"/cmd/gdu

--- a/app-utils/gdu/autobuild/defines
+++ b/app-utils/gdu/autobuild/defines
@@ -4,4 +4,11 @@ PKGDES="A CLI disk usage analyzer"
 PKGDEP="gcc-runtime"
 BUILDDEP="go"
 
-ABSPLITDBG=0
+ABTYPE=gomod
+
+GO_PACKAGES=("cmd/gdu")
+GO_LDFLAGS=(
+    "-X github.com/dundee/gdu/v5/build.Version=$PKGVER"
+    "-X github.com/dundee/gdu/v5/build.Time=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
+    "-X github.com/dundee/gdu/v5/build.User=AOSC"
+)

--- a/app-utils/gdu/autobuild/prepare
+++ b/app-utils/gdu/autobuild/prepare
@@ -1,9 +1,0 @@
-abinfo "Getting build time ..."
-DATE=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
-
-abinfo "Setting GO_LDFLAGS ..."
-GO_LDFLAGS+=(
-    "-X 'github.com/dundee/gdu/v5/build.Version=$PKGVER'"
-    "-X 'github.com/dundee/gdu/v5/build.Time=$DATE'"
-    "-X 'github.com/dundee/gdu/v5/build.User=AOSC'"
-)

--- a/app-utils/gdu/spec
+++ b/app-utils/gdu/spec
@@ -1,4 +1,4 @@
-VER=5.30.1
+VER=5.31.0
 SRCS="git::commit=tags/v$VER::https://github.com/dundee/gdu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141586"


### PR DESCRIPTION
Topic Description
-----------------

- gdu: update to 5.31.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- gdu: 5.31.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
