### PR TITLE
fennel: new, 1.5.3

### DIFF
--- a/lang-lua/fennel-ls/autobuild/build
+++ b/lang-lua/fennel-ls/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building fennel-ls ..."
+make LUA=lua5.4
+
+abinfo "Building fennel-ls documentation ..."
+make docs
+
+abinfo "Installing fennel-ls ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr LUA=lua5.4

--- a/lang-lua/fennel-ls/autobuild/defines
+++ b/lang-lua/fennel-ls/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=fennel-ls
+PKGSEC=devel
+PKGDEP="lua-5.4 fennel lua-dkjson"
+PKGDES="Language server for Fennel"
+BUILDDEP="pandoc"
+
+ABHOST=noarch

--- a/lang-lua/fennel-ls/autobuild/prepare
+++ b/lang-lua/fennel-ls/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Cleaning vendored documentations ..."
+make rm-docs
+
+abinfo "Cleaning vendored dependencies ..."
+make rm-deps

--- a/lang-lua/fennel-ls/spec
+++ b/lang-lua/fennel-ls/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+SRCS="git::commit=tags/${VER}::https://git.sr.ht/~xerool/fennel-ls"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378752"

--- a/lang-lua/fennel/autobuild/build
+++ b/lang-lua/fennel/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building Fennel ..."
+make LUA=lua5.4
+
+abinfo "Installing Fennel ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr LUA=lua5.4

--- a/lang-lua/fennel/autobuild/defines
+++ b/lang-lua/fennel/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=fennel
+PKGSEC=devel
+PKGDES="Lisp dialect for Lua"
+PKGDEP="lua-5.4"
+BUILDDEP="pandoc"
+
+ABHOST=noarch

--- a/lang-lua/fennel/spec
+++ b/lang-lua/fennel/spec
@@ -1,0 +1,4 @@
+VER=1.5.3
+SRCS="git::commit=tags/${VER}::https://git.sr.ht/~technomancy/fennel"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=22691"

--- a/lang-lua/lpeg/autobuild/build
+++ b/lang-lua/lpeg/autobuild/build
@@ -1,3 +1,11 @@
-make LUADIR=/usr/include/lua5.1
-install -Dm755 lpeg.so "$PKGDIR"/usr/lib/lua/5.1/lpeg.so
-install -Dm644 re.lua "$PKGDIR"/usr/share/lua/5.1/re.lua
+for lua in 5.1 5.3 5.4; do
+    abinfo "Building LPeg for Lua $lua ..."
+    make LUADIR=/usr/include/lua"$lua"
+
+    abinfo "Installing LPeg for Lua $lua ..."
+    install -Dvm755 lpeg.so "$PKGDIR"/usr/lib/lua/"$lua"/lpeg.so
+    install -Dvm644 re.lua "$PKGDIR"/usr/share/lua/"$lua"/re.lua
+
+    abinfo "Cleaning build directory for future builds ..."
+    make clean
+done

--- a/lang-lua/lpeg/autobuild/defines
+++ b/lang-lua/lpeg/autobuild/defines
@@ -2,3 +2,4 @@ PKGNAME=lpeg
 PKGSEC=libs
 PKGDEP="lua"
 PKGDES="Pattern-matching library for Lua"
+BUILDDEP="lua-5.1 lua-5.3 lua-5.4"

--- a/lang-lua/lpeg/spec
+++ b/lang-lua/lpeg/spec
@@ -1,4 +1,5 @@
 VER=1.1.0
+REL=1
 SRCS="tbl::http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-$VER.tar.gz"
 CHKSUMS="sha256::4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a"
 CHKUPDATE="anitya::id=1852"

--- a/lang-lua/lua-dkjson/autobuild/build
+++ b/lang-lua/lua-dkjson/autobuild/build
@@ -1,0 +1,7 @@
+for lua in 5.1 5.3 5.4; do
+    abinfo "Installing dkjson for Lua $lua ..."
+    install -Dvm644 dkjson.lua "$PKGDIR"/usr/share/lua/"$lua"/dkjson.lua
+done
+
+abinfo "Installing dkjson documentation ..."
+install -Dvm644 README.txt "$PKGDIR"/usr/share/doc/lua-dkjson/README.txt

--- a/lang-lua/lua-dkjson/autobuild/defines
+++ b/lang-lua/lua-dkjson/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=lua-dkjson
+PKGSEC=devel
+PKGDEP="lua"
+PKGDES="JSON parsing library for the Lua language"
+BUILDDEP="lua-5.1 lua-5.3 lua-5.4"
+PKGRECOM="lpeg"
+
+ABHOST=noarch

--- a/lang-lua/lua-dkjson/spec
+++ b/lang-lua/lua-dkjson/spec
@@ -1,0 +1,6 @@
+VER=2.8
+SRCS="file::rename=dkjson.lua::https://dkolf.de/dkjson-lua/dkjson-$VER.lua \
+    file::rename=README.txt::https://dkolf.de/dkjson-lua/readme-$VER.txt"
+CHKSUMS="sha256::eb3bf160688fb395a2db6bc52eeff4f7855a6321d2b41bdc754554d13f4e7d44 \
+         sha256::9c60064047b0f41092ee714d205b4b915f1da147fdf9afc4b3ee7bcf028a2238"
+CHKUPDATE="anitya::id=378747"


### PR DESCRIPTION
Topic Description
-----------------

- fennel-ls: new, 0.2.1
- lua-dkjson: new, 2.8
- lpeg: build for all lua versions
- fennel: new, 1.5.3

Package(s) Affected
-------------------

- fennel: 1.5.3
- fennel-ls: 0.2.1
- lpeg: 1.1.0-1
- lua-dkjson: 2.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit fennel lpeg lua-dkjson fennel-ls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
