### PR TITLE
libblockdev: update to 3.3.1

### DIFF
--- a/runtime-devices/libblockdev/autobuild/defines
+++ b/runtime-devices/libblockdev/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=libblockdev
 PKGSEC=libs
 PKGDEP="btrfs-progs dosfstools gptfdisk libbytesize lvm2 mdadm volume-key \
-        xfsprogs bcache-tools yaml ndctl parted"
+        xfsprogs bcache-tools yaml ndctl parted libatasmart json-glib"
 PKGDEP__RETRO=" \
         btrfs-progs dosfstools gptfdisk libbytesize lvm2 mdadm volume-key \
-        xfsprogs yaml parted"
+        xfsprogs yaml parted libatasmart json-glib"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"

--- a/runtime-devices/libblockdev/spec
+++ b/runtime-devices/libblockdev/spec
@@ -1,4 +1,4 @@
-VER=3.1.1
-SRCS="tbl::https://github.com/storaged-project/libblockdev/releases/download/${VER}-1/libblockdev-${VER}.tar.gz"
-CHKSUMS="sha256::a5cb33a53ff5969067982704f45399d02555fdb2313ed0c56eac9555397dc2db"
+VER=3.3.1
+SRCS="tbl::https://github.com/storaged-project/libblockdev/releases/download/${VER}/libblockdev-${VER}.tar.gz"
+CHKSUMS="sha256::a2e2e448a19d420480b8cce5e0752197482a65cb62a9ed55d88b237da36600d1"
 CHKUPDATE="anitya::id=9397"

--- a/topics/libblockdev-3.3.1.toml
+++ b/topics/libblockdev-3.3.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libblockdev 3.3.1"
+
+[caution]
+default = "Fixes a local privilege escalation vulnerability - CVE-2025-6019 (Severity: Critical)"
+zh_CN = "修复一处编号为 CVE-22025-6019 本地提权漏洞（严重性：严重）"
+
+[packages]
+"libblockdev" = "3.3.1"


### PR DESCRIPTION
Topic Description
-----------------

- libblockdev: update to 3.3.1
- topics: add libblockdev-3.3.1.toml

Package(s) Affected
-------------------

- libblockdev: 3.3.1

Security Update?
----------------

Yes, #11416 

Build Order
-----------

```
#buildit libblockdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
