### PR TITLE
musicfox: update to 4.6.2

### DIFF
--- a/app-multimedia/musicfox/spec
+++ b/app-multimedia/musicfox/spec
@@ -1,4 +1,4 @@
-VER=4.6.0
+VER=4.6.2
 SRCS="git::commit=tags/v$VER::https://github.com/go-musicfox/go-musicfox"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376106"


### PR DESCRIPTION
Topic Description
-----------------

- musicfox: update to 4.6.2

Package(s) Affected
-------------------

- musicfox: 4.6.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit musicfox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
