### PR TITLE
qt-6: add xcb private header

### DIFF
--- a/runtime-desktop/qt-6/01-runtime/beyond
+++ b/runtime-desktop/qt-6/01-runtime/beyond
@@ -3,3 +3,9 @@ mkdir -pv "$PKGDIR"/usr/bin
 for b in "$PKGDIR"/usr/lib/qt6/bin/*; do
     ln -sv ../lib/qt6/bin/"$(basename "$b")" "$PKGDIR"/usr/bin/"$(basename "$b")"-qt6
 done
+
+abinfo "Copying xcb private headers ..."
+install -dv -m755 "$PKGDIR"/usr/include/qt6xcb-private/{gl_integrations,nativepainting}
+cp -rv "$SRCDIR"/qtbase/src/plugins/platforms/xcb/*.h "$PKGDIR"/usr/include/qt6xcb-private/
+cp -rv "$SRCDIR"/qtbase/src/plugins/platforms/xcb/gl_integrations/*.h "$PKGDIR"/usr/include/qt6xcb-private/gl_integrations/
+cp -rv "$SRCDIR"/qtbase/src/plugins/platforms/xcb/nativepainting/*.h "$PKGDIR"/usr/include/qt6xcb-private/nativepainting/

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=8
+REL=9
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::659d8bb5931afac9ed5d89a78e868e6bd00465a58ab566e2123db02d674be559"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: add xcb private header
    Required by dde-qt6platform-plugins

Package(s) Affected
-------------------

- qt-6: 6.8.2-9
- qt-6-doc: 6.8.2-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
