### PR TITLE
zathura: update to 0.5.12

### DIFF
--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=zathura
 PKGSEC=doc
 PKGDEP="girara sqlite desktop-file-utils file libseccomp texlive"
-BUILDDEP="docutils sphinx appstream-glib bash-completion fish"
+BUILDDEP="docutils sphinx appstream-glib bash-completion fish librsvg"
 PKGDES="A minimalistic document viewer"
 
 ABTYPE=meson

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.11
+VER=0.5.12
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 0.5.12
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zathura: 0.5.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
