### PR TITLE
cifs-utils: update to 7.4

### DIFF
--- a/app-network/cifs-utils/spec
+++ b/app-network/cifs-utils/spec
@@ -1,5 +1,4 @@
-VER=7.0
-REL=2
+VER=7.4
 SRCS="tbl::https://download.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-$VER.tar.bz2"
-CHKSUMS="sha256::0defaab85bd3ea46ffc45ab41fb0d0ad54d05ae2cfaa7e503de86d4f12bc8161"
+CHKSUMS="sha256::53353d05c30b4fc9dac006a8f0c5054cdd8a1834c176313c91e4694025c4b891"
 CHKUPDATE="anitya::id=287"


### PR DESCRIPTION
Topic Description
-----------------

- cifs-utils: update to 7.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cifs-utils: 7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit cifs-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
