### PR TITLE
vscode: update to 1.102.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.102.1
+VER=1.102.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::da0c3893d5c3a8eb85ecfc72751f969632f1afad2a8037acee5673fa2674001d"
-CHKSUMS__ARM64="sha256::b89a3ad40f89eea0b354a73f93b1a5d77eacdcc04adfeebd2c8fc4365ef1b6a3"
+CHKSUMS__AMD64="sha256::2e035c295ca28f0eebc99d39e3b4f602b30eb4af0b65d94b7b35d0eb7bf7f0ea"
+CHKSUMS__ARM64="sha256::e5262b8c4a53bcb56519c8c7f362f5fce3e9e988ff1b97b224af7edad5ef657e"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.102.2

Package(s) Affected
-------------------

- vscode: 1.102.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
