### PR TITLE
icewm: update to 3.8.1

### DIFF
--- a/desktop-wm/icewm/spec
+++ b/desktop-wm/icewm/spec
@@ -1,4 +1,4 @@
-VER=3.6.0
+VER=3.8.1
 SRCS="tbl::https://github.com/ice-wm/icewm/releases/download/${VER}/icewm-${VER}.tar.lz"
-CHKSUMS="sha256::979fafd3a3371f73cbafe592e2be052475637ac4bb4385bb132331fd6924bc76"
+CHKSUMS="sha256::3c525512b1e4f4cf7999a4687f1b82311d7448d8c174780b5efd3b8aafbfb4a2"
 CHKUPDATE="anitya::id=1358"


### PR DESCRIPTION
Topic Description
-----------------

- icewm: update to 3.8.1
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- icewm: 3.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit icewm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
