### PR TITLE
labwc: update to 0.9.1

### DIFF
--- a/desktop-wm/labwc/spec
+++ b/desktop-wm/labwc/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.9.1
 SRCS="git::commit=tags/${VER}::https://github.com/labwc/labwc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=176073"


### PR DESCRIPTION
Topic Description
-----------------

- labwc: update to 0.9.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- labwc: 0.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit labwc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
