### PR TITLE
gtkspell: fix build error possibly undefined macro: AM_NLS

### DIFF
--- a/desktop-gnome/gtkspell/autobuild/defines
+++ b/desktop-gnome/gtkspell/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gtkspell
 PKGSEC=libs
 PKGDEP="gtk-2 enchant"
-BUILDDEP="gtk-doc intltool"
+BUILDDEP="gettext gtk-doc intltool"
 PKGDES="On-the-fly spell checking for GtkTextView widgets (GTK 2.x)"
 
 AUTOTOOLS_AFTER="--enable-gtk-doc"

--- a/desktop-gnome/gtkspell/spec
+++ b/desktop-gnome/gtkspell/spec
@@ -1,5 +1,5 @@
 VER=2.0.16
-REL=4
+REL=5
 SRCS="tbl::http://gtkspell.sourceforge.net/download/gtkspell-$VER.tar.gz"
 CHKSUMS="sha256::8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
 CHKUPDATE="anitya::id=13110"


### PR DESCRIPTION
Topic Description
-----------------

- gtkspell: fix build error possibly undefined macro: AM_NLS
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gtkspell: 2.0.16-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtkspell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
