### PR TITLE
incus: update to 6.15.0

### DIFF
--- a/app-containers/incus/01-incus/defines
+++ b/app-containers/incus/01-incus/defines
@@ -2,7 +2,7 @@ PKGNAME=incus
 PKGSEC=admin
 PKGDES="System container and virtual machine manager"
 PKGDEP="lxc lxcfs squashfs-tools dnsmasq cowsql libuv ebtables raft sqlite \
-    libcap acl systemd apparmor xdelta"
+    libcap acl systemd apparmor xdelta libgcc-s1"
 PKGRECOM="qemu lvm2 thin-provisioning-tools btrfs-progs criu"
 PKGSUG="zfs lego"
 BUILDDEP="go tcl apparmor libseccomp systemd"

--- a/app-containers/incus/01-incus/defines
+++ b/app-containers/incus/01-incus/defines
@@ -2,7 +2,7 @@ PKGNAME=incus
 PKGSEC=admin
 PKGDES="System container and virtual machine manager"
 PKGDEP="lxc lxcfs squashfs-tools dnsmasq cowsql libuv ebtables raft sqlite \
-    libcap acl systemd apparmor xdelta libgcc-s1"
+    libcap acl systemd apparmor xdelta gcc-runtime"
 PKGRECOM="qemu lvm2 thin-provisioning-tools btrfs-progs criu"
 PKGSUG="zfs lego"
 BUILDDEP="go tcl apparmor libseccomp systemd"

--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,4 @@
-VER=6.14.0
+VER=6.15.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"


### PR DESCRIPTION
Topic Description
-----------------

- incus: update to 6.15.0
    Co-authored-by: Billy Yang \(@handsomexdd1024\) <me@venti.love>

Package(s) Affected
-------------------

- incus: 6.15.0
- incus-agent: 6.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
