### PR TITLE
just: update to 1.42.2

### DIFF
--- a/app-devel/just/autobuild/defines
+++ b/app-devel/just/autobuild/defines
@@ -1,14 +1,7 @@
 PKGNAME="just"
 PKGDES="A tool for creating and running project-specific commands"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm-20"
 PKGSEC="utils"
 
 USECLANG=1
-ABSPLITDBG=0
-
-# FIXME: ld.lld does not support loongson3, loongarch64
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1
-USECLANG__LOONGARCH64=0
-NOLTO__LOONGARCH64=1

--- a/app-devel/just/spec
+++ b/app-devel/just/spec
@@ -1,4 +1,4 @@
-VER=1.42.1
+VER=1.42.2
 SRCS="git::commit=tags/$VER::https://github.com/casey/just"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141393"


### PR DESCRIPTION
Topic Description
-----------------

- just: update to 1.42.2
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- just: 1.42.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit just
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
