### PR TITLE
grub-customizer: rebuild to fix the position of grubcfg-proxy

### DIFF
--- a/app-admin/grub-customizer/spec
+++ b/app-admin/grub-customizer/spec
@@ -2,3 +2,4 @@ VER=5.2.5
 SRCS="tbl::https://launchpad.net/grub-customizer/${VER%.*}/$VER/+download/grub-customizer_$VER.tar.gz"
 CHKSUMS="sha256::a0b15150a0df792dd44313b88439fb01a60fdbf123d2558a55606a5d3f62cc63"
 CHKUPDATE="anitya::id=10153"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- grub-customizer: rebuild to fix the position of grubcfg-proxy

Package(s) Affected
-------------------

- grub-customizer: 5.2.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub-customizer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
