### PR TITLE
loonggpu-kernel-dkms: add patch to fix building on 6.15 and 6.16

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
@@ -1,7 +1,7 @@
 From 2e20048c55fa5ec168f5a44f4f5733c7e2703346 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:15 +0800
-Subject: [PATCH 1/8] chore: initialise a gitignore file
+Subject: [PATCH 01/37] chore: initialise a gitignore file
 
 Just to make my life easier.
 ---
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
@@ -1,7 +1,7 @@
 From f50458a8b381bb6b5858ad27b8ab51982d7655db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:29:59 +0800
-Subject: [PATCH 2/8] loonggpu: include: use video aperture helpers for Linux
+Subject: [PATCH 02/37] loonggpu: include: use video aperture helpers for Linux
  >= 6.13.
 
 Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM
@@ -54,5 +54,5 @@ index c4f9727..fa26309 100644
  #endif
  }
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
@@ -1,7 +1,7 @@
 From c8c543febf29491562e32a6c21805ca2af963c2f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:34:47 +0800
-Subject: [PATCH 3/8] loonggpu: pass string literal parameter to
+Subject: [PATCH 03/37] loonggpu: pass string literal parameter to
  MODULE_IMPORT_NS for Linux >= 6.13
 
 With commit cdd30ebb1b9f ("module: Convert symbol namespace to string
@@ -35,5 +35,5 @@ index 90bc2c4..8bcc5a2 100644
  static void gsgpu_display_flip_callback(struct dma_fence *f,
  					 struct dma_fence_cb *cb)
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
@@ -1,7 +1,8 @@
 From d78344d1e4534a20fbe9a9691fb20c86fa605701 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 11:51:25 +0800
-Subject: [PATCH 4/8] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes option
+Subject: [PATCH 04/37] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
+ option
 
 This option is marked deprecated and causes a warning during DKMS builds.
 
@@ -23,5 +24,5 @@ index d31fb96..044472a 100644
  MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
      make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
@@ -1,7 +1,7 @@
 From 37c11b5b83ccc184e10bdea24dc4c8ed02474d1d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:35 +0800
-Subject: [PATCH 5/8] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
+Subject: [PATCH 05/37] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
  unused variable i
 
 A variable `i' was defined under multiple functions, triggering
@@ -40,5 +40,5 @@ index 86daef6..b0a9185 100644
  
  	/* pick the first one */
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
@@ -1,7 +1,7 @@
 From fb033217bfa7ca1b3b900ba448bd96688910b164 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:30:31 +0800
-Subject: [PATCH 6/8] loonggpu: gsgpu_vm: move struct definition to
+Subject: [PATCH 06/37] loonggpu: gsgpu_vm: move struct definition to
  include/gsgpu_vm.h
 
 Move struct definition to header so that non-static functions may access
@@ -172,5 +172,5 @@ index 4e7da19..e71570a 100644
   * DIR0->DIR1->DIR2
   */
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
@@ -1,7 +1,7 @@
 From 960d2e37e3a0b833b7f5ce34fb4d80a22e6b0c7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:33:02 +0800
-Subject: [PATCH 7/8] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
+Subject: [PATCH 07/37] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
 
 Lots of functions in this driver were missing prototype definitions,
 triggering a large number of `-Wmissing-prototypes' warnings.
@@ -245,5 +245,5 @@ index e71570a..36e533f 100644
  			 struct gsgpu_task_info *task_info);
  
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 6 Feb 2025 18:12:15 +0800
-Subject: [PATCH 8/8] AOSCOS: loonggpu: remove driver date
+Subject: [PATCH 08/37] AOSCOS: loonggpu: remove driver date
 
 Following upstream changes.
 
@@ -42,5 +42,5 @@ index 8a34e3f..891c43b 100644
  long gsgpu_drm_ioctl(struct file *filp,
  		      unsigned int cmd, unsigned long arg);
 -- 
-2.48.1
+2.50.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,0 +1,28 @@
+From 535a3a5be05a569abe24eaa21ee6236a44744f3e Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 16:03:46 +0800
+Subject: [PATCH 09/37] loonggpu: Remove unused fbdev_list field in
+ gsgpu_framebuffer
+
+This field is referred nowhere.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/gsgpu_mode.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index e5d2cfd..4e21dbc 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -68,7 +68,6 @@ struct gsgpu_framebuffer {
+ struct gsgpu_fbdev {
+ 	struct drm_fb_helper helper;
+ 	struct gsgpu_framebuffer rfb;
+-	struct list_head fbdev_list;
+ 	struct gsgpu_device *adev;
+ };
+ 
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
@@ -1,0 +1,53 @@
+From 67052920d0d65c559f3d91cc1087dd7794eb9018 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 16:21:48 +0800
+Subject: [PATCH 10/37] loonggpu: Remove the unused gsgpu_fbdev_total_size
+ function
+
+It's referred nowhere.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c     | 13 -------------
+ include/gsgpu_mode.h |  1 -
+ 2 files changed, 14 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index c3f6bed..a1447af 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -340,19 +340,6 @@ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state)
+ 						   state);
+ }
+ 
+-int gsgpu_fbdev_total_size(struct gsgpu_device *adev)
+-{
+-	struct gsgpu_bo *robj;
+-	int size = 0;
+-
+-	if (!adev->mode_info.rfbdev)
+-		return 0;
+-
+-	robj = gem_to_gsgpu_bo(adev->mode_info.rfbdev->rfb.base.obj[0]);
+-	size += gsgpu_bo_size(robj);
+-	return size;
+-}
+-
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj)
+ {
+ 	if (!adev->mode_info.rfbdev)
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index 4e21dbc..0845aa2 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -170,7 +170,6 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ int gsgpu_fbdev_init(struct gsgpu_device *adev);
+ void gsgpu_fbdev_fini(struct gsgpu_device *adev);
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state);
+-int gsgpu_fbdev_total_size(struct gsgpu_device *adev);
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
+ int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
+ int gsgpu_display_modeset_create_props(struct gsgpu_device *adev);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,0 +1,52 @@
+From 6505d6bb76b24f59444420c3105d20052cf02c23 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 16:27:04 +0800
+Subject: [PATCH 11/37] loonggpu: Improve fbdev object-test helper
+
+Follow the change of our reference implementation, allowing us to
+remove struct gsgpu_fbdev later.
+
+Link: https://git.kernel.org/torvalds/c/276f7b4bd524
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index a1447af..81294a9 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -10,7 +10,7 @@
+ #include "gsgpu_drm.h"
+ 
+ #include <drm/drm_fb_helper.h>
+-
++#include <drm/drm_gem_framebuffer_helper.h>
+ 
+ #include "gsgpu_display.h"
+ #include "gsgpu_helper.h"
+@@ -342,9 +342,17 @@ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state)
+ 
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj)
+ {
+-	if (!adev->mode_info.rfbdev)
++	struct drm_fb_helper *fb_helper = adev->ddev->fb_helper;
++	struct drm_gem_object *gobj;
++
++	if (!fb_helper)
+ 		return false;
+-	if (robj == gem_to_gsgpu_bo(adev->mode_info.rfbdev->rfb.base.obj[0]))
+-		return true;
+-	return false;
++
++	gobj = drm_gem_fb_get_obj(fb_helper->fb, 0);
++	if (!gobj)
++		return false;
++	if (gobj != &robj->tbo.base)
++		return false;
++
++	return true;
+ }
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,0 +1,241 @@
+From 84c8becebd2d7d1429b514a9b887b785fc98dcaf Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 16:34:42 +0800
+Subject: [PATCH 12/37] loonggpu: Remove struct gsgpu_fbdev and add some clean
+ up code
+
+Both data fields in struct gsgpu_fbdev, the framebuffer and the
+device, are already available in struct drm_fb_helper. Simplify
+loonggpu by converting all callers and removing struct gsgpu_fbdev.
+
+Following the reference implementation change.
+
+Also add some clean up code which seems necessary to plug leaks and
+existing in the reference implementation.
+
+Link: https://kernel.org/torvalds/c/c4aab3499be2
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c     | 98 +++++++++++++++++++++++++-------------------
+ include/gsgpu_mode.h |  8 ----
+ 2 files changed, 55 insertions(+), 51 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 81294a9..aa213b4 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -87,11 +87,11 @@ static void gsgpufb_destroy_pinned_object(struct drm_gem_object *gobj)
+ 	lg_drm_gem_object_put(gobj);
+ }
+ 
+-static int gsgpufb_create_pinned_object(struct gsgpu_fbdev *rfbdev,
+-					 struct drm_mode_fb_cmd2 *mode_cmd,
+-					 struct drm_gem_object **gobj_p)
++static int gsgpufb_create_pinned_object(struct drm_fb_helper *fb_helper,
++					struct drm_mode_fb_cmd2 *mode_cmd,
++					struct drm_gem_object **gobj_p)
+ {
+-	struct gsgpu_device *adev = rfbdev->adev;
++	struct gsgpu_device *adev = fb_helper->dev->dev_private;
+ 	struct drm_gem_object *gobj = NULL;
+ 	const struct drm_format_info *info;
+ 	struct gsgpu_bo *abo = NULL;
+@@ -167,8 +167,7 @@ out_unref:
+ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 			   struct drm_fb_helper_surface_size *sizes)
+ {
+-	struct gsgpu_fbdev *rfbdev = (struct gsgpu_fbdev *)helper;
+-	struct gsgpu_device *adev = rfbdev->adev;
++	struct gsgpu_device *adev = helper->dev->dev_private;
+ 	struct fb_info *info;
+ 	struct drm_framebuffer *fb = NULL;
+ 	struct drm_mode_fb_cmd2 mode_cmd;
+@@ -186,7 +185,7 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	mode_cmd.pixel_format = drm_mode_legacy_fb_format(sizes->surface_bpp,
+ 							  sizes->surface_depth);
+ 
+-	ret = gsgpufb_create_pinned_object(rfbdev, &mode_cmd, &gobj);
++	ret = gsgpufb_create_pinned_object(helper, &mode_cmd, &gobj);
+ 	if (ret) {
+ 		DRM_ERROR("failed to create fbcon object %d\n", ret);
+ 		return ret;
+@@ -201,20 +200,24 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 		goto out;
+ 	}
+ 
+-	info->par = rfbdev;
++	info->par = helper;
+ 	info->skip_vt_switch = false;
+ 
+-	ret = gsgpu_display_framebuffer_init(adev->ddev, &rfbdev->rfb,
++	fb = kzalloc(sizeof(struct gsgpu_framebuffer), GFP_KERNEL);
++	if (!fb) {
++		ret = -ENOMEM;
++		goto out;
++	}
++
++	ret = gsgpu_display_framebuffer_init(adev->ddev, to_gsgpu_framebuffer(fb),
+ 					      &mode_cmd, gobj);
+ 	if (ret) {
+ 		DRM_ERROR("failed to initialize framebuffer %d\n", ret);
+ 		goto out;
+ 	}
+ 
+-	fb = &rfbdev->rfb.base;
+-
+ 	/* setup helper */
+-	rfbdev->helper.fb = fb;
++	helper->fb = fb;
+ 
+ 	info->fbops = &gsgpufb_ops;
+ 
+@@ -225,7 +228,7 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	info->screen_base = gsgpu_bo_kptr(abo);
+ 	info->screen_size = gsgpu_bo_size(abo);
+ 
+-	lg_drm_fb_helper_fill_info(info, &rfbdev->helper, sizes);
++	lg_drm_fb_helper_fill_info(info, helper, sizes);
+ 
+ 	/* setup aperture base/size for vesafb takeover */
+ 	lg_set_info_apertures(info, adev);
+@@ -261,19 +264,23 @@ out:
+ 	return ret;
+ }
+ 
+-static int gsgpu_fbdev_destroy(struct drm_device *dev, struct gsgpu_fbdev *rfbdev)
++static int gsgpu_fbdev_destroy(struct drm_device *dev, struct drm_fb_helper *fb_helper)
+ {
+-	struct gsgpu_framebuffer *rfb = &rfbdev->rfb;
++	struct drm_framebuffer *fb = fb_helper->fb;
+ 
+-	lg_drm_fb_helper_unregister_info(&rfbdev->helper);
++	lg_drm_fb_helper_unregister_info(fb_helper);
+ 
+-	if (rfb->base.obj[0]) {
+-		gsgpufb_destroy_pinned_object(rfb->base.obj[0]);
+-		rfb->base.obj[0] = NULL;
+-		drm_framebuffer_unregister_private(&rfb->base);
+-		drm_framebuffer_cleanup(&rfb->base);
++	if (fb) {
++		if (fb->obj[0]) {
++			gsgpufb_destroy_pinned_object(fb->obj[0]);
++			fb->obj[0] = NULL;
++			drm_framebuffer_unregister_private(fb);
++			drm_framebuffer_cleanup(fb);
++		}
++		kfree(fb);
++		fb_helper->fb = NULL;
+ 	}
+-	drm_fb_helper_fini(&rfbdev->helper);
++	drm_fb_helper_fini(fb_helper);
+ 
+ 	return 0;
+ }
+@@ -284,7 +291,7 @@ static const struct drm_fb_helper_funcs gsgpu_fb_helper_funcs = {
+ 
+ int gsgpu_fbdev_init(struct gsgpu_device *adev)
+ {
+-	struct gsgpu_fbdev *rfbdev;
++	struct drm_fb_helper *fb_helper;
+ 	int bpp_sel = 32;
+ 	int ret;
+ 
+@@ -300,44 +307,49 @@ int gsgpu_fbdev_init(struct gsgpu_device *adev)
+ 	if (adev->gmc.real_vram_size <= (32*1024*1024))
+ 		bpp_sel = 8;
+ 
+-	rfbdev = kzalloc(sizeof(struct gsgpu_fbdev), GFP_KERNEL);
+-	if (!rfbdev)
++	fb_helper = kzalloc(sizeof(*fb_helper), GFP_KERNEL);
++	if (!fb_helper)
+ 		return -ENOMEM;
+ 
+-	rfbdev->adev = adev;
+-	adev->mode_info.rfbdev = rfbdev;
+-
+-	lg_drm_fb_helper_prepare(adev->ddev, &rfbdev->helper,
++	lg_drm_fb_helper_prepare(adev->ddev, fb_helper,
+ 				bpp_sel, &gsgpu_fb_helper_funcs);
+ 
+-	ret = lg_drm_fb_helper_init(adev->ddev, &rfbdev->helper,
++	ret = lg_drm_fb_helper_init(adev->ddev, fb_helper,
+ 				 GSGPUFB_CONN_LIMIT);
+-	if (ret) {
+-		kfree(rfbdev);
+-		return ret;
+-	}
++	if (ret)
++		goto free;
+ 
+-	lg_drm_fb_helper_single_add_all_connectors(&rfbdev->helper);
+-	lg_drm_fb_helper_initial_config(&rfbdev->helper, bpp_sel);
++	lg_drm_fb_helper_single_add_all_connectors(fb_helper);
++	ret = drm_fb_helper_initial_config(fb_helper);
++	if (ret)
++		goto fini;
+ 
+ 	return 0;
++
++fini:
++	drm_fb_helper_fini(fb_helper);
++free:
++	drm_fb_helper_unprepare(fb_helper);
++	kfree(fb_helper);
++	return ret;
+ }
+ 
+ void gsgpu_fbdev_fini(struct gsgpu_device *adev)
+ {
+-	if (!adev->mode_info.rfbdev)
++	if (!adev->ddev->fb_helper)
+ 		return;
+ 
+-	gsgpu_fbdev_destroy(adev->ddev, adev->mode_info.rfbdev);
+-	kfree(adev->mode_info.rfbdev);
+-	adev->mode_info.rfbdev = NULL;
++	gsgpu_fbdev_destroy(adev->ddev, adev->ddev->fb_helper);
++	drm_fb_helper_unprepare(adev->ddev->fb_helper);
++	kfree(adev->ddev->fb_helper);
++	adev->ddev->fb_helper = NULL;
+ }
+ 
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state)
+ {
+-	if (adev->mode_info.rfbdev)
+-		drm_fb_helper_set_suspend_unlocked(&adev->mode_info.rfbdev->helper,
+-						   state);
++	if (adev->ddev->fb_helper)
++		drm_fb_helper_set_suspend_unlocked(adev->ddev->fb_helper,
++					        state);
+ }
+ 
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj)
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index 0845aa2..860a68d 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -65,12 +65,6 @@ struct gsgpu_framebuffer {
+ 	uint64_t address;
+ };
+ 
+-struct gsgpu_fbdev {
+-	struct drm_fb_helper helper;
+-	struct gsgpu_framebuffer rfb;
+-	struct gsgpu_device *adev;
+-};
+-
+ struct gsgpu_crtc {
+ 	struct drm_crtc base;
+ 	int crtc_id;
+@@ -140,8 +134,6 @@ struct gsgpu_mode_info {
+ 	struct drm_property *underscan_vborder_property;
+ 	/* audio */
+ 	struct drm_property *audio_property;
+-	/* pointer to fbdev info structure */
+-	struct gsgpu_fbdev *rfbdev;
+ 	int			num_crtc; /* number of crtcs */
+ 	int			num_hpd; /* number of hpd pins */
+ 	int			num_i2c;
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,0 +1,128 @@
+From a169f227222a60a30f99c4640de9823f6dbacfff Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 18:50:01 +0800
+Subject: [PATCH 13/37] loonggpu: Move fbdev cleanup code into fb_destroy
+ callback
+
+Fbdev calls struct fb_ops.fb_destroy after cleaning up the final
+reference to an fbdev framebuffer. Move loonggpu's fbdev cleanup code
+there.
+
+Following the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/62bb839d48ae
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 70 +++++++++++++++++++++++-------------------------
+ 1 file changed, 34 insertions(+), 36 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index aa213b4..5bee711 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -47,11 +47,44 @@ gsgpufb_release(struct fb_info *info, int user)
+ 	return 0;
+ }
+ 
++static void gsgpufb_destroy_pinned_object(struct drm_gem_object *gobj)
++{
++	struct gsgpu_bo *abo = gem_to_gsgpu_bo(gobj);
++	int ret;
++
++	ret = gsgpu_bo_reserve(abo, true);
++	if (likely(ret == 0)) {
++		gsgpu_bo_kunmap(abo);
++		gsgpu_bo_unpin(abo);
++		gsgpu_bo_unreserve(abo);
++	}
++	lg_drm_gem_object_put(gobj);
++}
++
++static void gsgpu_fbdev_fb_destroy(struct fb_info *info)
++{
++	struct drm_fb_helper *fb_helper = info->par;
++	struct drm_framebuffer *fb = fb_helper->fb;
++
++	if (fb) {
++		if (fb->obj[0]) {
++			gsgpufb_destroy_pinned_object(fb->obj[0]);
++			fb->obj[0] = NULL;
++			drm_framebuffer_unregister_private(fb);
++			drm_framebuffer_cleanup(fb);
++		}
++		kfree(fb);
++		fb_helper->fb = NULL;
++	}
++	drm_fb_helper_fini(fb_helper);
++}
++
+ static struct fb_ops gsgpufb_ops = {
+ 	.owner = THIS_MODULE,
+ 	DRM_FB_HELPER_DEFAULT_OPS,
+ 	.fb_open = gsgpufb_open,
+ 	.fb_release = gsgpufb_release,
++	.fb_destroy = gsgpu_fbdev_fb_destroy,
+ #if defined(__FB_DEFAULT_IOMEM_OPS_DRAW)
+ 	__FB_DEFAULT_IOMEM_OPS_DRAW
+ #else
+@@ -73,20 +106,6 @@ int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int cpp, bool tiled)
+ 	return aligned;
+ }
+ 
+-static void gsgpufb_destroy_pinned_object(struct drm_gem_object *gobj)
+-{
+-	struct gsgpu_bo *abo = gem_to_gsgpu_bo(gobj);
+-	int ret;
+-
+-	ret = gsgpu_bo_reserve(abo, true);
+-	if (likely(ret == 0)) {
+-		gsgpu_bo_kunmap(abo);
+-		gsgpu_bo_unpin(abo);
+-		gsgpu_bo_unreserve(abo);
+-	}
+-	lg_drm_gem_object_put(gobj);
+-}
+-
+ static int gsgpufb_create_pinned_object(struct drm_fb_helper *fb_helper,
+ 					struct drm_mode_fb_cmd2 *mode_cmd,
+ 					struct drm_gem_object **gobj_p)
+@@ -264,27 +283,6 @@ out:
+ 	return ret;
+ }
+ 
+-static int gsgpu_fbdev_destroy(struct drm_device *dev, struct drm_fb_helper *fb_helper)
+-{
+-	struct drm_framebuffer *fb = fb_helper->fb;
+-
+-	lg_drm_fb_helper_unregister_info(fb_helper);
+-
+-	if (fb) {
+-		if (fb->obj[0]) {
+-			gsgpufb_destroy_pinned_object(fb->obj[0]);
+-			fb->obj[0] = NULL;
+-			drm_framebuffer_unregister_private(fb);
+-			drm_framebuffer_cleanup(fb);
+-		}
+-		kfree(fb);
+-		fb_helper->fb = NULL;
+-	}
+-	drm_fb_helper_fini(fb_helper);
+-
+-	return 0;
+-}
+-
+ static const struct drm_fb_helper_funcs gsgpu_fb_helper_funcs = {
+ 	.fb_probe = gsgpufb_create,
+ };
+@@ -339,7 +337,7 @@ void gsgpu_fbdev_fini(struct gsgpu_device *adev)
+ 	if (!adev->ddev->fb_helper)
+ 		return;
+ 
+-	gsgpu_fbdev_destroy(adev->ddev, adev->ddev->fb_helper);
++	drm_fb_helper_unregister_info(adev->ddev->fb_helper);
+ 	drm_fb_helper_unprepare(adev->ddev->fb_helper);
+ 	kfree(adev->ddev->fb_helper);
+ 	adev->ddev->fb_helper = NULL;
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,0 +1,28 @@
+From 9b5968d63571d2beff31fe0fbadd6b98540c7473 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 18:59:39 +0800
+Subject: [PATCH 14/37] loonggpu: Remove redundant info->par assignment
+
+It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
+kernel version is).
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 5bee711..7b3f38b 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -219,7 +219,6 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 		goto out;
+ 	}
+ 
+-	info->par = helper;
+ 	info->skip_vt_switch = false;
+ 
+ 	fb = kzalloc(sizeof(struct gsgpu_framebuffer), GFP_KERNEL);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,0 +1,38 @@
+From 3d6e1f3088cddf98c0bc419812908fdc14534ee1 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 19:19:37 +0800
+Subject: [PATCH 15/37] loonggpu: Remove test for !screen_base in fbdev probing
+
+The screen_base field comes from the fbdev BO and contains the fbdev
+framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),
+which already reports the error -ENOMEM if the buffer could not be
+mapped. So remove the later test for screen_base, which will never
+be NULL at this point.
+
+Following the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/11b6005865e4
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 7b3f38b..fb0253c 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -253,11 +253,6 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 
+ 	/* Use default scratch pixmap (info->pixmap.flags = FB_PIXMAP_SYSTEM) */
+ 
+-	if (info->screen_base == NULL) {
+-		ret = -ENOSPC;
+-		goto out;
+-	}
+-
+ 	DRM_INFO("fb mappable at 0x%lX\n",  info->fix.smem_start);
+ 	DRM_INFO("vram apper at 0x%lX\n",  (unsigned long)adev->gmc.aper_base);
+ 	DRM_INFO("size %lu\n", (unsigned long)gsgpu_bo_size(abo));
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,0 +1,151 @@
+From fd00f34c73088c7a838276c85a188a441549bbb1 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 19:21:28 +0800
+Subject: [PATCH 16/37] loonggpu: Correctly clean up failed display probing
+
+Improve the fbdev probing function to fully clean up if it failed.
+Allows to remove special cases from fb_destroy as well.
+
+This change is reorders the operations within gsgpufb_create(). It
+first allocates a buffer object, then builds a DRM framebuffer for
+the object and finally creates the fbdev device. If every step
+succeeded, the probe function clears the framebuffer memory. This
+is the optimal order to rollback any changes if any of the steps
+fails.
+
+Following the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/3a745f6ac132
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 69 ++++++++++++++++++++++--------------------------
+ 1 file changed, 32 insertions(+), 37 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index fb0253c..ad1990e 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -65,17 +65,15 @@ static void gsgpu_fbdev_fb_destroy(struct fb_info *info)
+ {
+ 	struct drm_fb_helper *fb_helper = info->par;
+ 	struct drm_framebuffer *fb = fb_helper->fb;
++	struct drm_gem_object *gobj = drm_gem_fb_get_obj(fb, 0);
++
++	drm_framebuffer_unregister_private(fb);
++	drm_framebuffer_cleanup(fb);
++	kfree(fb);
++	fb_helper->fb = NULL;
++
++	gsgpufb_destroy_pinned_object(gobj);
+ 
+-	if (fb) {
+-		if (fb->obj[0]) {
+-			gsgpufb_destroy_pinned_object(fb->obj[0]);
+-			fb->obj[0] = NULL;
+-			drm_framebuffer_unregister_private(fb);
+-			drm_framebuffer_cleanup(fb);
+-		}
+-		kfree(fb);
+-		fb_helper->fb = NULL;
+-	}
+ 	drm_fb_helper_fini(fb_helper);
+ }
+ 
+@@ -187,11 +185,11 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 			   struct drm_fb_helper_surface_size *sizes)
+ {
+ 	struct gsgpu_device *adev = helper->dev->dev_private;
++	struct drm_mode_fb_cmd2 mode_cmd = { };
+ 	struct fb_info *info;
+-	struct drm_framebuffer *fb = NULL;
+-	struct drm_mode_fb_cmd2 mode_cmd;
+-	struct drm_gem_object *gobj = NULL;
+-	struct gsgpu_bo *abo = NULL;
++	struct drm_gem_object *gobj;
++	struct gsgpu_bo *abo;
++	struct drm_framebuffer *fb;
+ 	unsigned long tmp;
+ 	int ret;
+ 
+@@ -212,32 +210,33 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 
+ 	abo = gem_to_gsgpu_bo(gobj);
+ 
+-	/* okay we have an object now allocate the framebuffer */
+-	info = lg_drm_fb_helper_alloc_info(helper);
+-	if (IS_ERR(info)) {
+-		ret = PTR_ERR(info);
+-		goto out;
+-	}
+-
+-	info->skip_vt_switch = false;
+-
+ 	fb = kzalloc(sizeof(struct gsgpu_framebuffer), GFP_KERNEL);
+ 	if (!fb) {
+ 		ret = -ENOMEM;
+-		goto out;
++		goto err_gsgpufb_destroy_pinned_object;
+ 	}
+ 
+ 	ret = gsgpu_display_framebuffer_init(adev->ddev, to_gsgpu_framebuffer(fb),
+ 					      &mode_cmd, gobj);
+ 	if (ret) {
+ 		DRM_ERROR("failed to initialize framebuffer %d\n", ret);
+-		goto out;
++		goto err_kfree;
+ 	}
+ 
+ 	/* setup helper */
+ 	helper->fb = fb;
+ 
++	/* okay we have an object now allocate the framebuffer */
++	info = lg_drm_fb_helper_alloc_info(helper);
++	if (IS_ERR(info)) {
++		ret = PTR_ERR(info);
++		goto err_drm_framebuffer_unregister_private;
++	}
++
+ 	info->fbops = &gsgpufb_ops;
++	info->skip_vt_switch = false;
++
++	lg_drm_fb_helper_fill_info(info, helper, sizes);
+ 
+ 	/* not alloc from VRAM but GTT */
+ 	tmp = gsgpu_bo_gpu_offset(abo) - adev->gmc.vram_start;
+@@ -246,8 +245,6 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	info->screen_base = gsgpu_bo_kptr(abo);
+ 	info->screen_size = gsgpu_bo_size(abo);
+ 
+-	lg_drm_fb_helper_fill_info(info, helper, sizes);
+-
+ 	/* setup aperture base/size for vesafb takeover */
+ 	lg_set_info_apertures(info, adev);
+ 
+@@ -264,16 +261,14 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	vga_switcheroo_client_fb_set(adev->pdev, info);
+ 	return 0;
+ 
+-out:
+-	if (abo) {
+-
+-	}
+-	if (fb && ret) {
+-		lg_drm_gem_object_put(gobj);
+-		drm_framebuffer_unregister_private(fb);
+-		drm_framebuffer_cleanup(fb);
+-		kfree(fb);
+-	}
++err_drm_framebuffer_unregister_private:
++	helper->fb = NULL;
++	drm_framebuffer_unregister_private(fb);
++	drm_framebuffer_cleanup(fb);
++err_kfree:
++	kfree(fb);
++err_gsgpufb_destroy_pinned_object:
++	gsgpufb_destroy_pinned_object(gobj);
+ 	return ret;
+ }
+ 
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,0 +1,41 @@
+From 83ef7728a8f023468e5c0aa4ec907b442ddd7d54 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 20:10:14 +0800
+Subject: [PATCH 17/37] loonggpu: Remove load callback from kms_driver
+
+The ".load" callback in "struct drm_driver" is deprecated. In order to
+remove the callback, we have to manually call "gsgpu_driver_load_kms"
+instead.
+
+Following up the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/90985660ba48
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_drv.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gsgpu/gsgpu_drv.c b/gsgpu/gsgpu_drv.c
+index 94d9f88..d0d51cf 100644
+--- a/gsgpu/gsgpu_drv.c
++++ b/gsgpu/gsgpu_drv.c
+@@ -433,6 +433,8 @@ static int loongson_vga_pci_register(struct pci_dev *pdev,
+ 
+ 	pci_set_drvdata(pdev, dev);
+ 
++	ret = gsgpu_driver_load_kms(dev, ent->driver_data);
++
+ retry_init:
+ 	ret = drm_dev_register(dev, pci_gpu_flags);
+ 	if (ret == -EAGAIN && ++retry <= 3) {
+@@ -529,7 +531,6 @@ static struct drm_driver kms_driver = {
+ 		| DRIVER_SYNCOBJ_TIMELINE
+ #endif
+ 		| DRIVER_RENDER | DRIVER_ATOMIC,
+-	.load = gsgpu_driver_load_kms,
+ 	.open = gsgpu_driver_open_kms,
+ 	.postclose = gsgpu_driver_postclose_kms,
+ 	lg_drm_driver_set_lastclose
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,0 +1,271 @@
+From 6a2e84785264b6dfc36a910b86fa7acd1b54d114 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 20:21:11 +0800
+Subject: [PATCH 18/37] loonggpu: Implement client-based fbdev emulation
+
+Implement fbdev emulation on top of struct drm_client and its helpers.
+Replaces ad-hoc interfaces for restoring and closing fbdev emulation with
+per-client callbacks for hotplugging, restoring and unregistering.
+
+A single function, gsgpu_fbdev_setup(), starts fbdev emulation after
+the DRM device has been registered. Hence, fbdev acts like a regular
+DRM client.
+
+The setup call prepares the fbdev emulation and invokes connector
+hotplugging. The first successful hotplug event initializes fbdev
+emulation with a framebuffer, device file, etc.
+
+Unregistering depends on the hotplug status. Fully initialized emulation
+is cleaned up through drm_fb_helper_unregister_info() and fb_destroy.
+For prepared-only setups, unregistering unprepares the emulation and
+releases all resources. In both cases, fbdev emulation will be cleaned
+up.
+
+Following up the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/e317a69fe891
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_device.c |   3 --
+ gsgpu/gsgpu_drv.c    |   8 +--
+ gsgpu/gsgpu_fb.c     | 118 ++++++++++++++++++++++++++++++-------------
+ include/gsgpu_mode.h |   3 +-
+ 4 files changed, 88 insertions(+), 44 deletions(-)
+
+diff --git a/gsgpu/gsgpu_device.c b/gsgpu/gsgpu_device.c
+index 7dd02fb..1a70b60 100644
+--- a/gsgpu/gsgpu_device.c
++++ b/gsgpu/gsgpu_device.c
+@@ -1399,8 +1399,6 @@ int gsgpu_device_init(struct gsgpu_device *adev,
+ 		goto failed;
+ 	}
+ 
+-	gsgpu_fbdev_init(adev);
+-
+ 	r = gsgpu_pm_sysfs_init(adev);
+ 	if (r)
+ 		DRM_ERROR("registering pm debugfs failed (%d).\n", r);
+@@ -1478,7 +1476,6 @@ void gsgpu_device_fini(struct gsgpu_device *adev)
+ 
+ 	gsgpu_ib_pool_fini(adev);
+ 	gsgpu_fence_driver_fini(adev);
+-	gsgpu_fbdev_fini(adev);
+ 	r = gsgpu_device_ip_fini(adev);
+ 	if (adev->firmware.gpu_info_fw) {
+ 		release_firmware(adev->firmware.gpu_info_fw);
+diff --git a/gsgpu/gsgpu_drv.c b/gsgpu/gsgpu_drv.c
+index d0d51cf..a49a4b7 100644
+--- a/gsgpu/gsgpu_drv.c
++++ b/gsgpu/gsgpu_drv.c
+@@ -442,11 +442,14 @@ retry_init:
+ 		/* Don't request EX mode too frequently which is attacking */
+ 		msleep(5000);
+ 		goto retry_init;
+-	} else if (ret)
++	}
++
++	if (ret)
+ 		goto err_pci;
+ 
++	gsgpu_fbdev_setup(dev->dev_private);
+ 
+-	return ret;
++	return 0;
+ 
+ err_pci:
+ 	pci_disable_device(pdev);
+@@ -533,7 +536,6 @@ static struct drm_driver kms_driver = {
+ 		| DRIVER_RENDER | DRIVER_ATOMIC,
+ 	.open = gsgpu_driver_open_kms,
+ 	.postclose = gsgpu_driver_postclose_kms,
+-	lg_drm_driver_set_lastclose
+ 	.unload = gsgpu_driver_unload_kms,
+ 	lg_drm_driver_get_vblank_counter_setting(gsgpu_get_vblank_counter_kms)
+ 	lg_drm_driver_get_vblank_timestamp_setting()
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index ad1990e..5057665 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -67,14 +67,17 @@ static void gsgpu_fbdev_fb_destroy(struct fb_info *info)
+ 	struct drm_framebuffer *fb = fb_helper->fb;
+ 	struct drm_gem_object *gobj = drm_gem_fb_get_obj(fb, 0);
+ 
++	drm_fb_helper_fini(fb_helper);
++
+ 	drm_framebuffer_unregister_private(fb);
+ 	drm_framebuffer_cleanup(fb);
+ 	kfree(fb);
+ 	fb_helper->fb = NULL;
+ 
+ 	gsgpufb_destroy_pinned_object(gobj);
+-
+-	drm_fb_helper_fini(fb_helper);
++	drm_client_release(&fb_helper->client);
++	drm_fb_helper_unprepare(fb_helper);
++	kfree(fb_helper);
+ }
+ 
+ static struct fb_ops gsgpufb_ops = {
+@@ -258,7 +261,6 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	DRM_INFO("screen_base 0x%llX\n", (u64)info->screen_base);
+ 	DRM_INFO("screen_size 0x%lX\n", info->screen_size);
+ 
+-	vga_switcheroo_client_fb_set(adev->pdev, info);
+ 	return 0;
+ 
+ err_drm_framebuffer_unregister_private:
+@@ -276,19 +278,74 @@ static const struct drm_fb_helper_funcs gsgpu_fb_helper_funcs = {
+ 	.fb_probe = gsgpufb_create,
+ };
+ 
+-int gsgpu_fbdev_init(struct gsgpu_device *adev)
++static void gsgpu_fbdev_client_unregister(struct drm_client_dev *client)
+ {
+-	struct drm_fb_helper *fb_helper;
+-	int bpp_sel = 32;
++	struct drm_fb_helper *fb_helper = drm_fb_helper_from_client(client);
++	struct drm_device *dev = fb_helper->dev;
++	struct gsgpu_device *rdev = dev->dev_private;
++
++	if (fb_helper->info) {
++		vga_switcheroo_client_fb_set(rdev->pdev, NULL);
++		drm_fb_helper_unregister_info(fb_helper);
++	} else {
++		drm_client_release(&fb_helper->client);
++		drm_fb_helper_unprepare(fb_helper);
++		kfree(fb_helper);
++	}
++}
++
++static int gsgpu_fbdev_client_restore(struct drm_client_dev *client)
++{
++	drm_fb_helper_lastclose(client->dev);
++	vga_switcheroo_process_delayed_switch();
++
++	return 0;
++}
++
++static int gsgpu_fbdev_client_hotplug(struct drm_client_dev *client) {
++	struct drm_fb_helper *fb_helper = drm_fb_helper_from_client(client);
++	struct drm_device *dev = client->dev;
++	struct gsgpu_device *rdev = dev->dev_private;
+ 	int ret;
+ 
+-	/* don't init fbdev on hw without DCE */
+-	if (!adev->mode_info.mode_config_initialized)
+-		return 0;
++	if (dev->fb_helper)
++		return drm_fb_helper_hotplug_event(dev->fb_helper);
+ 
+-	/* don't init fbdev if there are no connectors */
+-	if (list_empty(&adev->ddev->mode_config.connector_list))
+-		return 0;
++	ret = drm_fb_helper_init(dev, fb_helper);
++	if (ret)
++		goto err_drm_err;
++
++	if (!drm_drv_uses_atomic_modeset(dev))
++		drm_helper_disable_unused_functions(dev);
++
++	ret = drm_fb_helper_initial_config(fb_helper);
++	if (ret)
++		goto err_drm_fb_helper_fini;
++
++	vga_switcheroo_client_fb_set(rdev->pdev, fb_helper->info);
++
++	return 0;
++
++err_drm_fb_helper_fini:
++	drm_fb_helper_fini(fb_helper);
++err_drm_err:
++	drm_err(dev, "Failed to setup gsgpu fbdev emulation (ret = %d)\n",
++		ret);
++	return ret;
++}
++
++static const struct drm_client_funcs gsgpu_fbdev_client_funcs = {
++	.owner = THIS_MODULE,
++	.unregister = gsgpu_fbdev_client_unregister,
++	.restore = gsgpu_fbdev_client_restore,
++	.hotplug = gsgpu_fbdev_client_hotplug,
++};
++
++void gsgpu_fbdev_setup(struct gsgpu_device *adev)
++{
++	struct drm_fb_helper *fb_helper;
++	int bpp_sel = 32;
++	int ret;
+ 
+ 	/* select 8 bpp console on low vram cards */
+ 	if (adev->gmc.real_vram_size <= (32*1024*1024))
+@@ -296,40 +353,29 @@ int gsgpu_fbdev_init(struct gsgpu_device *adev)
+ 
+ 	fb_helper = kzalloc(sizeof(*fb_helper), GFP_KERNEL);
+ 	if (!fb_helper)
+-		return -ENOMEM;
++		return;
+ 
+ 	lg_drm_fb_helper_prepare(adev->ddev, fb_helper,
+ 				bpp_sel, &gsgpu_fb_helper_funcs);
+ 
+-	ret = lg_drm_fb_helper_init(adev->ddev, fb_helper,
+-				 GSGPUFB_CONN_LIMIT);
+-	if (ret)
+-		goto free;
++	ret = drm_client_init(adev->ddev, &fb_helper->client, "gsgpu-fbdev",
++			      &gsgpu_fbdev_client_funcs);
++	if (ret) {
++		drm_err(adev->ddev, "Failed to register client: %d\n", ret);
++		goto err_drm_client_init;
++	}
+ 
+-	lg_drm_fb_helper_single_add_all_connectors(fb_helper);
+-	ret = drm_fb_helper_initial_config(fb_helper);
++	ret = gsgpu_fbdev_client_hotplug(&fb_helper->client);
+ 	if (ret)
+-		goto fini;
++		drm_dbg_kms(adev->ddev, "client hotplug ret = %d\n", ret);
+ 
+-	return 0;
++	drm_client_register(&fb_helper->client);
+ 
+-fini:
+-	drm_fb_helper_fini(fb_helper);
+-free:
++	return;
++
++err_drm_client_init:
+ 	drm_fb_helper_unprepare(fb_helper);
+ 	kfree(fb_helper);
+-	return ret;
+-}
+-
+-void gsgpu_fbdev_fini(struct gsgpu_device *adev)
+-{
+-	if (!adev->ddev->fb_helper)
+-		return;
+-
+-	drm_fb_helper_unregister_info(adev->ddev->fb_helper);
+-	drm_fb_helper_unprepare(adev->ddev->fb_helper);
+-	kfree(adev->ddev->fb_helper);
+-	adev->ddev->fb_helper = NULL;
+ }
+ 
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state)
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index 860a68d..a66bfaf 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -159,8 +159,7 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ 				   const struct drm_mode_fb_cmd2 *mode_cmd,
+ 				   struct drm_gem_object *obj);
+ 
+-int gsgpu_fbdev_init(struct gsgpu_device *adev);
+-void gsgpu_fbdev_fini(struct gsgpu_device *adev);
++void gsgpu_fbdev_setup(struct gsgpu_device *adev);
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state);
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
+ int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,0 +1,33 @@
+From 09c4bae40f4d1191a3d8a8caab81a70f8c5d35c3 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 20:31:20 +0800
+Subject: [PATCH 19/37] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+ call
+
+It's not needed anymore as now the generic drm_client_register() calls
+the hotplug hook.
+
+Link: https://git.kernel.org/torvalds/c/27655b9bb9f0
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 5057665..f1d9546 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -365,10 +365,6 @@ void gsgpu_fbdev_setup(struct gsgpu_device *adev)
+ 		goto err_drm_client_init;
+ 	}
+ 
+-	ret = gsgpu_fbdev_client_hotplug(&fb_helper->client);
+-	if (ret)
+-		drm_dbg_kms(adev->ddev, "client hotplug ret = %d\n", ret);
+-
+ 	drm_client_register(&fb_helper->client);
+ 
+ 	return;
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,0 +1,29 @@
+From 443a5275c42e8833079eb621775b7faf144e7b7c Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 20:35:32 +0800
+Subject: [PATCH 20/37] loonggpu: Disable outputs when releasing fbdev client
+
+Following up the reference implementation change to avoid potential
+errors.
+
+Link: https://git.kernel.org/torvalds/c/c069dbbcba73
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index f1d9546..4c16273 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -286,6 +286,7 @@ static void gsgpu_fbdev_client_unregister(struct drm_client_dev *client)
+ 
+ 	if (fb_helper->info) {
+ 		vga_switcheroo_client_fb_set(rdev->pdev, NULL);
++		drm_helper_force_disable_all(dev);
+ 		drm_fb_helper_unregister_info(fb_helper);
+ 	} else {
+ 		drm_client_release(&fb_helper->client);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,0 +1,222 @@
+From 5d470d0074d8db599d7aaf3334b56c9a51d266f6 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 23 Jun 2025 20:58:47 +0800
+Subject: [PATCH 21/37] loonggpu: Run DRM default client setup
+
+Rework fbdev probing to support fbdev_probe in struct drm_driver
+and remove the old fb_probe callback. Provide an initializer macro
+for struct drm_driver that sets the callback according to the kernel
+configuration.
+
+Call drm_client_setup() to run the kernel's default client setup
+for DRM. Set fbdev_probe in struct drm_driver, so that the client
+setup can start the common fbdev client.
+
+The loonggpu driver specifies a preferred color mode depending on
+the available video memory, with a default of 32. Adapt this for
+the new client interface.
+
+Following up the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/41d48e557e01
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_drv.c    |  10 +++-
+ gsgpu/gsgpu_fb.c     | 109 +++----------------------------------------
+ include/gsgpu_mode.h |   3 +-
+ 3 files changed, 17 insertions(+), 105 deletions(-)
+
+diff --git a/gsgpu/gsgpu_drv.c b/gsgpu/gsgpu_drv.c
+index a49a4b7..4e31e33 100644
+--- a/gsgpu/gsgpu_drv.c
++++ b/gsgpu/gsgpu_drv.c
+@@ -6,6 +6,7 @@
+ #include <linux/delay.h>
+ #include <linux/pci.h>
+ #include <linux/delay.h>
++#include <drm/clients/drm_client_setup.h>
+ #include <drm/drm_file.h>
+ #include <drm/drm_drv.h>
+ #include <drm/drm_device.h>
+@@ -401,7 +402,9 @@ static int loongson_vga_pci_register(struct pci_dev *pdev,
+ 	resource_size_t dc_rmmio_size;
+ 	void __iomem *dc_rmmio;
+ 	struct drm_device *dev;
++	struct gsgpu_device *adev;
+ 	int retry = 0;
++	const struct drm_format_info *format = NULL;
+ 
+ 	ret = pci_enable_device(pdev);
+ 	if (ret)
+@@ -447,7 +450,11 @@ retry_init:
+ 	if (ret)
+ 		goto err_pci;
+ 
+-	gsgpu_fbdev_setup(dev->dev_private);
++	adev = dev->dev_private;
++	if (adev->gmc.real_vram_size <= (32*1024*1024))
++		format = drm_format_info(DRM_FORMAT_C8);
++
++	drm_client_setup(dev, format);
+ 
+ 	return 0;
+ 
+@@ -572,6 +579,7 @@ static struct drm_driver kms_driver = {
+ 	.major = KMS_DRIVER_MAJOR,
+ 	.minor = KMS_DRIVER_MINOR,
+ 	.patchlevel = KMS_DRIVER_PATCHLEVEL,
++	.fbdev_probe = gsgpu_driver_fbdev_probe,
+ };
+ 
+ static struct drm_driver *driver;
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 4c16273..936c36b 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -184,8 +184,11 @@ out_unref:
+ 	return ret;
+ }
+ 
+-static int gsgpufb_create(struct drm_fb_helper *helper,
+-			   struct drm_fb_helper_surface_size *sizes)
++static const struct drm_fb_helper_funcs gsgpu_fbdev_fb_helper_funcs = {
++};
++
++int gsgpu_driver_fbdev_probe(struct drm_fb_helper *helper,
++			     struct drm_fb_helper_surface_size *sizes)
+ {
+ 	struct gsgpu_device *adev = helper->dev->dev_private;
+ 	struct drm_mode_fb_cmd2 mode_cmd = { };
+@@ -227,6 +230,7 @@ static int gsgpufb_create(struct drm_fb_helper *helper,
+ 	}
+ 
+ 	/* setup helper */
++	helper->funcs = &gsgpu_fbdev_fb_helper_funcs;
+ 	helper->fb = fb;
+ 
+ 	/* okay we have an object now allocate the framebuffer */
+@@ -274,107 +278,6 @@ err_gsgpufb_destroy_pinned_object:
+ 	return ret;
+ }
+ 
+-static const struct drm_fb_helper_funcs gsgpu_fb_helper_funcs = {
+-	.fb_probe = gsgpufb_create,
+-};
+-
+-static void gsgpu_fbdev_client_unregister(struct drm_client_dev *client)
+-{
+-	struct drm_fb_helper *fb_helper = drm_fb_helper_from_client(client);
+-	struct drm_device *dev = fb_helper->dev;
+-	struct gsgpu_device *rdev = dev->dev_private;
+-
+-	if (fb_helper->info) {
+-		vga_switcheroo_client_fb_set(rdev->pdev, NULL);
+-		drm_helper_force_disable_all(dev);
+-		drm_fb_helper_unregister_info(fb_helper);
+-	} else {
+-		drm_client_release(&fb_helper->client);
+-		drm_fb_helper_unprepare(fb_helper);
+-		kfree(fb_helper);
+-	}
+-}
+-
+-static int gsgpu_fbdev_client_restore(struct drm_client_dev *client)
+-{
+-	drm_fb_helper_lastclose(client->dev);
+-	vga_switcheroo_process_delayed_switch();
+-
+-	return 0;
+-}
+-
+-static int gsgpu_fbdev_client_hotplug(struct drm_client_dev *client) {
+-	struct drm_fb_helper *fb_helper = drm_fb_helper_from_client(client);
+-	struct drm_device *dev = client->dev;
+-	struct gsgpu_device *rdev = dev->dev_private;
+-	int ret;
+-
+-	if (dev->fb_helper)
+-		return drm_fb_helper_hotplug_event(dev->fb_helper);
+-
+-	ret = drm_fb_helper_init(dev, fb_helper);
+-	if (ret)
+-		goto err_drm_err;
+-
+-	if (!drm_drv_uses_atomic_modeset(dev))
+-		drm_helper_disable_unused_functions(dev);
+-
+-	ret = drm_fb_helper_initial_config(fb_helper);
+-	if (ret)
+-		goto err_drm_fb_helper_fini;
+-
+-	vga_switcheroo_client_fb_set(rdev->pdev, fb_helper->info);
+-
+-	return 0;
+-
+-err_drm_fb_helper_fini:
+-	drm_fb_helper_fini(fb_helper);
+-err_drm_err:
+-	drm_err(dev, "Failed to setup gsgpu fbdev emulation (ret = %d)\n",
+-		ret);
+-	return ret;
+-}
+-
+-static const struct drm_client_funcs gsgpu_fbdev_client_funcs = {
+-	.owner = THIS_MODULE,
+-	.unregister = gsgpu_fbdev_client_unregister,
+-	.restore = gsgpu_fbdev_client_restore,
+-	.hotplug = gsgpu_fbdev_client_hotplug,
+-};
+-
+-void gsgpu_fbdev_setup(struct gsgpu_device *adev)
+-{
+-	struct drm_fb_helper *fb_helper;
+-	int bpp_sel = 32;
+-	int ret;
+-
+-	/* select 8 bpp console on low vram cards */
+-	if (adev->gmc.real_vram_size <= (32*1024*1024))
+-		bpp_sel = 8;
+-
+-	fb_helper = kzalloc(sizeof(*fb_helper), GFP_KERNEL);
+-	if (!fb_helper)
+-		return;
+-
+-	lg_drm_fb_helper_prepare(adev->ddev, fb_helper,
+-				bpp_sel, &gsgpu_fb_helper_funcs);
+-
+-	ret = drm_client_init(adev->ddev, &fb_helper->client, "gsgpu-fbdev",
+-			      &gsgpu_fbdev_client_funcs);
+-	if (ret) {
+-		drm_err(adev->ddev, "Failed to register client: %d\n", ret);
+-		goto err_drm_client_init;
+-	}
+-
+-	drm_client_register(&fb_helper->client);
+-
+-	return;
+-
+-err_drm_client_init:
+-	drm_fb_helper_unprepare(fb_helper);
+-	kfree(fb_helper);
+-}
+-
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state)
+ {
+ 	if (adev->ddev->fb_helper)
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index a66bfaf..be2e123 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -159,7 +159,8 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ 				   const struct drm_mode_fb_cmd2 *mode_cmd,
+ 				   struct drm_gem_object *obj);
+ 
+-void gsgpu_fbdev_setup(struct gsgpu_device *adev);
++int gsgpu_driver_fbdev_probe(struct drm_fb_helper *helper,
++			     struct drm_fb_helper_surface_size *sizes);
+ void gsgpu_fbdev_set_suspend(struct gsgpu_device *adev, int state);
+ bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
+ int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
@@ -1,0 +1,131 @@
+From 0871ad4bb96b29174dd0cb86b4758bd77592b376 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 21 Jun 2025 17:36:09 +0800
+Subject: [PATCH 22/37] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
+
+A comment in Kbuild says "using EXTRA_CFLAGS for compatibility with
+kernel older than 2.6.24" which does not make any sense for loonggpu: we
+cannot run such an old kernel on LoongArch.
+
+Remove the comment and replace EXTRA_CFLAGS with ccflags-y to fix build
+on Linux >= 6.15.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ Kbuild | 55 ++++++++++++++++++++++++++-----------------------------
+ 1 file changed, 26 insertions(+), 29 deletions(-)
+
+diff --git a/Kbuild b/Kbuild
+index 9a5a508..84e0566 100644
+--- a/Kbuild
++++ b/Kbuild
+@@ -62,22 +62,19 @@ $(foreach _module, $(LG_KERNEL_MODULES), \
+ 
+ 
+ #
+-# Define CFLAGS that apply to all the Loongson kernel modules. EXTRA_CFLAGS
+-# is deprecated since 2.6.24 in favor of ccflags-y, but we need to support
+-# older kernels which do not have ccflags-y. Newer kernels append
+-# $(EXTRA_CFLAGS) to ccflags-y for compatibility.
++# Define CFLAGS that apply to all the Loongson kernel modules.
+ #
+ 
+-EXTRA_CFLAGS += -I$(src)/
+-EXTRA_CFLAGS += -I$(src)/include
+-EXTRA_CFLAGS += -I$(src)/common/inc
+-EXTRA_CFLAGS += -I$(src)/gsgpu-bridge/
+-EXTRA_CFLAGS += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-error -Wno-format-extra-args
+-EXTRA_CFLAGS += -D__KERNEL__ -DMODULE -DNVRM
+-EXTRA_CFLAGS += -DLG_VERSION_STRING=\"2024.01.16\"
++ccflags-y += -I$(src)/
++ccflags-y += -I$(src)/include
++ccflags-y += -I$(src)/common/inc
++ccflags-y += -I$(src)/gsgpu-bridge/
++ccflags-y += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-error -Wno-format-extra-args
++ccflags-y += -D__KERNEL__ -DMODULE -DNVRM
++ccflags-y += -DLG_VERSION_STRING=\"2024.01.16\"
+ 
+ ifneq ($(SYSSRCHOST1X),)
+- EXTRA_CFLAGS += -I$(SYSSRCHOST1X)
++ ccflags-y += -I$(SYSSRCHOST1X)
+ endif
+ 
+ # Some Android kernels prohibit driver use of filesystem functions like
+@@ -87,49 +84,49 @@ endif
+ PLATFORM_IS_ANDROID ?= 0
+ 
+ ifeq ($(PLATFORM_IS_ANDROID),1)
+- EXTRA_CFLAGS += -DLG_FILESYSTEM_ACCESS_AVAILABLE=0
++ ccflags-y += -DLG_FILESYSTEM_ACCESS_AVAILABLE=0
+ else
+- EXTRA_CFLAGS += -DLG_FILESYSTEM_ACCESS_AVAILABLE=1
++ ccflags-y += -DLG_FILESYSTEM_ACCESS_AVAILABLE=1
+ endif
+ 
+-EXTRA_CFLAGS += -Wno-unused-function
++ccflags-y += -Wno-unused-function
+ 
+ ifneq ($(LG_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -Wuninitialized
++ ccflags-y += -Wuninitialized
+ endif
+ 
+-EXTRA_CFLAGS += -fno-strict-aliasing
++ccflags-y += -fno-strict-aliasing
+ 
+ ifeq ($(LG_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -g
++ ccflags-y += -g
+ endif
+ 
+-EXTRA_CFLAGS += -ffreestanding
++ccflags-y += -ffreestanding
+ 
+ ifeq ($(ARCH),arm64)
+- EXTRA_CFLAGS += -mgeneral-regs-only -march=armv8-a
+- EXTRA_CFLAGS += $(call cc-option,-mno-outline-atomics,)
++ ccflags-y += -mgeneral-regs-only -march=armv8-a
++ ccflags-y += $(call cc-option,-mno-outline-atomics,)
+ endif
+ 
+ ifeq ($(ARCH),x86_64)
+- EXTRA_CFLAGS += -mno-red-zone -mcmodel=kernel
++ ccflags-y += -mno-red-zone -mcmodel=kernel
+ endif
+ 
+ ifeq ($(ARCH),powerpc)
+- EXTRA_CFLAGS += -mlittle-endian -mno-strict-align -mno-altivec
++ ccflags-y += -mlittle-endian -mno-strict-align -mno-altivec
+ endif
+ 
+-EXTRA_CFLAGS += -DLG_UVM_ENABLE
+-EXTRA_CFLAGS += $(call cc-option,-Werror=undef,)
+-EXTRA_CFLAGS += -DLG_SPECTRE_V2=$(LG_SPECTRE_V2)
+-EXTRA_CFLAGS += -DLG_KERNEL_INTERFACE_LAYER
++ccflags-y += -DLG_UVM_ENABLE
++ccflags-y += $(call cc-option,-Werror=undef,)
++ccflags-y += -DLG_SPECTRE_V2=$(LG_SPECTRE_V2)
++ccflags-y += -DLG_KERNEL_INTERFACE_LAYER
+ 
+ #
+ # Detect SGI UV systems and apply system-specific optimizations.
+ #
+ 
+ ifneq ($(wildcard /proc/sgi_uv),)
+- EXTRA_CFLAGS += -DLG_CONFIG_X86_UV
++ ccflags-y += -DLG_CONFIG_X86_UV
+ endif
+ 
+ 
+@@ -157,7 +154,7 @@ LG_CONFTEST_CMD := /bin/sh $(LG_CONFTEST_SCRIPT) \
+ 
+ LG_CFLAGS_FROM_CONFTEST := $(shell $(LG_CONFTEST_CMD) build_cflags)
+ 
+-LG_CONFTEST_CFLAGS = $(LG_CFLAGS_FROM_CONFTEST) $(EXTRA_CFLAGS) -fno-pie
++LG_CONFTEST_CFLAGS = $(LG_CFLAGS_FROM_CONFTEST) $(ccflags-y) -fno-pie
+ 
+ LG_CONFTEST_COMPILE_TEST_HEADERS := $(obj)/conftest/macros.h
+ LG_CONFTEST_COMPILE_TEST_HEADERS += $(obj)/conftest/functions.h
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
@@ -1,0 +1,119 @@
+From 8a7019df11c908bddbcc0ded58a6a38ce557318d Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 21 Jun 2025 17:59:23 +0800
+Subject: [PATCH 23/37] AOSCOS: loonggpu: Adapt for drm_sched_init struct
+ params
+
+Since kernel commit 796a9f55a8d1 ("drm/sched: Use struct for
+drm_sched_init() params"), most parameters of drm_sched_init() are
+packed into a struct.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 18 ++++++++++++++++++
+ gsgpu/gsgpu.Kbuild     |  1 +
+ include/gsgpu_helper.h | 22 +++++++++++++++++-----
+ 3 files changed, 36 insertions(+), 5 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 5766f93..55581c8 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -1074,6 +1074,24 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ" "" "types"
+         ;;
+ 
++        drm_sched_init_has_struct_arg)
++            #
++            # Determine if drm_sched_init uses struct drm_sched_init_args arg.
++            #
++            # Changed by commit 796a9f55a8d1d85387b973df9a06cbf4bc2d6327
++            # drm/sched: Use struct for drm_sched_init() params
++            #
++            CODE="
++            #include <drm/gpu_scheduler.h>
++            typeof(drm_sched_init) conftest_drm_sched_init_has_submit_wq;
++            int conftest_drm_sched_init_has_submit_wq(struct drm_gpu_scheduler *sched,
++                                                      const struct drm_sched_init_args *args
++                                                      ) {
++                return 0;
++            }"
++            compile_check_conftest "$CODE" "LG_DRM_SCHED_INIT_HAS_STRUCT_ARG" "" "types"
++        ;;
++
+         drm_sched_job_init_has_credits)
+             #
+             # Determine if drm_sched_job_init has credits arg.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 0e2ee64..6b93c57 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -181,3 +181,4 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_lastclose
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_fb_helper_single_add_all_connectors
+ LG_CONFTEST_TYPE_COMPILE_TESTS += pwm_request
+ LG_CONFTEST_TYPE_COMPILE_TESTS += atomic_check
++LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_init_has_struct_arg
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index fa26309..ebe56f0 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -729,7 +729,7 @@ static inline long lg_get_user_pages(uint64_t userptr, unsigned num_pages,
+ static inline struct drm_sched_rq *lg_sched_to_sched_rq(struct drm_gpu_scheduler *sched,
+ 					enum drm_sched_priority priority)
+ {
+-#if defined(LG_DRM_SCHED_INIT_HAS_DEVICE_RQ) || defined (LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ)
++#if defined(LG_DRM_SCHED_INIT_HAS_DEVICE_RQ) || defined (LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ) || defined (LG_DRM_SCHED_INIT_HAS_STRUCT_ARG)
+ 	return sched->sched_rq[priority];
+ #else
+ 	return &sched->sched_rq[priority];
+@@ -742,7 +742,19 @@ static inline int lg_drm_sched_init(struct gsgpu_ring *ring,
+ 				unsigned hang_limit,
+ 				long timeout, struct gsgpu_device *adev)
+ {
+-#if defined(LG_DRM_SCHED_INIT_HAS_DEVICE)
++#if defined (LG_DRM_SCHED_INIT_HAS_STRUCT_ARG)
++	const struct drm_sched_init_args args = {
++		.ops = ops,
++		.num_rqs = DRM_SCHED_PRIORITY_COUNT,
++		.credit_limit = num_hw_submission,
++		.hang_limit = hang_limit,
++		.timeout = timeout,
++		.name = ring->name,
++		.dev = adev->dev,
++	};
++
++	return drm_sched_init(&ring->sched, &args);
++#elif defined(LG_DRM_SCHED_INIT_HAS_DEVICE)
+ 	return drm_sched_init(&ring->sched, ops,
+ 			   num_hw_submission, hang_limit,
+ 			   timeout, NULL,
+@@ -1132,7 +1144,7 @@ static inline bool lg_ring_sched_thread_avai(struct gsgpu_ring *ring)
+ {
+ 	if (!ring)
+ 		return false;
+-#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ)
++#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ) || defined(LG_DRM_SCHED_INIT_HAS_STRUCT_ARG) 
+ 	if (!drm_sched_wqueue_ready(&ring->sched))
+ 		return false;
+ #else
+@@ -1144,7 +1156,7 @@ static inline bool lg_ring_sched_thread_avai(struct gsgpu_ring *ring)
+ 
+ static inline void lg_ring_sched_thread_park(struct gsgpu_ring *ring)
+ {
+-#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ)
++#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ) || defined(LG_DRM_SCHED_INIT_HAS_STRUCT_ARG)
+ 	drm_sched_wqueue_stop(&ring->sched);
+ #else
+ 	kthread_park(ring->sched.thread);
+@@ -1153,7 +1165,7 @@ static inline void lg_ring_sched_thread_park(struct gsgpu_ring *ring)
+ 
+ static inline void lg_ring_sched_thread_unpark(struct gsgpu_ring *ring)
+ {
+-#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ)
++#if defined(LG_DRM_SCHED_INIT_HAS_SUBMIT_WQ) || defined(LG_DRM_SCHED_INIT_HAS_STRUCT_ARG)
+ 	drm_sched_wqueue_start(&ring->sched);
+ #else
+ 	kthread_unpark(ring->sched.thread);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
@@ -1,0 +1,83 @@
+From 7b7a3db4e073f207cff231791a11d6a11a80c2cb Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 21 Jun 2025 21:07:26 +0800
+Subject: [PATCH 24/37] AOSCOS: loonggpu: Adapt for renaming of from_timer to
+ timer_container_of
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 17 +++++++++++++++++
+ gsgpu/gsgpu.Kbuild     |  1 +
+ gsgpu/gsgpu_fence.c    |  2 +-
+ include/gsgpu_helper.h |  7 +++++++
+ 4 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 55581c8..5f49286 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -2586,6 +2586,23 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DRM_DRIVER_SYNCOBJ_TIMELINE_PRESENT" "" "types"
+         ;;
+ 
++        timer_container_of)
++            #
++            # Determine whether from_timer is renamed to timer_container_of.
++            #
++            # Changed by commit 41cb08555c4164996d67c78b3bf1c658075b75f1
++			# ("treewide, timers: Rename from_timer() to timer_container_of()")
++            #
++            CODE="
++            #include <linux/timer.h>
++
++            #ifndef timer_container_of
++            #error no timer_container_of
++            #endif"
++
++            compile_check_conftest "$CODE" "LG_DRM_DRIVER_TIMER_CONTAINER_OF" "" "types"
++        ;;
++
+         uts_release)
+             #
+             # print the kernel's UTS_RELEASE string.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 6b93c57..3c12c9e 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -182,3 +182,4 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_fb_helper_single_add_all_connectors
+ LG_CONFTEST_TYPE_COMPILE_TESTS += pwm_request
+ LG_CONFTEST_TYPE_COMPILE_TESTS += atomic_check
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_init_has_struct_arg
++LG_CONFTEST_TYPE_COMPILE_TESTS += timer_container_of
+diff --git a/gsgpu/gsgpu_fence.c b/gsgpu/gsgpu_fence.c
+index 8d5c967..5d68920 100644
+--- a/gsgpu/gsgpu_fence.c
++++ b/gsgpu/gsgpu_fence.c
+@@ -255,7 +255,7 @@ void gsgpu_fence_process(struct gsgpu_ring *ring)
+  */
+ static void gsgpu_fence_fallback(struct timer_list *t)
+ {
+-	struct gsgpu_ring *ring = from_timer(ring, t,
++	struct gsgpu_ring *ring = lg_drm_timer_container_of(ring, t,
+ 					      fence_drv.fallback_timer);
+ 
+ 	gsgpu_fence_process(ring);
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index ebe56f0..4d56c91 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -1220,4 +1220,11 @@ static inline void lg_ttm_placement_set_num_busy(struct ttm_placement *placement
+ #else
+ #define lg_drm_driver_set_lastclose
+ #endif
++
++#if defined(LG_DRM_DRIVER_TIMER_CONTAINER_OF)
++#define lg_drm_timer_container_of timer_container_of
++#else
++#define lg_drm_timer_container_of from_timer
++#endif
++
+ #endif /* __GSGPU_HELPER_H__ */
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
@@ -1,0 +1,80 @@
+From 51778b8977329840486c9c0c3d7b65a9917461dd Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 21 Jun 2025 21:15:51 +0800
+Subject: [PATCH 25/37] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
+ to timer_delete_sync
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 15 +++++++++++++++
+ gsgpu/gsgpu.Kbuild     |  1 +
+ gsgpu/gsgpu_fence.c    |  2 +-
+ include/gsgpu_helper.h |  6 ++++++
+ 4 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 5f49286..af8b46b 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -2603,6 +2603,21 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DRM_DRIVER_TIMER_CONTAINER_OF" "" "types"
+         ;;
+ 
++        timer_delete_sync)
++            #
++            # Determine whether del_timer_sync has been renamed to timer_delete_sync
++            #
++            # Changed by commit 8fa7292fee5c5240402371ea89ab285ec856c916
++			# ("treewide: Switch/rename to timer_delete[_sync]()")
++            #
++            CODE="
++            #include <linux/timer.h>
++
++            void *func = timer_delete_sync;"
++
++            compile_check_conftest "$CODE" "LG_DRM_DRIVER_TIMER_DELETE_SYNC" "" "types"
++        ;;
++
+         uts_release)
+             #
+             # print the kernel's UTS_RELEASE string.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 3c12c9e..cdba666 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -183,3 +183,4 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += pwm_request
+ LG_CONFTEST_TYPE_COMPILE_TESTS += atomic_check
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_init_has_struct_arg
+ LG_CONFTEST_TYPE_COMPILE_TESTS += timer_container_of
++LG_CONFTEST_TYPE_COMPILE_TESTS += timer_delete_sync
+diff --git a/gsgpu/gsgpu_fence.c b/gsgpu/gsgpu_fence.c
+index 5d68920..a244695 100644
+--- a/gsgpu/gsgpu_fence.c
++++ b/gsgpu/gsgpu_fence.c
+@@ -472,7 +472,7 @@ void gsgpu_fence_driver_fini(struct gsgpu_device *adev)
+ 		gsgpu_irq_put(adev, ring->fence_drv.irq_src,
+ 			       ring->fence_drv.irq_type);
+ 		drm_sched_fini(&ring->sched);
+-		del_timer_sync(&ring->fence_drv.fallback_timer);
++		lg_drm_timer_delete_sync(&ring->fence_drv.fallback_timer);
+ 		for (j = 0; j <= ring->fence_drv.num_fences_mask; ++j)
+ 			dma_fence_put(ring->fence_drv.fences[j]);
+ 		kfree(ring->fence_drv.fences);
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index 4d56c91..8cb4fa3 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -1227,4 +1227,10 @@ static inline void lg_ttm_placement_set_num_busy(struct ttm_placement *placement
+ #define lg_drm_timer_container_of from_timer
+ #endif
+ 
++#if defined(LG_DRM_DRIVER_TIMER_DELETE_SYNC)
++#define lg_drm_timer_delete_sync timer_delete_sync
++#else
++#define lg_drm_timer_delete_sync del_timer_sync
++#endif
++
+ #endif /* __GSGPU_HELPER_H__ */
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,0 +1,52 @@
+From 5a01159f90249c17dd9acafe01b42ddd27f06e15 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sun, 22 Jun 2025 16:05:51 +0800
+Subject: [PATCH 26/37] loonggpu: bridge: Adapt for recent kernel API changes
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu-bridge/bridge_phy.c | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/gsgpu-bridge/bridge_phy.c b/gsgpu-bridge/bridge_phy.c
+index 921583e..353a481 100644
+--- a/gsgpu-bridge/bridge_phy.c
++++ b/gsgpu-bridge/bridge_phy.c
+@@ -48,9 +48,15 @@ static int bridge_phy_connector_get_modes(struct drm_connector *connector)
+ 	return count;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++#define MODE_VALID_CONST const
++#else
++#define MODE_VALID_CONST
++#endif
++
+ static enum drm_mode_status
+ bridge_phy_connector_mode_valid(struct drm_connector *connector,
+-				struct drm_display_mode *mode)
++				MODE_VALID_CONST struct drm_display_mode *mode)
+ {
+ 	struct gsgpu_device *adev = connector->dev->dev_private;
+ 	struct gsgpu_bridge_phy *phy =
+@@ -169,7 +175,16 @@ void bridge_phy_mode_set(struct gsgpu_bridge_phy *phy,
+ 	__bridge_phy_mode_set(phy, mode, adj_mode);
+ }
+ 
+-static int bridge_phy_attach (lg_bridge_phy_attach_args)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++#define lg_bridge_phy_attach_args_1 \
++	struct drm_bridge *bridge, \
++	struct drm_encoder *encoder, \
++	enum drm_bridge_attach_flags flags
++#else
++#define lg_bridge_phy_attach_args_1 lg_bridge_phy_attach_args
++#endif
++
++static int bridge_phy_attach (lg_bridge_phy_attach_args_1)
+ {
+ 	struct gsgpu_bridge_phy *phy = to_bridge_phy(bridge);
+ 	struct gsgpu_connector *lconnector;
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,0 +1,33 @@
+From cbfbdeabb1ae75c3979ddb0f8c35d1d7c01685f2 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 10:49:40 +0800
+Subject: [PATCH 27/37] loonggpu: Remove the check against moving pinned BOs
+
+The check is already in the generic code.
+
+Following the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/f87c1f0b7b79
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index 6d06d42..e048982 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -607,10 +607,7 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+                         return r;
+         }
+ 
+-	/* Can't move a pinned BO */
+ 	abo = ttm_to_gsgpu_bo(bo);
+-	if (WARN_ON_ONCE(lg_bo_pin_count(abo) > 0))
+-		return -EINVAL;
+ 	adev = gsgpu_ttm_adev(bo->bdev);
+ 
+ 	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL)) {
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
@@ -1,0 +1,31 @@
+From f24dbfb4d81ab70a5919f9281d349accdebcf2e2 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 11:18:49 +0800
+Subject: [PATCH 28/37] loonggpu: Remove dead code
+
+The body of this if statement is obviously unreachable.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index e048982..4c85ac3 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -617,11 +617,6 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 		return 0;
+ 	}
+ 
+-	if (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL) {
+-		gsgpu_move_null(bo, new_mem);
+-		return 0;
+-	}
+-
+ 	if ((old_mem->mem_type == TTM_PL_TT &&
+ 	     new_mem->mem_type == TTM_PL_SYSTEM) ||
+ 	    (old_mem->mem_type == TTM_PL_SYSTEM &&
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,0 +1,54 @@
+From 3f819995623623251838683cd761144fcd961d0d Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 12:11:28 +0800
+Subject: [PATCH 29/37] loonggpu: NFC: Clean up gsgpu_bo_move
+
+Just use goto to deduplicate some identical code, and wrap a long line
+to make the flow more similar to the reference implementation.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index 4c85ac3..8f4d6a3 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -610,11 +610,10 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 	abo = ttm_to_gsgpu_bo(bo);
+ 	adev = gsgpu_ttm_adev(bo->bdev);
+ 
+-	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL)) {
++	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM
++			 && bo->ttm == NULL)) {
+ 		gsgpu_move_null(bo, new_mem);
+-		atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
+-		gsgpu_bo_move_notify(bo, evict, new_mem);
+-		return 0;
++		goto out;
+ 	}
+ 
+ 	if ((old_mem->mem_type == TTM_PL_TT &&
+@@ -623,9 +622,7 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 	     new_mem->mem_type == TTM_PL_TT)) {
+ 		/* bind is enough */
+ 		gsgpu_move_null(bo, new_mem);
+-		atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
+-		gsgpu_bo_move_notify(bo, evict, new_mem);
+-		return 0;
++		goto out;
+ 	}
+ 
+ 	if (!adev->mman.buffer_funcs_enabled)
+@@ -659,6 +656,7 @@ memcpy:
+ 		abo->flags &= ~GSGPU_GEM_CREATE_CPU_ACCESS_REQUIRED;
+ 	}
+ 
++out:
+ 	/* update statistics */
+ 	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
+ 	gsgpu_bo_move_notify(bo, evict, new_mem);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
@@ -1,0 +1,62 @@
+From c9a04e21d03f0385b57a074d8018e4011e3ec9df Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 13:08:07 +0800
+Subject: [PATCH 30/37] loonggpu: Handle tt moves properly
+
+It seems required since a TTM move refactoring in 2020.  Following up the
+reference implementation change (and several changes after that).
+
+Link: https://git.kernel.org/torvalds/c/3a08446b31e3
+Link: https://git.kernel.org/torvalds/c/c37d951cb42a
+Link: https://git.kernel.org/torvalds/c/9764c35348b4
+Link: https://git.kernel.org/torvalds/c/29a1d482e404
+Link: https://git.kernel.org/torvalds/c/18ab7e88778f
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index 8f4d6a3..a12f0c0 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -583,6 +583,8 @@ out_cleanup:
+ 	return r;
+ }
+ 
++static lg_ttm_backend_unbind_ret gsgpu_ttm_backend_unbind(lg_ttm_backend_func_arg);
++
+ /**
+  * gsgpu_bo_move - Move a buffer object to a new memory location
+  *
+@@ -616,15 +618,23 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 		goto out;
+ 	}
+ 
+-	if ((old_mem->mem_type == TTM_PL_TT &&
+-	     new_mem->mem_type == TTM_PL_SYSTEM) ||
+-	    (old_mem->mem_type == TTM_PL_SYSTEM &&
+-	     new_mem->mem_type == TTM_PL_TT)) {
++	if (old_mem->mem_type == TTM_PL_SYSTEM &&
++	    new_mem->mem_type == TTM_PL_TT) {
+ 		/* bind is enough */
+ 		gsgpu_move_null(bo, new_mem);
+ 		goto out;
+ 	}
+ 
++	if (old_mem->mem_type == TTM_PL_TT &&
++	    new_mem->mem_type == TTM_PL_SYSTEM) {
++		r = ttm_bo_wait_ctx(bo, ctx);
++		if (r)
++			return r;
++
++		gsgpu_ttm_backend_unbind(bo->bdev, bo->ttm);
++		gsgpu_move_null(bo, new_mem);
++	}
++
+ 	if (!adev->mman.buffer_funcs_enabled)
+ 		goto memcpy;
+ 
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
@@ -1,0 +1,235 @@
+From 95174f237cc75370e7c99a69ab8779e2b263324a Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 13:35:15 +0800
+Subject: [PATCH 31/37] loonggpu: Use multihop
+
+Remove the code to move resources directly between
+SYSTEM and VRAM in favour of using the core ttm mulithop code.
+
+Following the reference implementation change and various fixes after
+it.
+
+Link: https://git.kernel.org/torvalds/c/f5a89a5cae81
+Link: https://git.kernel.org/torvalds/c/aefec40938e4
+Link: https://git.kernel.org/torvalds/c/c92db8d64f9e
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 178 +++++++---------------------------------------
+ 1 file changed, 25 insertions(+), 153 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index a12f0c0..dd76658 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -414,7 +414,7 @@ error:
+ /**
+  * gsgpu_move_blit - Copy an entire buffer to another buffer
+  *
+- * This is a helper called by gsgpu_bo_move() and gsgpu_move_vram_ram() to
++ * This is a helper called by gsgpu_bo_move() to
+  * help move buffers to and from VRAM.
+  */
+ static int gsgpu_move_blit(struct ttm_buffer_object *bo,
+@@ -452,137 +452,6 @@ error:
+ 	return r;
+ }
+ 
+-/**
+- * gsgpu_move_vram_ram - Copy VRAM buffer to RAM buffer
+- *
+- * Called by gsgpu_bo_move().
+- */
+-static int gsgpu_move_vram_ram(struct ttm_buffer_object *bo, bool evict,
+-				struct ttm_operation_ctx *ctx,
+-				lg_ttm_mem_t *new_mem)
+-{
+-	struct gsgpu_device *adev;
+-	lg_ttm_mem_t *old_mem = lg_tbo_to_mem(bo);
+-	lg_ttm_mem_t tmp_mem, *p;
+-	struct ttm_place placements;
+-	struct ttm_placement placement;
+-	int r;
+-
+-	adev = gsgpu_ttm_adev(bo->bdev);
+-
+-	/* create space/pages for new_mem in GTT space */
+-	tmp_mem = *new_mem;
+-	p = &tmp_mem;
+-	lg_clear_drm_node(lg_res_to_drm_node(&tmp_mem));
+-	placement.num_placement = 1;
+-	placement.placement = &placements;
+-	lg_ttm_placement_set_busy_place(&placement, &placements, 1);
+-	placements.fpfn = 0;
+-	placements.lpfn = 0;
+-#if defined(TTM_PL_FLAG_TT)
+-#if defined(TTM_PL_MASK_CACHING)
+-	placements.flags = TTM_PL_MASK_CACHING | TTM_PL_FLAG_TT;
+-#else
+-	placements.flags = TTM_PL_FLAG_TT;
+-#endif
+-#else
+-#if defined(TTM_PL_MASK_CACHING)
+-	placements.flags = TTM_PL_MASK_CACHING;
+-#endif
+-	placements.mem_type = TTM_PL_TT;
+-#endif
+-	r = lg_ttm_bo_mem_space(bo, &placement, p, ctx);
+-	if (unlikely(r)) {
+-		return r;
+-	}
+-
+-#if defined(TTM_PL_FLAG_WC)
+-	/* set caching flags */
+-	r = ttm_tt_set_placement_caching(bo->ttm, tmp_mem.placement);
+-	if (unlikely(r)) {
+-		goto out_cleanup;
+-	}
+-#endif
+-	/* Bind the memory to the GTT space */
+-	r = lg_ttm_tt_bind(bo, &tmp_mem, ctx);
+-	if (unlikely(r)) {
+-		goto out_cleanup;
+-	}
+-
+-	/* blit VRAM to GTT */
+-	r = gsgpu_move_blit(bo, evict, ctx->no_wait_gpu, &tmp_mem, old_mem);
+-	if (unlikely(r)) {
+-		goto out_cleanup;
+-	}
+-
+-	/* move BO (in tmp_mem) to new_mem */
+-	r = lg_ttm_bo_move_ttm(bo, ctx, new_mem);
+-out_cleanup:
+-	lg_ttm_bo_mem_put(bo, &tmp_mem);
+-	return r;
+-}
+-
+-/**
+- * gsgpu_move_ram_vram - Copy buffer from RAM to VRAM
+- *
+- * Called by gsgpu_bo_move().
+- */
+-static int gsgpu_move_ram_vram(struct ttm_buffer_object *bo, bool evict,
+-				struct ttm_operation_ctx *ctx,
+-				lg_ttm_mem_t *new_mem)
+-{
+-	struct gsgpu_device *adev;
+-	lg_ttm_mem_t *old_mem = lg_tbo_to_mem(bo);
+-	lg_ttm_mem_t tmp_mem, *p;
+-	struct ttm_placement placement;
+-	struct ttm_place placements;
+-	int r;
+-
+-	adev = gsgpu_ttm_adev(bo->bdev);
+-
+-	/* make space in GTT for old_mem buffer */
+-	tmp_mem = *new_mem;
+-	p = &tmp_mem;
+-	lg_clear_drm_node(lg_res_to_drm_node(&tmp_mem));
+-	placement.num_placement = 1;
+-	placement.placement = &placements;
+-	lg_ttm_placement_set_busy_place(&placement, &placements, 1);
+-	placements.fpfn = 0;
+-	placements.lpfn = 0;
+-#if defined(TTM_PL_FLAG_TT)
+-#if defined(TTM_PL_MASK_CACHING)
+-	placements.flags = TTM_PL_MASK_CACHING | TTM_PL_FLAG_TT;
+-#else
+-	placements.flags = TTM_PL_FLAG_TT;
+-#endif
+-#else
+-	placements.mem_type = TTM_PL_TT;
+-#if defined(TTM_PL_MASK_CACHING)
+-	placements.flags = TTM_PL_MASK_CACHING;
+-#endif
+-#endif
+-
+-	r = lg_ttm_bo_mem_space(bo, &placement, p, ctx);
+-	if (unlikely(r)) {
+-		return r;
+-	}
+-
+-	/* move/bind old memory to GTT space */
+-	r = lg_ttm_bo_move_ttm(bo, ctx, &tmp_mem);
+-	if (unlikely(r)) {
+-		goto out_cleanup;
+-	}
+-
+-	/* copy to VRAM */
+-	r = gsgpu_move_blit(bo, evict, ctx->no_wait_gpu, new_mem, old_mem);
+-	if (unlikely(r)) {
+-		goto out_cleanup;
+-	}
+-out_cleanup:
+-	lg_ttm_bo_mem_put(bo, &tmp_mem);
+-	return r;
+-}
+-
+ static lg_ttm_backend_unbind_ret gsgpu_ttm_backend_unbind(lg_ttm_backend_func_arg);
+ 
+ /**
+@@ -635,37 +504,40 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 		gsgpu_move_null(bo, new_mem);
+ 	}
+ 
+-	if (!adev->mman.buffer_funcs_enabled)
+-		goto memcpy;
++	if (bo->type == ttm_bo_type_device &&
++	    new_mem->mem_type == TTM_PL_VRAM &&
++	    old_mem->mem_type != TTM_PL_VRAM) {
++		/* gsgpu_bo_fault_reserve_notify will re-set this if the CPU
++		 * accesses the BO after it's moved.
++		 */
++		abo->flags &= ~GSGPU_GEM_CREATE_CPU_ACCESS_REQUIRED;
++	}
+ 
+-	if (old_mem->mem_type == TTM_PL_VRAM &&
+-	    new_mem->mem_type == TTM_PL_SYSTEM) {
+-		r = gsgpu_move_vram_ram(bo, evict, ctx, new_mem);
+-	} else if (old_mem->mem_type == TTM_PL_SYSTEM &&
+-		   new_mem->mem_type == TTM_PL_VRAM) {
+-		r = gsgpu_move_ram_vram(bo, evict, ctx, new_mem);
+-	} else {
+-		r = gsgpu_move_blit(bo, evict, ctx->no_wait_gpu,
+-				     new_mem, old_mem);
++	if (adev->mman.buffer_funcs_enabled &&
++	    ((old_mem->mem_type == TTM_PL_SYSTEM &&
++	      new_mem->mem_type == TTM_PL_VRAM) ||
++	     (old_mem->mem_type == TTM_PL_VRAM &&
++	      new_mem->mem_type == TTM_PL_SYSTEM))) {
++		hop->fpfn = 0;
++		hop->lpfn = 0;
++		hop->mem_type = TTM_PL_TT;
++		hop->flags = 0;
++		return -EMULTIHOP;
+ 	}
+ 
++	if (adev->mman.buffer_funcs_enabled)
++		r = gsgpu_move_blit(bo, evict, ctx->no_wait_gpu, new_mem,
++				    old_mem);
++	else
++		r = -ENODEV;
++
+ 	if (r) {
+-memcpy:
+ 		r = ttm_bo_move_memcpy(bo, ctx, new_mem);
+ 		if (r) {
+ 			return r;
+ 		}
+ 	}
+ 
+-	if (bo->type == ttm_bo_type_device &&
+-	    new_mem->mem_type == TTM_PL_VRAM &&
+-	    old_mem->mem_type != TTM_PL_VRAM) {
+-		/* gsgpu_bo_fault_reserve_notify will re-set this if the CPU
+-		 * accesses the BO after it's moved.
+-		 */
+-		abo->flags &= ~GSGPU_GEM_CREATE_CPU_ACCESS_REQUIRED;
+-	}
+-
+ out:
+ 	/* update statistics */
+ 	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,0 +1,37 @@
+From 859801da3ffd26fdc27a5a6f77484c9137a100f5 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 13:42:37 +0800
+Subject: [PATCH 32/37] loonggpu: Drop the unused no_wait_gpu parameter of
+ gsgpu_move_blit
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index dd76658..95ccd5e 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -418,7 +418,7 @@ error:
+  * help move buffers to and from VRAM.
+  */
+ static int gsgpu_move_blit(struct ttm_buffer_object *bo,
+-			    bool evict, bool no_wait_gpu,
++			    bool evict,
+ 			    lg_ttm_mem_t *new_mem,
+ 			    lg_ttm_mem_t *old_mem)
+ {
+@@ -526,8 +526,7 @@ static int gsgpu_bo_move(struct ttm_buffer_object *bo, bool evict,
+ 	}
+ 
+ 	if (adev->mman.buffer_funcs_enabled)
+-		r = gsgpu_move_blit(bo, evict, ctx->no_wait_gpu, new_mem,
+-				    old_mem);
++		r = gsgpu_move_blit(bo, evict, new_mem, old_mem);
+ 	else
+ 		r = -ENODEV;
+ 
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,0 +1,87 @@
+From fef5eeb09edd5421ab852efc8e1bff0db0030e80 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 13:49:20 +0800
+Subject: [PATCH 33/37] loonggpu: Drop lg_ttm_tt_bind
+
+Get rid of the ttm_tt_populate usage: this symbol is only exported if
+DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.
+
+I plan to drop all the conftest mess and use multiple branches for
+different kernel versions later.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh                | 15 ---------------
+ gsgpu/gsgpu.Kbuild         |  1 -
+ include/gsgpu_ttm_helper.h | 17 -----------------
+ 3 files changed, 33 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index af8b46b..497c1f4 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -1541,21 +1541,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_TTM_BO_PIPELINE_MOVE" "" "functions"
+         ;;
+ 
+-        ttm_tt_bind)
+-            #
+-            # Determine if the ttm_tt_bind function exists.
+-            #
+-            # Changed by commit 9e9a153bdf2555a931fd37678a8e44d170a5d943 ("drm/ttm:
+-            # move ttm binding/unbinding out of ttm_tt paths") in v5.9-rc6
+-            #
+-            CODE="
+-            #include <drm/ttm/ttm_tt.h>
+-            int conftest_ttm_tt_bind(void) {
+-                return ttm_tt_bind();
+-            }"
+-            compile_check_conftest "$CODE" "LG_TTM_TT_BIND" "" "functions"
+-        ;;
+-
+         ttm_bo_mem_put)
+             #
+             # Determine if the ttm_bo_mem_put function exists.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index cdba666..dcaa194 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -73,7 +73,6 @@ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_bo_init_mm
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_bo_clean_mm
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_resource_alloc
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_bo_pipeline_move
+-LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_tt_bind
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_bo_mem_put
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_tt_set_populated
+ LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_resource_manager_evict_all
+diff --git a/include/gsgpu_ttm_helper.h b/include/gsgpu_ttm_helper.h
+index 5eeebf3..f352344 100644
+--- a/include/gsgpu_ttm_helper.h
++++ b/include/gsgpu_ttm_helper.h
+@@ -152,23 +152,6 @@ static inline int lg_ttm_bo_pipeline_move(struct ttm_buffer_object *bo,
+ 	return r;
+ }
+ 
+-static inline int lg_ttm_tt_bind(struct ttm_buffer_object *bo, lg_ttm_mem_t *mem,
+-				 struct ttm_operation_ctx *ctx)
+-{
+-#if defined(LG_TTM_TT_BIND)
+-	return ttm_tt_bind(bo->ttm, mem, ctx);
+-#else
+-	int r;
+-	r = ttm_tt_populate(bo->bdev, bo->ttm, ctx);
+-	if (r)
+-		return r;
+-	r = gsgpu_ttm_backend_bind(bo->bdev, bo->ttm, mem);
+-	if (r)
+-		return r;
+-	return r;
+-#endif
+-}
+-
+ static inline void lg_ttm_bo_mem_put(struct ttm_buffer_object *bo, lg_ttm_mem_t *mem)
+ {
+ #if defined(LG_TTM_BO_MEM_PUT) && defined(LG_DRM_TTM_TTM_BO_DRIVER_H_PRESENT)
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
@@ -1,0 +1,57 @@
+From 17d2c2dec632865fbb4bde88ac66e838153ace10 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 14:09:20 +0800
+Subject: [PATCH 34/37] loonggpu: Make the mode parameter of the mode_valid
+ callback of bridge_phy_cfg_funcs a pointer to const
+
+Fix a -Wdiscarded-qualifiers warning.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu-bridge/bridge_phy.h | 2 +-
+ gsgpu-bridge/lt6711_drv.c | 2 +-
+ gsgpu-bridge/lt8718_drv.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gsgpu-bridge/bridge_phy.h b/gsgpu-bridge/bridge_phy.h
+index 40818ef..6db4392 100644
+--- a/gsgpu-bridge/bridge_phy.h
++++ b/gsgpu-bridge/bridge_phy.h
+@@ -198,7 +198,7 @@ struct bridge_phy_cfg_funcs {
+ 			     const struct drm_display_mode *mode,
+ 			     const struct drm_display_mode *adj_mode);
+ 	enum drm_mode_status (*mode_valid)(struct drm_connector *connector,
+-					   struct drm_display_mode *mode);
++					   const struct drm_display_mode *mode);
+ };
+ 
+ struct bridge_phy_misc_funcs {
+diff --git a/gsgpu-bridge/lt6711_drv.c b/gsgpu-bridge/lt6711_drv.c
+index ce438c7..7b667dc 100644
+--- a/gsgpu-bridge/lt6711_drv.c
++++ b/gsgpu-bridge/lt6711_drv.c
+@@ -5,7 +5,7 @@
+ #include "bridge_phy.h"
+ 
+ static enum drm_mode_status lt6711_mode_valid(struct drm_connector *connector,
+-					      struct drm_display_mode *mode)
++					      const struct drm_display_mode *mode)
+ {
+ 	if (mode->hdisplay < 1920)
+ 		return MODE_BAD;
+diff --git a/gsgpu-bridge/lt8718_drv.c b/gsgpu-bridge/lt8718_drv.c
+index 1e494ec..7abb77c 100644
+--- a/gsgpu-bridge/lt8718_drv.c
++++ b/gsgpu-bridge/lt8718_drv.c
+@@ -623,7 +623,7 @@ static int lt8718_video_output(struct gsgpu_bridge_phy *phy)
+ }
+ 
+ static enum drm_mode_status lt8718_mode_valid(struct drm_connector *connector,
+-					      struct drm_display_mode *mode)
++					      const struct drm_display_mode *mode)
+ {
+         if (mode->hdisplay == 1680 && mode->vdisplay == 1050)
+             return MODE_BAD;
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,0 +1,28 @@
+From f2f40bb47d116791d979df9fd1e6f09b5210bc0f Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 14:24:23 +0800
+Subject: [PATCH 35/37] loonggpu: Remove an invalid "const" qualifier
+
+You obviously cannot sprintf things into a const char array!
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_backlight.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gsgpu/gsgpu_backlight.c b/gsgpu/gsgpu_backlight.c
+index 8a2fa3b..8b97512 100644
+--- a/gsgpu/gsgpu_backlight.c
++++ b/gsgpu/gsgpu_backlight.c
+@@ -146,7 +146,7 @@ static int gsgpu_backlight_hw_request_init(struct gsgpu_backlight *ls_bl)
+ 	bool pwm_enable_default;
+ 	struct pwm_state state;
+ 	struct gsgpu_device *adev = ls_bl->driver_private;
+-	const char pwm_name[10];
++	char pwm_name[16];
+ 
+ 	sprintf(pwm_name, "pwm%d", ls_bl->pwm_id);
+ 	ls_bl->pwm = lg_pwm_request(adev->ddev->dev, pwm_name, ls_bl->pwm_id, "Loongson_bl");
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,0 +1,29 @@
+From 45ca1bad62a6824155b08fdbe627bb0a74d49763 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 14:26:21 +0800
+Subject: [PATCH 36/37] loonggpu: Fix the parameter order of a kmalloc_array
+ call
+
+The element size should be the second parameter.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ids.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gsgpu/gsgpu_ids.c b/gsgpu/gsgpu_ids.c
+index ed06003..cc3d157 100644
+--- a/gsgpu/gsgpu_ids.c
++++ b/gsgpu/gsgpu_ids.c
+@@ -183,7 +183,7 @@ static int gsgpu_vmid_grab_idle(struct gsgpu_vm *vm,
+ 	if (ring->vmid_wait && !dma_fence_is_signaled(ring->vmid_wait))
+ 		return gsgpu_sync_fence(adev, sync, ring->vmid_wait, false);
+ 
+-	fences = kmalloc_array(sizeof(void *), id_mgr->num_ids, GFP_KERNEL);
++	fences = kmalloc_array(id_mgr->num_ids, sizeof(void *), GFP_KERNEL);
+ 	if (!fences)
+ 		return -ENOMEM;
+ 
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,0 +1,32 @@
+From 5d88458aaf0edfb43d7674b8afa674e80406ea8e Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 24 Jun 2025 16:10:04 +0800
+Subject: [PATCH 37/37] loonggpu: Handle the different drm_client_setup.h
+ location in 6.12
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_drv.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/gsgpu/gsgpu_drv.c b/gsgpu/gsgpu_drv.c
+index 4e31e33..924d3bb 100644
+--- a/gsgpu/gsgpu_drv.c
++++ b/gsgpu/gsgpu_drv.c
+@@ -6,7 +6,13 @@
+ #include <linux/delay.h>
+ #include <linux/pci.h>
+ #include <linux/delay.h>
++
++#if __has_include(<drm/clients/drm_client_setup.h>)
+ #include <drm/clients/drm_client_setup.h>
++#else
++#include <drm/drm_client_setup.h>
++#endif
++
+ #include <drm/drm_file.h>
+ #include <drm/drm_drv.h>
+ #include <drm/drm_device.h>
+-- 
+2.50.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=1
+REL=2
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- Track AOSC OS patches at https://github.com/AOSC-Tracking/loonggpu-kernel-dkms, current HEAD is 5d88458aaf0edfb43d7674b8afa674e80406ea8e.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: 1.0.1-alpha-lnd-25.5-2

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`
