### PR TITLE
i2pd: update to 2.57.0

### DIFF
--- a/app-web/i2pd/autobuild/beyond
+++ b/app-web/i2pd/autobuild/beyond
@@ -8,7 +8,6 @@ install -Dvm644 "$SRCDIR"/../contrib/tunnels.conf \
 install -dvm755 "$PKGDIR"/etc/i2pd/tunnels.d
     
 abinfo "Installing certificates ..."    # certificates
-local _file
 while read -r -d '' _file; do
     install -Dvm644 "$_file" \
         "$PKGDIR"/usr/share/i2pd/certificates/${_file#contrib/certificates/}

--- a/app-web/i2pd/spec
+++ b/app-web/i2pd/spec
@@ -1,6 +1,5 @@
-VER=2.41.0
+VER=2.57.0
 SRCS="tbl::https://github.com/PurpleI2P/i2pd/archive/$VER.tar.gz"
-CHKSUMS="sha256::7b333cd26670903ef0672cf87aa9f895814ce2bbef2e587e69d66ad9427664e6"
+CHKSUMS="sha256::e2327f816d92a369eaaf9fd1661bc8b350495199e2f2cb4bfd4680107cd1d4b4"
 SUBDIR="i2pd-$VER/build"
 CHKUPDATE="anitya::id=21355"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- i2pd: update to 2.57.0
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- i2pd: 2.57.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit i2pd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
