### PR TITLE
telegram-desktop: fix taskbar icon on Wayland

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0013-Fix-desktop-file-name-on-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-Fix-desktop-file-name-on-Qt-5.patch
@@ -1,0 +1,41 @@
+From d0e73422d952c5c061f8c85bc4294291fb3d421e Mon Sep 17 00:00:00 2001
+From: Kirikaze Chiyuki <me@chyk.ink>
+Date: Sun, 27 Jul 2025 16:15:27 +0800
+Subject: [PATCH] Fix desktop file name on Qt 5
+
+- Fixed missing task selector icon on Wayland
+---
+ Telegram/SourceFiles/platform/linux/specific_linux.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+index 1710805..b2af33a 100644
+--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+@@ -27,6 +27,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "base/platform/linux/base_linux_xcb_utilities.h"
+ #endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION
+ 
++#include <QtGlobal>
+ #include <QtWidgets/QApplication>
+ #include <QtWidgets/QSystemTrayIcon>
+ #include <QtCore/QStandardPaths>
+@@ -693,8 +694,14 @@ void start() {
+ 			return u"org.telegram.desktop._%1"_q.arg(
+ 				Core::Launcher::Instance().instanceHash().constData());
+ 		}
+-
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
++		// Qt 6
+ 		return u"org.telegram.desktop"_q;
++#else
++		// Qt 5 requires full desktop file name
++		// fix for task selector icon on Wayland
++		return u"org.telegram.desktop.desktop"_q;
++#endif
+ 	}());
+ 
+ 	LOG(("App ID: %1").arg(QGuiApplication::desktopFileName()));
+-- 
+2.50.1
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.16.6
+REL=1
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
 TDLIBVER=6d74326c5ce53aeb52496f157f0080d9b8515970


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: fix taskbar icon on Wayland

<img width="835" height="119" alt="图片" src="https://github.com/user-attachments/assets/44e7b62d-84f0-4d9a-af0e-f4d204aa4e8a" />

Telegram Desktop is written in Qt 6, but is built with Qt 5 on AOSC OS. Because of an API change on `setDesktopFilename`, task selector icon breaks on KDE Wayland.

This pull request fixes the issue by introducing a patch.

Package(s) Affected
-------------------

- telegram-desktop: 5.16.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
