### PR TITLE
pyside2: fix disappearing libraries

### DIFF
--- a/lang-python/pyside2/autobuild/beyond
+++ b/lang-python/pyside2/autobuild/beyond
@@ -1,2 +1,8 @@
 abinfo "Removing redundant files ..."
 rm -fv "$PKGDIR/usr/bin/"{designer,uic,rcc}
+
+abinfo "Linking libpyside2 and libshiboken to /usr/lib ..."
+cd "$PKGDIR"/usr/lib
+for name in PySide2 shiboken2; do
+	ln -sv "python${ABPY3VER}/site-packages/$name/lib${name,,}"*.cpython*.so.*
+done

--- a/lang-python/pyside2/spec
+++ b/lang-python/pyside2/spec
@@ -1,4 +1,5 @@
 VER=5.15.16
-SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.16-src/pyside-setup-opensource-src-5.15.16.tar.xz"
+REL=1
+SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${VER}-src/pyside-setup-opensource-src-${VER}.tar.xz"
 CHKSUMS="sha256::6d3ed6fd17275ea74829ab56df9c2e7641bfca6b5b201cf244998fa81cf07360"
 CHKUPDATE="anitya::id=58277"


### PR DESCRIPTION
Topic Description
-----------------

- pyside2: link necessary libraries to /usr/lib
    The upstream recommends setup.py, but this makes libpyside2 and
    libshiboken2 disappear from /usr/lib. Let's make a symlink for them.

Package(s) Affected
-------------------

- pyside2: 5.15.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
