### PR TITLE
dracut-ng: update to 107

### DIFF
--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,4 @@
-VER=106
-REL=1
+VER=107
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: update to 107
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- dracut-ng: 107

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
