### PR TITLE
gyp: Update to 20240207 and use Python 3 (instead of 2) for it

### DIFF
--- a/app-devel/gyp/autobuild/defines
+++ b/app-devel/gyp/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=gyp
 PKGSEC=devel
-PKGDEP="setuptools-python2 ninja"
+PKGDEP="python-3 ninja"
 PKGDES="System for generating build configurations"
 
+ABTYPE=pep517
 ABHOST=noarch
-NOPYTHON3=1
+NOPYTHON2=1

--- a/app-devel/gyp/spec
+++ b/app-devel/gyp/spec
@@ -1,4 +1,3 @@
-VER=20191203
-REL=2
-SRCS="git::commit=e87d37d6bce611abed35e854d5ae1a401e9ce04c::https://chromium.googlesource.com/external/gyp"
+VER=20240207
+SRCS="git::commit=1615ec326858f8c2bd8f30b3a86ea71830409ce4::https://chromium.googlesource.com/external/gyp"
 CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

gyp: Update to 20240207 and use Python 3 (instead of 2) for it

Package(s) Affected
-------------------

gyp: 20240207

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit gyp
```

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`
