### PR TITLE
bear: rebuild for grpc

### DIFF
--- a/app-devel/bear/spec
+++ b/app-devel/bear/spec
@@ -1,4 +1,5 @@
 VER=3.1.6
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/rizsotto/bear"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18436"


### PR DESCRIPTION
Topic Description
-----------------

- bear: rebuild for grpc
    Apparently not all platforms had grpc v1.72.0 when bear 3.1.6
    was built.

Package(s) Affected
-------------------

- bear: 3.1.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bear
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
