### PR TITLE
castxml: fix build error

### DIFF
--- a/app-devel/castxml/autobuild/beyond
+++ b/app-devel/castxml/autobuild/beyond
@@ -1,6 +1,10 @@
 abinfo "Detecting clang headers location ..."
-# The location will change with each LLVM release, so we need to search for it
-INC_LOCATION="$(find /usr/lib/clang/ -maxdepth 2 -name "include" -type d)"
+# NOTE: The location will change with each LLVM release, so we need to search for it
+LLVMDIR="$(llvm-config --prefix)"
+LLVMMAJOR="$(llvm-config --version)"
+LLVMMAJOR="${LLVMMAJOR%%.*}"
+# You may have to export this.
+export INC_LOCATION="$LLVMDIR"/lib/clang/"$LLVMMAJOR"/include
 
 abinfo "Making symlinks to system clang headers ..."
 install -d "$PKGDIR/usr/share/castxml/clang"

--- a/app-devel/castxml/autobuild/defines
+++ b/app-devel/castxml/autobuild/defines
@@ -4,4 +4,6 @@ PKGDES="A C-family abstract syntax tree XML output tool"
 PKGDEP="llvm"
 BUILDDEP="cmake ninja"
 
-CMAKE_AFTER="-DClang_DIR=/usr/lib/cmake/clang/"
+CMAKE_AFTER=(
+    "-DClang_DIR=/usr/lib/cmake/clang/"
+)

--- a/app-devel/castxml/spec
+++ b/app-devel/castxml/spec
@@ -1,5 +1,5 @@
 VER=0.6.8
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/CastXML/CastXML"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9347"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- The dir "/usr/lib/clang/xx" is llvm link now, so use "find -L" to find "include" dir. 
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- castxml: 0.6.8-2
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit castxml
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
