### PR TITLE
lolcat: rebuild due to ruby update

### DIFF
--- a/app-utils/lolcat/autobuild/build
+++ b/app-utils/lolcat/autobuild/build
@@ -1,0 +1,12 @@
+abinfo "Building lolcat ..."
+gem build "$SRCDIR"/lolcat.gemspec
+
+abinfo "Installing lolcat ..."
+gem install \
+    --ignore-dependencies \
+    --no-user-install \
+    -i "$PKGDIR"/$(gem env gemdir) \
+    -n "$PKGDIR"/usr/bin lolcat-$PKGVER.gem
+
+abinfo "Removing cached gem ..."
+rm -v "$PKGDIR"/$(gem env gemdir)/cache/lolcat-$PKGVER.gem

--- a/app-utils/lolcat/autobuild/defines
+++ b/app-utils/lolcat/autobuild/defines
@@ -4,6 +4,5 @@ PKGDEP="ruby-manpages ruby-optimist ruby-paint"
 BUILDDEP="ruby-bundler"
 PKGDES="A rainbow-colored cat(1) utility"
 
-ABTYPE=ruby
-
+ABTYPE=self
 ABHOST=noarch

--- a/app-utils/lolcat/autobuild/patches/0001-relax-dep-version-constraint-to-fix-run-error.patch
+++ b/app-utils/lolcat/autobuild/patches/0001-relax-dep-version-constraint-to-fix-run-error.patch
@@ -1,0 +1,25 @@
+From 7b0dd0eae675ea5e002953453283082f71ff0755 Mon Sep 17 00:00:00 2001
+From: ShellWen <me@shellwen.com>
+Date: Tue, 15 Jul 2025 02:23:30 +0800
+Subject: [PATCH 1/2] relax dep version constraint to fix run error
+
+---
+ lolcat.gemspec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lolcat.gemspec b/lolcat.gemspec
+index 633ba3f..929366b 100644
+--- a/lolcat.gemspec
++++ b/lolcat.gemspec
+@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
+ 
+   s.add_development_dependency "rake"
+   s.add_dependency "paint", "~> 2.1"
+-  s.add_dependency "optimist", "~> 3.0.0"
++  s.add_dependency "optimist", "~> 3.0"
+   s.add_dependency "manpages", "~> 0.6.1"
+ 
+   s.files         = `git ls-files`.split("\n")
+-- 
+2.50.0
+

--- a/app-utils/lolcat/autobuild/patches/0002-fix-build-error-from-tarball.patch
+++ b/app-utils/lolcat/autobuild/patches/0002-fix-build-error-from-tarball.patch
@@ -1,0 +1,28 @@
+From 786336509d5699e888e0afd6ead3fea0d3c0769e Mon Sep 17 00:00:00 2001
+From: ShellWen <me@shellwen.com>
+Date: Tue, 15 Jul 2025 03:05:36 +0800
+Subject: [PATCH 2/2] fix build error from tarball
+
+---
+ lolcat.gemspec | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lolcat.gemspec b/lolcat.gemspec
+index 929366b..e44648d 100644
+--- a/lolcat.gemspec
++++ b/lolcat.gemspec
+@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
+   s.add_dependency "optimist", "~> 3.0"
+   s.add_dependency "manpages", "~> 0.6.1"
+ 
+-  s.files         = `git ls-files`.split("\n")
+-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
++  s.files         = `find -type f`.split("\n")
++  s.test_files    = `echo`.split("\n")
++  s.executables   = `find bin -type f`.split("\n").map{ |f| File.basename(f) }
+   s.require_paths = ["lib"]
+ end
+-- 
+2.50.0
+

--- a/app-utils/lolcat/spec
+++ b/app-utils/lolcat/spec
@@ -1,5 +1,5 @@
 VER=100.0.1
-REL=1
-SRCS="file::https://rubygems.org/downloads/lolcat-$VER.gem"
-CHKSUMS="sha256::983c8a9bc2742bfcd3a5174564b2710cf177ae96884ee9f112cfe1b61188e88e"
-CHKUPDATE="anitya::id=78207"
+REL=3
+SRCS="git::commit=tags/v$VER::https://github.com/busyloop/lolcat.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379120"

--- a/app-utils/lolcat/spec
+++ b/app-utils/lolcat/spec
@@ -1,4 +1,5 @@
 VER=100.0.1
+REL=1
 SRCS="file::https://rubygems.org/downloads/lolcat-$VER.gem"
 CHKSUMS="sha256::983c8a9bc2742bfcd3a5174564b2710cf177ae96884ee9f112cfe1b61188e88e"
 CHKUPDATE="anitya::id=78207"

--- a/groups/ruby-rebuilds
+++ b/groups/ruby-rebuilds
@@ -35,5 +35,6 @@ lang-ruby/ruby-pkg-config
 lang-ruby/ruby-rainbow
 lang-ruby/ruby-term-ansicolor
 lang-ruby/ruby-text
+lang-ruby/lolcat
 runtime-electronics/libsigrok
 runtime-virtualization/libguestfs


### PR DESCRIPTION
Topic Description
-----------------

- lolcat: patch to fix runtime gem test error
    Build from source code instead of gem due to gem doesn't allow to patch
- lolcat: rebuild due to ruby update
- groups/ruby-rebuilds: add missing lolcat

Package(s) Affected
-------------------

- lolcat: 100.0.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lolcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
