### PR TITLE
lua-5.4: update to 5.4.8

### DIFF
--- a/lang-lua/lua-5.4/autobuild/patches/0001-lua-5.4-dyn-linkage.patch
+++ b/lang-lua/lua-5.4/autobuild/patches/0001-lua-5.4-dyn-linkage.patch
@@ -23,7 +23,7 @@ diff -Naur lua-5.4.7/Makefile lua-5.4.7.modded/Makefile
  
 +# Lua version and release.
 +V= 5.4
-+R= $V.7
++R= $V.8
 +
  # What to install.
 -TO_BIN= lua luac
@@ -34,7 +34,7 @@ diff -Naur lua-5.4.7/Makefile lua-5.4.7.modded/Makefile
  
 -# Lua version and release.
 -V= 5.4
--R= $V.7
+-R= $V.8
 -
  # Targets start here.
  all:	$(PLAT)

--- a/lang-lua/lua-5.4/spec
+++ b/lang-lua/lua-5.4/spec
@@ -1,5 +1,4 @@
-VER=5.4.7
-REL=1
+VER=5.4.8
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
-CHKSUMS="sha256::9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30"
+CHKSUMS="sha256::4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae"
 CHKUPDATE="anitya::id=328514"


### PR DESCRIPTION
Topic Description
-----------------

- lua-5.4: update to 5.4.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lua-5.4: 5.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit lua-5.4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
