### PR TITLE
oma: update to 1.18.0

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -9,11 +9,6 @@ PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"
 PKGREP="mirrormgr<=0.11.1"
 
-# FIXME: nettle-sys does not build on loongson3 due to LLVM brokenness.
-# Use openssl backend for sequoia-openpgp, which is used by oma-refresh.
-CARGO_AFTER__LOONGSON3="--no-default-features \
-                        --features=aosc,sequoia-openssl-backend"
-
 USECLANG=1
 
 # FIXME: ld.lld is not yet available.

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.17.4
+VER=1.18.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.18.0

Package(s) Affected
-------------------

- oma: 1.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



