### PR TITLE
vscode: update to 1.101.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.101.0
+VER=1.101.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::c0cb221aa17ef63d818957c63f33d43dd4deb96b4d7b069b0bd3513b920e4492"
-CHKSUMS__ARM64="sha256::bf1f6895514ba1b2f01c4da6e9543f1a430b29c15f79032b1672012c11cc8724"
+CHKSUMS__AMD64="sha256::e1f65b55302c3e81af5102ec291cd8f71ea25fbc4259f24772fd57ccc7810871"
+CHKSUMS__ARM64="sha256::ef60deb1d270ef588eaf718df134162c51687b2b468e273dba9ed052961040b7"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.101.1
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscode: 1.101.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
