### PR TITLE
pyqt5: update to 5.15.11

### DIFF
--- a/lang-python/pyqt5/spec
+++ b/lang-python/pyqt5/spec
@@ -1,5 +1,4 @@
-VER=5.15.5
-REL=4
+VER=5.15.11
 SRCS="tbl::https://pypi.python.org/packages/source/P/PyQt5/PyQt5-$VER.tar.gz"
-CHKSUMS="sha256::b411b7a8fa03901c9feb1dcbac7ea1fc3ce20b9ae682762b777cd5398749ca2b"
+CHKSUMS="sha256::fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52"
 CHKUPDATE="anitya::id=20104"


### PR DESCRIPTION
Topic Description
-----------------

- pyqt5: update to 5.15.11
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- pyqt5: 5.15.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyqt5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
