### PR TITLE
vscode: update to 1.102.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.101.2
+VER=1.102.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::b8a90a787778ce79ff616fcac689339479e7eab1dc541ece208a97caa51a153b"
-CHKSUMS__ARM64="sha256::b3518d070bb87867f14ee72c12803b7b03fbd3bd051314338e53d472160ec204"
+CHKSUMS__AMD64="sha256::236bee2d6d9373e779e65c62be0fcb277ac57c0acdc14f3469b148574f1232be"
+CHKSUMS__ARM64="sha256::c5011e6d752e14cd2d9951632ff0106196654873725d9b3af1f59de3755e0394"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.102.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.102.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
