### PR TITLE
fcitx5-pinyin-moegirl: update to 20250609

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250509
+VER=20250609
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::334a2ab85a11e3821163776f4e3a59e3cb514e2f8e3fe1aa31f6f9b1d51cbab6
-         sha256::2ed7b5c6381aca146b930d519010b2f848adcec45bc0586d62b8654ea6cebed0
+CHKSUMS="sha256::614af5a1bbb0b1ef17658e0270d5293e0d0718f56353b6e6ccc7980584984bdf
+         sha256::66bcbbe2af7872ea41c471314ef5124bfb05e95a7c2db00b85a121887110ed46
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: upgrade to 20250609

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250609
- rime-pinyin-moegirl: 20250609

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
