### PR TITLE
cloudflared: update to 2025.6.1

### DIFF
--- a/app-proxy/cloudflared/autobuild/build
+++ b/app-proxy/cloudflared/autobuild/build
@@ -1,6 +1,3 @@
-abinfo "Downloading Cloudflare Go ..."
-make install-go
-
 abinfo "Building Cloudflared ..."
 make cloudflared PREFIX=$PKGDIR/usr PACKAGE_MANAGER=oma
 

--- a/app-proxy/cloudflared/autobuild/defines
+++ b/app-proxy/cloudflared/autobuild/defines
@@ -3,5 +3,7 @@ PKGSEC=net
 PKGDEP="glibc"
 PKGDES="Cloudflare Tunnel client"
 
+# upstream created then deleted tag 2025.100.150 between 2025.4.0 and 2025.4.2
+PKGEPOCH=1
+
 BUILDDEP="go"
-FAIL_ARCH="!(amd64|arm64)"

--- a/app-proxy/cloudflared/autobuild/patches/0001-Add-loongarch64-architecture-support.patch
+++ b/app-proxy/cloudflared/autobuild/patches/0001-Add-loongarch64-architecture-support.patch
@@ -1,0 +1,25 @@
+From 30fbc18f87fc9be69649ed5b7ed1aff41c130040 Mon Sep 17 00:00:00 2001
+From: DWwanghao <wanghao03@loongson.cn>
+Date: Tue, 24 Jun 2025 20:52:37 +0800
+Subject: [PATCH 1/3] Add loongarch64 architecture support
+
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index e9b411dc..6df88f2c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -76,6 +76,8 @@ else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
+     TARGET_ARCH ?= arm
+ else ifeq ($(LOCAL_ARCH),s390x)
+     TARGET_ARCH ?= s390x
++else ifeq ($(LOCAL_ARCH),loongarch64)
++    TARGET_ARCH ?= loong64
+ else
+     $(error This system's architecture $(LOCAL_ARCH) isn't supported)
+ endif
+-- 
+2.50.0
+

--- a/app-proxy/cloudflared/autobuild/patches/0002-support-build-from-source-on-risc64.patch
+++ b/app-proxy/cloudflared/autobuild/patches/0002-support-build-from-source-on-risc64.patch
@@ -1,0 +1,25 @@
+From 0dd900a5af074ea5db8ef3d5521bd40bef379253 Mon Sep 17 00:00:00 2001
+From: "maple@max" <maple@max>
+Date: Mon, 27 Jan 2025 18:42:39 +0800
+Subject: [PATCH 2/3] support build from source on risc64
+
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 6df88f2c..f34e7eeb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -78,6 +78,8 @@ else ifeq ($(LOCAL_ARCH),s390x)
+     TARGET_ARCH ?= s390x
+ else ifeq ($(LOCAL_ARCH),loongarch64)
+     TARGET_ARCH ?= loong64
++else ifeq ($(LOCAL_ARCH),riscv64)
++    TARGET_ARCH ?= riscv64
+ else
+     $(error This system's architecture $(LOCAL_ARCH) isn't supported)
+ endif
+-- 
+2.50.0
+

--- a/app-proxy/cloudflared/autobuild/patches/0003-add-ppc64le-and-mips64-architecture-support.patch
+++ b/app-proxy/cloudflared/autobuild/patches/0003-add-ppc64le-and-mips64-architecture-support.patch
@@ -1,0 +1,27 @@
+From ca358a46e9ff59a6a86b8487e506f67876cd8bfb Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Sat, 28 Jun 2025 02:34:50 +0000
+Subject: [PATCH 3/3] add ppc64le and mips64 architecture support
+
+---
+ Makefile | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index f34e7eeb..27086ced 100644
+--- a/Makefile
++++ b/Makefile
+@@ -80,6 +80,10 @@ else ifeq ($(LOCAL_ARCH),loongarch64)
+     TARGET_ARCH ?= loong64
+ else ifeq ($(LOCAL_ARCH),riscv64)
+     TARGET_ARCH ?= riscv64
++else ifeq ($(LOCAL_ARCH),mips64)
++    TARGET_ARCH ?= mips64
++else ifeq ($(LOCAL_ARCH),ppc64le)
++    TARGET_ARCH ?= ppc64le
+ else
+     $(error This system's architecture $(LOCAL_ARCH) isn't supported)
+ endif
+-- 
+2.50.0
+

--- a/app-proxy/cloudflared/spec
+++ b/app-proxy/cloudflared/spec
@@ -1,4 +1,4 @@
-VER=2025.100.150
+VER=2025.6.1
 # copy repo required by auto version detection logic in makefile
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/cloudflare/cloudflared"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- cloudflared: update to 2025.6.1

Package(s) Affected
-------------------

- cloudflared: 1:2025.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cloudflared
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
