### PR TITLE
glab: update to 1.60.2

### DIFF
--- a/app-devel/glab/spec
+++ b/app-devel/glab/spec
@@ -1,4 +1,4 @@
-VER=1.59.2
+VER=1.60.2
 SRCS="git::commit=tags/v$VER::https://gitlab.com/gitlab-org/cli.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=127208"


### PR DESCRIPTION
Topic Description
-----------------

- glab: update to 1.60.2
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- glab: 1.60.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit glab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
