### PR TITLE
rocm-base: update metapackage dependencies

### DIFF
--- a/meta-bases/rocm-base/autobuild/defines
+++ b/meta-bases/rocm-base/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=rocm-base
 PKGDES="Meta package for AMD ROCm support"
 PKGSEC=Bases
-PKGDEP="rocm-smi-lib rocminfo rocm-bandwidth-test rocm-clr hipify"
+PKGDEP="rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-hipcc rocm-rocprofiler-register rocr-runtime rocminfo rocm-cmake rocm-clr rocm-bandwidth-test rocm-half rocm-smi-lib rocm-hipify rocm-rocprim rocm-hipcub rocm-rocmlir rocm-hipfort rocm-roctracer rocm-hipblas-common rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand rocm-rccl rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver rocm-hipblas rocm-hiprand"
 
 VER_NONE=1
 ABHOST=noarch

--- a/meta-bases/rocm-base/spec
+++ b/meta-bases/rocm-base/spec
@@ -1,2 +1,2 @@
-VER=0
+VER=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- rocm-base: update metapackage dependencies

Package(s) Affected
-------------------

- rocm-base: 0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
