### PR TITLE
bash-startup: set bash-pinyin-completion-rs as recomdep

### DIFF
--- a/runtime-data/bash-startup/autobuild/defines
+++ b/runtime-data/bash-startup/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=bash-startup
 PKGSEC=misc
 PKGDEP="bash sed bash-git-status"
+PKGRECOM="bash-pinyin-completion-rs"
 PKGDES="Generic Bash Startup Files for AOSC OS"
 
 PKGEPOCH=2

--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,4 +1,5 @@
-VER=0.6.8
+VER=0.7.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-startup: set bash-pinyin-completion-rs as recomdep
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>

Package(s) Affected
-------------------

- bash-startup: 2:0.7.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
