### PR TITLE
xorg-server: update to 21.1.17

### DIFF
--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.16
+VER=21.1.17
 SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::b14a116d2d805debc5b5b2aac505a279e69b217dae2fae2dfcb62400471a9970"
+CHKSUMS="sha256::a29441c21a55f4cd2c2d93d3a4ec24a4c15f053d55aea104f97da32f66efecd0"
 CHKUPDATE="anitya::id=5250"

--- a/topics/xorg-server-21.1.17.toml
+++ b/topics/xorg-server-21.1.17.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "X.Org Server 21.1.17"
+
+[caution]
+default = "Fixes 6 security vulnerabilities disclosed in X.Org's Security Advisory on June 17, 2025"
+zh_CN = "修复 X.Org 在 2025 年 6 月 17 日的安全公告中披露的 6 个安全漏洞"
+
+[packages]
+"xorg-server" = "21.1.17"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: update to 21.1.17
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xorg-server: 21.1.17

Security Update?
----------------

Yes, #11415

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
