### PR TITLE
colord-kde: add kirigami-addons dependency

### DIFF
--- a/desktop-kde/colord-kde/autobuild/defines
+++ b/desktop-kde/colord-kde/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=colord-kde
 PKGSEC=kde
 PKGDEP="colord kcmutils kconfigwidgets kcoreaddons kdbusaddons kdeclarative \
-        ki18n kitemmodels kpackage kwidgetsaddons kwindowsystem"
+        ki18n kitemmodels kpackage kwidgetsaddons kwindowsystem kirigami-addons"
 BUILDDEP="extra-cmake-modules"
 PKGDES="A Colord session daemon to colord for KDE"

--- a/desktop-kde/colord-kde/spec
+++ b/desktop-kde/colord-kde/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/colord-kde-$VER.tar.xz"
 CHKSUMS="sha256::466b27bc6131a7c0263cb4e9350702c96d2123050d0312487a6472d0156e00b9"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- colord-kde: add kirigami-addons dependency
    - Add missing dependency kirigami-addons, fixing #9552.

Package(s) Affected
-------------------

- colord-kde: 23.08.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit colord-kde
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
