### PR TITLE
qscintilla: remove PKGBREAK

### DIFF
--- a/runtime-common/qscintilla/autobuild/defines
+++ b/runtime-common/qscintilla/autobuild/defines
@@ -3,5 +3,3 @@ PKGSEC=libs
 PKGDEP="qt-5 python-3"
 BUILDDEP="pyqt5 pyqt-builder chrpath"
 PKGDES="A port to Qt of Neil Hodgson's Scintilla C++ editor class"
-
-PKGBREAK="octave<=9.2.0-2 openscad<=2021.01+git20230825"

--- a/runtime-common/qscintilla/spec
+++ b/runtime-common/qscintilla/spec
@@ -1,4 +1,5 @@
 VER=2.14.1
+REL=1
 SRCS="tbl::https://www.riverbankcomputing.com/static/Downloads/QScintilla/${VER}/QScintilla_src-${VER}.tar.gz"
 CHKSUMS="sha256::dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d"
 CHKUPDATE="anitya::id=37195"


### PR DESCRIPTION
Topic Description
-----------------

- qscintilla: remove PKGBREAK
    Those package rebuilts were removed per previous review suggestions,
    but PKGBREAK was not removed, leading to unmet dependencies.

Package(s) Affected
-------------------

- qscintilla: 2.14.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qscintilla
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
