### PR TITLE
ostree: update to 2025.4

### DIFF
--- a/app-admin/ostree/autobuild/defines
+++ b/app-admin/ostree/autobuild/defines
@@ -15,6 +15,9 @@ AUTOTOOLS_AFTER=(
     '--enable-libsoup-client-certs'
     '--enable-man'
     '--enable-man-html'
+    '--disable-gtk-doc'
+    '--disable-gtk-doc-html'
+    '--disable-gtk-doc-pdf'
     '--enable-rofiles-fuse'
     '--with-curl'
     '--without-soup'
@@ -36,3 +39,4 @@ AUTOTOOLS_AFTER=(
 )
 
 ABSHADOW=0
+RECONF=0

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,4 @@
-VER=2025.3
-SRCS="git::commit=tags/v$VER::https://github.com/ostreedev/ostree"
-CHKSUMS="SKIP"
+VER=2025.4
+SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
+CHKSUMS="sha256::014d12d19ea664fae53fe147d3d2c0b7465a3c37e099c87d289df908adeb5669"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: update to 2025.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- ostree: 2025.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
