### PR TITLE
aide: update to 0.19.1

### DIFF
--- a/app-utils/aide/autobuild/defines
+++ b/app-utils/aide/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=aide
 PKGSEC=utils
-PKGDEP="elfutils mhash"
+PKGDEP="elfutils"
 PKGDES="File integrity checker and intrusion detector"
 
-AUTOTOOLS_AFTER="--with-mhash --with-posix-acl --with-xattr \
+AUTOTOOLS_AFTER="--with-posix-acl --with-xattr \
                  --with-zlib --with-e2fsattrs --disable-static"
 ABSHADOW=no

--- a/app-utils/aide/spec
+++ b/app-utils/aide/spec
@@ -1,4 +1,3 @@
-VER=0.16.2
+VER=0.19.1
 SRCS="tbl::https://github.com/aide/aide/releases/download/v$VER/aide-$VER.tar.gz"
-CHKSUMS='sha256::17f998ae6ae5afb9c83578e4953115ab8a2705efc50dee5c6461cef3f521b797'
-CHKUPDATE="anitya::id=10341"
+CHKSUMS="sha256::6df8bf5f0403d74af7dbdb91eb3c8f61fe07e964669db8cfa1ee7e4ee3e90b52"


### PR DESCRIPTION
Topic Description
-----------------

- aide: update to 0.19.1
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- aide: 0.19.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
