### PR TITLE
pyqt5: update to 5.15.9

### DIFF
--- a/lang-python/pyqt5/spec
+++ b/lang-python/pyqt5/spec
@@ -1,5 +1,4 @@
-VER=5.15.5
-REL=4
+VER=5.15.9
 SRCS="tbl::https://pypi.python.org/packages/source/P/PyQt5/PyQt5-$VER.tar.gz"
-CHKSUMS="sha256::b411b7a8fa03901c9feb1dcbac7ea1fc3ce20b9ae682762b777cd5398749ca2b"
+CHKSUMS="sha256::dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0"
 CHKUPDATE="anitya::id=20104"


### PR DESCRIPTION
Topic Description
-----------------

- pyqt5: update to 5.15.9
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- pyqt5: 5.15.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyqt5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
