### PR TITLE
anubis: update to 1.21.0

### DIFF
--- a/app-web/anubis/spec
+++ b/app-web/anubis/spec
@@ -1,4 +1,4 @@
-VER=1.20.0
+VER=1.21.0
 SRCS="git::commit=tags/v$VER::https://github.com/TecharoHQ/anubis"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377999"


### PR DESCRIPTION
Topic Description
-----------------

- anubis: update to 1.21.0

Package(s) Affected
-------------------

- anubis: 1.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit anubis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
