### PR TITLE
libtorrent-rasterbar: fix wrong python-2 dep to python-3

### DIFF
--- a/runtime-web/libtorrent-rasterbar/autobuild/defines
+++ b/runtime-web/libtorrent-rasterbar/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libtorrent-rasterbar
 PKGSEC=libs
-PKGDEP="boost geoip-api-c python-2"
+PKGDEP="boost geoip-api-c python-3"
 PKGDES="C++ BitTorrent support library"
 
 ABTYPE=cmakeninja

--- a/runtime-web/libtorrent-rasterbar/spec
+++ b/runtime-web/libtorrent-rasterbar/spec
@@ -2,3 +2,4 @@ VER=2.0.10
 SRCS="tbl::https://github.com/arvidn/libtorrent/releases/download/v${VER}/libtorrent-rasterbar-$VER.tar.gz"
 CHKSUMS="sha256::fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d"
 CHKUPDATE="anitya::id=4166"
+REL=1

--- a/runtime-web/libtorrent-rasterbar/spec
+++ b/runtime-web/libtorrent-rasterbar/spec
@@ -1,5 +1,4 @@
-VER=2.0.10
+VER=2.0.11
 SRCS="tbl::https://github.com/arvidn/libtorrent/releases/download/v${VER}/libtorrent-rasterbar-$VER.tar.gz"
-CHKSUMS="sha256::fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d"
+CHKSUMS="sha256::f0db58580f4f29ade6cc40fa4ba80e2c9a70c90265cd77332d3cdec37ecf1e6d"
 CHKUPDATE="anitya::id=4166"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libtorrent-rasterbar: fix wrong \`python-2\` dep to \`python-3\`

Package(s) Affected
-------------------

- libtorrent-rasterbar: 2.0.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtorrent-rasterbar
```

Test Build(s) Done
------------------

