### PR TITLE
wofi: update to 1.5.1

### DIFF
--- a/app-utils/wofi/spec
+++ b/app-utils/wofi/spec
@@ -1,4 +1,4 @@
-VER=1.5
+VER=1.5.1
 SRCS="hg::commit=v${VER}::https://hg.sr.ht/~scoopta/wofi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=70994"


### PR DESCRIPTION
Topic Description
-----------------

- wofi: update to 1.5.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wofi: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
