### PR TITLE
mpd: update to 0.24.5

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,4 @@
-VER=0.24.4
+VER=0.24.5
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
-CHKSUMS="sha256::86035d6c63af32afa77fd5eb5ecd1c6afaef7cc352b28064edf51eea60f40d66"
+CHKSUMS="sha256::69dfcba5c99c8d828d8f35dfb31eb0a4e34ce3813f54666af4d8247558160a13"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- mpd: 0.24.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
