### PR TITLE
webkit2gtk: correct WSA numbers in TUM data

### DIFF
--- a/topics/webkit2gtk-2.48.3.toml
+++ b/topics/webkit2gtk-2.48.3.toml
@@ -4,8 +4,8 @@ security = true
 default = "WebKitGTK 2.48.3"
 
 [caution]
-default = "Fixes 16 security vulnerabilities disclosed in WebKitGTK and WPE WebKit Security Advisories WSA-2025-0001, WSA-2025-0002, and WSA-2025-0003 (2 of critical, 6 of high severity)"
-zh_CN = "修复 WebKitGTK 及 WPE WebKit 第 WSA-2025-0001、WSA-2025-0002 及 WSA-2025-0003 号安全公告中披露的 16 个安全漏洞（含 2 个严重、6 个高危漏洞）"
+default = "Fixes 16 security vulnerabilities disclosed in WebKitGTK and WPE WebKit Security Advisories WSA-2025-0002, WSA-2025-0003, and WSA-2025-0004 (2 of critical, 6 of high severity)"
+zh_CN = "修复 WebKitGTK 及 WPE WebKit 第 WSA-2025-0002、WSA-2025-0003 及 WSA-2025-0004 号安全公告中披露的 16 个安全漏洞（含 2 个严重、6 个高危漏洞）"
 
 [packages]
 "webkit2gtk" = "1:2.48.3"


### PR DESCRIPTION
Topic Description
-----------------

- topics: correct WSA numbers in webkit2gtk-2.48.3.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
