### PR TITLE
uv: update to 0.7.21

### DIFF
--- a/lang-python/uv/autobuild/defines
+++ b/lang-python/uv/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=uv
 PKGSEC=utils
-BUILDDEP="llvm rustc maturin"
+BUILDDEP="llvm-20 rustc maturin"
 PKGDEP="glibc gcc-runtime zlib bzip2"
 PKGDES="A Python package and project manager"
 

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.7.19
+VER=0.7.21
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.7.21
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.7.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
