### PR TITLE
vscode: update to 1.101.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,9 +1,8 @@
-VER=1.100.3
+VER=1.101.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::e7cb412158c61cd9022e89d06650b913c5a27b88f9b36ddd6e8fa2812ff69a58"
-CHKSUMS__ARM64="sha256::cb8996d905ca591ea27a46d6b3f8e9abbddfdbe4d87b443a47bf6fd64e94ae40"
+CHKSUMS__AMD64="sha256::c0cb221aa17ef63d818957c63f33d43dd4deb96b4d7b069b0bd3513b920e4492"
+CHKSUMS__ARM64="sha256::bf1f6895514ba1b2f01c4da6e9543f1a430b29c15f79032b1672012c11cc8724"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.101.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscode: 1.101.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
