### PR TITLE
ocserv: update to 1.3.0

### DIFF
--- a/app-network/ocserv/autobuild/defines
+++ b/app-network/ocserv/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=ocserv
 PKGSEC=net
 PKGDEP="autogen freeradius-client gnutls http-parser libev libnl libseccomp \
         linux-pam oath-toolkit pcl protobuf-c systemd talloc"
-BUILDDEP="gperf"
+BUILDDEP="gperf ipcalc"
 PKGDES="OpenConnect VPN Server"
 
 ABSHADOW=0

--- a/app-network/ocserv/spec
+++ b/app-network/ocserv/spec
@@ -1,5 +1,5 @@
-VER=1.1.2
+VER=1.3.0
 REL=1
-SRCS="tbl::https://gitlab.com/ocserv/ocserv/-/archive/ocserv_0_12_1/ocserv-ocserv_${VER//./_}.tar.gz"
-CHKSUMS="sha256::3ebcad5855691c302d46957c035f3c01d0c8e2d275cfca78abbb37fdaf91c204"
+SRCS="git::commit=tags/$VER::https://gitlab.com/openconnect/ocserv"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2527"


### PR DESCRIPTION
Topic Description
-----------------

- ocserv: use git instead of source tarballs
    - Bump version to 1.3.0.
    - Fix source code info in spec.
    - Add ipcalc as build dependency.

Package(s) Affected
-------------------

- ocserv: 1.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocserv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
