### PR TITLE
desktop-base: reset nullglob to off after xdg-data-dirs-opt-apps.sh

### DIFF
--- a/meta-bases/desktop-base/autobuild/overrides/etc/profile.d/xdg-data-dirs-opt-apps.sh
+++ b/meta-bases/desktop-base/autobuild/overrides/etc/profile.d/xdg-data-dirs-opt-apps.sh
@@ -22,3 +22,6 @@ for opt_apps_path in /opt/apps/*/entries; do
 		export XDG_DATA_DIRS="${XDG_DATA_DIRS}:${opt_apps_path}"
 	fi
 done
+
+# Reset to default (off).
+shopt -u nullglob

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,4 @@
-VER=15
+VER=16
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: reset nullglob to off after xdg-data-dirs-opt-apps.sh
    This option, when enabled, would cause the asterisk/glob marker to be
    ignored if no match is found. This resulted in a very confusing behaviour
    with ls\(1\), where \`ls \*random-nonexistent\*' would be treated as equivalent
    to \`ls' with no parameter at all.
    Make sure to unset this shell option after whatever was done in
    xdg-data-dirs-opt-apps.sh.
    Link: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html

Package(s) Affected
-------------------

- desktop-base: 16

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
