### PR TITLE
arch-test: new, 0.22

### DIFF
--- a/app-utils/arch-test/autobuild/build
+++ b/app-utils/arch-test/autobuild/build
@@ -1,0 +1,12 @@
+abinfo "Adding cross binutils to path ..."
+for i in /opt/abcross/*/bin/; do export PATH=$i:$PATH; done;
+echo $PATH
+
+abinfo "Configuring with perl ..."
+./configure
+
+abinfo "Building arch-test ..."
+make -j$(nproc)
+
+abinfo "Installing arch-test ..."
+make DESTDIR="$PKGDIR" PREFIX=/usr install

--- a/app-utils/arch-test/autobuild/defines
+++ b/app-utils/arch-test/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=arch-test
+PKGSEC=utils
+PKGDEP="binutils+cross-arm-none-eabi \
+	binutils+cross-arm64 \
+	binutils+cross-amd64 \
+	binutils+cross-loongarch64 \
+	binutils+cross-riscv64 \
+	binutils+cross-ppc64el \
+	binutils+cross-loongson3"
+PKGDES="Detect architectures supported by your machine/kernel"

--- a/app-utils/arch-test/autobuild/prepare
+++ b/app-utils/arch-test/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Patching triple prefix ..."
+sed -i -e"s/arm-linux-gnueabihf/arm-none-eabi/g" -e "s/linux-gnu/aosc-linux-gnu/g" configure

--- a/app-utils/arch-test/spec
+++ b/app-utils/arch-test/spec
@@ -1,0 +1,4 @@
+VER=0.22
+SRCS="git::commit=tags/v$VER::https://github.com/kilobyte/arch-test"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=301834"


### PR DESCRIPTION
Topic Description
-----------------

- arch-test: new, 0.22

Package(s) Affected
-------------------

- arch-test

Security Update?
----------------

No

Build Order
-----------


```
#buildit arch-test
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
