### PR TITLE
cowsql: update to 1.15.9

### DIFF
--- a/runtime-database/cowsql/spec
+++ b/runtime-database/cowsql/spec
@@ -1,4 +1,4 @@
-VER=1.15.8
+VER=1.15.9
 SRCS="git::commit=tags/v$VER::https://github.com/cowsql/cowsql"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371077"


### PR DESCRIPTION
Topic Description
-----------------

- cowsql: update to 1.15.9
    Co-authored-by: Billy Yang \(@handsomexdd1024\) <me@venti.love>

Package(s) Affected
-------------------

- cowsql: 1.15.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit cowsql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
