### PR TITLE
libsigrok: fix wrong `python-2` dep to `python-3`

### DIFF
--- a/runtime-electronics/libsigrok/autobuild/defines
+++ b/runtime-electronics/libsigrok/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=libsigrok
 PKGSEC=electronics
 PKGDES="The main data acquiring library of Sigrok"
 PKGDEP="libserialport libftdi libzip glib libieee1284 libusb \
-        glibmm check python-2 pygobject-3 ruby numpy"
+        glibmm check python-3 pygobject-3 ruby numpy"
 BUILDDEP="openjdk swig doxygen setuptools"
 
 ABSHADOW=0

--- a/runtime-electronics/libsigrok/spec
+++ b/runtime-electronics/libsigrok/spec
@@ -2,4 +2,4 @@ VER=0.5.2
 SRCS="tbl::https://sigrok.org/download/source/libsigrok/libsigrok-$VER.tar.gz"
 CHKSUMS="sha256::4d341f90b6220d3e8cb251dacf726c41165285612248f2c52d15df4590a1ce3c"
 CHKUPDATE="anitya::id=21369"
-REL=1
+REL=2


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
`libsigrok` has the wrong `python-2` listed in PKGDEP. It no longer supports Python 2 bindings, and only has Python 3 bindings.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
`libsigrok`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit libsigrok
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
