### PR TITLE
intel-gpu-tools: update to 2.1

### DIFF
--- a/app-admin/intel-gpu-tools/spec
+++ b/app-admin/intel-gpu-tools/spec
@@ -1,4 +1,4 @@
-VER=2.0
+VER=2.1
 SRCS="tbl::https://www.x.org/archive/individual/app/igt-gpu-tools-$VER.tar.xz"
-CHKSUMS="sha256::ab060a2652509e3bbaeb19d8b227c3b063074c9a905a37508830360435d2bb8f"
+CHKSUMS="sha256::bf72beff71093db692f386c9359b557dfa8e8c45250439c952564b1b6fe343f8"
 CHKUPDATE="anitya::id=12378"


### PR DESCRIPTION
Topic Description
-----------------

- intel-gpu-tools: update to 2.1
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- intel-gpu-tools: 2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gpu-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
