### PR TITLE
lego: update to 4.25.1

### DIFF
--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,4 +1,4 @@
-VER=4.25.0
+VER=4.25.1
 SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20764"

--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,4 +1,4 @@
-VER=4.24.0
+VER=4.25.0
 SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20764"


### PR DESCRIPTION
Topic Description
-----------------

- lego: update to 4.25.1
    Co-authored-by: Billy Yang \(@handsomexdd1024\) <me@venti.love>

Package(s) Affected
-------------------

- lego: 4.25.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lego
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
