### PR TITLE
gsettings-qt: new, 1.0.0

### DIFF
--- a/app-devel/cmake-extras/autobuild/defines
+++ b/app-devel/cmake-extras/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=cmake-extras
+PKGSEC=devel
+BUILDDEP="cmake ninja"
+PKGDES="A collection of add-ons for the CMake build tool"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)
+ABSPLITDBG=0

--- a/app-devel/cmake-extras/spec
+++ b/app-devel/cmake-extras/spec
@@ -1,0 +1,4 @@
+VER=1.8
+SRCS="git::commit=tags/$VER::https://gitlab.com/ubports/development/core/cmake-extras.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=266330"

--- a/runtime-desktop/gsettings-qt/autobuild/defines
+++ b/runtime-desktop/gsettings-qt/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=gsettings-qt
+PKGSEC=libs
+PKGDEP="glibc qt-6"
+BUILDDEP="cmake cmake-extras ninja"
+PKGDES="Library to access GSettings from Qt"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DENABLE_QT6=ON'
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+)

--- a/runtime-desktop/gsettings-qt/spec
+++ b/runtime-desktop/gsettings-qt/spec
@@ -1,0 +1,4 @@
+VER=1.0.0
+SRCS="git::commit=tags/v$VER::https://gitlab.com/ubports/development/core/gsettings-qt.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375581"


### PR DESCRIPTION
Topic Description
-----------------

- gsettings-qt: new, 1.0.0
- cmake-extras: new, 1.8

Package(s) Affected
-------------------

- cmake-extras: 1.8
- gsettings-qt: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake-extras gsettings-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
