### PR TITLE
lfortran: update to 0.53.0

### DIFF
--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.52.0
+VER=0.53.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::51fb60960cce602bf439ee3949e9e52fc8feb0b14794263f2654e692387f23a2"
+CHKSUMS="sha256::785248d87d9d1b7608dab5ff85e7af32e6614dbeb4378f430b7102ed4bdd4aa5"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.53.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.53.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
