### PR TITLE
btrfs-progs: update to 6.15

### DIFF
--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.14
+VER=6.15
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::df5ab804fcb36e291c42ad8361f801ad1e10241b43bd304fe50ce3df9e7e3da1"
+CHKSUMS="sha256::57da428dd2199fd88d83ecf1cad05678ce78640ef7e52d7633be9887cef674bb"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 6.15
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- btrfs-progs: 6.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
