### PR TITLE
chore(github): update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,5 @@
-<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->
+<!-- For description on topic creation and maintenance, please refer to
+     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->
 
 Topic Description
 -----------------
@@ -14,29 +15,26 @@ Security Update?
 ----------------
 
 <!-- If this topic contains security update(s), please uncomment "Yes,"
-     mark with the `security` and `priority` labels, and make sure to mark your commits to relevant issue numbers.
+     mark with the `security` label and make sure to mark your commits to
+     relevant issue numbers.
 
      Please see GitHub's documentation on "Linking a pull request to an issue":
 
      https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
 
-<!-- Yes - Issue Number: ISSUENUMBER -->
+<!-- Yes, #ISSUENUMBER -->
 <!-- No -->
 
-<!-- Please uncomment the "Build Order" section if your topic affects more than one package. -->
-
-<!--
 Build Order
 -----------
--->
 
-<!-- Please describe in what order maintainers should build this pull request. You can use the following template, use space to separate packages. -->
+<!-- Please describe in what order the packages affected by this pull request
+     should be built. Please use the following template, making sure to keep
+     the `#buildit` prefix, and use space to separate packages. -->
 
-<!--
 ```
-pkg1 pkg2 pkg3 ...
+#buildit pkg1 pkg2 pkg3 ...
 ```
--->
 
 Test Build(s) Done
 ------------------
@@ -48,23 +46,34 @@ Test Build(s) Done
 - [ ] AMD64 `amd64`
 - [ ] AArch64 `arm64`
 - [ ] LoongArch 64-bit `loongarch64`
-<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
+<!-- If the pull request involves a `+32` counterpart, please uncomment the
+     line below. -->
 <!-- - [ ] 32-bit Optional Environment `optenv32` -->
 
-<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
+<!-- If all package(s) affected by this topic is `noarch`, please use the
+     following and remove all other architectures. -->
 <!-- - [ ] Architecture-independent `noarch` -->
 
 **Secondary Architectures**
 
 <!-- Please remove any architecture to which this topic does not apply. -->
 
-Architectural progress for secondary ports does not impede on merging of this topic.
+<!-- Should build failures amongst secondary architectures be found as
+     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
+     maintainer for assistance. -->
 
 - [ ] Loongson 3 `loongson3`
 - [ ] PowerPC 64-bit (Little Endian) `ppc64el`
 - [ ] RISC-V 64-bit `riscv64`
 
-<!-- Maintainers should review file changes and make sure that the change(s) made complies with our [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->
+<!-- Maintainers should review file changes and make sure that the change(s)
+     complies with our
+     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->
 
-<!-- Maintainers and users may now test the packages in this topic and, once user/maintainer feedback indicates that the update(s) work as expected and find its quality satisfactory,
-     another maintainer may now review this pull request and mark it as Approved. After which, the maintainer will build affected package(s) and upload them to the `stable` repository. -->
+<!-- Maintainers and users may now test the packages in this topic and, once
+     user/maintainer feedback indicates that the update(s) work as expected and
+     find its quality satisfactory, another maintainer may now review this pull
+     request and mark it as "Approved."
+
+     After which, the maintainer will build affected package(s) and upload them
+     to the `stable` repository. -->


### PR DESCRIPTION
- Update all descriptions to match the current workflow.
- Instruct contributors to keep a `#buildit` line to help with automation.
- Clarify that in principle, secondary architecture failures should also be paid attention to, and add instruction on how to get help.
