### PR TITLE
flashrom: update to 1.6.0

### DIFF
--- a/app-admin/flashrom/autobuild/defines
+++ b/app-admin/flashrom/autobuild/defines
@@ -1,14 +1,16 @@
 PKGNAME=flashrom
 PKGDES="A utility for identifying, reading, writing, verifying and erasing flash chips"
-PKGDEP="libusb libftdi pciutils libusb-compat"
-BUILDDEP="cmocka"
+PKGDEP="libusb libftdi pciutils libjaylink"
+BUILDDEP="cmocka sphinx"
 PKGSEC=admin
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+    '-Dman-pages=enabled'
+    '-Ddocumentation=disabled'
+)
 
 # Note: To handle misbundling of flashrom files in fwupd.
 PKGBREAK="fwupd<=1.8.14"
 PKGREP="fwupd<=1.8.14"
-
-# FIXME: currently a hack for LTO crashing on arm64, needs fixing GCC
-NOLTO__ARM64=1

--- a/app-admin/flashrom/spec
+++ b/app-admin/flashrom/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
-SRCS="tbl::https://download.flashrom.org/releases/flashrom-v$VER.tar.bz2"
-CHKSUMS="sha256::a053234453ccd012e79f3443bdcc61625cf97b7fd7cb4cdd8bfbffbe8b149623"
+VER=1.6.0
+SRCS="tbl::https://download.flashrom.org/releases/flashrom-v$VER.tar.xz"
+CHKSUMS="sha256::8b9db3987df9b5fc81e70189d017905dd5f6be1e1410347f22687ab6d4c94423"
 CHKUPDATE="anitya::id=10202"


### PR DESCRIPTION
Topic Description
-----------------

- flashrom: update to 1.6.0
    - Adjust PKGDEP.
    - Enable LTO on arm64.

Package(s) Affected
-------------------

- flashrom: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flashrom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
