### PR TITLE
oma: update to 1.18.1

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -11,6 +11,15 @@ PKGREP="mirrormgr<=0.11.1"
 
 USECLANG=1
 
+# FIXME: Disable the `mirror` subcommand for looongarch64_nosimd,
+# oma does not yet support writing to sources.list via a custom template.
+#
+# loongarch64_nosimd uses a custom sources.list template:
+#
+#   deb ${mirror}/debs stable bsp-loongarch64-nosimd
+#   deb [arch=all] ${mirror} debs stable main
+CARGO_AFTER__LOONGARCH64_NOSIMD="--no-default-features --features aosc,generic"
+
 # FIXME: ld.lld is not yet available.
 NOLTO__LOONGSON3=1
 NOLTO__MIPS64R6EL=1

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.18.0
+VER=1.18.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.18.1

Package(s) Affected
-------------------

- oma: 1.18.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



