### PR TITLE
gstreamer: update to 1.26.4, fix build with rustc >= 1.88

### DIFF
--- a/lang-python/pygobject-3/autobuild/defines
+++ b/lang-python/pygobject-3/autobuild/defines
@@ -11,3 +11,5 @@ ABTYPE=meson
 
 PKGREP="pygobject-3+rt3"
 PKGPROV="pygobject-3+rt3"
+
+PKGEPOCH=1

--- a/lang-python/pygobject-3/spec
+++ b/lang-python/pygobject-3/spec
@@ -1,4 +1,4 @@
-VER=3.52.3
-SRCS="https://download.gnome.org/sources/pygobject/${VER:0:4}/pygobject-$VER.tar.gz"
-CHKSUMS="sha256::00e427d291e957462a8fad659a9f9c8be776ff82a8b76bdf402f1eaeec086d82"
+VER=3.48.2
+SRCS="https://download.gnome.org/sources/pygobject/${VER:0:4}/pygobject-$VER.tar.xz"
+CHKSUMS="sha256::0794aeb4a9be31a092ac20621b5f54ec280f9185943d328b105cdae6298ad1a7"
 CHKUPDATE="anitya::id=13158"

--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -15,7 +15,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         dssim-c openjpeg rav1e libsodium"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
-BUILDDEP="bash-completion gobject-introspection graphviz llvm \
+BUILDDEP="bash-completion gobject-introspection graphviz llvm-20 \
           nasm opencv qt-5 rustc shaderc tomli vulkan-headers \
           vulkan-loader vulkan-validationlayers wayland-protocols"
 PKGDES="A modular and extensible multimedia framework"

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -15,7 +15,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         dssim-c openjpeg rav1e libsodium"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
-BUILDDEP="bash-completion gobject-introspection graphviz llvm \
+BUILDDEP="bash-completion gobject-introspection graphviz llvm-20 \
           nasm shaderc tomli vulkan-headers vulkan-loader \
           vulkan-validationlayers wayland-protocols"
 PKGDES="A modular and extensible multimedia framework"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.26.1
-REL=3
+VER=1.26.4
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.26.1
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.26.4
    Co-authored-by: Ilikara \(@AirFortressIlikara\)
- pygobject-3: downgrade to 3.48.2
    This reverts commit 667e7edcd25a1b91ba7c1e3f65a50e51482128c2.
- gstreamer: fix build for rustc >= 1.88
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gstreamer: 1.26.4
- pygobject-3: 1:3.48.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pygobject-3 gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
