### PR TITLE
chezmoi: update to 2.62.7

### DIFF
--- a/app-utils/chezmoi/spec
+++ b/app-utils/chezmoi/spec
@@ -1,4 +1,4 @@
-VER=2.62.5
+VER=2.62.7
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/twpayne/chezmoi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232604"


### PR DESCRIPTION
Topic Description
-----------------

- chezmoi: update to 2.62.7
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- chezmoi: 2.62.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit chezmoi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
