### PR TITLE
vkpeak: update to 20250531

### DIFF
--- a/app-utils/vkpeak/autobuild/defines
+++ b/app-utils/vkpeak/autobuild/defines
@@ -1,5 +1,3 @@
 PKGNAME=vkpeak
 PKGSEC=utils
-PKGDEP="vulkan-loader"
-BUILDDEP="vulkan-headers"
 PKGDES="Measure peak performance using Vulkan"

--- a/app-utils/vkpeak/spec
+++ b/app-utils/vkpeak/spec
@@ -1,4 +1,4 @@
-VER=20240505
+VER=20250531
 SRCS="git::commit=tags/$VER::https://github.com/nihui/vkpeak"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375832"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

update to 20250531
vulkan-header and vulkan-loader are not needed, drop the deps

Package(s) Affected
-------------------

vkpeak

Security Update?
----------------

No

Build Order
-----------


Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
