### PR TITLE
anubis: update to 1.21.3

### DIFF
--- a/app-web/anubis/autobuild/build
+++ b/app-web/anubis/autobuild/build
@@ -5,7 +5,7 @@ abinfo "Building static assets..."
 make assets
 
 abinfo "Building anubis..."
-make build
+make prebaked-build
 
 abinfo "Installing Anubis binaries..."
 install -Dvm755 "$SRCDIR"/var/anubis "$PKGDIR"/usr/bin/anubis

--- a/app-web/anubis/spec
+++ b/app-web/anubis/spec
@@ -1,4 +1,4 @@
-VER=1.21.0
+VER=1.21.3
 SRCS="git::commit=tags/v$VER::https://github.com/TecharoHQ/anubis"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377999"


### PR DESCRIPTION
Topic Description
-----------------

- anubis: update to 1.21.3
    Co-authored-by: abc1763613206 \(@abc1763613206\) <abc1763613206@163.com>

Package(s) Affected
-------------------

- anubis: 1.21.3

Security Update?
----------------

No

Note: There is a security report [GHSA-jhjj-2g64-px7c](https://github.com/TecharoHQ/anubis/security/advisories/GHSA-jhjj-2g64-px7c) in the upstream changelog, but after evaluation, I found that this vulnerability is not relevant to the operating system.

Build Order
-----------

```
#buildit anubis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
