### PR TITLE
pyside2: update to 5.15.16


### DIFF
--- a/lang-python/pyside2/autobuild/beyond
+++ b/lang-python/pyside2/autobuild/beyond
@@ -1,17 +1,2 @@
 abinfo "Removing redundant files ..."
 rm -fv "$PKGDIR/usr/bin/"{designer,uic,rcc}
-
-abinfo "Copying generated files back ..."
-cp -v "$SRCDIR"/abbuild/sources/shiboken2/shibokenmodule/{*.py,*.txt} "$SRCDIR"/sources/shiboken2/shibokenmodule/
-cp -v "$SRCDIR"/abbuild/sources/pyside2/PySide2/*.py "$SRCDIR"/sources/pyside2/PySide2/
-
-abinfo "Generating egg_info ..."
-python3 setup.py egg_info
-
-abinfo "Installing Python Egg-info files ..."
-# Copied from Fedora F32 tree
-for name in PySide2 shiboken2 shiboken2_generator; do
-  install -dv "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"
-  cp -pv $name.egg-info/{PKG-INFO,not-zip-safe,top_level.txt} \
-        "$PKGDIR/usr/lib/python${ABPY3VER}/$name-${PKGVER}-py${ABPY3VER}.egg-info"/
-done

--- a/lang-python/pyside2/autobuild/defines
+++ b/lang-python/pyside2/autobuild/defines
@@ -1,13 +1,10 @@
 PKGNAME=pyside2
 PKGSEC=libs
 PKGDEP="qt-5 python-3 llvm"
-BUILDDEP="sphinx"
+BUILDDEP="sphinx packaging distro patchelf"
 PKGDES="Python bindings for the Qt 5 cross-platform application and UI framework"
 
 PKGPROV="shiboken2"
 
-# FIXME: race condition if ABTYPE=cmakeninja
-ABTYPE=cmake
-
-CMAKE_AFTER="-DUSE_PYTHON_VERSION=3 \
-             -DBUILD_TESTS=OFF"
+ABTYPE=python
+NOPYTHON2=1

--- a/lang-python/pyside2/autobuild/patches/0001-AOSCOS-Fix-numpy-header-path.patch
+++ b/lang-python/pyside2/autobuild/patches/0001-AOSCOS-Fix-numpy-header-path.patch
@@ -1,0 +1,35 @@
+From e81c84fa84abe3d42ca0406b73da98925cb801cf Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Wed, 30 Jul 2025 17:44:29 +0800
+Subject: [PATCH 01/23] AOSCOS: Fix numpy header path
+X-Developer-Signature: v=1; a=openpgp-sha256; l=906; i=xtexchooser@duck.com;
+ h=from:subject; bh=aBTj0qq+Nwfu3Qu/8ZP0DntZvxZUseARZ73JzkpRxQc=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9yN/yNsmVdPXs6XwX3kd2dVcVbrlav/vfGlnVN0
+ /7pFmWBHaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIlMW8XIcPmv2OndzOufdPLp
+ P0s1OBEdfnJy94waxTLdj+qeTUeqDzL8z0sTe15/oKI+0Pj/e6X1Lw5Xvl0rNS/4wyq5STHbNta
+ c4gMA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ sources/shiboken2/libshiboken/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sources/shiboken2/libshiboken/CMakeLists.txt b/sources/shiboken2/libshiboken/CMakeLists.txt
+index 96effd280134..4353706b1997 100644
+--- a/sources/shiboken2/libshiboken/CMakeLists.txt
++++ b/sources/shiboken2/libshiboken/CMakeLists.txt
+@@ -111,7 +111,7 @@ target_include_directories(libshiboken PUBLIC
+ )
+ 
+ if (NOT "${PYTHON_NUMPY_LOCATION}" STREQUAL "")
+-    target_include_directories(libshiboken PRIVATE ${PYTHON_NUMPY_LOCATION}/core/include)
++    target_include_directories(libshiboken PRIVATE ${PYTHON_NUMPY_LOCATION}/_core/include)
+     target_compile_definitions(libshiboken PRIVATE -DHAVE_NUMPY
+                                            PRIVATE -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
+ 
+
+base-commit: a454ae6ce7a18b01161ecf61aa88b127cea7de8b
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0002-AOSCOS-Allow-unsupported-python-versions.patch
+++ b/lang-python/pyside2/autobuild/patches/0002-AOSCOS-Allow-unsupported-python-versions.patch
@@ -1,0 +1,46 @@
+From 62141b9ccfffdda4f14c8ae9e8a01e49e80992d9 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 10 May 2025 22:58:00 +0800
+Subject: [PATCH 02/23] AOSCOS: Allow unsupported python versions
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1242; i=xtexchooser@duck.com;
+ h=from:subject; bh=sHvmW9lMSCoN+vIHYyGyRne+ihT+2VMiODHfHikybeA=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw+WPF+e5++oZW74PTHA46rUr2P1jMZ3W4t6vlgbM
+ 1ZYTCzpKGVhEONikBVTZCkybPBm1UnnF11WLgszh5UJZAgDF6cATKSZlZHhysaW7n+5ijNWfq3Q
+ qA1tV5vb5ro4o2nGvrM7M/NqyqNkGf5ZCzUfDJsS279d8hEXr624XvNOvU5Zt0T5tEWHF/Z1T2A
+ FAA==
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ build_scripts/config.py | 2 +-
+ build_scripts/main.py   | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/build_scripts/config.py b/build_scripts/config.py
+index f2b4c40b119d..cc8636a43127 100644
+--- a/build_scripts/config.py
++++ b/build_scripts/config.py
+@@ -137,7 +137,7 @@ class Config(object):
+         setup_kwargs['zip_safe'] = False
+         setup_kwargs['cmdclass'] = cmd_class_dict
+         setup_kwargs['version'] = package_version
+-        setup_kwargs['python_requires'] = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.12"
++        setup_kwargs['python_requires'] = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+ 
+         if quiet:
+             # Tells distutils / setuptools to be quiet, and only print warnings or errors.
+diff --git a/build_scripts/main.py b/build_scripts/main.py
+index f74845503060..7aa94f6c2b7b 100644
+--- a/build_scripts/main.py
++++ b/build_scripts/main.py
+@@ -282,7 +282,6 @@ def check_allowed_python_version():
+     if this_py not in supported:
+         print("Unsupported python version detected. Only these python versions are supported: {}"
+               .format(supported))
+-        sys.exit(1)
+ 
+ 
+ qt_src_dir = ''
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0003-AOSCOS-Remove-.gitmodules-file.patch
+++ b/lang-python/pyside2/autobuild/patches/0003-AOSCOS-Remove-.gitmodules-file.patch
@@ -1,0 +1,30 @@
+From 0fcb684ecf90e59110f8493c66523a8d7bc7426d Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 10 May 2025 23:03:35 +0800
+Subject: [PATCH 03/23] AOSCOS: Remove .gitmodules file
+X-Developer-Signature: v=1; a=openpgp-sha256; l=358; i=xtexchooser@duck.com;
+ h=from:subject; bh=wqiYJGILvLdTQoIqeoC03pb7MIEpeVbk2364rTYiwho=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw8KssTPelRU0SDu3p3sHrWXtf/i9++rTq9UTDp6V
+ bN63/N3HaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIlsPMrwV8D1hvomlZAiF35z
+ 0ylFrTM017lyr9tzQ1yq8uCVu0szzBj+V2rVZl/lZBXdU30vRX/hRLs3i0yc6pKEfl6K3mS+7v1
+ fJgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ .gitmodules | 3 ---
+ 1 file changed, 3 deletions(-)
+ delete mode 100644 .gitmodules
+
+diff --git a/.gitmodules b/.gitmodules
+deleted file mode 100644
+index 42712d639f15..000000000000
+--- a/.gitmodules
++++ /dev/null
+@@ -1,3 +0,0 @@
+-[submodule "sources/pyside2-tools"]
+-	path = sources/pyside2-tools
+-	url = ../pyside-tools.git
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0004-DEBIAN-Update-import-of-PyQt5-private-sip-module-and.patch
+++ b/lang-python/pyside2/autobuild/patches/0004-DEBIAN-Update-import-of-PyQt5-private-sip-module-and.patch
@@ -1,0 +1,45 @@
+From 826f85596607376ba52932f281cd3f7e4c498c26 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sun, 11 May 2025 09:03:29 +0800
+Subject: [PATCH 04/23] DEBIAN: Update import of PyQt5 private sip module and
+ remove Python 2/PyQt4 setapi calls
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1114; i=xtexchooser@duck.com;
+ h=from:subject; bh=rsqwExmJ3H0JS7uW/y5bwJ6MMDvoBCDHhMtqmpWvJ0g=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw+KZ1YfKHZZYMZ1evMJznCFpnOnc99eVyxhXvd4H
+ 0vlUW+LjlIWBjEuBlkxRZYiwwZvVp10ftFl5bIwc1iZQIYwcHEKwEQUJjEy/MnjZXzG/2jWvxO9
+ yzyNRN2mJ0yIenxa72t1Hh+LaLHeakaGh0fvHhcR7D0xSWHO7hefddbPuRSnUuaxmat1xfWOxTI
+ tzAA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Author: Kurt Kremitzki <kkremitzki@debian.org>
+---
+ sources/pyside2/tests/tools/list-class-hierarchy.py | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/sources/pyside2/tests/tools/list-class-hierarchy.py b/sources/pyside2/tests/tools/list-class-hierarchy.py
+index b734ae69e2ee..ab0c657ad838 100755
+--- a/sources/pyside2/tests/tools/list-class-hierarchy.py
++++ b/sources/pyside2/tests/tools/list-class-hierarchy.py
+@@ -96,14 +96,10 @@ if __name__=='__main__':
+     for l in libraries:
+         dictionary = []
+         if l =="PyQt5":
+-            import sip
+-            sip.setapi('QDate',2)
+-            sip.setapi('QDateTime',2)
+-            sip.setapi('QString',2)
+-            sip.setapi('QTextStream',2)
+-            sip.setapi('QTime',2)
+-            sip.setapi('QUrl',2)
+-            sip.setapi('QVariant',2)
++            try:
++                from PyQt5 import sip
++            except ModuleNotFoundError:
++                import sip
+ 
+         for m in modules:
+             exec("from %s import %s" % (l,m), globals(), locals())
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0005-DEBIAN-Fix-spelling-errors.patch
+++ b/lang-python/pyside2/autobuild/patches/0005-DEBIAN-Fix-spelling-errors.patch
@@ -1,0 +1,34 @@
+From fe75cccb4981322813733c507e1084109c190df5 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sun, 11 May 2025 09:03:56 +0800
+Subject: [PATCH 05/23] DEBIAN: Fix spelling errors
+X-Developer-Signature: v=1; a=openpgp-sha256; l=791; i=xtexchooser@duck.com;
+ h=from:subject; bh=WS1ZMpKpxU343wfwVP+eJskxfnTlVTvdSSYXAvEMKok=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw8JZCyRCMxKbC8+foLp9vPj3/Wi/9QW579ebNAU5
+ O5ZsudFRykLgxgXg6yYIkuRYYM3q046v+iyclmYOaxMIEMYuDgFYCJXmhn+6R3rm3zww5v23U/X
+ nXlpc7QhfPrXpHsF7sW6U6bxT/7QtIWR4ZXG2yub5PU5/T8rv7gYX/72+JO9N/pDX6lVSU09ntg
+ 2jQEA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Author: Sophie Brun <sophie@freexian.com>
+---
+ sources/pyside2/libpyside/pysideproperty.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sources/pyside2/libpyside/pysideproperty.cpp b/sources/pyside2/libpyside/pysideproperty.cpp
+index 0d0957f55135..86909d3bc25b 100644
+--- a/sources/pyside2/libpyside/pysideproperty.cpp
++++ b/sources/pyside2/libpyside/pysideproperty.cpp
+@@ -519,7 +519,7 @@ int setValue(PySideProperty *self, PyObject *source, PyObject *value)
+         Shiboken::AutoDecRef result(PyObject_CallObject(fdel, args));
+         return (result.isNull() ? -1 : 0);
+     }
+-    PyErr_SetString(PyExc_AttributeError, "Attibute read only");
++    PyErr_SetString(PyExc_AttributeError, "Attribute read only");
+     return -1;
+ }
+ 
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0006-DEBIAN-Find-the-build-directory-matching-the-current.patch
+++ b/lang-python/pyside2/autobuild/patches/0006-DEBIAN-Find-the-build-directory-matching-the-current.patch
@@ -1,0 +1,42 @@
+From b89d8f513c386c319d3fc4595a426060c9510a01 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sun, 11 May 2025 09:04:28 +0800
+Subject: [PATCH 06/23] DEBIAN: Find the build directory matching the current
+ interpreter
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1046; i=xtexchooser@duck.com;
+ h=from:subject; bh=s8UUu/TCk0nyNBCVxh/eYOgqUrAQLA67iZNkN0AFEl4=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw/5PvZbwrllwYnfftd3RpVyTfTqfPUqg1ds9ub6n
+ UHTdtzp6yhlYRDjYpAVU2QpMmzwZtVJ5xddVi4LM4eVCWQIAxenAExEzZqRoff7y+vBXxrTcnwu
+ OUilmuo9WTmRab1/97MLrS38V3ecdmH4w9M6+cCBl/NmrHqxMuvK1a3/Syzvibq6a/IVL7OOn/R
+ IlRUA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+This is needed to allow us to run tests with all supported Python versions.
+Without this patch, the latest build directory will be always picked, no
+matter what the current interpreter is.
+
+From: Dmitry Shachnev <mitya57@debian.org>
+---
+ testing/buildlog.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/testing/buildlog.py b/testing/buildlog.py
+index 216282b4cbaa..5d3aa1f933ba 100644
+--- a/testing/buildlog.py
++++ b/testing/buildlog.py
+@@ -94,6 +94,11 @@ class BuildLog(object):
+                     """.format(fpath)))
+                     sys.exit(1)
+ 
++                # We need to find the build directory for the current interpreter
++                py_version = "{}.{}".format(sys.version_info[0], sys.version_info[1])
++                if py_version not in build_classifiers:
++                    continue
++
+                 if not os.path.exists(build_dir):
+                     rel_dir, low_part = os.path.split(build_dir)
+                     rel_dir, two_part = os.path.split(rel_dir)
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0007-DEBIAN-Shiboken-Fix-the-oldest-shiboken-bug-ever-whi.patch
+++ b/lang-python/pyside2/autobuild/patches/0007-DEBIAN-Shiboken-Fix-the-oldest-shiboken-bug-ever-whi.patch
@@ -1,0 +1,56 @@
+From 0afc13b1c808147b564922e430cc6668a6c6e57a Mon Sep 17 00:00:00 2001
+From: Christian Tismer <tismer@stackless.com>
+Date: Tue, 21 Jun 2022 10:22:04 +0200
+Subject: [PATCH 07/23] DEBIAN: Shiboken: Fix the oldest shiboken bug ever
+ which shows up on Python 3.11
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1697; i=xtexchooser@duck.com;
+ h=from:subject; bh=yzrtCRLuqEEuYVbBfv8wG4BjWdsEvA4qutk5xwO5vWQ=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9Zb2QLPfd8jY/ITPnuDS2eex71Pj51debaZ203j
+ 5yVVN62vKOUhUGMi0FWTJGlyLDBm1UnnV90WbkszBxWJpAhDFycAjCRmfcYGdo4AnIbn5w0VHnR
+ sXB2ys1ej7zpE5lDuJt4u4z/mJis/MjwT+cq0542v44Fy3cKrDQ7v165z3K7yVv9jqIfKd9fe8d
+ M5QEA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+b7df2f1c0 "Fix signal initializer.", 18. May 2010 at 00:55
+
+There was a `PySequence_Check` in the evaluation of some signature
+function parameter processing, which should have been `PyTuple_Check`.
+
+Since the new PyEnums are also sequences, the new optimization in
+Python 3.11 changed the parameter handling in a correct way and
+replaced the argument tuple by a direct single argument of an enum
+type. And that is also a sequence ...
+
+There are probably still dormant issues like this in the codebase
+which gives reason to submit a task that checks all Python interface
+functions for correctness.
+
+Change-Id: I45996a0458c3e60795d2eb802eb98f7dd3678d92
+Pick-to: 6.3
+Task-number: PYSIDE-1735
+Task-number: PYSIDE-1987
+Fixes: PYSIDE-1988
+Reviewed-by: Cristian Maureira-Fredes <cristian.maureira-fredes@qt.io>
+Reviewed-by: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
+(cherry picked from commit 2720e01f21f3771cb755ef183b8160f691bdb575)
+---
+ sources/pyside2/libpyside/pysidesignal.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sources/pyside2/libpyside/pysidesignal.cpp b/sources/pyside2/libpyside/pysidesignal.cpp
+index 607ce163c4db..6824a7113477 100644
+--- a/sources/pyside2/libpyside/pysidesignal.cpp
++++ b/sources/pyside2/libpyside/pysidesignal.cpp
+@@ -726,7 +726,7 @@ static QByteArray buildSignature(const QByteArray &name, const QByteArray &signa
+ 
+ static QByteArray parseSignature(PyObject *args)
+ {
+-    if (args && (Shiboken::String::check(args) || !PySequence_Check(args)))
++    if (args && (Shiboken::String::check(args) || !PyTuple_Check(args)))
+         return getTypeName(args);
+ 
+     QByteArray signature;
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0008-DEBIAN-PyEnum-make-forgiving-duplicates-work-with-Py.patch
+++ b/lang-python/pyside2/autobuild/patches/0008-DEBIAN-PyEnum-make-forgiving-duplicates-work-with-Py.patch
@@ -1,0 +1,76 @@
+From 5cb720239e806209e686307aa0aece7558eb272a Mon Sep 17 00:00:00 2001
+From: Christian Tismer <tismer@stackless.com>
+Date: Tue, 21 Jun 2022 10:22:04 +0200
+Subject: [PATCH 08/23] DEBIAN: PyEnum: make forgiving duplicates work with
+ Python 3.11
+X-Developer-Signature: v=1; a=openpgp-sha256; l=3222; i=xtexchooser@duck.com;
+ h=from:subject; bh=SCIr73ASHLNu9F/Oxrr86UQRX9n9Kz5KSX5n+/dH+60=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw893sr94MgcoRfFPGzTe1daS16+sLgwsUzdy/li/
+ 1//QIVjHaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIkcm8rwz+CGq5GEHreM3bET
+ 2b2lGbLOucfirzYeYd4198brlDnzORn+yhbIOV14f2Fyw/fA5nz3wiWfrdl+T/MP0Ml/Uq1am7O
+ aCwA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+There was a silent change in PyEnums that turns Enum attributes
+into properties. This does not harm the Python interface but
+needed some change in the duplication emulation.
+
+Furthermore, new internal enums are created with an underscore name.
+
+The meta class was changed from EnumMeta to EnumType.
+
+[ChangeLog][shiboken6] The new Python Enums are now compatible with Python 3.11
+
+Change-Id: I3b1ab63dc5eed15a75ebd0f42dddf4001f640c00
+Pick-to: 6.3
+Task-number: PYSIDE-1735
+Fixes: PYSIDE-1960
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+Reviewed-by: Cristian Maureira-Fredes <cristian.maureira-fredes@qt.io>
+(cherry picked from commit da2cf031521815a9559ca784beadb70c7a2852d9)
+---
+ sources/pyside2/tests/QtCore/qenum_test.py                  | 6 ++++--
+ .../files.dir/shibokensupport/signature/lib/enum_sig.py     | 3 ++-
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/sources/pyside2/tests/QtCore/qenum_test.py b/sources/pyside2/tests/QtCore/qenum_test.py
+index f99a893d97ea..0981c26c8e1d 100644
+--- a/sources/pyside2/tests/QtCore/qenum_test.py
++++ b/sources/pyside2/tests/QtCore/qenum_test.py
+@@ -197,14 +197,16 @@ class SomeClass(QObject):
+ 
+ @unittest.skipUnless(HAVE_ENUM, "requires 'enum' module (use 'pip install enum34' for Python 2)")
+ class TestQEnumMacro(unittest.TestCase):
++    meta_name = "EnumType" if sys.version_info[:2] >= (3, 11) else "EnumMeta"
++
+     def testTopLevel(self):
+         self.assertEqual(type(OuterEnum).__module__, "enum")
+-        self.assertEqual(type(OuterEnum).__name__, "EnumMeta")
++        self.assertEqual(type(OuterEnum).__name__, self.meta_name)
+         self.assertEqual(len(OuterEnum.__members__), 2)
+ 
+     def testSomeClass(self):
+         self.assertEqual(type(SomeClass.SomeEnum).__module__, "enum")
+-        self.assertEqual(type(SomeClass.SomeEnum).__name__, "EnumMeta")
++        self.assertEqual(type(SomeClass.SomeEnum).__name__, self.meta_name)
+         self.assertEqual(len(SomeClass.SomeEnum.__members__), 3)
+         with self.assertRaises(TypeError):
+             int(SomeClass.SomeEnum.C) == 6
+diff --git a/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/lib/enum_sig.py b/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/lib/enum_sig.py
+index 088a93aa42e8..2f78718d8ebc 100644
+--- a/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/lib/enum_sig.py
++++ b/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/lib/enum_sig.py
+@@ -139,7 +139,8 @@ class ExactEnumerator(object):
+                     functions.append((func_name, thing))
+             elif type(type(thing)) is EnumMeta:
+                 # take the real enum name, not what is in the dict
+-                enums.append((thing_name, type(thing).__qualname__, thing))
++                if not thing_name.startswith("_"):
++                    enums.append((thing_name, type(thing).__qualname__, thing))
+         init_signature = getattr(klass, "__signature__", None)
+         enums.sort(key=lambda tup: tup[1 : 3])  # sort by class then enum value
+         self.fmt.have_body = bool(subclasses or functions or enums or init_signature)
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0009-DEBIAN-Python-3.12-Fix-the-structure-of-class-proper.patch
+++ b/lang-python/pyside2/autobuild/patches/0009-DEBIAN-Python-3.12-Fix-the-structure-of-class-proper.patch
@@ -1,0 +1,51 @@
+From 146fb6aeee71091faa53c6676bf744ed754cadb7 Mon Sep 17 00:00:00 2001
+From: Christian Tismer <tismer@stackless.com>
+Date: Tue, 14 Feb 2023 14:46:22 +0100
+Subject: [PATCH 09/23] DEBIAN: Python 3.12: Fix the structure of class
+ property
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1408; i=xtexchooser@duck.com;
+ h=from:subject; bh=bqckAAf4k9rJqYeuQ1U4JdXwEgPoC+G0G98ShU0QzDE=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9Ffg2TXHFZaM703puZ0fXPv6fUekhPE5kyvd7mx
+ i7X7WVJHaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIl8zGZkOMjjN8vjQ0tjT1te
+ yWLJhqXvVrxT40p4ccXsxlaHj1Izqxj+u56Xl5GS6GxVvq6Y8SHz9wndxVVbOP5It4iVfO51m3K
+ RCQA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+There is a PySide bug in Python 3.10 already: The structure for
+classproperty derives from the property structure. This was extended
+in Python 3.10, already, but the type generation check was made more
+exhaustive in Python 3.12 and recognized that.
+
+This change is only for making the compiler/C API happy.
+In order to use the extension field, it is necessary to do a runtime
+check because of the Limited API.
+
+Task-number: PYSIDE-2230
+Change-Id: I88dcaa11589ff41852f08fa2defa5200a0dd4eb6
+Reviewed-by: Adrian Herrmann <adrian.herrmann@qt.io>
+Reviewed-by: Friedemann Kleint <Friedemann.Kleint@qt.io>
+(cherry picked from commit edfd9a5ad174a48f8d7da511dc6a1c69e931a418)
+---
+ sources/pyside2/libpyside/feature_select.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sources/pyside2/libpyside/feature_select.cpp b/sources/pyside2/libpyside/feature_select.cpp
+index 3011b3584c39..b9e14709a8e6 100644
+--- a/sources/pyside2/libpyside/feature_select.cpp
++++ b/sources/pyside2/libpyside/feature_select.cpp
+@@ -671,6 +671,11 @@ typedef struct {
+     PyObject *prop_set;
+     PyObject *prop_del;
+     PyObject *prop_doc;
++#if PY_VERSION_HEX >= 0x030A0000
++    // Note: This is a problem with Limited API: We have no direct access.
++    //       You need to pick it from runtime info.
++    PyObject *prop_name;
++#endif
+     int getter_doc;
+ } propertyobject;
+ 
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0010-DEBIAN-Support-running-PySide-on-Python-3.12.patch
+++ b/lang-python/pyside2/autobuild/patches/0010-DEBIAN-Support-running-PySide-on-Python-3.12.patch
@@ -1,0 +1,309 @@
+From 5651f8d0c45243551c347417d03b2a62adf5e1b1 Mon Sep 17 00:00:00 2001
+From: Christian Tismer <tismer@stackless.com>
+Date: Tue, 14 Feb 2023 14:46:22 +0100
+Subject: [PATCH 10/23] DEBIAN: Support running PySide on Python 3.12
+X-Developer-Signature: v=1; a=openpgp-sha256; l=13840; i=xtexchooser@duck.com;
+ h=from:subject; bh=8Zvsu6pXjfBn5pNDulRI73XF++XrbBD6ChNq1nkiqXw=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw/5Xl79lqnAfoZA9AlFz+URuQsUV+6U5p+gMNXLY
+ 13Lo5YVHaUsDGJcDLJiiixFhg3erDrp/KLLymVh5rAygQxh4OIUgIlotzL8rw57VXyCgUuwzDj7
+ XNnGi7XBua++Zb81mJidP2P6a+e3AYwMv1dz1y8N2j25kfmZaKDK6kK7xIpNMyXn5zLe6ZO6/WA
+ ODwA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Builtin types no longer have tp_dict set. We need to
+use PyType_GetDict, instead. This works without Limited API
+at the moment.
+
+With some great cheating, this works with Limited API, too.
+We emulate PyType_GetDict by tp_dict if that is not 0.
+Otherwise we create an empty dict.
+
+Some small changes to Exception handling and longer
+warm-up in leaking tests were found, too.
+
+Pick-to: 6.6 6.5 6.2
+Task-number: PYSIDE-2230
+Change-Id: I8a56de6208ec00979255b39b5784dfc9b4b92def
+Reviewed-by: Friedemann Kleint <Friedemann.Kleint@qt.io>
+(cherry picked from commit 441ffbd4fc622e67acd81e9c1c6d3a0b0fbcacf0)
+---
+ build_scripts/config.py                       |  3 +-
+ .../pyside2/PySide2/support/generate_pyi.py   |  8 +++--
+ sources/pyside2/libpyside/feature_select.cpp  | 10 +++---
+ sources/pyside2/libpyside/pysideproperty.cpp  |  4 +--
+ sources/pyside2/libpyside/pysidesignal.cpp    |  4 +--
+ sources/pyside2/tests/QtWidgets/bug_662.py    |  3 +-
+ sources/pyside2/tests/signals/bug_79.py       |  5 +++
+ sources/shiboken2/libshiboken/pep384impl.cpp  | 33 +++++++++++++++++++
+ sources/shiboken2/libshiboken/pep384impl.h    |  8 +++++
+ .../libshiboken/signature/signature.cpp       |  2 +-
+ .../signature/signature_helper.cpp            |  6 ++--
+ .../shibokensupport/signature/errorhandler.py |  6 ++++
+ .../tests/samplebinding/enum_test.py          |  2 +-
+ 13 files changed, 78 insertions(+), 16 deletions(-)
+
+diff --git a/build_scripts/config.py b/build_scripts/config.py
+index cc8636a43127..b2d6fc5eef64 100644
+--- a/build_scripts/config.py
++++ b/build_scripts/config.py
+@@ -94,7 +94,8 @@ class Config(object):
+             'Programming Language :: Python :: 3.8',
+             'Programming Language :: Python :: 3.9',
+             'Programming Language :: Python :: 3.10',
+-            'Programming Language :: Python :: 3.11'
++            'Programming Language :: Python :: 3.11',
++            'Programming Language :: Python :: 3.12',
+         ]
+ 
+         self.setup_script_dir = None
+diff --git a/sources/pyside2/PySide2/support/generate_pyi.py b/sources/pyside2/PySide2/support/generate_pyi.py
+index 19565338fc58..fd05b1ffec4d 100644
+--- a/sources/pyside2/PySide2/support/generate_pyi.py
++++ b/sources/pyside2/PySide2/support/generate_pyi.py
+@@ -116,8 +116,12 @@ class Formatter(Writer):
+         """
+         def _typevar__repr__(self):
+             return "typing." + self.__name__
+-        typing.TypeVar.__repr__ = _typevar__repr__
+-
++        # This is no longer necessary for modern typing versions.
++        # Ignore therefore if the repr is read-only and cannot be changed.
++        try:
++            typing.TypeVar.__repr__ = _typevar__repr__
++        except TypeError:
++            pass
+         # Adding a pattern to substitute "Union[T, NoneType]" by "Optional[T]"
+         # I tried hard to replace typing.Optional by a simple override, but
+         # this became _way_ too much.
+diff --git a/sources/pyside2/libpyside/feature_select.cpp b/sources/pyside2/libpyside/feature_select.cpp
+index b9e14709a8e6..533c09d477cf 100644
+--- a/sources/pyside2/libpyside/feature_select.cpp
++++ b/sources/pyside2/libpyside/feature_select.cpp
+@@ -358,7 +358,8 @@ static bool SelectFeatureSetSubtype(PyTypeObject *type, PyObject *select_id)
+      * This is the selector for one sublass. We need to call this for
+      * every subclass until no more subclasses or reaching the wanted id.
+      */
+-    if (Py_TYPE(type->tp_dict) == Py_TYPE(PyType_Type.tp_dict)) {
++    static const auto *pyTypeType_tp_dict = PepType_GetDict(&PyType_Type);
++    if (Py_TYPE(type->tp_dict) == Py_TYPE(pyTypeType_tp_dict)) {
+         // On first touch, we initialize the dynamic naming.
+         // The dict type will be replaced after the first call.
+         if (!replaceClassDict(type)) {
+@@ -385,7 +386,8 @@ static inline PyObject *SelectFeatureSet(PyTypeObject *type)
+      * Generated functions call this directly.
+      * Shiboken will assign it via a public hook of `basewrapper.cpp`.
+      */
+-    if (Py_TYPE(type->tp_dict) == Py_TYPE(PyType_Type.tp_dict)) {
++    static const auto *pyTypeType_tp_dict = PepType_GetDict(&PyType_Type);
++    if (Py_TYPE(type->tp_dict) == Py_TYPE(pyTypeType_tp_dict)) {
+         // We initialize the dynamic features by using our own dict type.
+         if (!replaceClassDict(type))
+             return nullptr;
+@@ -721,11 +723,11 @@ static bool patch_property_impl()
+     // Turn `__doc__` into a computed attribute without changing writability.
+     auto gsp = property_getset;
+     auto type = &PyProperty_Type;
+-    auto dict = type->tp_dict;
++    AutoDecRef dict(PepType_GetDict(type));
+     AutoDecRef descr(PyDescr_NewGetSet(type, gsp));
+     if (descr.isNull())
+         return false;
+-    if (PyDict_SetItemString(dict, gsp->name, descr) < 0)
++    if (PyDict_SetItemString(dict.object(), gsp->name, descr) < 0)
+         return false;
+     // Replace property_descr_get/set by slightly changed versions
+     return true;
+diff --git a/sources/pyside2/libpyside/pysideproperty.cpp b/sources/pyside2/libpyside/pysideproperty.cpp
+index 86909d3bc25b..d2e2c68055b0 100644
+--- a/sources/pyside2/libpyside/pysideproperty.cpp
++++ b/sources/pyside2/libpyside/pysideproperty.cpp
+@@ -445,8 +445,8 @@ namespace {
+ 
+ static PyObject *getFromType(PyTypeObject *type, PyObject *name)
+ {
+-    PyObject *attr = nullptr;
+-    attr = PyDict_GetItem(type->tp_dict, name);
++    AutoDecRef tpDict(PepType_GetDict(type));
++    auto *attr = PyDict_GetItem(tpDict.object(), name);
+     if (!attr) {
+         PyObject *bases = type->tp_bases;
+         int size = PyTuple_GET_SIZE(bases);
+diff --git a/sources/pyside2/libpyside/pysidesignal.cpp b/sources/pyside2/libpyside/pysidesignal.cpp
+index 6824a7113477..f15d7aa67736 100644
+--- a/sources/pyside2/libpyside/pysidesignal.cpp
++++ b/sources/pyside2/libpyside/pysidesignal.cpp
+@@ -670,8 +670,8 @@ void updateSourceObject(PyObject *source)
+     Py_ssize_t pos = 0;
+     PyObject *value;
+     PyObject *key;
+-
+-    while (PyDict_Next(objType->tp_dict, &pos, &key, &value)) {
++    Shiboken::AutoDecRef tpDict(PepType_GetDict(objType));
++    while (PyDict_Next(tpDict, &pos, &key, &value)) {
+         if (PyObject_TypeCheck(value, PySideSignalTypeF())) {
+             Shiboken::AutoDecRef signalInstance(reinterpret_cast<PyObject *>(PyObject_New(PySideSignalInstance, PySideSignalInstanceTypeF())));
+             instanceInitialize(signalInstance.cast<PySideSignalInstance *>(), key, reinterpret_cast<PySideSignal *>(value), source, 0);
+diff --git a/sources/pyside2/tests/QtWidgets/bug_662.py b/sources/pyside2/tests/QtWidgets/bug_662.py
+index 7fb97deb6604..ec0e6f95496a 100644
+--- a/sources/pyside2/tests/QtWidgets/bug_662.py
++++ b/sources/pyside2/tests/QtWidgets/bug_662.py
+@@ -40,7 +40,8 @@ from PySide2.QtWidgets import QTextEdit, QApplication
+ import sys
+ 
+ class testQTextBlock(unittest.TestCase):
+-    def tesIterator(self):
++
++    def testIterator(self):
+         edit = QTextEdit()
+         cursor = edit.textCursor()
+         fmt = QTextCharFormat()
+diff --git a/sources/pyside2/tests/signals/bug_79.py b/sources/pyside2/tests/signals/bug_79.py
+index ca25fb3f4d20..b70c8c5a2957 100644
+--- a/sources/pyside2/tests/signals/bug_79.py
++++ b/sources/pyside2/tests/signals/bug_79.py
+@@ -60,6 +60,11 @@ class ConnectTest(unittest.TestCase):
+         gc.collect()
+         # if this is no debug build, then we check at least that
+         # we do not crash any longer.
++        for idx in range(200):
++            # PYSIDE-2230: Warm-up is necessary before measuring, because
++            # the code changes the constant parts after some time.
++            o.selectionModel().destroyed.connect(self.callback)
++            o.selectionModel().destroyed.disconnect(self.callback)
+         if not skiptest:
+             total = gettotalrefcount()
+         for idx in range(1000):
+diff --git a/sources/shiboken2/libshiboken/pep384impl.cpp b/sources/shiboken2/libshiboken/pep384impl.cpp
+index d12dae392147..fed27164baaf 100644
+--- a/sources/shiboken2/libshiboken/pep384impl.cpp
++++ b/sources/shiboken2/libshiboken/pep384impl.cpp
+@@ -810,6 +810,39 @@ init_PepRuntime()
+         PepRuntime_38_flag = 1;
+ }
+ 
++#ifdef Py_LIMITED_API
++static PyObject *emulatePyType_GetDict(PyTypeObject *type)
++{
++    if (_PepRuntimeVersion() < 0x030C00 || type->tp_dict) {
++        auto *res = type->tp_dict;
++        Py_XINCREF(res);
++        return res;
++    }
++    // PYSIDE-2230: Here we are really cheating. We don't know how to
++    //              access an internal dict, and so we simply pretend
++    //              it were an empty dict. This works great for our types.
++    // This was an unexpectedly simple solution :D
++    return PyDict_New();
++}
++#endif
++
++// PyType_GetDict: replacement for <static type>.tp_dict, which is
++// zero for builtin types since 3.12.
++PyObject *PepType_GetDict(PyTypeObject *type)
++{
++#if !defined(Py_LIMITED_API)
++#  if PY_VERSION_HEX >= 0x030C0000
++    return PyType_GetDict(type);
++#  else
++    // pre 3.12 fallback code, mimicking the addref-behavior.
++    Py_XINCREF(type->tp_dict);
++    return type->tp_dict;
++#  endif
++#else
++    return emulatePyType_GetDict(type);
++#endif // Py_LIMITED_API
++}
++
+ /*****************************************************************************
+  *
+  * Module Initialization
+diff --git a/sources/shiboken2/libshiboken/pep384impl.h b/sources/shiboken2/libshiboken/pep384impl.h
+index a870d6b29574..440784e571d8 100644
+--- a/sources/shiboken2/libshiboken/pep384impl.h
++++ b/sources/shiboken2/libshiboken/pep384impl.h
+@@ -567,6 +567,14 @@ extern LIBSHIBOKEN_API PyObject *PepMapping_Items(PyObject *o);
+ 
+ extern LIBSHIBOKEN_API int PepRuntime_38_flag;
+ 
++/*****************************************************************************
++ *
++ * Runtime support for Python 3.12 incompatibility
++ *
++ */
++
++LIBSHIBOKEN_API PyObject *PepType_GetDict(PyTypeObject *type);
++
+ /*****************************************************************************
+  *
+  * Module Initialization
+diff --git a/sources/shiboken2/libshiboken/signature/signature.cpp b/sources/shiboken2/libshiboken/signature/signature.cpp
+index 191af3d9b669..f817e4745844 100644
+--- a/sources/shiboken2/libshiboken/signature/signature.cpp
++++ b/sources/shiboken2/libshiboken/signature/signature.cpp
+@@ -482,7 +482,7 @@ static PyObject *adjustFuncName(const char *func_name)
+ 
+     // Find the feature flags
+     auto type = reinterpret_cast<PyTypeObject *>(obtype.object());
+-    auto dict = type->tp_dict;
++    AutoDecRef dict(PepType_GetDict(type));
+     int id = SbkObjectType_GetReserved(type);
+     id = id < 0 ? 0 : id;   // if undefined, set to zero
+     auto lower = id & 0x01;
+diff --git a/sources/shiboken2/libshiboken/signature/signature_helper.cpp b/sources/shiboken2/libshiboken/signature/signature_helper.cpp
+index 0246ec61d0bb..05eaa14b21ea 100644
+--- a/sources/shiboken2/libshiboken/signature/signature_helper.cpp
++++ b/sources/shiboken2/libshiboken/signature/signature_helper.cpp
+@@ -105,7 +105,8 @@ int add_more_getsets(PyTypeObject *type, PyGetSetDef *gsp, PyObject **doc_descr)
+      */
+     assert(PyType_Check(type));
+     PyType_Ready(type);
+-    PyObject *dict = type->tp_dict;
++    AutoDecRef tpDict(PepType_GetDict(type));
++    auto *dict = tpDict.object();
+     for (; gsp->name != nullptr; gsp++) {
+         PyObject *have_descr = PyDict_GetItemString(dict, gsp->name);
+         if (have_descr != nullptr) {
+@@ -346,7 +347,8 @@ static int _build_func_to_type(PyObject *obtype)
+      * We also check for hidden methods, see below.
+      */
+     auto *type = reinterpret_cast<PyTypeObject *>(obtype);
+-    PyObject *dict = type->tp_dict;
++    AutoDecRef tpDict(PepType_GetDict(type));
++    auto *dict = tpDict.object();
+     PyMethodDef *meth = type->tp_methods;
+ 
+     if (meth == nullptr)
+diff --git a/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/errorhandler.py b/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/errorhandler.py
+index 47ab89ab8fbe..3e1266cfdc36 100644
+--- a/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/errorhandler.py
++++ b/sources/shiboken2/shibokenmodule/files.dir/shibokensupport/signature/errorhandler.py
+@@ -113,6 +113,12 @@ def seterror_argument(args, func_name, info):
+             msg = "{func_name}(): {info}".format(**locals())
+             err = AttributeError
+         return err, msg
++    if isinstance(info, Exception):
++        # PYSIDE-2230: Python 3.12 seems to always do normalization.
++        err = type(info)
++        info = info.args[0]
++        msg = f"{func_name}(): {info}"
++        return err, msg
+     if info and type(info) is dict:
+         keyword = tuple(info)[0]
+         msg = "{func_name}(): unsupported keyword '{keyword}'".format(**locals())
+diff --git a/sources/shiboken2/tests/samplebinding/enum_test.py b/sources/shiboken2/tests/samplebinding/enum_test.py
+index 0beb72033055..f2606a4df0c7 100644
+--- a/sources/shiboken2/tests/samplebinding/enum_test.py
++++ b/sources/shiboken2/tests/samplebinding/enum_test.py
+@@ -95,7 +95,7 @@ class EnumTest(unittest.TestCase):
+ 
+     def testEnumConstructorWithTooManyParameters(self):
+         '''Calling the constructor of non-extensible enum with the wrong number of parameters.'''
+-        self.assertRaises(TypeError, SampleNamespace.InValue, 13, 14)
++        self.assertRaises((TypeError, ValueError), SampleNamespace.InValue, 13, 14)
+ 
+     def testEnumConstructorWithNonNumberParameter(self):
+         '''Calling the constructor of non-extensible enum with a string.'''
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0011-DEBIAN-Stop-using-imp-module.patch
+++ b/lang-python/pyside2/autobuild/patches/0011-DEBIAN-Stop-using-imp-module.patch
@@ -1,0 +1,44 @@
+From c296882c5d6049e44f18f0645d496803809912c0 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 3 Sep 2020 11:14:55 +0200
+Subject: [PATCH 11/23] DEBIAN: Stop using imp module
+X-Developer-Signature: v=1; a=openpgp-sha256; l=999; i=xtexchooser@duck.com;
+ h=from:subject; bh=Alv7KfwABnQhin0p4HyHTeAVOQpzTiL60w/Tf03CVr4=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9P27xF2s11sp7RodmTzGMX+ay65zxdwaJXsG4i7
+ 7/N89IOdZSyMIhxMciKKbIUGTZ4s+qk84suK5eFmcPKBDKEgYtTACZi+5Thv0+fpqLWjfBVi6Xm
+ 2f/7vujhYZ6yfEXRDX81d+u4J6jvncPIsPcVa3DOvst5H3senNybm1LcJlzsqj/Lv0kvh6/z5V4
+ 3FgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Part of commit e796600c9663a26ccf1929aca8336eb0cb23fe5d.
+---
+ sources/shiboken2/tests/otherbinding/module_reload_test.py | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/sources/shiboken2/tests/otherbinding/module_reload_test.py b/sources/shiboken2/tests/otherbinding/module_reload_test.py
+index 368425cd051f..c63af188ecb2 100644
+--- a/sources/shiboken2/tests/otherbinding/module_reload_test.py
++++ b/sources/shiboken2/tests/otherbinding/module_reload_test.py
+@@ -29,6 +29,7 @@
+ ##
+ #############################################################################
+ 
++from importlib import reload
+ import os
+ import shutil
+ import sys
+@@ -38,10 +39,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+ from shiboken_paths import init_paths
+ init_paths()
+ 
+-from py3kcompat import IS_PY3K
+-
+-if IS_PY3K:
+-    from imp import reload
+ 
+ orig_path = os.path.join(os.path.dirname(__file__))
+ workdir = os.getcwd()
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0012-DEBIAN-Do-not-change-RPATH.patch
+++ b/lang-python/pyside2/autobuild/patches/0012-DEBIAN-Do-not-change-RPATH.patch
@@ -1,0 +1,49 @@
+From 609b4763150791e6e2c74100c24ca5ab7d15cb59 Mon Sep 17 00:00:00 2001
+From: Dmitry Shachnev <mitya57@debian.org>
+Date: Thu, 25 Jan 2024 14:21:09 +0300
+Subject: [PATCH 12/23] DEBIAN: Do not change RPATH
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1330; i=xtexchooser@duck.com;
+ h=from:subject; bh=CppHqLM2fQGSQAdFRaZrX3UX+VSOvB5p51vkhXhbVOQ=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9Lcy5ijJ+UYT3xnV+b1/vm1RcXd+wzfXBs4pkyw
+ 4BuxWq1jlIWBjEuBlkxRZYiwwZvVp10ftFl5bIwc1iZQIYwcHEKwETWcjP807aYa+SuVT5Vag/z
+ I8eIo5rxUt+yDnsoKQpeO7hn17kJ7YwM/x9fMz2SFC10YY6OUm/CrkNaB3xigsqf7Hi8Plhl7WE
+ PXgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Forwarded: not-needed
+---
+ build_scripts/main.py           | 3 ---
+ build_scripts/platforms/unix.py | 5 -----
+ 2 files changed, 8 deletions(-)
+
+diff --git a/build_scripts/main.py b/build_scripts/main.py
+index 7aa94f6c2b7b..d1b83d5188a3 100644
+--- a/build_scripts/main.py
++++ b/build_scripts/main.py
+@@ -630,9 +630,6 @@ class PysideBuild(_build, DistUtilsCommandMixin):
+                 log.info("Created {}".format(build_history))
+ 
+         if not OPTION["SKIP_PACKAGING"]:
+-            # Build patchelf if needed
+-            self.build_patchelf()
+-
+             # Prepare packages
+             self.prepare_packages()
+ 
+diff --git a/build_scripts/platforms/unix.py b/build_scripts/platforms/unix.py
+index b842510ff4bb..8df0e739c585 100644
+--- a/build_scripts/platforms/unix.py
++++ b/build_scripts/platforms/unix.py
+@@ -220,8 +220,3 @@ def prepare_packages_posix(self, vars):
+         if config.is_internal_shiboken_generator_build():
+             # Copy over clang before rpath patching.
+             self.prepare_standalone_clang(is_win=False)
+-
+-    # Update rpath to $ORIGIN
+-    if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+-        rpath_path = "{st_build_dir}/{st_package_name}".format(**vars)
+-        self.update_rpath(rpath_path, executables)
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0013-DEBIAN-shiboken2-clang-Fix-clashes-between-type-name.patch
+++ b/lang-python/pyside2/autobuild/patches/0013-DEBIAN-shiboken2-clang-Fix-clashes-between-type-name.patch
@@ -1,0 +1,104 @@
+From 9d51262a22c63228cf1313ed9f9e7723b520ecab Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Tue, 25 Apr 2023 15:30:30 +0200
+Subject: [PATCH 13/23] DEBIAN: shiboken2/clang: Fix clashes between type name
+ and enumeration values
+X-Developer-Signature: v=1; a=openpgp-sha256; l=4452; i=xtexchooser@duck.com;
+ h=from:subject; bh=L1zRT9Z1T/XpbOK3gidgpEuCYYem4f1HYEDCP4Tloi8=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9zcGWuvfG3qXNj648Lh413Z/z7cmG9kefHS8FKy
+ z+9uP95X0cpC4MYF4OsmCJLkWGDN6tOOr/osnJZmDmsTCBDGLg4BWAi0vcY/ueVL7vW2FTyUvxx
+ zI77ttI2G6zVjlStlz7HYVbD8edi032Gf5oSf76z6DearSgNnsX+4q9RwUFvkzv1d2Ue/dgwMYi
+ 1jAsA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Remove all constant and enum value type entries found in the type lookup
+unless it is looking for template arguments; where it may be a
+non-type template argument.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: If0609ce0d0223f551ed6dee1d1e0ea3ef49d6917
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+(cherry picked from commit e22f717153a5e9855531f45c0bf82ff2461a3f7e)
+---
+ .../ApiExtractor/abstractmetabuilder.cpp      | 21 +++++++++++++++++--
+ .../ApiExtractor/abstractmetabuilder.h        |  3 ++-
+ .../ApiExtractor/typesystem_typedefs.h        |  1 +
+ 3 files changed, 22 insertions(+), 3 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp b/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
+index 5a413ecaa82b..2f34e16b6d0f 100644
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
+@@ -2144,6 +2144,13 @@ static bool isNumber(const QString &s)
+                        [](QChar c) { return c.isDigit(); });
+ }
+ 
++// A type entry relevant only for non type template "X<5>"
++static bool isNonTypeTemplateArgument(const TypeEntryCPtr &te)
++{
++    const auto type = te->type();
++    return type == TypeEntry::EnumValue || type == TypeEntry::ConstantValueType;
++}
++
+ AbstractMetaType *AbstractMetaBuilderPrivate::translateTypeStatic(const TypeInfo &_typei,
+                                                                   AbstractMetaClass *currentClass,
+                                                                   AbstractMetaBuilderPrivate *d,
+@@ -2271,7 +2278,15 @@ AbstractMetaType *AbstractMetaBuilderPrivate::translateTypeStatic(const TypeInfo
+         typeInfo.clearInstantiations();
+     }
+ 
+-    const TypeEntries types = findTypeEntries(qualifiedName, name, currentClass, d);
++    TypeEntries types = findTypeEntries(qualifiedName, name, currentClass, d);
++    if (!flags.testFlag(AbstractMetaBuilder::TemplateArgument)) {
++        // Avoid clashes between QByteArray and enum value QMetaType::QByteArray
++        // unless we are looking for template arguments.
++        auto end = std::remove_if(types.begin(), types.end(),
++                                  isNonTypeTemplateArgument);
++        types.erase(end, types.end());
++    }
++
+     if (types.isEmpty()) {
+         if (errorMessageIn) {
+             *errorMessageIn =
+@@ -2293,7 +2308,9 @@ AbstractMetaType *AbstractMetaBuilderPrivate::translateTypeStatic(const TypeInfo
+     const auto &templateArguments = typeInfo.instantiations();
+     for (int t = 0, size = templateArguments.size(); t < size; ++t) {
+         const  TypeInfo &ti = templateArguments.at(t);
+-        AbstractMetaType *targType = translateTypeStatic(ti, currentClass, d, flags, &errorMessage);
++        AbstractMetaType *targType = translateTypeStatic(ti, currentClass, d,
++                                                         flags | AbstractMetaBuilder::TemplateArgument,
++                                                         &errorMessage);
+         // For non-type template parameters, create a dummy type entry on the fly
+         // as is done for classes.
+         if (!targType) {
+diff --git a/sources/shiboken2/ApiExtractor/abstractmetabuilder.h b/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
+index d2dc080a2cbc..8916eaf25db8 100644
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
+@@ -93,7 +93,8 @@ public:
+     void setSkipDeprecated(bool value);
+ 
+     enum TranslateTypeFlag {
+-        DontResolveType = 0x1
++        DontResolveType = 0x1,
++        TemplateArgument = 0x2
+     };
+     Q_DECLARE_FLAGS(TranslateTypeFlags, TranslateTypeFlag);
+ 
+diff --git a/sources/shiboken2/ApiExtractor/typesystem_typedefs.h b/sources/shiboken2/ApiExtractor/typesystem_typedefs.h
+index 73f92b294a87..5dcc65c6513f 100644
+--- a/sources/shiboken2/ApiExtractor/typesystem_typedefs.h
++++ b/sources/shiboken2/ApiExtractor/typesystem_typedefs.h
+@@ -48,6 +48,7 @@ using CodeSnipList = QVector<CodeSnip>;
+ using DocModificationList = QVector<DocModification>;
+ using FieldModificationList = QVector<FieldModification>;
+ using FunctionModificationList = QVector<FunctionModification>;
++using TypeEntryCPtr = const TypeEntry *;
+ using TypeEntries = QVector<const TypeEntry *>;
+ 
+ #endif // TYPESYSTEM_TYPEDEFS_H
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0014-DEBIAN-shiboken2-clang-Fix-and-simplify-resolveType-.patch
+++ b/lang-python/pyside2/autobuild/patches/0014-DEBIAN-shiboken2-clang-Fix-and-simplify-resolveType-.patch
@@ -1,0 +1,101 @@
+From d647c91c1665ac91c207d086252dcb819d66a8b3 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Tue, 25 Apr 2023 10:00:39 +0200
+Subject: [PATCH 14/23] DEBIAN: shiboken2/clang: Fix and simplify resolveType()
+ helper
+X-Developer-Signature: v=1; a=openpgp-sha256; l=3916; i=xtexchooser@duck.com;
+ h=from:subject; bh=8+K26Vr41XzbU/yscPMa6O1R0r5gNZYoB34dLHvC+kQ=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw93B/K2bOmx3Wj3cO/2NTXm8uzyMfYRVTVvxW8eX
+ aDjnry9o5SFQYyLQVZMkaXIsMGbVSedX3RZuSzMHFYmkCEMXJwCMJF73IwMbSerX3gsylx4er9U
+ jpd4yN8zviy9CkJf1st8Nzn4y66onOF/LPtlVtnXnzfbfr8wM6h6+6pZrEZFlmtWfNA/L7VNzHA
+ +GwA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+The function had a bug which only manifested with clang 16:
+"type" should have been assigned the type of the cursor
+obtained from clang_getTypeDeclaration(). With this, the complicated
+lookup code in getBaseClass() can be removed.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5
+Change-Id: I861e30451b3f4af2ec0c2e4ffa4179a429854533
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+---
+ .../ApiExtractor/clangparser/clangbuilder.cpp | 39 +++++++++----------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+index e8e5bcfde302..1b4c81c52da2 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+@@ -627,6 +627,9 @@ long clang_EnumDecl_isScoped4(BaseVisitor *bv, const CXCursor &cursor)
+ #endif // CLANG_NO_ENUMDECL_ISSCOPED
+ 
+ // Resolve declaration and type of a base class
++// Note: TypeAliasTemplateDecl ("using QVector<T>=QList<T>") is automatically
++// resolved by clang_getTypeDeclaration(), but it stops at
++// TypeAliasDecl / TypedefDecl.
+ 
+ struct TypeDeclaration
+ {
+@@ -634,19 +637,23 @@ struct TypeDeclaration
+     CXCursor declaration;
+ };
+ 
++static inline bool isTypeAliasDecl(const CXCursor &cursor)
++{
++    const auto kind = clang_getCursorKind(cursor);
++    return kind == CXCursor_TypeAliasDecl || kind == CXCursor_TypedefDecl;
++}
++
+ static TypeDeclaration resolveBaseSpecifier(const CXCursor &cursor)
+ {
+     Q_ASSERT(clang_getCursorKind(cursor) == CXCursor_CXXBaseSpecifier);
+     CXType inheritedType = clang_getCursorType(cursor);
+     CXCursor decl = clang_getTypeDeclaration(inheritedType);
+-    if (inheritedType.kind != CXType_Unexposed) {
+-        while (true) {
+-            auto kind = clang_getCursorKind(decl);
+-            if (kind != CXCursor_TypeAliasDecl && kind != CXCursor_TypedefDecl)
+-                break;
+-            inheritedType = clang_getTypedefDeclUnderlyingType(decl);
+-            decl = clang_getTypeDeclaration(inheritedType);
+-        }
++    auto resolvedType = clang_getCursorType(decl);
++    if (resolvedType.kind != CXType_Invalid && resolvedType.kind != inheritedType.kind)
++        inheritedType = resolvedType;
++    while (isTypeAliasDecl(decl)) {
++        inheritedType = clang_getTypedefDeclUnderlyingType(decl);
++        decl = clang_getTypeDeclaration(inheritedType);
+     }
+     return {inheritedType, decl};
+ }
+@@ -656,20 +663,10 @@ void BuilderPrivate::addBaseClass(const CXCursor &cursor)
+ {
+     Q_ASSERT(clang_getCursorKind(cursor) == CXCursor_CXXBaseSpecifier);
+     // Note: spelling has "struct baseClass", use type
+-    QString baseClassName;
+     const auto decl = resolveBaseSpecifier(cursor);
+-    if (decl.type.kind == CXType_Unexposed) {
+-        // The type is unexposed when the base class is a template type alias:
+-        // "class QItemSelection : public QList<X>" where QList is aliased to QVector.
+-        // Try to resolve via code model.
+-        TypeInfo info = createTypeInfo(decl.type);
+-        auto parentScope = m_scopeStack.at(m_scopeStack.size() - 2); // Current is class.
+-        auto resolved = TypeInfo::resolveType(info, parentScope);
+-        if (resolved != info)
+-            baseClassName = resolved.toString();
+-    }
+-    if (baseClassName.isEmpty())
+-        baseClassName = getTypeName(decl.type);
++    QString baseClassName = getTypeName(decl.type);
++    if (baseClassName.startsWith(u"std::")) // Simplify "std::" types
++        baseClassName = createTypeInfo(decl.type).toString();
+ 
+     auto it = m_cursorClassHash.constFind(decl.declaration);
+     const CodeModel::AccessPolicy access = accessPolicy(clang_getCXXAccessSpecifier(cursor));
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0015-DEBIAN-shiboken2-clang-Remove-typedef-expansion.patch
+++ b/lang-python/pyside2/autobuild/patches/0015-DEBIAN-shiboken2-clang-Remove-typedef-expansion.patch
@@ -1,0 +1,113 @@
+From 359f6dd9ad6c7f5720a689cec71e33a7a83efa89 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 20 Apr 2023 11:16:15 +0200
+Subject: [PATCH 15/23] DEBIAN: shiboken2/clang: Remove typedef expansion
+X-Developer-Signature: v=1; a=openpgp-sha256; l=4380; i=xtexchooser@duck.com;
+ h=from:subject; bh=T/S6aQMQ3+reuVyAbWBnKTtrFCMH0TqCw+K0tgiMnPs=;
+ b=kA0DAAoWuRgIbtgEW5EByyZiAGiJ6cOgAjxF46TLWydaBMK4X9W6h1sPjXuNwL2O9WSBfJ38F
+ Ih1BAAWCgAdFiEEcjGASwUsZw8VpncduRgIbtgEW5EFAmiJ6cMACgkQuRgIbtgEW5HZRAD9GCmm
+ 7hO0McpRf7GUpQntN732JahV/SGm+1lc4WHEuWUA/2jF4EpD3VdditxuF1gSPF04VUPHvDFdD5K
+ dhl6NjLAG
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+The functionality will be re-added by a subsequent change
+expanding elaborated types.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: I3245c6dccba7de0ed1ce0e7820e1edb4567ca3c2
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+(cherry picked from commit 24742dca014109bd3c2a9775fc15ca306ab22c9c)
+---
+ .../ApiExtractor/clangparser/clangbuilder.cpp | 39 -------------------
+ 1 file changed, 39 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+index 1b4c81c52da2..332f1dac9af7 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+@@ -140,7 +140,6 @@ static bool isSigned(CXTypeKind kind)
+ class BuilderPrivate {
+ public:
+     using CursorClassHash = QHash<CXCursor, ClassModelItem>;
+-    using CursorTypedefHash = QHash<CXCursor, TypeDefModelItem>;
+     using TypeInfoHash = QHash<CXType, TypeInfo>;
+ 
+     explicit BuilderPrivate(BaseVisitor *bv) : m_baseVisitor(bv), m_model(new CodeModel)
+@@ -197,9 +196,6 @@ public:
+     QString cursorValueExpression(BaseVisitor *bv, const CXCursor &cursor) const;
+     void addBaseClass(const CXCursor &cursor);
+ 
+-    template <class Item>
+-    void qualifyTypeDef(const CXCursor &typeRefCursor, const QSharedPointer<Item> &item) const;
+-
+     bool visitHeader(const char *cFileName) const;
+ 
+     void setFileName(const CXCursor &cursor, _CodeModelItem *item);
+@@ -213,7 +209,6 @@ public:
+     // classes can be correctly parented in case of forward-declared inner classes
+     // (QMetaObject::Connection)
+     CursorClassHash m_cursorClassHash;
+-    CursorTypedefHash m_cursorTypedefHash;
+ 
+     mutable TypeInfoHash m_typeInfoHash; // Cache type information
+     mutable QHash<QString, TemplateTypeAliasModelItem> m_templateTypeAliases;
+@@ -561,7 +556,6 @@ void BuilderPrivate::addTypeDef(const CXCursor &cursor, const CXType &cxType)
+     item->setType(createTypeInfo(cxType));
+     item->setScope(m_scope);
+     m_scopeStack.back()->addTypeDef(item);
+-    m_cursorTypedefHash.insert(cursor, item);
+ }
+ 
+ void BuilderPrivate::startTemplateTypeAlias(const CXCursor &cursor)
+@@ -703,31 +697,6 @@ static inline CXCursor definitionFromTypeRef(const CXCursor &typeRefCursor)
+     return clang_getTypeDeclaration(clang_getCursorType(typeRefCursor));
+ }
+ 
+-// Qualify function arguments or fields that are typedef'ed from another scope:
+-// enum ConversionFlag {};
+-// typedef QFlags<ConversionFlag> ConversionFlags;
+-// class QTextCodec {
+-//      enum ConversionFlag {};
+-//      typedef QFlags<ConversionFlag> ConversionFlags;
+-//      struct ConverterState {
+-//          explicit ConverterState(ConversionFlags);
+-//                                  ^^ qualify to QTextCodec::ConversionFlags
+-//          ConversionFlags m_flags;
+-//                          ^^ ditto
+-
+-template <class Item> // ArgumentModelItem, VariableModelItem
+-void BuilderPrivate::qualifyTypeDef(const CXCursor &typeRefCursor, const QSharedPointer<Item> &item) const
+-{
+-    TypeInfo type = item->type();
+-    if (type.qualifiedName().size() == 1) { // item's type is unqualified.
+-        const auto it = m_cursorTypedefHash.constFind(definitionFromTypeRef(typeRefCursor));
+-        if (it != m_cursorTypedefHash.constEnd() && !it.value()->scope().isEmpty()) {
+-            type.setQualifiedName(it.value()->scope() + type.qualifiedName());
+-            item->setType(type);
+-        }
+-    }
+-}
+-
+ void BuilderPrivate::setFileName(const CXCursor &cursor, _CodeModelItem *item)
+ {
+     const SourceRange range = getCursorRange(cursor);
+@@ -1120,14 +1089,6 @@ BaseVisitor::StartTokenResult Builder::startToken(const CXCursor &cursor)
+     }
+         break;
+     case CXCursor_TypeRef:
+-        if (!d->m_currentFunction.isNull()) {
+-            if (d->m_currentArgument.isNull())
+-                d->qualifyTypeDef(cursor, d->m_currentFunction); // return type
+-            else
+-                d->qualifyTypeDef(cursor, d->m_currentArgument);
+-        } else if (!d->m_currentField.isNull()) {
+-            d->qualifyTypeDef(cursor, d->m_currentField);
+-        }
+         break;
+     case CXCursor_CXXFinalAttr:
+          if (!d->m_currentFunction.isNull())
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0016-DEBIAN-shiboken2-clang-Fix-build-with-clang-16.patch
+++ b/lang-python/pyside2/autobuild/patches/0016-DEBIAN-shiboken2-clang-Fix-build-with-clang-16.patch
@@ -1,0 +1,120 @@
+From 4a60d81be497fe1b0c04a90aa4db90e980776391 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Tue, 25 Apr 2023 14:01:45 +0200
+Subject: [PATCH 16/23] DEBIAN: shiboken2/clang: Fix build with clang 16
+X-Developer-Signature: v=1; a=openpgp-sha256; l=5002; i=xtexchooser@duck.com;
+ h=from:subject; bh=BOAXB0M/hOEUZMdjhW+UASfI+hp+QlaH28Pe5F+UPWw=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdLw9Pqhc7IrJ8+SbNa13eZt9sviaXfynrLWXe/e6xz
+ S/f9xfSOkpZGMS4GGTFFFmKDBu8WXXS+UWXlcvCzGFlAhnCwMUpABNR2MfwT6uJ58afu6kz/m7k
+ DN65yuHrhcdsn7tmR3larM3TmpjrPpuRoW1dwNO+9x/CPy28UqH1+efD4JXrJ36d8+LZkd4KAd4
+ yYz4A
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+clang 16 returns more elaborated types instead of fully qualified type
+names. Qualify elaborated types when retrieving the type name.
+
+[ChangeLog][shiboken6] Support for libclang version 16 has been added.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: Ibd428280180967f11d82a72159e744c016afc927
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+(cherry picked from commit 44ef1859214c66861a251d4a0faf5c38dc050850)
+---
+ .../ApiExtractor/clangparser/clangbuilder.cpp |  2 +-
+ .../ApiExtractor/clangparser/clangutils.cpp   | 23 +++++++++++++++++++
+ .../ApiExtractor/clangparser/clangutils.h     |  1 +
+ .../ApiExtractor/tests/testtemplates.cpp      |  3 +--
+ 4 files changed, 26 insertions(+), 3 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+index 332f1dac9af7..ed1e15d4e778 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+@@ -524,7 +524,7 @@ TypeInfo BuilderPrivate::createTypeInfoHelper(const CXType &type) const
+     typeInfo.setConstant(clang_isConstQualifiedType(nestedType) != 0);
+     typeInfo.setVolatile(clang_isVolatileQualifiedType(nestedType) != 0);
+ 
+-    QString typeName = getTypeName(nestedType);
++    QString typeName = getResolvedTypeName(nestedType);
+     while (TypeInfo::stripLeadingConst(&typeName)
+            || TypeInfo::stripLeadingVolatile(&typeName)) {
+     }
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
+index 57271ef71f19..295ede39b25d 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
+@@ -130,6 +130,23 @@ QString getCursorDisplayName(const CXCursor &cursor)
+     return result;
+ }
+ 
++static inline bool isBuiltinType(CXTypeKind kind)
++{
++    return kind >= CXType_FirstBuiltin && kind <= CXType_LastBuiltin;
++}
++
++// Resolve elaborated types occurring with clang 16
++static CXType resolveType(const CXType &type)
++{
++    if (!isBuiltinType(type.kind)) {
++        CXCursor decl = clang_getTypeDeclaration(type);
++        auto resolvedType = clang_getCursorType(decl);
++        if (resolvedType.kind != CXType_Invalid && resolvedType.kind != type.kind)
++            return resolvedType;
++    }
++    return type;
++}
++
+ QString getTypeName(const CXType &type)
+ {
+     CXString typeSpelling = clang_getTypeSpelling(type);
+@@ -138,6 +155,12 @@ QString getTypeName(const CXType &type)
+     return result;
+ }
+ 
++// Resolve elaborated types occurring with clang 16
++QString getResolvedTypeName(const CXType &type)
++{
++    return getTypeName(resolveType(type));
++}
++
+ Diagnostic::Diagnostic(const QString &m, const CXCursor &c, CXDiagnosticSeverity s)
+     : message(m), source(Other), severity(s)
+ {
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangutils.h b/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
+index f7c230a6666b..aacaf63ff2f9 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
+@@ -52,6 +52,7 @@ QString getCursorKindName(CXCursorKind cursorKind);
+ QString getCursorSpelling(const CXCursor &cursor);
+ QString getCursorDisplayName(const CXCursor &cursor);
+ QString getTypeName(const CXType &type);
++QString getResolvedTypeName(const CXType &type);
+ inline QString getCursorTypeName(const CXCursor &cursor)
+     { return getTypeName(clang_getCursorType(cursor)); }
+ inline QString getCursorResultTypeName(const CXCursor &cursor)
+diff --git a/sources/shiboken2/ApiExtractor/tests/testtemplates.cpp b/sources/shiboken2/ApiExtractor/tests/testtemplates.cpp
+index 9f929c432ad9..fbc5c4c90228 100644
+--- a/sources/shiboken2/ApiExtractor/tests/testtemplates.cpp
++++ b/sources/shiboken2/ApiExtractor/tests/testtemplates.cpp
+@@ -236,7 +236,6 @@ struct List {
+     const AbstractMetaFunction *erase = list->findFunction(QStringLiteral("erase"));
+     QVERIFY(erase);
+     QCOMPARE(erase->arguments().size(), 1);
+-    QEXPECT_FAIL("", "Clang: Some other code changes the parameter type", Abort);
+     QCOMPARE(erase->arguments().at(0)->type()->cppSignature(), QLatin1String("List::Iterator"));
+ }
+ 
+@@ -389,7 +388,7 @@ typedef BaseTemplateClass<TypeOne> TypeOneClass;
+     const ComplexTypeEntry* oneType = one->typeEntry();
+     const ComplexTypeEntry* baseType = base->typeEntry();
+     QCOMPARE(oneType->baseContainerType(), baseType);
+-    QCOMPARE(one->baseClassNames(), QStringList(QLatin1String("BaseTemplateClass<TypeOne>")));
++    QCOMPARE(one->baseClassNames(), QStringList(QLatin1String("NSpace::BaseTemplateClass<NSpace::TypeOne>")));
+ 
+     QVERIFY(one->hasTemplateBaseClassInstantiations());
+     AbstractMetaTypeList instantiations = one->templateBaseClassInstantiations();
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0017-DEBIAN-shiboken2-clang-Record-scope-resolution-of-ar.patch
+++ b/lang-python/pyside2/autobuild/patches/0017-DEBIAN-shiboken2-clang-Record-scope-resolution-of-ar.patch
@@ -1,0 +1,190 @@
+From bcf28fbde3fb2718696566715f03e6c77b86dbe7 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 27 Apr 2023 12:44:10 +0200
+Subject: [PATCH 17/23] DEBIAN: shiboken2/clang: Record scope resolution of
+ arguments/function return
+X-Developer-Signature: v=1; a=openpgp-sha256; l=7496; i=xtexchooser@duck.com;
+ h=from:subject; bh=iha4Mtf8+uBy0OfiJY+m8z55lEcuOj5Wg1ZSXWspkCw=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL48YHuSrXyV/sc70wpsA5YW/FurXZCSZuT4S2++nf
+ cjIJ5yro5SFQYyLQVZMkaXIsMGbVSedX3RZuSzMHFYmkCEMXJwCMJFNBQz/lJ9VF3f17hA4YNS7
+ 7wp3yw3H6umW0s/CJnCJXLGdZ/e/lJHh3Va2iwnm56QmfgjYkBuu3vz9P+ueWwn9qdMbP974mOf
+ ICgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Add a flag indicating whether a type was specified with a leading "::"
+(scope resolution). Such parameters previously caused the function to
+rejected due to the "::TypeName" not being found. The type resolution
+added for clang 16 strips these qualifiers though, so, the information
+needs to be stored.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: I27d27c94ec43bcc4cb3b79e6e9ce6706c749a1e9
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+(cherry picked from commit 075d8ad4660f05e6d2583ff1c05e9987ad624bfe)
+---
+ .../ApiExtractor/clangparser/clangbuilder.cpp |  8 +++++--
+ .../ApiExtractor/clangparser/clangutils.cpp   | 11 +++++++++
+ .../ApiExtractor/clangparser/clangutils.h     |  1 +
+ .../ApiExtractor/parser/codemodel.cpp         | 24 +++++++++++++++++++
+ .../shiboken2/ApiExtractor/parser/codemodel.h |  8 +++++++
+ 5 files changed, 50 insertions(+), 2 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+index ed1e15d4e778..1b5cc5c8f588 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp
+@@ -294,7 +294,9 @@ FunctionModelItem BuilderPrivate::createFunction(const CXCursor &cursor,
+         name = fixTypeName(name);
+     FunctionModelItem result(new _FunctionModelItem(m_model, name));
+     setFileName(cursor, result.data());
+-    result->setType(createTypeInfoHelper(clang_getCursorResultType(cursor)));
++    const auto type = clang_getCursorResultType(cursor);
++    result->setType(createTypeInfoHelper(type));
++    result->setScopeResolution(hasScopeResolution(type));
+     result->setFunctionType(t);
+     result->setScope(m_scope);
+     result->setStatic(clang_Cursor_getStorageClass(cursor) == CX_SC_Static);
+@@ -1031,7 +1033,9 @@ BaseVisitor::StartTokenResult Builder::startToken(const CXCursor &cursor)
+         if (d->m_currentArgument.isNull() && !d->m_currentFunction.isNull()) {
+             const QString name = getCursorSpelling(cursor);
+             d->m_currentArgument.reset(new _ArgumentModelItem(d->m_model, name));
+-            d->m_currentArgument->setType(d->createTypeInfo(cursor));
++            const auto type = clang_getCursorType(cursor);
++            d->m_currentArgument->setScopeResolution(hasScopeResolution(type));
++            d->m_currentArgument->setType(d->createTypeInfo(type));
+             d->m_currentFunction->addArgument(d->m_currentArgument);
+             QString defaultValueExpression = d->cursorValueExpression(this, cursor);
+             if (!defaultValueExpression.isEmpty()) {
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp b/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
+index 295ede39b25d..ec6d228384ee 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangutils.cpp
+@@ -155,6 +155,17 @@ QString getTypeName(const CXType &type)
+     return result;
+ }
+ 
++// Quick check for "::Type"
++bool hasScopeResolution(const CXType &type)
++{
++    CXString typeSpelling = clang_getTypeSpelling(type);
++    const QString spelling = QString::fromUtf8(clang_getCString(typeSpelling));
++    const bool result = spelling.startsWith(QLatin1String("::"))
++        || spelling.contains(QLatin1String(" ::"));
++    clang_disposeString(typeSpelling);
++    return result;
++}
++
+ // Resolve elaborated types occurring with clang 16
+ QString getResolvedTypeName(const CXType &type)
+ {
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/clangutils.h b/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
+index aacaf63ff2f9..33f362cbcca3 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
++++ b/sources/shiboken2/ApiExtractor/clangparser/clangutils.h
+@@ -52,6 +52,7 @@ QString getCursorKindName(CXCursorKind cursorKind);
+ QString getCursorSpelling(const CXCursor &cursor);
+ QString getCursorDisplayName(const CXCursor &cursor);
+ QString getTypeName(const CXType &type);
++bool hasScopeResolution(const CXType &type);
+ QString getResolvedTypeName(const CXType &type);
+ inline QString getCursorTypeName(const CXCursor &cursor)
+     { return getTypeName(clang_getCursorType(cursor)); }
+diff --git a/sources/shiboken2/ApiExtractor/parser/codemodel.cpp b/sources/shiboken2/ApiExtractor/parser/codemodel.cpp
+index dea081286e1a..ba07a016f152 100644
+--- a/sources/shiboken2/ApiExtractor/parser/codemodel.cpp
++++ b/sources/shiboken2/ApiExtractor/parser/codemodel.cpp
+@@ -1121,11 +1121,23 @@ void _ArgumentModelItem::setDefaultValue(bool defaultValue)
+     m_defaultValue = defaultValue;
+ }
+ 
++bool _ArgumentModelItem::scopeResolution() const
++{
++    return m_scopeResolution;
++}
++
++void _ArgumentModelItem::setScopeResolution(bool v)
++{
++    m_scopeResolution = v;
++}
++
+ #ifndef QT_NO_DEBUG_STREAM
+ void _ArgumentModelItem::formatDebug(QDebug &d) const
+ {
+     _CodeModelItem::formatDebug(d);
+     d << ", type=" << m_type;
++    if (m_scopeResolution)
++        d << ", [m_scope resolution]";
+     if (m_defaultValue)
+         d << ", defaultValue=\"" << m_defaultValueExpression << '"';
+ }
+@@ -1200,6 +1212,16 @@ void _FunctionModelItem::setVariadics(bool isVariadics)
+     m_isVariadics = isVariadics;
+ }
+ 
++bool _FunctionModelItem::scopeResolution() const
++{
++    return m_scopeResolution;
++}
++
++void _FunctionModelItem::setScopeResolution(bool v)
++{
++    m_scopeResolution = v;
++}
++
+ bool _FunctionModelItem::isNoExcept() const
+ {
+     return m_exceptionSpecification == ExceptionSpecification::NoExcept;
+@@ -1343,6 +1365,8 @@ void _FunctionModelItem::formatDebug(QDebug &d) const
+         d << " [explicit]";
+     if (m_isInvokable)
+         d << " [invokable]";
++    if (m_scopeResolution)
++        d << " [scope resolution]";
+     formatModelItemList(d, ", arguments=", m_arguments);
+     if (m_isVariadics)
+         d << ",...";
+diff --git a/sources/shiboken2/ApiExtractor/parser/codemodel.h b/sources/shiboken2/ApiExtractor/parser/codemodel.h
+index b990ad913757..85f298cc0068 100644
+--- a/sources/shiboken2/ApiExtractor/parser/codemodel.h
++++ b/sources/shiboken2/ApiExtractor/parser/codemodel.h
+@@ -499,6 +499,10 @@ public:
+     QString defaultValueExpression() const { return m_defaultValueExpression; }
+     void setDefaultValueExpression(const QString &expr) { m_defaultValueExpression = expr; }
+ 
++    // Argument type has scope resolution "::ArgumentType"
++    bool scopeResolution() const;
++    void setScopeResolution(bool v);
++
+ #ifndef QT_NO_DEBUG_STREAM
+     void formatDebug(QDebug &d) const override;
+ #endif
+@@ -507,6 +511,7 @@ private:
+     TypeInfo m_type;
+     QString m_defaultValueExpression;
+     bool m_defaultValue = false;
++    bool m_scopeResolution = false;
+ };
+ 
+ class _MemberModelItem: public _CodeModelItem
+@@ -623,6 +628,8 @@ public:
+     bool isVariadics() const;
+     void setVariadics(bool isVariadics);
+ 
++    bool scopeResolution() const; // Return type has scope resolution "::ReturnType"
++    void setScopeResolution(bool v);
+ 
+     bool isSimilar(const FunctionModelItem &other) const;
+ 
+@@ -652,6 +659,7 @@ private:
+             uint m_isExplicit: 1;
+             uint m_isVariadics: 1;
+             uint m_isInvokable : 1; // Qt
++            uint m_scopeResolution: 1;
+         };
+         uint m_flags;
+     };
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0018-DEBIAN-shiboken2-clang-Suppress-class-scope-look-up-.patch
+++ b/lang-python/pyside2/autobuild/patches/0018-DEBIAN-shiboken2-clang-Suppress-class-scope-look-up-.patch
@@ -1,0 +1,108 @@
+From 37f8b8d9820e7ef30d796c8a44bd9f6042da4ab8 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 27 Apr 2023 13:00:37 +0200
+Subject: [PATCH 18/23] DEBIAN: shiboken2/clang: Suppress class scope look up
+ for parameters with scope resolution
+X-Developer-Signature: v=1; a=openpgp-sha256; l=4950; i=xtexchooser@duck.com;
+ h=from:subject; bh=HkxOYJJfMbJEOw0PEeC888UGb6PqdmlDflshFhZud+8=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL4/EfUr2POJRtuoJu9b5WecOy23guqj578uZw4qaa
+ +ecmPDnXEcpC4MYF4OsmCJLkWGDN6tOOr/osnJZmDmsTCBDGLg4BWAiaQkM/yMTHkmUXWCqbp1x
+ JzRsz8edq9u/ndDhubbP+0WE2v0lrH8Z/nC4fM6aLNYtMj3DKrhMcPW3FotdhwwOTZt4psqS4bu
+ OORcA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Add a flag to AbstractMetaBuilderPrivate::findTypeEntriesHelper()
+to suppress the class scope look in case scope resolution.
+
+Task-number: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: I04a4810d03845fb48393c5efed3641220bd12d87
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+---
+ .../ApiExtractor/abstractmetabuilder.cpp         | 16 ++++++++++++----
+ .../shiboken2/ApiExtractor/abstractmetabuilder.h |  3 ++-
+ .../ApiExtractor/abstractmetabuilder_p.h         |  1 +
+ 3 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp b/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
+index 2f34e16b6d0f..4bf4ab40a722 100644
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
+@@ -1845,7 +1845,10 @@ AbstractMetaFunction *AbstractMetaBuilderPrivate::traverseFunction(const Functio
+             return nullptr;
+         }
+ 
+-        AbstractMetaType *type = translateType(returnType, currentClass, {}, &errorMessage);
++        TranslateTypeFlags flags;
++        if (functionItem->scopeResolution())
++            flags.setFlag(AbstractMetaBuilder::NoClassScopeLookup);
++        AbstractMetaType *type = translateType(returnType, currentClass, flags, &errorMessage);
+         if (!type) {
+             const QString reason = msgUnmatchedReturnType(functionItem, errorMessage);
+             qCWarning(lcShiboken, "%s",
+@@ -1880,7 +1883,10 @@ AbstractMetaFunction *AbstractMetaBuilderPrivate::traverseFunction(const Functio
+             return nullptr;
+         }
+ 
+-        AbstractMetaType *metaType = translateType(arg->type(), currentClass, {}, &errorMessage);
++        TranslateTypeFlags flags;
++        if (arg->scopeResolution())
++            flags.setFlag(AbstractMetaBuilder::NoClassScopeLookup);
++        AbstractMetaType *metaType = translateType(arg->type(), currentClass, flags, &errorMessage);
+         if (!metaType) {
+             // If an invalid argument has a default value, simply remove it
+             // unless the function is virtual (since the override in the
+@@ -2073,11 +2079,13 @@ static const TypeEntry* findTypeEntryUsingContext(const AbstractMetaClass* metaC
+ // Helper for translateTypeStatic()
+ TypeEntries AbstractMetaBuilderPrivate::findTypeEntries(const QString &qualifiedName,
+                                                         const QString &name,
++                                                        TranslateTypeFlags flags,
+                                                         AbstractMetaClass *currentClass,
+                                                         AbstractMetaBuilderPrivate *d)
+ {
+     // 5.1 - Try first using the current scope
+-    if (currentClass) {
++    if (currentClass != nullptr
++        && !flags.testFlag(AbstractMetaBuilder::NoClassScopeLookup)) {
+         if (auto type = findTypeEntryUsingContext(currentClass, qualifiedName))
+             return {type};
+ 
+@@ -2278,7 +2286,7 @@ AbstractMetaType *AbstractMetaBuilderPrivate::translateTypeStatic(const TypeInfo
+         typeInfo.clearInstantiations();
+     }
+ 
+-    TypeEntries types = findTypeEntries(qualifiedName, name, currentClass, d);
++    TypeEntries types = findTypeEntries(qualifiedName, name, flags, currentClass, d);
+     if (!flags.testFlag(AbstractMetaBuilder::TemplateArgument)) {
+         // Avoid clashes between QByteArray and enum value QMetaType::QByteArray
+         // unless we are looking for template arguments.
+diff --git a/sources/shiboken2/ApiExtractor/abstractmetabuilder.h b/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
+index 8916eaf25db8..f333ad5c89ba 100644
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder.h
+@@ -94,7 +94,8 @@ public:
+ 
+     enum TranslateTypeFlag {
+         DontResolveType = 0x1,
+-        TemplateArgument = 0x2
++        TemplateArgument = 0x2,
++        NoClassScopeLookup = 0x4
+     };
+     Q_DECLARE_FLAGS(TranslateTypeFlags, TranslateTypeFlag);
+ 
+diff --git a/sources/shiboken2/ApiExtractor/abstractmetabuilder_p.h b/sources/shiboken2/ApiExtractor/abstractmetabuilder_p.h
+index 846895089035..8ddd3692a7f5 100644
+--- a/sources/shiboken2/ApiExtractor/abstractmetabuilder_p.h
++++ b/sources/shiboken2/ApiExtractor/abstractmetabuilder_p.h
+@@ -154,6 +154,7 @@ public:
+                                                  TranslateTypeFlags flags = {},
+                                                  QString *errorMessageIn = nullptr);
+     static TypeEntries findTypeEntries(const QString &qualifiedName, const QString &name,
++                                       TranslateTypeFlags flags = {},
+                                        AbstractMetaClass *currentClass = nullptr,
+                                        AbstractMetaBuilderPrivate *d = nullptr);
+ 
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0019-DEBIAN-shiboken2-clang-Write-scope-resolution-for-al.patch
+++ b/lang-python/pyside2/autobuild/patches/0019-DEBIAN-shiboken2-clang-Write-scope-resolution-for-al.patch
@@ -1,0 +1,77 @@
+From 92af6bb8cb4210aa689afef07aa0484dc8c045e1 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 27 Apr 2023 12:18:39 +0200
+Subject: [PATCH 19/23] DEBIAN: shiboken2/clang: Write scope resolution for all
+ parameters of native wrappers
+X-Developer-Signature: v=1; a=openpgp-sha256; l=2702; i=xtexchooser@duck.com;
+ h=from:subject; bh=HW2O8OehmDqZj45KVZVQ1BlcqwiChVA4qyBHdx1wtmE=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL4/oVr8V5ohpebzvFktDfOnUZacfztp4YDZzwvqGx
+ 7Iz9py81VHKwiDGxSArpshSZNjgzaqTzi+6rFwWZg4rE8gQBi5OAZhI4CyGf0oP6ybt/eHaLLup
+ WOmyUWRZPtteTtfNGxwaniznePJyihsjw26x+KJ7/9+wv/whnuEiyXZVXyLNM7Vj/9Yg6dxVO5Z
+ JsgAA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Make sure types are correct for cases like:
+
+- QtDBusHelper::QDBusReply::QDBusReply(::QDBusReply<void>)
+- Qt3DInput*Event constructors taking the equivalent QtGui classes
+  (Qt3DInput::QMouseEvent(::QMouseEvent *);
+
+[ChangeLog][shiboken6] Support for parameters/function return
+types with scope resolution has been improved.
+
+Fixes: PYSIDE-2288
+Pick-to: 6.5 5.15
+Change-Id: Id29758fceb88188f4cd834fbd5a7cc0ab511fb1a
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+(cherry picked from commit dd863857436bbeeba4c0a1077f5ad16653296277)
+---
+ sources/shiboken2/generator/generator.cpp | 30 ++++++++++++-----------
+ 1 file changed, 16 insertions(+), 14 deletions(-)
+
+diff --git a/sources/shiboken2/generator/generator.cpp b/sources/shiboken2/generator/generator.cpp
+index 60282828a7e0..6147b8ab797e 100644
+--- a/sources/shiboken2/generator/generator.cpp
++++ b/sources/shiboken2/generator/generator.cpp
+@@ -899,21 +899,23 @@ QString Generator::translateType(const AbstractMetaType *cType,
+                 if (index >= (s.size() - (constLen + 1))) // (VarType const)  or (VarType const[*|&])
+                     s = s.remove(index, constLen);
+             }
+-        } else if (options & Generator::ExcludeConst || options & Generator::ExcludeReference) {
+-            AbstractMetaType *copyType = cType->copy();
+-
+-            if (options & Generator::ExcludeConst)
+-                copyType->setConstant(false);
+-
+-            if (options & Generator::ExcludeReference)
+-                copyType->setReferenceType(NoReference);
+-
+-            s = copyType->cppSignature();
+-            if (!copyType->typeEntry()->isVoid() && !copyType->typeEntry()->isCppPrimitive())
+-                s.prepend(QLatin1String("::"));
+-            delete copyType;
+         } else {
+-            s = cType->cppSignature();
++            AbstractMetaType *copyType = cType->copy();
++            if (options & Generator::ExcludeConst || options & Generator::ExcludeReference) {
++                if (options & Generator::ExcludeConst)
++                    copyType->setConstant(false);
++
++                if (options & Generator::ExcludeReference)
++                    copyType->setReferenceType(NoReference);
++            }
++            s = copyType->cppSignature();
++            const auto te = copyType->typeEntry();
++            if (!te->isVoid() && !te->isCppPrimitive()) { // Add scope resolution
++                const auto pos = s.indexOf(te->qualifiedCppName()); // Skip const/volatile
++                Q_ASSERT(pos >= 0);
++                s.insert(pos, QLatin1String("::"));
++            }
++            delete copyType;
+         }
+     }
+ 
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0020-DEBIAN-Do-the-transition-to-Python-3.13.patch
+++ b/lang-python/pyside2/autobuild/patches/0020-DEBIAN-Do-the-transition-to-Python-3.13.patch
@@ -1,0 +1,36 @@
+From c1e3ca8ad45eb6db4a6996154a2f0fb934643051 Mon Sep 17 00:00:00 2001
+From: Christian Tismer <tismer@stackless.com>
+Date: Fri, 7 Jun 2024 14:57:14 +0200
+Subject: [PATCH 20/23] DEBIAN: Do the transition to Python 3.13
+X-Developer-Signature: v=1; a=openpgp-sha256; l=779; i=xtexchooser@duck.com;
+ h=from:subject; bh=5MCf2OWaGmycrHobsFTxlAKHFMe/OOvhtKtdqdmXzDY=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL48kvkhO6jsmwH1yxrNrt8yrSp3UEi/vCbCKefxSN
+ mOBzEnXjlIWBjEuBlkxRZYiwwZvVp10ftFl5bIwc1iZQIYwcHEKwE1WZ2To7zLTrBJ0LZ2h0ywm
+ /CB5ksond+bp7OGnT8e/DtzKvEaX4Z/G0bdKj7/LPn/659cS5sf/61bF5Eq86daTWV5jolKUKs4
+ CAA==
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Task-number: PYSIDE-2751
+Change-Id: I37b447148787e2923a58c091a5c8ac808d579bc0
+Reviewed-by: Friedemann Kleint <Friedemann.Kleint@qt.io>
+(cherry picked from commit ad18260e583a30505e42b04fd242c52ff36f735c)
+---
+ build_scripts/config.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build_scripts/config.py b/build_scripts/config.py
+index b2d6fc5eef64..f02ae41a6872 100644
+--- a/build_scripts/config.py
++++ b/build_scripts/config.py
+@@ -96,6 +96,7 @@ class Config(object):
+             'Programming Language :: Python :: 3.10',
+             'Programming Language :: Python :: 3.11',
+             'Programming Language :: Python :: 3.12',
++            'Programming Language :: Python :: 3.13',
+         ]
+ 
+         self.setup_script_dir = None
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0021-DEBIAN-Use-public-version-of-PyLong_AsInt-for-Python.patch
+++ b/lang-python/pyside2/autobuild/patches/0021-DEBIAN-Use-public-version-of-PyLong_AsInt-for-Python.patch
@@ -1,0 +1,35 @@
+From f5ea263968f3f83a736665a7c4d963c40347a7aa Mon Sep 17 00:00:00 2001
+From: Dmitry Shachnev <mitya57@debian.org>
+Date: Sat, 4 Jan 2025 21:20:12 +0300
+Subject: [PATCH 21/23] DEBIAN: Use public version of PyLong_AsInt for Python
+ >= 3.13
+X-Developer-Signature: v=1; a=openpgp-sha256; l=664; i=xtexchooser@duck.com;
+ h=from:subject; bh=LQKQjAKKkFZokjk8Uo2tH0QFOv7KxjP06wZDoONRfAY=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL4+Ybw8MX5rfs6vyyJtvZs9NJ/w7+cZSOzv940b/y
+ Tsn2Pbt7ihlYRDjYpAVU2QpMmzwZtVJ5xddVi4LM4eVCWQIAxenAEykiJfhvxt/56Wz56Ilvx8I
+ 3Lps2aF3zwXfBmbapS37f1a2e2ZgpzfDP/0qoXcXUg5Y7PdtE18swvFAIJgp+2JepERflFeqp/w
+ 1BgA=
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+Forwarded: no
+---
+ sources/shiboken2/libshiboken/pep384impl.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sources/shiboken2/libshiboken/pep384impl.h b/sources/shiboken2/libshiboken/pep384impl.h
+index 440784e571d8..323715bfbdf6 100644
+--- a/sources/shiboken2/libshiboken/pep384impl.h
++++ b/sources/shiboken2/libshiboken/pep384impl.h
+@@ -183,6 +183,8 @@ LIBSHIBOKEN_API const char *PepType_GetNameStr(PyTypeObject *type);
+  */
+ #ifdef Py_LIMITED_API
+ LIBSHIBOKEN_API int _PepLong_AsInt(PyObject *);
++#elif PY_VERSION_HEX >= 0x030D0000
++#define _PepLong_AsInt PyLong_AsInt
+ #else
+ #define _PepLong_AsInt _PyLong_AsInt
+ #endif
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0022-AOSCOS-Disable-pyi-generation.patch
+++ b/lang-python/pyside2/autobuild/patches/0022-AOSCOS-Disable-pyi-generation.patch
@@ -1,0 +1,45 @@
+From 0c41b643c2e4e8f02206695be060bc271496daa4 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sun, 11 May 2025 13:54:24 +0800
+Subject: [PATCH 22/23] AOSCOS: Disable pyi generation
+X-Developer-Signature: v=1; a=openpgp-sha256; l=1497; i=xtexchooser@duck.com;
+ h=from:subject; bh=mvBKy0hlctx6SuUbsB9RlIZV8jRmd81Q2FUVs5oPgAU=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL48s3zPjjt1dzj31rn8urtp9o2DB5/354q+XvnWpE
+ uwKr5u5taOUhUGMi0FWTJGlyLDBm1UnnV90WbkszBxWJpAhDFycAjARhy6G/8HqZj9VXq46sOhl
+ HYOd7eZk+dm6vFMCwqpN9949kLxq5S5GhnZ944tP2aa8+eg57/YWiUU2e59nXTFM10kSvPLz4MH
+ OnbwA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+It is currently broken on Python 3.14 b1.
+
+PySide2 is so old and should be replaced with other things.
+I have no interest in maintaining it.
+---
+ sources/pyside2/cmake/Macros/PySideModules.cmake | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/sources/pyside2/cmake/Macros/PySideModules.cmake b/sources/pyside2/cmake/Macros/PySideModules.cmake
+index 14707f96435f..4919612d9041 100644
+--- a/sources/pyside2/cmake/Macros/PySideModules.cmake
++++ b/sources/pyside2/cmake/Macros/PySideModules.cmake
+@@ -204,11 +204,11 @@ macro(create_pyside_module)
+     endif()
+ 
+     # Add target to generate pyi file, which depends on the module target.
+-    add_custom_target("${module_NAME}_pyi" ALL
+-                      COMMAND ${CMAKE_COMMAND} -E env ${ld_prefix}
+-                      "${SHIBOKEN_PYTHON_INTERPRETER}"
+-                      "${CMAKE_CURRENT_SOURCE_DIR}/../support/generate_pyi.py" ${generate_pyi_options})
+-    add_dependencies("${module_NAME}_pyi" ${module_NAME})
++    # add_custom_target("${module_NAME}_pyi" ALL
++    #                   COMMAND ${CMAKE_COMMAND} -E env ${ld_prefix}
++    #                   "${SHIBOKEN_PYTHON_INTERPRETER}"
++    #                   "${CMAKE_CURRENT_SOURCE_DIR}/../support/generate_pyi.py" ${generate_pyi_options})
++    # add_dependencies("${module_NAME}_pyi" ${module_NAME})
+ 
+     # install
+     install(TARGETS ${module_NAME} LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/PySide2")
+-- 
+2.50.1
+

--- a/lang-python/pyside2/autobuild/patches/0023-AOSCOS-Fix-missing-includes.patch
+++ b/lang-python/pyside2/autobuild/patches/0023-AOSCOS-Fix-missing-includes.patch
@@ -1,0 +1,63 @@
+From 5389ed523d1fcf4826a41d488b54bd3c72f78db5 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Fri, 16 May 2025 22:33:07 +0800
+Subject: [PATCH 23/23] AOSCOS: Fix missing includes
+X-Developer-Signature: v=1; a=openpgp-sha256; l=2016; i=xtexchooser@duck.com;
+ h=from:subject; bh=rYEJwIbiXtpPRbjfpyXgS6jyMysRHaVCsDE6J58CKfU=;
+ b=owGbwMvMwCW2U4Ij7wZL9ETG02pJDBmdL4+e5NrS/lpMfxurRMuBnldcLiyzm0uaL0yJ6qpZI
+ xKq83dxRykLgxgXg6yYIkuRYYM3q046v+iyclmYOaxMIEMYuDgFYCJrwxn+Z92Y/FtxU8XneepP
+ N/BP13ja8cx29t47Be0+055/Orm6xpDhn7HNqsSgmbPO3lgZW13+zWYxz9SFhkslH8ipLvsj9Vn
+ uHzsA
+X-Developer-Key: i=xtexchooser@duck.com; a=openpgp;
+ fpr=7231804B052C670F15A6771DB918086ED8045B91
+
+---
+ sources/pyside2/PySide2/Qt3DCore/typesystem_3dcore.xml | 3 +++
+ sources/pyside2/libpyside/pyside.h                     | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/sources/pyside2/PySide2/Qt3DCore/typesystem_3dcore.xml b/sources/pyside2/PySide2/Qt3DCore/typesystem_3dcore.xml
+index 8696a128cf74..65862d45d2f8 100644
+--- a/sources/pyside2/PySide2/Qt3DCore/typesystem_3dcore.xml
++++ b/sources/pyside2/PySide2/Qt3DCore/typesystem_3dcore.xml
+@@ -43,6 +43,7 @@
+ <typesystem package="PySide2.Qt3DCore">
+     <load-typesystem name="QtGui/typesystem_gui.xml" generate="no"/>
+     <namespace-type name="Qt3DCore" generate-using="no">
++      <include file-name="Qt3DCore/QNodeCommand" location="global" />
+         <enum-type name="ChangeFlag" flags="ChangeFlags"/>
+         <object-type name="QAbstractAspect"/>
+         <object-type name="QAbstractSkeleton" since="5.10"/>
+@@ -58,6 +59,7 @@
+         <object-type name="QAspectJob"/>
+         <object-type name="QBackendNode">
+             <enum-type name="Mode"/>
++            <include file-name="Qt3DCore/QNodeCommand" location="global" />
+         </object-type>
+         <!-- TODO: Solve issues related to windows and a unresolved
+             external symbol
+@@ -82,6 +84,7 @@
+         </object-type>
+         <object-type name="QNode">
+             <enum-type name="PropertyTrackingMode"/>
++            <include file-name="Qt3DCore/QNodeCommand" location="global" />
+         </object-type>
+         <object-type name="QNodeCommand" since="5.10"/>
+         <object-type name="QNodeCreatedChangeBase"/>
+diff --git a/sources/pyside2/libpyside/pyside.h b/sources/pyside2/libpyside/pyside.h
+index c72f37ae7274..4a86dabd37a5 100644
+--- a/sources/pyside2/libpyside/pyside.h
++++ b/sources/pyside2/libpyside/pyside.h
+@@ -51,6 +51,9 @@
+ #include <QtCore/QMetaType>
+ #include <QtCore/QHash>
+ 
++#include <Qt3DCore/QNodeCommand>
++using Qt3DCore::QNodeCommand;
++
+ struct SbkObjectType;
+ 
+ namespace PySide
+-- 
+2.50.1
+

--- a/lang-python/pyside2/spec
+++ b/lang-python/pyside2/spec
@@ -1,5 +1,4 @@
-VER=5.15.14
-SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${VER}-src/pyside-setup-opensource-src-${VER}.tar.xz"
-CHKSUMS="sha256::32651194f6a6b7bce42f04e68b1401ad2087e4789a4c8f3fb8649e86189c6372"
+VER=5.15.16
+SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.16-src/pyside-setup-opensource-src-5.15.16.tar.xz"
+CHKSUMS="sha256::6d3ed6fd17275ea74829ab56df9c2e7641bfca6b5b201cf244998fa81cf07360"
 CHKUPDATE="anitya::id=58277"
-REL=1


### PR DESCRIPTION
Don't merge before Python 3.14 packages on ARM64/LoongArch64 are pushed to repository.

Topic Description
-----------------

- pyside2: update to 5.15.16

Package(s) Affected
-------------------

- pyside2: 5.15.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
