### PR TITLE
eza: update to 0.23.0

### DIFF
--- a/app-utils/eza/autobuild/defines
+++ b/app-utils/eza/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=eza
 PKGSEC=utils
 PKGDEP="libgit2 libssh2"
-BUILDDEP="rustc llvm"
-PKGDES="A ls(1) implementation in Rust"
+BUILDDEP="rustc llvm-20"
+PKGDES="An ls(1) implementation in Rust"
 
 ABTYPE=rust
 USECLANG=1

--- a/app-utils/eza/autobuild/prepare
+++ b/app-utils/eza/autobuild/prepare
@@ -1,0 +1,4 @@
+if ab_match_arch riscv64; then
+    abinfo "Adding libatomic for riscv64 ..."
+    export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-latomic"
+fi

--- a/app-utils/eza/spec
+++ b/app-utils/eza/spec
@@ -1,4 +1,4 @@
-VER=0.22.1
+VER=0.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/eza-community/eza"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369474"


### PR DESCRIPTION
Topic Description
-----------------

- eza: update to 0.23.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- eza: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit eza
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
