### PR TITLE
kanshi: update to 1.8.0

### DIFF
--- a/app-utils/kanshi/spec
+++ b/app-utils/kanshi/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
-SRCS="git::commit=tags/v$VER::https://git.sr.ht/~emersion/kanshi"
+VER=1.8.0
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/emersion/kanshi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=94895"


### PR DESCRIPTION
Topic Description
-----------------

- kanshi: update to 1.8.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- kanshi: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit kanshi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
