### PR TITLE
mmdebstrap: new, 1.5.7

### DIFF
--- a/app-utils/mmdebstrap/autobuild/build
+++ b/app-utils/mmdebstrap/autobuild/build
@@ -1,0 +1,23 @@
+abinfo "Building mmdebstrap ..."
+source <(perl -V:vendorarch)
+mkdir -p "$PKGDIR""$vendorarch"
+h2ph -d "$PKGDIR""$vendorarch" -a syscall.h sys/ioctl.h || true
+
+abinfo "Installing mmdebstrap ..."
+mkdir -vp "$PKGDIR"/usr/bin
+cp -va mmdebstrap "$PKGDIR"/usr/bin/mmdebstrap
+cp -va tarfilter "$PKGDIR"/usr/bin/mmtarfilter
+cp -va mmdebstrap-autopkgtest-build-qemu "$PKGDIR"/usr/bin/mmdebstrap-autopkgtest-build-qemu
+mkdir -vp "$PKGDIR"/usr/libexec/apt/solvers
+cp -va proxysolver "$PKGDIR"/usr/libexec/apt/solvers/mmdebstrap-dump-solution
+mkdir -vp "$PKGDIR"/usr/share/mmdebstrap
+cp -va hooks "$PKGDIR"/usr/share/mmdebstrap
+mkdir -vp "$PKGDIR"/usr/libexec/mmdebstrap
+cp -va gpgvnoexpkeysig "$PKGDIR"/usr/libexec/mmdebstrap
+cp -va ldconfig.fakechroot "$PKGDIR"/usr/libexec/mmdebstrap
+
+abinfo "Installing docs ..."
+mkdir -vp "$PKGDIR"/usr/share/man/man1
+pod2man mmdebstrap > "$PKGDIR"/usr/share/man/man1/mmdebstrap.1
+
+abinfo "Complete install mmdebstrap!"

--- a/app-utils/mmdebstrap/autobuild/defines
+++ b/app-utils/mmdebstrap/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=mmdebstrap
+PKGSEC=utils
+PKGDEP=""
+PKGDES="create a Debian chroot with super cow power from apt"
+PKGRECOM="gnupg debian-archive-keyring debian-ports-archive-keyring ubuntu-keyring"
+ABHOST=noarch

--- a/app-utils/mmdebstrap/spec
+++ b/app-utils/mmdebstrap/spec
@@ -1,0 +1,4 @@
+VER=1.5.7
+SRCS="git::commit=tags/$VER::https://gitlab.mister-muffin.de/josch/mmdebstrap/"
+CHKSUMS="SKIP"
+CHKUPDATE="gitlab::repo=josch/mmdebstrap;instance=https://gitlab.mister-muffin.de"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- mmdebstrap: new, 1.5.7

Package(s) Affected
-------------------

- mmdebstrap: new, 1.5.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit mmdebstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
