### PR TITLE
iosevka-fonts: update to 33.2.7

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.6
+VER=33.2.7
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::cdc5d97f4a417658ec24b85cb35621a79451a366afa28619b613e64d8f605cd9 \
-         sha256::c97f0a3850db9cf30635d19e62d74c3536b089953dfc56ec3c101b0d892a8e03 \
-         sha256::8187170dcd82e0afc73b709f37e16da6f6d703242683c55322059bd058a9ee2a \
-         sha256::67e20e3f6c449d7fe1dc05f06cdd70f2665a2a4ad4905006b71e2ffa8b52103e \
-         sha256::6f1b353b54fa786cbc6f8b4242e897022990a55a2a4dc0af39c03566539092dc \
-         sha256::3c8dfbc7c7c054d16aa0aa9f624947277e7e9f039b9ef70df85c3d961a1182b1 \
-         sha256::5e21a1280a6f4d16dbfa7c7b56cb59840ab5f21f696ad21f41852ffeff16280a \
-         sha256::52e275134c837b5e0cc59ccfb817c25a58a3ea0c6fed7eefafaa66d6ab94fef2 \
-         sha256::7ab66bb56bfec4e0bd9253330662e1461dbb02f8e8c9d80b2ebe559368d45a16 \
-         sha256::265a71b2dcd753226993c681777e755eaff78ac3d92907c0dfc8ea5cd9a189fd \
-         sha256::86946d1c183adb04c095aa52b387cb58f94da34334a039c8f5e6f914d9b873f6 \
-         sha256::40577d6abadcda1fad044e22e95cdc49a62a20078ec956fe526259eb5d796114 \
-         sha256::0b912234a0c90efa784235908476524e4470c70bc82411ed39a4b30b00eff0ec \
-         sha256::43df361b83dcb45f0857640d225864b0dda242420e319992e6330134658980b1 \
-         sha256::162d90f7fed784ccdafa7bae7bc691876b6d9c25cd677f31ee6bcfd13388f2fc \
-         sha256::2cddb861f610dbc68273e830f414fc4b4d215361b0871e5598713668da77d339 \
-         sha256::1b1a4a78f3ebf7f560cb60cd0076f9d859fa784e088deeba5d4051fd48097878 \
-         sha256::0cb258493a2fb8d21eb734ad3681df8dd94fd80439580f85f64233b861a1c215 \
-         sha256::697a255104880045da1dc64995ab4f5414b90bbee30ed3ac81525a06064b7c59 \
-         sha256::7bd5ac6edf8f33f768b561ea07bd0da4e553075d8b27871225afa59a3b41a6e3 \
-         sha256::81c70d968a60c0b9b929a1d9205c48571962555b3773057d4c5792540f969b81 \
-         sha256::d19062a57d2ba455589acdd3e45f0c66db823ad48d9bed9db97236c91359ba21 \
-         sha256::2d0623914952570777377833b8aef162d0c1e7d7486e088ea1789e5575ee4a17 \
-         sha256::17437f0dcbd3570b97e474bf07464eb7dda5b46054496faa751b0ab6546d4e81 \
+CHKSUMS="sha256::1ec79743bb88d3dbe204df44c288402285a9f91c760a98058fcf146afa08206c \
+         sha256::a9e3b3c702bfd5870a180eeba746efbfa2955e83e67bc531f13dbc11993bc85b \
+         sha256::18e68b7f59677d924379c5746373c7e90ab24b77cbf0ead12b1eb2dd9f605c3e \
+         sha256::c6dfcef8c0ca413fd0318c81fd62b08cac47cd1a3d7ee8dbf536f1a9cec66843 \
+         sha256::cd83a4017ab0e71634f2675a9d159b33c1556a5f9db543dfbc6e5da795f7c13c \
+         sha256::b26f1aad5b47600dbc622324c274c586f2d286186f5c54c1c7c34426dbb9a805 \
+         sha256::f8231d777ee4e76ad3abae31ca987eeaabd118efa56cbe697e5196c1f5a7f98b \
+         sha256::4643b7afd1c108a40446567b4c17ca0670aa7b4a04aebb906d2e83444fe44e9f \
+         sha256::b52ebaf70e70890e0b544f84240cc767a9f89f78cf9404b1bf036808f582347e \
+         sha256::0e0c3d564d7136d817f27662119eb09c0fba31d3eec0ec22eb3d2cb4b21833db \
+         sha256::af5842b56b423aa01ad7819e4a5a3e7df5cd5bcfbdfee6422c1f7fba4c0ab562 \
+         sha256::279e43c31ddcba95717666f516936a9736d034a41de88e1eaa2b9d4f849089a8 \
+         sha256::252de7db420754268164f277fb4a67d1bc56ccc2f80104b05038762241dd54b8 \
+         sha256::33f322f5966b9ba21829657a1be704998d702d4afaf0146b0faa283b15c5c0cd \
+         sha256::a3a679e352046dce8c73a4ed872c8e4f93461f70416a12c674065ced7925baf3 \
+         sha256::8f7ee9014b71717d410ae7ec20a3530c1f38d7ec4232aa09e5c6306ee77eab24 \
+         sha256::73935c382ea54a1ccb1d60c4ab32af9cd8e0ea65acd14660a94f9eab4dc1e0f2 \
+         sha256::ddd640fa509b2b4e1ae2a3346b534ade25ccbc35281e837df4fcda9fe2ef423b \
+         sha256::d5a1b1f2635dc5f2f98a2d3782bf82d80b66ca949ca240c5b723b6d01841f3fe \
+         sha256::279210d3ab1ddd7ac1766637ef80d00a0dc1e8601485be6b9673c27014a3d0e4 \
+         sha256::acebd04263c18b26f37c053e2a457f5e53086ea335d70789b707fa6bb15a73a9 \
+         sha256::cf83b268aa872bd4a47dc7c41a9df7374074568d8d4259e6e6a1e92639a9df7b \
+         sha256::721f93e907b9d7fd532c56e441670b8b0919e8cdfb6b6c236d5e0ba22f96d44d \
+         sha256::533496ae185a0c65feb3f0f8a20cc35b23f49f978b5033d3725d03deab86be1e \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.7
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
