### PR TITLE
Qualcomm SoC-based Devices Support Survey 20250706

### DIFF
--- a/app-admin/qbootctl/autobuild/defines
+++ b/app-admin/qbootctl/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=qbootctl
+PKGSEC=admin
+PKGDES="Qualcomm bootctl HAL for Linux"
+PKGDEP=zlib
+
+ABTYPE=meson
+
+# Note: This package is strictly for AArch64 systems.
+FAIL_ARCH="!(arm64)"

--- a/app-admin/qbootctl/spec
+++ b/app-admin/qbootctl/spec
@@ -1,0 +1,4 @@
+VER=0.2.2
+SRCS="git::commit=tags/${VER}::https://github.com/linux-msm/qbootctl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379011"

--- a/app-devel/qmic/autobuild/build
+++ b/app-devel/qmic/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building ..."
+make prefix=/usr ${ABMK}
+
+abinfo "Installing ..."
+make prefix=/usr DESTDIR="$PKGDIR" install

--- a/app-devel/qmic/autobuild/defines
+++ b/app-devel/qmic/autobuild/defines
@@ -1,0 +1,3 @@
+PKGNAME=qmic
+PKGSEC=devel
+PKGDES="Compiler for the Qualcomm QMI IDL"

--- a/app-devel/qmic/spec
+++ b/app-devel/qmic/spec
@@ -1,0 +1,4 @@
+VER=1.0
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-msm/qmic"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369591"

--- a/runtime-admin/pd-mapper/autobuild/build
+++ b/runtime-admin/pd-mapper/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building ..."
+make prefix=/usr ${ABMK}
+
+abinfo "Installing ..."
+make prefix=/usr DESTDIR="$PKGDIR" install

--- a/runtime-admin/pd-mapper/autobuild/defines
+++ b/runtime-admin/pd-mapper/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pd-mapper
+PKGSEC=admin
+PKGDES="Userspace implementation for Qualcomm Protection Domain Mapper"
+PKGDEP=qrtr
+
+# Note: This package is strictly for AArch64 systems.
+FAIL_ARCH="!(arm64)"

--- a/runtime-admin/pd-mapper/spec
+++ b/runtime-admin/pd-mapper/spec
@@ -1,0 +1,4 @@
+VER=1.0
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-msm/pd-mapper"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369566"

--- a/runtime-admin/qrtr/autobuild/defines
+++ b/runtime-admin/qrtr/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=qrtr
+PKGSEC=admin
+PKGDES="Userspace reference for Qualcomm IPC Router protocol"
+
+ABTYPE=meson
+MESON_AFTER="-Dqrtr-ns=enabled -Dsystemd-service=enabled"
+
+# Note: This package is strictly for AArch64 systems.
+FAIL_ARCH="!(arm64)"

--- a/runtime-admin/qrtr/spec
+++ b/runtime-admin/qrtr/spec
@@ -1,0 +1,4 @@
+VER=1.1
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-msm/qrtr"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369564"

--- a/runtime-admin/rmtfs/autobuild/build
+++ b/runtime-admin/rmtfs/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building ..."
+make prefix=/usr ${ABMK}
+
+abinfo "Installing ..."
+make prefix=/usr DESTDIR="$PKGDIR" install

--- a/runtime-admin/rmtfs/autobuild/defines
+++ b/runtime-admin/rmtfs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=rmtfs
+PKGSEC=admin
+PKGDES="Userspace implementation for Qualcomm Remote Filesystem service"
+PKGDEP=qrtr
+BUILDDEP=qmic
+
+# Note: This package is strictly for AArch64 systems.
+FAIL_ARCH="!(arm64)"

--- a/runtime-admin/rmtfs/spec
+++ b/runtime-admin/rmtfs/spec
@@ -1,0 +1,4 @@
+VER=1.1.1
+SRCS="git::commit=tags/v${VER}::https://github.com/linux-msm/rmtfs"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379009"

--- a/runtime-admin/tqftpserv/autobuild/defines
+++ b/runtime-admin/tqftpserv/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=tqftpserv
+PKGSEC=admin
+PKGDES="Userspace implementation for Qualcomm TFTP server over the QRTR protocol"
+PKGDEP=qrtr
+
+ABTYPE=meson
+
+# Note: This package is strictly for AArch64 systems.
+FAIL_ARCH="!(arm64)"

--- a/runtime-admin/tqftpserv/spec
+++ b/runtime-admin/tqftpserv/spec
@@ -1,0 +1,4 @@
+VER=1.1
+SRCS="git::commit=tags/v$VER::https://github.com/linux-msm/tqftpserv"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377521"


### PR DESCRIPTION
Topic Description
-----------------

- qbootctl: new, 0.2.2
- pd-mapper: new, 1.0
- tqftpserv: new, 1.1
- rmtfs: new, 1.1.1
- qrtr: new, 1.1
- qmic: new, 1.0

Package(s) Affected
-------------------

- pd-mapper: 1.0
- qbootctl: 0.2.2
- qmic: 1.0
- qrtr: 1.1
- rmtfs: 1.1.1
- tqftpserv: 1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qmic qrtr rmtfs tqftpserv pd-mapper qbootctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
