### PR TITLE
tig: update to 2.5.12

### DIFF
--- a/app-utils/tig/autobuild/beyond
+++ b/app-utils/tig/autobuild/beyond
@@ -1,2 +1,24 @@
-install -Dm0644 contrib/tig-completion.bash \
+abinfo "Installing manpages ..."
+# upstream makefile does have a target for generation doc
+# but it is not invoked by default and seems broken:
+# $ make doc
+#     XMLTO  doc/tig.1
+# make: *** [Makefile:444: doc/tig.1] Error 1
+
+asciidoctor -b manpage "$SRCDIR"/doc/tig.1.adoc
+install -Dvm644 "$SRCDIR"/doc/tig.1 \
+    "$PKGDIR"/usr/share/man/man1/tig.1
+
+asciidoctor -b manpage "$SRCDIR"/doc/tigmanual.7.adoc
+install -Dvm644 "$SRCDIR"/doc/tigmanual.7 \
+    "$PKGDIR"/usr/share/man/man7/tigmanual.7
+
+asciidoctor -b manpage "$SRCDIR"/doc/tigrc.5.adoc
+install -Dvm644 "$SRCDIR"/doc/tigrc.5 \
+    "$PKGDIR"/usr/share/man/man5/tigrc.5
+
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR"/contrib/tig-completion.bash \
     "$PKGDIR"/usr/share/bash-completion/completions/tig
+install -Dvm644 "$SRCDIR"/contrib/tig-completion.bash \
+    "$PKGDIR"/usr/share/zsh/site-functions/_tig

--- a/app-utils/tig/autobuild/defines
+++ b/app-utils/tig/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=tig
 PKGSEC=devel
 PKGDEP="git ncurses"
-BUILDDEP="asciidoc xmlto"
+BUILDDEP="asciidoctor"
 PKGDES="A curses based GUI for Git"
 
 ABSHADOW=no

--- a/app-utils/tig/spec
+++ b/app-utils/tig/spec
@@ -1,5 +1,4 @@
-VER=2.5.10
-SRCS="tbl::https://github.com/jonas/tig/archive/tig-$VER.tar.gz"
-CHKSUMS="sha256::bb0ceda7694ed161a830d022c2f282388c7979d97a409a81028d489738ad127a"
-SUBDIR="tig-tig-$VER"
+VER=2.5.12
+SRCS="git::commit=tags/tig-$VER::https://github.com/jonas/tig.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4969"


### PR DESCRIPTION
Topic Description
-----------------

- tig: update to 2.5.12

Package(s) Affected
-------------------

- tig: 2.5.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit tig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
