### PR TITLE
breezy: use LLVM 20


### DIFF
--- a/app-vcs/breezy/autobuild/defines
+++ b/app-vcs/breezy/autobuild/defines
@@ -3,13 +3,9 @@ PKGPROV="brz bzr"
 PKGSEC=vcs
 PKGDEP="python-3 configobj dulwich urllib3 pyyaml patiencediff merge3 tzlocal fastbencode"
 PKGSUG="fastimport dulwich"
-BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-rust setuptools-gettext llvm cython"
+BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-rust setuptools-gettext llvm-20 cython"
 PKGDES="Command line tools for the Breezy distributed version control system"
 
 ABTYPE=pep517
 NOPYTHON2=1
-
-# ld.lld does not support loongson3
 USECLANG=1
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1


### PR DESCRIPTION
Topic Description
-----------------

- breezy: use LLVM 20

Package(s) Affected
-------------------

- breezy: 3.3.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastbencode breezy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
