### PR TITLE
linux-pam: update to 1.7.1

### DIFF
--- a/app-admin/linux-pam/spec
+++ b/app-admin/linux-pam/spec
@@ -1,5 +1,4 @@
-VER=1.7.0
+VER=1.7.1
 SRCS="tbl::https://github.com/linux-pam/linux-pam/releases/download/v$VER/Linux-PAM-$VER.tar.xz"
-CHKSUMS="sha256::57dcd7a6b966ecd5bbd95e1d11173734691e16b68692fa59661cdae9b13b1697"
+CHKSUMS="sha256::21dbcec6e01dd578f14789eac9024a18941e6f2702a05cf91b28c232eeb26ab0"
 CHKUPDATE="anitya::id=12244"
-REL=1

--- a/topics/linux-pam-1.7.1.toml
+++ b/topics/linux-pam-1.7.1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Linux PAM 1.7.1"
+zh_CN = "Linux PAM 1.7.1"
+
+[caution]
+default = "Fixes two security vulnerabilities - CVE-2024-10963, CVE-2025-6020 (1 of high severity)"
+zh_CN = "修复编号为 CVE-2024-10963 及 CVE-2025-6020 的安全漏洞（含 1 个高危漏洞）"
+
+[packages]
+"linux-pam" = "1.7.1"


### PR DESCRIPTION
Topic Description
-----------------

- linux-pam: update to 1.7.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- linux-pam: 1.7.1

Security Update?
----------------

Yes, #11412 

Build Order
-----------

```
#buildit linux-pam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
