### PR TITLE
webkit2gtk: add libwebkit2gtk-4.0-37 spiral alias

### DIFF
--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -62,3 +62,6 @@ PKGBREAK="gnome-online-accounts<=3.40.0 devhelp<=40.1 \
 
 # Disable LTO due to OOM.
 NOLTO__LOONGSON3=1
+
+# Note: Extra Provides for Spiral (Debian compatibility).
+PKGPROV="libwebkit2gtk-4.0-37_spiral"

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -4,4 +4,4 @@ CHKSUMS="sha256::523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"
-REL=5
+REL=6


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: add libwebkit2gtk-4.0-37 spiral alias

Package(s) Affected
-------------------

- webkit2gtk: 2.44.2-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
