### PR TITLE
halloy: update to 2025.8

### DIFF
--- a/app-web/halloy/spec
+++ b/app-web/halloy/spec
@@ -1,4 +1,4 @@
-VER=2025.7
+VER=2025.8
 SRCS="git::commit=tags/$VER::https://github.com/squidowl/halloy.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373405"


### PR DESCRIPTION
Topic Description
-----------------

- halloy: update to 2025.8

Package(s) Affected
-------------------

- halloy: 2025.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit halloy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
