### PR TITLE
pinentry: update to 1.3.2

### DIFF
--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
+VER=1.3.2
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
-CHKSUMS="sha256::bc72ee27c7239007ab1896c3c2fae53b076e2c9bd2483dc2769a16902bce8c04"
+CHKSUMS="sha256::8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e"
 CHKUPDATE="anitya::id=3643"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pinentry: update to 1.3.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- pinentry: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
