### PR TITLE
pathlib: disable Python 3 building

### DIFF
--- a/lang-python/pathlib/autobuild/defines
+++ b/lang-python/pathlib/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="python-2 python-3"
 PKGDES="A set of classes to handle filesystem paths"
 
 ABHOST=noarch
+NOPYTHON3=1

--- a/lang-python/pathlib/spec
+++ b/lang-python/pathlib/spec
@@ -1,5 +1,5 @@
 VER=1.0.1
-REL=6
+REL=7
 SRCS="tbl::https://pypi.io/packages/source/p/pathlib/pathlib-$VER.tar.gz"
 CHKSUMS="sha256::6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f"
 CHKUPDATE="anitya::id=20065"


### PR DESCRIPTION
Topic Description
-----------------

- pathlib: disable Python 3 building
    It is no longer compatible with the lastest py 3.12 API. This module is also included in Python 3.4+ stdlib therefore is no longer needed.

Package(s) Affected
-------------------

- pathlib: 1.0.1-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit pathlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
