### PR TITLE
rocm 6.4.1, update PKGBREAK/PKGREP, mark PKGDES

### DIFF
--- a/runtime-rocm/rocm-core/autobuild/defines
+++ b/runtime-rocm/rocm-core/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=rocm-core
-PKGDES=""
+PKGDES="ROCm Runtime software stack"
 PKGSEC=devel
 BUILDDEP="cmake"
 

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,5 @@
 VER=6.4.1
+REL=1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,5 +1,5 @@
 VER=6.4.1
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
-REL=1
+REL=2
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"


### PR DESCRIPTION
Topic Description
-----------------

- rocr-runtime: rebuild for PKGBREAK/REP
- rocm-core: mark PKGDES

Package(s) Affected
-------------------

- rocm-core: 6.4.1-1
- rocr-runtime: 6.4.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocr-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
