### PR TITLE
iosevka-fonts: update to 33.2.5

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.4
+VER=33.2.5
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::e19e4291f874c3a5dbb68221a86cae5a96c4f2866a17668b5981df9dc7e7d97f \
-         sha256::b377ac7f2c75e72a50b36e4147ca39794aa705052c9f79245d00fcbf84ca0cac \
-         sha256::b2f1bd382d35478c9ec53f1a45fd5edce964ae749fd7d560fa5f4c2d3a6710a2 \
-         sha256::5028705a445810752d2f1746e798478f5794ecf4071a887984b519a4ce55976b \
-         sha256::e380d08233266b09a68d1924cada552383a8b398dd5c027b5b9f415e09e0fcda \
-         sha256::18cae71b5b62d671bc5a71b7c962c3feff6c558165aee346a3e06f54efeaf247 \
-         sha256::46448c9583830ffde57beb714bbccdce9d2f4e9f68ac2b32a0f0e5a2f89e74a5 \
-         sha256::37ac4155dae08e9eb2a507d0bf416dc534a24f61381090225d6b6328c7c1dc16 \
-         sha256::095ea3f5ec83c6b2f705c7ee0b3a69ac0894751061734104e663eeb6fa4c4bdb \
-         sha256::52729f2f2c2a4b7970f93b6024402deadda226ee9eb05bbc8ee40c80d8502c66 \
-         sha256::99be2059565dbbc95bbe44281fed182f41458a67f1e9800d814df77b78b4bc60 \
-         sha256::af07f14952b8b1014aada3dcb00b296cf4ac62e7234735ec59b4dd426316ff34 \
-         sha256::690f6c886ee3b6bd4bd7564469de5493684a327698eea8c4c3c128587e33a495 \
-         sha256::3abb2864650131b425d3e672e01811f32bcc7b5730eaeb896ef2873553eba80f \
-         sha256::f46dd3f219ca7e63ce62b7d9f4ba711cb2ce3836b696439ef3fc53291de87b95 \
-         sha256::c4d590fb6463b4702b7a5274274202f07019b254a86584826e130b2ea4c77de3 \
-         sha256::58fcbe80fcad359cd22bc78a8ceabcea03434d4856abc1e2dc5aefffd6ff96e3 \
-         sha256::51a061320de6744aebdee0ca56d6140ed936aecca333c0509bfb7969b182594c \
-         sha256::de7c892cb2f5dd248c4d452d43be9ec3bc8d59a0e4d578d6ddb533e23a592e37 \
-         sha256::ba28b02780cef35e6b310ac9e5261b637abead47432de08510d9ef99235e840a \
-         sha256::6ea1f792574d369d07187b216ae5ecc8fac20f39cf190a64ffb17bd5b797a84f \
-         sha256::d710af4b9451260e3c90c94f2699917e92c2dc39d47839892517e286d5b8d227 \
-         sha256::c348f3b15e7fe4d7e162acd4c573ea1552cb263f7ba7dda58e7558ed8a6922a8 \
-         sha256::a84970853b1d92a9260d6421fd9bfb680b5d7c13b81924bfb19cde7c8ca825ac \
+CHKSUMS="sha256::6239f2cf6fa421abc1455a74fcbb5380b7005c3da52e27b6e63728668607cf9f \
+         sha256::b21b0d1be237b092f39ada414b84d9a64e2db7762ac47751d460097f7d59b083 \
+         sha256::0f244a33e5fbbaac4a57dd94268f38e8cf30baf6489bc7eab35936fc278b220c \
+         sha256::b2d7de76a1023dde8673e1dca9bac787a4f613c5d53139f26fc1b3fe7558ea24 \
+         sha256::88d324ad93bdbd563005f6d3cffc72350a622078da8ccefe362c705cda5d973e \
+         sha256::6d59fe5213f2eb4ac0ecd3f9cb87e00d6c09f5bfcb2e2b375ca6ccafec98c96f \
+         sha256::0c394c91cb9fa4da045f4cdea27d5023a6d30202a7c6aa3fcfb9961b3d676508 \
+         sha256::c0d5b927bec017c389e9de1808b2cb94250ee7146061042a3a2a4da11d140238 \
+         sha256::21312d09b46588ec06b043873924a5ab2e44553cafe4e69220cfbb3831fb40ea \
+         sha256::339ccb7f5d6b0087ad9a1e8e9751697ae57eab9939986219f10c9cc7f818b740 \
+         sha256::18f338de5113c8f6f438010a8784a1053138931e4fbc882ccf11b7179586ad61 \
+         sha256::6ce59d7b82d83996f1edc1777f78ba41b3bf1149346ddfe94ab4cea49fc6c5fb \
+         sha256::50d35b27bf15ee80e65a9269d5cfef0cb7b925e52055bafb47c4604e7766e224 \
+         sha256::97b8040adcdbad64eb535807d02d40e29efa07115589d6941f49f8a996a764a9 \
+         sha256::146891d119e8b7e452d6855283f8ff693eef1e7a57840a65f40937cfc5e76077 \
+         sha256::42b94d00129be74c626e1c2bdb49b42c1d65a88e9dbf6f047eac5f6babe22142 \
+         sha256::5c969ff6a4a6a43a3c9a0da6623818c0272d9dbf2f6f0f650b64a4e30222d61b \
+         sha256::ecd74821f08d9b25f634b1d952e79087459033123c7d3c6bcb3eb8a651b8d2c3 \
+         sha256::6f873d4f4c2306bffbe258861b5359188c7f61824abe2088c34b07e8b1105194 \
+         sha256::acc877eaa7595406e050420dfd93f26dbb6070ae85bdbc1a3ef3472446186e75 \
+         sha256::f2c9ee61397a3964071e617ab9a950563941549fbc4f951dedf800a9ea3c1143 \
+         sha256::feb7cb79018bd52cac366ce0823514fbd4b6c49e6bc03d69986a689ae891fcb6 \
+         sha256::77e0fec6efe793da34d5418a6b19bbbb5958527d167109e67aed93fc047c594e \
+         sha256::687e37cae4cd6e7322b251317c7e14a30cdd98ccfd8e65448e88b7c99d5a2b8a \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
