### PR TITLE
rocm 6.4.1, update PKGBREAK/PKGREP, mark PKGDES, update rocm-llama-cpp, add rocm-stable-diffusion-cpp

### DIFF
--- a/runtime-rocm/rocm-core/autobuild/defines
+++ b/runtime-rocm/rocm-core/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=rocm-core
-PKGDES=""
+PKGDES="ROCm Runtime software stack"
 PKGSEC=devel
 BUILDDEP="cmake"
 

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,5 @@
 VER=6.4.1
+REL=1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"

--- a/runtime-rocm/rocm-llama-cpp/spec
+++ b/runtime-rocm/rocm-llama-cpp/spec
@@ -1,4 +1,5 @@
 VER=6.4.1
-SRCS="git::commit=b5473::https://github.com/ggml-org/llama.cpp.git"
+SRCS="git::commit=b5650::https://github.com/ggml-org/llama.cpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328681"
+REL=1

--- a/runtime-rocm/rocm-stable-diffusion-cpp/autobuild/defines
+++ b/runtime-rocm/rocm-stable-diffusion-cpp/autobuild/defines
@@ -1,0 +1,31 @@
+PKGNAME=rocm-stable-diffusion-cpp
+PKGDES="Stable Diffusion in pure C/C++/HIP"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-smi-lib rocm-hipify rocm-rccl rocm-rocsolver rocm-hipblas"
+BUILDDEP="cmake"
+
+# FIXME LTO BFD without gold, HIP compiler unsupport LTO LLD
+#   Check for working C compiler: /usr/lib/rocm/lib/llvm/bin/clang - broken
+# LTO Detecting HIP compiler ABI info
+#   LINKER_TYPE 'LLD' is unknown or not supported by this toolchain.
+NOLTO=1
+
+USECLANG=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm/stable-diffusion-cpp'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DAMDGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DGGML_HIP=ON'
+    '-DSD_HIPBLAS=ON'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib;/usr/lib/rocm/stable-diffusion-cpp/lib'
+    "-DCMAKE_HIP_COMPILER=$SRCDIR/hipclang-agent.sh"
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-stable-diffusion-cpp/autobuild/prepare
+++ b/runtime-rocm/rocm-stable-diffusion-cpp/autobuild/prepare
@@ -1,0 +1,19 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Adding hipclang agent script. Because cmake does not accept HIPCC, and clang++ will recognize .cu as a CUDA source file and cannot build. "
+cat >> "$SRCDIR"/hipclang-agent.sh << EOF
+#!/usr/bin/sh
+\$HIPCC_AGENT \${@}
+exit \$?
+EOF
+chmod +x $SRCDIR/hipclang-agent.sh
+
+abinfo "Adding hipclang agent environment ..."
+export HIPCC_AGENT=/usr/lib/rocm/bin/hipcc

--- a/runtime-rocm/rocm-stable-diffusion-cpp/spec
+++ b/runtime-rocm/rocm-stable-diffusion-cpp/spec
@@ -1,0 +1,4 @@
+VER=6.4.1
+SRCS="git::commit=master-d7c7a34::https://github.com/leejet/stable-diffusion.cpp.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378677"

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,5 +1,5 @@
 VER=6.4.1
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
-REL=1
+REL=2
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-stable-diffusion-cpp: add, 6.4.1
- rocm-llama-cpp: update to b5650
- rocr-runtime: rebuild for PKGBREAK/REP
- rocm-core: mark PKGDES

Package(s) Affected
-------------------

- rocm-core: 6.4.1-1
- rocm-llama-cpp: 6.4.1-1
- rocm-stable-diffusion-cpp: 6.4.1
- rocr-runtime: 6.4.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocr-runtime rocm-llama-cpp rocm-stable-diffusion-cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
