### PR TITLE
catch2: fix cmake build flags

### DIFF
--- a/runtime-common/catch2/autobuild/defines
+++ b/runtime-common/catch2/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME="catch2"
-PKGDES="Modern, C++-native, header-only, test framework for unit-tests, TDD and BDD"
-BUILDDEP="cmake python-3"
 PKGSEC=libs
+PKGDES="C++-native test framework for unit-tests, TDD, and BDD"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="cmake python-3"
 
-ABHOST=noarch
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+)

--- a/runtime-common/catch2/spec
+++ b/runtime-common/catch2/spec
@@ -1,4 +1,5 @@
 VER=3.8.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/catchorg/Catch2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7680"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
1. 'header-only' is removed from github about, and it's always build 'Catch2', 'Catch2WithMain' target.
2. Resolve 'zug', 'immer' rebuild errors.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
No
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit catch2
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
