### PR TITLE
telegram-desktop: update to 5.15.2

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 413eae03b9baeee2d9b6f7c5902e984dc158e5ad Mon Sep 17 00:00:00 2001
+From 0907ec76929eea9344f42dc1abdc8aa00c5a6ec1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 01/11] fix(window.style): set default window width to 360px
+Subject: [PATCH 01/12] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From 5527c0062917b0c3291897f3f6e366f82209a083 Mon Sep 17 00:00:00 2001
+From 804c01bc1141a54a9242807172032684b793fd6c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 02/11] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 02/12] fix(core_settings.h): use system window decoration by
  default
 
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From bd8663361e6db457a491bca4deb5112fccdb6681 Mon Sep 17 00:00:00 2001
+From 3faf9eafe509dcca0e8e70606d43143843e5c6c3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 03/11] fix(ui): fix build with Qt 5
+Subject: [PATCH 03/12] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From 2e8a56b78e81f8254f187d8bedccfd89943677f5 Mon Sep 17 00:00:00 2001
+From 5687b6d46bb4f5072564883c3a376ec41bd9b2a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 04/11] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 04/12] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,7 +1,7 @@
-From 8a4bc213ef6610c4edd7461721a6c19f62cad793 Mon Sep 17 00:00:00 2001
+From 82876ae01a4773b39aecb3054708ecf4edc21b89 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 05/11] fix(settings): use system fonts by default
+Subject: [PATCH 05/12] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 3ca78271d6938129d09c7b0583982b4d7c6f50b9 Mon Sep 17 00:00:00 2001
+From e03e032616dc4deaa1ec53f9f2c3ae7f07cdd2b9 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 06/11] Remove the confusing "Default" option from selectable
+Subject: [PATCH 06/12] Remove the confusing "Default" option from selectable
  fonts
 
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From 460a485b3810c008dea2ac8b7e6715e996d76674 Mon Sep 17 00:00:00 2001
+From 57382b3de36525a5d3397d4f50997efe7e2195a2 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 07/11] fix(lib_tl): add missing cstring include
+Subject: [PATCH 07/12] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From e4a332ecd1a1d7ae35c2f989afb18555a57e45ee Mon Sep 17 00:00:00 2001
+From c58576dc4d66283be00f3fcf0c1cade77db17121 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 08/11] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 08/12] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,7 +1,7 @@
-From 5015169700060e3284888be438947ec4fde53c53 Mon Sep 17 00:00:00 2001
+From 41a0751146704a0bbaf838efa34c901eedbf78fd Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
-Subject: [PATCH 09/11] fix(current_geo_location_linux): add missing
+Subject: [PATCH 09/12] fix(current_geo_location_linux): add missing
  QGuiApplication include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,7 +1,7 @@
-From e6677a50e8c9b82f9436d3d584f0134dedf643a6 Mon Sep 17 00:00:00 2001
+From 618c9562e5511dab500efb2b8226951b7f482345 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
-Subject: [PATCH 10/11] fix(core_settings.h): enable video hardware
+Subject: [PATCH 10/12] fix(core_settings.h): enable video hardware
  acceleration by default
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,7 +1,7 @@
-From 13ef1a4b7a30ea73bd89cbf5c129f9f253a50036 Mon Sep 17 00:00:00 2001
+From 536c7a090af56fd77288176eff437405d12d3712 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
-Subject: [PATCH 11/11] fix(cmake): disable CMP0160 to workaround KF5 cmake
+Subject: [PATCH 11/12] fix(cmake): disable CMP0160 to workaround KF5 cmake
  errors
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 36e54053d7..23f8e77e00 100644
+index fc7b239b03..d9f278a357 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -6,6 +6,12 @@

--- a/app-web/telegram-desktop/autobuild/patches/0012-BACKPORT-Add-missing-conditionals-to-the-kimageforma.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-BACKPORT-Add-missing-conditionals-to-the-kimageforma.patch
@@ -1,0 +1,59 @@
+From 93857b2bb8e7657cfe7d1f8c7bae0ded3ab8774f Mon Sep 17 00:00:00 2001
+From: Ilya Fedin <fedin-ilja2010@ya.ru>
+Date: Fri, 6 Jun 2025 03:16:41 +0000
+Subject: [PATCH 12/12] BACKPORT: Add missing conditionals to the kimageformats
+ initializer
+
+Link: https://github.com/desktop-app/cmake_helpers/pull/413
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../qt_static_plugins/kimageformats/CMakeLists.txt | 14 ++++++++++++++
+ .../qt/qt_static_plugins/kimageformats/init.cpp    |  6 ++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/cmake/external/qt/qt_static_plugins/kimageformats/CMakeLists.txt b/cmake/external/qt/qt_static_plugins/kimageformats/CMakeLists.txt
+index 499f5ad783..bb54fcb14f 100644
+--- a/cmake/external/qt/qt_static_plugins/kimageformats/CMakeLists.txt
++++ b/cmake/external/qt/qt_static_plugins/kimageformats/CMakeLists.txt
+@@ -134,6 +134,20 @@ PRIVATE
+     desktop-app::external_qt
+ )
+ 
++if (DESKTOP_APP_USE_PACKAGED OR LINUX)
++    if (NOT libavif_FOUND AND NOT DESKTOP_APP_AVIF_FOUND)
++        target_compile_definitions(external_qt_static_plugins_kimageformats_init PRIVATE QT_STATIC_PLUGINS_DISABLE_AVIF)
++    endif()
++
++    if (NOT libheif_FOUND)
++        target_compile_definitions(external_qt_static_plugins_kimageformats_init PRIVATE QT_STATIC_PLUGINS_DISABLE_HEIF)
++    endif()
++
++    if (NOT DESKTOP_APP_JXL_FOUND)
++        target_compile_definitions(external_qt_static_plugins_kimageformats_init PRIVATE QT_STATIC_PLUGINS_DISABLE_JXL)
++    endif()
++endif()
++
+ target_link_libraries(external_qt_static_plugins_kimageformats
+ INTERFACE
+     external_qt_static_plugins_kimageformats_init
+diff --git a/cmake/external/qt/qt_static_plugins/kimageformats/init.cpp b/cmake/external/qt/qt_static_plugins/kimageformats/init.cpp
+index b6a1859552..42d55938ff 100644
+--- a/cmake/external/qt/qt_static_plugins/kimageformats/init.cpp
++++ b/cmake/external/qt/qt_static_plugins/kimageformats/init.cpp
+@@ -7,7 +7,13 @@ https://github.com/desktop-app/legal/blob/master/LEGAL
+ */
+ #include <QtCore/QtPlugin>
+ 
++#ifndef QT_STATIC_PLUGINS_DISABLE_AVIF
+ Q_IMPORT_PLUGIN(QAVIFPlugin)
++#endif // !QT_STATIC_PLUGINS_DISABLE_AVIF
++#ifndef QT_STATIC_PLUGINS_DISABLE_HEIF
+ Q_IMPORT_PLUGIN(HEIFPlugin)
++#endif // !QT_STATIC_PLUGINS_DISABLE_HEIF
++#ifndef QT_STATIC_PLUGINS_DISABLE_JXL
+ Q_IMPORT_PLUGIN(QJpegXLPlugin)
++#endif // !QT_STATIC_PLUGINS_DISABLE_JXL
+ Q_IMPORT_PLUGIN(QOIPlugin)
+-- 
+2.49.0
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=5.14.3
+VER=5.15.2
 # Update tg_owt to the latest Git snapshot when updating Telegram Desktop
 OWTVER=232ec410502e773024e8d83cfae83a52203306c0
 TDLIBVER=51743dfd01dff6179e2d8f7095729caa4e2222e9
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::af15716f053403dc42233775e931a711759c8f0468a0aff5f3dfabdf98bf6861 \
+CHKSUMS="sha256::96c09b5c6831279c8d7fdfc3a04728d5a9294b8b26f4d96c6ac6984d10351870 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.15.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
