### PR TITLE
remmina: update to 1.4.40

### DIFF
--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,5 +1,4 @@
-VER=1.4.39
-REL=1
+VER=1.4.40
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::885d41b3e91192c08d89599485a1b0054ca036cf2b8291ccbbcd99269ca86106"
+CHKSUMS="sha256::a1881003474211368fa18ec2a46f29ce55458932faedc6dca02a28e713470b73"
 CHKUPDATE="anitya::id=4188"


### PR DESCRIPTION
Topic Description
-----------------

- remmina: update to 1.4.40
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- remmina: 1.4.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
