### PR TITLE
webkit2gtk: update to 2.48.4

### DIFF
--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,6 +1,6 @@
-VER=2.48.3
+VER=2.48.4
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::d4dc5970f0fc6a529ff7fd67bcbfab2bbb5e91be789b2e9279640b3217a782c3"
+CHKSUMS="sha256::f62c1077d3a0f63d50259a802d1143be5d4d0c7c4c05e581819af1ce935afab3"
 CHKUPDATE="anitya::id=324014"
 ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem=100"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.48.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.48.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
