### PR TITLE
efibootmgr: backport patch to fix boot reordering


### DIFF
--- a/app-admin/efibootmgr/autobuild/defines
+++ b/app-admin/efibootmgr/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=efibootmgr
 PKGSEC=admin
-PKGDEP="pciutils zlib efivar"
+PKGDEP="glibc pciutils zlib efivar"
 PKGDES="A tool to modify UEFI Firmware Boot Manager variables"
 

--- a/app-admin/efibootmgr/autobuild/patches/0001-BACKPORT-Fix-boot-reorder.patch
+++ b/app-admin/efibootmgr/autobuild/patches/0001-BACKPORT-Fix-boot-reorder.patch
@@ -1,0 +1,32 @@
+From 3eac27c5fccf93d2d6e634d6fe2a76d06708ec6e Mon Sep 17 00:00:00 2001
+From: kmicki <1463619+kmicki@users.noreply.github.com>
+Date: Tue, 15 Nov 2022 14:37:25 +0100
+Subject: [PATCH] Update efibootmgr.c
+X-Developer-Signature: v=1; a=openpgp-sha256; l=485; i=xtexchooser@duck.com;
+ h=from:subject; bh=ZzUVhQTprv7kb20zoiOQQavHeswfkvzpzF8bpICoADE=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBkdVgZn76wXvnZOddvHwBzD6Qwu7jGthkYapbbxv2ZUH
+ 1hsE87cUcrCIMbFICumyFJk2ODNqpPOL7qsXBZmDisTyBAGLk4BmEgqH8N/l3l3Gfo+FB9ht9bf
+ cM2V47jBbpcSHtET9qZXs+q22259xvA/6PjNZR9VeKoc4zo8NsWa2m8zerHBb/3M9K0XtktNWdD
+ HCwA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+get_entry: return entry if it was found before reaching the end of the list
+
+Signed-off-by: kmicki <1463619+kmicki@users.noreply.github.com>
+---
+ src/efibootmgr.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/efibootmgr.c b/src/efibootmgr.c
+index b980bcd..4b15d6d 100644
+--- a/src/efibootmgr.c
++++ b/src/efibootmgr.c
+@@ -1192,6 +1192,7 @@ get_entry(list_t *entries, uint16_t num)
+ 			entry = NULL;
+ 			continue;
+ 		}
++		return entry;
+ 	}
+ 
+ 	return entry;

--- a/app-admin/efibootmgr/spec
+++ b/app-admin/efibootmgr/spec
@@ -1,4 +1,5 @@
 VER=18
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/rhinstaller/efibootmgr"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=663"


### PR DESCRIPTION
Topic Description
-----------------

- efibootmgr: backport patch to fix boot reordering

Package(s) Affected
-------------------

- efibootmgr: 18-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit efibootmgr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
