### PR TITLE
sbsigntool: update to 0.9.5

### DIFF
--- a/app-admin/sbsigntool/spec
+++ b/app-admin/sbsigntool/spec
@@ -1,5 +1,4 @@
-VER=0.9.4
-REL=2
+VER=0.9.5
 SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16340"


### PR DESCRIPTION
Topic Description
-----------------

- sbsigntool: update to 0.9.5
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- sbsigntool: 0.9.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbsigntool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
