### PR TITLE
nvidia: update to 575.64

### DIFF
--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=575.57.08
+VER=575.64
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::2aa701dac180a7b20a6e578cccd901ded8d44e57d60580f08f9d28dd1fffc6f2"
+CHKSUMS__AMD64="sha256::eb01bcfe73b06c7d24b6083c27e6414f6979542f06e65601421b64ccc0ad68b1"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::549e73e4f7402f66275ee665b6e3a2ae5d7bf57296b743b824d713f205203bdf"
+CHKSUMS__ARM64="sha256::b878fc7c1d6c4897d7d0d599104d5e64dd4b41091fec9d233d5dc47900921b5d"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia: update to 575.64
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nvidia: 575.64
- nvidia-firmware: 575.64
- nvidia-utils: 575.64

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
