### PR TITLE
libdatachannel: update to 0.23.0

### DIFF
--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,5 @@
 VER=31.0.3
+REL=1
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # Check https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux#obs-browser
 # for upstream required CEF version for reference.

--- a/runtime-multimedia/libdatachannel/autobuild/defines
+++ b/runtime-multimedia/libdatachannel/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="openssl libnice srtp usrsctp glib"
 BUILDDEP="cmake nlohmann-json plog"
 PKGDES="A C/C++ WebRTC network library"
 
-PKGBREAK="obs-studio<=30.2.3-1"
+PKGBREAK="obs-studio<=31.0.3"
 
 ABTYPE=cmake
 CMAKE_AFTER="-DUSE_GNUTLS=ON \

--- a/runtime-multimedia/libdatachannel/spec
+++ b/runtime-multimedia/libdatachannel/spec
@@ -1,4 +1,4 @@
-VER=0.22.6
+VER=0.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/paullouisageneau/libdatachannel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369160"


### PR DESCRIPTION
Topic Description
-----------------

- libdatachannel: update to 0.23.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libdatachannel: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdatachannel:-pkgbreak obs-studio libdatachannel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
