### PR TITLE
ninja: Move re2c to BUILDDEP

### DIFF
--- a/app-devel/ninja/autobuild/defines
+++ b/app-devel/ninja/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=ninja
 PKGSEC=devel
-PKGDEP="re2c"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="re2c"
 PKGDES="Small build system with a focus on speed"

--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -2,3 +2,4 @@ VER=1.12.1
 SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2089"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

For ninja re2c is only needed at build time (for regenerating the lexical analyzers).

Move it to BUILDDEP so most ninja users can avoid installing re2c.

Package(s) Affected
-------------------

- ninja: 1.12.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
