### PR TITLE
a2ps: update to 4.15.7

### DIFF
--- a/app-doc/a2ps/spec
+++ b/app-doc/a2ps/spec
@@ -1,6 +1,6 @@
-VER=4.15.6
+VER=4.15.7
 SRCS="tbl::https://ftp.gnu.org/gnu/a2ps/a2ps-$VER.tar.gz \
       file::rename=i18n-fonts-0.1.tar.gz::http://src.fedoraproject.org/repo/pkgs/a2ps/i18n-fonts-0.1.tar.gz/fee1456d0e6e94af4fc5b5a1bb9687b7/i18n-fonts-0.1.tar.gz"
-CHKSUMS="sha256::87ff9d801cb11969181d5b8cf8b65e65e5b24bb0c76a1b825e8098f2906fbdf4 \
+CHKSUMS="sha256::715f38670afd950b4ca71c01f468feefad265ca52d3f112934c63c0a8bfbb8af \
          sha256::20628df682359044b8e5241c97a3c8da7a098aa260a7d281a87f67486a531786"
 CHKUPDATE="anitya::id=5"


### PR DESCRIPTION
Topic Description
-----------------

- a2ps: update to 4.15.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- a2ps: 4.15.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit a2ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
