### PR TITLE
nvidia-open: update to 575.64

### DIFF
--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,10 +1,7 @@
-_DRIVER_VER=575.57.08
-# Note: sometimes utilities are not updated timely
-_UTILS_VERS=575.57.08
-VER=${_DRIVER_VER}+utils${_UTILS_VERS}
-SRCS="git::rename=nvidia-driver;commit=tags/${_DRIVER_VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
-	git::rename=nvidia-xconfig;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-xconfig
-	git::rename=nvidia-persistenced;commit=tags/${_UTILS_VERS}::https://github.com/NVIDIA/nvidia-persistenced"
+VER=575.64
+SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
+	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
+	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"
 CHKSUMS="SKIP \
          SKIP \
          SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-open: update to 575.64
    Unify driver and utility versions as updates seem pretty timely now.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nvidia-open: 575.64

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia-open
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
