### PR TITLE
 gstreamer: add loongarch64_nosimd compile option

### DIFF
--- a/runtime-multimedia/gstreamer/autobuild/defines
+++ b/runtime-multimedia/gstreamer/autobuild/defines
@@ -82,6 +82,7 @@ MESON_AFTER__LOONGARCH64=(
     "${MESON_AFTER[@]}"
     '-Ddevtools=disabled'
 )
+MESON_AFTER__LOONGARCH64_NOSIMD=("${MESON_AFTER__LOONGARCH64[@]}")
 
 ABTYPE=meson
 

--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -82,6 +82,7 @@ MESON_AFTER__LOONGARCH64=(
     "${MESON_AFTER[@]}"
     '-Ddevtools=disabled'
 )
+MESON_AFTER__LOONGARCH64_NOSIMD=("${MESON_AFTER__LOONGARCH64[@]}")
 
 ABTYPE=meson
 

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,4 +1,5 @@
 VER=1.26.4
+REL=1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: add loongarch64_nosimd compile option
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gstreamer: 1.26.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
