### PR TITLE
coturn: new, 4.7.0

### DIFF
--- a/app-network/coturn/autobuild/beyond
+++ b/app-network/coturn/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Moving documents to correct location ..."
+mv -v "$PKGDIR"/usr/man "$PKGDIR"/usr/share/man
+mv -v "$PKGDIR"/usr/doc "$PKGDIR"/usr/share/doc
+mv -v "$PKGDIR"/usr/share/examples "$PKGDIR"/usr/share/doc/turnserver/examples
+
+abinfo "Setting executable bits for all binary executables ..."
+chmod -v +x "$PKGDIR"/usr/bin/*

--- a/app-network/coturn/autobuild/defines
+++ b/app-network/coturn/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=coturn
+PKGSEC=net
+PKGDES="TURN server and TURN client messaging library"
+PKGDEP="glibc libevent openssl sqlite"
+
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_SYSCONFDIR=/etc'
+)

--- a/app-network/coturn/spec
+++ b/app-network/coturn/spec
@@ -1,0 +1,4 @@
+VER=4.7.0
+SRCS="git::commit=tags/$VER::https://github.com/coturn/coturn.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=105341"


### PR DESCRIPTION
Topic Description
-----------------

- coturn: new, 4.7.0
- incus: update to 6.13.0
    - Add lego as a dependency for ACME functionality.
- lego: 4.23.1, new

Package(s) Affected
-------------------

- coturn: 4.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit coturn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
