### PR TITLE
pulseaudio: backport patches to fix ALSA UCM-related assertion errors

### DIFF
--- a/app-multimedia/pulseaudio/autobuild/patches/0001-alsa-ucm-Check-UCM-verb-before-working-with-device-s.patch
+++ b/app-multimedia/pulseaudio/autobuild/patches/0001-alsa-ucm-Check-UCM-verb-before-working-with-device-s.patch
@@ -1,0 +1,96 @@
+From 663bb23fdb0568e0d88ff38de409745e348fc021 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Thu, 30 Nov 2023 20:17:22 +0300
+Subject: [PATCH 1/2] alsa-ucm: Check UCM verb before working with device
+ status
+
+Some versions of the ALSA libraries run into a segmentation fault when
+we query a UCM device/modifier status without first setting a UCM verb.
+It's not a reasonable thing to do anyway, so check for this case and
+return an error. Also do the check in other helpers.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/801>
+---
+ src/modules/alsa/alsa-ucm.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index bb9438f79..7f5136249 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -624,6 +624,11 @@ static long ucm_device_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+     char *devstatus;
+     long status = 0;
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to get status for UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     devstatus = pa_sprintf_malloc("_devstatus/%s", dev_name);
+     if (snd_use_case_geti(ucm->ucm_mgr, devstatus, &status) < 0) {
+         pa_log_debug("Failed to get status for UCM device %s", dev_name);
+@@ -637,6 +642,11 @@ static long ucm_device_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+ static int ucm_device_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev) {
+     const char *dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     /* If any of dev's conflicting devices is enabled, trying to disable
+      * dev gives an error despite the fact that it's already disabled.
+      * Check that dev is enabled to avoid this error. */
+@@ -657,6 +667,11 @@ static int ucm_device_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+ static int ucm_device_enable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev) {
+     const char *dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to enable UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     /* We don't need to enable devices that are already enabled */
+     if (ucm_device_status(ucm, dev) > 0) {
+         pa_log_debug("UCM device %s is already enabled", dev_name);
+@@ -707,6 +722,11 @@ static long ucm_modifier_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+     char *modstatus;
+     long status = 0;
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to get status for UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     modstatus = pa_sprintf_malloc("_modstatus/%s", mod_name);
+     if (snd_use_case_geti(ucm->ucm_mgr, modstatus, &status) < 0) {
+         pa_log_debug("Failed to get status for UCM modifier %s", mod_name);
+@@ -720,6 +740,11 @@ static long ucm_modifier_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+ static int ucm_modifier_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *mod) {
+     const char *mod_name = pa_proplist_gets(mod->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     /* We don't need to disable modifiers that are already disabled */
+     if (ucm_modifier_status(ucm, mod) == 0) {
+         pa_log_debug("UCM modifier %s is already disabled", mod_name);
+@@ -738,6 +763,11 @@ static int ucm_modifier_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+ static int ucm_modifier_enable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *mod) {
+     const char *mod_name = pa_proplist_gets(mod->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     /* We don't need to enable modifiers that are already enabled */
+     if (ucm_modifier_status(ucm, mod) > 0) {
+         pa_log_debug("UCM modifier %s is already enabled", mod_name);
+-- 
+2.50.1
+

--- a/app-multimedia/pulseaudio/autobuild/patches/0002-alsa-ucm-Replace-port-device-UCM-context-assertion-w.patch
+++ b/app-multimedia/pulseaudio/autobuild/patches/0002-alsa-ucm-Replace-port-device-UCM-context-assertion-w.patch
@@ -1,0 +1,64 @@
+From 708fa267b7f35161579a11c1be69187fc80da625 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Fri, 1 Dec 2023 13:28:05 +0300
+Subject: [PATCH 2/2] alsa-ucm: Replace port device UCM context assertion with
+ an error
+
+The pa_alsa_ucm_set_port() function is passed both a mapping context and
+a device port, and both of these refer to their respective UCM device.
+While switching over to having one port per mapping per UCM device, I
+expected both of these to be the same device struct, so added an assert
+checking so.
+
+This assertion gets triggered when we have multiple UCM verbs declaring
+the same UCM device name. The root cause here is that the ports' UCM
+device references are set once while creating the ports for the card, so
+they happen to be those of a specific verb and may not match those from
+a different UCM verb's profiles' mappings.
+
+Solving the root cause necessitates a larger refactor. What we actually
+assume here is that name of the UCM device is same for both the port and
+the UCM context, which ends up always true in practice. For now, replace
+the assert with a check and error.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/802>
+---
+ src/modules/alsa/alsa-ucm.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index 7f5136249..018c01739 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -1581,6 +1581,7 @@ int pa_alsa_ucm_set_port(pa_alsa_ucm_mapping_context *context, pa_device_port *p
+     pa_alsa_ucm_config *ucm;
+     pa_alsa_ucm_device *dev;
+     pa_alsa_ucm_port_data *data;
++    const char *dev_name, *ucm_dev_name;
+ 
+     pa_assert(context && context->ucm);
+ 
+@@ -1588,8 +1589,17 @@ int pa_alsa_ucm_set_port(pa_alsa_ucm_mapping_context *context, pa_device_port *p
+     pa_assert(ucm->ucm_mgr);
+ 
+     data = PA_DEVICE_PORT_DATA(port);
+-    dev = context->ucm_device;
+-    pa_assert(dev == data->device);
++    dev = data->device;
++    pa_assert(dev);
++
++    if (context->ucm_device) {
++        dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
++        ucm_dev_name = pa_proplist_gets(context->ucm_device->proplist, PA_ALSA_PROP_UCM_NAME);
++        if (!pa_streq(dev_name, ucm_dev_name)) {
++            pa_log_error("Failed to set port %s with wrong UCM context: %s", dev_name, ucm_dev_name);
++            return -1;
++        }
++    }
+ 
+     return ucm_device_enable(ucm, dev);
+ }
+-- 
+2.50.1
+

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=17.0
 XRDP_VER=0.7
 VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
-REL=1
+REL=2
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: backport patches to fix ALSA UCM-related assertion errors
    Issue was first reported on AOSC OS with an ASUS ROG STRIX B660-A.
    Link: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/801
    Link: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/802

Package(s) Affected
-------------------

- pulseaudio: 17.0+xrdp0.7-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
