### PR TITLE
ab-download-manager: update to 1.6.8

### DIFF
--- a/app-web/ab-download-manager/autobuild/build
+++ b/app-web/ab-download-manager/autobuild/build
@@ -1,6 +1,7 @@
 abinfo "Building ab-download-manager..."
-chmod -v +x "$SRCDIR"/gradlew
-"$SRCDIR"/gradlew createReleaseDistributable
+echo "org.gradle.java.installations.auto-detect=true" >> "$SRCDIR"/gradle.properties
+echo "org.gradle.java.installations.auto-download=false" >> "$SRCDIR"/gradle.properties
+gradle createReleaseDistributable
 
 abinfo "Installing ab-download-manager..."
 install -dvm755 "$PKGDIR/usr/lib/ab-download-manager"

--- a/app-web/ab-download-manager/autobuild/defines
+++ b/app-web/ab-download-manager/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ab-download-manager
 PKGSEC=web
 PKGDES="A multifunctional file downloader"
-BUILDDEP="openjdk"
-PKGDEP="openjdk gcc-runtime"
+PKGDEP="gcc-runtime glibc libappindicator openjdk"
+BUILDDEP="gradle"
 
 PKGPROV=abdownloadmanager
 

--- a/app-web/ab-download-manager/spec
+++ b/app-web/ab-download-manager/spec
@@ -1,4 +1,4 @@
-VER=1.6.6
+VER=1.6.8
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/amir1376/ab-download-manager"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376269"


### PR DESCRIPTION
Topic Description
-----------------

- ab-download-manager: update to 1.6.8
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- ab-download-manager: 1.6.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit ab-download-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
