### PR TITLE
nexttrace: update to 1.4.2

### DIFF
--- a/app-network/nexttrace/autobuild/defines
+++ b/app-network/nexttrace/autobuild/defines
@@ -4,5 +4,4 @@ PKGDES="Command line tool for visual route tracking"
 PKGDEP="gcc-runtime"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
-ABSPLITDBG=0
+ABTYPE=gomod

--- a/app-network/nexttrace/autobuild/prepare
+++ b/app-network/nexttrace/autobuild/prepare
@@ -3,7 +3,7 @@ COMMIT=$(git rev-parse --short HEAD)
 DATE=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
 
 abinfo "Setting GO_LDFLAGS ..."
-GO_LDFLAGS+=(
+GO_LDFLAGS=(
     "-X 'github.com/nxtrace/NTrace-core/config.Version=$PKGVER'"
     "-X 'github.com/nxtrace/NTrace-core/config.CommitID=$COMMIT'"
     "-X 'github.com/nxtrace/NTrace-core/config.BuildDate=$DATE'"

--- a/app-network/nexttrace/spec
+++ b/app-network/nexttrace/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
+VER=1.4.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/nxtrace/NTrace-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=356726"


### PR DESCRIPTION
Topic Description
-----------------

- nexttrace: update to 1.4.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- nexttrace: 1.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nexttrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
