### PR TITLE
rocm 6.4.1, add PKGBREAK and PKGREP

### DIFF
--- a/runtime-rocm/rocm-comgr/autobuild/defines
+++ b/runtime-rocm/rocm-comgr/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=rocm-comgr
 PKGDES="Library for compiling and inspecting AMDGPU code objects"
 PKGSEC=devel
 PKGDEP="zlib rocm-llvm rocm-device-libs rocm-core"
+PKGBREAK="rocm-compilersupport-comgr<=6.0.2"
+PKGREP="rocm-compilersupport-comgr<=6.0.2"
 BUILDDEP="cmake"
 
 USECLANG=1

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -1,5 +1,6 @@
 VER=6.4.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
+REL=1
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"
 CHKUPDATE="anitya::id=231449"

--- a/runtime-rocm/rocm-hipify/autobuild/defines
+++ b/runtime-rocm/rocm-hipify/autobuild/defines
@@ -3,6 +3,8 @@ PKGDES="Tools to convert CUDA source code to HIP"
 PKGSEC=devel
 PKGDEP="rocm-llvm"
 BUILDDEP="cmake"
+PKGBREAK="hipify<=6.0.2"
+PKGREP="hipify<=6.0.2"
 
 USECLANG=1
 

--- a/runtime-rocm/rocm-hipify/spec
+++ b/runtime-rocm/rocm-hipify/spec
@@ -1,4 +1,5 @@
 VER=6.4.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/HIPIFY.git"
+REL=1
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378519"

--- a/runtime-rocm/rocr-runtime/autobuild/defines
+++ b/runtime-rocm/rocr-runtime/autobuild/defines
@@ -3,7 +3,9 @@ PKGDES="User space library for launching compute kernels on ROCm-compatible Rade
 PKGSEC=devel
 PKGDEP="numactl libdrm elfutils zlib rocm-llvm rocm-rocprofiler-register zstd rocm-device-libs rocm-comgr rocm-hipcc"
 BUILDDEP="cmake vim"
-
+# Note: roct has been deprecated.
+PKGBREAK="roct-thunk-interface<=6.0.2"
+PKGREP="roct-thunk-interface<=6.0.2"
 USECLANG=1
 
 ABTYPE=cmakeninja

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,4 +1,5 @@
 VER=6.4.1
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
+REL=1
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"


### PR DESCRIPTION
Topic Description
-----------------

- rocr-runtime: mark PKGBREAK/REP
- rocm-hipify: mark PKGBREAK/REP
- rocm-comgr: mark PKGBREAK/REP

Package(s) Affected
-------------------

- rocm-comgr: 6.4.1-1
- rocm-device-libs: 6.4.1
- rocm-hipify: 6.4.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-device-libs rocm-comgr rocm-hipify
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
