### PR TITLE
open-vm-tools: update to 13.0.0 and add arm64 architecture support

### DIFF
--- a/app-virtualization/open-vm-tools/autobuild/defines
+++ b/app-virtualization/open-vm-tools/autobuild/defines
@@ -28,4 +28,4 @@ ABSHADOW=0
 # FIXME: autogen.sh fails to complete, manually running autoreconf in prepare.
 RECONF=0
 
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-virtualization/open-vm-tools/spec
+++ b/app-virtualization/open-vm-tools/spec
@@ -1,6 +1,6 @@
-VER=12.5.0
-BUILDNBR=24276846
+VER=13.0.0
+BUILDNBR=24696409
 SRCS="tbl::https://github.com/vmware/open-vm-tools/releases/download/stable-${VER}/open-vm-tools-${VER}-${BUILDNBR}.tar.gz"
-CHKSUMS="sha256::7eefd632f10ed4afc48559bcae31a598501377e72dec4b9965cee53e8c4f47ce"
+CHKSUMS="sha256::ce855a7d9a0a6561e6009784eb2a34f6a1d98b2a883afce5290cd426f78e7a6d"
 SUDDIR="open-vm-tools-${VER}-${BUILDNBR}"
 CHKUPDATE="anitya::id=10998"


### PR DESCRIPTION
Topic Description
-----------------

- open-vm-tools: update to 13.0.0 and add arm64 architecture support

Package(s) Affected
-------------------

- open-vm-tools: 13.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit open-vm-tools
```

Test Build(s) Done
------------------

