### PR TITLE
fcft: update to 3.3.2

### DIFF
--- a/runtime-display/fcft/spec
+++ b/runtime-display/fcft/spec
@@ -1,5 +1,4 @@
-VER=3.3.1
+VER=3.3.2
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fcft"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143240"
-REL=1

--- a/runtime-imaging/nanosvg/autobuild/prepare
+++ b/runtime-imaging/nanosvg/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Appending -fPIC to CFLAGS ..."
+export CFLAGS="${CFLAGS} -fPIC"

--- a/runtime-imaging/nanosvg/spec
+++ b/runtime-imaging/nanosvg/spec
@@ -2,4 +2,4 @@ VER=0+git20241219
 SRCS="git::commit=ea6a6aca009422bba0dbad4c80df6e6ba0c82183::https://github.com/memononen/nanosvg.git"
 CHKSUMS="SKIP"
 # FIXME: upstream never tagged so no CHKUPDATE
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- fcft: update to 3.3.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fcft: 3.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nanosvg fcft
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
