### PR TITLE
vscode: update to 1.101.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.101.1
+VER=1.101.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::e1f65b55302c3e81af5102ec291cd8f71ea25fbc4259f24772fd57ccc7810871"
-CHKSUMS__ARM64="sha256::ef60deb1d270ef588eaf718df134162c51687b2b468e273dba9ed052961040b7"
+CHKSUMS__AMD64="sha256::b8a90a787778ce79ff616fcac689339479e7eab1dc541ece208a97caa51a153b"
+CHKSUMS__ARM64="sha256::b3518d070bb87867f14ee72c12803b7b03fbd3bd051314338e53d472160ec204"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.101.2
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscode: 1.101.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
