### PR TITLE
openslide: update to 4.0.0

### DIFF
--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.3.0
-REL=7
+REL=8
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"

--- a/runtime-imaging/libvips/autobuild/defines
+++ b/runtime-imaging/libvips/autobuild/defines
@@ -5,7 +5,8 @@ PKGDEP="gcc-runtime glibc glib expat zlib libarchive fftw cfitsio cgif \
         libimagequant libexif libjpeg-turbo libpng libwebp pango fontconfig \
         libtiff librsvg cairo lcms2 openexr openjpeg highway nifti matio"
 PKGRECOM="imagemagick openslide libheif libjxl poppler python-3"
-BUILDDEP="imagemagick openslide libheif libjxl poppler vala gtk-doc doxygen"
+BUILDDEP="imagemagick openslide libdicom libheif libjxl poppler vala gtk-doc \
+	doxygen"
 
 MESON_AFTER=(
     '-Dexamples=false'

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,5 @@
 VER=8.16.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"

--- a/runtime-imaging/openslide/autobuild/defines
+++ b/runtime-imaging/openslide/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=openslide
 PKGSEC=graphic
 PKGDES="A C library for reading whole-slide images / virtual slides"
-PKGDEP="gdk-pixbuf"
-BUILDDEP="cairo glib libjpeg-turbo libpng libtiff libxml2 openjpeg sqlite zlib"
+PKGDEP="cairo gdk-pixbuf glib libdicom libjpeg-turbo libpng libtiff libxml2 openjpeg sqlite zlib"
+BUILDDEP="cairo glib libdicom libjpeg-turbo libpng libtiff libxml2 openjpeg sqlite zlib"
 
 AUTOTOOLS_AFTER="--disable-static"
+
+PKGBREAK="vtk<=9.3.0-7 libvips<=8.16.1-2"

--- a/runtime-imaging/openslide/spec
+++ b/runtime-imaging/openslide/spec
@@ -1,4 +1,4 @@
-VER=3.4.1
+VER=4.0.0
 SRCS="tbl::https://github.com/openslide/openslide/releases/download/v$VER/openslide-$VER.tar.xz"
-CHKSUMS="sha256::9938034dba7f48fadc90a2cdf8cfe94c5613b04098d1348a5ff19da95b990564"
+CHKSUMS="sha256::cc227c44316abb65fb28f1c967706eb7254f91dbfab31e9ae6a48db6cf4ae562"
 CHKUPDATE="anitya::id=5600"

--- a/runtime-scientific/libdicom/autobuild/defines
+++ b/runtime-scientific/libdicom/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libdicom
+PKGSEC=graphic
+PKGDES="A C library and a set of command-line tools for reading DICOM WSI files"
+PKGDEP=""
+BUILDDEP="check gcc meson uthash"
+
+AUTOTOOLS_AFTER="--disable-static"

--- a/runtime-scientific/libdicom/autobuild/prepare
+++ b/runtime-scientific/libdicom/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "disabling build tests..."
+sed -i 's/\btrue\b/false/g' ${SRCDIR}/meson_options.txt

--- a/runtime-scientific/libdicom/spec
+++ b/runtime-scientific/libdicom/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="tbl::https://github.com/ImagingDataCommons/libdicom/releases/download/v$VER/libdicom-$VER.tar.xz"
+CHKSUMS="sha256::3b8c05ceb6bf667fed997f23b476dd32c3dc6380eee1998185c211d86a7b4918"
+CHKUPDATE="anitya::id=372898"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: rebuild caused by openslide
    Signed-off-by: Ilikara <3435193369@qq.com>
- vtk: rebuild caused by openslide
    Signed-off-by: Ilikara <3435193369@qq.com>
- openslide: update to 4.0.0
    Co-authored-by: Ilikara \(@AirFortressIlikara\)
- libdicom: new, 1.2.0
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libdicom: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdicom  openslide  libvips  vtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
