### PR TITLE
filezilla: update to 3.69.2

### DIFF
--- a/app-network/filezilla/spec
+++ b/app-network/filezilla/spec
@@ -1,4 +1,4 @@
-VER=3.66.4
-SRCS="tbl::https://download.filezilla-project.org/client/FileZilla_${VER}_src.tar.xz"
-CHKSUMS="sha256::a40f04e02efaae7b50d1515ee1c36c4b0e445818566c450e440bfd6c70e9b203"
+VER=3.69.2
+SRCS="svn::commit=11290::https://svn.filezilla-project.org/svn/FileZilla3/trunk"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=809"

--- a/runtime-web/libfilezilla/spec
+++ b/runtime-web/libfilezilla/spec
@@ -1,4 +1,4 @@
-VER=0.45.0
-SRCS="tbl::https://download.filezilla-project.org/libfilezilla/libfilezilla-$VER.tar.xz"
-CHKSUMS="sha256::3c1454bc1586d17776f62c7505d43a06d3abd2e2e35642cca477fa22f27d982f"
+VER=0.51.0
+SRCS="svn::commit=11287::https://svn.filezilla-project.org/svn/libfilezilla/trunk"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15391"


### PR DESCRIPTION
Topic Description
-----------------

- filezilla: update to 3.69.2
    Co-authored-by: Suyun \(@Suyun114\)
- libfilezilla: update to 0.51.0

Package(s) Affected
-------------------

- filezilla: 3.69.2
- libfilezilla: 0.51.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfilezilla filezilla
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
