### PR TITLE
poppler: update to 25.06.0

### DIFF
--- a/app-creativity/inkscape/autobuild/patches/0001-BACKPORT-Fix-build-against-Poppler-25.06.patch
+++ b/app-creativity/inkscape/autobuild/patches/0001-BACKPORT-Fix-build-against-Poppler-25.06.patch
@@ -1,0 +1,118 @@
+From 1fdfb889bba9ee146c8b826e97bc58a88cb1e529 Mon Sep 17 00:00:00 2001
+From: Rafael Siejakowski <rs@rs-math.net>
+Date: Sun, 8 Jun 2025 21:30:44 +0200
+Subject: [PATCH] Fix build against Poppler 25.06
+
+Accommodate for the private API change, whereby an array of pointers
+has been replaced with a vector of unique_ptr.
+
+Fixes https://gitlab.com/inkscape/inkscape/-/issues/5836
+---
+ .../internal/pdfinput/pdf-parser.cpp          | 23 +++++++++++--------
+ .../pdfinput/poppler-transition-api.h         | 12 ++++++++++
+ 2 files changed, 25 insertions(+), 10 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index b0b6aa9eec4..22c86fbc3a4 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -24,6 +24,7 @@
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>
++#include <memory>
+ #include <mutex> // std::call_once()
+ #include <utility>
+ #include <vector>
+@@ -693,7 +694,6 @@ void PdfParser::opSetLineWidth(Object args[], int /*numArgs*/)
+ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+ {
+     Object obj1, obj2, obj3, obj4, obj5;
+-    Function *funcs[4] = {nullptr, nullptr, nullptr, nullptr};
+     GfxColor backdropColor;
+     GBool haveBackdropColor = gFalse;
+     GBool alpha = gFalse;
+@@ -751,13 +751,14 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+         state->setLineWidth(obj2.getNum());
+     }
+ 
++    _POPPLER_DECLARE_TRANSFER_FUNCTION_VECTOR(funcs);
++
+     // transfer function
+     if (_POPPLER_CALL_ARGS_DEREF(obj2, obj1.dictLookup, "TR2").isNull()) {
+         _POPPLER_CALL_ARGS(obj2, obj1.dictLookup, "TR");
+     }
+     if (obj2.isName(const_cast<char *>("Default")) || obj2.isName(const_cast<char *>("Identity"))) {
+-        funcs[0] = funcs[1] = funcs[2] = funcs[3] = nullptr;
+-        state->setTransfer(funcs);
++        state->setTransfer(std::move(funcs));
+     } else if (obj2.isArray() && obj2.arrayGetLength() == 4) {
+         int pos = 4;
+         for (int i = 0; i < 4; ++i) {
+@@ -770,12 +771,14 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+         }
+         _POPPLER_FREE(obj3);
+         if (pos == 4) {
+-            state->setTransfer(funcs);
++            state->setTransfer(std::move(funcs));
+         }
+     } else if (obj2.isName() || obj2.isDict() || obj2.isStream()) {
+         if ((funcs[0] = Function::parse(&obj2))) {
+-            funcs[1] = funcs[2] = funcs[3] = nullptr;
+-            state->setTransfer(funcs);
++            funcs[1] = nullptr;
++            funcs[2] = nullptr;
++            funcs[3] = nullptr;
++            state->setTransfer(std::move(funcs));
+         }
+     } else if (!obj2.isNull()) {
+         error(errSyntaxError, getPos(), "Invalid transfer function in ExtGState");
+@@ -797,8 +800,7 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+                 funcs[0] = Function::parse(&obj3);
+                 if (funcs[0]->getInputSize() != 1 || funcs[0]->getOutputSize() != 1) {
+                     error(errSyntaxError, getPos(), "Invalid transfer function in soft mask in ExtGState");
+-                    delete funcs[0];
+-                    funcs[0] = nullptr;
++                    _POPPLER_DELETE_TRANSFER_FUNCTION(funcs[0]);
+                 }
+             }
+             _POPPLER_FREE(obj3);
+@@ -842,9 +844,10 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+                             }
+                         }
+                     }
+-                    doSoftMask(&obj3, alpha, blendingColorSpace.get(), isolated, knockout, funcs[0], &backdropColor);
++                    doSoftMask(&obj3, alpha, blendingColorSpace.get(), isolated, knockout,
++                               _POPPLER_GET_TRANSFER_FUNCTION_POINTER(funcs[0]), &backdropColor);
+                     if (funcs[0]) {
+-                        delete funcs[0];
++                        _POPPLER_DELETE_TRANSFER_FUNCTION(funcs[0]);
+                     }
+                 } else {
+                     error(errSyntaxError, getPos(), "Invalid soft mask in ExtGState - missing group");
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index a67132ba6bd..d04412757bc 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,18 @@
+ #include <glib/poppler-features.h>
+ #include <poppler/UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(25, 6, 0)
++#define _POPPLER_DECLARE_TRANSFER_FUNCTION_VECTOR(name) std::vector<std::unique_ptr<Function>> name(4)
++#define _POPPLER_DELETE_TRANSFER_FUNCTION(name) name.reset()
++#define _POPPLER_GET_TRANSFER_FUNCTION_POINTER(name) name.get()
++#else
++#define _POPPLER_DECLARE_TRANSFER_FUNCTION_VECTOR(name) Function *name[4] = {}
++#define _POPPLER_DELETE_TRANSFER_FUNCTION(name) \
++    delete name;                                \
++    name = nullptr
++#define _POPPLER_GET_TRANSFER_FUNCTION_POINTER(name) name
++#endif
++
+ #if POPPLER_CHECK_VERSION(25,2,0)
+ #define _POPPLER_GET_CODE_TO_GID_MAP(ff, len) getCodeToGIDMap(ff)
+ #define _POPPLER_GET_CID_TO_GID_MAP(len) getCIDToGIDMap()
+-- 
+GitLab
+

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=1_4_1
+UPSTREAM_VER=1_4_2
 VER=${UPSTREAM_VER//_/.}
-REL=4
 SRCS="git::commit=tags/INKSCAPE_${UPSTREAM_VER}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
 VER=25.2.4.3
-REL=1
+REL=2
 SRCS="tbl::https://download.documentfoundation.org/libreoffice/src/${VER:0:6}/libreoffice-$VER.tar.xz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_am.tar.gz \
       file::rename=LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz::https://downloadarchive.documentfoundation.org/libreoffice/old/${VER}/rpm/x86_64/LibreOffice_${VER}_Linux_x86-64_rpm_helppack_ar.tar.gz \

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
-REL=3
+REL=4
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::0ae58ced410101e82655e3b4c20a070cf1767145ada233dcef7c20b8ba6bd487"
 CHKUPDATE="anitya::id=4773"

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.3.0
-REL=7
+REL=8
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=6
+REL=7
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/koffice-trinity/spec
+++ b/desktop-trinity/koffice-trinity/spec
@@ -5,4 +5,4 @@ CHKSUMS="sha256::06aa9488747a3c92a68d6a057b9bd238251465b21afc74c3c0d3faad85f58fe
          sha256::0e3d99fee00cdf3c257166dacc5c8679ad7418c8e8f22d6d71f4a5e67014387e"
 CHKUPDATE="anitya::id=16065"
 SUBDIR="koffice-trinity-$VER"
-REL=5
+REL=6

--- a/desktop-trinity/tdegraphics/spec
+++ b/desktop-trinity/tdegraphics/spec
@@ -1,5 +1,5 @@
 VER=14.1.2
-REL=4
+REL=5
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdegraphics-trinity-$VER.tar.xz"
 CHKSUMS="sha256::8771c5c80156dd2a3747f2138d98c6a2d63fe11dc008d52022293946dd4ebe2f"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-doc/poppler/autobuild/defines
+++ b/runtime-doc/poppler/autobuild/defines
@@ -21,13 +21,13 @@ CMAKE_AFTER__RETRO=" \
              -DENABLE_GTK_DOC=OFF"
 
 PKGBREAK="atril<=1.28.1 cantor<=23.08.5 evince<=42.3-1 \
-          gdal<=3.10.1-3 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
-          graphviz<=12.2.1 inkscape<=1.4-3 kfilemetadata<=5.115.0-1 \
-          kitinerary<=23.08.5-5 koffice-trinity<=14.1.2-4 krita<=5.2.2-1 \
-          libcupsfilters<=2.0.0-1 libreoffice<=25.2.2.2 okular<=23.08.5-2 \
+          gdal<=3.10.3-1 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
+          graphviz<=12.2.1 inkscape<=1.4.1-4 kfilemetadata<=5.115.0-1 \
+          kitinerary<=23.08.5-6 koffice-trinity<=14.1.2-5 krita<=5.2.2-1 \
+          libcupsfilters<=2.0.0-1 libreoffice<=25.2.4.3-1 okular<=23.08.5-2 \
           openscenegraph<=3:3.6.5-4 pdfgrep<=2.1.2-4 \
           python-poppler-qt5<=21.1.0+git20210304-3 rnote<=0.11.0 \
-          sane-backends<=1.0.32-2 scribus<=1.6.3-2 tdegraphics<=14.1.2-3 \
+          sane-backends<=1.0.32-2 scribus<=1.6.3-3 tdegraphics<=14.1.2-4 \
           texstudio<=4.0.2-4 texworks<=0.6.6-4 tracker-miners<=3.3.1-3 \
           tumbler<=4.20.0 xournalpp<=1.2.5 xreader<=4.2.2 \
           zathura-pdf-poppler<=0.3.3"

--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -1,4 +1,4 @@
-VER=25.04.0
+VER=25.06.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
-CHKSUMS="sha256::b010c596dce127fba88532fd2f1043e55ea30601767952d0f2c0a80e7dc0da3d"
+CHKSUMS="sha256::8199532d38984fab46dbd0020ec9c40f20e928e33e9b4cc6043572603a821d83"
 CHKUPDATE="anitya::id=3686"

--- a/runtime-games/openscenegraph/spec
+++ b/runtime-games/openscenegraph/spec
@@ -1,5 +1,5 @@
 VER=3.6.5
-REL=6
+REL=7
 SRCS="tbl::https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-$VER.tar.gz"
 CHKSUMS="sha256::aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12"
 CHKUPDATE="anitya::id=6848"

--- a/runtime-gis/gdal/autobuild/defines
+++ b/runtime-gis/gdal/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="c-blosc cfitsio crypto++ curl expat freexl gcc-runtime geos giflib glibc
         hdf5 imath json-c libarchive libavif libcl libdeflate libgeotiff libheif \
         libjpeg-turbo libjxl libpng libspatialite libtiff libwebp libxml2 lz4 \
         mariadb netcdf openexr openjdk openjpeg openssl pcre2 podofo poppler \
-        postgresql-runtime proj python-3 qhull sqlite unixodbc xerces-c xz zlib zstd"
+        postgresql-runtime proj python-3 qhull sqlite unixodbc xerces-c xz \
+        zlib zstd muparser"
 PKGRECOM="numpy"
 PKGSUG="postgresql"
 BUILDDEP="apache-ant opencl-registry-api postgresql setuptools swig"
@@ -60,6 +61,7 @@ CMAKE_AFTER=(
     "-DGDAL_USE_MRSID=OFF"
     "-DGDAL_USE_MSSQL_NCLI=OFF"
     "-DGDAL_USE_MSSQL_ODBC=OFF"
+    "-DGDAL_USE_MUPARSER=ON"
     "-DGDAL_USE_MYSQL=ON"
     "-DGDAL_USE_NETCDF=ON"
     "-DGDAL_USE_ODBC=ON"
@@ -96,4 +98,4 @@ CMAKE_AFTER=(
     "-DBUILD_JAVA_BINDINGS=ON"
 )
 
-PKGBREAK="opencv<=4.9.0-6 openscenegraph<=3:3.6.5-4 vtk<=9.3.0-3"
+PKGBREAK="opencv<=4.9.0-8 openscenegraph<=3:3.6.5-6 pdal<=2.8.4 vtk<=9.3.0-7"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,4 @@
-VER=3.10.3
-REL=1
+VER=3.11.1
 SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
-CHKSUMS="sha256::335a8d2c7567d783563d3fed37e8b58d72d9c1723f6fd1d8c299fe4c0d936781"
+CHKSUMS="sha256::21341b39a960295bd3194bcc5f119f773229b4701cd752499fbd850f3cc160fd"
 CHKUPDATE="anitya::id=881"

--- a/runtime-gis/pdal/autobuild/defines
+++ b/runtime-gis/pdal/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=pdal
 PKGSEC=science
 PKGDES="C++ library for translating and manipulating point cloud data"
 PKGDEP="curl gcc-runtime gdal glibc hdf5 libgeotiff libunwind libxml2 \
-        openscenegraph openssl pcl postgresql proj vtk xerces-c zlib \
+        openscenegraph openssl pcl postgresql-runtime-17 proj vtk xerces-c zlib \
         zstd draco tiledb teaserpp pdal-nitro ceres apache-arrow libcpd"
 BUILDDEP="nlohmann-json gtest"
 

--- a/runtime-gis/pdal/autobuild/prepare
+++ b/runtime-gis/pdal/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Specifying PostgreSQL include path ..."
+export PostgreSQL_INCLUDE_DIR="/usr/lib/postgresql-17/include"

--- a/runtime-gis/pdal/spec
+++ b/runtime-gis/pdal/spec
@@ -1,4 +1,5 @@
 VER=2.8.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/PDAL/PDAL"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138228"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.9.0
-REL=8
+REL=9
 SRCS="git::commit=tags/$VER::https://github.com/opencv/opencv \
       git::commit=tags/$VER;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- poppler: update to 25.06.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- poppler: 1:25.06.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit poppler:-pkgbreak gdal:-pkgbreak vtk opencv openscenegraph pdal gdal inkscape kitinerary tdegraphics koffice-trinity libreoffice scribus poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
