### PR TITLE
box64: new,0.3.6

### DIFF
--- a/app-emulation/box64/autobuild/alternatives
+++ b/app-emulation/box64/autobuild/alternatives
@@ -1,0 +1,1 @@
+alternative /usr/lib/binfmt.d/emu-x86_64.conf /usr/lib/binfmt.alternatives/box64.conf 70

--- a/app-emulation/box64/autobuild/beyond
+++ b/app-emulation/box64/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x "$PKGDIR/usr/lib/box64-x86_64-linux-gnu/"*
+abinfo "Moving binfmt configuration to /usr/lib/binfmt.alternatives ..."
+mkdir -v "$PKGDIR/usr/lib/binfmt.alternatives/"
+mv -v "$PKGDIR/etc/binfmt.d/box64.conf" "$PKGDIR/usr/lib/binfmt.alternatives/"
+rm -rv "$PKGDIR/etc/binfmt.d/"

--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -1,0 +1,37 @@
+PKGNAME=box64
+PKGSEC=utils
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="mold"
+PKGDES="Userspace emulator for running x86-64 applications on non-x86 systems"
+ABTYPE="cmakeninja"
+
+# Note: -DCI=ON, regenerates function wrappers, which is unnecessary for packaging?
+CMAKE_AFTER=(
+    "-DCI=ON"
+    "-DWITH_MOLD=ON"
+)
+
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    "-DARM64=ON"
+    "-DARM_DYNAREC=ON"
+)
+
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER[@]}"
+    "-DLARCH64=ON"
+    "-DLARCH64_DYNAREC=ON"
+)
+
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER[@]}"
+    "-DPPC64LE=ON"
+)
+
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER[@]}"
+    "-DRV64=ON"
+    "-DRV64_DYNAREC=ON"
+)
+
+FAIL_ARCH="!(arm64|loongarch64|ppc64el|riscv64)"

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,0 +1,4 @@
+VER=0.3.6
+SRCS="git::commit=tags/v$VER::https://github.com/ptitSeb/box64.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: new, 0.3.6

Package(s) Affected
-------------------

- box64: 0.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
