### PR TITLE
znc: update to 1.10.1

### DIFF
--- a/app-web/znc/spec
+++ b/app-web/znc/spec
@@ -1,4 +1,4 @@
-VER=1.10.0
+VER=1.10.1
 SRCS="git::commit=tags/znc-$VER::https://github.com/znc/znc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5305"


### PR DESCRIPTION
Topic Description
-----------------

- znc: update to 1.10.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- znc: 1.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit znc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
