### PR TITLE
git: update to 2.50.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,7 +1,6 @@
-VER=2.49.0
+VER=2.50.0
 
 # Use this for stable releases.
-REL=3
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 
 # Use this for RC releases.
@@ -9,5 +8,5 @@ SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 #REL=0.${RC}
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::f8047f572f665bebeb637fd5f14678f31b3ca5d2ff9a18f20bd925bd48f75d3c"
+CHKSUMS="sha256::920f8ca563d16a7d4fdecb44349cbffbc5cb814a8b36c96028463478197050da"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.50.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- git: 2.50.0
- git-gui: 2.50.0
- gitk: 2.50.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
