### PR TITLE
libusb: update to 1.0.29

### DIFF
--- a/runtime-devices/libusb/autobuild/defines
+++ b/runtime-devices/libusb/autobuild/defines
@@ -3,7 +3,7 @@ PKGDES="A library providing USB device access and manipulation support"
 PKGDEP="glibc systemd"
 PKGSEC=libs
 
-NOPARALLEL=1
+ABTYPE=autotools
 
 # Note: Sync with Debian.
 PKGEPOCH_SPIRAL=2

--- a/runtime-devices/libusb/spec
+++ b/runtime-devices/libusb/spec
@@ -1,4 +1,4 @@
-VER=1.0.28
+VER=1.0.29
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
-CHKSUMS="sha256::966bb0d231f94a474eaae2e67da5ec844d3527a1f386456394ff432580634b29"
+CHKSUMS="sha256::5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
 CHKUPDATE="anitya::id=1749"

--- a/runtime-optenv32/libusb+32/spec
+++ b/runtime-optenv32/libusb+32/spec
@@ -1,5 +1,4 @@
-VER=1.0.23
-REL=2
+VER=1.0.29
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
-CHKSUMS="sha256::db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
+CHKSUMS="sha256::5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
 CHKUPDATE="anitya::id=1749"


### PR DESCRIPTION
Topic Description
-----------------

- libusb+32: update to 1.0.29
- libusb: update to 1.0.29

Package(s) Affected
-------------------

- libusb: 1.0.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit libusb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
