### PR TITLE
libva-nvidia-driver: update to 0.0.14

### DIFF
--- a/runtime-multimedia/libva-nvidia-driver/spec
+++ b/runtime-multimedia/libva-nvidia-driver/spec
@@ -1,5 +1,4 @@
-VER=0.0.13
-REL=2
+VER=0.0.14
 SRCS="git::commit=tags/v$VER::https://github.com/elFarto/nvidia-vaapi-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242346"


### PR DESCRIPTION
Topic Description
-----------------

- libva-nvidia-driver: update to 0.0.14
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libva-nvidia-driver: 0.0.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit libva-nvidia-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
