### PR TITLE
pinentry: Ship a shell initialization script for setting GPG_TTY

### DIFF
--- a/app-utils/pinentry/autobuild/defines
+++ b/app-utils/pinentry/autobuild/defines
@@ -17,3 +17,6 @@ AUTOTOOLS_AFTER=(
 )
 
 ABRPMAUTOPROVONLY=1
+
+# FIXME: reconf fails due to gettext version mismatch
+RECONF=0

--- a/app-utils/pinentry/autobuild/overrides/etc/bashrc.d/pinentry.sh
+++ b/app-utils/pinentry/autobuild/overrides/etc/bashrc.d/pinentry.sh
@@ -1,0 +1,1 @@
+../profile.d/pinentry.sh

--- a/app-utils/pinentry/autobuild/overrides/etc/profile.d/pinentry.sh
+++ b/app-utils/pinentry/autobuild/overrides/etc/profile.d/pinentry.sh
@@ -1,0 +1,1 @@
+tty -s && export GPG_TTY=$(tty)

--- a/app-utils/pinentry/autobuild/overrides/etc/zsh/zshrc.d/pinentry.sh
+++ b/app-utils/pinentry/autobuild/overrides/etc/zsh/zshrc.d/pinentry.sh
@@ -1,0 +1,1 @@
+../../profile.d/pinentry.sh

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -2,3 +2,4 @@ VER=1.3.1
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::bc72ee27c7239007ab1896c3c2fae53b076e2c9bd2483dc2769a16902bce8c04"
 CHKUPDATE="anitya::id=3643"
+REL=1


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Under some circumstances (like, using git commit -S in a ssh session), this is needed to support pinentry-curses.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- pinentry: 1.3.1-1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
