### PR TITLE
lua: install alternatives for /usr/bin/lua

### DIFF
--- a/lang-lua/lua-5.1/autobuild/postinst
+++ b/lang-lua/lua-5.1/autobuild/postinst
@@ -1,0 +1,2 @@
+update-alternatives --install /usr/bin/lua lua /usr/bin/lua5.1 50 \
+    --slave /usr/bin/luac luac /usr/bin/luac5.1

--- a/lang-lua/lua-5.1/spec
+++ b/lang-lua/lua-5.1/spec
@@ -1,5 +1,5 @@
 VER=5.1.5
-REL=5
+REL=6
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
 CHKSUMS="sha256::2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
 CHKUPDATE="anitya::id=230578"

--- a/lang-lua/lua-5.3/autobuild/postinst
+++ b/lang-lua/lua-5.3/autobuild/postinst
@@ -1,0 +1,2 @@
+update-alternatives --install /usr/bin/lua lua /usr/bin/lua5.3 50 \
+    --slave /usr/bin/luac luac /usr/bin/luac5.3

--- a/lang-lua/lua-5.3/spec
+++ b/lang-lua/lua-5.3/spec
@@ -1,5 +1,5 @@
 VER=5.3.6
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
 CHKSUMS="sha256::fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=328511"

--- a/lang-lua/lua-5.4/autobuild/postinst
+++ b/lang-lua/lua-5.4/autobuild/postinst
@@ -1,0 +1,2 @@
+update-alternatives --install /usr/bin/lua lua /usr/bin/lua5.4 50 \
+    --slave /usr/bin/luac luac /usr/bin/luac5.4

--- a/lang-lua/lua-5.4/spec
+++ b/lang-lua/lua-5.4/spec
@@ -2,3 +2,4 @@ VER=5.4.8
 SRCS="tbl::https://www.lua.org/ftp/lua-$VER.tar.gz"
 CHKSUMS="sha256::4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae"
 CHKUPDATE="anitya::id=328514"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- lua-5.4: install alternatives for /usr/bin/lua
- lua-5.3: install alternatives for /usr/bin/lua
- lua-5.1: install alternatives for /usr/bin/lua

Package(s) Affected
-------------------

- lua-5.1: 5.1.5-6
- lua-5.3: 1:5.3.6-3
- lua-5.4: 5.4.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lua-5.1 lua-5.3 lua-5.4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
