### PR TITLE
Add missing setuptools-dependency (July 2025)

### DIFF
--- a/lang-python/addict/autobuild/defines
+++ b/lang-python/addict/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=addict
 PKGSEC=python
 PKGDES="A Python module that exposes a dictionary subclass that allows items to be set like attributes"
 PKGDEP="python-2 python-3"
+BUILDDEP="setuptools setuptools-python2"
 
 ABHOST=noarch
 ABTYPE=python

--- a/lang-python/addict/spec
+++ b/lang-python/addict/spec
@@ -2,4 +2,4 @@ VER=2.4.0
 SRCS="https://pypi.org/packages/source/a/addict/addict-${VER}.tar.gz"
 CHKSUMS="sha256::b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"
 CHKUPDATE="anitya::id=133395"
-REL=1
+REL=2

--- a/lang-python/argcomplete/autobuild/defines
+++ b/lang-python/argcomplete/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=argcomplete
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools setuptools-scm"
 PKGDES="Shells tab completion for argparse"
 
 ABHOST=noarch

--- a/lang-python/argcomplete/spec
+++ b/lang-python/argcomplete/spec
@@ -1,4 +1,5 @@
 VER=3.5.0
-SRCS="git::commit=tags/v${VER}::https://github.com/kislyuk/argcomplete.git"
-CHKSUMS="SKIP"
+SRCS="pypi::version=${VER}::argcomplete"
+CHKSUMS="sha256::4349400469dccfb7950bb60334a680c58d88699bff6159df61251878dc6bf74b"
 CHKUPDATE="anitya::id=3773"
+REL=1

--- a/lang-python/blessings/autobuild/build
+++ b/lang-python/blessings/autobuild/build
@@ -1,7 +1,0 @@
-pushd blessings-$PKGVER
-python2 setup.py install --root="$PKGDIR" --prefix=/usr --optimize=0
-popd
-
-pushd blessings3-$PKGVER
-python3 setup.py install --root="$PKGDIR" --prefix=/usr --optimize=0
-popd

--- a/lang-python/blessings/autobuild/defines
+++ b/lang-python/blessings/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=blessings
 PKGSEC=python
 PKGDEP="python-2 python-3"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="A thin, practical wrapper around terminal coloring, styling, and positioning"
 
 ABHOST=noarch

--- a/lang-python/blessings/autobuild/patch
+++ b/lang-python/blessings/autobuild/patch
@@ -1,1 +1,0 @@
-cp -r blessings-$PKGVER blessings3-$PKGVER

--- a/lang-python/blessings/spec
+++ b/lang-python/blessings/spec
@@ -1,6 +1,5 @@
 VER=1.7
-REL=3
-SRCS="tbl::https://pypi.python.org/packages/source/b/blessings/blessings-$VER.tar.gz"
+REL=4
+SRCS="pypi::version=$VER::blessings"
 CHKSUMS="sha256::98e5854d805f50a5b58ac2333411b0482516a8210f23f43308baeb58d77c157d"
-SUBDIR=.
 CHKUPDATE="anitya::id=3783"

--- a/lang-python/cerberus/autobuild/defines
+++ b/lang-python/cerberus/autobuild/defines
@@ -2,6 +2,8 @@ PKGNAME=cerberus
 PKGSEC=python
 PKGDES="Lightweight, extensible schema and data validation tool for Python dictionaries"
 PKGDEP="python-3"
+BUILDDEP="setuptools"
 
 ABHOST=noarch
 ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/cerberus/spec
+++ b/lang-python/cerberus/spec
@@ -2,4 +2,4 @@ VER=1.3.2
 SRCS="https://pypi.io/packages/source/C/Cerberus/Cerberus-${VER}.tar.gz"
 CHKSUMS="sha256::302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589"
 CHKUPDATE="anitya::id=34668"
-REL=1
+REL=2

--- a/lang-python/click-plugins/autobuild/defines
+++ b/lang-python/click-plugins/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=click-plugins
 PKGSEC=python
 PKGDEP="python-3 python-2 click"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="Command Line Interface Creation Kit"
 
 ABTYPE=python

--- a/lang-python/click-plugins/spec
+++ b/lang-python/click-plugins/spec
@@ -2,4 +2,4 @@ VER=1.1.1
 SRCS="https://github.com/click-contrib/click-plugins/releases/download/$VER/click-plugins-$VER.tar.gz"
 CHKSUMS="sha256::46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b"
 CHKUPDATE="anitya::id=15791"
-REL=1
+REL=2

--- a/lang-python/diff-match-patch/autobuild/defines
+++ b/lang-python/diff-match-patch/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=diff-match-patch
 PKGSEC=python
 PKGDEP="python-2 python-3"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="Robust algorithms to perform the operations required for synchronizing plain text"
 
 ABHOST=noarch

--- a/lang-python/diff-match-patch/spec
+++ b/lang-python/diff-match-patch/spec
@@ -2,3 +2,4 @@ VER=20200713
 SRCS="tbl::https://pypi.io/packages/source/d/diff-match-patch/diff-match-patch-$VER.tar.gz"
 CHKSUMS="sha256::da6f5a01aa586df23dfc89f3827e1cafbb5420be9d87769eeb079ddfd9477a18"
 CHKUPDATE="anitya::id=12238"
+REL=1

--- a/lang-python/kitchen/autobuild/defines
+++ b/lang-python/kitchen/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=kitchen
 PKGSEC=python
 PKGDEP="python-2 python-3"
+BUILDDEP="setuptools setuptools-python2"
 PKGDES="Useful snippets of python code"
 
 ABTYPE=python

--- a/lang-python/kitchen/spec
+++ b/lang-python/kitchen/spec
@@ -2,5 +2,5 @@ VER=1.2.6
 SRCS="tbl::https://github.com/fedora-infra/kitchen/archive/$VER.tar.gz"
 CHKSUMS="sha256::6963dd84819713aafdd55e5314dcce6df5a37430b62fd9c48770e9f1a467b2b0"
 
-REL=2
+REL=3
 CHKUPDATE="anitya::id=3903"

--- a/lang-python/lazy-object-proxy/autobuild/defines
+++ b/lang-python/lazy-object-proxy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=lazy-object-proxy
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="pip setuptools"
+BUILDDEP="pip setuptools setuptools-scm"
 PKGDES="A fast and thorough lazy object proxy"
 
 NOPYTHON2=1

--- a/lang-python/lazy-object-proxy/spec
+++ b/lang-python/lazy-object-proxy/spec
@@ -1,5 +1,5 @@
 VER=1.7.1
-REL=1
+REL=2
 SRCS="tbl::https://pypi.io/packages/source/l/lazy-object-proxy/lazy-object-proxy-$VER.tar.gz"
 CHKSUMS="sha256::d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"
 CHKUPDATE="anitya::id=32988"

--- a/lang-python/pyacoustid/autobuild/defines
+++ b/lang-python/pyacoustid/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=pyacoustid
 PKGSEC=python
 PKGDEP="python-2 chromaprint"
+BUILDDEP="setuptools-python2"
 PKGDES="Bindings for Chromaprint acoustic fingerprinting and the Acoustid API"
 
 NOPYTHON3=1

--- a/lang-python/pyacoustid/spec
+++ b/lang-python/pyacoustid/spec
@@ -1,5 +1,5 @@
 VER=1.1.7
 SRCS="tbl::https://pypi.io/packages/source/p/pyacoustid/pyacoustid-$VER.tar.gz"
 CHKSUMS="sha256::07394a8ae84625a0a6fef2d891d19687ff59cd955caaf48097da2826043356fd"
-REL=1
+REL=2
 CHKUPDATE="anitya::id=9207"

--- a/lang-python/pyscss/autobuild/defines
+++ b/lang-python/pyscss/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=pyscss
 PKGDES="a Scss compiler for Python"
 PKGDEP="python-2 python-3 six pathlib enum34"
+BUILDDEP="setuptools setuptools-python2"
 PKGSEC=python
 
 ABHOST=noarch

--- a/lang-python/pyscss/autobuild/defines
+++ b/lang-python/pyscss/autobuild/defines
@@ -3,5 +3,3 @@ PKGDES="a Scss compiler for Python"
 PKGDEP="python-2 python-3 six pathlib enum34"
 BUILDDEP="setuptools setuptools-python2"
 PKGSEC=python
-
-ABHOST=noarch

--- a/lang-python/pyscss/spec
+++ b/lang-python/pyscss/spec
@@ -1,6 +1,5 @@
 VER=1.3.7
-CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://github.com/Kronuz/pyScss/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=87682"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- kitchen: add missing setuptools build dependency
- addict: add missing setuptools build dependency
- argcomplete: add missing setuptools-scm build dep
- blessings: use python build template, add setuptools to builddep
- cerberus: add setuptools as build dep
- click-plugins: add missing setuptools build dependency
- diff-match-patch: add missing setuptools build dependency
- lazy-object-proxy: add setuptools-scm as build dep
- pyacoustid: add missing setuptools build dependency
- pyscss: add missing setuptools build dependency

Package(s) Affected
-------------------

- addict: 2.4.0-2
- argcomplete: 3.5.0-1
- blessings: 1.7-4
- cerberus: 1.3.2-2
- click-plugins: 1.1.1-2
- diff-match-patch: 20200713-1
- kitchen: 1.2.6-3
- lazy-object-proxy: 1.7.1-2
- pyacoustid: 1.1.7-2
- pyscss: 1.3.7-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit addict argcomplete blessings cerberus click-plugins diff-match-patch kitchen lazy-object-proxy pyacoustid pyscss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
