### PR TITLE
lxgwcleargothic-font: update to 0.503

### DIFF
--- a/desktop-fonts/lxgwcleargothic-font/spec
+++ b/desktop-fonts/lxgwcleargothic-font/spec
@@ -1,8 +1,8 @@
-VER=0.300.4
+VER=0.503
 SRCS="file::rename=LXGWXiHeiCL.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiCL.ttf \
       file::rename=LXGWXiHeiMN.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiMN.ttf
       file::rename=LICENSE.md::https://raw.githubusercontent.com/lxgw/LxgwXiHei/v$VER/LICENSE.md"
-CHKSUMS="sha256::7bc05c32f5741c830676ea2346d80af050b452d9407f36051da13e54378930a6 \
-         sha256::e7102c3cae0934a6d0d08796ab079d97dbcc017491daca1b44ab501cc85a6660 \
+CHKSUMS="sha256::d7789de0ca4954ea900cd75b1aa1f7735b3ce20d116a1723f56b888ce8e536e6 \
+         sha256::e9408f431996b4a9c1227a0f26f2ab4001cdbfab412ece085485a4703009d745 \
          sha256::a186b1f3ad4b8d56a43dc96637ce55f5aa4f4446025d6247641d4ef13c4bb29b"
 CHKUPDATE="anitya::id=234782"


### PR DESCRIPTION
Topic Description
-----------------

- lxgwcleargothic-font: update to 0.503
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- lxgwcleargothic-font: 0.503

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
