### PR TITLE
talosctl: new 1.10.5

### DIFF
--- a/app-containers/talosctl/autobuild/beyond
+++ b/app-containers/talosctl/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing talosctl shell completions..."
+"$PKGDIR"/usr/bin/talosctl completion bash | install -Dvm644 /dev/stdin \
+	"$PKGDIR"/usr/share/bash-completion/completions/talosctl
+"$PKGDIR"/usr/bin/talosctl completion zsh | install -Dvm644 /dev/stdin \
+	"$PKGDIR"/usr/share/zsh/site-functions/_talosctl
+"$PKGDIR"/usr/bin/talosctl completion fish | install -Dvm644 /dev/stdin \
+	"$PKGDIR"/usr/share/fish/vendor_completions.d/talosctl.fish

--- a/app-containers/talosctl/autobuild/defines
+++ b/app-containers/talosctl/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=talosctl
+PKGDES="Utility for controling Talos, a container-optimized Linux distro"
+BUILDDEP="go git"
+PKGDEP="glibc"
+PKGSUG="kubectl"
+PKGSEC=admin
+
+ABTYPE=gomod
+ABSPLITDBG=0
+GO_PACKAGES=(
+	"cmd/talosctl"
+)

--- a/app-containers/talosctl/spec
+++ b/app-containers/talosctl/spec
@@ -1,0 +1,4 @@
+VER=1.10.5
+SRCS="git::commit=tags/v$VER::https://github.com/siderolabs/talos"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379061"


### PR DESCRIPTION
Topic Description
-----------------

- talosctl: new, 1.10.5

Package(s) Affected
-------------------

- talosctl: 1.10.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit talosctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
