### PR TITLE
z3: update to 4.15.2

### DIFF
--- a/app-devel/z3/spec
+++ b/app-devel/z3/spec
@@ -1,4 +1,4 @@
-VER=4.15.1
+VER=4.15.2
 SRCS="git::commit=tags/z3-$VER::https://github.com/Z3Prover/z3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7812"


### PR DESCRIPTION
Topic Description
-----------------

- z3: update to 4.15.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- z3: 4.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit z3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
