### PR TITLE
pdal: rework for postgresql-17

### DIFF
--- a/groups/postgresql-rebuilds
+++ b/groups/postgresql-rebuilds
@@ -20,3 +20,4 @@ runtime-desktop/qt-5
 runtime-desktop/qt-6
 runtime-gis/gdal
 runtime-network/poco
+runtime-gis/pdal

--- a/runtime-gis/pdal/autobuild/defines
+++ b/runtime-gis/pdal/autobuild/defines
@@ -33,6 +33,8 @@ CMAKE_AFTER=(
     -DWITH_TESTS=FALSE
     -DENABLE_CTEST=FALSE
     -DWITH_ABSEIL=FALSE
+
+    -DPostgreSQL_INCLUDE_DIR=/usr/lib/postgresql-17/include    # FIXME: Could NOT find PostgreSQL.
 )
 
 ABTYPE=cmakeninja

--- a/runtime-gis/pdal/spec
+++ b/runtime-gis/pdal/spec
@@ -1,4 +1,5 @@
 VER=2.8.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/PDAL/PDAL"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138228"


### PR DESCRIPTION
Topic Description
-----------------

- pdal: specify PostgreSQL installation path explicitly
    Add pdal to groups/postgresql-rebuilds

Package(s) Affected
-------------------

- pdal: 2.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pdal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
