### PR TITLE
amberol: new, 2025.1

### DIFF
--- a/app-multimedia/amberol/autobuild/defines
+++ b/app-multimedia/amberol/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=amberol
+PKGSEC=sound
+PKGDEP="gcc-runtime gdk-pixbuf glib glibc graphene gstreamer gtk-4 libadwaita pango gtk-update-icon-cache"
+BUILDDEP="llvm rustc"
+PKGDES="Sound and music player with playlist functionality"
+
+ABTYPE=meson
+
+# FIXME: ld.lld not yet available on loongson3
+NOLTO__LOONGSON3=1

--- a/app-multimedia/amberol/spec
+++ b/app-multimedia/amberol/spec
@@ -1,0 +1,4 @@
+VER=2025.1
+SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/World/amberol.git/"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=352876"


### PR DESCRIPTION
Topic Description
-----------------

- amberol: new, 2025.1

Package(s) Affected
-------------------

- amberol: 2025.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit amberol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
