### PR TITLE
mediainfo: update to 25.04

### DIFF
--- a/app-multimedia/mediainfo/spec
+++ b/app-multimedia/mediainfo/spec
@@ -1,5 +1,5 @@
-VER=24.12
+VER=25.04
 SRCS="https://mediaarea.net/download/source/mediainfo/$VER/mediainfo_$VER.tar.xz"
-CHKSUMS="sha256::3699ae650ce71893a932ce2eaa2a35f8da47e6f721f93d695b0beb0aad4e9997"
+CHKSUMS="sha256::4b2553fe9104332d3baca5fe61b6b87af4d493108c5b863801cdb0a4826a33ae"
 CHKUPDATE="anitya::id=8240"
 SUBDIR="MediaInfo/Project/GNU/CLI"


### PR DESCRIPTION
Topic Description
-----------------

- mediainfo: update to 25.04

Package(s) Affected
-------------------

- mediainfo: 25.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit mediainfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
