### PR TITLE
gcc: use ftpmirror.gnu.org for sources


### DIFF
--- a/core-devel/gcc/spec
+++ b/core-devel/gcc/spec
@@ -2,6 +2,6 @@ VER=14.3.0
 # Note: Use with Git snapshots.
 # SRCS="tbl::https://repo.aosc.io/aosc-repacks/gcc-$VER.tar.xz"
 # Note: Use with upstream stable releases.
-SRCS="tbl::https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz"
+SRCS="tbl::https://ftpmirror.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz"
 CHKSUMS="sha256::e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a"
 CHKUPDATE="anitya::id=6502"


### PR DESCRIPTION
Topic Description
-----------------

- gcc: use ftpmirror.gnu.org for sources

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
