### PR TITLE
sbcl: update to 2.5.7

### DIFF
--- a/app-scientific/fricas/spec
+++ b/app-scientific/fricas/spec
@@ -1,5 +1,4 @@
-VER=1.3.11
-REL=2
+VER=1.3.12
 SRCS="git::commit=tags/$VER::https://github.com/fricas/fricas"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376467"

--- a/app-scientific/maxima/spec
+++ b/app-scientific/maxima/spec
@@ -1,4 +1,5 @@
 VER=5.48.0
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/maxima/maxima-$VER.tar.gz"
 CHKSUMS="sha256::75af2bf1894df2a17aef8a5c378d72d4d53c669b9f47d60ec5ba8c8676c4aaab"
 CHKUPDATE="anitya::id=6365"

--- a/lang-lisp/sbcl/autobuild/defines
+++ b/lang-lisp/sbcl/autobuild/defines
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-3 fricas<=1.3.11-1"
+PKGBREAK="maxima<=5.48.0 fricas<=1.3.11-2"

--- a/lang-lisp/sbcl/autobuild/defines.stage2
+++ b/lang-lisp/sbcl/autobuild/defines.stage2
@@ -10,4 +10,4 @@ PKGDES="Steel Bank Common Lisp"
 # riscv64: infinite hang
 FAIL_ARCH="!(amd64|arm64|ppc64el)"
 
-PKGBREAK="maxima<=5.46.0-3 fricas<=1.3.11-1"
+PKGBREAK="maxima<=5.48.0 fricas<=1.3.11-2"

--- a/lang-lisp/sbcl/spec
+++ b/lang-lisp/sbcl/spec
@@ -1,4 +1,4 @@
-VER=2.5.2
+VER=2.5.7
 SRCS="tbl::https://downloads.sourceforge.net/project/sbcl/sbcl/$VER/sbcl-$VER-source.tar.bz2"
-CHKSUMS="sha256::5dc27eba7dda433df53fd7441de8b11474a82cdac1689c1f6ce55fa065d65fac"
+CHKSUMS="sha256::c4fafeb795699d5bcff9085091acc762dcf5e55f85235625f3d7aef12c89d1d3"
 CHKUPDATE="anitya::id=16339"


### PR DESCRIPTION
Topic Description
-----------------

- sbcl: update to 2.5.7
   - update pkgbreak
- maxima: rebuilt because of sbcl update
- fricas: update to 1.3.12

Package(s) Affected
-------------------

- fricas: 1.3.12
- maxima: 5.48.0-1
- sbcl: 2.5.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbcl maxima fricas
```

Test Build(s) Done
------------------

