### PR TITLE
ruby: update to 3.4.5

### DIFF
--- a/lang-ruby/ruby/autobuild/alternatives
+++ b/lang-ruby/ruby/autobuild/alternatives
@@ -1,3 +1,5 @@
+alternative /usr/bin/bundle /usr/bin/bundle-ruby 80
+alternative /usr/bin/bundler /usr/bin/bundler-ruby 80
 alternative /usr/bin/erb /usr/bin/erb-ruby 80
 alternative /usr/bin/gem /usr/bin/gem-ruby 80
 alternative /usr/bin/irb /usr/bin/irb-ruby 80

--- a/lang-ruby/ruby/autobuild/beyond
+++ b/lang-ruby/ruby/autobuild/beyond
@@ -8,11 +8,6 @@ sed -e 's|-O3|-O2|g' \
     -e 's|-specs=/usr/lib/gcc/specs/hardened-ld||g' \
     -i `find "$PKGDIR" -name 'rbconfig.rb'`
 
-abinfo "Arch Linux: De-bundling ruby-bundler ..."
-rm -rv "$PKGDIR"/usr/lib/ruby/${PKGVER:0:3}.0/{bundler,bundler.rb}
-rm -v "$PKGDIR"/usr/bin/{bundle,bundler}
-rm -v "$PKGDIR"/usr/lib/ruby/gems/${PKGVER:0:3}.0/specifications/default/bundler-*.gemspec
-
 abinfo "Renaming executables for alternatives ..."
 for i in "$PKGDIR"/usr/bin/*; do
     mv -v ${i} ${i}-ruby

--- a/lang-ruby/ruby/spec
+++ b/lang-ruby/ruby/spec
@@ -1,4 +1,4 @@
-VER=3.4.2
+VER=3.4.5
 SRCS="tbl::https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.xz"
-CHKSUMS="sha256::ebf1c2eb58f5da17c23e965d658dd7e6202c5c50f5179154c5574452bef4b3e0"
+CHKSUMS="sha256::7b3a905b84b8777aa29f557bada695c3ce108390657e614d2cc9e2fb7e459536"
 CHKUPDATE="anitya::id=4223"


### PR DESCRIPTION
Topic Description
-----------------

- ruby: update to 3.4.5
    Bundle ruby-bundler as it is now a transitional package.

Package(s) Affected
-------------------

- ruby: 3.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ruby
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
