### PR TITLE
topics: fix syntax error in linux-kernel-lts-6.12.34


### DIFF
--- a/topics/linux-kernel-lts-6.12.34.toml
+++ b/topics/linux-kernel-lts-6.12.34.toml
@@ -9,4 +9,4 @@ default = "Fixes an issue where the display output on Intel Skylake devices may 
 zh_CN = "修复 Intel Skylake 设备上启用 IOMMU 特性后显示输出时有闪黑的问题，并修复龙芯 3A6000 笔记本（如攀升 NL38-N11 及其他型号）触摸板不可用的问题"
 
 [packages]
-"linux+kernel+lts" = "2:6.12.34
+"linux+kernel+lts" = "2:6.12.34"


### PR DESCRIPTION
Topic Description
-----------------

- topics: fix syntax error in linux-kernel-lts-6.12.34

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
