### PR TITLE
vim: update to 9.1.1537

### DIFF
--- a/app-editors/vim/01-vim/build
+++ b/app-editors/vim/01-vim/build
@@ -14,6 +14,7 @@ abinfo "Configuring Vim ..."
     --enable-gpm \
     --enable-acl \
     --with-x=yes \
+    --with-wayland=yes \
     --enable-gui=no \
     --enable-multibyte \
     --enable-cscope \

--- a/app-editors/vim/01-vim/defines
+++ b/app-editors/vim/01-vim/defines
@@ -1,7 +1,7 @@
 PKGNAME=vim
 PKGSEC=editors
 PKGDEP="gpm ruby lua python-3 tk tcl acl ncurses x11-lib libsodium \
-        perl"
+        perl wayland"
 PKGDEP__RETRO="gpm acl"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-editors/vim/02-gvim/build
+++ b/app-editors/vim/02-gvim/build
@@ -16,6 +16,7 @@ abinfo "Configuring Vim ..."
     --enable-gpm \
     --enable-acl \
     --with-x=yes \
+    --with-wayland=yes \
     --enable-gui=gtk3 \
     --enable-multibyte \
     --enable-cscope \

--- a/app-editors/vim/02-gvim/defines
+++ b/app-editors/vim/02-gvim/defines
@@ -1,7 +1,7 @@
 PKGNAME=gvim
 PKGSEC=editor
 PKGDEP="gpm ruby lua python-3 tk tcl acl gtk-3 ncurses x11-lib \
-        libsodium perl"
+        libsodium perl wayland"
 PKGDES="VI Improved (with GTK frontend)"
 
 PKGBREAK="vim<=9.0.0859 gvim<=8.1.1968 vim-nox<=8.1.1968 vim-runtime<=8.1.1968"

--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.1.1418
+VER=9.1.1537
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.1.1537
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- gvim: 9.1.1537
- vim: 9.1.1537

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
