### PR TITLE
rocm-base: add new subpackage

### DIFF
--- a/runtime-common/frugally-deep/autobuild/defines
+++ b/runtime-common/frugally-deep/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=frugally-deep
+PKGSEC=libs
+PKGDES="Header-only library for using Keras models in C++"
+# it's just headers
+PKGDEP="functional-plus eigen-3 nlohmann-json"
+BUILDDEP="cmake ninja"
+
+# just headers and cmake files
+# the building process is just to verify the headers work correctly
+ABHOST=noarch

--- a/runtime-common/frugally-deep/spec
+++ b/runtime-common/frugally-deep/spec
@@ -1,0 +1,4 @@
+VER=0.18.2
+SRCS="tbl::https://github.com/Dobiasd/frugally-deep/archive/v$VER.tar.gz"
+CHKSUMS="sha256::e4274735261c89fd312e5a23e16bfa540752d1a61a190037f63f4d2612495c64"
+CHKUPDATE="anitya::id=378969"

--- a/runtime-common/functional-plus/autobuild/defines
+++ b/runtime-common/functional-plus/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=functional-plus
+PKGSEC=libs
+PKGDES="Functional Programming Library for C++. Write concise and readable C++ code."
+# it's just headers
+PKGDEP=""
+BUILDDEP="cmake ninja"
+
+# just headers and cmake files
+# the building process is just to verify the headers work correctly
+ABHOST=noarch

--- a/runtime-common/functional-plus/spec
+++ b/runtime-common/functional-plus/spec
@@ -1,0 +1,4 @@
+VER=0.2.25
+SRCS="tbl::https://github.com/Dobiasd/FunctionalPlus/archive/v$VER.tar.gz"
+CHKSUMS="sha256::9b5e24bbc92f43b977dc83efbc173bcf07dbe07f8718fc2670093655b56fcee3"
+CHKUPDATE="anitya::id=378970"

--- a/runtime-rocm/rocm-composable-kernel/autobuild/defines
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/defines
@@ -1,0 +1,53 @@
+PKGNAME=rocm-composable-kernel
+PKGDES="High Performance Composable Kernel for AMD GPUs"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-rocfft"
+BUILDDEP="cmake"
+
+USECLANG=1
+
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+# FIXME: LTO Detecting HIP compiler ABI info
+#   LINKER_TYPE 'LLD' is unknown or not supported by this toolchain.
+NOLTO=1
+# FIXME: Build Fail DWARF DebugLoc
+#
+#  llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp:557
+#  bool llvm::DwarfExpression::addExpression(DIExpressionCursor &&, llvm::function_ref<bool (unsigned int, DIExpressionCursor &)>)
+#  Assertion `OffsetInBits >= FragmentOffset && "fragment offset not added?"' failed.
+ABSPLITDBG=0
+
+# Note: Keep libdevice_other_operations.a and etc...
+#  This is necessary for subsequent packages that depend on composable-kernel.
+NOSTATIC=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DDL_KERNELS=ON'
+    '-DDPP_KERNELS=ON'
+    '-DCK_USE_FP8_ON_UNSUPPORTED_ARCH=ON'
+    '-DBUILD_DEV=OFF'
+    '-DROCM_WARN_TOOLCHAIN_VAR=OFF'
+    '-DCMAKE_BUILD_TYPE=Release'
+)
+
+BUILD_READY(){
+# FIXME Limit Memory Used
+  MJOBS=$(free -g |tail -n2|head -1|awk '{print int($2/9)}')
+  CJOBS=$(nproc)
+  ninja -v -j $(( MJOBS > CJOBS ? CJOBS : MJOBS ))
+}
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-composable-kernel/autobuild/patches/0001-disable-composable-kernel-test-tidy.patch
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/patches/0001-disable-composable-kernel-test-tidy.patch
@@ -1,0 +1,195 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1fe1bc91d..075b87b31 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,7 @@ endif()
+ set(version 1.1.0)
+ # Check support for CUDA/HIP in Cmake
+ project(composable_kernel VERSION ${version} LANGUAGES CXX HIP)
+-include(CTest)
++# include(CTest)
+ 
+ # Usage: for customized Python location cmake -DCK_USE_ALTERNATIVE_PYTHON="/opt/Python-3.8.13/bin/python3.8"
+ # CK Codegen requires dataclass which is added in Python 3.7
+@@ -380,147 +380,6 @@ else()
+     add_compile_definitions(__HIP_PLATFORM_HCC__=1)
+ endif()
+ 
+-## tidy
+-include(EnableCompilerWarnings)
+-set(CK_TIDY_ERRORS ERRORS * -readability-inconsistent-declaration-parameter-name)
+-if(CMAKE_CXX_COMPILER MATCHES ".*hcc" OR CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+")
+-    set(CK_TIDY_CHECKS -modernize-use-override -readability-non-const-parameter)
+-# Enable tidy on hip
+-elseif(CK_BACKEND STREQUAL "HIP" OR CK_BACKEND STREQUAL "HIPNOGPU")
+-    set(CK_TIDY_ERRORS ALL)
+-endif()
+-
+-
+-include(ClangTidy)
+-enable_clang_tidy(
+-    CHECKS
+-        *
+-        -abseil-*
+-        -android-cloexec-fopen
+-        # Yea we shouldn't be using rand()
+-        -cert-msc30-c
+-        -bugprone-exception-escape
+-        -bugprone-macro-parentheses
+-        -cert-env33-c
+-        -cert-msc32-c
+-        -cert-msc50-cpp
+-        -cert-msc51-cpp
+-        -cert-dcl37-c
+-        -cert-dcl51-cpp
+-        -clang-analyzer-alpha.core.CastToStruct
+-        -clang-analyzer-optin.performance.Padding
+-        -clang-diagnostic-deprecated-declarations
+-        -clang-diagnostic-extern-c-compat
+-        -clang-diagnostic-unused-command-line-argument
+-        -cppcoreguidelines-avoid-c-arrays
+-        -cppcoreguidelines-avoid-magic-numbers
+-        -cppcoreguidelines-explicit-virtual-functions
+-        -cppcoreguidelines-init-variables
+-        -cppcoreguidelines-macro-usage
+-        -cppcoreguidelines-non-private-member-variables-in-classes
+-        -cppcoreguidelines-pro-bounds-array-to-pointer-decay
+-        -cppcoreguidelines-pro-bounds-constant-array-index
+-        -cppcoreguidelines-pro-bounds-pointer-arithmetic
+-        -cppcoreguidelines-pro-type-member-init
+-        -cppcoreguidelines-pro-type-reinterpret-cast
+-        -cppcoreguidelines-pro-type-union-access
+-        -cppcoreguidelines-pro-type-vararg
+-        -cppcoreguidelines-special-member-functions
+-        -fuchsia-*
+-        -google-explicit-constructor
+-        -google-readability-braces-around-statements
+-        -google-readability-todo
+-        -google-runtime-int
+-        -google-runtime-references
+-        -hicpp-vararg
+-        -hicpp-braces-around-statements
+-        -hicpp-explicit-conversions
+-        -hicpp-named-parameter
+-        -hicpp-no-array-decay
+-        # We really shouldn't use bitwise operators with signed integers, but
+-        # opencl leaves us no choice
+-        -hicpp-avoid-c-arrays
+-        -hicpp-signed-bitwise
+-        -hicpp-special-member-functions
+-        -hicpp-uppercase-literal-suffix
+-        -hicpp-use-auto
+-        -hicpp-use-equals-default
+-        -hicpp-use-override
+-        -llvm-header-guard
+-        -llvm-include-order
+-        #-llvmlibc-*
+-        -llvmlibc-restrict-system-libc-headers
+-        -llvmlibc-callee-namespace
+-        -llvmlibc-implementation-in-namespace
+-        -llvm-else-after-return
+-        -llvm-qualified-auto
+-        -misc-misplaced-const
+-        -misc-non-private-member-variables-in-classes
+-        -misc-no-recursion
+-        -modernize-avoid-bind
+-        -modernize-avoid-c-arrays
+-        -modernize-pass-by-value
+-        -modernize-use-auto
+-        -modernize-use-default-member-init
+-        -modernize-use-equals-default
+-        -modernize-use-trailing-return-type
+-        -modernize-use-transparent-functors
+-        -performance-unnecessary-value-param
+-        -readability-braces-around-statements
+-        -readability-else-after-return
+-        # we are not ready to use it, but very useful
+-        -readability-function-cognitive-complexity
+-        -readability-isolate-declaration
+-        -readability-magic-numbers
+-        -readability-named-parameter
+-        -readability-uppercase-literal-suffix
+-        -readability-convert-member-functions-to-static
+-        -readability-qualified-auto
+-        -readability-redundant-string-init
+-        # too many narrowing conversions in our code
+-        -bugprone-narrowing-conversions
+-        -cppcoreguidelines-narrowing-conversions
+-        -altera-struct-pack-align
+-        -cppcoreguidelines-prefer-member-initializer
+-        ${CK_TIDY_CHECKS}
+-        ${CK_TIDY_ERRORS}
+-    HEADER_FILTER
+-        "\.hpp$"
+-    EXTRA_ARGS
+-        -DCK_USE_CLANG_TIDY
+-)
+-
+-include(CppCheck)
+-enable_cppcheck(
+-    CHECKS
+-        warning
+-        style
+-        performance
+-        portability
+-    SUPPRESS
+-        ConfigurationNotChecked
+-        constStatement
+-        duplicateCondition
+-        noExplicitConstructor
+-        passedByValue
+-        preprocessorErrorDirective
+-        shadowVariable
+-        unusedFunction
+-        unusedPrivateFunction
+-        unusedStructMember
+-        unmatchedSuppression
+-    FORCE
+-    SOURCES
+-        library/src
+-    INCLUDE
+-        ${CMAKE_CURRENT_SOURCE_DIR}/include
+-        ${CMAKE_CURRENT_BINARY_DIR}/include
+-        ${CMAKE_CURRENT_SOURCE_DIR}/library/include
+-    DEFINE
+-        CPPCHECK=1
+-        __linux__=1
+-)
+-
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index bcb62df62..365b1a56a 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -119,7 +119,7 @@ function(add_example_executable EXAMPLE_NAME FILE_NAME)
+         add_test(NAME ${EXAMPLE_NAME} COMMAND $<TARGET_FILE:${EXAMPLE_NAME}> ${ARGN})
+         set_property(TARGET ${EXAMPLE_NAME} PROPERTY HIP_ARCHITECTURES ${EX_TARGETS} )
+         add_dependencies(examples ${EXAMPLE_NAME})
+-        add_dependencies(check ${EXAMPLE_NAME})
++#        add_dependencies(check ${EXAMPLE_NAME})
+         rocm_install(TARGETS ${EXAMPLE_NAME} COMPONENT examples)
+         set(result 0)
+     endif()
+diff --git a/library/src/tensor_operation_instance/gpu/CMakeLists.txt b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+index 5b88d5f25..2ef26ee0b 100755
+--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
++++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+@@ -159,7 +159,6 @@ function(add_instance_library INSTANCE_NAME)
+         endif()
+ 
+         set_target_properties(${INSTANCE_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+-        clang_tidy_check(${INSTANCE_NAME})
+         set(result 0)
+         message("add_instance_library ${INSTANCE_NAME}")
+     else()
+diff --git a/library/src/utility/CMakeLists.txt b/library/src/utility/CMakeLists.txt
+index 28883efef..1573c84cb 100644
+--- a/library/src/utility/CMakeLists.txt
++++ b/library/src/utility/CMakeLists.txt
+@@ -31,4 +31,3 @@ rocm_install(
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/composable_kernel
+ )
+ 
+-clang_tidy_check(utility)

--- a/runtime-rocm/rocm-composable-kernel/autobuild/prepare
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Use LLD for Link ..."
+export LDFLAGS="${LDFLAGS} -fuse-ld=lld"

--- a/runtime-rocm/rocm-composable-kernel/spec
+++ b/runtime-rocm/rocm-composable-kernel/spec
@@ -1,0 +1,5 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/composable_kernel.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378814"
+ENVREQ="big_job total_mem=100"

--- a/runtime-rocm/rocm-hipsolver/autobuild/defines
+++ b/runtime-rocm/rocm-hipsolver/autobuild/defines
@@ -1,0 +1,27 @@
+PKGNAME=rocm-hipsolver
+PKGDES="Radeon Open Compute LAPACK marshalling library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocblas rocm-rocsolver rocm-hipblas rocm-hipsparse"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-hipsolver/autobuild/prepare
+++ b/runtime-rocm/rocm-hipsolver/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-hipsolver/spec
+++ b/runtime-rocm/rocm-hipsolver/spec
@@ -1,0 +1,4 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipSOLVER.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378810"

--- a/runtime-rocm/rocm-migraphx/autobuild/defines
+++ b/runtime-rocm/rocm-migraphx/autobuild/defines
@@ -1,0 +1,34 @@
+PKGNAME=rocm-migraphx
+PKGDES="AMD graph optimizer"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocblas rocm-rocsolver rocm-hipblas rocm-hipblaslt rocm-half rocm-rocmlir"
+BUILDDEP="cmake nlohmann-json msgpack-c++ pybind11"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DROCM_ENABLE_CLANG_TIDY=OFF'
+    '-DBUILD_TESTING=OFF'
+# FIXME: Unsupported component: jit_library
+    '-DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF'
+
+# FIXME: sending SIGSEGV to migraphx-driver for invalid read access from
+    '-DMIGRAPHX_USE_MIOPEN=OFF'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-migraphx/autobuild/patches/0001-use-msgpack-cpp.patch
+++ b/runtime-rocm/rocm-migraphx/autobuild/patches/0001-use-msgpack-cpp.patch
@@ -1,0 +1,22 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 248054301..00d7b6a57 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -329,13 +329,13 @@ target_link_libraries(migraphx PRIVATE nlohmann_json::nlohmann_json)
+ find_package(SQLite3 REQUIRED)
+ target_link_libraries(migraphx PRIVATE SQLite::SQLite3)
+
+-find_package(msgpackc-cxx QUIET)
+-if(NOT msgpackc-cxx_FOUND)
++find_package(msgpack-cxx QUIET)
++if(NOT msgpack-cxx_FOUND)
+     find_package(msgpack REQUIRED)
+ endif()
+-target_link_libraries(migraphx PRIVATE msgpackc-cxx)
++target_link_libraries(migraphx PRIVATE msgpack-cxx)
+ # Make this available to the tests
+-target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpackc-cxx>)
++target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpack-cxx>)
+
+ add_library(migraphx_all_targets INTERFACE)
+

--- a/runtime-rocm/rocm-migraphx/autobuild/prepare
+++ b/runtime-rocm/rocm-migraphx/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-migraphx/spec
+++ b/runtime-rocm/rocm-migraphx/spec
@@ -1,0 +1,4 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/AMDMIGraphX.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379160"

--- a/runtime-rocm/rocm-miopen/autobuild/defines
+++ b/runtime-rocm/rocm-miopen/autobuild/defines
@@ -1,0 +1,32 @@
+PKGNAME=rocm-miopen
+PKGDES="AMD DNN Library"
+PKGSEC=devel
+PKGDEP="frugally-deep rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-rocblas rocm-hipblas rocm-rocmlir rocm-hipblaslt rocm-rocrand rocm-half rocm-composable-kernel"
+BUILDDEP="cmake git-lfs"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_HIP_COMPILER=/usr/lib/rocm/lib/llvm/bin/amdclang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_BUILD_TYPE=Release'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DMIOPEN_BACKEND=HIP'
+    '-DBUILD_DEV=OFF'
+    '-DBUILD_TESTING=OFF'
+    '-DBoost_USE_STATIC_LIBS=OFF'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-miopen/autobuild/prepare
+++ b/runtime-rocm/rocm-miopen/autobuild/prepare
@@ -1,0 +1,16 @@
+acbs_copy_git
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Fetch Git LFS ..."
+cd "$SRCDIR"
+git lfs install
+git lfs fetch origin "rocm-$PKGVER"
+git lfs pull --exclude=
+git lfs checkout

--- a/runtime-rocm/rocm-miopen/spec
+++ b/runtime-rocm/rocm-miopen/spec
@@ -1,0 +1,4 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/MIOpen.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=241712"

--- a/runtime-rocm/rocm-rocalution/autobuild/defines
+++ b/runtime-rocm/rocm-rocalution/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=rocm-rocalution
+PKGDES="ROCm library for sparse linear systems"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocrand rocm-rocblas rocm-rocsparse"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_HIP_COMPILER=/usr/lib/rocm/lib/llvm/bin/amdclang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rocalution/autobuild/prepare
+++ b/runtime-rocm/rocm-rocalution/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-rocalution/spec
+++ b/runtime-rocm/rocm-rocalution/spec
@@ -1,0 +1,4 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocALUTION.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378813"

--- a/runtime-rocm/rocm-rocthrust/autobuild/defines
+++ b/runtime-rocm/rocm-rocthrust/autobuild/defines
@@ -1,0 +1,29 @@
+PKGNAME=rocm-rocthrust
+PKGDES="Radeon Open Compute Thrust library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocprim"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+# Note: Depends on architecture-specific runtime. Treat as ELF-less.
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rocthrust/autobuild/prepare
+++ b/runtime-rocm/rocm-rocthrust/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-rocthrust/spec
+++ b/runtime-rocm/rocm-rocthrust/spec
@@ -1,0 +1,4 @@
+VER=6.4.3
+SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocThrust.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378811"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-migraphx: add, 6.4.3
- rocm-miopen: add, 6.4.3
- frugally-deep: add, 0.18.2
- functional-plus: add, 0.2.25
- rocm-composable-kernel: add, 6.4.3
- rocm-rocalution: add, 6.4.3
- rocm-rocthrust: add, 6.4.3
- rocm-hipsolver: add, 6.4.3

Package(s) Affected
-------------------

- frugally-deep: 0.18.2
- functional-plus: 0.2.25
- rocm-composable-kernel: 6.4.3
- rocm-hipsolver: 6.4.3
- rocm-migraphx: 6.4.3
- rocm-miopen: 6.4.3
- rocm-rocalution: 6.4.3
- rocm-rocthrust: 6.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipsolver rocm-rocthrust rocm-rocalution rocm-composable-kernel functional-plus frugally-deep rocm-miopen rocm-migraphx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
