### PR TITLE
neomutt: update to 20250510


### DIFF
--- a/app-web/neomutt/spec
+++ b/app-web/neomutt/spec
@@ -1,4 +1,4 @@
-VER=20241114
+VER=20250510
 SRCS="git::commit=tags/$VER::https://github.com/neomutt/neomutt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10882"


### PR DESCRIPTION
Topic Description
-----------------

- neomutt: update to 20250510

Package(s) Affected
-------------------

- neomutt: 20250510

Security Update?
----------------

No

Build Order
-----------

```
#buildit neomutt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
