### PR TITLE
opentabletdriver: fix checkupdate

### DIFF
--- a/runtime-devices/opentabletdriver/spec
+++ b/runtime-devices/opentabletdriver/spec
@@ -1,4 +1,4 @@
 VER=0.6.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/OpenTabletDriver/OpenTabletDriver"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::241822"
+CHKUPDATE="anitya::id=241822"


### PR DESCRIPTION
Topic Description
-----------------

- opentabletdriver: fix checkupdate

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
