### PR TITLE
coreboot-utils: update to 25.06

### DIFF
--- a/app-admin/coreboot-utils/spec
+++ b/app-admin/coreboot-utils/spec
@@ -1,4 +1,4 @@
-VER=24.08
+VER=25.06
 SRCS="https://www.coreboot.org/releases/coreboot-$VER.tar.xz"
-CHKSUMS="sha256::1fc9a997d497539f915dc6498e4aca4bf049955d4db9a17a85454ad6b342710c"
+CHKSUMS="sha256::53ec8b4d187196e812e23d27ec251aeb8d09e194ab737509ec664c8fb904d459"
 CHKUPDATE="anitya::id=10128"


### PR DESCRIPTION
Topic Description
-----------------

- coreboot-utils: update to 25.06
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreboot-utils: 25.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreboot-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
