### PR TITLE
lfortran: update to 0.54.0

### DIFF
--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.53.0
+VER=0.54.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::785248d87d9d1b7608dab5ff85e7af32e6614dbeb4378f430b7102ed4bdd4aa5"
+CHKSUMS="sha256::a46c44f8398ed0d14ca051a08982a3001642449c06a3be1c30944c3e027bbf51"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.54.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.54.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
