### PR TITLE
bash-startup: set bash-pinyin-completion-rs as recomdep

### DIFF
--- a/runtime-data/bash-startup/autobuild/defines
+++ b/runtime-data/bash-startup/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=bash-startup
 PKGSEC=misc
 PKGDEP="bash sed bash-git-status"
+PKGRECOM="bash-pinyin-completion-rs"
 PKGDES="Generic Bash Startup Files for AOSC OS"
 
 PKGEPOCH=2

--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,5 @@
 VER=0.7.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------
bash-startup: set bash-pinyin-completion-rs as recomdep
- add bash-pinyin-completion-rs as recomdep in bash-startup

Package(s) Affected
-------------------

bash-startup-0.7.2

Security Update?
----------------
No
<!-- No -->

<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->

<!--
Build Order
-----------
-->

<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->

<!--
```
pkg1 pkg2 pkg3 ...
```
-->

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
[ ] Architecture-independent `noarch`

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
