### PR TITLE
ruri: update to 3.9-beta1

### DIFF
--- a/app-admin/ruri/spec
+++ b/app-admin/ruri/spec
@@ -1,4 +1,4 @@
-VER=3.8 
+VER=3.9-beta1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/Moe-Hacker/ruri" 
 CHKSUMS="SKIP" 
 CHKUPDATE="anitya::id=376165"


### PR DESCRIPTION
Topic Description
-----------------

- ruri: update to 3.9-beta1
    Co-authored-by: \(@dabao1955\) <dabao1955@163.com>

Package(s) Affected
-------------------

- ruri: 3.9-beta1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ruri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
