### PR TITLE
easytier: update to 2.3.2

### DIFF
--- a/app-network/easytier/autobuild/defines
+++ b/app-network/easytier/autobuild/defines
@@ -7,7 +7,7 @@ BUILDDEP="rustc llvm"
 # FIXME: mimalloc does not support LoongArch, use jemalloc instead.
 CARGO_AFTER__LOONGARCH64=(
     '--no-default-features'
-    '--features=wireguard,jemalloc,websocket,smoltcp,tun,socks5'
+    '--features=wireguard,jemalloc,websocket,smoltcp,tun,socks5,quic'
 )
 
 # FIXME: 

--- a/app-network/easytier/spec
+++ b/app-network/easytier/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
+VER=2.3.2
 SRCS="git::commit=tags/v$VER::https://github.com/EasyTier/EasyTier"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377832"


### PR DESCRIPTION
Topic Description
-----------------

- easytier: update to 2.3.2
    - Add QUIC support.
    - Link: https://github.com/EasyTier/EasyTier/pull/993
    Signed-off-by: Qing Yun <kf@aosc.io>

Package(s) Affected
-------------------

- easytier: 2.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit easytier
```

Test Build(s) Done
------------------

