### PR TITLE
ninja: update to 1.13.1

### DIFF
--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -1,5 +1,4 @@
-VER=1.12.1
+VER=1.13.1
 SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2089"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ninja: update to 1.13.1

Package(s) Affected
-------------------

- ninja: 1.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
