### PR TITLE
qtscrcpy: update to 3.3.1

### DIFF
--- a/app-utils/qtscrcpy/autobuild/defines
+++ b/app-utils/qtscrcpy/autobuild/defines
@@ -2,5 +2,8 @@ PKGNAME=qtscrcpy
 PKGSEC=utils
 PKGDES="Display and control your Android device (Qt frontend)"
 PKGDEP="qt-6 android-platform-tools ffmpeg"
-#Note: Use Qt 6
-CMAKE_AFTER="-DQT_ROOT=/usr/lib/cmake/Qt6"
+# Note: Use Qt 6
+CMAKE_AFTER=(
+    '-DQT_ROOT=/usr/lib/cmake/Qt6'
+)
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/app-utils/qtscrcpy/autobuild/patches/0003-Modify-the-hard-coded-paths-to-properly-access-resou.patch
+++ b/app-utils/qtscrcpy/autobuild/patches/0003-Modify-the-hard-coded-paths-to-properly-access-resou.patch
@@ -1,35 +1,23 @@
-From 1ba3918248bd6c87214c82dc52c6ccc48a456416 Mon Sep 17 00:00:00 2001
-From: Shyliuli <1658347525@qq.com>
-Date: Thu, 1 May 2025 19:04:05 +0800
-Subject: [PATCH 3/5] Modify the hard-coded paths to properly access resources
- stored in the /usr/share directory
-
----
- QtScrcpy/audio/audiooutput.cpp | 25 ++++++++++++++++++++++---
- QtScrcpy/ui/dialog.cpp         | 19 ++++++++++++++++---
- 2 files changed, 38 insertions(+), 6 deletions(-)
-
 diff --git a/QtScrcpy/audio/audiooutput.cpp b/QtScrcpy/audio/audiooutput.cpp
-index 033abc8..30985a2 100644
+index e6825f7..bd5ea5f 100644
 --- a/QtScrcpy/audio/audiooutput.cpp
 +++ b/QtScrcpy/audio/audiooutput.cpp
-@@ -3,7 +3,9 @@
- #include <QAudioOutput>
+@@ -5,6 +5,10 @@
+ #include <QTcpSocket>
  #include <QTime>
- #include <QElapsedTimer>
--
+ 
 +#include <QStandardPaths>
 +#include <QFileInfo>
 +#include <QCoreApplication>
++
  #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
  #include <QAudioSink>
  #include <QAudioDevice>
-@@ -73,6 +75,23 @@ void AudioOutput::installonly(const QString &serial, int port)
- {
+@@ -75,6 +79,21 @@ void AudioOutput::installonly(const QString &serial, int port)
      runSndcpyProcess(serial, port, false);
  }
-+#ifdef Q_OS_WIN32
-+#else
+ 
++#ifndef Q_OS_WIN32
 +QString tryFindSndcpy()
 +{
 +    QStringList paths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
@@ -44,42 +32,37 @@ index 033abc8..30985a2 100644
 +}
 +#endif
 +
-+
- 
  bool AudioOutput::runSndcpyProcess(const QString &serial, int port, bool wait)
  {
-@@ -82,9 +101,9 @@ bool AudioOutput::runSndcpyProcess(const QString &serial, int port, bool wait)
- 
- #ifdef Q_OS_WIN32
+     if (QProcess::NotRunning != m_sndcpy.state()) {
+@@ -85,7 +104,7 @@ bool AudioOutput::runSndcpyProcess(const QString &serial, int port, bool wait)
      QStringList params{serial, QString::number(port)};
--    m_sndcpy.start("sndcpy.bat", params);
-+    m_sndcpy.start(tryFindSndcpy(), params);
+     m_sndcpy.start("sndcpy.bat", params);
  #else
 -    QStringList params{"sndcpy.sh", serial, QString::number(port)};
 +    QStringList params{tryFindSndcpy(), serial, QString::number(port)};
+     m_sndcpy.setWorkingDirectory(QCoreApplication::applicationDirPath());
      m_sndcpy.start("bash", params);
  #endif
- 
 diff --git a/QtScrcpy/ui/dialog.cpp b/QtScrcpy/ui/dialog.cpp
-index ea59d23..94f421a 100644
+index ea59d23..dae7361 100644
 --- a/QtScrcpy/ui/dialog.cpp
 +++ b/QtScrcpy/ui/dialog.cpp
-@@ -5,7 +5,9 @@
- #include <QRandomGenerator>
+@@ -6,6 +6,10 @@
  #include <QTime>
  #include <QTimer>
--
+ 
 +#include <QStandardPaths>
 +#include <QFileInfo>
 +#include <QCoreApplication>
++
  #include "config.h"
  #include "dialog.h"
  #include "ui_dialog.h"
-@@ -743,7 +745,18 @@ quint32 Dialog::getBitRate()
-     return ui->bitRateEdit->text().trimmed().toUInt() *
+@@ -744,6 +748,19 @@ quint32 Dialog::getBitRate()
              (ui->bitRateBox->currentText() == QString("Mbps") ? 1000000 : 1000);
  }
--
+ 
 +QString tryFindScrcpyServer()
 +{
 +    QStringList paths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
@@ -92,10 +75,11 @@ index ea59d23..94f421a 100644
 +    QString fallback = QCoreApplication::applicationDirPath() + "/scrcpy-server";
 +    return fallback;
 +}
++
  const QString &Dialog::getServerPath()
  {
      static QString serverPath;
-@@ -751,7 +764,7 @@ const QString &Dialog::getServerPath()
+@@ -751,7 +768,7 @@ const QString &Dialog::getServerPath()
          serverPath = QString::fromLocal8Bit(qgetenv("QTSCRCPY_SERVER_PATH"));
          QFileInfo fileInfo(serverPath);
          if (serverPath.isEmpty() || !fileInfo.isFile()) {
@@ -104,6 +88,4 @@ index ea59d23..94f421a 100644
          }
      }
      return serverPath;
--- 
-2.49.0
 

--- a/app-utils/qtscrcpy/spec
+++ b/app-utils/qtscrcpy/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.3.1
 # The upstream use a ssh repo, which can't be handled correctly.
 # So I replace it with the HTTP repo in the patch, and update it in the prepare.
 SRCS="git::submodule=false;copy-repo=true;commit=tags/v$VER::https://github.com/barry-ran/QtScrcpy.git"


### PR DESCRIPTION
Topic Description
-----------------

- qtscrcpy: update to 3.3.1

Package(s) Affected
-------------------

- qtscrcpy: 3.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtscrcpy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

