### PR TITLE
luajit: update to 2.1.0b3+git20250528


### DIFF
--- a/lang-lua/luajit/spec
+++ b/lang-lua/luajit/spec
@@ -1,4 +1,4 @@
-VER=2.1.0b3+git20240222
-SRCS="git::commit=0d313b243194a0b8d2399d8b549ca5a0ff234db5::https://luajit.org/git/luajit.git"
+VER=2.1.0b3+git20250528
+SRCS="git::commit=f9140a622a0c44a99efb391cc1c2358bc8098ab7::https://luajit.org/git/luajit.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6444"


### PR DESCRIPTION
Topic Description
-----------------

- luajit: update to 2.1.0b3+git20250528

Package(s) Affected
-------------------

- luajit: 2.1.0b3+git20250528

Security Update?
----------------

No

Build Order
-----------

```
#buildit luajit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
