### PR TITLE
bitwarden: update to 2025.7.0

### DIFF
--- a/app-utils/bitwarden/autobuild/defines
+++ b/app-utils/bitwarden/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=bitwarden
 PKGSEC=utils
 PKGDEP="libsecret glib x11-lib"
-BUILDDEP="nodejs rustc llvm"
+BUILDDEP="nodejs rustc llvm-20"
 PKGDES="A desktop client for Bitwarden password manager"
 
 # FIXME: USECLANG fails on arm64 with

--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,4 +1,4 @@
-From 9137a94f5cbced3074f8846522bae96506af14f2 Mon Sep 17 00:00:00 2001
+From d094d2ef861f9d6fec665b70dfc9db015308f9e9 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
 Subject: [PATCH 1/2] napi: prefer glibc instead of musl libc
@@ -36,5 +36,5 @@ index acfd0dffb8..bfb0e4aa69 100644
          );
          localFileExisted = existsSync(join(__dirname, "desktop_napi.linux-arm-gnueabihf.node"));
 -- 
-2.49.0
+2.50.1
 

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,4 +1,4 @@
-From c70e792aea6608037859d549e1d0850051b2e7bf Mon Sep 17 00:00:00 2001
+From ef75cd6a2bc2f968631f53baba77d8b1f658682d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
 Subject: [PATCH 2/2] napi: enable lto
@@ -9,10 +9,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index f5b6d6b7c0..960cb4c96f 100644
+index 669f166e74..5d9f108617 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -31,3 +31,9 @@ windows-registry = { workspace = true }
+@@ -33,3 +33,9 @@ windows_plugin_authenticator = { path = "../windows_plugin_authenticator" }
  
  [build-dependencies]
  napi-build = { workspace = true }
@@ -23,5 +23,5 @@ index f5b6d6b7c0..960cb4c96f 100644
 +strip = false
 +incremental = false
 -- 
-2.49.0
+2.50.1
 

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2025.6.1
+VER=2025.7.0
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2025.7.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- bitwarden: 2025.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
