### PR TITLE
wayland: update to 1.24.0

### DIFF
--- a/runtime-display/wayland/spec
+++ b/runtime-display/wayland/spec
@@ -1,4 +1,4 @@
-VER=1.23.1
+VER=1.24.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10061"


### PR DESCRIPTION
Topic Description
-----------------

- wayland: update to 1.24.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wayland: 1.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
