### PR TITLE
uv: update to 0.8.0

### DIFF
--- a/lang-python/uv/autobuild/defines
+++ b/lang-python/uv/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=uv
 PKGSEC=utils
+# FIXME: rustc depends on llvm-20 while our default llvm is llvm-18.
+# Invalid attribute group entry (Producer: 'LLVM20.1.6' Reader: 'LLVM 18.1.8')
 BUILDDEP="llvm-20 rustc maturin"
 PKGDEP="glibc gcc-runtime zlib bzip2"
 PKGDES="A Python package and project manager"

--- a/lang-python/uv/autobuild/prepare
+++ b/lang-python/uv/autobuild/prepare
@@ -1,4 +1,9 @@
 # This resolves the LTO issue when compiling a static library from C code in a Cargo crate
 # Ref: https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/issues/20
 abinfo "Appending -ffat-lto-objects to workaround linkage failure ..."
-CFLAGS+=' -ffat-lto-objects'
+CFLAGS="${CFLAGS} -ffat-lto-objects"
+
+if ab_match_arch riscv64; then
+	abinfo "Adding libatomic for riscv64 ..."
+	export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-latomic"
+fi

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.7.21
+VER=0.8.0
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.8.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
