### PR TITLE
nlohmann-json: update to 3.12.0

### DIFF
--- a/runtime-common/nlohmann-json/spec
+++ b/runtime-common/nlohmann-json/spec
@@ -1,4 +1,4 @@
-VER=3.11.3
+VER=3.12.0
 SRCS="tbl::https://github.com/nlohmann/json/archive/v$VER.tar.gz"
-CHKSUMS="sha256::0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406"
+CHKSUMS="sha256::4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187"
 CHKUPDATE="anitya::id=11152"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

update nlohmann-json to 3.12.0

Package(s) Affected
-------------------

nlohmann-json

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit nlohmann-json
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
