### PR TITLE
fzf: update to 0.64.0

### DIFF
--- a/app-utils/fzf/spec
+++ b/app-utils/fzf/spec
@@ -1,4 +1,4 @@
-VER=0.60.0
+VER=0.64.0
 SRCS="git::commit=tags/v$VER::https://github.com/junegunn/fzf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15856"


### PR DESCRIPTION
Topic Description
-----------------

- fzf: update to 0.64.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- fzf: 0.64.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fzf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
