### PR TITLE
lazygit: update to 0.52.0

### DIFF
--- a/app-vcs/lazygit/spec
+++ b/app-vcs/lazygit/spec
@@ -1,5 +1,4 @@
-VER=0.48.0
-REL=1
+VER=0.52.0
 SRCS="git::commit=tags/v$VER::https://github.com/jesseduffield/lazygit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268930"


### PR DESCRIPTION
Topic Description
-----------------

- lazygit: update to 0.52.0
    Co-authored-by: purofle \(@purofle\) <purofle@gmail.com>

Package(s) Affected
-------------------

- lazygit: 0.52.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lazygit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
