### PR TITLE
xwayland: update to 24.1.7

### DIFF
--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.6
+VER=24.1.7
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::737e612ca36bbdf415a911644eb7592cf9389846847b47fa46dc705bd754d2d7"
+CHKSUMS="sha256::f7d97e248092878a3f7d3c68b25dab652bf970d9e6a17d30fbf457aaea139ccb"
 CHKUPDATE="anitya::id=180949"

--- a/topics/xwayland-24.1.7.toml
+++ b/topics/xwayland-24.1.7.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Xwayland 24.1.7"
+
+[caution]
+default = "Fixes 6 security vulnerabilities disclosed in X.Org's Security Advisory on June 17, 2025"
+zh_CN = "修复 X.Org 在 2025 年 6 月 17 日的安全公告中披露的 6 个安全漏洞"
+
+[packages]
+"xwayland" = "24.1.7"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 24.1.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xwayland: 24.1.7

Security Update?
----------------

Yes, #11415

Build Order
-----------

```
#buildit xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
