### PR TITLE
freerdp: update to 3.16.0

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,5 +1,4 @@
-VER=3.15.0
-REL=1
+VER=3.16.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::e8cd58decef4c970faea2fbea675970eea60e440ebe8033c54889acb83787371"
+CHKSUMS="sha256::385af54245560493698730b688b5e6e5d56d5c7ecf2fa7c1d7cedfde8a4ba456"
 CHKUPDATE="anitya::id=10442"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.16.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- freerdp: 2:3.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
