### PR TITLE
mesa: update to 25.1.7+dxheaders1.616.0

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 74fc705bae7a308b739639f347542be4963ee749 Mon Sep 17 00:00:00 2001
+From 61d093552ee2d81b41434d991a7b77617f310d64 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding
@@ -33,5 +33,5 @@ index 0502c50b48d..a3727ce2ca7 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From e7f7deef5a82e96ae69d8c921c6e9c6bfdf12c93 Mon Sep 17 00:00:00 2001
+From 8e35dbfa8bb9e3cbcc8b83e2dd709ec7c843ae62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
@@ -35,5 +35,5 @@ index 2f4c2765276..0d81b79a7d4 100644
  #define WARN_ONCE(cond, fmt...) do {                            \
     if (unlikely(cond)) {                                        \
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,4 +1,4 @@
-From b551e21d7e5ff04cb34cea39b6c067ed0423d5da Mon Sep 17 00:00:00 2001
+From f2aaa80c8fecad2371c28f9bd65c3faac89fb75b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
 Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
@@ -19,7 +19,7 @@ Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33051>
  3 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_compiler.c b/src/gallium/drivers/zink/zink_compiler.c
-index bef1cf0a3a4..4d8ecb5ec66 100644
+index 1d751d51495..1ba5d70d16f 100644
 --- a/src/gallium/drivers/zink/zink_compiler.c
 +++ b/src/gallium/drivers/zink/zink_compiler.c
 @@ -1362,7 +1362,8 @@ zink_screen_init_compiler(struct zink_screen *screen)
@@ -33,7 +33,7 @@ index bef1cf0a3a4..4d8ecb5ec66 100644
  
     screen->nir_options.support_indirect_inputs = (uint8_t)BITFIELD_MASK(PIPE_SHADER_TYPES);
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 8c489ab0b89..0f6238be7e4 100644
+index 58f1f740239..4c4a104366c 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
 @@ -859,8 +859,9 @@ zink_init_screen_caps(struct zink_screen *screen)
@@ -48,7 +48,7 @@ index 8c489ab0b89..0f6238be7e4 100644
  
     caps->sample_shading = screen->info.feats.features.sampleRateShading;
  
-@@ -2938,6 +2939,16 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2940,6 +2941,16 @@ init_driver_workarounds(struct zink_screen *screen)
        break;
     }
  
@@ -66,10 +66,10 @@ index 8c489ab0b89..0f6238be7e4 100644
     screen->driver_compiler_workarounds.lower_robustImageAccess2 =
        !screen->info.rb2_feats.robustImageAccess2 &&
 diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
-index 5430197f099..66a3fc1200f 100644
+index 6551a6df636..200648ff50d 100644
 --- a/src/gallium/drivers/zink/zink_types.h
 +++ b/src/gallium/drivers/zink/zink_types.h
-@@ -1544,6 +1544,7 @@ struct zink_screen {
+@@ -1548,6 +1548,7 @@ struct zink_screen {
        bool needs_sanitised_layer;
        bool io_opt;
        bool broken_const;
@@ -78,5 +78,5 @@ index 5430197f099..66a3fc1200f 100644
     struct {
        bool broken_l4a4;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,4 +1,4 @@
-From ed19f53dd99dee3e6cb0b28482af6fa40aa52f03 Mon Sep 17 00:00:00 2001
+From bee4bb4c2452ea9c61a7eed2ca18be93cbec8d98 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 30 Nov 2024 17:11:09 +0800
 Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 0f6238be7e4..9e4047673b5 100644
+index 4c4a104366c..5ac299e6639 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2849,10 +2849,9 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2851,10 +2851,9 @@ init_driver_workarounds(struct zink_screen *screen)
     }
  
     if (zink_driverid(screen) ==
@@ -32,5 +32,5 @@ index 0f6238be7e4..9e4047673b5 100644
     /* This is a workarround for the lack of
      * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-display/mesa/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,4 +1,4 @@
-From e05e4ea4382f43da652779ddebbcf1fdb1fff6cb Mon Sep 17 00:00:00 2001
+From c70111a2c386b2e26ff4b2c82109821f2acec342 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 09:00:21 +0800
 Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting
@@ -30,5 +30,5 @@ index c7e746829ed..c861587538e 100644
     si[ZINK_SUBMIT_CMDBUF].waitSemaphoreCount = util_dynarray_num_elements(&bs->wait_semaphores, VkSemaphore);
     si[ZINK_SUBMIT_CMDBUF].pWaitSemaphores = bs->wait_semaphores.data;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-display/mesa/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,4 +1,4 @@
-From 2242873c64c9301c35f2be750eccb3425bc9deea Mon Sep 17 00:00:00 2001
+From 3263adf5275d503477bb19b9779e0fcb206679a3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 20:49:58 +0800
 Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
@@ -40,10 +40,10 @@ index c861587538e..e621da37cef 100644
     simple_mtx_lock(&screen->queue_lock);
     VRAM_ALLOC_LOOP(result,
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 9e4047673b5..70c70b70bba 100644
+index 5ac299e6639..4734b490f7e 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2853,6 +2853,12 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2855,6 +2855,12 @@ init_driver_workarounds(struct zink_screen *screen)
         screen->info.feats.features.geometryShader)
        screen->driver_workarounds.no_linesmooth = true;
  
@@ -57,10 +57,10 @@ index 9e4047673b5..70c70b70bba 100644
      * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
      * proprietary driver.
 diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
-index 66a3fc1200f..da6e92a8df9 100644
+index 200648ff50d..b3cedf9bfd3 100644
 --- a/src/gallium/drivers/zink/zink_types.h
 +++ b/src/gallium/drivers/zink/zink_types.h
-@@ -1565,6 +1565,7 @@ struct zink_screen {
+@@ -1569,6 +1569,7 @@ struct zink_screen {
        bool inconsistent_interpolation;
        bool can_2d_view_sparse;
        bool general_depth_layout;
@@ -69,5 +69,5 @@ index 66a3fc1200f..da6e92a8df9 100644
        unsigned z24_unscaled_bias;
     } driver_workarounds;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-display/mesa/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,4 +1,4 @@
-From dbdefe0eafb088b00947bc1c559eecdb4204a525 Mon Sep 17 00:00:00 2001
+From a3ec6eac9bf1c6b22514893064153e3551cdf695 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 29 Nov 2024 16:10:29 +0800
 Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 6 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 70c70b70bba..5765d1c9912 100644
+index 4734b490f7e..ab7bffa2859 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3422,12 +3422,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3424,12 +3424,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  
@@ -32,5 +32,5 @@ index 70c70b70bba..5765d1c9912 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-display/mesa/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,4 +1,4 @@
-From 1916d7ebdfdf7f1788c2500260f9a63173ef5be2 Mon Sep 17 00:00:00 2001
+From e627b189fd08f6ada7400f4f152cdc2e7027742f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 26 Apr 2025 22:13:35 +0800
 Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 9 insertions(+)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 5765d1c9912..36e85124d76 100644
+index ab7bffa2859..383bc272eee 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3422,6 +3422,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3424,6 +3424,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  
@@ -35,5 +35,5 @@ index 5765d1c9912..36e85124d76 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=25.1.4
+UPSTREAM_VER=25.1.7
 DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::164872a5e792408aa72fecd52b7be6409724c4ad81700798675a7d801d976704 \
+CHKSUMS="sha256::4afd26a3cc93c3dd27183d4c4845f1ca7d683f6343900b54995809b3271ebed6 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 74fc705bae7a308b739639f347542be4963ee749 Mon Sep 17 00:00:00 2001
+From 61d093552ee2d81b41434d991a7b77617f310d64 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/8] AOSCOS: r600: disable buggy VC-1 hardware decoding
@@ -33,5 +33,5 @@ index 0502c50b48d..a3727ce2ca7 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From e7f7deef5a82e96ae69d8c921c6e9c6bfdf12c93 Mon Sep 17 00:00:00 2001
+From 8e35dbfa8bb9e3cbcc8b83e2dd709ec7c843ae62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/8] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
@@ -35,5 +35,5 @@ index 2f4c2765276..0d81b79a7d4 100644
  #define WARN_ONCE(cond, fmt...) do {                            \
     if (unlikely(cond)) {                                        \
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-zink-Do-not-use-demote-on-IMG-blobs.patch
@@ -1,4 +1,4 @@
-From b551e21d7e5ff04cb34cea39b6c067ed0423d5da Mon Sep 17 00:00:00 2001
+From f2aaa80c8fecad2371c28f9bd65c3faac89fb75b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Thu, 16 Jan 2025 09:05:31 +0800
 Subject: [PATCH 3/8] BACKPORT: zink: Do not use demote on IMG blobs
@@ -19,7 +19,7 @@ Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33051>
  3 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_compiler.c b/src/gallium/drivers/zink/zink_compiler.c
-index bef1cf0a3a4..4d8ecb5ec66 100644
+index 1d751d51495..1ba5d70d16f 100644
 --- a/src/gallium/drivers/zink/zink_compiler.c
 +++ b/src/gallium/drivers/zink/zink_compiler.c
 @@ -1362,7 +1362,8 @@ zink_screen_init_compiler(struct zink_screen *screen)
@@ -33,7 +33,7 @@ index bef1cf0a3a4..4d8ecb5ec66 100644
  
     screen->nir_options.support_indirect_inputs = (uint8_t)BITFIELD_MASK(PIPE_SHADER_TYPES);
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 8c489ab0b89..0f6238be7e4 100644
+index 58f1f740239..4c4a104366c 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
 @@ -859,8 +859,9 @@ zink_init_screen_caps(struct zink_screen *screen)
@@ -48,7 +48,7 @@ index 8c489ab0b89..0f6238be7e4 100644
  
     caps->sample_shading = screen->info.feats.features.sampleRateShading;
  
-@@ -2938,6 +2939,16 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2940,6 +2941,16 @@ init_driver_workarounds(struct zink_screen *screen)
        break;
     }
  
@@ -66,10 +66,10 @@ index 8c489ab0b89..0f6238be7e4 100644
     screen->driver_compiler_workarounds.lower_robustImageAccess2 =
        !screen->info.rb2_feats.robustImageAccess2 &&
 diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
-index 5430197f099..66a3fc1200f 100644
+index 6551a6df636..200648ff50d 100644
 --- a/src/gallium/drivers/zink/zink_types.h
 +++ b/src/gallium/drivers/zink/zink_types.h
-@@ -1544,6 +1544,7 @@ struct zink_screen {
+@@ -1548,6 +1548,7 @@ struct zink_screen {
        bool needs_sanitised_layer;
        bool io_opt;
        bool broken_const;
@@ -78,5 +78,5 @@ index 5430197f099..66a3fc1200f 100644
     struct {
        bool broken_l4a4;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-zink-don-t-assert-geometryShader-for-IMG-pr.patch
@@ -1,4 +1,4 @@
-From ed19f53dd99dee3e6cb0b28482af6fa40aa52f03 Mon Sep 17 00:00:00 2001
+From bee4bb4c2452ea9c61a7eed2ca18be93cbec8d98 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 30 Nov 2024 17:11:09 +0800
 Subject: [PATCH 4/8] FROMLIST: zink: don't assert geometryShader for IMG
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 0f6238be7e4..9e4047673b5 100644
+index 4c4a104366c..5ac299e6639 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2849,10 +2849,9 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2851,10 +2851,9 @@ init_driver_workarounds(struct zink_screen *screen)
     }
  
     if (zink_driverid(screen) ==
@@ -32,5 +32,5 @@ index 0f6238be7e4..9e4047673b5 100644
     /* This is a workarround for the lack of
      * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0005-FROMLIST-zink-skip-empty-VkSubmitInfo-when-submittin.patch
@@ -1,4 +1,4 @@
-From e05e4ea4382f43da652779ddebbcf1fdb1fff6cb Mon Sep 17 00:00:00 2001
+From c70111a2c386b2e26ff4b2c82109821f2acec342 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 09:00:21 +0800
 Subject: [PATCH 5/8] FROMLIST: zink: skip empty VkSubmitInfo when submitting
@@ -30,5 +30,5 @@ index c7e746829ed..c861587538e 100644
     si[ZINK_SUBMIT_CMDBUF].waitSemaphoreCount = util_dynarray_num_elements(&bs->wait_semaphores, VkSemaphore);
     si[ZINK_SUBMIT_CMDBUF].pWaitSemaphores = bs->wait_semaphores.data;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0006-FROMLIST-zink-try-to-merge-two-VkSubmitInfo-s-for-Im.patch
@@ -1,4 +1,4 @@
-From 2242873c64c9301c35f2be750eccb3425bc9deea Mon Sep 17 00:00:00 2001
+From 3263adf5275d503477bb19b9779e0fcb206679a3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 19 Jan 2025 20:49:58 +0800
 Subject: [PATCH 6/8] FROMLIST: zink: try to merge two VkSubmitInfo's for
@@ -40,10 +40,10 @@ index c861587538e..e621da37cef 100644
     simple_mtx_lock(&screen->queue_lock);
     VRAM_ALLOC_LOOP(result,
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 9e4047673b5..70c70b70bba 100644
+index 5ac299e6639..4734b490f7e 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -2853,6 +2853,12 @@ init_driver_workarounds(struct zink_screen *screen)
+@@ -2855,6 +2855,12 @@ init_driver_workarounds(struct zink_screen *screen)
         screen->info.feats.features.geometryShader)
        screen->driver_workarounds.no_linesmooth = true;
  
@@ -57,10 +57,10 @@ index 9e4047673b5..70c70b70bba 100644
      * gl_PointSize + glPolygonMode(..., GL_LINE), in the imagination
      * proprietary driver.
 diff --git a/src/gallium/drivers/zink/zink_types.h b/src/gallium/drivers/zink/zink_types.h
-index 66a3fc1200f..da6e92a8df9 100644
+index 200648ff50d..b3cedf9bfd3 100644
 --- a/src/gallium/drivers/zink/zink_types.h
 +++ b/src/gallium/drivers/zink/zink_types.h
-@@ -1565,6 +1565,7 @@ struct zink_screen {
+@@ -1569,6 +1569,7 @@ struct zink_screen {
        bool inconsistent_interpolation;
        bool can_2d_view_sparse;
        bool general_depth_layout;
@@ -69,5 +69,5 @@ index 66a3fc1200f..da6e92a8df9 100644
        unsigned z24_unscaled_bias;
     } driver_workarounds;
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0007-FROMLIST-Revert-zink-reject-Imagination-proprietary-.patch
@@ -1,4 +1,4 @@
-From dbdefe0eafb088b00947bc1c559eecdb4204a525 Mon Sep 17 00:00:00 2001
+From a3ec6eac9bf1c6b22514893064153e3551cdf695 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Fri, 29 Nov 2024 16:10:29 +0800
 Subject: [PATCH 7/8] FROMLIST: Revert "zink: reject Imagination proprietary
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 6 deletions(-)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 70c70b70bba..5765d1c9912 100644
+index 4734b490f7e..ab7bffa2859 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3422,12 +3422,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3424,12 +3424,6 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  
@@ -32,5 +32,5 @@ index 70c70b70bba..5765d1c9912 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0008-FROMLIST-zink-reject-IMG-blob-1.17-6210866-unless-en.patch
@@ -1,4 +1,4 @@
-From 1916d7ebdfdf7f1788c2500260f9a63173ef5be2 Mon Sep 17 00:00:00 2001
+From e627b189fd08f6ada7400f4f152cdc2e7027742f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 26 Apr 2025 22:13:35 +0800
 Subject: [PATCH 8/8] FROMLIST: zink: reject IMG blob <= 1.17@6210866 unless
@@ -15,10 +15,10 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 9 insertions(+)
 
 diff --git a/src/gallium/drivers/zink/zink_screen.c b/src/gallium/drivers/zink/zink_screen.c
-index 5765d1c9912..36e85124d76 100644
+index ab7bffa2859..383bc272eee 100644
 --- a/src/gallium/drivers/zink/zink_screen.c
 +++ b/src/gallium/drivers/zink/zink_screen.c
-@@ -3422,6 +3422,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
+@@ -3424,6 +3424,15 @@ zink_internal_create_screen(const struct pipe_screen_config *config, int64_t dev
        goto fail;
     }
  
@@ -35,5 +35,5 @@ index 5765d1c9912..36e85124d76 100644
        simple_mtx_init(&screen->debug_mem_lock, mtx_plain);
        screen->debug_mem_sizes = _mesa_hash_table_create(screen, _mesa_hash_string, _mesa_key_string_equal);
 -- 
-2.49.0
+2.50.1
 

--- a/runtime-optenv32/mesa+32/spec
+++ b/runtime-optenv32/mesa+32/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=25.1.4
+UPSTREAM_VER=25.1.7
 DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::164872a5e792408aa72fecd52b7be6409724c4ad81700798675a7d801d976704 \
+CHKSUMS="sha256::4afd26a3cc93c3dd27183d4c4845f1ca7d683f6343900b54995809b3271ebed6 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.1.7+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.7
    \(HEAD: e627b189fd08f6ada7400f4f152cdc2e7027742f\).
- mesa: update to 25.1.7+dxheaders1.616.0
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.1.7
    \(HEAD: e627b189fd08f6ada7400f4f152cdc2e7027742f\).

Package(s) Affected
-------------------

- mesa: 1:25.1.7+dxheaders1.616.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
