### PR TITLE
wesnoth: update to 1.18.5

### DIFF
--- a/app-games/wesnoth/spec
+++ b/app-games/wesnoth/spec
@@ -1,4 +1,4 @@
-VER=1.18.4
+VER=1.18.5
 SRCS="tbl::https://sourceforge.net/projects/wesnoth/files/wesnoth-${VER:0:4}/wesnoth-$VER/wesnoth-$VER.tar.bz2"
-CHKSUMS="sha256::2b95351729fcf1384d521d540aa0adfc80a9be2991aa4791f3b090678e4364ae"
+CHKSUMS="sha256::e15db3caf446d91d389fc275f10c1a9e7ca3c6176c3b8ce94f5ee4a7a0c81bd6"
 CHKUPDATE="anitya::id=8621"


### PR DESCRIPTION
Topic Description
-----------------

- wesnoth: update to 1.18.5
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- wesnoth: 1.18.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit wesnoth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
