### PR TITLE
nginx: update to 1.28.0

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,4 +1,5 @@
-VER=1.27.4
+# Stable branch
+VER=1.28.0
 SRCS="tbl::https://nginx.org/download/nginx-$VER.tar.gz"
-CHKSUMS="sha256::294816f879b300e621fa4edd5353dd1ec00badb056399eceb30de7db64b753b2"
+CHKSUMS="sha256::c6b5c6b086c0df9d3ca3ff5e084c1d0ef909e6038279c71c1c3e985f576ff76a"
 CHKUPDATE="anitya::id=5413"


### PR DESCRIPTION
Topic Description
-----------------

- nginx: update to 1.28.0

Package(s) Affected
-------------------

- nginx: 1.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
