### PR TITLE
surfer: new, 0.3.0

### DIFF
--- a/app-electronics/surfer/autobuild/defines
+++ b/app-electronics/surfer/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=surfer
+PKGDES="A waveform viewer"
+PKGSEC=electronics
+PKGDEP="openssl"
+BUILDDEP="rustc llvm openssl pkg-config pkgconf"
+
+USECLANG=1
+
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; recompile with -fPIC
+NOLTO__LOONGSON3=1
+USECLANG__LOONGSON3=0

--- a/app-electronics/surfer/spec
+++ b/app-electronics/surfer/spec
@@ -1,0 +1,4 @@
+VER=0.3.0
+
+SRCS="git::commit=tags/v$VER::https://gitlab.com/surfer-project/surfer"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- surfer: new, 0.3.0

Package(s) Affected
-------------------

- surfer: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit surfer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
