### PR TITLE
vscode: update to 1.102.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.102.0
+VER=1.102.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::236bee2d6d9373e779e65c62be0fcb277ac57c0acdc14f3469b148574f1232be"
-CHKSUMS__ARM64="sha256::c5011e6d752e14cd2d9951632ff0106196654873725d9b3af1f59de3755e0394"
+CHKSUMS__AMD64="sha256::da0c3893d5c3a8eb85ecfc72751f969632f1afad2a8037acee5673fa2674001d"
+CHKSUMS__ARM64="sha256::b89a3ad40f89eea0b354a73f93b1a5d77eacdcc04adfeebd2c8fc4365ef1b6a3"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.102.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.102.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
