### PR TITLE
bgpq4: new, 1.15

### DIFF
--- a/app-network/bgpq4/autobuild/defines
+++ b/app-network/bgpq4/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=bgpq4
+PKGSEC=net
+PKGDEP=glibc
+BUILDDEP="autoconf automake libtool gcc make"
+PKGDES="Automate BGP filter generation based on routing database information"

--- a/app-network/bgpq4/spec
+++ b/app-network/bgpq4/spec
@@ -1,0 +1,4 @@
+VER=1.15
+SRCS="git::commit=tags/$VER::https://github.com/bgp/bgpq4.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=116791"


### PR DESCRIPTION
Topic Description
-----------------

- bgpq4: new, 1.15

Package(s) Affected
-------------------

- bgpq4: 1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit bgpq4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
