### PR TITLE
fastfetch: update to 2.47.0

### DIFF
--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,4 @@
-VER=2.46.0
+VER=2.47.0
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: update to 2.47.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fastfetch: 2.47.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
