### PR TITLE
xray: update to 25.6.8

### DIFF
--- a/app-network/xray/autobuild/defines
+++ b/app-network/xray/autobuild/defines
@@ -4,8 +4,8 @@ PKGDES="V2Ray with XTLS support"
 PKGDEP="glibc v2ray-rules-dat"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols
-# from Go executables.
-ABSPLITDBG=0
 ABTYPE=gomod
 GO_PACKAGES=("main")
+GO_LDFLAGS=(
+    "-X github.com/xtls/xray-core/core.build=$(git rev-parse --short HEAD)"
+)

--- a/app-network/xray/autobuild/prepare
+++ b/app-network/xray/autobuild/prepare
@@ -1,5 +1,0 @@
-abinfo "Getting build information ..."
-commit=$(git rev-parse --short HEAD)
-
-abinfo "Setting GO_LDFLAGS ..."
-GO_LDFLAGS=("-X 'github.com/xtls/xray-core/core.build=$commit'")

--- a/app-network/xray/spec
+++ b/app-network/xray/spec
@@ -1,4 +1,4 @@
-VER=25.5.16
+VER=25.6.8
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/XTLS/Xray-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- xray: update to 25.6.8
    - Drop unused prepare script.
    - Enable ABSPLITDBG.

Package(s) Affected
-------------------

- xray: 25.6.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
