### PR TITLE
btrfs-assistant: new, 2.2

### DIFF
--- a/app-admin/btrfs-assistant/autobuild/defines
+++ b/app-admin/btrfs-assistant/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=btrfs-assistant
+PKGSEC=admin
+PKGDEP="btrfs-progs qt-6 polkit"
+PKGSUG="snapper timeshift"
+PKGDES="A Btrfs management tool"
+
+ABTYPE=cmakeninja

--- a/app-admin/btrfs-assistant/spec
+++ b/app-admin/btrfs-assistant/spec
@@ -1,0 +1,4 @@
+VER=2.2
+SRCS="git::commit=tags/$VER::https://gitlab.com/btrfs-assistant/btrfs-assistant.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=254195"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-assistant: new, 2.2
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- btrfs-assistant: 2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-assistant
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
