### PR TITLE
7-zip: update to 25.00

### DIFF
--- a/app-utils/7-zip/spec
+++ b/app-utils/7-zip/spec
@@ -1,4 +1,4 @@
-VER=24.09
+VER=25.00
 SRCS="git::commit=tags/$VER::https://github.com/ip7z/7zip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17875"

--- a/topics/7-zip-25.00.toml
+++ b/topics/7-zip-25.00.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "7-Zip 25.00"
+zh_CN = "7-Zip 25.00"
+
+[caution]
+default = "Fixes a heap buffer overflow vulnerability - CVE-2025-53816 (Severity: Medium); Fixes a null pointer dereference vulnerability - CVE-2025-53817 (Severity: Medium)"
+zh_CN = "修复一处堆缓冲区溢出漏洞，漏洞编号 CVE-2025-53816（严重性：中）；修复一处空指针解引用漏洞，漏洞编号 CVE-2025-53817（严重性：中）"
+
+[packages]
+"7-zip" = "25.00"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add 7-zip-25.00
- 7-zip: update to 25.00

Package(s) Affected
-------------------

- 7-zip: 25.00

Security Update?
----------------

fixes #11761 

Build Order
-----------

```
#buildit 7-zip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
