### PR TITLE
hplip:patch doctor.py to make it use python3

### DIFF
--- a/app-doc/hplip/autobuild/patches/1001-AOSCOS-use-python3.patch
+++ b/app-doc/hplip/autobuild/patches/1001-AOSCOS-use-python3.patch
@@ -1,0 +1,10 @@
+diff --git a/doctor.py b/doctor.py
+index b489ca1..06e906e 100644
+--- a/doctor.py
++++ b/doctor.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ # -*- coding: utf-8 -*-
+ #
+ # (c) Copyright 2012-2020 HP Development Company, L.P.

--- a/app-doc/hplip/spec
+++ b/app-doc/hplip/spec
@@ -1,5 +1,5 @@
 VER=3.25.2
-REL=1
+REL=2
 SRCS="tbl::https://prdownloads.sourceforge.net/hplip/hplip-$VER.tar.gz"
 CHKSUMS="sha256::e872ff28eb2517705a95f6e1839efa1e50a77a33aae8905278df2bd820919653"
 CHKUPDATE="anitya::id=1327"


### PR DESCRIPTION
Topic Description
-----------------

- hplip: patch doctor.py to make it use python3

Package(s) Affected
-------------------

- hplip: 2:3.25.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hplip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
