### PR TITLE
helix: update to 25.07

### DIFF
--- a/app-editors/helix/autobuild/defines
+++ b/app-editors/helix/autobuild/defines
@@ -1,11 +1,7 @@
 PKGNAME=helix
 PKGSEC=editors
 PKGDES="A Vim-like terminal-based text editor"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm-20"
 
 USECLANG=1
 ABSPLITDBG=0
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGARCH64=1
-NOLTO__LOONGSON3=1

--- a/app-editors/helix/spec
+++ b/app-editors/helix/spec
@@ -1,5 +1,5 @@
-VER=25.01.1
+VER=25.07
 SRCS="tbl::https://github.com/helix-editor/helix/releases/download/$VER/helix-${VER}-source.tar.xz"
-CHKSUMS="sha256::12508c4f5b9ae6342299bd40d281cd9582d3b51487bffe798f3889cb8f931609"
+CHKSUMS="sha256::22f037e8c4bbef67b7aa6db3448063f87004159fde6a9ce684082963bfeba4e5"
 CHKUPDATE="anitya::id=219661"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- helix: update to 25.07
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- helix: 25.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit helix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
