### PR TITLE
bird: update to 2.17.1

### DIFF
--- a/app-network/bird/spec
+++ b/app-network/bird/spec
@@ -1,4 +1,4 @@
-VER=2.15.1
+VER=2.17.1
 SRCS="tbl::https://bird.network.cz/download/bird-$VER.tar.gz"
-CHKSUMS="sha256::48e85c622de164756c132ea77ad1a8a95cc9fd0137ffd0d882746589ce75c75d"
+CHKSUMS="sha256::bfd718dfa596819b3801688783212514b467163329aec9bbcd0fa3dee03e10e9"
 CHKUPDATE="anitya::id=192"


### PR DESCRIPTION
Topic Description
-----------------

- bird: update to 2.17.1

Package(s) Affected
-------------------

- bird: 2.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
