### PR TITLE
element-desktop: update to 1.11.106

### DIFF
--- a/app-web/element-desktop/autobuild/defines
+++ b/app-web/element-desktop/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=element-desktop
 PKGSEC=web
 PKGDEP="sqlcipher"
-BUILDDEP="nodejs rustc llvm"
+BUILDDEP="nodejs rustc llvm-20"
 PKGDES="A Matrix client for desktop"
 
 USECLANG=1

--- a/app-web/element-desktop/spec
+++ b/app-web/element-desktop/spec
@@ -1,4 +1,4 @@
-VER=1.11.105
+VER=1.11.106
 SRCS="git::commit=tags/v$VER;rename=element-web::https://github.com/element-hq/element-web \
       git::commit=tags/v$VER;rename=element-desktop::https://github.com/element-hq/element-desktop"
 CHKSUMS="SKIP SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- element-desktop: update to 1.11.106
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- element-desktop: 1.11.106

Security Update?
----------------

No

Build Order
-----------

```
#buildit element-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
