### PR TITLE
electron-netease-cloud-music: new, 0.9.40

### DIFF
--- a/app-multimedia/electron-netease-cloud-music/autobuild/build
+++ b/app-multimedia/electron-netease-cloud-music/autobuild/build
@@ -1,0 +1,20 @@
+abinfo "Fetching dependencies ..."
+yarn install --verbose
+
+abinfo "Bundling ..."
+yarn dist
+
+abinfo "Packaging ..."
+yarn electron-packager "$SRCDIR"/dist --out="$SRCDIR"/build
+BUILDDIR=$(ls "$SRCDIR"/build/ | grep electron-netease-cloud-music-)
+abinfo "Set BUILDDIR to $BUILDDIR ."
+
+abinfo "Installing ..."
+mkdir -vp "$PKGDIR"/usr/lib/electron-netease-cloud-music/
+cp -vr "$SRCDIR"/build/"$BUILDDIR"/* "$PKGDIR"/usr/lib/electron-netease-cloud-music/
+chmod -vR 755 "$PKGDIR"/usr/lib/electron-netease-cloud-music/
+mkdir -vp "$PKGDIR"/usr/bin/
+ln -s ../lib/electron-netease-cloud-music/electron-netease-cloud-music "$PKGDIR"/usr/bin/electron-netease-cloud-music
+
+abinfo "Installing icon .."
+install -Dvm644 "$SRCDIR"/assets/icons/icon.svg "$PKGDIR"/usr/share/pixmaps/electron-netease-cloud-music.svg

--- a/app-multimedia/electron-netease-cloud-music/autobuild/defines
+++ b/app-multimedia/electron-netease-cloud-music/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=electron-netease-cloud-music
+PKGSEC=sound
+PKGDES="Unofficial client for NetEase Cloud Music. Powered by Electron and Vue"
+PKGDEP="alsa-lib at-spi2-core cups fontconfig gtk-3 nss x11-lib dbus"
+BUILDDEP="yarn"
+FAIL_ARCH="!(amd64|arm64)"
+ABTYPE=self

--- a/app-multimedia/electron-netease-cloud-music/autobuild/overrides/usr/share/applications/electron-netease-cloud-music.desktop
+++ b/app-multimedia/electron-netease-cloud-music/autobuild/overrides/usr/share/applications/electron-netease-cloud-music.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=ElectronNCM
+Name[zh_CN]=ElectronNCM
+Name[zh_TW]=ElectronNCM
+Comment=Unofficial client for NetEase Cloud Music
+Comment[zh_CN]=网易云音乐非官方客户端
+Comment[zh_TW]=網易雲音樂非官方用戶端
+Icon=electron-netease-cloud-music
+Exec=/usr/bin/electron-netease-cloud-music
+Categories=AudioVideo;Player;

--- a/app-multimedia/electron-netease-cloud-music/spec
+++ b/app-multimedia/electron-netease-cloud-music/spec
@@ -1,0 +1,5 @@
+VER=0.9.40
+
+SRCS="git::commit=tags/v$VER::https://github.com/Rocket1184/electron-netease-cloud-music.git"
+CHKSUMS="SKIP"
+CHKUPDATE="antiya::id=371637"


### PR DESCRIPTION
Topic Description
-----------------

- electron-netease-cloud-music: new, 0.9.40

Package(s) Affected
-------------------

- electron-netease-cloud-music: 0.9.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit electron-netease-cloud-music
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`