### PR TITLE
perl-image-exiftool: update to 13.30

### DIFF
--- a/lang-perl/perl-image-exiftool/spec
+++ b/lang-perl/perl-image-exiftool/spec
@@ -1,4 +1,4 @@
-VER=12.50
-SRCS="tbl::https://www.cpan.org/modules/by-module/Image/EXIFTOOL/Image-ExifTool-$VER.tar.gz"
-CHKSUMS="sha256::bce841fc5c10302f0f3ef7678c3bf146953a8c065c0ba18c41f734007e2ec0a8"
+VER=13.30
+SRCS="tbl::https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-${VER}.tar.gz"
+CHKSUMS="sha256::885afd06c4efcc60d1df703cc88ba7ddc3bb6fed854cfbaa9e6cd72adfbe8da9"
 CHKUPDATE="anitya::id=6175"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- perl-image-exiftool update to 13.30.
- View [Image::ExifTool](https://metacpan.org/dist/Image-ExifTool/view/lib/Image/ExifTool.pod) for more information.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- perl-image-exiftool: 12.50
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit perl-image-exiftool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
