### PR TITLE
gearlever: update to 3.3.3

### DIFF
--- a/app-utils/gearlever/spec
+++ b/app-utils/gearlever/spec
@@ -1,4 +1,4 @@
-VER=3.3.1
+VER=3.3.3
 SRCS="git::commit=tags/${VER}::https://github.com/mijorus/gearlever"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378021"


### PR DESCRIPTION
Topic Description
-----------------

- gearlever: update to 3.3.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gearlever: 3.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gearlever
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
