### PR TITLE
pakfixer: update to 0.1.4


### DIFF
--- a/app-utils/pakfixer/autobuild/defines
+++ b/app-utils/pakfixer/autobuild/defines
@@ -1,11 +1,10 @@
 PKGNAME=pakfixer
 PKGSEC=utils
-BUILDDEP="rustc llvm"
-PKGDES="A static code analyzer for AOSC packaging scripts"
+PKGDEP="glibc xz openssl gcc-runtime zlib"
+BUILDDEP="rustc llvm-20"
+PKGRECOM="autobuild4"
+PKGDES="Static code analyzer for AOSC packaging scripts"
 
 ABTYPE=rust
 USECLANG=1
 CARGO_AFTER=("-ppakfixer")
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGSON3=1

--- a/app-utils/pakfixer/spec
+++ b/app-utils/pakfixer/spec
@@ -1,4 +1,4 @@
-VER=0.1.3
+VER=0.1.4
 SRCS="git::commit=tags/pakfixer-${VER}::https://github.com/AOSC-Dev/pfu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377930"


### PR DESCRIPTION
Topic Description
-----------------

- pakfixer: update to 0.1.4

Package(s) Affected
-------------------

- pakfixer: 0.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pakfixer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
