### PR TITLE
slick-greeter: update to 2.0.9

### DIFF
--- a/desktop-displaymanagers/slick-greeter/spec
+++ b/desktop-displaymanagers/slick-greeter/spec
@@ -1,4 +1,4 @@
-VER=2.0.4
+VER=2.0.9
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/slick-greeter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14546"


### PR DESCRIPTION
Topic Description
-----------------

- slick-greeter: update to 2.0.9
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- slick-greeter: 2.0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit slick-greeter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
