### PR TITLE
fcitx5-chinese-addons: fix crashing on loongson3 (fix qt-6: nowebengine dependency geoclue => geoclue2)

### DIFF
--- a/app-i18n/fcitx5-chinese-addons/autobuild/patches/0001-check-file-descriptor-before-using-user.history-file.patch
+++ b/app-i18n/fcitx5-chinese-addons/autobuild/patches/0001-check-file-descriptor-before-using-user.history-file.patch
@@ -1,0 +1,27 @@
+From 3f3fc052aa1a97411e3a1b90910a282dd6dad9ac Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sat, 7 Jun 2025 16:40:02 +0800
+Subject: [PATCH] check file descriptor before using user.history file
+
+On Loongson3, exceptions thrown by Boost cannot be caught by catch here.
+---
+ im/pinyin/pinyin.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/im/pinyin/pinyin.cpp b/im/pinyin/pinyin.cpp
+index fa92040..e83dba0 100644
+--- a/im/pinyin/pinyin.cpp
++++ b/im/pinyin/pinyin.cpp
+@@ -726,6 +726,10 @@ PinyinEngine::PinyinEngine(Instance *instance)
+         auto file = standardPath.openUser(StandardPath::Type::PkgData,
+                                           "pinyin/user.history", O_RDONLY);
+
++        if (file.fd() < 0) {
++            break;
++        }
++
+         try {
+             boost::iostreams::stream_buffer<
+                 boost::iostreams::file_descriptor_source>
+--
+2.43.0

--- a/app-i18n/fcitx5-chinese-addons/spec
+++ b/app-i18n/fcitx5-chinese-addons/spec
@@ -1,4 +1,5 @@
 VER=5.1.8
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-chinese-addons \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5-chinese-addons/fcitx5-chinese-addons-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \

--- a/runtime-desktop/qt-6/01-runtime/defines
+++ b/runtime-desktop/qt-6/01-runtime/defines
@@ -23,7 +23,7 @@ BUILDDEP__PPC64EL="${BUILDDEP__NOWEBENGINE}"
 BUILDDEP__RISCV64="${BUILDDEP__NOWEBENGINE}"
 
 PKGDEP__NOWEBENGINE="alsa-lib bluez cups dbus desktop-file-utils
-        double-conversion fontconfig geoclue gst-plugins-base-1-0 glib \
+        double-conversion fontconfig geoclue2 gst-plugins-base-1-0 glib \
         harfbuzz hicolor-icon-theme hyphen icu libb2 libdrm libinput \
         libglvnd libjpeg-turbo libmng libpng libproxy libxkbcommon libxslt \
         mesa pcre2 perl protobuf pulseaudio re2 snappy sqlite srtp systemd \

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=5
+REL=6
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::659d8bb5931afac9ed5d89a78e868e6bd00465a58ab566e2123db02d674be559"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-chinese-addons: fix crashing on loongson3
- qt-6: fix nowebengine dependency geoclue => geoclue2

Package(s) Affected
-------------------

- fcitx5-chinese-addons: 1:5.1.8-1
- qt-6: 6.8.2-6
- qt-6-doc: 6.8.2-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6 fcitx5-chinese-addons
```

Test Build(s) Done
------------------

