### PR TITLE
pygments: update to 2.19.1


### DIFF
--- a/lang-python/pygments/autobuild/defines
+++ b/lang-python/pygments/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pygments
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools hatchling"
+BUILDDEP="hatchling"
 PKGDES="Python syntax highlighter"
 
 ABTYPE=pep517

--- a/lang-python/pygments/spec
+++ b/lang-python/pygments/spec
@@ -1,4 +1,4 @@
-VER=2.18.0
-SRCS="tbl::https://pypi.python.org/packages/source/p/pygments/pygments-$VER.tar.gz"
-CHKSUMS="sha256::786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"
+VER=2.19.1
+SRCS="pypi::version=$VER::pygments"
+CHKSUMS="sha256::61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"
 CHKUPDATE="anitya::id=3986"


### PR DESCRIPTION
Topic Description
-----------------

- pygments: update to 2.19.1

Package(s) Affected
-------------------

- pygments: 2.19.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pygments
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
