### PR TITLE
yubikey-manager: update to 5.7.2

### DIFF
--- a/app-devices/yubikey-manager/autobuild/defines
+++ b/app-devices/yubikey-manager/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=yubikey-manager
 PKGSEC=admin
 PKGDEP="click enum34 pcsclite ccid swig pyscard pyusb \
-        yubikey-personalization fido2 pyopenssl"
-BUILDDEP="setuptools"
+        fido2 pyopenssl"
+BUILDDEP="setuptools poetry-core"
 PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"
 
 NOPYTHON2=1

--- a/app-devices/yubikey-manager/spec
+++ b/app-devices/yubikey-manager/spec
@@ -1,5 +1,4 @@
-VER=4.0.1
-SRCS="https://pypi.io/packages/source/y/yubikey-manager/yubikey-manager-${VER}.tar.gz"
-CHKSUMS="sha384::8619ca211172ab50fcb71eaa61f5ef59a2a0ff970172b9455dcea7de854aa683f00db8d781ab39f15cf97cbe00688dd5"
+VER=5.7.2
+SRCS="https://pypi.io/packages/source/y/yubikey-manager/yubikey_manager-${VER}.tar.gz"
+CHKSUMS="sha256::9aeb4035dcff8f6cb792e83f36e6a9152a9b5b65ac2c2e25e5f20d53c6064e62"
 CHKUPDATE="anitya::id=67946"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

pyscard: update to 2.3.0
fido2: update to 2.0.0
yubikey-manager: update to 5.7.2

Package(s) Affected
-------------------

pyscard: 2.3.0
fido2: 2.0.0
yubikey-manager: 5.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyscard fido2 yubikey-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

  - [ ] Architecture-independent `noarch`

