### PR TITLE
Fcitx5 Theme Survey

### DIFF
--- a/app-i18n/fcitx5-theme-black-simplicity/autobuild/build
+++ b/app-i18n/fcitx5-theme-black-simplicity/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Installing Black Simplicity ..."
+mkdir -vp "$PKGDIR"/usr/share/fcitx5/themes
+cp -vr "$SRCDIR"/Black-Simplicity \
+    "$PKGDIR"/usr/share/fcitx5/themes/Black-Simplicity

--- a/app-i18n/fcitx5-theme-black-simplicity/autobuild/defines
+++ b/app-i18n/fcitx5-theme-black-simplicity/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="fcitx5-theme-black-simplicity"
+PKGDES="Simple monochrome theme for Fcitx5"
+PKGDEP="fcitx5"
+PKGSEC="x11"
+
+ABHOST=noarch

--- a/app-i18n/fcitx5-theme-black-simplicity/spec
+++ b/app-i18n/fcitx5-theme-black-simplicity/spec
@@ -1,0 +1,4 @@
+VER=0.0.0+git20211223
+SRCS="git::commit=27e279c4e4f1c2318b19360367a0b9a5ef83efbb::https://github.com/fuzakebito/fcitx5-Black-Simplicity.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379214"

--- a/app-i18n/fcitx5-theme-fluent/autobuild/build
+++ b/app-i18n/fcitx5-theme-fluent/autobuild/build
@@ -1,0 +1,8 @@
+for i in */; do
+    [[ -e "$SRCDIR"/"$i"/theme.conf ]] || continue
+    abinfo "Installing $i theme ..."
+    install -Dvm644 "$SRCDIR"/"$i"/theme.conf \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
+    install -Dvm644 "$SRCDIR"/"$i"/*.png \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
+done

--- a/app-i18n/fcitx5-theme-fluent/autobuild/defines
+++ b/app-i18n/fcitx5-theme-fluent/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="fcitx5-theme-fluent"
+PKGDES="Fluent-Design theme with blur effect and shadow for Fcitx5"
+PKGDEP="fcitx5"
+PKGSEC="x11"
+
+ABHOST=noarch

--- a/app-i18n/fcitx5-theme-fluent/spec
+++ b/app-i18n/fcitx5-theme-fluent/spec
@@ -1,0 +1,4 @@
+VER=0.4+git20250107
+SRCS="git::commit=399699ac7d366ed6c1952646ed71647e3c8f99b5::https://github.com/Reverier-Xu/Fluent-fcitx5.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379215"

--- a/app-i18n/fcitx5-theme-neo-dark/autobuild/build
+++ b/app-i18n/fcitx5-theme-neo-dark/autobuild/build
@@ -1,0 +1,14 @@
+abinfo "Installing Fcitx5 neo-dark theme, wide variant ..."
+install -Dvm644 "$SRCDIR"/input_panel.png \
+    -t "$PKGDIR"/usr/share/fcitx5/themes/neo-dark-wide/input_panel.png
+install -Dvm644 "$SRCDIR"/theme-wide.conf \
+    -t "$PKGDIR"/usr/share/fcitx5/themes/neo-dark-wide/theme.conf
+
+abinfo "Installing Fcitx5 neo-dark theme, thin variant ..."
+install -Dvm644 "$SRCDIR"/input_panel-thin.png \
+    -t "$PKGDIR"/usr/share/fcitx5/themes/neo-dark-thin/input_panel.png
+install -Dvm644 "$SRCDIR"/theme-thin.conf \
+    -t "$PKGDIR"/usr/share/fcitx5/themes/neo-dark-thin/theme.conf
+
+abinfo "Installing license file ..."
+install -Dvm644 UNLICENSE "$PKGDIR"/usr/share/doc/"$PKGNAME"/LICENSE

--- a/app-i18n/fcitx5-theme-neo-dark/autobuild/defines
+++ b/app-i18n/fcitx5-theme-neo-dark/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="fcitx5-theme-neo-dark"
+PKGDES="Dark theme for Fcitx5"
+PKGDEP="fcitx5"
+PKGSEC="x11"
+
+ABHOST=noarch

--- a/app-i18n/fcitx5-theme-neo-dark/autobuild/patches/0001-AOSCOS-Distinguish-two-variants.patch
+++ b/app-i18n/fcitx5-theme-neo-dark/autobuild/patches/0001-AOSCOS-Distinguish-two-variants.patch
@@ -1,0 +1,47 @@
+From c1397d72c29424f269e5a18990148be785f3cae3 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sun, 20 Jul 2025 20:33:23 +0800
+Subject: [PATCH] AOSCOS: Distinguish two variants
+X-Developer-Signature: v=1; a=openpgp-sha256; l=678; i=xtexchooser@duck.com;
+ h=from:subject; bh=Fe6klLNS9Rqg5SYjMVZDob6tL00mJF3Q8gp7y8cuzO0=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBk1j9RPJntdPfivSO628+P+vr+6Z6Zt3NXW3XJJJGnpn
+ djp8tved5SyMIhxMciKKbIUGTZ4s+qk84suK5eFmcPKBDKEgYtTACbSeYGR4evhqefFIr1YzpUm
+ B38y2zchSniniFjvtwcx2wyXBrvtXsDIcFQz/Mz6o57zmeUuXc0UbWxo/ZF/SOiyxt/86kYj6+o
+ aPgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ theme-thin.conf | 2 +-
+ theme-wide.conf | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/theme-thin.conf b/theme-thin.conf
+index ec2e9a086dc5..493d2f34ae83 100644
+--- a/theme-thin.conf
++++ b/theme-thin.conf
+@@ -1,6 +1,6 @@
+ [Metadata]
+ # 名称
+-Name="Neo Dark"
++Name="Neo Dark Thin"
+ # 版本
+ Version=1
+ # 作者
+diff --git a/theme-wide.conf b/theme-wide.conf
+index 978b992c2426..a04c7e4cc310 100644
+--- a/theme-wide.conf
++++ b/theme-wide.conf
+@@ -1,6 +1,6 @@
+ [Metadata]
+ # 名称
+-Name=Neo Dark
++Name="Neo Dark Wide"
+ # 版本
+ Version=1
+ # 作者
+
+base-commit: dbe6a7c42e1fd383e1e1a462b5714cbf930f377b
+-- 
+2.50.1
+

--- a/app-i18n/fcitx5-theme-neo-dark/spec
+++ b/app-i18n/fcitx5-theme-neo-dark/spec
@@ -1,0 +1,4 @@
+VER=0.0.0+git20220215
+SRCS="git::commit=dbe6a7c42e1fd383e1e1a462b5714cbf930f377b::https://github.com/weearc/fcitx5-theme-neo-dark.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379213"

--- a/app-i18n/fcitx5-theme-opensuse/autobuild/build
+++ b/app-i18n/fcitx5-theme-opensuse/autobuild/build
@@ -1,14 +1,8 @@
-cd "$SRCDIR"/fcitx5-theme-opensuse/
 for i in */; do
-    abinfo "Installing Fcitx5 openSUSE theme, variant $i ..."
-    install -Dvm644 "$SRCDIR"/fcitx5-theme-opensuse/$i/highlight.png \
-        "$PKGDIR"/usr/share/fcitx5/themes/$i/highlight.png
-    install -Dvm644 "$SRCDIR"/fcitx5-theme-opensuse/$i/bar.png \
-        "$PKGDIR"/usr/share/fcitx5/themes/$i/bar.png
-    install -Dvm644 "$SRCDIR"/fcitx5-theme-opensuse/$i/theme.conf \
-        "$PKGDIR"/usr/share/fcitx5/themes/$i/theme.conf
+    [[ -e "$SRCDIR"/"$i"/theme.conf ]] || continue
+    abinfo "Installing $i theme ..."
+    install -Dvm644 "$SRCDIR"/"$i"/theme.conf \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
+    install -Dvm644 "$SRCDIR"/"$i"/*.png \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
 done
-
-abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/fcitx5-theme-opensuse/LICENSE \
-    "$PKGDIR"/usr/share/doc/fcitx5-theme-opensuse/LICENSE

--- a/app-i18n/fcitx5-theme-opensuse/autobuild/defines
+++ b/app-i18n/fcitx5-theme-opensuse/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME="fcitx5-theme-opensuse"
-PKGDES="Fcitx5 theme on openSUSE, including Dartmouth, Harlequin, and New Air"
+PKGDES="Fcitx5 themes on openSUSE"
 PKGDEP="fcitx5"
 PKGSEC="x11"
 

--- a/app-i18n/fcitx5-theme-opensuse/spec
+++ b/app-i18n/fcitx5-theme-opensuse/spec
@@ -1,5 +1,4 @@
-VER=0.1.0
-SRCS="git::commit=e94acf2a7903baf5030a8e15625108cf6e17c51a::https://github.com/xuzhao9/fcitx5-theme-opensuse"
+VER=0.1.0+git20231211
+SRCS="git::commit=5196ff2e1ab3a259d32ef2d1a77f3f7d22adeada::https://github.com/xuzhao9/fcitx5-theme-opensuse"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372321"
-SUBDIR="."

--- a/app-i18n/fcitx5-theme-ori/autobuild/build
+++ b/app-i18n/fcitx5-theme-ori/autobuild/build
@@ -1,0 +1,8 @@
+for i in */; do
+    [[ -e "$SRCDIR"/"$i"/theme.conf ]] || continue
+    abinfo "Installing $i theme ..."
+    install -Dvm644 "$SRCDIR"/"$i"/theme.conf \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
+    install -Dvm644 "$SRCDIR"/"$i"/*.svg \
+        -t "$PKGDIR"/usr/share/fcitx5/themes/"$i"
+done

--- a/app-i18n/fcitx5-theme-ori/autobuild/defines
+++ b/app-i18n/fcitx5-theme-ori/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="fcitx5-theme-ori"
+PKGDES="Ori theme for Fcitx5"
+PKGDEP="fcitx5"
+PKGSEC="x11"
+
+ABHOST=noarch

--- a/app-i18n/fcitx5-theme-ori/spec
+++ b/app-i18n/fcitx5-theme-ori/spec
@@ -1,0 +1,4 @@
+VER=0.1+git20240716
+SRCS="git::commit=d2cf5df38f11e4e14dcf9436af5b9f8fa0087c55::https://github.com/Reverier-Xu/Ori-Fcitx5.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379215"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-theme-ori: new, 0.1+git20240716
- fcitx5-theme-neo-dark: new, 0.0.0+git20220215
- fcitx5-theme-fluent: new, 0.4+git20250107
- fcitx5-theme-black-simplicity: new, 0.0.0+git20211223
- fcitx5-theme-opensuse: update to 0.1.0+git20231211

Package(s) Affected
-------------------

- fcitx5-theme-black-simplicity: 0.0.0+git20211223
- fcitx5-theme-fluent: 0.4+git20250107
- fcitx5-theme-neo-dark: 0.0.0+git20220215
- fcitx5-theme-opensuse: 1:0.1.0+git20231211
- fcitx5-theme-ori: 0.1+git20240716

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-theme-black-simplicity fcitx5-theme-fluent fcitx5-theme-neo-dark fcitx5-theme-opensuse fcitx5-theme-ori
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
