### PR TITLE
telegram-desktop: update to 5.16.3

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=5.16.1
+VER=5.16.3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
 TDLIBVER=5d1fe744712fbc752840176135b39e82086f5578
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::12b4d0b484c6e1569b582caa11a677ac81077cbd82ad629c2ff74d1bd405a5ea \
+CHKSUMS="sha256::24fc952d920db66fa1ca4748ee5674220c99f329b289acee0273ed8729ee310c \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.16.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.16.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
