### PR TITLE
wine: update to 10.12+gecko2.47.4+mono10.1.0

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,16 +1,16 @@
 __GECKO_VER=2.47.4
-__MONO_VER=10.0.0
-UPSTREAM_VER=10.6
+__MONO_VER=10.1.0
+UPSTREAM_VER=10.12
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::2af8809a3e987363752c8f7640efa72a7c9d3213d332437db87ce1d0d98e9061 \
+CHKSUMS="sha256::cd572c71a3d72e87f98490b228c7c26aaeb3fde38dd9e79fc3b56391d599d6bf \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::b487c444415789a8b25b3a6542afa668a6b6d6067c648626f323884443f7b70d"
+         sha256::7f4763edd350503a3a70b1bbbdbff944f1f4bb1552f0731957363d162ce2589a"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 10.12+gecko2.47.4+mono10.0.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wine: 3:10.12+gecko2.47.4+mono10.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
