### PR TITLE
ncdu: update to 1.22

### DIFF
--- a/app-utils/ncdu/spec
+++ b/app-utils/ncdu/spec
@@ -1,4 +1,4 @@
-VER=1.16
+VER=1.22
 SRCS="tbl::https://dev.yorhel.nl/download/ncdu-$VER.tar.gz"
-CHKSUMS="sha256::2b915752a183fae014b5e5b1f0a135b4b408de7488c716e325217c2513980fd4"
+CHKSUMS="sha256::0ad6c096dc04d5120581104760c01b8f4e97d4191d6c9ef79654fa3c691a176b"
 CHKUPDATE="anitya::id=6045"


### PR DESCRIPTION
Topic Description
-----------------

- ncdu: update to 1.22

Package(s) Affected
-------------------

- ncdu: 1.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncdu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
