### PR TITLE
git: update to 2.50.1

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,4 @@
-VER=2.50.0
+VER=2.50.1
 
 # Use this for stable releases.
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
@@ -8,5 +8,5 @@ SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 #REL=0.${RC}
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::920f8ca563d16a7d4fdecb44349cbffbc5cb814a8b36c96028463478197050da"
+CHKSUMS="sha256::522d1635f8b62b484b0ce24993818aad3cab8e11ebb57e196bda38a3140ea915"
 CHKUPDATE="anitya::id=5350"

--- a/topics/git-2.50.1.toml
+++ b/topics/git-2.50.1.toml
@@ -1,0 +1,15 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Git 2.50.1"
+zh_CN = "Git 2.50.1"
+
+[caution]
+default = "Fixes 5 high severity vulnerabilities including 2 remote code execution vulnerabilities - CVE-2025-48385 and CVE-2025-48386"
+zh_CN = "修复五处高危漏洞，包含两处远程代码执行漏洞 (CVE-2025-48385, CVE-2025-48386)"
+
+[packages]
+git = "2.50.1"
+gitk = "2.50.1"
+git-gui = "2.50.1"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.50.1

Package(s) Affected
-------------------

- git: 2.50.1
- git-gui: 2.50.1
- gitk: 2.50.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
