### PR TITLE
oma: update to 1.18.2

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp \
         nettle openssl systemd xz glibc ripgrep zstd \
         aosc-os-repository-data aosc-os-keyring"
 PKGDEP__LOONGSON3="${PKGDEP/gmp/} openssl"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm-20"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"
 PKGREP="mirrormgr<=0.11.1"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.18.1
+VER=1.18.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.18.2

Package(s) Affected
-------------------

- oma: 1.18.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



