### PR TITLE
mesa: update to 25.1.4+dxheaders1.616.0

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 99e281a9d34038b2ea30a3468d7b3391c30767fe Mon Sep 17 00:00:00 2001
+From 74fc705bae7a308b739639f347542be4963ee749 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding

--- a/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From 4224e69ff4ead6b15479e5ea8b2aab06fd9a39af Mon Sep 17 00:00:00 2001
+From e7f7deef5a82e96ae69d8c921c6e9c6bfdf12c93 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on

--- a/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,4 +1,4 @@
-From d255a59654e39c3cc04cf1285e1044066f2f0623 Mon Sep 17 00:00:00 2001
+From b551e21d7e5ff04cb34cea39b6c067ed0423d5da Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
 Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
@@ -33,7 +33,7 @@ index bef1cf0a3a4..4d8ecb5ec66 100644
  
     screen->nir_options.support_indirect_inputs = (uint8_t)BITFIELD_MASK(PIPE_SHADER_TYPES);
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index a7fe1d683eb..26254397268 100644
+index 8c489ab0b89..0f6238be7e4 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
 @@ -859,8 +859,9 @@ zink_init_screen_caps(struct zink_screen *screen)
@@ -48,7 +48,7 @@ index a7fe1d683eb..26254397268 100644
  
     caps->sample_shading = screen->info.feats.features.sampleRateShading;
  
-@@ -2933,6 +2934,16 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2938,6 +2939,16 @@ init_driver_workarounds(struct zink_screen *screen)
        break;
     }
  

--- a/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,4 +1,4 @@
-From ab4fe57b31696f0dd7b434721a0736880e8b1301 Mon Sep 17 00:00:00 2001
+From ed19f53dd99dee3e6cb0b28482af6fa40aa52f03 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 30 Nov 2024 17:11:09 +0800
 Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 26254397268..75b60dfd5b9 100644
+index 0f6238be7e4..9e4047673b5 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2844,10 +2844,9 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2849,10 +2849,9 @@ init_driver_workarounds(struct zink_screen *screen)
     }
  
     if (zink_driverid(screen) ==

--- a/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,4 +1,4 @@
-From fad00a643412f3bea7e43ead1f044bc3b5b421ab Mon Sep 17 00:00:00 2001
+From e05e4ea4382f43da652779ddebbcf1fdb1fff6cb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 09:00:21 +0800
 Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting

--- a/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,4 +1,4 @@
-From da54f142b26757566ed40ce7bc4eca9bf474e1e6 Mon Sep 17 00:00:00 2001
+From 2242873c64c9301c35f2be750eccb3425bc9deea Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 20:49:58 +0800
 Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
@@ -40,10 +40,10 @@ index c861587538e..e621da37cef 100644
     simple_mtx_lock(&screen->queue_lock);
     VRAM_ALLOC_LOOP(result,
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 75b60dfd5b9..9e2a29ccfd5 100644
+index 9e4047673b5..70c70b70bba 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2848,6 +2848,12 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2853,6 +2853,12 @@ init_driver_workarounds(struct zink_screen *screen)
         screen->info.feats.features.geometryShader)
        screen->driver_workarounds.no_linesmooth = true;
  

--- a/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,4 +1,4 @@
-From 9f56af714748cf49a8821fff95eb326297cf8b0f Mon Sep 17 00:00:00 2001
+From dbdefe0eafb088b00947bc1c559eecdb4204a525 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 29 Nov 2024 16:10:29 +0800
 Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 6 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 9e2a29ccfd5..44e6b6a8cbd 100644
+index 70c70b70bba..5765d1c9912 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3414,12 +3414,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3422,12 +3422,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  

--- a/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,4 +1,4 @@
-From 850c85abdd33b0aca5b999172cf55bed0eeb40f3 Mon Sep 17 00:00:00 2001
+From 1916d7ebdfdf7f1788c2500260f9a63173ef5be2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 26 Apr 2025 22:13:35 +0800
 Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 9 insertions(+)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 44e6b6a8cbd..ec0117db081 100644
+index 5765d1c9912..36e85124d76 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3414,6 +3414,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3422,6 +3422,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=25.1.1
+UPSTREAM_VER=25.1.4
 DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
-REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::cf942a18b7b9e9b88524dcbf0b31fed3cde18e6d52b3375b0ab6587a14415bce \
+CHKSUMS="sha256::164872a5e792408aa72fecd52b7be6409724c4ad81700798675a7d801d976704 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 99e281a9d34038b2ea30a3468d7b3391c30767fe Mon Sep 17 00:00:00 2001
+From 74fc705bae7a308b739639f347542be4963ee749 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding

--- a/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From 4224e69ff4ead6b15479e5ea8b2aab06fd9a39af Mon Sep 17 00:00:00 2001
+From e7f7deef5a82e96ae69d8c921c6e9c6bfdf12c93 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on

--- a/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,4 +1,4 @@
-From d255a59654e39c3cc04cf1285e1044066f2f0623 Mon Sep 17 00:00:00 2001
+From b551e21d7e5ff04cb34cea39b6c067ed0423d5da Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
 Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
@@ -33,7 +33,7 @@ index bef1cf0a3a4..4d8ecb5ec66 100644
  
     screen->nir_options.support_indirect_inputs = (uint8_t)BITFIELD_MASK(PIPE_SHADER_TYPES);
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index a7fe1d683eb..26254397268 100644
+index 8c489ab0b89..0f6238be7e4 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
 @@ -859,8 +859,9 @@ zink_init_screen_caps(struct zink_screen *screen)
@@ -48,7 +48,7 @@ index a7fe1d683eb..26254397268 100644
  
     caps->sample_shading = screen->info.feats.features.sampleRateShading;
  
-@@ -2933,6 +2934,16 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2938,6 +2939,16 @@ init_driver_workarounds(struct zink_screen *screen)
        break;
     }
  

--- a/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,4 +1,4 @@
-From ab4fe57b31696f0dd7b434721a0736880e8b1301 Mon Sep 17 00:00:00 2001
+From ed19f53dd99dee3e6cb0b28482af6fa40aa52f03 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 30 Nov 2024 17:11:09 +0800
 Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 26254397268..75b60dfd5b9 100644
+index 0f6238be7e4..9e4047673b5 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2844,10 +2844,9 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2849,10 +2849,9 @@ init_driver_workarounds(struct zink_screen *screen)
     }
  
     if (zink_driverid(screen) ==

--- a/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,4 +1,4 @@
-From fad00a643412f3bea7e43ead1f044bc3b5b421ab Mon Sep 17 00:00:00 2001
+From e05e4ea4382f43da652779ddebbcf1fdb1fff6cb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 09:00:21 +0800
 Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting

--- a/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,4 +1,4 @@
-From da54f142b26757566ed40ce7bc4eca9bf474e1e6 Mon Sep 17 00:00:00 2001
+From 2242873c64c9301c35f2be750eccb3425bc9deea Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 20:49:58 +0800
 Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
@@ -40,10 +40,10 @@ index c861587538e..e621da37cef 100644
     simple_mtx_lock(&screen->queue_lock);
     VRAM_ALLOC_LOOP(result,
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 75b60dfd5b9..9e2a29ccfd5 100644
+index 9e4047673b5..70c70b70bba 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2848,6 +2848,12 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2853,6 +2853,12 @@ init_driver_workarounds(struct zink_screen *screen)
         screen->info.feats.features.geometryShader)
        screen->driver_workarounds.no_linesmooth = true;
  

--- a/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,4 +1,4 @@
-From 9f56af714748cf49a8821fff95eb326297cf8b0f Mon Sep 17 00:00:00 2001
+From dbdefe0eafb088b00947bc1c559eecdb4204a525 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 29 Nov 2024 16:10:29 +0800
 Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 6 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 9e2a29ccfd5..44e6b6a8cbd 100644
+index 70c70b70bba..5765d1c9912 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3414,12 +3414,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3422,12 +3422,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  

--- a/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,4 +1,4 @@
-From 850c85abdd33b0aca5b999172cf55bed0eeb40f3 Mon Sep 17 00:00:00 2001
+From 1916d7ebdfdf7f1788c2500260f9a63173ef5be2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 26 Apr 2025 22:13:35 +0800
 Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 9 insertions(+)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 44e6b6a8cbd..ec0117db081 100644
+index 5765d1c9912..36e85124d76 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3414,6 +3414,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3422,6 +3422,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  

--- a/runtime-optenv32/mesa+32/spec
+++ b/runtime-optenv32/mesa+32/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=25.1.1
+UPSTREAM_VER=25.1.4
 DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
-REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::cf942a18b7b9e9b88524dcbf0b31fed3cde18e6d52b3375b0ab6587a14415bce \
+CHKSUMS="sha256::164872a5e792408aa72fecd52b7be6409724c4ad81700798675a7d801d976704 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.1.4+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.4
    \(HEAD: 1916d7ebdfdf7f1788c2500260f9a63173ef5be2\).
- mesa: update to 25.1.4+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.4
    \(HEAD: 1916d7ebdfdf7f1788c2500260f9a63173ef5be2\).

Package(s) Affected
-------------------

- mesa: 1:25.1.4+dxheaders1.616.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
