### PR TITLE
polymake: update to 4.13

### DIFF
--- a/app-scientific/polymake/spec
+++ b/app-scientific/polymake/spec
@@ -1,5 +1,4 @@
-VER=3.3
+VER=4.13
 SRCS="tbl::https://polymake.org/lib/exe/fetch.php/download/polymake-$VER-minimal.tar.bz2"
-CHKSUMS="sha256::f7867137f99d5e8b86035ba05b59a63c5b73a95b21b88059fd2439216c128792"
-REL=3
+CHKSUMS="sha256::f3adacd063b9ea60d5e9c37c6183f5dbb7458b0cb3491eba3efc38f20c565ceb"
 CHKUPDATE="anitya::id=7783"


### PR DESCRIPTION
Topic Description
-----------------

- polymake: update to 4.13
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- polymake: 4.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit polymake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
