### PR TITLE
listenbrainz-mpd: update to 2.3.9

### DIFF
--- a/app-multimedia/listenbrainz-mpd/spec
+++ b/app-multimedia/listenbrainz-mpd/spec
@@ -1,4 +1,4 @@
-VER=2.3.8
+VER=2.3.9
 SRCS="git::commit=tags/v$VER::https://codeberg.org/elomatreb/listenbrainz-mpd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376364"


### PR DESCRIPTION
Topic Description
-----------------

- listenbrainz-mpd: update to 2.3.9
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- listenbrainz-mpd: 2.3.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit listenbrainz-mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
