### PR TITLE
TigerVNC: update builtin xorg-server to 21.1.18

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,9 +1,9 @@
 UPSTREAM_VER=1.15.0
-XORG_VER=21.1.17
+XORG_VER=21.1.18
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::a29441c21a55f4cd2c2d93d3a4ec24a4c15f053d55aea104f97da32f66efecd0"
+         sha256::c878d1930d87725d4a5bf498c24f4be8130d5b2646a9fd0f2994deff90116352"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"

--- a/topics/tigervnc-1.15.0-xserver21.1.18.toml
+++ b/topics/tigervnc-1.15.0-xserver21.1.18.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "TigerVNC builtin X.Org Server Update"
+zh_CN = "TigerVNC 内建 X.Org Server 更新"
+
+[caution]
+default = "Fixes 6 security vulnerabilities disclosed in X.Org's Security Advisory on June 17, 2025"
+zh_CN = "修复 X.Org 在 2025 年 6 月 17 日的安全公告中披露的 6 个安全漏洞"
+
+[packages]
+"tigervnc" = "1.15.0+xserver21.1.18"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update builtin xorg-server to 21.1.18

Package(s) Affected
-------------------

- tigervnc: 1.15.0+xserver21.1.18

Security Update?
----------------

Yes, #11415

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
