### PR TITLE
qutebrowser: update to 3.5.1+pdfjs5.3.31

### DIFF
--- a/app-web/qutebrowser/spec
+++ b/app-web/qutebrowser/spec
@@ -1,11 +1,11 @@
-_QUTEBROWSER_VER=3.5.0
+UPSTREAM_VER=3.5.1
 # NOTE: Find the latest pdf.js version in
 # https://github.com/mozilla/pdf.js/releases
-_PDFJS_VER=5.1.91
-VER=${_QUTEBROWSER_VER}+pdfjs${_PDFJS_VER}
-SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$_QUTEBROWSER_VER/qutebrowser-$_QUTEBROWSER_VER.tar.gz \
-      file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$_PDFJS_VER/pdfjs-$_PDFJS_VER-dist.zip"
-CHKSUMS="sha256::fa142c8d1c2825b068b71b3604a8b2d682e2ed84a14c3e68b6de7844331d80bb \
-         sha256::a8378a45f0929496be79bfbf1a472c44c198243b055696fd892d62d14131a140"
-SUBDIR="qutebrowser-$_QUTEBROWSER_VER"
+PDFJS_VER=5.3.31
+VER=${UPSTREAM_VER}+pdfjs${PDFJS_VER}
+SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$UPSTREAM_VER/qutebrowser-$UPSTREAM_VER.tar.gz \
+      file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$PDFJS_VER/pdfjs-$PDFJS_VER-dist.zip"
+CHKSUMS="sha256::826bba328a08357248d5e5a86faab0a73655497439ad54d269e212055926b38e \
+         sha256::65fbef25ea90e3e4c0ab632da87022ca2099af0c394e94447843c61181dea190"
+SUBDIR="qutebrowser-$UPSTREAM_VER"
 CHKUPDATE="anitya::id=9759"


### PR DESCRIPTION
Topic Description
-----------------

- qutebrowser: update to 3.5.1+pdfjs5.3.31
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- qutebrowser: 3.5.1+pdfjs5.3.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit qutebrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
