### PR TITLE
fcitx5-pinyin-zhwiki: update to 0.2.5+20250526

### DIFF
--- a/app-i18n/fcitx5-pinyin-zhwiki/spec
+++ b/app-i18n/fcitx5-pinyin-zhwiki/spec
@@ -1,13 +1,13 @@
-UPSTREAM_VER=0.2.3
-DICT_VER=20210823
+UPSTREAM_VER=0.2.5
+DICT_VER=20250526
 VER="${UPSTREAM_VER}"+dict"${DICT_VER}"
 
 # Arch Linux (felixonmars, also fcitx5-pinyin-zhwiki author): use FDL 1.3 LICENSE
 SRCS="file::rename=zhwiki.dict::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${UPSTREAM_VER}/zhwiki-${DICT_VER}.dict \
       file::rename=zhwiki.dict.yaml::https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${UPSTREAM_VER}/zhwiki-${DICT_VER}.dict.yaml \
       file::rename=LICENSE::https://www.gnu.org/licenses/fdl-1.3.txt"
-CHKSUMS="sha256::b355b16a5c8c90edc0e859ccf2bd1509dd604180fe6631b852756f65a13ddacf \
-         sha256::e9ff15c746477cb8157a9825e22c5fa44c70c2676bb1bf5f1710a47149c0da7c \
-         sha256::6adc7b4f7c74882dbe7564f7b8285ff194d760727ab30036dfe9704039fe32d7"
+CHKSUMS="sha256::ce71e2736fe63f41d62603b5bfbb2a1765b85efd998610bcc6e7da52ef3b6731 \
+         sha256::188fe7d179afd5d9f27a62131335e51dafd03f9450bba67d4d450979e4fe6494 \
+         sha256::110535522396708cea37c72a802c5e7e81391139f5f7985631c93ef242b206a4"
 CHKUPDATE="anitya::id=228872"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-zhwiki: update to 0.2.5+20250526

Package(s) Affected
-------------------

- fcitx5-pinyin-zhwiki: 0.2.5+dict20250526
- rime-pinyin-zhwiki: 0.2.5+dict20250526

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-zhwiki rime-pinyin-zhwiki
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
