### PR TITLE
fcitx5-pinyin-moegirl: update to 20250610

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250609
+VER=20250610
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::614af5a1bbb0b1ef17658e0270d5293e0d0718f56353b6e6ccc7980584984bdf
-         sha256::66bcbbe2af7872ea41c471314ef5124bfb05e95a7c2db00b85a121887110ed46
+CHKSUMS="sha256::92bb412d5705eaa290ef1214b89b316266c19455decf319773383d4e1d0d3d8a
+         sha256::72d03117f1f8827980bc7c8bb02e2850d09d1856e2e57efe0dbfcbc2692796cc
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250610

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250610
- rime-pinyin-moegirl: 20250610

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
