### PR TITLE
erofs-utils: update to 1.8.9

### DIFF
--- a/app-admin/erofs-utils/spec
+++ b/app-admin/erofs-utils/spec
@@ -1,4 +1,4 @@
-VER=1.8.7
+VER=1.8.9
 SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=63188"


### PR DESCRIPTION
Topic Description
-----------------

- erofs-utils: update to 1.8.9
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- erofs-utils: 1.8.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit erofs-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
