### PR TITLE
libdicom: new, 1.2.0

### DIFF
--- a/runtime-scientific/libdicom/autobuild/defines
+++ b/runtime-scientific/libdicom/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libdicom
+PKGSEC=graphic
+PKGDES="A C library and a set of command-line tools for reading DICOM WSI files"
+PKGDEP=""
+BUILDDEP="gcc meson uthash"
+
+AUTOTOOLS_AFTER="--disable-static"

--- a/runtime-scientific/libdicom/spec
+++ b/runtime-scientific/libdicom/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="tbl::https://github.com/ImagingDataCommons/libdicom/releases/download/v$VER/libdicom-$VER.tar.xz"
+CHKSUMS="sha256::3b8c05ceb6bf667fed997f23b476dd32c3dc6380eee1998185c211d86a7b4918"
+CHKUPDATE="anitya::id=372898"


### PR DESCRIPTION
Topic Description
-----------------

- libdicom: new, 1.2.0
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libdicom: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdicom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
