### PR TITLE
intel-oneapi-basekit: update to 2025.2.0

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,7 +1,6 @@
-VER=2025.1.2
-PKG_URL=ac050ae7-da93-4108-823d-4334de3f4ee8
-PKG_CODE=9
+VER=2025.2.0
+PKG_URL=bd1d0273-a931-4f7e-ab76-6a2a67d646c7
+PKG_CODE=592
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha384::281cb8183e18baccd001b2442dec46ca4ac70ba3e1e72e457042020cccb5a2223073df933bacf880bcb5c0023c72d237"
+CHKSUMS="sha384::176c5400c7f7df83d19ac03e3f8d9f11a10c7b6e44f641ca3129fae3b4aac65541185bb6501451a57df664e4f6031eb0"
 CHKUPDATE="anitya::id=372585"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.2.0

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
