### PR TITLE
glab: update to 1.62.0

### DIFF
--- a/app-devel/glab/spec
+++ b/app-devel/glab/spec
@@ -1,4 +1,5 @@
 VER=1.62.0
-SRCS="git::commit=tags/v$VER::https://gitlab.com/gitlab-org/cli.git"
+# Note: copy-repo is required to generate docs
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://gitlab.com/gitlab-org/cli.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=127208"

--- a/app-devel/glab/spec
+++ b/app-devel/glab/spec
@@ -1,4 +1,4 @@
-VER=1.61.0
+VER=1.62.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/gitlab-org/cli.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=127208"


### PR DESCRIPTION
Topic Description
-----------------

- glab: set copy-repo to true
    It is required for gen-docs to work since upstream commit 4ced0cd7f0f1f2fa24755b0811cde33773903d27.
- glab: update to 1.62.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- glab: 1.62.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit glab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
