### PR TITLE
gamemode: refine debconf templates

### DIFF
--- a/app-games/gamemode/autobuild/templates
+++ b/app-games/gamemode/autobuild/templates
@@ -10,6 +10,8 @@ Description: GameMode Configuration
  You may also enable GameMode automatically as you log in with the following command:
  .
  systemctl --user enable gamemoded
+ .
+ This command enables GameMode to launch automatically upon login.
 Description-zh_CN.UTF-8: GameMode 配置贴士
  要利用 GameMode 的所有功能，请使用如下命令将您的用户添加到 `gamemode' 用户组：
  .
@@ -21,4 +23,4 @@ Description-zh_CN.UTF-8: GameMode 配置贴士
  .
  systemctl enable gamemode --user
  .
- 即可让 GameMode 的登录自启动。
+ 即可让 GameMode 在登录时自动启动。

--- a/app-games/gamemode/spec
+++ b/app-games/gamemode/spec
@@ -2,4 +2,4 @@ VER=1.8.2
 SRCS="git::commit=tags/$VER::https://github.com/FeralInteractive/gamemode.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17410"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gamemode: refine debconf templates

Package(s) Affected
-------------------

- gamemode: 1.8.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gamemode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
