### PR TITLE
nodejs-22: update to 22.17.1

### DIFF
--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,6 +1,6 @@
-VER=22.16.0
+VER=22.17.1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::720894F323E5C1AC24968EB2676660C90730D715CB7F090BE71A668662A17C37"
+CHKSUMS="sha256::327415FD76FCEBB98133BF56E2D90E3AC048B038FAC2676F03B6DB91074575B9"
 CHKUPDATE="anitya::id=374342"
 # Note: Node.js currently requires large memory to build. 
 #       Prefer 3C5000 (or faster) build hosts.


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: update to 22.17.1

Package(s) Affected
-------------------

- nodejs-22: 22.17.1

Security Update?
----------------

No

Linux is actually not affected by the vulnerability mentioned at <https://nodejs.org/en/blog/vulnerability/july-2025-security-releases> .

Build Order
-----------

```
#buildit nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
