### PR TITLE
tailscale: update to 1.86.2

### DIFF
--- a/app-network/tailscale/spec
+++ b/app-network/tailscale/spec
@@ -1,4 +1,4 @@
-VER=1.86.0
+VER=1.86.2
 SRCS="git::commit=tags/v${VER}::https://github.com/tailscale/tailscale"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141585"


### PR DESCRIPTION
Topic Description
-----------------

- tailscale: update to 1.86.2
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- tailscale: 1.86.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tailscale
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
