### PR TITLE
telegram-desktop: update to 5.16.5

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=5.16.4
+VER=5.16.5
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
 TDLIBVER=0ece11a1ae5aa514a76a459f4904276494434bd2
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::cad9dba07c5814bd83463be89b160cef57832e16b9973f13e195afe10c164072 \
+CHKSUMS="sha256::ea0da730a2ac63dbbcc0c9039ca872f2d04cedb2443025c95cf51b553a88dd9c \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 5.16.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 5.16.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
