### PR TITLE
gstreamer: update to 1.26.4

### DIFF
--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -15,7 +15,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         dssim-c openjpeg rav1e libsodium"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
-BUILDDEP="bash-completion gobject-introspection graphviz llvm \
+BUILDDEP="bash-completion gobject-introspection graphviz llvm-20 \
           nasm opencv qt-5 rustc shaderc tomli vulkan-headers \
           vulkan-loader vulkan-validationlayers wayland-protocols"
 PKGDES="A modular and extensible multimedia framework"

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -15,7 +15,7 @@ PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         dssim-c openjpeg rav1e libsodium"
 PKGDEP__AMD64="${PKGDEP} openmpt svt-hevc"
 PKGDEP__ARM64="${PKGDEP} openmpt"
-BUILDDEP="bash-completion gobject-introspection graphviz llvm \
+BUILDDEP="bash-completion gobject-introspection graphviz llvm-20 \
           nasm shaderc tomli vulkan-headers vulkan-loader \
           vulkan-validationlayers wayland-protocols"
 PKGDES="A modular and extensible multimedia framework"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.26.1
-REL=2
+VER=1.26.4
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.26.4
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- gstreamer: 1.26.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
