### PR TITLE
telegram-desktop: update to 5.16.1

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 8af838cfe76c2d18dfc553b0ad9da7c71e791faf Mon Sep 17 00:00:00 2001
+From f5e7c46e53c66342cd4c5871993689a4f28ade86 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 01/11] fix(window.style): set default window width to 360px
+Subject: [PATCH 01/12] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -31,5 +31,5 @@ index acdda31299..899bcb5827 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From a6af0bd51741a808dc842eff23b30450064bc1db Mon Sep 17 00:00:00 2001
+From 194e15bdcdcbf9d8b94e7cb2b37220c34b9e8015 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 02/11] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 02/12] fix(core_settings.h): use system window decoration by
  default
 
 ---
@@ -22,5 +22,5 @@ index 8ce8d72818..a116d04020 100644
  	rpl::variable<bool> _systemDarkModeEnabled = true;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From 8eda8dd824e46740cefb4b021400242fe1e6cce6 Mon Sep 17 00:00:00 2001
+From cdcfccf854f70b896b654d57e7a2b8e5a123c340 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 03/11] fix(ui): fix build with Qt 5
+Subject: [PATCH 03/12] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---
@@ -68,5 +68,5 @@ index 24274c3794..a57c4fab1f 100644
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From 53b7f13dc668a7ed5641f6c77518de264886dae6 Mon Sep 17 00:00:00 2001
+From d90a2ff31a4c5d5f4b29765c6cdd8f3e0a129c81 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 04/11] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 04/12] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst
@@ -28,5 +28,5 @@ index e844acf9ee..adb4b80fb6 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,7 +1,7 @@
-From 96d8b290f99943c556d49ea67c9cee805f4f76e8 Mon Sep 17 00:00:00 2001
+From a72244ae434989c343e1dac1ab0b293b47914846 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 05/11] fix(settings): use system fonts by default
+Subject: [PATCH 05/12] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-
@@ -29,5 +29,5 @@ index a116d04020..ad75558a52 100644
  	std::optional<bool> _weatherInCelsius;
  	QByteArray _tonsiteStorageToken;
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 674856574e9e2f1c4cf99da06b4a33324e19231a Mon Sep 17 00:00:00 2001
+From 360bb552a3fcdaae7bf7859983bbc921cae21453 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 06/11] Remove the confusing "Default" option from selectable
+Subject: [PATCH 06/12] Remove the confusing "Default" option from selectable
  fonts
 
 ---
@@ -45,5 +45,5 @@ index 97f65b65d9..9eff4830c3 100644
  		std::swap(result[2], *nowIt);
  		++skip;
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From 01860860b1b5e826baf4c11fd00de0e11e9e44d4 Mon Sep 17 00:00:00 2001
+From 852ee247a623e54af0d842ae052a75f9ecc6e65d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 07/11] fix(lib_tl): add missing cstring include
+Subject: [PATCH 07/12] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -21,5 +21,5 @@ index 5eadf62a93..961f7febe0 100644
  
  namespace tl {
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From 06bb4d64721431cec4c04002a4139384a23a6d06 Mon Sep 17 00:00:00 2001
+From 3f286d01e9fa4b7890f1cd33e7ff62c93cb2dfa6 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 08/11] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 08/12] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -21,5 +21,5 @@ index 4a92fe3020..3cf6125358 100644
  #include <rpl/never.h>
  #include <rpl/producer.h>
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,7 +1,7 @@
-From 769ef3b8fc40c2b4a74cb664f26ccd11f400108f Mon Sep 17 00:00:00 2001
+From 4e025fb57c6d29c22746b51aeeb70d6e5117061d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
-Subject: [PATCH 09/11] fix(current_geo_location_linux): add missing
+Subject: [PATCH 09/12] fix(current_geo_location_linux): add missing
  QGuiApplication include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -22,5 +22,5 @@ index 7015af7398..d48fc7025a 100644
  namespace Platform {
  namespace {
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,7 +1,7 @@
-From a649a51da7efa91626c73e8c32fe086b96fc5934 Mon Sep 17 00:00:00 2001
+From 3528d978865341d1efa3f30bd353937bcd4cbba4 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
-Subject: [PATCH 10/11] fix(core_settings.h): enable video hardware
+Subject: [PATCH 10/12] fix(core_settings.h): enable video hardware
  acceleration by default
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -26,5 +26,5 @@ index ad75558a52..e9fb514bff 100644
  		= HistoryView::DoubleClickQuickAction();
  	bool _translateButtonEnabled = false;
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,7 +1,7 @@
-From 6dc0e94edd6a5258ac797cf62f51b66036c99ede Mon Sep 17 00:00:00 2001
+From f6010f4edaeccba592619bed208dbd5e82d35abc Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
-Subject: [PATCH 11/11] fix(cmake): disable CMP0160 to workaround KF5 cmake
+Subject: [PATCH 11/12] fix(cmake): disable CMP0160 to workaround KF5 cmake
  errors
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -27,5 +27,5 @@ index fc7b239b03..d9f278a357 100644
  
  include(cmake/validate_special_target.cmake)
 -- 
-2.49.0
+2.50.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,0 +1,26 @@
+From 6fb69e2cb3c037fea9d29319d25deb81689088da Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Thu, 3 Jul 2025 19:04:36 -0700
+Subject: [PATCH 12/12] fix(credits_amount.h): include cmath for std::floor
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ Telegram/SourceFiles/core/credits_amount.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Telegram/SourceFiles/core/credits_amount.h b/Telegram/SourceFiles/core/credits_amount.h
+index 098266d887..a5d329c417 100644
+--- a/Telegram/SourceFiles/core/credits_amount.h
++++ b/Telegram/SourceFiles/core/credits_amount.h
+@@ -7,6 +7,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ */
+ #pragma once
+ 
++#include <cmath>
++
+ #include "base/algorithm.h"
+ #include "base/basic_types.h"
+ 
+-- 
+2.50.0
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=5.15.4
-# Update tg_owt to the latest Git snapshot when updating Telegram Desktop
+VER=5.16.1
+# Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
-TDLIBVER=fb04b8d40e5e3d24c30001af2e9784c91d4606c0
+TDLIBVER=5d1fe744712fbc752840176135b39e82086f5578
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::3705dc2ecf51e9290a565b7a06dcdfc5ecbac13ec536afe582f3411653ad50d9 \
+CHKSUMS="sha256::12b4d0b484c6e1569b582caa11a677ac81077cbd82ad629c2ff74d1bd405a5ea \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.16.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
