### PR TITLE
iosevka-fonts: update to 33.2.6

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.5
+VER=33.2.6
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::6239f2cf6fa421abc1455a74fcbb5380b7005c3da52e27b6e63728668607cf9f \
-         sha256::b21b0d1be237b092f39ada414b84d9a64e2db7762ac47751d460097f7d59b083 \
-         sha256::0f244a33e5fbbaac4a57dd94268f38e8cf30baf6489bc7eab35936fc278b220c \
-         sha256::b2d7de76a1023dde8673e1dca9bac787a4f613c5d53139f26fc1b3fe7558ea24 \
-         sha256::88d324ad93bdbd563005f6d3cffc72350a622078da8ccefe362c705cda5d973e \
-         sha256::6d59fe5213f2eb4ac0ecd3f9cb87e00d6c09f5bfcb2e2b375ca6ccafec98c96f \
-         sha256::0c394c91cb9fa4da045f4cdea27d5023a6d30202a7c6aa3fcfb9961b3d676508 \
-         sha256::c0d5b927bec017c389e9de1808b2cb94250ee7146061042a3a2a4da11d140238 \
-         sha256::21312d09b46588ec06b043873924a5ab2e44553cafe4e69220cfbb3831fb40ea \
-         sha256::339ccb7f5d6b0087ad9a1e8e9751697ae57eab9939986219f10c9cc7f818b740 \
-         sha256::18f338de5113c8f6f438010a8784a1053138931e4fbc882ccf11b7179586ad61 \
-         sha256::6ce59d7b82d83996f1edc1777f78ba41b3bf1149346ddfe94ab4cea49fc6c5fb \
-         sha256::50d35b27bf15ee80e65a9269d5cfef0cb7b925e52055bafb47c4604e7766e224 \
-         sha256::97b8040adcdbad64eb535807d02d40e29efa07115589d6941f49f8a996a764a9 \
-         sha256::146891d119e8b7e452d6855283f8ff693eef1e7a57840a65f40937cfc5e76077 \
-         sha256::42b94d00129be74c626e1c2bdb49b42c1d65a88e9dbf6f047eac5f6babe22142 \
-         sha256::5c969ff6a4a6a43a3c9a0da6623818c0272d9dbf2f6f0f650b64a4e30222d61b \
-         sha256::ecd74821f08d9b25f634b1d952e79087459033123c7d3c6bcb3eb8a651b8d2c3 \
-         sha256::6f873d4f4c2306bffbe258861b5359188c7f61824abe2088c34b07e8b1105194 \
-         sha256::acc877eaa7595406e050420dfd93f26dbb6070ae85bdbc1a3ef3472446186e75 \
-         sha256::f2c9ee61397a3964071e617ab9a950563941549fbc4f951dedf800a9ea3c1143 \
-         sha256::feb7cb79018bd52cac366ce0823514fbd4b6c49e6bc03d69986a689ae891fcb6 \
-         sha256::77e0fec6efe793da34d5418a6b19bbbb5958527d167109e67aed93fc047c594e \
-         sha256::687e37cae4cd6e7322b251317c7e14a30cdd98ccfd8e65448e88b7c99d5a2b8a \
+CHKSUMS="sha256::cdc5d97f4a417658ec24b85cb35621a79451a366afa28619b613e64d8f605cd9 \
+         sha256::c97f0a3850db9cf30635d19e62d74c3536b089953dfc56ec3c101b0d892a8e03 \
+         sha256::8187170dcd82e0afc73b709f37e16da6f6d703242683c55322059bd058a9ee2a \
+         sha256::67e20e3f6c449d7fe1dc05f06cdd70f2665a2a4ad4905006b71e2ffa8b52103e \
+         sha256::6f1b353b54fa786cbc6f8b4242e897022990a55a2a4dc0af39c03566539092dc \
+         sha256::3c8dfbc7c7c054d16aa0aa9f624947277e7e9f039b9ef70df85c3d961a1182b1 \
+         sha256::5e21a1280a6f4d16dbfa7c7b56cb59840ab5f21f696ad21f41852ffeff16280a \
+         sha256::52e275134c837b5e0cc59ccfb817c25a58a3ea0c6fed7eefafaa66d6ab94fef2 \
+         sha256::7ab66bb56bfec4e0bd9253330662e1461dbb02f8e8c9d80b2ebe559368d45a16 \
+         sha256::265a71b2dcd753226993c681777e755eaff78ac3d92907c0dfc8ea5cd9a189fd \
+         sha256::86946d1c183adb04c095aa52b387cb58f94da34334a039c8f5e6f914d9b873f6 \
+         sha256::40577d6abadcda1fad044e22e95cdc49a62a20078ec956fe526259eb5d796114 \
+         sha256::0b912234a0c90efa784235908476524e4470c70bc82411ed39a4b30b00eff0ec \
+         sha256::43df361b83dcb45f0857640d225864b0dda242420e319992e6330134658980b1 \
+         sha256::162d90f7fed784ccdafa7bae7bc691876b6d9c25cd677f31ee6bcfd13388f2fc \
+         sha256::2cddb861f610dbc68273e830f414fc4b4d215361b0871e5598713668da77d339 \
+         sha256::1b1a4a78f3ebf7f560cb60cd0076f9d859fa784e088deeba5d4051fd48097878 \
+         sha256::0cb258493a2fb8d21eb734ad3681df8dd94fd80439580f85f64233b861a1c215 \
+         sha256::697a255104880045da1dc64995ab4f5414b90bbee30ed3ac81525a06064b7c59 \
+         sha256::7bd5ac6edf8f33f768b561ea07bd0da4e553075d8b27871225afa59a3b41a6e3 \
+         sha256::81c70d968a60c0b9b929a1d9205c48571962555b3773057d4c5792540f969b81 \
+         sha256::d19062a57d2ba455589acdd3e45f0c66db823ad48d9bed9db97236c91359ba21 \
+         sha256::2d0623914952570777377833b8aef162d0c1e7d7486e088ea1789e5575ee4a17 \
+         sha256::17437f0dcbd3570b97e474bf07464eb7dda5b46054496faa751b0ab6546d4e81 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.6
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
