### PR TITLE
beaker: remove funcsigs dependency

### DIFF
--- a/lang-python/beaker/autobuild/defines
+++ b/lang-python/beaker/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=beaker
 PKGSEC=python
-PKGDEP="python-2 python-3 funcsigs"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Caching and sessions WSGI middleware for use with web applications and stand-alone Python scripts and applications"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/beaker/spec
+++ b/lang-python/beaker/spec
@@ -1,5 +1,4 @@
-VER=1.11.0
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/B/Beaker/Beaker-$VER.tar.gz"
-CHKSUMS="sha256::ad5d1c05027ee3be3a482ea39f8cb70339b41e5d6ace0cb861382754076d187e"
+VER=1.13.0
+SRCS="pypi::version=${VER}::Beaker"
+CHKSUMS="sha256::e956cd8a35ad5de1b5212c7bff8fc01e2b3d34ab92466d24684c666abb8c9c30"
 CHKUPDATE="anitya::id=3778"

--- a/lang-python/mako/autobuild/defines
+++ b/lang-python/mako/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=mako
 PKGSEC=python
-PKGDEP="beaker markupsafe python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="markupsafe python-3"
+BUILDDEP="setuptools wheel"
 PKGDES="Hyper-fast and lightweight template engine for Python"
 
 ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/mako/spec
+++ b/lang-python/mako/spec
@@ -1,5 +1,4 @@
-VER=1.1.4
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/M/Mako/Mako-$VER.tar.gz"
-CHKSUMS="sha256::17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"
+VER=1.3.10
+SRCS="pypi::version=${VER}::mako"
+CHKSUMS="sha256::99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"
 CHKUPDATE="anitya::id=3915"


### PR DESCRIPTION
Topic Description
-----------------

- mako: update to 1.3.10, drop python-2
- beaker: update to 1.13.0, drop python2 support

Package(s) Affected
-------------------

- beaker: 1.13.0
- mako: 1.3.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit beaker mako
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
