### PR TITLE
dpkg: update to 1.22.21

### DIFF
--- a/app-admin/dpkg/spec
+++ b/app-admin/dpkg/spec
@@ -1,4 +1,4 @@
-VER=1.22.18
+VER=1.22.21
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/dpkg-team/dpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8127"


### PR DESCRIPTION
Topic Description
-----------------

- dpkg: update to 1.22.21
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dpkg: 1.22.21
- update-alternatives: 1.22.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit dpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
