### PR TITLE
flatpak: create sysusers and tmpfiles in postinst

### DIFF
--- a/app-admin/flatpak/autobuild/postinst
+++ b/app-admin/flatpak/autobuild/postinst
@@ -1,0 +1,3 @@
+systemd-sysusers flatpak.conf
+systemd-tmpfiles --create flatpak.conf
+systemd-tmpfiles --create flatpak-sideload-repos.conf

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,5 +1,5 @@
 VER=1.16.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- flatpak: create sysusers and tmpfiles in postinst
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- flatpak: 1.16.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
