### PR TITLE
rocm: support arm64

### DIFF
--- a/runtime-rocm/rocm-clr/autobuild/patch
+++ b/runtime-rocm/rocm-clr/autobuild/patch
@@ -4,6 +4,6 @@ ab_apply_patches "$SRCDIR"/autobuild/patches/0003-hip-header-disbale-glibcxx-ass
 abinfo "Apply CLR patch..."
 cd "$SRCDIR"
 ab_apply_patches "$SRCDIR"/autobuild/patches/0001-HIPAMD-DISABLE-glibcxx_assert.patch
-ab_apply_patches "$SRCDIR"/autobuild/patches/0002-support-LoongArch-RISCV.patch
+ab_apply_patches "$SRCDIR"/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
 ab_apply_patches "$SRCDIR"/autobuild/patches/0004-rewrite-hip-embed-pch.patch
 ab_apply_patches "$SRCDIR"/autobuild/patches/*.patch."${CROSS:-$ARCH}"

--- a/runtime-rocm/rocm-clr/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
+++ b/runtime-rocm/rocm-clr/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
@@ -1,51 +1,67 @@
 diff --git a/hipamd/src/hip_graph_internal.cpp b/hipamd/src/hip_graph_internal.cpp
-index 794293b7f..3054f93aa 100644
+index e88454e12..7c792b44e 100644
 --- a/hipamd/src/hip_graph_internal.cpp
 +++ b/hipamd/src/hip_graph_internal.cpp
-@@ -979,9 +979,21 @@ void GraphKernelArgManager::ReadBackOrFlush() {
+@@ -797,9 +797,29 @@ void GraphKernelArgManager::ReadBackOrFlush() {
        address dev_ptr =
            kernarg_graph_.back().kernarg_pool_addr_ + kernarg_graph_.back().kernarg_pool_size_;
        auto kSentinel = *reinterpret_cast<volatile unsigned char*>(dev_ptr - 1);
 +#if defined(__x86_64__)
        _mm_sfence();
++#elif defined(__aarch64__)
++      asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+      asm("dbar 0");
++      asm volatile("dbar 0");
 +#elif defined(__riscv)
-+      asm("fence rw,rw");
++      asm volatile("fence rw,rw");
++#else
++#error
 +#endif
        *(dev_ptr - 1) = kSentinel;
 +#if defined(__x86_64__)
        _mm_mfence();
++#elif defined(__aarch64__)
++      asm volatile("DMB ish":::"memory");
 +#elif defined(__loongarch_lp64)
-+      asm("dbar 0");
++      asm volatile("dbar 0");
 +#elif defined(__riscv)
-+      asm("fence rw,rw");
++      asm volatile("fence rw,rw");
++#else
++#error
 +#endif
        kSentinel = *reinterpret_cast<volatile unsigned char*>(dev_ptr - 1);
      }
    }
 diff --git a/rocclr/device/rocm/rocvirtual.cpp b/rocclr/device/rocm/rocvirtual.cpp
-index 722450a14..772bb552f 100644
+index cb170365d..80bf53a25 100755
 --- a/rocclr/device/rocm/rocvirtual.cpp
 +++ b/rocclr/device/rocm/rocvirtual.cpp
-@@ -3282,9 +3282,21 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes,
+@@ -3464,9 +3464,29 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes,
            auto kSentinel = *reinterpret_cast<volatile int*>(dev().info().hdpMemFlushCntl);
          } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback &&
                     argSize != 0) {
 +#if defined(__x86_64__)
            _mm_sfence();
++#elif defined(__aarch64__)
++          asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+          asm("dbar 0");
++          asm volatile("dbar 0");
 +#elif defined(__riscv)
-+          asm("fence rw,rw");
++          asm volatile("fence rw,rw");
++#else
++#error
 +#endif
            *(argBuffer + argSize - 1) = *(parameters + argSize - 1);
 +#if defined(__x86_64__)
            _mm_mfence();
++#elif defined(__aarch64__)
++          asm volatile("DMB ish":::"memory");
 +#elif defined(__loongarch_lp64)
-+          asm("dbar 0");
++          asm volatile("dbar 0");
 +#elif defined(__riscv)
-+          asm("fence rw,rw");
++          asm volatile("fence rw,rw");
++#else
++#error
 +#endif
            auto kSentinel = *reinterpret_cast<volatile unsigned char*>(
                argBuffer + argSize - 1);

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -7,3 +7,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="clr"
 CHKUPDATE="anitya::id=369562"
+REL=1

--- a/runtime-rocm/rocm-hipblas-common/autobuild/defines
+++ b/runtime-rocm/rocm-hipblas-common/autobuild/defines
@@ -14,4 +14,4 @@ CMAKE_AFTER=(
     '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLAS-common.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378524"
+REL=1

--- a/runtime-rocm/rocm-hipblas/autobuild/defines
+++ b/runtime-rocm/rocm-hipblas/autobuild/defines
@@ -27,5 +27,14 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
+# FIXME: lld unsupport fix-cortex-a53-835769
+#  : && /usr/bin/gfortran -Wl,-O1,--sort-common,--as-needed -Wl,-build-id=sha1 -Wl,-z,relro -Wl,-z,now -fPIC -fPIE -flto -fuse-linker-plugin \
+#        -fuse-ld=lld  CMakeFiles/cmTC_38cf2.dir/testFortranCompiler.f.o -o cmTC_38cf2
+#  ld.lld: error: unknown argument '--fix-cortex-a53-835769'
+CMAKE_AFTER__ARM64=(
+    ${CMAKE_AFTER[@]}
+    '-DCMAKE_Fortran_FLAGS=-mno-fix-cortex-a53-835769'
+)
 
-FAIL_ARCH="!(amd64|loongarch64)"
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipblas/spec
+++ b/runtime-rocm/rocm-hipblas/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLAS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378433"
+REL=1

--- a/runtime-rocm/rocm-hipblaslt/autobuild/defines
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/defines
@@ -40,4 +40,4 @@ CMAKE_AFTER=(
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLASLt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378523"
+REL=1

--- a/runtime-rocm/rocm-hipfft/autobuild/defines
+++ b/runtime-rocm/rocm-hipfft/autobuild/defines
@@ -24,4 +24,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipFFT.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378521"
+REL=1

--- a/runtime-rocm/rocm-hipfort/autobuild/defines
+++ b/runtime-rocm/rocm-hipfort/autobuild/defines
@@ -31,4 +31,4 @@ CMAKE_AFTER=(
     '-DClang_DIR=/usr/lib/rocm/lib/llvm/lib/cmake/clang/'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipfort/spec
+++ b/runtime-rocm/rocm-hipfort/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipfort.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378520"
+REL=1

--- a/runtime-rocm/rocm-hiprand/autobuild/defines
+++ b/runtime-rocm/rocm-hiprand/autobuild/defines
@@ -24,4 +24,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hiprand/spec
+++ b/runtime-rocm/rocm-hiprand/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipRAND.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378518"
+REL=1

--- a/runtime-rocm/rocm-hipsparse/autobuild/defines
+++ b/runtime-rocm/rocm-hipsparse/autobuild/defines
@@ -23,4 +23,13 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+# FIXME: lld unsupport fix-cortex-a53-835769
+#  : && /usr/bin/gfortran -Wl,-O1,--sort-common,--as-needed -Wl,-build-id=sha1 -Wl,-z,relro -Wl,-z,now -fPIC -fPIE -flto -fuse-linker-plugin \
+#        -fuse-ld=lld  CMakeFiles/cmTC_38cf2.dir/testFortranCompiler.f.o -o cmTC_38cf2
+#  ld.lld: error: unknown argument '--fix-cortex-a53-835769'
+CMAKE_AFTER__ARM64=(
+    ${CMAKE_AFTER[@]}
+    '-DCMAKE_Fortran_FLAGS=-mno-fix-cortex-a53-835769'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipSPARSE.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378517"
+REL=1

--- a/runtime-rocm/rocm-llama-cpp/autobuild/defines
+++ b/runtime-rocm/rocm-llama-cpp/autobuild/defines
@@ -28,11 +28,11 @@ CMAKE_AFTER=(
     '-DROCM_PATH=/usr/lib/rocm'
     '-DAMDGPU_TARGETS=gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
     '-DGGML_HIP=ON'
-    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DGGML_NATIVE=OFF'
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib;/usr/lib/rocm/llama-cpp/lib'
     '-DCMAKE_BUILD_TYPE=Release'
     "-DCMAKE_HIP_COMPILER=$SRCDIR/hipclang-agent.sh"
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-llama-cpp/spec
+++ b/runtime-rocm/rocm-llama-cpp/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=b6122::https://github.com/ggml-org/llama.cpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328681"
+REL=1

--- a/runtime-rocm/rocm-rccl/autobuild/defines
+++ b/runtime-rocm/rocm-rccl/autobuild/defines
@@ -32,4 +32,4 @@ CMAKE_AFTER=(
     '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"
+REL=1

--- a/runtime-rocm/rocm-rocblas/autobuild/defines
+++ b/runtime-rocm/rocm-rocblas/autobuild/defines
@@ -38,4 +38,4 @@ CMAKE_AFTER=(
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocBLAS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241713"
+REL=1

--- a/runtime-rocm/rocm-rocfft/autobuild/defines
+++ b/runtime-rocm/rocm-rocfft/autobuild/defines
@@ -26,4 +26,4 @@ CMAKE_AFTER=(
     '-DSQLITE_USE_SYSTEM_PACKAGE=ON'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocFFT.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378516"
+REL=1

--- a/runtime-rocm/rocm-rocmlir/autobuild/defines
+++ b/runtime-rocm/rocm-rocmlir/autobuild/defines
@@ -26,4 +26,4 @@ CMAKE_AFTER=(
     '-DLLVM_TARGETS_TO_BUILD=AMDGPU'
 )
 
-FAIL_ARCH="!(loongarch64|amd64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocmlir/spec
+++ b/runtime-rocm/rocm-rocmlir/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocMLIR"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378515"
+REL=1

--- a/runtime-rocm/rocm-rocrand/autobuild/defines
+++ b/runtime-rocm/rocm-rocrand/autobuild/defines
@@ -25,4 +25,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocRAND.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378511"
+REL=1

--- a/runtime-rocm/rocm-rocsolver/autobuild/defines
+++ b/runtime-rocm/rocm-rocsolver/autobuild/defines
@@ -25,4 +25,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocSOLVER.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378510"
+REL=1

--- a/runtime-rocm/rocm-rocsparse/autobuild/defines
+++ b/runtime-rocm/rocm-rocsparse/autobuild/defines
@@ -32,4 +32,4 @@ CMAKE_AFTER=(
     '-DCMAKE_BUILD_TYPE=Release'
 )
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocSPARSE.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378508"
+REL=1

--- a/runtime-rocm/rocm-roctracer/autobuild/defines
+++ b/runtime-rocm/rocm-roctracer/autobuild/defines
@@ -19,4 +19,4 @@ CMAKE_AFTER=(
 )
 
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-roctracer/spec
+++ b/runtime-rocm/rocm-roctracer/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/roctracer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378506"
+REL=1

--- a/runtime-rocm/rocr-runtime/autobuild/patches/0001-support-arm64-loongarch64-riscv64.patch
+++ b/runtime-rocm/rocr-runtime/autobuild/patches/0001-support-arm64-loongarch64-riscv64.patch
@@ -12,110 +12,137 @@ index 177465c0..1d0166e6 100644
  namespace amd {
  namespace elf {
 diff --git a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
-index 0045289e..d5d5c49e 100644
+index 0045289e..02ac2edf 100644
 --- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
 +++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
-@@ -435,9 +435,21 @@ class GpuAgent : public GpuAgentInt {
+@@ -435,9 +435,29 @@ class GpuAgent : public GpuAgentInt {
    /// @brief Force a WC flush on PCIe devices by doing a write and then read-back
    __forceinline void PcieWcFlush(void *ptr, size_t size) const {
      if (!xgmi_cpu_gpu_) {
-+#if defined(_M_X64)
++#if defined(__x86_64__)
        _mm_sfence();
++#elif defined(__aarch64__)
++        asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+      asm("dbar 0");
++        asm volatile("dbar 0");
 +#elif defined(__riscv)
-+      asm volatile("fence w, w");
++        asm volatile("fence w, w");
++#else
++#error
 +#endif
        *((uint8_t*)ptr + size - 1) = *((uint8_t*)ptr + size - 1);
-+#if defined(_M_X64)
++#if defined(__x86_64__)
        _mm_mfence();
++#elif defined(__aarch64__)
++        asm volatile("DMB ish":::"memory");
 +#elif defined(__loongarch_lp64)
-+      asm("dbar 0");
++        asm volatile("dbar 0");
 +#elif defined(__riscv)
-+      asm volatile("fence rw, rw");
++        asm volatile("fence rw, rw");
++#else
++#error
 +#endif
        auto readback = *(reinterpret_cast<volatile uint8_t*>(ptr) + size - 1);
      }
    }
 diff --git a/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp b/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
-index f8613dbb..3fd71aee 100644
+index f8613dbb..293ce203 100644
 --- a/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
 +++ b/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
-@@ -1665,7 +1665,13 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
+@@ -1665,7 +1665,17 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
    memcpy(&queue_slot[1], &slot_data[1], slot_size_b - sizeof(uint32_t));
    if (core::Runtime::runtime_singleton_->flag().dev_mem_queue() && !agent_->is_xgmi_cpu_gpu()) {
      // Ensure the packet body is written as header may get reordered when writing over PCIE
-+#if defined(_M_X64)
++#if defined(__x86_64__)
      _mm_sfence();
++#elif defined(__aarch64__)
++      asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+    asm("dbar 0");
++      asm volatile("dbar 0");
 +#elif defined(__riscv)
-+    asm volatile("fence w, w");
++      asm volatile("fence w, w");
++#else
++#error
 +#endif
    }
    atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
- 
+
 diff --git a/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp b/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
-index 36d21fa1..92b8f980 100644
+index 36d21fa1..0dd14b2d 100644
 --- a/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
 +++ b/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
-@@ -1274,7 +1274,13 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
+@@ -1274,7 +1274,17 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
    std::atomic_thread_fence(std::memory_order_release);
    if (core::Runtime::runtime_singleton_->flag().dev_mem_queue() && !queue_->needsPcieOrdering()) {
      // Ensure the packet body is written as header may get reordered when writing over PCIE
-+#if defined(_M_X64)
++#if defined(__x86_64__)
      _mm_sfence();
++#elif defined(__aarch64__)
++    asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+    asm("dbar 0");
++    asm volatile("dbar 0");
 +#elif defined(__riscv)
 +    asm volatile("fence w, w");
++#else
++#error
 +#endif
    }
    queue_buffer[index & queue_bitmask_].header = kDispatchPacketHeader;
- 
+
 diff --git a/runtime/hsa-runtime/core/runtime/intercept_queue.cpp b/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
-index a86dabb3..3173d809 100644
+index a86dabb3..b85db5ed 100644
 --- a/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
 +++ b/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
-@@ -258,7 +258,13 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
+@@ -258,7 +258,17 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
        ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
        if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
          // Ensure the packet body is written as header may get reordered when writing over PCIE
--        _mm_sfence();
-+#if defined(_M_X64)
-+    _mm_sfence();
++#if defined(__x86_64__)
+         _mm_sfence();
++#elif defined(__aarch64__)
++        asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+    asm("dbar 0");
++        asm volatile("dbar 0");
 +#elif defined(__riscv)
-+    asm volatile("fence w, w");
++        asm volatile("fence w, w");
++#else
++#error
 +#endif
        }
        atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                      std::memory_order_release);
-@@ -305,7 +311,13 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
+@@ -305,7 +315,17 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
        if (write_index != 0) {
          if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
            // Ensure the packet body is written as header may get reordered when writing over PCIE
-+#if defined(_M_X64)
++#if defined(__x86_64__)
            _mm_sfence();
++#elif defined(__aarch64__)
++          asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+          asm("dbar 0");
++          asm volatile("dbar 0");
 +#elif defined(__riscv)
 +          asm volatile("fence w,w");
++#else
++#error
 +#endif
          }
          atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                        std::memory_order_release);
-@@ -374,7 +386,13 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
+@@ -374,7 +394,17 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
      handler.first(&ring[i & mask], 1, i, handler.second, PacketWriter);
      if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
        // Ensure the packet body is written as header may get reordered when writing over PCIE
-+#if defined(_M_X64)
++#if defined(__x86_64__)
        _mm_sfence();
++#elif defined(__aarch64__)
++      asm volatile("DMB ishst":::"memory");
 +#elif defined(__loongarch_lp64)
-+      asm("dbar 0");
++      asm volatile("dbar 0");
 +#elif defined(__riscv)
 +      asm volatile("fence w, w");
++#else
++#error
 +#endif
      }
      // Invalidate consumed packet.
@@ -127,21 +154,21 @@ index 4d629798..efb0fc73 100644
 @@ -65,7 +65,7 @@
  #include <cpuid.h>
  #endif
- 
+
 -#ifdef __GLIBC__
 +#if defined(__GLIBC__) && !defined(__riscv)
  #define ABS_ADDR(base, ptr) (ptr)
  #else
  #define ABS_ADDR(base, ptr) ((base) + (ptr))
 diff --git a/runtime/hsa-runtime/core/util/locks.h b/runtime/hsa-runtime/core/util/locks.h
-index 6c0de49a..052d04ac 100644
+index 6c0de49a..e8fc7de8 100644
 --- a/runtime/hsa-runtime/core/util/locks.h
 +++ b/runtime/hsa-runtime/core/util/locks.h
 @@ -72,7 +72,11 @@ class HybridMutex {
      while (!lock_.compare_exchange_strong(old, 1)) {
        cnt--;
        if (cnt > maxSpinIterPause) {
-+#if defined(_M_X64)
++#if defined(__x86_64__)
          _mm_pause();
 +#else
 +        os::YieldThread();
@@ -150,7 +177,7 @@ index 6c0de49a..052d04ac 100644
          os::YieldThread();
        } else {
 diff --git a/runtime/hsa-runtime/core/util/utils.h b/runtime/hsa-runtime/core/util/utils.h
-index 66c2028a..d9c2968f 100644
+index 66c2028a..2e8bd00a 100644
 --- a/runtime/hsa-runtime/core/util/utils.h
 +++ b/runtime/hsa-runtime/core/util/utils.h
 @@ -354,6 +354,7 @@ static __forceinline std::string& trim(std::string& s) { return ltrim(rtrim(s));
@@ -159,31 +186,37 @@ index 66c2028a..d9c2968f 100644
  inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
 +#if defined(__x86_64__)
    static long cacheline_size = 0;
- 
+
    if (!cacheline_size) {
-@@ -369,6 +370,11 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
+@@ -369,6 +370,15 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
      _mm_clflush((const void*)cur);
      cur += cacheline_size;
    } while (cur <= (const char*)lastline);
++#elif defined(__aarch64__)
++  asm volatile("DMB ish":::"memory");
 +#elif defined(__loongarch_lp64)
 +  asm volatile("dbar 0");
 +#elif defined(__riscv)
 +  asm volatile("fence rw, rw");
++#else
++#error
 +#endif
  }
- 
+
  }  // namespace rocr
 diff --git a/runtime/hsa-runtime/image/util.h b/runtime/hsa-runtime/image/util.h
-index 88cdf4cc..4db31e7b 100644
+index 88cdf4cc..a28fc031 100644
 --- a/runtime/hsa-runtime/image/util.h
 +++ b/runtime/hsa-runtime/image/util.h
-@@ -74,8 +74,8 @@ namespace image {
- 
- 
+@@ -74,9 +74,10 @@ namespace image {
+
+
  #if defined(__GNUC__)
 -#include "mm_malloc.h"
  #if defined(__i386__) || defined(__x86_64__)
 +#include "mm_malloc.h"
  #include <x86intrin.h>
++#elif defined(__aarch64__)
  #elif defined(__loongarch64)
  #else
+ #error                                                                                             \

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- rocm-llama-cpp: enable arm64 build
- rocm-hiprand: enable arm64 build
- rocm-hipblas: enable arm64 build
- rocm-rocsolver: enable arm64 build
- rocm-hipsparse: enable arm64 build
- rocm-hipfft: enable arm64 build
- rocm-rocsparse: enable arm64 build
- rocm-rccl: enable arm64 build
- rocm-rocrand: enable arm64 build
- rocm-rocfft: enable arm64 build

... and 8 more commits

Package(s) Affected
-------------------

- rocm-clr: 6.4.3-1
- rocm-hipblas: 6.4.3-1
- rocm-hipblas-common: 6.4.3-1
- rocm-hipblaslt: 6.4.3-1
- rocm-hipfft: 6.4.3-1
- rocm-hipfort: 6.4.3-1
- rocm-hiprand: 6.4.3-1
- rocm-hipsparse: 6.4.3-1
- rocm-llama-cpp: 6.4.3-1
- rocm-rccl: 6.4.3-1
- rocm-rocblas: 6.4.3-1
- rocm-rocfft: 6.4.3-1
- rocm-rocmlir: 6.4.3-1
- rocm-rocrand: 6.4.3-1
- rocm-rocsolver: 6.4.3-1
- rocm-rocsparse: 6.4.3-1
- rocm-roctracer: 6.4.3-1
- rocr-runtime: 6.4.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocr-runtime rocm-clr rocm-rocmlir rocm-hipfort rocm-roctracer  rocm-hipblas-common rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand rocm-rccl rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver rocm-hipblas rocm-hiprand rocm-llama-cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
