### PR TITLE
darktable: update to 5.2.0

### DIFF
--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,4 @@
-VER=5.0.1
-REL=3
+VER=5.2.0
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: update to 5.2.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- darktable: 1:5.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
