### PR TITLE
miniupnpc: use a custom build script instead of plainmake

### DIFF
--- a/app-network/miniupnpc/autobuild/build
+++ b/app-network/miniupnpc/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing miniupnpc ..."
+make install DESTDIR="$PKGDIR"

--- a/app-network/miniupnpc/autobuild/defines
+++ b/app-network/miniupnpc/autobuild/defines
@@ -1,10 +1,6 @@
 PKGNAME=miniupnpc
 PKGSEC=net
 PKGDEP="glibc"
-PKGDES="A small UPnP client library/tool to access Internet Gateway Devices"
-
-ABTYPE=plainmake
-MAKE_INSTALL_DEF=""
-MAKE_AFTER="DESTDIR=$PKGDIR PREFIX=/usr"
+PKGDES="UPnP client library/tool to access Internet Gateway Devices"
 
 PKGBREAK="0ad<=0.0.20 dante<=1.4.1-4 dolphin-emu<=5.0"

--- a/app-network/miniupnpc/autobuild/patches/0001-AOSCOS-remove-gzip-compress-for-man-page.patch
+++ b/app-network/miniupnpc/autobuild/patches/0001-AOSCOS-remove-gzip-compress-for-man-page.patch
@@ -1,0 +1,27 @@
+From 82ddf7955970f6d692cb79aa1b57c3c07353b5d7 Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Sat, 7 Jun 2025 20:51:30 +0800
+Subject: [PATCH] AOSCOS: remove gzip compress for man page
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9028345..6da8321 100644
+--- a/Makefile
++++ b/Makefile
+@@ -252,9 +252,6 @@ endif
+ ifeq (, $(findstring amiga, $(OS)))
+ 	$(INSTALL) -d $(DESTDIR)$(INSTALLDIRMAN)/man3
+ 	$(INSTALL) -m 644 man3/miniupnpc.3 $(DESTDIR)$(INSTALLDIRMAN)/man3/miniupnpc.3
+-ifneq (, $(findstring linux, $(OS)))
+-	gzip -f $(DESTDIR)$(INSTALLDIRMAN)/man3/miniupnpc.3
+-endif
+ endif
+ 
+ install-static:	updateversion $(FILESTOINSTALL)
+-- 
+2.49.0
+

--- a/app-network/miniupnpc/spec
+++ b/app-network/miniupnpc/spec
@@ -1,5 +1,5 @@
 VER=2.1
-REL=4
+REL=5
 SRCS="tbl::http://miniupnp.free.fr/files/miniupnpc-$VER.tar.gz"
 CHKSUMS="sha256::e19fb5e01ea5a707e2a8cb96f537fbd9f3a913d53d804a3265e3aeab3d2064c6"
 CHKUPDATE="anitya::id=1986"


### PR DESCRIPTION
Topic Description
-----------------

- miniupnpc: use a custom build script instead of plainmake
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- miniupnpc: 2.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit miniupnpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
