### PR TITLE
gdbm: update to 1.26

### DIFF
--- a/app-database/gdbm/autobuild/beyond
+++ b/app-database/gdbm/autobuild/beyond
@@ -1,4 +1,4 @@
-abinfo "Fixing build failures in some packages..."
+abinfo "Creating compatibility symlinks for gdbm headers ..."
 install -dvm755 "$PKGDIR"/usr/include/gdbm
 ln -svf ../gdbm.h "$PKGDIR"/usr/include/gdbm/gdbm.h
 ln -svf ../ndbm.h "$PKGDIR"/usr/include/gdbm/ndbm.h

--- a/app-database/gdbm/autobuild/defines
+++ b/app-database/gdbm/autobuild/defines
@@ -3,5 +3,7 @@ PKGDES="GNU Database Manager library"
 PKGSEC=libs
 PKGDEP="glibc"
 
-# Enable GDBM compatibility libraries, disable when applicable.
-AUTOTOOLS_AFTER="--enable-libgdbm-compat"
+# Note: Enable GDBM compatibility libraries, disable when applicable.
+AUTOTOOLS_AFTER=(
+    '--enable-libgdbm-compat'
+)

--- a/app-database/gdbm/autobuild/defines.stage2
+++ b/app-database/gdbm/autobuild/defines.stage2
@@ -3,7 +3,9 @@ PKGDES="GNU Database Manager library"
 PKGSEC=libs
 PKGDEP="glibc"
 
-# Enable GDBM compatibility libraries, disable when applicable.
-AUTOTOOLS_AFTER="--enable-libgdbm-compat"
+# Note: Enable GDBM compatibility libraries, disable when applicable.
+AUTOTOOLS_AFTER=(
+    '--enable-libgdbm-compat'
+)
 
 RECONF=0

--- a/app-database/gdbm/spec
+++ b/app-database/gdbm/spec
@@ -1,4 +1,4 @@
-VER=1.25
+VER=1.26
 SRCS="https://ftp.gnu.org/gnu/gdbm/gdbm-$VER.tar.gz"
-CHKSUMS="sha256::d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec"
+CHKSUMS="sha256::6a24504a14de4a744103dcb936be976df6fbe88ccff26065e54c1c47946f4a5e"
 CHKUPDATE="anitya::id=882"

--- a/runtime-optenv32/gdbm+32/spec
+++ b/runtime-optenv32/gdbm+32/spec
@@ -1,4 +1,4 @@
-VER=1.25
+VER=1.26
 SRCS="https://ftp.gnu.org/gnu/gdbm/gdbm-$VER.tar.gz"
-CHKSUMS="sha256::d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec"
+CHKSUMS="sha256::6a24504a14de4a744103dcb936be976df6fbe88ccff26065e54c1c47946f4a5e"
 CHKUPDATE="anitya::id=882"


### PR DESCRIPTION
Topic Description
-----------------

- gdbm+32: update to 1.26
- gdbm: update to 1.26
    - Improve comments in build scripts.
    - Refactor AUTOTOOLS_AFTER as an array.

Package(s) Affected
-------------------

- gdbm: 1.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdbm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
