### PR TITLE
firefox: Package the debug symbol

### DIFF
--- a/app-web/firefox/autobuild/defines
+++ b/app-web/firefox/autobuild/defines
@@ -29,9 +29,5 @@ USECLANG__RISCV64=0
 # >>> defined in ../../../xpcom/reflect/xptcall/md/unix/xptcstubs_asm_riscv64.o
 NOLTO__RISCV64=1
 
-# No debug symbols found in /var/cache/acbs/build/acbs.xatt16c9/firefox-128.0.2/abdist/usr/lib/firefox/firefox
-ABSTRIP=0
-ABSPLITDBG=0
-
 # FIXME: STL code can only be used with -fno-exceptions
 AB_FLAGS_EXC=0

--- a/app-web/firefox/autobuild/mozconfig
+++ b/app-web/firefox/autobuild/mozconfig
@@ -28,6 +28,7 @@ ac_add_options --with-google-safebrowsing-api-keyfile="$SRCDIR"/autobuild/google
 # Toolchain settings.
 ac_add_options --enable-release
 ac_add_options --disable-strip
+ac_add_options --disable-install-strip
 ac_add_options --enable-hardening
 
 ## Optimize

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -215,3 +215,4 @@ ENVREQ__LOONGSON3="total_mem=60"
 ENVREQ__RISCV64="total_mem=120"
 # Note: Prefer at least 3C5000-class buildbots.
 ENVREQ__LOONGARCH64="core=16"
+REL=1


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Make a split debug symbol package for firefox.

Package(s) Affected
-------------------

- firefox: 140.0.2-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
