### PR TITLE
xray: update to 25.7.25

### DIFF
--- a/app-proxy/xray/spec
+++ b/app-proxy/xray/spec
@@ -1,4 +1,4 @@
-VER=25.6.8
+VER=25.7.25
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/XTLS/Xray-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"


### PR DESCRIPTION
Topic Description
-----------------

- xray: update to 25.7.25
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- xray: 25.7.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
