### PR TITLE
pocl: update to 7.0

### DIFF
--- a/runtime-common/pocl/autobuild/defines
+++ b/runtime-common/pocl/autobuild/defines
@@ -6,6 +6,7 @@ PKGDES="An OpenCL implementation that allows running kernels on the host (CPU)"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
+    -DENABLE_CONFORMANCE=ON \
     # CUDA and rusticl have provided OpenCL support on NVIDIA GPUs.
     -DENABLE_CUDA:BOOL=OFF \
     # Examples are not required to use the library.

--- a/runtime-common/pocl/spec
+++ b/runtime-common/pocl/spec
@@ -1,4 +1,4 @@
-VER=6.0
+VER=7.0
 SRCS="git::commit=tags/v${VER}::https://github.com/pocl/pocl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3676"


### PR DESCRIPTION
Topic Description
-----------------

- pocl: update to 7.0

Package(s) Affected
-------------------

- pocl: 1:7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pocl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
