### PR TITLE
level-zero: update to 1.23.0

### DIFF
--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.22.2
+VER=1.23.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"


### PR DESCRIPTION
Topic Description
-----------------

- level-zero: update to 1.23.0
    Co-authored-by: purofle \(@purofle\) <purofle@gmail.com>

Package(s) Affected
-------------------

- level-zero: 1.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit level-zero
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
