### PR TITLE
verilator: fix data install path

### DIFF
--- a/app-electronics/verilator/autobuild/patches/0002-Fix-data-install-path.patch
+++ b/app-electronics/verilator/autobuild/patches/0002-Fix-data-install-path.patch
@@ -1,0 +1,55 @@
+From af547ed4fb2ae981ccd860fd669aa5f987b96e9b Mon Sep 17 00:00:00 2001
+From: DehaoGao <13207280@qq.com>
+Date: Fri, 4 Jul 2025 14:02:39 +0800
+Subject: [PATCH] Fix data install path
+
+---
+ Makefile.in | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index d963d8402..c4741d492 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -279,14 +279,14 @@ installman: $(VL_INST_MAN_FILES)
+ 	done
+ 
+ installdata:
+-	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/include/gtkwave
+-	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/include/vltstd
++	$(MKINSTALLDIRS) $(DESTDIR)$(pkglibdir)/include/gtkwave
++	$(MKINSTALLDIRS) $(DESTDIR)$(pkglibdir)/include/vltstd
+ 	for p in $(VL_INST_INC_BLDDIR_FILES) ; do \
+-	  $(INSTALL_DATA) $$p $(DESTDIR)$(pkgdatadir)/$$p; \
++	  $(INSTALL_DATA) $$p $(DESTDIR)$(pkglibdir)/$$p; \
+ 	done
+ 	cd $(srcdir) \
+ 	; for p in $(VL_INST_INC_SRCDIR_FILES) ; do \
+-	  $(INSTALL_DATA) $$p $(DESTDIR)$(pkgdatadir)/$$p; \
++	  $(INSTALL_DATA) $$p $(DESTDIR)$(pkglibdir)/$$p; \
+ 	done
+ 	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/examples/make_hello_binary
+ 	$(MKINSTALLDIRS) $(DESTDIR)$(pkgdatadir)/examples/make_hello_c
+@@ -313,13 +313,13 @@ installdata:
+ uninstall:
+ 	-cd $(DESTDIR)$(bindir) && rm -f $(VL_INST_PUBLIC_SCRIPT_FILES)
+ 	-cd $(DESTDIR)$(bindir) && rm -f $(VL_INST_PUBLIC_BIN_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PUBLIC_SCRIPT_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PUBLIC_BIN_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir)/bin && rm -f $(VL_INST_PRIVATE_SCRIPT_FILES)
++	-cd $(DESTDIR)$(pkglibdir)/bin && rm -f $(VL_INST_PUBLIC_SCRIPT_FILES)
++	-cd $(DESTDIR)$(pkglibdir)/bin && rm -f $(VL_INST_PUBLIC_BIN_FILES)
++	-cd $(DESTDIR)$(pkglibdir)/bin && rm -f $(VL_INST_PRIVATE_SCRIPT_FILES)
+ 	-cd $(DESTDIR)$(mandir)/man1 && rm -f $(VL_INST_MAN_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir) && rm -f $(VL_INST_INC_BLDDIR_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir) && rm -f $(VL_INST_INC_SRCDIR_FILES)
+-	-cd $(DESTDIR)$(pkgdatadir) && rm -f $(VL_INST_DATA_SRCDIR_FILES)
++	-cd $(DESTDIR)$(pkglibdir) && rm -f $(VL_INST_INC_BLDDIR_FILES)
++	-cd $(DESTDIR)$(pkglibdir) && rm -f $(VL_INST_INC_SRCDIR_FILES)
++	-cd $(DESTDIR)$(pkglibdir) && rm -f $(VL_INST_DATA_SRCDIR_FILES)
+ 	-rm $(DESTDIR)$(pkgconfigdir)/verilator.pc
+ 	-rm $(DESTDIR)$(pkgdatadir)/verilator-config.cmake
+ 	-rm $(DESTDIR)$(pkgdatadir)/verilator-config-version.cmake
+-- 
+2.50.0
+

--- a/app-electronics/verilator/spec
+++ b/app-electronics/verilator/spec
@@ -1,4 +1,5 @@
 VER=5.026
+REL=1
 SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/verilator/verilator"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5085"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- verilator: fix data install path
    - The original patch 0001 defines `pkglibdir` to changes the install path of binary, for architecture relevant files need to be placed at `/usr/lib` instead of `usr/share` .
    - But verilator needs some other files such as `verilated.h` during compiling verilog. While compiling, it tries finding these files in `pkglibdir`, but they are not installed to there. 
    - The newly added patch 0002 makes files needed by verilator installed to `pkglibdir` , too.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- verilator: 5.026
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit verilator
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
