### PR TITLE
motif: fix build error with GCC>=14

### DIFF
--- a/runtime-desktop/motif/autobuild/patches/0001-AOSCOS-fix-build-issue-for-GCC-14.patch
+++ b/runtime-desktop/motif/autobuild/patches/0001-AOSCOS-fix-build-issue-for-GCC-14.patch
@@ -1,0 +1,1977 @@
+From f822c1cb940a0395257b1726128278dd26e88195 Mon Sep 17 00:00:00 2001
+From: ilikara <3435193369@qq.com>
+Date: Sun, 20 Jul 2025 15:02:41 +0800
+Subject: [PATCH] AOSCOS: fix build issue for GCC >= 14
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+error: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ clients/mwm/WmCmd.c                       | 2 ++
+ clients/mwm/WmError.c                     | 1 +
+ clients/mwm/WmEvent.c                     | 2 ++
+ clients/mwm/WmFeedback.c                  | 1 +
+ clients/mwm/WmFunction.c                  | 1 +
+ clients/mwm/WmGraphics.c                  | 1 +
+ clients/mwm/WmIconBox.c                   | 2 ++
+ clients/mwm/WmImage.c                     | 1 +
+ clients/mwm/WmInitWs.c                    | 1 +
+ clients/mwm/WmMain.c                      | 1 +
+ clients/mwm/WmManage.c                    | 2 ++
+ clients/mwm/WmMenu.c                      | 1 +
+ clients/mwm/WmProperty.c                  | 1 +
+ clients/mwm/WmResParse.c                  | 1 +
+ clients/mwm/WmResource.c                  | 1 +
+ clients/mwm/WmWinInfo.c                   | 1 +
+ clients/mwm/WmWinList.c                   | 1 +
+ clients/mwm/WmWsmLib/debug.c              | 1 +
+ clients/mwm/WmWsmLib/pack.c               | 1 +
+ clients/mwm/WmXSMP.c                      | 1 +
+ clients/uil/UilCmd.c                      | 1 +
+ clients/uil/UilDefI.h                     | 1 +
+ clients/uil/UilDiags.c                    | 1 +
+ clients/uil/UilKeyTab.c                   | 2 ++
+ clients/uil/UilLstLst.c                   | 1 +
+ clients/uil/UilLstMac.c                   | 1 +
+ clients/uil/UilP2Out.c                    | 1 +
+ clients/uil/UilSarMod.c                   | 1 +
+ clients/uil/UilSarObj.c                   | 2 ++
+ clients/uil/UilSarVal.c                   | 1 +
+ clients/uil/UilSemCSet.c                  | 1 +
+ clients/uil/UilSrcSrc.c                   | 1 +
+ clients/uil/UilSymNam.c                   | 1 +
+ clients/xmbind/xmbind.c                   | 1 +
+ config/util/checktree.c                   | 2 ++
+ config/util/chownxterm.c                  | 1 +
+ config/util/lndir.c                       | 2 ++
+ config/util/makestrs.c                    | 1 +
+ demos/lib/Exm/Grid.c                      | 1 +
+ demos/lib/Exm/StringTrans.c               | 1 +
+ demos/lib/Exm/wml/wmldbcreate.c           | 1 +
+ demos/lib/Wsm/debug.c                     | 1 +
+ demos/lib/Wsm/pack.c                      | 1 +
+ demos/lib/Xmd/Help.c                      | 2 ++
+ demos/lib/Xmd/Menus.c                     | 1 +
+ demos/lib/Xmd/RegEdit.c                   | 1 +
+ demos/programs/ColorSel/util-c.c          | 1 +
+ demos/programs/Ext18List/callbacks-c.c    | 1 +
+ demos/programs/Ext18List/util-c.c         | 1 +
+ demos/programs/IconB/misc.c               | 1 +
+ demos/programs/TabStack/bxutils.c         | 1 +
+ demos/programs/Tree/bxutil-c.c            | 1 +
+ demos/programs/animate/xmanimate.c        | 1 +
+ demos/programs/drag_and_drop/DNDDraw.c    | 1 +
+ demos/programs/drag_and_drop/simpledrop.c | 1 +
+ demos/programs/draw/draw.c                | 1 +
+ demos/programs/filemanager/actions.c      | 1 +
+ demos/programs/filemanager/convert.c      | 1 +
+ demos/programs/filemanager/readdir.c      | 1 +
+ demos/programs/fileview/main.c            | 1 +
+ demos/programs/getsubres/getsubres.c      | 1 +
+ demos/programs/hellomotifi18n/helloint.c  | 1 +
+ demos/programs/i18ninput/input.c          | 1 +
+ demos/programs/periodic/periodic.c        | 1 +
+ demos/programs/sampler2_0/sampler2_0.c    | 1 +
+ demos/programs/todo/actions.c             | 1 +
+ demos/programs/todo/io.c                  | 1 +
+ demos/programs/todo/todo.c                | 1 +
+ demos/programs/workspace/command_ui.c     | 1 +
+ demos/programs/workspace/wsm.c            | 1 +
+ demos/programs/workspace/wsmData.c        | 1 +
+ demos/programs/workspace/wsmStruct.c      | 1 +
+ demos/programs/workspace/wsm_cb.c         | 1 +
+ demos/programs/workspace/xrmLib.c         | 1 +
+ demos/unsupported/aicon/aicon.c           | 1 +
+ demos/unsupported/dainput/dainput_dlg.c   | 1 +
+ demos/unsupported/motifshell/motifshell.c | 1 +
+ demos/unsupported/uilsymdump/uilsymdump.c | 1 +
+ demos/unsupported/xmapdef/xmapdef.c       | 1 +
+ demos/unsupported/xmfonts/xmfonts.c       | 1 +
+ demos/unsupported/xmforc/xmforc.c         | 1 +
+ demos/unsupported/xmform/xmform.c         | 2 ++
+ lib/Mrm/MrmIfile.c                        | 1 +
+ lib/Mrm/MrmIheader.c                      | 1 +
+ lib/Mrm/MrmIindex.c                       | 1 +
+ lib/Mrm/Mrmerror.c                        | 1 +
+ lib/Mrm/Mrmhier.c                         | 1 +
+ lib/Mrm/Mrmlread.c                        | 1 +
+ lib/Mrm/Mrmmodule.c                       | 1 +
+ lib/Mrm/Mrmptrlist.c                      | 1 +
+ lib/Mrm/Mrmtable.c                        | 1 +
+ lib/Mrm/Mrmvm.c                           | 1 +
+ lib/Mrm/Mrmwci.c                          | 1 +
+ lib/Mrm/Mrmwcrw.c                         | 1 +
+ lib/Mrm/Mrmwcrwr.c                        | 1 +
+ lib/Mrm/Mrmwrefs.c                        | 1 +
+ lib/Mrm/Mrmwvalues.c                      | 1 +
+ lib/Xm/BaseClass.c                        | 2 ++
+ lib/Xm/BulletinB.c                        | 2 ++
+ lib/Xm/ClipWindow.c                       | 1 +
+ lib/Xm/Color.c                            | 1 +
+ lib/Xm/ColorObj.c                         | 2 ++
+ lib/Xm/ColorS.c                           | 1 +
+ lib/Xm/Column.c                           | 2 ++
+ lib/Xm/Container.c                        | 2 ++
+ lib/Xm/DataFSel.c                         | 2 ++
+ lib/Xm/DialogS.c                          | 1 +
+ lib/Xm/DragC.c                            | 2 ++
+ lib/Xm/DropSMgr.c                         | 2 ++
+ lib/Xm/EditresCom.c                       | 1 +
+ lib/Xm/ExtP.h                             | 2 ++
+ lib/Xm/FileSB.c                           | 1 +
+ lib/Xm/I18List.c                          | 1 +
+ lib/Xm/IconButton.c                       | 2 ++
+ lib/Xm/IconFile.c                         | 1 +
+ lib/Xm/Manager.c                          | 1 +
+ lib/Xm/MapEvents.c                        | 1 +
+ lib/Xm/Obso1_2.c                          | 1 +
+ lib/Xm/Obso2_0.c                          | 1 +
+ lib/Xm/RCMenu.c                           | 1 +
+ lib/Xm/ResConvert.c                       | 1 +
+ lib/Xm/RowColumn.c                        | 1 +
+ lib/Xm/Scale.c                            | 1 +
+ lib/Xm/TextFSel.c                         | 1 +
+ lib/Xm/TextFind.c                         | 1 +
+ lib/Xm/TextFunc.c                         | 1 +
+ lib/Xm/TextOut.c                          | 1 +
+ lib/Xm/TextSel.c                          | 1 +
+ lib/Xm/TextStrSo.c                        | 1 +
+ lib/Xm/Transfer.c                         | 1 +
+ lib/Xm/VaSimple.c                         | 2 ++
+ lib/Xm/VendorS.c                          | 1 +
+ lib/Xm/Xm.c                               | 1 +
+ lib/Xm/XmExtUtil.c                        | 1 +
+ lib/Xm/XmIm.c                             | 1 +
+ lib/Xm/XmStringGet.c                      | 1 +
+ lib/Xm/Xmos.c                             | 1 +
+ lib/Xm/XpmCrBufFrI.c                      | 1 +
+ lib/Xm/XpmCrDatFrI.c                      | 1 +
+ lib/Xm/XpmRdFToI.c                        | 1 +
+ lib/Xm/XpmWrFFrBuf.c                      | 1 +
+ lib/Xm/XpmWrFFrI.c                        | 1 +
+ lib/Xm/Xpmcreate.c                        | 1 +
+ lib/Xm/Xpmdata.c                          | 1 +
+ lib/Xm/Xpmhashtab.c                       | 2 ++
+ lib/Xm/Xpmmisc.c                          | 2 ++
+ lib/Xm/Xpmrgb.c                           | 1 +
+ lib/Xm/Xpmscan.c                          | 1 +
+ tools/wml/wmldbcreate.c                   | 1 +
+ 149 files changed, 172 insertions(+)
+
+diff --git a/clients/mwm/WmCmd.c b/clients/mwm/WmCmd.c
+index 2c2060b..1de75b2 100644
+--- a/clients/mwm/WmCmd.c
++++ b/clients/mwm/WmCmd.c
+@@ -26,6 +26,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ #include <Xm/Xm.h>
+ #include <Xm/ScrollBarP.h>
+ #include "./WmWsmLib/utm_send.h"
+diff --git a/clients/mwm/WmError.c b/clients/mwm/WmError.c
+index 6af544f..cb571c4 100644
+--- a/clients/mwm/WmError.c
++++ b/clients/mwm/WmError.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmEvent.c b/clients/mwm/WmEvent.c
+index 3235879..5e28d01 100644
+--- a/clients/mwm/WmEvent.c
++++ b/clients/mwm/WmEvent.c
+@@ -28,6 +28,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ #ifdef REV_INFO
+ #ifndef lint
+ static char rcsid[] = "$XConsortium: WmEvent.c /main/7 1996/11/20 15:27:47 rswiston $"
+diff --git a/clients/mwm/WmFeedback.c b/clients/mwm/WmFeedback.c
+index 474dd91..14c81de 100644
+--- a/clients/mwm/WmFeedback.c
++++ b/clients/mwm/WmFeedback.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmFunction.c b/clients/mwm/WmFunction.c
+index 495b258..0016026 100644
+--- a/clients/mwm/WmFunction.c
++++ b/clients/mwm/WmFunction.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmGraphics.c b/clients/mwm/WmGraphics.c
+index 7bf5c6f..4761704 100644
+--- a/clients/mwm/WmGraphics.c
++++ b/clients/mwm/WmGraphics.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+  
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmIconBox.c b/clients/mwm/WmIconBox.c
+index 6c49840..bee09a1 100644
+--- a/clients/mwm/WmIconBox.c
++++ b/clients/mwm/WmIconBox.c
+@@ -28,6 +28,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ #ifdef REV_INFO
+ #ifndef lint
+ static char rcsid[] = "$TOG: WmIconBox.c /main/7 1999/05/20 16:35:12 mgreess $"
+diff --git a/clients/mwm/WmImage.c b/clients/mwm/WmImage.c
+index 700b365..fcd2a5a 100644
+--- a/clients/mwm/WmImage.c
++++ b/clients/mwm/WmImage.c
+@@ -34,6 +34,7 @@ static char rcsid[] = "$XConsortium: WmImage.c /main/7 1996/11/14 13:50:30 rswis
+ #endif
+ #endif
+ 
++#include <string.h>
+ /*
+  * Included Files:
+  */
+diff --git a/clients/mwm/WmInitWs.c b/clients/mwm/WmInitWs.c
+index d727d46..bc770ad 100644
+--- a/clients/mwm/WmInitWs.c
++++ b/clients/mwm/WmInitWs.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmMain.c b/clients/mwm/WmMain.c
+index 7ddcbcf..b75ac9f 100644
+--- a/clients/mwm/WmMain.c
++++ b/clients/mwm/WmMain.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmManage.c b/clients/mwm/WmManage.c
+index 15de37f..abaab61 100644
+--- a/clients/mwm/WmManage.c
++++ b/clients/mwm/WmManage.c
+@@ -27,6 +27,8 @@
+ #include <config.h>
+ #endif
+ 
++
++#include <string.h>
+  
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmMenu.c b/clients/mwm/WmMenu.c
+index 2045c18..2d497c3 100644
+--- a/clients/mwm/WmMenu.c
++++ b/clients/mwm/WmMenu.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmProperty.c b/clients/mwm/WmProperty.c
+index 2d7661a..8cdfad9 100644
+--- a/clients/mwm/WmProperty.c
++++ b/clients/mwm/WmProperty.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmResParse.c b/clients/mwm/WmResParse.c
+index 14c8f0e..f894ee7 100644
+--- a/clients/mwm/WmResParse.c
++++ b/clients/mwm/WmResParse.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmResource.c b/clients/mwm/WmResource.c
+index 9ba0ee9..d8c228e 100644
+--- a/clients/mwm/WmResource.c
++++ b/clients/mwm/WmResource.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmWinInfo.c b/clients/mwm/WmWinInfo.c
+index c5dde8e..8b29581 100644
+--- a/clients/mwm/WmWinInfo.c
++++ b/clients/mwm/WmWinInfo.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+  
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/clients/mwm/WmWinList.c b/clients/mwm/WmWinList.c
+index 8b92491..47cf936 100644
+--- a/clients/mwm/WmWinList.c
++++ b/clients/mwm/WmWinList.c
+@@ -37,6 +37,7 @@ static char rcsid[] = "$TOG: WmWinList.c /main/8 1997/06/10 15:50:50 samborn $"
+ /*
+  * Included Files:
+  */
++#include <string.h>
+ 
+ #include "WmGlobal.h"
+ 
+diff --git a/clients/mwm/WmWsmLib/debug.c b/clients/mwm/WmWsmLib/debug.c
+index bd639b0..a4e0179 100644
+--- a/clients/mwm/WmWsmLib/debug.c
++++ b/clients/mwm/WmWsmLib/debug.c
+@@ -27,6 +27,7 @@
+  */
+ 
+ #include "wsm_proto.h"
++#include <string.h>
+ 
+ static void PrintWindowInfo(
+      String,
+diff --git a/clients/mwm/WmWsmLib/pack.c b/clients/mwm/WmWsmLib/pack.c
+index b447a69..ed7ac68 100644
+--- a/clients/mwm/WmWsmLib/pack.c
++++ b/clients/mwm/WmWsmLib/pack.c
+@@ -28,6 +28,7 @@
+ 
+ #include "wsm_proto.h"
+ 
++#include <string.h>
+ /* this will redifine bzero to memset if needed. */
+ #include <Xm/XmosP.h>
+ 
+diff --git a/clients/mwm/WmXSMP.c b/clients/mwm/WmXSMP.c
+index 6d83161..bcec4ac 100644
+--- a/clients/mwm/WmXSMP.c
++++ b/clients/mwm/WmXSMP.c
+@@ -26,6 +26,7 @@
+ #endif
+ 
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+diff --git a/clients/uil/UilCmd.c b/clients/uil/UilCmd.c
+index 30a352a..cb70a12 100644
+--- a/clients/uil/UilCmd.c
++++ b/clients/uil/UilCmd.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$XConsortium: UilCmd.c /main/11 1995/07/14 09:32:29 drk $
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilDefI.h b/clients/uil/UilDefI.h
+index aad7e2d..4d6a2bc 100644
+--- a/clients/uil/UilDefI.h
++++ b/clients/uil/UilDefI.h
+@@ -44,6 +44,7 @@
+ **  INCLUDE FILES
+ **
+ **/
++#include <string.h>
+ 
+ #define X_INCLUDE_TIME_H
+ #define XOS_USE_XT_LOCKING
+diff --git a/clients/uil/UilDiags.c b/clients/uil/UilDiags.c
+index 4ac4ed6..d9bbe14 100644
+--- a/clients/uil/UilDiags.c
++++ b/clients/uil/UilDiags.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$XConsortium: UilDiags.c /main/15 1996/10/21 11:06:46 cde
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilKeyTab.c b/clients/uil/UilKeyTab.c
+index aa65de3..94c5aab 100644
+--- a/clients/uil/UilKeyTab.c
++++ b/clients/uil/UilKeyTab.c
+@@ -31,6 +31,8 @@ static char rcsid[] = "$XConsortium: UilKeyTab.c /main/11 1995/07/14 09:34:29 dr
+ #endif
+ 
+ 
++#include <string.h>
++
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilLstLst.c b/clients/uil/UilLstLst.c
+index 54a57c0..f5e7008 100644
+--- a/clients/uil/UilLstLst.c
++++ b/clients/uil/UilLstLst.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: UilLstLst.c /main/20 1999/07/21 09:03:16 vipin $"
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilLstMac.c b/clients/uil/UilLstMac.c
+index 4c61a82..61fc0ac 100644
+--- a/clients/uil/UilLstMac.c
++++ b/clients/uil/UilLstMac.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: UilLstMac.c /main/15 1997/03/12 15:21:48 dbl $"
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilP2Out.c b/clients/uil/UilP2Out.c
+index 15276da..4de456a 100644
+--- a/clients/uil/UilP2Out.c
++++ b/clients/uil/UilP2Out.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: UilP2Out.c /main/15 1997/03/12 15:17:24 dbl $"
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilSarMod.c b/clients/uil/UilSarMod.c
+index cf8c5d8..56f5c2f 100644
+--- a/clients/uil/UilSarMod.c
++++ b/clients/uil/UilSarMod.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: UilSarMod.c /main/13 1997/03/12 15:21:36 dbl $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /*
+ **++
+diff --git a/clients/uil/UilSarObj.c b/clients/uil/UilSarObj.c
+index 8b27f25..d229d36 100644
+--- a/clients/uil/UilSarObj.c
++++ b/clients/uil/UilSarObj.c
+@@ -30,6 +30,8 @@ static char rcsid[] = "$XConsortium: UilSarObj.c /main/14 1995/07/14 09:37:30 dr
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
++
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilSarVal.c b/clients/uil/UilSarVal.c
+index c060cb8..3b9637e 100644
+--- a/clients/uil/UilSarVal.c
++++ b/clients/uil/UilSarVal.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: UilSarVal.c /main/13 1997/12/06 16:14:16 cshi $"
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilSemCSet.c b/clients/uil/UilSemCSet.c
+index 078e373..c5930e3 100644
+--- a/clients/uil/UilSemCSet.c
++++ b/clients/uil/UilSemCSet.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: UilSemCSet.c /main/10 1997/03/12 15:21:53 dbl $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /*
+ **++
+diff --git a/clients/uil/UilSrcSrc.c b/clients/uil/UilSrcSrc.c
+index 2b57598..e24c27c 100644
+--- a/clients/uil/UilSrcSrc.c
++++ b/clients/uil/UilSrcSrc.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: UilSrcSrc.c /main/13 1997/03/12 15:21:40 dbl $"
+ #endif
+ 
+ 
++#include <string.h>
+ /*
+ **++
+ **  FACILITY:
+diff --git a/clients/uil/UilSymNam.c b/clients/uil/UilSymNam.c
+index ee563bc..b4a4533 100644
+--- a/clients/uil/UilSymNam.c
++++ b/clients/uil/UilSymNam.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: UilSymNam.c /main/13 1997/09/08 11:12:50 cshi $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /*
+ **++
+diff --git a/clients/xmbind/xmbind.c b/clients/xmbind/xmbind.c
+index a16e2d9..e656690 100644
+--- a/clients/xmbind/xmbind.c
++++ b/clients/xmbind/xmbind.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: xmbind.c /main/10 1997/06/18 17:34:48 samborn $"
+ #endif
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ #include <Xm/Xm.h>
+ 
+ /* Internal routines "borrowed" from libXm.  Don't try this at home! */
+diff --git a/config/util/checktree.c b/config/util/checktree.c
+index 393a5db..4c4eb5d 100644
+--- a/config/util/checktree.c
++++ b/config/util/checktree.c
+@@ -30,6 +30,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ #include <X11/Xos.h>
+ #include <stdio.h>
+ #include <sys/stat.h>
+diff --git a/config/util/chownxterm.c b/config/util/chownxterm.c
+index 6d85720..f6596c2 100644
+--- a/config/util/chownxterm.c
++++ b/config/util/chownxterm.c
+@@ -35,6 +35,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #define XTERM_PATH "/x11/programs/xterm/xterm"
+ 
+diff --git a/config/util/lndir.c b/config/util/lndir.c
+index 42e6dae..7ce3ceb 100644
+--- a/config/util/lndir.c
++++ b/config/util/lndir.c
+@@ -32,6 +32,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ /* From the original /bin/sh script:
+ 
+   Used to create a copy of the a directory tree that has links for all
+diff --git a/config/util/makestrs.c b/config/util/makestrs.c
+index 53c3ec9..9983065 100644
+--- a/config/util/makestrs.c
++++ b/config/util/makestrs.c
+@@ -31,6 +31,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <X11/Xos.h>
+ #ifndef X_NOT_STDC_ENV
+diff --git a/demos/lib/Exm/Grid.c b/demos/lib/Exm/Grid.c
+index fb0aff7..fc2e4ca 100644
+--- a/demos/lib/Exm/Grid.c
++++ b/demos/lib/Exm/Grid.c
+@@ -50,6 +50,7 @@
+ #include <Xm/DialogSavvyT.h> /* for XmQTdialogSavvy trait */
+ #include <Xm/SpecRenderT.h> /* for XmQTspecifyRenderTable trait */
+ 
++#include <string.h>
+ 
+ /* Define macros. */
+ #define Max(x, y) (((x) > (y)) ? (x) : (y))
+diff --git a/demos/lib/Exm/StringTrans.c b/demos/lib/Exm/StringTrans.c
+index 9d1f32c..5633b8b 100644
+--- a/demos/lib/Exm/StringTrans.c
++++ b/demos/lib/Exm/StringTrans.c
+@@ -42,6 +42,7 @@
+  *
+  ******************************************************************************/
+ 
++#include <string.h>
+ #include <Xm/XmP.h>           /* private header file for XmPrimitive */
+ #include <Exm/StringTransP.h> /* private header file for ExmStringTransfer */
+ #include <Xm/Screen.h>        /* for screen information */
+diff --git a/demos/lib/Exm/wml/wmldbcreate.c b/demos/lib/Exm/wml/wmldbcreate.c
+index 20ef0d9..42c2323 100644
+--- a/demos/lib/Exm/wml/wmldbcreate.c
++++ b/demos/lib/Exm/wml/wmldbcreate.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: wmldbcreate.c /main/7 1997/04/15 10:20:28 dbl $"
+  */
+ 
+ 
++#include <string.h>
+ #include <stdio.h>
+ 
+ #include <Mrm/MrmWidget.h>
+diff --git a/demos/lib/Wsm/debug.c b/demos/lib/Wsm/debug.c
+index af44a80..e657701 100644
+--- a/demos/lib/Wsm/debug.c
++++ b/demos/lib/Wsm/debug.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include "wsm_proto.h"
+ 
+ static void PrintWindowInfo(
+diff --git a/demos/lib/Wsm/pack.c b/demos/lib/Wsm/pack.c
+index 4cba1d5..f687e8d 100644
+--- a/demos/lib/Wsm/pack.c
++++ b/demos/lib/Wsm/pack.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include "wsm_proto.h"
+ 
+ /* this will redifine bzero to memset if needed. */
+diff --git a/demos/lib/Xmd/Help.c b/demos/lib/Xmd/Help.c
+index 8d69607..cd7fb18 100644
+--- a/demos/lib/Xmd/Help.c
++++ b/demos/lib/Xmd/Help.c
+@@ -34,6 +34,8 @@
+ /* the text_display area. */
+ #define USE_LABEL 1
+ 
++#include <string.h>
++
+ #include <stdio.h>
+ #include <Xm/XmP.h>
+ #include <Xm/PrimitiveP.h>
+diff --git a/demos/lib/Xmd/Menus.c b/demos/lib/Xmd/Menus.c
+index 549f4a3..b38375f 100644
+--- a/demos/lib/Xmd/Menus.c
++++ b/demos/lib/Xmd/Menus.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/XmP.h>
+diff --git a/demos/lib/Xmd/RegEdit.c b/demos/lib/Xmd/RegEdit.c
+index e79257e..35cb9f1 100644
+--- a/demos/lib/Xmd/RegEdit.c
++++ b/demos/lib/Xmd/RegEdit.c
+@@ -25,6 +25,7 @@
+ /*
+  * HISTORY
+  */
++#include <string.h>
+ #include <stdio.h>
+ #include <Xm/XmP.h>		
+ #include <X11/ShellP.h>		
+diff --git a/demos/programs/ColorSel/util-c.c b/demos/programs/ColorSel/util-c.c
+index 250503f..b245e14 100644
+--- a/demos/programs/ColorSel/util-c.c
++++ b/demos/programs/ColorSel/util-c.c
+@@ -36,6 +36,7 @@
+ #include <Xm/RowColumn.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+  * Include stdlib.h and malloc.h if code is C++, ANSI, or Extended ANSI.
+diff --git a/demos/programs/Ext18List/callbacks-c.c b/demos/programs/Ext18List/callbacks-c.c
+index 9c90454..6beeb86 100644
+--- a/demos/programs/Ext18List/callbacks-c.c
++++ b/demos/programs/Ext18List/callbacks-c.c
+@@ -14,6 +14,7 @@
+ #include "extlist.h"
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ extern PlayerData players[];
+ extern Pixmap porsche_pix;
+diff --git a/demos/programs/Ext18List/util-c.c b/demos/programs/Ext18List/util-c.c
+index 3da7b5d..c948b39 100644
+--- a/demos/programs/Ext18List/util-c.c
++++ b/demos/programs/Ext18List/util-c.c
+@@ -36,6 +36,7 @@
+ #include <Xm/RowColumn.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+  * Include stdlib.h and malloc.h if code is C++, ANSI, or Extended ANSI.
+diff --git a/demos/programs/IconB/misc.c b/demos/programs/IconB/misc.c
+index 8cad20e..58e0c70 100644
+--- a/demos/programs/IconB/misc.c
++++ b/demos/programs/IconB/misc.c
+@@ -6,6 +6,7 @@
+ #include <Xm/RowColumn.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+  * Include stdlib.h and malloc.h if code is C++, ANSI, or Extended ANSI.
+diff --git a/demos/programs/TabStack/bxutils.c b/demos/programs/TabStack/bxutils.c
+index 1584960..90e838c 100644
+--- a/demos/programs/TabStack/bxutils.c
++++ b/demos/programs/TabStack/bxutils.c
+@@ -40,6 +40,7 @@
+ #include <Xm/RowColumn.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+  * Include stdlib.h and malloc.h if code is C++, ANSI, or Extended ANSI.
+diff --git a/demos/programs/Tree/bxutil-c.c b/demos/programs/Tree/bxutil-c.c
+index 7803109..013fdd4 100644
+--- a/demos/programs/Tree/bxutil-c.c
++++ b/demos/programs/Tree/bxutil-c.c
+@@ -36,6 +36,7 @@
+ #include <Xm/RowColumn.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+  * Include stdlib.h and malloc.h if code is C++, ANSI, or Extended ANSI.
+diff --git a/demos/programs/animate/xmanimate.c b/demos/programs/animate/xmanimate.c
+index 6c7ee33..e92aa40 100644
+--- a/demos/programs/animate/xmanimate.c
++++ b/demos/programs/animate/xmanimate.c
+@@ -49,6 +49,7 @@
+ *          Daniel Dardailler, 88 (xdog version)
+ ****************************************************************************/
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <Xm/Xm.h>          /* Motif Toolkit */
+ #include <Xm/Scale.h>
+diff --git a/demos/programs/drag_and_drop/DNDDraw.c b/demos/programs/drag_and_drop/DNDDraw.c
+index 27caa16..0eb18fd 100644
+--- a/demos/programs/drag_and_drop/DNDDraw.c
++++ b/demos/programs/drag_and_drop/DNDDraw.c
+@@ -20,6 +20,7 @@
+  * to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  * Floor, Boston, MA 02110-1301 USA
+ */ 
++#include <string.h>
+ #ifdef REV_INFO
+ #ifndef lint
+ static char rcsid[] = "$TOG: DNDDraw.c /main/7 1997/03/31 13:33:37 dbl $"
+diff --git a/demos/programs/drag_and_drop/simpledrop.c b/demos/programs/drag_and_drop/simpledrop.c
+index 39296aa..893bba9 100644
+--- a/demos/programs/drag_and_drop/simpledrop.c
++++ b/demos/programs/drag_and_drop/simpledrop.c
+@@ -38,6 +38,7 @@
+  * ===================== include ========================================
+  */
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <Xm/XmAll.h>
+diff --git a/demos/programs/draw/draw.c b/demos/programs/draw/draw.c
+index faded37..93b08d6 100644
+--- a/demos/programs/draw/draw.c
++++ b/demos/programs/draw/draw.c
+@@ -34,6 +34,7 @@
+ **
+ */
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+diff --git a/demos/programs/filemanager/actions.c b/demos/programs/filemanager/actions.c
+index d4fb40e..43ec8c2 100644
+--- a/demos/programs/filemanager/actions.c
++++ b/demos/programs/filemanager/actions.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/demos/programs/filemanager/convert.c b/demos/programs/filemanager/convert.c
+index 54e2f68..1d34b90 100644
+--- a/demos/programs/filemanager/convert.c
++++ b/demos/programs/filemanager/convert.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <Xm/Xm.h>
+ #include <Xm/Container.h>
+ #include <Xm/Transfer.h>
+diff --git a/demos/programs/filemanager/readdir.c b/demos/programs/filemanager/readdir.c
+index 90a9b69..7b316f8 100644
+--- a/demos/programs/filemanager/readdir.c
++++ b/demos/programs/filemanager/readdir.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <unistd.h>
+diff --git a/demos/programs/fileview/main.c b/demos/programs/fileview/main.c
+index 6f4e167..91aa4cc 100644
+--- a/demos/programs/fileview/main.c
++++ b/demos/programs/fileview/main.c
+@@ -23,6 +23,7 @@
+ /* 
+  * HISTORY
+ */ 
++#include <string.h>
+ #ifdef REV_INFO
+ #ifndef lint
+ static char rcsid[] = "$TOG: main.c /main/8 1997/03/31 13:54:57 dbl $"
+diff --git a/demos/programs/getsubres/getsubres.c b/demos/programs/getsubres/getsubres.c
+index 52794cf..20d09a7 100644
+--- a/demos/programs/getsubres/getsubres.c
++++ b/demos/programs/getsubres/getsubres.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <Xm/XmAll.h>
+ #include <Xmd/Help.h>   
+diff --git a/demos/programs/hellomotifi18n/helloint.c b/demos/programs/hellomotifi18n/helloint.c
+index d58f7f8..4928ad0 100644
+--- a/demos/programs/hellomotifi18n/helloint.c
++++ b/demos/programs/hellomotifi18n/helloint.c
+@@ -24,6 +24,7 @@
+ /*
+  * HISTORY
+  */
++#include <string.h>
+ #include <stdlib.h>		/* for getenv() */
+ #include <Xm/Xm.h>              /* Motif Toolkit */
+ #include <Mrm/MrmPublic.h>      /* Mrm Toolkit */
+diff --git a/demos/programs/i18ninput/input.c b/demos/programs/i18ninput/input.c
+index e5bbbd8..8b31403 100644
+--- a/demos/programs/i18ninput/input.c
++++ b/demos/programs/i18ninput/input.c
+@@ -24,6 +24,7 @@
+ /* 
+  * HISTORY
+ */ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <memory.h>
+diff --git a/demos/programs/periodic/periodic.c b/demos/programs/periodic/periodic.c
+index ad6a445..653089e 100644
+--- a/demos/programs/periodic/periodic.c
++++ b/demos/programs/periodic/periodic.c
+@@ -39,6 +39,7 @@ static char rcsid[] = "$XConsortium: periodic.c /main/8 1996/04/22 23:28:50 pasc
+  *
+  *****************************************************************************/
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/Xm.h>
+diff --git a/demos/programs/sampler2_0/sampler2_0.c b/demos/programs/sampler2_0/sampler2_0.c
+index d289030..e6869e6 100644
+--- a/demos/programs/sampler2_0/sampler2_0.c
++++ b/demos/programs/sampler2_0/sampler2_0.c
+@@ -26,6 +26,7 @@
+  * HISTORY
+  */
+ 
++#include <string.h>
+ #include <stdlib.h> 
+ #include <Xm/XmAll.h>
+ #include <Xmd/RegEdit.h>   
+diff --git a/demos/programs/todo/actions.c b/demos/programs/todo/actions.c
+index 913d300..33d16f0 100644
+--- a/demos/programs/todo/actions.c
++++ b/demos/programs/todo/actions.c
+@@ -30,6 +30,7 @@ static char *rcsid = "$TOG: actions.c /main/7 1997/05/02 10:01:40 dbl $";
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+ #include <X11/Intrinsic.h>
+diff --git a/demos/programs/todo/io.c b/demos/programs/todo/io.c
+index 66f621d..3bef065 100644
+--- a/demos/programs/todo/io.c
++++ b/demos/programs/todo/io.c
+@@ -30,6 +30,7 @@ static char *rcsid = "$XConsortium: io.c /main/6 1995/07/14 09:46:23 drk $";
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <Xm/Xm.h>
+diff --git a/demos/programs/todo/todo.c b/demos/programs/todo/todo.c
+index 8bb1c70..a9c5f0f 100644
+--- a/demos/programs/todo/todo.c
++++ b/demos/programs/todo/todo.c
+@@ -30,6 +30,7 @@ static char *rcsid = "$XConsortium: todo.c /main/6 1995/07/14 09:46:43 drk $";
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <pwd.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+diff --git a/demos/programs/workspace/command_ui.c b/demos/programs/workspace/command_ui.c
+index 7004221..3cb6f07 100644
+--- a/demos/programs/workspace/command_ui.c
++++ b/demos/programs/workspace/command_ui.c
+@@ -29,6 +29,7 @@ static char rcsid[] = "$TOG: command_ui.c /main/8 1997/05/02 10:08:26 dbl $"
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdlib.h>
+ #include <Xm/Xm.h>
+ #include <Xm/ToggleB.h>
+diff --git a/demos/programs/workspace/wsm.c b/demos/programs/workspace/wsm.c
+index 5d8194c..3520090 100644
+--- a/demos/programs/workspace/wsm.c
++++ b/demos/programs/workspace/wsm.c
+@@ -29,6 +29,7 @@ static char rcsid[] = "$TOG: wsm.c /main/8 1997/05/02 10:08:35 dbl $"
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <signal.h>
+diff --git a/demos/programs/workspace/wsmData.c b/demos/programs/workspace/wsmData.c
+index 66c0358..602ef46 100644
+--- a/demos/programs/workspace/wsmData.c
++++ b/demos/programs/workspace/wsmData.c
+@@ -28,6 +28,7 @@
+ static char rcsid[] = "$XConsortium: wsmData.c /main/6 1995/07/14 09:48:38 drk $"
+ #endif
+ #endif
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/Xm.h>
+diff --git a/demos/programs/workspace/wsmStruct.c b/demos/programs/workspace/wsmStruct.c
+index 8c23a31..366587f 100644
+--- a/demos/programs/workspace/wsmStruct.c
++++ b/demos/programs/workspace/wsmStruct.c
+@@ -28,6 +28,7 @@
+ static char rcsid[] = "$TOG: wsmStruct.c /main/7 1997/05/02 10:04:46 dbl $"
+ #endif
+ #endif
++#include <string.h>
+ #include <stdio.h>
+ #include <Xm/Xm.h>
+ #include <Xm/AtomMgr.h>
+diff --git a/demos/programs/workspace/wsm_cb.c b/demos/programs/workspace/wsm_cb.c
+index c8d307f..b619ab3 100644
+--- a/demos/programs/workspace/wsm_cb.c
++++ b/demos/programs/workspace/wsm_cb.c
+@@ -28,6 +28,7 @@
+ static char rcsid[] = "$TOG: wsm_cb.c /main/8 1997/05/02 10:05:18 dbl $"
+ #endif
+ #endif
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/Xm.h>
+diff --git a/demos/programs/workspace/xrmLib.c b/demos/programs/workspace/xrmLib.c
+index d056e03..792a9af 100644
+--- a/demos/programs/workspace/xrmLib.c
++++ b/demos/programs/workspace/xrmLib.c
+@@ -29,6 +29,7 @@ static char rcsid[] = "$XConsortium: xrmLib.c /main/6 1995/07/14 10:01:41 drk $"
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/Xm.h>
+diff --git a/demos/unsupported/aicon/aicon.c b/demos/unsupported/aicon/aicon.c
+index 12f8f17..517809a 100644
+--- a/demos/unsupported/aicon/aicon.c
++++ b/demos/unsupported/aicon/aicon.c
+@@ -25,6 +25,7 @@
+ /*
+  * HISTORY
+  */
++#include <string.h>
+ #include <stdlib.h>
+ #include <Xm/XmAll.h>
+ #include <Xmd/AdjView.h>   
+diff --git a/demos/unsupported/dainput/dainput_dlg.c b/demos/unsupported/dainput/dainput_dlg.c
+index 6d6d034..7f298ed 100644
+--- a/demos/unsupported/dainput/dainput_dlg.c
++++ b/demos/unsupported/dainput/dainput_dlg.c
+@@ -25,6 +25,7 @@
+ /*
+  * HISTORY
+  */
++#include <string.h>
+ #include <Xm/XmP.h> /* for XmeGetDefaultRenderTable */
+ #include <Xm/XmIm.h>
+ #include <stdlib.h>
+diff --git a/demos/unsupported/motifshell/motifshell.c b/demos/unsupported/motifshell/motifshell.c
+index 7b10ef7..94dded6 100644
+--- a/demos/unsupported/motifshell/motifshell.c
++++ b/demos/unsupported/motifshell/motifshell.c
+@@ -23,6 +23,7 @@
+ /* 
+  * HISTORY
+ */ 
++#include <string.h>
+ #ifdef REV_INFO
+ #ifndef lint
+ static char rcsid[] = "$TOG: motifshell.c /main/7 1997/03/31 13:41:20 dbl $"
+diff --git a/demos/unsupported/uilsymdump/uilsymdump.c b/demos/unsupported/uilsymdump/uilsymdump.c
+index ed0b478..638c738 100644
+--- a/demos/unsupported/uilsymdump/uilsymdump.c
++++ b/demos/unsupported/uilsymdump/uilsymdump.c
+@@ -29,6 +29,7 @@ static char rcsid[] = "$TOG: uilsymdump.c /main/6 1998/04/17 11:26:22 mgreess $"
+ #include <uil/UilDef.h>
+ #include <stdio.h>
+ #include <ctype.h>
++#include <string.h>
+ 
+ /*
+ **
+diff --git a/demos/unsupported/xmapdef/xmapdef.c b/demos/unsupported/xmapdef/xmapdef.c
+index 028f081..c3833d8 100644
+--- a/demos/unsupported/xmapdef/xmapdef.c
++++ b/demos/unsupported/xmapdef/xmapdef.c
+@@ -33,6 +33,7 @@
+ **
+ */
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <Xm/XmAll.h>
+diff --git a/demos/unsupported/xmfonts/xmfonts.c b/demos/unsupported/xmfonts/xmfonts.c
+index 7c38e12..4e0fbf0 100644
+--- a/demos/unsupported/xmfonts/xmfonts.c
++++ b/demos/unsupported/xmfonts/xmfonts.c
+@@ -39,6 +39,7 @@ Xmfonts.ad:
+   xmfonts*row_column.XmNpacking:        XmPACK_COLUMN
+ 
+ ***-------------------------------------------------------------------*/
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <X11/Intrinsic.h>
+diff --git a/demos/unsupported/xmforc/xmforc.c b/demos/unsupported/xmforc/xmforc.c
+index 4710298..97fcd60 100644
+--- a/demos/unsupported/xmforc/xmforc.c
++++ b/demos/unsupported/xmforc/xmforc.c
+@@ -29,6 +29,7 @@
+ **  the demo by itself illustrates the RowColumn layout resources.
+ **
+ */
++#include <string.h>
+ 
+ #include <Xm/XmAll.h>
+ #include <stdlib.h>
+diff --git a/demos/unsupported/xmform/xmform.c b/demos/unsupported/xmform/xmform.c
+index 0e04674..9baddbf 100644
+--- a/demos/unsupported/xmform/xmform.c
++++ b/demos/unsupported/xmform/xmform.c
+@@ -50,6 +50,8 @@ xmform*topShadowColor:           white
+ xmform*bottomShadowColor:        black
+ ***-------------------------------------------------------------------*/
+ 
++#include <stdlib.h>
++#include <string.h>
+ #include <Xm/Xm.h>
+ #include <Xm/Form.h>
+ #include <Xm/PushB.h>
+diff --git a/lib/Mrm/MrmIfile.c b/lib/Mrm/MrmIfile.c
+index 5761f11..3580c6f 100644
+--- a/lib/Mrm/MrmIfile.c
++++ b/lib/Mrm/MrmIfile.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/MrmIheader.c b/lib/Mrm/MrmIheader.c
+index 289f85c..12d7683 100644
+--- a/lib/Mrm/MrmIheader.c
++++ b/lib/Mrm/MrmIheader.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/MrmIindex.c b/lib/Mrm/MrmIindex.c
+index 1e30986..b10e5d7 100644
+--- a/lib/Mrm/MrmIindex.c
++++ b/lib/Mrm/MrmIindex.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmerror.c b/lib/Mrm/Mrmerror.c
+index 472583c..2503e0b 100644
+--- a/lib/Mrm/Mrmerror.c
++++ b/lib/Mrm/Mrmerror.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmhier.c b/lib/Mrm/Mrmhier.c
+index 666854f..2109309 100644
+--- a/lib/Mrm/Mrmhier.c
++++ b/lib/Mrm/Mrmhier.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmlread.c b/lib/Mrm/Mrmlread.c
+index 489b66a..94d5bc9 100644
+--- a/lib/Mrm/Mrmlread.c
++++ b/lib/Mrm/Mrmlread.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmmodule.c b/lib/Mrm/Mrmmodule.c
+index ced2b3b..789a000 100644
+--- a/lib/Mrm/Mrmmodule.c
++++ b/lib/Mrm/Mrmmodule.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmptrlist.c b/lib/Mrm/Mrmptrlist.c
+index 284333a..99f4bc6 100644
+--- a/lib/Mrm/Mrmptrlist.c
++++ b/lib/Mrm/Mrmptrlist.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmtable.c b/lib/Mrm/Mrmtable.c
+index c52cad7..ebc68c7 100644
+--- a/lib/Mrm/Mrmtable.c
++++ b/lib/Mrm/Mrmtable.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmvm.c b/lib/Mrm/Mrmvm.c
+index aad2497..4f4e792 100644
+--- a/lib/Mrm/Mrmvm.c
++++ b/lib/Mrm/Mrmvm.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmwci.c b/lib/Mrm/Mrmwci.c
+index f7b4af0..0d78f6e 100644
+--- a/lib/Mrm/Mrmwci.c
++++ b/lib/Mrm/Mrmwci.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmwcrw.c b/lib/Mrm/Mrmwcrw.c
+index ada9aa3..00a6482 100644
+--- a/lib/Mrm/Mrmwcrw.c
++++ b/lib/Mrm/Mrmwcrw.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmwcrwr.c b/lib/Mrm/Mrmwcrwr.c
+index f6ed035..a5c104c 100644
+--- a/lib/Mrm/Mrmwcrwr.c
++++ b/lib/Mrm/Mrmwcrwr.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmwrefs.c b/lib/Mrm/Mrmwrefs.c
+index 5353ceb..87e8cd3 100644
+--- a/lib/Mrm/Mrmwrefs.c
++++ b/lib/Mrm/Mrmwrefs.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Mrm/Mrmwvalues.c b/lib/Mrm/Mrmwvalues.c
+index d8209bd..6c343d2 100644
+--- a/lib/Mrm/Mrmwvalues.c
++++ b/lib/Mrm/Mrmwvalues.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/BaseClass.c b/lib/Xm/BaseClass.c
+index cea0005..a319913 100644
+--- a/lib/Xm/BaseClass.c
++++ b/lib/Xm/BaseClass.c
+@@ -32,6 +32,8 @@ static char rcsid[] = "$TOG: BaseClass.c /main/20 1997/03/31 13:14:31 dbl $"
+ #endif
+ 
+ 
++#include <string.h>
++
+ #include <Xm/XmP.h>
+ #include <X11/ShellP.h>
+ #include <Xm/ExtObjectP.h>
+diff --git a/lib/Xm/BulletinB.c b/lib/Xm/BulletinB.c
+index 1c82101..c4aa4f2 100644
+--- a/lib/Xm/BulletinB.c
++++ b/lib/Xm/BulletinB.c
+@@ -31,6 +31,8 @@ static char rcsid[] = "$TOG: BulletinB.c /main/22 1999/10/13 16:15:40 mgreess $"
+ #endif
+ 
+ 
++#include <string.h>
++
+ #include "BulletinBI.h"
+ #include <Xm/AtomMgr.h>
+ #include <Xm/BaseClassP.h>
+diff --git a/lib/Xm/ClipWindow.c b/lib/Xm/ClipWindow.c
+index ab3a574..de639ba 100644
+--- a/lib/Xm/ClipWindow.c
++++ b/lib/Xm/ClipWindow.c
+@@ -29,6 +29,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include <Xm/ClipWindowP.h>
+ #include <Xm/TransltnsP.h>
+diff --git a/lib/Xm/Color.c b/lib/Xm/Color.c
+index 371568f..ce8257d 100644
+--- a/lib/Xm/Color.c
++++ b/lib/Xm/Color.c
+@@ -30,6 +30,7 @@
+ #endif
+ 
+ 
++#include <string.h>
+ #include <ctype.h>
+ #include <stdio.h>
+ #include <X11/IntrinsicP.h>
+diff --git a/lib/Xm/ColorObj.c b/lib/Xm/ColorObj.c
+index 7dd2223..195fd18 100644
+--- a/lib/Xm/ColorObj.c
++++ b/lib/Xm/ColorObj.c
+@@ -27,6 +27,8 @@
+ #include <config.h>
+ #endif
+ 
++#include "string.h"
++
+ #define FIX_1400
+ #define FIX_1181
+ 
+diff --git a/lib/Xm/ColorS.c b/lib/Xm/ColorS.c
+index 6baf2e3..911864c 100644
+--- a/lib/Xm/ColorS.c
++++ b/lib/Xm/ColorS.c
+@@ -29,6 +29,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+diff --git a/lib/Xm/Column.c b/lib/Xm/Column.c
+index e3f2626..135b686 100644
+--- a/lib/Xm/Column.c
++++ b/lib/Xm/Column.c
+@@ -26,6 +26,8 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
++
+ #include <Xm/ColumnP.h>
+ #include <Xm/RowColumn.h>
+ #include <Xm/Label.h>
+diff --git a/lib/Xm/Container.c b/lib/Xm/Container.c
+index 6576783..20a702e 100644
+--- a/lib/Xm/Container.c
++++ b/lib/Xm/Container.c
+@@ -35,6 +35,8 @@
+ #include <stdlib.h>
+ #endif
+ 
++#include <string.h>
++
+ #include <Xm/AtomMgr.h>
+ #include <Xm/ClipWindowP.h>
+ #include <Xm/ContItemT.h>
+diff --git a/lib/Xm/DataFSel.c b/lib/Xm/DataFSel.c
+index 42c6ad5..88a3f2e 100644
+--- a/lib/Xm/DataFSel.c
++++ b/lib/Xm/DataFSel.c
+@@ -27,6 +27,8 @@ static char rcsid[] = "$RCSfile: DataFSel.c,v $ $Revision: 1.6 $ $Date: 2003/10/
+ #endif
+ #endif
+ 
++#include <string.h>
++
+ #include <Xm/Ext.h>
+ #include <Xm/DataFSelP.h>
+ #include <Xm/DataFP.h>
+diff --git a/lib/Xm/DialogS.c b/lib/Xm/DialogS.c
+index 1fcd056..ebb21b9 100644
+--- a/lib/Xm/DialogS.c
++++ b/lib/Xm/DialogS.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$XConsortium: DialogS.c /main/17 1996/03/25 17:50:11 bars
+ #include <config.h>
+ #endif
+ 
++#include "string.h"
+ 
+ #include "XmI.h"
+ #include <Xm/DialogSP.h>
+diff --git a/lib/Xm/DragC.c b/lib/Xm/DragC.c
+index 6d39e6d..e4b92f5 100644
+--- a/lib/Xm/DragC.c
++++ b/lib/Xm/DragC.c
+@@ -35,6 +35,8 @@ static char rcsid[] = "$TOG: DragC.c /main/29 1997/10/07 12:19:52 cshi $"
+ #define DEFAULT_WM_TIMEOUT 5000
+ #endif
+ 
++#include <string.h>
++
+ #include <X11/Xatom.h>
+ #include <X11/cursorfont.h>
+ #include <Xm/AtomMgr.h>
+diff --git a/lib/Xm/DropSMgr.c b/lib/Xm/DropSMgr.c
+index c7c8bc2..2f57a9b 100644
+--- a/lib/Xm/DropSMgr.c
++++ b/lib/Xm/DropSMgr.c
+@@ -31,6 +31,8 @@ static char rcsid[] = "$TOG: DropSMgr.c /main/21 1999/08/11 14:44:57 vipin $"
+ #endif
+ 
+ 
++#include <string.h>
++
+ /*****************************************************************************
+  * THE DROPSITE DATABASE
+  * 
+diff --git a/lib/Xm/EditresCom.c b/lib/Xm/EditresCom.c
+index 4114ff8..ea894af 100644
+--- a/lib/Xm/EditresCom.c
++++ b/lib/Xm/EditresCom.c
+@@ -43,6 +43,7 @@ in this Software without prior written authorization from the X Consortium.
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include <X11/IntrinsicP.h>	/* To get into the composite and core widget
+ 				   structures. */
+diff --git a/lib/Xm/ExtP.h b/lib/Xm/ExtP.h
+index 6dfcc9c..753e14b 100644
+--- a/lib/Xm/ExtP.h
++++ b/lib/Xm/ExtP.h
+@@ -25,6 +25,8 @@
+ #ifndef _XmExtP_h_
+ #define _XmExtP_h_
+ 
++#include <string.h>
++
+ #include <Xm/Ext.h>
+ 
+ /************************************************************
+diff --git a/lib/Xm/FileSB.c b/lib/Xm/FileSB.c
+index 82f6d56..f44171c 100644
+--- a/lib/Xm/FileSB.c
++++ b/lib/Xm/FileSB.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: FileSB.c /main/21 1997/09/26 13:38:52 bill $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include <Xm/XmosP.h>
+ 
+diff --git a/lib/Xm/I18List.c b/lib/Xm/I18List.c
+index f34e94e..4470074 100644
+--- a/lib/Xm/I18List.c
++++ b/lib/Xm/I18List.c
+@@ -26,6 +26,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include "XmI.h"
+diff --git a/lib/Xm/IconButton.c b/lib/Xm/IconButton.c
+index 5f2cae7..59cc05a 100644
+--- a/lib/Xm/IconButton.c
++++ b/lib/Xm/IconButton.c
+@@ -26,6 +26,8 @@
+ *	INCLUDE FILES
+ *************************************************************/
+ 
++#include <string.h>
++
+ #include <Xm/XmP.h>
+ #include <Xm/DrawP.h>
+ #include <Xm/TraitP.h>
+diff --git a/lib/Xm/IconFile.c b/lib/Xm/IconFile.c
+index 68105e0..44d53aa 100644
+--- a/lib/Xm/IconFile.c
++++ b/lib/Xm/IconFile.c
+@@ -42,6 +42,7 @@
+ #endif
+ 
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <X11/Xlocale.h>
+ 
+diff --git a/lib/Xm/Manager.c b/lib/Xm/Manager.c
+index 50707ec..d524324 100644
+--- a/lib/Xm/Manager.c
++++ b/lib/Xm/Manager.c
+@@ -30,6 +30,7 @@
+ static char rcsid[] = "$TOG: Manager.c /main/22 1999/01/27 16:07:30 mgreess $"
+ #endif
+ #endif
++#include <string.h>
+ 
+ #include <Xm/AccColorT.h>
+ #include <Xm/CareVisualT.h>
+diff --git a/lib/Xm/MapEvents.c b/lib/Xm/MapEvents.c
+index 3272225..8b3b3f6 100644
+--- a/lib/Xm/MapEvents.c
++++ b/lib/Xm/MapEvents.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/Obso1_2.c b/lib/Xm/Obso1_2.c
+index 10bf230..e274109 100644
+--- a/lib/Xm/Obso1_2.c
++++ b/lib/Xm/Obso1_2.c
+@@ -31,6 +31,7 @@
+ #endif
+ 
+ 
++#include <string.h>
+ #include <ctype.h>
+ #ifndef X_NOT_STDC_ENV
+ #include <stdlib.h>
+diff --git a/lib/Xm/Obso2_0.c b/lib/Xm/Obso2_0.c
+index 9a012ec..0295353 100644
+--- a/lib/Xm/Obso2_0.c
++++ b/lib/Xm/Obso2_0.c
+@@ -31,6 +31,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include <ctype.h>
+ #ifndef X_NOT_STDC_ENV
+diff --git a/lib/Xm/RCMenu.c b/lib/Xm/RCMenu.c
+index 2c698d4..881ff5c 100644
+--- a/lib/Xm/RCMenu.c
++++ b/lib/Xm/RCMenu.c
+@@ -50,6 +50,7 @@ static char *rcsid = "$TOG: RCMenu.c /main/25 1999/05/24 18:06:57 samborn $";
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <ctype.h>
+ #include "XmI.h"
+diff --git a/lib/Xm/ResConvert.c b/lib/Xm/ResConvert.c
+index 63041ac..274c72e 100644
+--- a/lib/Xm/ResConvert.c
++++ b/lib/Xm/ResConvert.c
+@@ -30,6 +30,7 @@ static char rcsid[] = "$TOG: ResConvert.c /main/29 1999/05/18 19:19:39 mgreess $
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #define X_INCLUDE_STRING_H
+ #define XOS_USE_XT_LOCKING
+diff --git a/lib/Xm/RowColumn.c b/lib/Xm/RowColumn.c
+index ea538de..ef8236d 100644
+--- a/lib/Xm/RowColumn.c
++++ b/lib/Xm/RowColumn.c
+@@ -29,6 +29,7 @@ static char rcsid[] = "$TOG: RowColumn.c /main/25 1998/07/22 15:41:49 mgreess $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <ctype.h>
+ #include "XmI.h"
+diff --git a/lib/Xm/Scale.c b/lib/Xm/Scale.c
+index 76843d1..1af0135 100644
+--- a/lib/Xm/Scale.c
++++ b/lib/Xm/Scale.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: Scale.c /main/31 1999/10/13 16:18:07 mgreess $"
+ #endif
+ 
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <limits.h>
+ #ifndef CSRG_BASED
+diff --git a/lib/Xm/TextFSel.c b/lib/Xm/TextFSel.c
+index ee324ca..d55726e 100644
+--- a/lib/Xm/TextFSel.c
++++ b/lib/Xm/TextFSel.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: TextFSel.c /main/22 1997/10/14 15:38:30 cshi $"
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <X11/Xatom.h>
+ #include <Xm/AtomMgr.h>
+ #include <Xm/DragC.h>
+diff --git a/lib/Xm/TextFind.c b/lib/Xm/TextFind.c
+index 162fac4..3d6794f 100644
+--- a/lib/Xm/TextFind.c
++++ b/lib/Xm/TextFind.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <ctype.h>
+ #include <X11/Xmd.h>
+ #include <Xm/XmosP.h>		/* for <stdlib.h>, and wcstombs() */
+diff --git a/lib/Xm/TextFunc.c b/lib/Xm/TextFunc.c
+index b773803..b317b03 100644
+--- a/lib/Xm/TextFunc.c
++++ b/lib/Xm/TextFunc.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include <Xm/XmosP.h>
+ #include <Xm/TextStrSoP.h>
+diff --git a/lib/Xm/TextOut.c b/lib/Xm/TextOut.c
+index 8a86427..bd7c706 100644
+--- a/lib/Xm/TextOut.c
++++ b/lib/Xm/TextOut.c
+@@ -32,6 +32,7 @@ static char rcsid[] = "$TOG: TextOut.c /main/41 1999/08/12 11:37:30 vipin $"
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ #include <limits.h>
+ #include <Xm/XmosP.h>
+diff --git a/lib/Xm/TextSel.c b/lib/Xm/TextSel.c
+index ced7eb6..ecc6f56 100644
+--- a/lib/Xm/TextSel.c
++++ b/lib/Xm/TextSel.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/TextStrSo.c b/lib/Xm/TextStrSo.c
+index 0c949bc..f0cfd5d 100644
+--- a/lib/Xm/TextStrSo.c
++++ b/lib/Xm/TextStrSo.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include "string.h"
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/Transfer.c b/lib/Xm/Transfer.c
+index 0ea601f..bafd19a 100644
+--- a/lib/Xm/Transfer.c
++++ b/lib/Xm/Transfer.c
+@@ -30,6 +30,7 @@
+ #endif
+ 
+ 
++#include <string.h>
+ #include <X11/Xatom.h>
+ #include <Xm/AtomMgr.h>
+ #include <Xm/DragDrop.h>
+diff --git a/lib/Xm/VaSimple.c b/lib/Xm/VaSimple.c
+index f688e3a..ee5634f 100644
+--- a/lib/Xm/VaSimple.c
++++ b/lib/Xm/VaSimple.c
+@@ -31,6 +31,8 @@ static char rcsid[] = "$XConsortium: VaSimple.c /main/11 1995/10/25 20:26:43 cde
+ #endif
+ #endif
+ 
++#include <string.h>
++
+ #include <Xm/VaSimpleP.h>
+ #include <X11/StringDefs.h>
+ #include <X11/Shell.h>
+diff --git a/lib/Xm/VendorS.c b/lib/Xm/VendorS.c
+index 4da7f24..ea10f3a 100644
+--- a/lib/Xm/VendorS.c
++++ b/lib/Xm/VendorS.c
+@@ -24,6 +24,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/Xm.c b/lib/Xm/Xm.c
+index 657f904..e410dbb 100644
+--- a/lib/Xm/Xm.c
++++ b/lib/Xm/Xm.c
+@@ -29,6 +29,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include "XmI.h"
+ #include "MessagesI.h"
+diff --git a/lib/Xm/XmExtUtil.c b/lib/Xm/XmExtUtil.c
+index d5c28ea..5c4b2ab 100644
+--- a/lib/Xm/XmExtUtil.c
++++ b/lib/Xm/XmExtUtil.c
+@@ -25,6 +25,7 @@
+ /************************************************************
+ *	INCLUDE FILES
+ *************************************************************/
++#include <string.h>
+ #include <stdio.h>
+ #include <stdarg.h>
+ #include <X11/IntrinsicP.h>
+diff --git a/lib/Xm/XmIm.c b/lib/Xm/XmIm.c
+index f966a69..96d2e85 100644
+--- a/lib/Xm/XmIm.c
++++ b/lib/Xm/XmIm.c
+@@ -27,6 +27,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+  
+ #ifdef REV_INFO
+ #ifndef lint
+diff --git a/lib/Xm/XmStringGet.c b/lib/Xm/XmStringGet.c
+index d9d95d2..e9f30b2 100644
+--- a/lib/Xm/XmStringGet.c
++++ b/lib/Xm/XmStringGet.c
+@@ -30,6 +30,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ #include "XmStringI.h"
+ #include "XmI.h"
+diff --git a/lib/Xm/Xmos.c b/lib/Xm/Xmos.c
+index 92cc795..7c6d5ef 100644
+--- a/lib/Xm/Xmos.c
++++ b/lib/Xm/Xmos.c
+@@ -31,6 +31,7 @@ static char rcsid[] = "$TOG: Xmos.c /main/33 1998/01/21 11:07:25 csn $"
+ #endif
+ #endif
+ 
++#include <string.h>
+ #include <stdio.h>
+ 
+ #ifdef __cplusplus
+diff --git a/lib/Xm/XpmCrBufFrI.c b/lib/Xm/XpmCrBufFrI.c
+index 5fa9563..42d5a7f 100644
+--- a/lib/Xm/XpmCrBufFrI.c
++++ b/lib/Xm/XpmCrBufFrI.c
+@@ -40,6 +40,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/lib/Xm/XpmCrDatFrI.c b/lib/Xm/XpmCrDatFrI.c
+index 5d34114..f5a5424 100644
+--- a/lib/Xm/XpmCrDatFrI.c
++++ b/lib/Xm/XpmCrDatFrI.c
+@@ -37,6 +37,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/lib/Xm/XpmRdFToI.c b/lib/Xm/XpmRdFToI.c
+index 6af58dc..43afd4f 100644
+--- a/lib/Xm/XpmRdFToI.c
++++ b/lib/Xm/XpmRdFToI.c
+@@ -37,6 +37,7 @@
+ #include <config.h>
+ #endif
+ 
++#include "string.h"
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/lib/Xm/XpmWrFFrBuf.c b/lib/Xm/XpmWrFFrBuf.c
+index b3663b5..c72153a 100644
+--- a/lib/Xm/XpmWrFFrBuf.c
++++ b/lib/Xm/XpmWrFFrBuf.c
+@@ -37,6 +37,7 @@
+ #include <config.h>
+ #endif
+ 
++#include "string.h"
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/lib/Xm/XpmWrFFrI.c b/lib/Xm/XpmWrFFrI.c
+index 1eaf1c9..d0db138 100644
+--- a/lib/Xm/XpmWrFFrI.c
++++ b/lib/Xm/XpmWrFFrI.c
+@@ -37,6 +37,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/lib/Xm/Xpmcreate.c b/lib/Xm/Xpmcreate.c
+index d0f3c3b..7768322 100644
+--- a/lib/Xm/Xpmcreate.c
++++ b/lib/Xm/Xpmcreate.c
+@@ -48,6 +48,7 @@
+ 
+ #include "XpmI.h"
+ #include <ctype.h>
++#include <string.h>
+ 
+ LFUNC(xpmVisualType, int, (Visual *visual));
+ 
+diff --git a/lib/Xm/Xpmdata.c b/lib/Xm/Xpmdata.c
+index d65ae57..14b5e9e 100644
+--- a/lib/Xm/Xpmdata.c
++++ b/lib/Xm/Xpmdata.c
+@@ -48,6 +48,7 @@ static char *RCS_Id = "$XpmId: xpm.shar,v 3.62 96/09/14 02:33:07 lehors Exp $";
+ 
+ #include "XpmI.h"
+ #include <ctype.h>
++#include <string.h>
+ 
+ 
+ LFUNC(ParseComment, int, (xpmData * mdata));
+diff --git a/lib/Xm/Xpmhashtab.c b/lib/Xm/Xpmhashtab.c
+index 2548912..748b27b 100644
+--- a/lib/Xm/Xpmhashtab.c
++++ b/lib/Xm/Xpmhashtab.c
+@@ -39,6 +39,8 @@
+ #endif
+ 
+ 
++#include <string.h>
++
+ #include "XpmI.h"
+ 
+ LFUNC(AtomMake, xpmHashAtom, (char *name, void *data));
+diff --git a/lib/Xm/Xpmmisc.c b/lib/Xm/Xpmmisc.c
+index d51e110..05a5de9 100644
+--- a/lib/Xm/Xpmmisc.c
++++ b/lib/Xm/Xpmmisc.c
+@@ -42,6 +42,8 @@
+ #define NO_XPMFREE_MACRO
+ #include "XpmI.h"
+ 
++#include <string.h>
++
+ #ifdef NEED_STRDUP
+ /*
+  * in case strdup is not provided by the system here is one
+diff --git a/lib/Xm/Xpmrgb.c b/lib/Xm/Xpmrgb.c
+index 1234042..df2744c 100644
+--- a/lib/Xm/Xpmrgb.c
++++ b/lib/Xm/Xpmrgb.c
+@@ -50,6 +50,7 @@
+ 
+ #include "XpmI.h"
+ #include <ctype.h>
++#include "string.h"
+ 
+ #ifndef FOR_MSW				/* normal part first, MSW part at
+ 					 * the end, (huge ifdef!) */
+diff --git a/lib/Xm/Xpmscan.c b/lib/Xm/Xpmscan.c
+index f458b6d..0ef0372 100644
+--- a/lib/Xm/Xpmscan.c
++++ b/lib/Xm/Xpmscan.c
+@@ -42,6 +42,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ 
+ /* October 2004, source code review by Thomas Biege <thomas@suse.de> */
+ 
+diff --git a/tools/wml/wmldbcreate.c b/tools/wml/wmldbcreate.c
+index 878220e..6198e8a 100644
+--- a/tools/wml/wmldbcreate.c
++++ b/tools/wml/wmldbcreate.c
+@@ -35,6 +35,7 @@ static char rcsid[] = "$TOG: wmldbcreate.c /main/8 1997/04/14 12:55:30 dbl $"
+  */
+ 
+ 
++#include <string.h>
+ #include <stdio.h>
+ #ifndef X_NOT_STDC_ENV
+ #include <stdlib.h>
+-- 
+2.50.0
+

--- a/runtime-desktop/motif/spec
+++ b/runtime-desktop/motif/spec
@@ -1,5 +1,5 @@
 VER=2.3.8
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/motif/files/Motif%20${VER}%20Source%20Code/motif-${VER}.tar.gz"
 CHKSUMS="sha256::859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7"
 CHKUPDATE="anitya::id=2015"


### PR DESCRIPTION
Topic Description
-----------------

- motif: fix build error with GCC >= 14
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- motif: 2.3.8-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit motif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
