### PR TITLE
gn: update to 0+git20250718

### DIFF
--- a/app-devel/gn/spec
+++ b/app-devel/gn/spec
@@ -1,3 +1,3 @@
-VER=0+git20250311
-SRCS="git::commit=18602f6cf1168cf78302024043edc02e8bad2ffb;copy-repo=true::https://gn.googlesource.com/gn"
+VER=0+git20250718
+SRCS="git::commit=85f62c164c829442fb662f6aa1243c02bcc47155;copy-repo=true::https://gn.googlesource.com/gn"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- gn: update to 0+git20250718

Package(s) Affected
-------------------

- gn: 1:0+git20250718

Security Update?
----------------

No

Build Order
-----------

```
#buildit gn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
