### PR TITLE
obs-studio: update to 31.0.4

### DIFF
--- a/app-multimedia/obs-studio/autobuild/defines
+++ b/app-multimedia/obs-studio/autobuild/defines
@@ -6,6 +6,8 @@ PKGDEP="ffmpeg jansson libfdk-aac x11-lib libxkbcommon qt-6 curl imagemagick \
 PKGDEP__INTEL_QSV="libvpl"
 PKGDEP__AMD64="${PKGDEP} ${PKGDEP__INTEL_QSV}"
 
+PKGRECOM="v4l2loopback"
+
 BUILDDEP="cmake x264 swig vlc pipewire jack patchelf python-3 nlohmann-json ffnvcodec"
 BUILDDEP__AMD64="${BUILDDEP} luajit"
 BUILDDEP__ARM64="${BUILDDEP__AMD64}"

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,4 @@
-VER=31.0.3
+VER=31.0.4
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # Check https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux#obs-browser
 # for upstream required CEF version for reference.


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: update to 31.0.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- obs-studio: 31.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
