### PR TITLE
pyside6: use cmake to build the project and bring back cmake config files

### DIFF
--- a/lang-python/pyside6/autobuild/beyond
+++ b/lang-python/pyside6/autobuild/beyond
@@ -1,0 +1,39 @@
+# Fedora: Copy CMake files to the SRCDIR for setuptools to find them.
+# https://src.fedoraproject.org/rpms/python-pyside6/blob/rawhide/f/python-pyside6.spec#_282
+abinfo "Copying CMake files ..."
+cp -v "$BLDDIR"/sources/shiboken6/shibokenmodule/{*.py,*.txt} "$SRCDIR"/sources/shiboken6/shibokenmodule/
+cp -v "$BLDDIR"/sources/pyside6/PySide6/*.py "$SRCDIR"/sources/pyside6/PySide6/
+
+# They are NOT user facing tools. Get them out of here.
+abinfo "Moving Pyside6 scripts out of /usr/bin ..."
+mkdir -pv "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/shiboken6_generator/scripts
+mkdir -pv "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/PySide6/scripts
+for file in $(find "$PKGDIR"/usr/bin -mindepth 1 -maxdepth 1 -printf '%P\n') ; do
+	if [ "$file" = "shiboken6" ] ; then
+		 continue
+	fi
+	if [ "$file" = "shiboken_tool.py" ] ; then
+		# It belongs to shiboken6_generator.
+		mv -v "$PKGDIR"/usr/bin/"$file" \
+			"$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/shiboken6_generator/scripts/
+		continue
+	fi
+	# The rest of them goes to PySide6/scrpits.
+	mv -v "$PKGDIR"/usr/bin/"$file" \
+		"$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/PySide6/scripts/
+done
+
+abinfo "Installing shiboken6 proper for shiboken6_generator ..."
+cp -v "$BLDDIR"/sources/shiboken6/generator/shiboken6 "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/shiboken6_generator/shiboken6
+
+abinfo "Installing tools ..."
+python3 "$SRCDIR"/setup.py --qtpaths=/usr/lib/qt6/bin/qtpaths install_scripts --install-dir="$PKGDIR"/usr/bin/
+
+abinfo "Generating egg_info ..."
+env PATH="/usr/lib/qt6/bin:$PATH" python3 "$SRCDIR"/setup.py egg_info
+
+abinfo "Installing Python Egg-info files ..."
+for name in PySide6 shiboken6 shiboken6_generator; do
+  cp -av $name.egg-info \
+        "$PKGDIR"/usr/lib/python${ABPY3VER}/site-packages/
+done

--- a/lang-python/pyside6/autobuild/build
+++ b/lang-python/pyside6/autobuild/build
@@ -1,7 +1,0 @@
-abinfo "Building Pyside6 and Shibiken6 ..."
-python3 "$SRCDIR"/setup.py install \
-    --root="$PKGDIR" \
-    --relwithdebinfo \
-    --verbose-build \
-    --qtpaths=/usr/bin/qtpaths6-qt6 \
-    --no-strip

--- a/lang-python/pyside6/autobuild/defines
+++ b/lang-python/pyside6/autobuild/defines
@@ -1,11 +1,17 @@
 PKGNAME=pyside6
 PKGSEC=libs
 PKGDEP="qt-6 python-3 llvm"
-BUILDDEP="sphinx patchelf wheel setuptools"
+BUILDDEP="sphinx wheel setuptools"
 PKGDES="Python bindings for the Qt 6 cross-platform application and UI framework"
 
 PKGPROV="shiboken6"
 
-# Note: The setup.py script supplied by this package's source is really
-# a wrapper for a series of custom build procedures.
-ABTYPE=self
+ABTYPE=cmakeninja
+
+CMAKE_AFTER=(
+	"-DUSE_PYTHON_VERSION=3"
+	"-DBUILD_TESTS=OFF"
+	"-DCMAKE_BUILD_TYPE=None"
+	"-DFORCE_LIMITED_API=no"
+	"-DNO_QT_TOOLS=yes"
+)

--- a/lang-python/pyside6/autobuild/prepare
+++ b/lang-python/pyside6/autobuild/prepare
@@ -1,0 +1,18 @@
+abinfo "Determining LLVM installation directory ..."
+_LLVMDIR=$(realpath /usr/bin/clang)
+_LLVMDIR=$(dirname "$_LLVMDIR")
+_LLVMDIR=$(realpath "$_LLVMDIR"/..)
+
+if [ ! -x "$_LLVMDIR"/bin/clang ] ; then
+	abdie "Expecting a LLVM installation at $_LLVMDIR, but we can't find one!"
+fi
+
+# Let CMake (or, the CMake scripts from PySide6) use the correct LLVM version.
+abinfo "Setting the correct path of LLVM installation ..."
+export CLANG_INSTALL_DIR="$_LLVMDIR"
+
+# One of the build stages makes use of shiboken module.
+# Make sure the build sysem uses the just-built modules instead of searching
+# from the system site-packages.
+abinfo "Adding path to the built modules in BLDDIR to PYTHONPATH ..."
+export PYTHONPATH="$BLDDIR"/sources

--- a/lang-python/pyside6/spec
+++ b/lang-python/pyside6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2.1
-REL=1
+REL=2
 SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-$VER-src/pyside-setup-everywhere-src-$VER.tar.xz"
 CHKSUMS="sha256::13f7a00b360a5869084fcc085c48ba236915a200bb5a13c1548ed8ab7a8b606b"
 CHKUPDATE="anitya::id=148812"


### PR DESCRIPTION
Topic Description
-----------------

- pyside6: use cmake to build the project and bring back cmake config files
    Co-authored-by: Xinhui Yang <cyan@cyano.uk>

Package(s) Affected
-------------------

- pyside6: 6.8.2.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
