### PR TITLE
httplib2: update to 0.22.0

### DIFF
--- a/lang-python/httplib2/autobuild/defines
+++ b/lang-python/httplib2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=httplib2
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-2 python-3 setuptools"
 PKGDES="Comprehensive HTTP client library supporting many features"
 
 ABHOST=noarch

--- a/lang-python/httplib2/spec
+++ b/lang-python/httplib2/spec
@@ -1,5 +1,4 @@
-VER=0.19.0
+VER=0.22.0
 SRCS="tbl::https://pypi.io/packages/source/h/httplib2/httplib2-$VER.tar.gz"
-CHKSUMS="sha256::e0d428dad43c72dbce7d163b7753ffc7a39c097e6788ef10f4198db69b92f08e"
+CHKSUMS="sha256::d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"
 CHKUPDATE="anitya::id=3887"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- httplib2: update to 0.22.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- httplib2: 0.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit httplib2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
