### PR TITLE
vscodium: update to 1.101.24242

### DIFF
--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
-PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-BUILDDEP="jq llvm make nodejs pkg-config rustc"
+PKGDEP="alsa-lib at-spi2-core ca-certs cairo cups curl dbus expat glib gtk-3 krb5 libsecret libxcb libxkbcommon mesa nspr nss pango systemd x11-lib xdg-utils"
+BUILDDEP="jq llvm-20 nodejs python-3 rustc"
 PKGPROV="codium"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.100.33714
+VER=1.102.14746
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.101.03933
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vscodium: 1.101.03933

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
