### PR TITLE
cmake: update to 4.0.3

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,6 +1,6 @@
-VER=3.31.6
-SRCS="tbl::https://cmake.org/files/v${VER:0:4}/cmake-$VER.tar.gz"
-CHKSUMS="sha256::653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0"
+VER=4.0.3
+SRCS="tbl::https://github.com/Kitware/CMake/releases/download/v$VER/cmake-$VER.tar.gz"
+CHKSUMS="sha256::8d3537b7b7732660ea247398f166be892fe6131d63cc291944b45b91279f3ffb"
 CHKUPDATE="anitya::id=306"
 
 # lto-wrapper: fatal error: write: No space left on device


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 4.0.3
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cmake: 4.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
