### PR TITLE
cinnamon: replace py2cairo dep with py3cairo


### DIFF
--- a/desktop-cinnamon/cinnamon/autobuild/defines
+++ b/desktop-cinnamon/cinnamon/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=cinnamon
 PKGSEC=Cinnamon
 PKGDEP="accountsservice blueberry caribou cinnamon-settings-daemon cinnamon-session \
         cjs clutter-gtk gnome-backgrounds gconf gnome-themes-standard gstreamer-1-0 \
-        libgnome-keyring librsvg network-manager-applet muffin py2cairo dbus-python \
+        libgnome-keyring librsvg network-manager-applet muffin py3cairo dbus-python \
         pillow lxml python-pam pyinotify pexpect cinnamon-control-center \
         cinnamon-screensaver cinnamon-menus libgnomekbd nemo polkit-gnome xapps \
         python-xapp startup-notification tinycss2 timezonemap pciutils util-linux \

--- a/desktop-cinnamon/cinnamon/spec
+++ b/desktop-cinnamon/cinnamon/spec
@@ -1,5 +1,5 @@
 VER=5.8.3
-REL=1
+REL=2
 SRCS="tbl::https://github.com/linuxmint/Cinnamon/archive/$VER.tar.gz"
 CHKSUMS="sha256::ffc948d251d9ac7e38c164334e0fee77922de31724ccee63ea50c2d3a81eec89"
 CHKUPDATE="anitya::id=6265"


### PR DESCRIPTION
Topic Description
-----------------

- cinnamon: replace py2cairo dep with py3cairo

Package(s) Affected
-------------------

- cinnamon: 5.8.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinnamon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
