### PR TITLE
wireshark: update to 4.4.8

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,4 +1,4 @@
-VER=4.4.7
+VER=4.4.8
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::5644143fed6363fa6c0cf58c2a6fe9ba0922efaea8f981c7228260bf46f1494b"
+CHKSUMS="sha256::dd648c5c5994843205cd73e57d6673f6f4e12718e1c558c674cb8bdafeacde47"
 CHKUPDATE="anitya::id=5137"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.4.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireshark: 4.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
