### PR TITLE
git-cliff: update to 2.10.0

### DIFF
--- a/app-vcs/git-cliff/autobuild/defines
+++ b/app-vcs/git-cliff/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=git-cliff
 PKGDES="Generate changelog files from the Git history"
 PKGDEP="glibc gcc-runtime zlib pcre http-parser libgit2 openssl"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm-20"
 PKGSEC="utils"
 
 USECLANG=1

--- a/app-vcs/git-cliff/spec
+++ b/app-vcs/git-cliff/spec
@@ -1,4 +1,4 @@
-VER=2.9.1
+VER=2.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/orhun/git-cliff"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368021"


### PR DESCRIPTION
Topic Description
-----------------

- git-cliff: update to 2.10.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- git-cliff: 2.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-cliff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
