### PR TITLE
aoscbootstrap: update to 0.10.2

### DIFF
--- a/app-utils/aoscbootstrap/autobuild/beyond
+++ b/app-utils/aoscbootstrap/autobuild/beyond
@@ -3,8 +3,8 @@ install -dv "$PKGDIR/usr/share/aoscbootstrap"
 cp -rv "$SRCDIR/"{contrib,scripts,config,recipes} "$PKGDIR/usr/share/aoscbootstrap/"
 
 abinfo 'Creating a symlink for generate-{emukit,releases} ...'
-chmod -v +x "$PKGDIR"/usr/share/aoscbootstrap/contrib/generate-releases.sh
-ln -sv ../share/aoscbootstrap/contrib/generate-releases.sh \
+chmod -v +x "$PKGDIR"/usr/share/aoscbootstrap/contrib/generate-releases
+ln -sv ../share/aoscbootstrap/contrib/generate-releases \
     "$PKGDIR"/usr/bin/generate-releases
 ln -sv ../share/aoscbootstrap/contrib/generate-emukit \
     "$PKGDIR"/usr/bin/generate-emukit

--- a/app-utils/aoscbootstrap/spec
+++ b/app-utils/aoscbootstrap/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

- aoscbootstrap: update to 0.10.2
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- aoscbootstrap: 0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
