### PR TITLE
intel-media-driver: update to 25.2.6

### DIFF
--- a/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
@@ -1,7 +1,7 @@
-From a01861e7b566a03ae5f9b07beb9ef23041cca982 Mon Sep 17 00:00:00 2001
+From 27ad288af3fc4219284db965e64a2fc11667fcd9 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Thu, 24 Apr 2025 10:20:33 +0800
-Subject: [PATCH] AOSCOS: remove compiler options exceeding baseline
+Subject: [PATCH 1/3] AOSCOS: remove compiler options exceeding baseline
 
 Signed-off-by: Qing Yun <kf@aosc.io>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Qing Yun <kf@aosc.io>
  3 files changed, 24 deletions(-)
 
 diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
-index 48d054c..f6e8386 100644
+index dc29431..78b7fbf 100644
 --- a/Source/GmmLib/CMakeLists.txt
 +++ b/Source/GmmLib/CMakeLists.txt
 @@ -165,12 +165,6 @@ else()
@@ -82,5 +82,5 @@ index e090fd6..c412853 100644
                      #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
                      StreamingLoadSupported = 0;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
@@ -1,7 +1,7 @@
-From 9b1d60246eab77779e200bc74dede0734e99a474 Mon Sep 17 00:00:00 2001
+From dd30fd3e3d51e1cf1f39b0c6c56505b3a1cef711 Mon Sep 17 00:00:00 2001
 From: Vihang Mehta <vihang@gimletlabs.ai>
 Date: Wed, 26 Feb 2025 09:59:15 -0800
-Subject: [PATCH] ARM64: FROMEXT: Disable AuxTable test on aarch64
+Subject: [PATCH 2/3] ARM64: FROMEXT: Disable AuxTable test on aarch64
 
 Link: https://github.com/intel/gmmlib/commit/5f7d53ef6c1a6c40d0ff2d717dca59533ad633d5
 Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
@@ -29,5 +29,5 @@ index c6a9b53..46a66f5 100644
      GmmPageTableMgr *mgr = pGmmULTClientContext->CreatePageTblMgrObject(&DeviceCBInt, TT_TYPE::AUXTT);
  
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0003-HACK-add-experimental-support-for-LoongArch.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0003-HACK-add-experimental-support-for-LoongArch.am.loongarch64
@@ -1,7 +1,7 @@
-From 8b12cee8d780a9d370c24b4a0eba2376d975694b Mon Sep 17 00:00:00 2001
+From c7b088acbb833922211703973b24fcc18319cf45 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:03:47 +0800
-Subject: [PATCH] HACK: add experimental support for LoongArch
+Subject: [PATCH 3/3] HACK: add experimental support for LoongArch
 
 Ref: https://github.com/FanFansfan/gmmlib/commit/5b95524c513b00f93bbcf0f23b4d7226facf773d
 ---
@@ -24,7 +24,7 @@ index 0000000..e5233a0
 +	path = third_party/simde
 +	url = https://github.com/simd-everywhere/simde
 diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
-index f6e8386..d67c56b 100644
+index 78b7fbf..8b46af2 100644
 --- a/Source/GmmLib/CMakeLists.txt
 +++ b/Source/GmmLib/CMakeLists.txt
 @@ -437,6 +437,8 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR})
@@ -110,5 +110,5 @@ index 0000000..4379740
 @@ -0,0 +1 @@
 +Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,4 @@
-VER=22.7.2
+VER=22.8.1
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
@@ -1,7 +1,7 @@
-From 406db17b61fde694780e919974109fd2705b9902 Mon Sep 17 00:00:00 2001
+From d015dd28276a8dd60e86489b688ed49d72bc7893 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:23:27 +0800
-Subject: [PATCH] LOONGARCH64: FROMEXT: loongarch
+Subject: [PATCH 1/3] LOONGARCH64: FROMEXT: loongarch
 
 Link: https://github.com/FanFansfan/media-driver/commit/538521b276c2dd33a1ef80969a45b35b3d31ed3f
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -303,5 +303,5 @@ index 000000000..4379740aa
 @@ -0,0 +1 @@
 +Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
@@ -1,7 +1,7 @@
-From 383aff9a570123d4394ee79637982eea2bca3648 Mon Sep 17 00:00:00 2001
+From ca77a3f397f62e1172f604c633e151438b13c8ae Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 31 Mar 2024 16:00:55 +0800
-Subject: [PATCH] LOONGARCH64: FROMEXT: fix lsx
+Subject: [PATCH 2/3] LOONGARCH64: FROMEXT: fix lsx
 
 Link: https://github.com/FanFansfan/media-driver/commit/e31a1f6a7112cf789fae290df1e83ee7f5e31555
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -17,5 +17,5 @@ index 4379740aa..87cd663a9 160000
 -Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 +Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
@@ -1,7 +1,8 @@
-From 3d855c54ec0bc31e52751dd96d3ed0d4e3a3d031 Mon Sep 17 00:00:00 2001
+From 14ed056b7d5df12712c950e1e5403e86d7337715 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Fri, 18 Apr 2025 09:21:59 +0800
-Subject: [PATCH] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on arm64
+Subject: [PATCH 3/3] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on
+ arm64
 
 Signed-off-by: Qing Yun <kf@aosc.io>
 ---
@@ -23,5 +24,5 @@ index d5f04d1f8..396ec89b1 100644
      #define __cdecl         __attribute__((__cdecl__))
      #define __stdcall       __attribute__((__stdcall__))
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=25.1.4
+VER=25.2.6
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: update to 25.2.6
    - Track patches at AOSC-Tracking/media-driver @ aosc/intel-media-25.2.6
    \(HEAD: 14ed056b7d5df12712c950e1e5403e86d7337715\).
- intel-gmmlib: update to 22.8.1
    - Track patches at AOSC-Tracking/gmmlib @ aosc/intel-gmmlib-22.8.1
    \(HEAD: c7b088acbb833922211703973b24fcc18319cf45\).

Package(s) Affected
-------------------

- intel-gmmlib: 22.8.1
- intel-media-driver: 25.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
