### PR TITLE
incus: update to 6.13.0

### DIFF
--- a/app-containers/incus/01-incus/defines
+++ b/app-containers/incus/01-incus/defines
@@ -4,7 +4,7 @@ PKGDES="System container and virtual machine manager"
 PKGDEP="lxc lxcfs squashfs-tools dnsmasq cowsql libuv ebtables raft sqlite \
     libcap acl systemd apparmor xdelta"
 PKGRECOM="qemu lvm2 thin-provisioning-tools btrfs-progs criu"
-PKGSUG="zfs"
+PKGSUG="zfs lego"
 BUILDDEP="go tcl apparmor libseccomp systemd"
 
 # Incus repo itself is not a buildable gomod, which fails autobuild gomod

--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,4 @@
-VER=6.11.0
+VER=6.13.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"

--- a/app-web/lego/autobuild/defines
+++ b/app-web/lego/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=lego
+PKGSEC=web
+PKGDES="Let's Encrypt/ACME client and library"
+PKGDEP="glibc"
+BUILDDEP="go"
+ABTYPE=gomod
+GO_PACKAGES=("./cmd/lego/")
+GO_LDFLAGS=("-X \"main.version=v${PKGVER}\"")

--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,0 +1,4 @@
+VER=4.23.1
+SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=20764"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- incus: update to 6.13.0
- lego: new, 4.23.1

Package(s) Affected
-------------------
- incus: 6.13.0
- lego: 4.23.1

Security Update?
----------------
no

Build Order
-----------
```
#buildit lego incus
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for secondary ports does not impede on merging of this topic.

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
