### PR TITLE
acbs: update to 20250802

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20250506.1
+VER=20250802
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"


### PR DESCRIPTION
Topic Description
-----------------

- acbs: update to 20250802
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- acbs: 2:20250802

Security Update?
----------------

No

Build Order
-----------

```
#buildit acbs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
