### PR TITLE
cbindgen: update to 0.29.0

### DIFF
--- a/lang-rust/cbindgen/autobuild/defines
+++ b/lang-rust/cbindgen/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="llvm rustc"
 PKGDES="A project for generating C bindings from Rust code"
 
 USECLANG=1
-NOLTO__LOONGSON3=1
 ABSPLITDBG=0

--- a/lang-rust/cbindgen/spec
+++ b/lang-rust/cbindgen/spec
@@ -1,4 +1,4 @@
-VER=0.28.0
+VER=0.29.0
 SRCS="git::commit=tags/v$VER::https://github.com/mozilla/cbindgen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16690"


### PR DESCRIPTION
Topic Description
-----------------

- cbindgen: update to 0.29.0
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- cbindgen: 0.29.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cbindgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
