### PR TITLE
Clp: fix build error with GCC >= 14

### DIFF
--- a/app-scientific/clp/autobuild/patches/0001-FROMEXT-fedora-coin-or-Clp-configure-amd_defaults-c9.patch
+++ b/app-scientific/clp/autobuild/patches/0001-FROMEXT-fedora-coin-or-Clp-configure-amd_defaults-c9.patch
@@ -1,0 +1,56 @@
+From b7c1713155cb9bd947091f807b8603410e9c5edd Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Thu, 10 Jul 2025 09:04:55 +0800
+Subject: [PATCH] FROMEXT: fedora: coin-or-Clp-configure-amd_defaults-c99
+
+Avoid an implicit function declaration of amd_defaults, cholmod_start.
+Without this change, detection results change with compilers which do
+not support implicit function declarations.  The fake prototypes match
+those that autoconf uses.
+
+The source code for all the autoconf macros is not included here, so
+patch only the generated shell script.
+
+This was solved upstream via:
+
+commit fea612b2327ad347b6e8aba96ff33e87b98d10fb
+Author: Stefan Vigerske <svigerske@gams.com>
+Date:   Fri Feb 26 06:08:27 2021 +0100
+
+    use CHK_LIBHDR macro for amd, cholesky, and (system-)mumps
+
+Signed-off-by: Florian Weimer <fweimer@redhat.com>
+
+Imported to solve error:
+configure: error: Cannot find symbol(s) cholmod_start with CHOLMOD
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ Clp/configure | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Clp/configure b/Clp/configure
+index b2d3cad6..e5c17d66 100755
+--- a/Clp/configure
++++ b/Clp/configure
+@@ -23387,6 +23387,8 @@ cat confdefs.h >>conftest.$ac_ext
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ 
++char $fnm (void);
++
+ int
+ main ()
+ {
+@@ -23580,6 +23582,8 @@ cat confdefs.h >>conftest.$ac_ext
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ 
++char $fnm (void);
++
+ int
+ main ()
+ {
+-- 
+2.50.0
+

--- a/app-scientific/clp/spec
+++ b/app-scientific/clp/spec
@@ -1,5 +1,5 @@
 VER=1.17.6
-REL=2
+REL=3
 SRCS="tbl::https://www.coin-or.org/download/source/Clp/Clp-$VER.tgz"
 CHKSUMS="sha256::f9cfcdd3db23bbc2d18b562012a7e25b99a40e8ce72dc296bd46dddb2970e12a"
 SUBDIR="Clp-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- Clp: fix build error with GCC >= 14
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- clp: 1.17.6-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit clp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
