### PR TITLE
evolution-data-server: update to 3.56.2

### DIFF
--- a/desktop-gnome/evolution-data-server/spec
+++ b/desktop-gnome/evolution-data-server/spec
@@ -1,5 +1,4 @@
-VER=3.44.4
-REL=4
+VER=3.56.2
 SRCS="https://download.gnome.org/sources/evolution-data-server/${VER:0:4}/evolution-data-server-$VER.tar.xz"
-CHKSUMS="sha256::c0c6658838d58ba46042a4b9e50a3bb1129691e4cdb84b5eba0bf330b2ccb2eb"
+CHKSUMS="sha256::df4ec29950f29a76eac6fbe0f814c48d2cef7d3fdb905002a4a883dd761ce93c"
 CHKUPDATE="anitya::id=10935"


### PR DESCRIPTION
Topic Description
-----------------

- evolution-data-server: update to 3.56.2
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- evolution-data-server: 3.56.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit evolution-data-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
