### PR TITLE
linthesia: update to 0.8.0

### DIFF
--- a/app-games/linthesia/autobuild/beyond
+++ b/app-games/linthesia/autobuild/beyond
@@ -1,4 +1,5 @@
-mkdir -p "${PKGDIR}/usr/share/applications"
-mkdir -p "${PKGDIR}/usr/share/pixmaps"
-cp "${SRCDIR}/extra/linthesia.desktop" "${PKGDIR}/usr/share/applications"
-cp "${SRCDIR}/extra/linthesia.xpm" "${PKGDIR}/usr/share/pixmaps"
+abinfo "Installing .desktop entry and icon ..."
+install -Dvm644 "$SRCDIR"/extra/linthesia.desktop \
+    "$PKGDIR"/usr/share/applications/linthesia.desktop
+install -Dvm644 "$SRCDIR"/extra/linthesia.xpm \
+    "$PKGDIR"/usr/share/pixmaps/linthesia.xpm

--- a/app-games/linthesia/autobuild/defines
+++ b/app-games/linthesia/autobuild/defines
@@ -1,7 +1,12 @@
 PKGNAME=linthesia
 PKGSEC=sound
-PKGDEP="gtkmm gconfmm gtkglextmm alsa-lib fluidsynth pangox-compat"
-BUILDDEP="subversion"
-PKGDES="A game of playing music"
+PKGDEP="gtkmm gconfmm gtkglextmm alsa-lib fluidsynth sdl2-ttf"
+PKGDES="Rhythm game based on Synthesia"
 
-ABSHADOW=no
+MESON_AFTER=(
+    '-Dgraphdir=/usr/share/linthesia/graphics'
+    '-Dmusicdir=/usr/share/linthesia/music'
+    '-Dprofile=default'
+)
+
+PKGEPOCH=1

--- a/app-games/linthesia/autobuild/prepare
+++ b/app-games/linthesia/autobuild/prepare
@@ -1,2 +1,0 @@
-export MAKE_AFTER="GRAPHDIR=/usr/share/linthesia/graphics"
-export CPPFLAGs="${CPPFLAGS} -O2"

--- a/app-games/linthesia/spec
+++ b/app-games/linthesia/spec
@@ -1,5 +1,4 @@
-VER=20161105
-REL=2
-SRCS="git::commit=32d30fb188b375f017dc121c7ae3449b37af177b::https://github.com/linthesia/linthesia.git"
+VER=0.8.0
+SRCS="git::commit=tags/$VER::https://github.com/linthesia/linthesia.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230932"


### PR DESCRIPTION
Topic Description
-----------------

- linthesia: update to 0.8.0
    Switch to Meson build type and clean up scripting.

Package(s) Affected
-------------------

- linthesia: 1:0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit linthesia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
