### PR TITLE
botan-2: fix build error

### DIFF
--- a/runtime-cryptography/botan-2/autobuild/build
+++ b/runtime-cryptography/botan-2/autobuild/build
@@ -3,7 +3,8 @@ abinfo "Configuring botan-2 ..."
                --with-bzip \
                --with-lzma \
                --with-zlib \
-               --with-os-feature=getrandom
+               --with-os-feature=getrandom \
+               --with-rst2man
 
 abinfo "Building botan-2 ..."
 make

--- a/runtime-cryptography/botan-2/autobuild/defines
+++ b/runtime-cryptography/botan-2/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=botan-2
 PKGSEC=libs
 PKGDEP="bzip2 python-2 xz zlib"
 PKGDES="C++ cryptography library (version 2)"
+BUILDDEP="docutils"
 
 AB_FLAGS_O3=1

--- a/runtime-cryptography/botan-2/spec
+++ b/runtime-cryptography/botan-2/spec
@@ -1,5 +1,5 @@
 VER=2.12.1
-REL=3
+REL=4
 SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
 CHKSUMS="sha256::7e035f142a51fca1359705792627a282456d49749bf62a37a8e48375d41baaa9"
 CHKUPDATE="anitya::id=369470"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Fix the error: "mv: cannot stat '/usr/share/man/man1/botan.1': No such file or directory".
- Need rst2man to create man file.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- botan-2: 2.12.1-3
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit botan-2
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
