### PR TITLE
gst-plugins-rs: Demote nasm to BUILDDEP

### DIFF
--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=gst-plugins-rs
 PKGSEC=libs
-PKGDEP="glib gstreamer nasm gtk-4 libsodium pango openssl cairo dav1d \
+PKGDEP="glib gstreamer gtk-4 libsodium pango openssl cairo dav1d \
         libwebp"
-BUILDDEP="rustc llvm cargo-c hotdoc"
+BUILDDEP="rustc llvm cargo-c hotdoc nasm"
 PKGDES="GStreamer plugins and elements written in Rust"
 
 ABTYPE=meson

--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -16,3 +16,6 @@ MESON_AFTER=(
 
 # FIXME: ld.lld is not yet available on loongson3
 NOLTO__LOONGSON3=1
+
+# FIXME: "Invalid configuration `riscv64gc-unknown-linux-gnu': machine `riscv64gc-unknown' not recognized"
+FAIL_ARCH="riscv64"

--- a/runtime-multimedia/gst-plugins-rs/spec
+++ b/runtime-multimedia/gst-plugins-rs/spec
@@ -2,3 +2,4 @@ VER=0.13.5
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328366"
+REL=1


### PR DESCRIPTION

Topic Description
-----------------

The nasm package is only referred by the nasm-rs crate in this package, and the crate is described as "Run NASM during your Cargo build."  Thus it cannot be a runtime dependency.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- gst-plugins-rs: 0.13.5-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit gst-plugins-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
