### PR TITLE
jq: update to 1.8.1

### DIFF
--- a/app-devel/jq/spec
+++ b/app-devel/jq/spec
@@ -1,4 +1,4 @@
-VER=1.8.0
+VER=1.8.1
 SRCS="tbl::https://github.com/jqlang/jq/releases/download/jq-$VER/jq-$VER.tar.gz"
-CHKSUMS="sha256::91811577f91d9a6195ff50c2bffec9b72c8429dc05ec3ea022fd95c06d2b319c"
+CHKSUMS="sha256::2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0"
 CHKUPDATE="anitya::id=13252"


### PR DESCRIPTION
Topic Description
-----------------

- jq: update to 1.8.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- jq: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit jq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
