### PR TITLE
openal-soft: update to 1.24.3

### DIFF
--- a/runtime-multimedia/openal-soft/spec
+++ b/runtime-multimedia/openal-soft/spec
@@ -1,5 +1,4 @@
-VER=1.23.1
-REL=1
+VER=1.24.3
 SRCS="git::commit=tags/$VER::https://github.com/kcat/openal-soft"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8172"


### PR DESCRIPTION
Topic Description
-----------------

- openal-soft: update to 1.24.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- openal-soft: 1.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit openal-soft
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
