### PR TITLE
sing-box: update to 1.11.14

### DIFF
--- a/app-proxy/sing-box/autobuild/defines
+++ b/app-proxy/sing-box/autobuild/defines
@@ -4,9 +4,6 @@ PKGDES="A universal proxy platform"
 PKGDEP="glibc"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols
-# from Go executables.
-ABSPLITDBG=0
 ABTYPE=gomod
 GO_LDFLAGS=("-X github.com/sagernet/sing-box/constant.Version=$PKGVER")
 GO_PACKAGES=("cmd/sing-box")

--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.11.13
+VER=1.11.14
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.11.14
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- sing-box: 1.11.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
