### PR TITLE
evolution-data-server: fix build error when checking HAVE_GPOWERPROFILEMONITO

### DIFF
--- a/desktop-gnome/evolution-data-server/autobuild/defines
+++ b/desktop-gnome/evolution-data-server/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=evolution-data-server
 PKGSEC=gnome
 PKGDEP="gnome-online-accounts nss krb5 libgweather libical db \
         libgdata libphonenumber webkit2gtk icu libcanberra"
-BUILDDEP="gnome-common gobject-introspection gperf gtk-doc intltool \
+BUILDDEP="gnome-common gobject-introspection gperf gtk-doc glib intltool \
           vala vim cmake"
 PKGDES="Centralized access to appointments and contacts"
 

--- a/desktop-gnome/evolution-data-server/spec
+++ b/desktop-gnome/evolution-data-server/spec
@@ -1,5 +1,5 @@
 VER=3.44.4
-REL=4
+REL=5
 SRCS="https://download.gnome.org/sources/evolution-data-server/${VER:0:4}/evolution-data-server-$VER.tar.xz"
 CHKSUMS="sha256::c0c6658838d58ba46042a4b9e50a3bb1129691e4cdb84b5eba0bf330b2ccb2eb"
 CHKUPDATE="anitya::id=10935"


### PR DESCRIPTION
Topic Description
-----------------

- evolution-data-server: fix build error when checking HAVE_GPOWERPROFILEMONITOR
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- evolution-data-server: 3.44.4-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit evolution-data-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
