### PR TITLE
nginx: add ngx_brotli module

### DIFF
--- a/app-web/nginx/autobuild/build
+++ b/app-web/nginx/autobuild/build
@@ -41,7 +41,8 @@ abinfo "Configuring nginx ..."
     --with-stream_realip_module \
     --with-stream_ssl_module \
     --with-stream_ssl_preread_module \
-    --with-threads
+    --with-threads \
+    --add-module="$SRCDIR/../ngx_brotli"
 
 abinfo "Building nginx ..."
 make

--- a/app-web/nginx/autobuild/patches/0002-add-comments-about-compression-in-nginx.conf.patch
+++ b/app-web/nginx/autobuild/patches/0002-add-comments-about-compression-in-nginx.conf.patch
@@ -1,0 +1,16 @@
+diff --git a/conf/nginx.conf b/conf/nginx.conf
+index 29bc085f2..9432b06a7 100644
+--- a/conf/nginx.conf
++++ b/conf/nginx.conf
+@@ -29,8 +29,10 @@ http {
+ 
+     #keepalive_timeout  0;
+     keepalive_timeout  65;
+-
++    # To enable gzip compression, uncomment the following line.
+     #gzip  on;
++    # To enable brotli compression, uncomment the following line.
++    #brotli on;
+ 
+     server {
+         listen       80;

--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,5 +1,12 @@
-# Stable branch
-VER=1.28.0
-SRCS="tbl::https://nginx.org/download/nginx-$VER.tar.gz"
-CHKSUMS="sha256::c6b5c6b086c0df9d3ca3ff5e084c1d0ef909e6038279c71c1c3e985f576ff76a"
+NGINX_VER=1.28.0
+BROTLI_VER=1.0.0~rc1+git20231009
+VER="${NGINX_VER}+brotli${BROTLI_VER}"
+# Note: After v1.0.0rc, there are still some necessary updates (including upstream submodules), 
+# so the following commit refers to the latest one in master branch.
+SRCS="tbl::https://nginx.org/download/nginx-$NGINX_VER.tar.gz \
+      git::commit=a71f9312c2deb28875acc7bacfdd5695a111aa53;rename=ngx_brotli::https://github.com/google/ngx_brotli.git"
+CHKSUMS="sha256::c6b5c6b086c0df9d3ca3ff5e084c1d0ef909e6038279c71c1c3e985f576ff76a \
+         SKIP"
 CHKUPDATE="anitya::id=5413"
+SUBDIR="nginx-$NGINX_VER"
+


### PR DESCRIPTION
Topic Description
-----------------

- nginx: add ngx_brotli module

Package(s) Affected
-------------------

- nginx: 1.28.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
