### PR TITLE
swww: update to 0.10.3

### DIFF
--- a/app-utils/swww/spec
+++ b/app-utils/swww/spec
@@ -1,4 +1,4 @@
-VER=0.10.2
+VER=0.10.3
 SRCS="git::commit=tags/v$VER::https://github.com/LGFae/swww"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373570"


### PR DESCRIPTION
Topic Description
-----------------

- swww: update to 0.10.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- swww: 0.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit swww
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
