### PR TITLE
OpenJDK: 2025 Q3 GA Survey

### DIFF
--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=11.0.27-ga
+UPSTREAM_VER=11.0.28-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=17.0.15-ga
+UPSTREAM_VER=17.0.16-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235001"

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=21.0.7-ga
+UPSTREAM_VER=21.0.8-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369281"

--- a/lang-java/openjdk-24/spec
+++ b/lang-java/openjdk-24/spec
@@ -1,7 +1,6 @@
 MAJOR_VER=24
-UPSTREAM_VER=24.0.1-ga
+UPSTREAM_VER=24.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376246"

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=8u452-ga
+UPSTREAM_VER=8u462-ga
 VER=${UPSTREAM_VER/-/+}
-REL=1
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17307"

--- a/topics/openjdk-july-2025.toml
+++ b/topics/openjdk-july-2025.toml
@@ -1,0 +1,17 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenJDK Security Updates (July, 2025)"
+zh_CN = "OpenJDK 安全更新（2025 年 7 月）"
+
+[caution]
+default = "Fixes over 10 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - July 2025 (multiple of high severity)"
+zh_CN = "修复 Oracle 重要更新公告（2025 年 7 月）中披露的逾 10 个安全漏洞（含多个高危漏洞）"
+
+[packages]
+"openjdk-8" = "8u462+ga"
+"openjdk-11" = "11.0.28+ga"
+"openjdk-17" = "17.0.16+ga"
+"openjdk-21" = "21.0.8+ga"
+"openjdk-24" = "24.0.2+ga"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-8: update to 8u462+ga
    - Track patches at AOSC-Tracking/jdk @ aosc/8/8u462-ga/0
    Tag: 847224722fd1ac040a556c42bd9b6324c2e77af6
    HEAD: 795fedcfdb90459f3b0f573256bc5105979828dd
    Signed by xtex <xtex@xtexx.eu.org>
- openjdk-24: update to 24.0.2+ga
    - Track patches at AOSC-Tracking/jdk @ aosc/24/24.0.2-ga/0
    Tag: 4380bdbbafcd99f412c0bfbe22be7ac449d58d61
    HEAD: 4534fcaafc149f649105dc9914c7cf4aaf8c802c
    Signed by xtex <xtex@xtexx.eu.org>
- openjdk-21: update to 21.0.8+ga
    - Track patches at AOSC-Tracking/jdk @ aosc/21/21.0.8-ga/0
    Tag: bc23df65a7b50f8242789ee56542df11a3cda166
    HEAD: 52be8f488f40b177e2eb4110d09c8e3da08b09c3
    Signed by xtex <xtex@xtexx.eu.org>
- openjdk-17: update to 17.0.16+ga
    - Track patches at AOSC-Tracking/jdk @ aosc/17/17.0.16-ga/0
    Tag: 86d2724187594eb86e3ae4f04e80768abd1a0073
    HEAD: af806fb8a299b4554bcc06652b38e01db979d7f0
    Signed by xtex <xtex@xtexx.eu.org>
- openjdk-11: update to 11.0.28+ga
    - Track patches at AOSC-Tracking/jdk @ aosc/11/11.0.28-ga/base/0
    Tag: 1fd6a202f7718f36987655f65a76ced39b4200dc
    HEAD: 2125aac807f9c945fd0160b611df284e34110b96
    Signed by xtex <xtex@xtexx.eu.org>
    - Track patches at AOSC-Tracking/jdk @ aosc/11/11.0.28-ga/riscv/0
    Tag: 54b6b5aab85632db25d8dc622d9928dcd7e43870
    HEAD: be9ded6b635c8d33f70ecce5ef0654d9c27bbc52
    Signed by xtex <xtex@xtexx.eu.org>

Package(s) Affected
-------------------

- openjdk-11: 3:11.0.28+ga
- openjdk-17: 3:17.0.16+ga
- openjdk-21: 3:21.0.8+ga
- openjdk-24: 24.0.2+ga
- openjdk-8: 3:8u462+ga

Security Update?
----------------

Yes, https://github.com/AOSC-Dev/aosc-os-abbs/issues/11731

Build Order
-----------

```
#buildit openjdk-8 openjdk-11 openjdk-17 openjdk-21 openjdk-24
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
