### PR TITLE
hwinfo: update to 25.0

### DIFF
--- a/app-utils/hwinfo/spec
+++ b/app-utils/hwinfo/spec
@@ -1,4 +1,4 @@
-VER=23.2
+VER=25.0
 SRCS="git::commit=tags/$VER::https://github.com/openSUSE/hwinfo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13400"


### PR DESCRIPTION
Topic Description
-----------------

- hwinfo: update to 25.0

Package(s) Affected
-------------------

- hwinfo: 25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hwinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
