### PR TITLE
cloudflared: update to 2025.7.0

### DIFF
--- a/app-proxy/cloudflared/spec
+++ b/app-proxy/cloudflared/spec
@@ -1,4 +1,4 @@
-VER=2025.6.1
+VER=2025.7.0
 # copy repo required by auto version detection logic in makefile
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/cloudflare/cloudflared"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- cloudflared: update to 2025.7.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- cloudflared: 1:2025.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cloudflared
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
