### PR TITLE
gcc+cross: correctly set riscv64 as FAIL_ARCH

### DIFF
--- a/app-devel/gcc+cross/06-riscv64/defines
+++ b/app-devel/gcc+cross/06-riscv64/defines
@@ -3,7 +3,6 @@ PKGSEC=devel
 PKGDEP="binutils+cross-riscv64"
 
 __CROSS="riscv64"
-FAIL_ARCH="${__CROSS}"
 
 PKGDES="GNU Compiler Collection (cross compiler for RISC-V 64-bit GNU/Linux targets)"
 
@@ -12,7 +11,10 @@ NOSTATIC=0
 # FIXME: Relocation truncated to fit.
 #
 # Seems simply too large to handle even with LTO disabled. Fail for now.
-FAIL_ARCH="loongson3"
+#
+# FIXME: ACBS does not read variable for FAIL_ARCH matching, using hard-
+# coded architecture name.
+FAIL_ARCH="(loongson3|riscv64)"
 
 # Note: Sync from core-devel/gcc.
 TARGET_OPTIONS="""

--- a/app-devel/gcc+cross/spec
+++ b/app-devel/gcc+cross/spec
@@ -15,6 +15,7 @@ __NEWLIB_VER=4.5.0.20241231
 # Target architecture - this variable is used during build process
 
 VER=${GCC_VER}+glibc${GLIBC_VER/-/+}
+REL=1
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.xz \
       tbl::https://sourceware.org/pub/newlib/newlib-${__NEWLIB_VER}.tar.gz \
       file::rename=glibc_amd64.deb::https://repo.aosc.io/debs/pool/stable/main/g/glibc_${GLIBC_VER}_amd64.deb \


### PR DESCRIPTION
Topic Description
-----------------

- gcc+cross: correctly set riscv64 as FAIL_ARCH

Package(s) Affected
-------------------

- gcc+cross-amd64: 14.3.0+glibc2.40+3-1
- gcc+cross-arm-none-eabi: 14.3.0+glibc2.40+3-1
- gcc+cross-arm64: 14.3.0+glibc2.40+3-1
- gcc+cross-loongarch64: 14.3.0+glibc2.40+3-1
- gcc+cross-loongson3: 14.3.0+glibc2.40+3-1
- gcc+cross-ppc64el: 14.3.0+glibc2.40+3-1
- gcc+cross-riscv64: 14.3.0+glibc2.40+3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc+cross
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
