### PR TITLE
poetry: update to 2.1.3

### DIFF
--- a/lang-python/findpython/autobuild/defines
+++ b/lang-python/findpython/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=findpython
+PKGSEC=python
+PKGDEP="packaging platformdirs python-3"
+BUILDDEP="python-build wheel"
+PKGDES="A utility to find python versions on your system"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/findpython/spec
+++ b/lang-python/findpython/spec
@@ -1,0 +1,4 @@
+VER=0.7.0
+SRCS="https://pypi.io/packages/source/f/findpython/findpython-$VER.tar.gz"
+CHKSUMS="sha256::8b31647c76352779a3c1a0806699b68e6a7bdc0b5c2ddd9af2a07a0d40c673dc"
+CHKUPDATE="anitya::id=275615"

--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=1
+VER=2.1.3
 SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
-CHKSUMS="sha256::fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"
+CHKSUMS="sha256::0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4"
 CHKUPDATE="anitya::id=71155"

--- a/lang-python/poetry/spec
+++ b/lang-python/poetry/spec
@@ -1,5 +1,4 @@
-VER=1.8.3
+VER=2.1.3
 SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
-CHKSUMS="sha256::67f4eb68288eab41e841cc71a00d26cf6bdda9533022d0189a145a34d0a35f48"
+CHKSUMS="sha256::f2c9bd6790b19475976d88ea4553bcc3533c0dc73f740edc4fffe9e2add50594"
 CHKUPDATE="anitya::id=32514"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

Poetry 2.1.3 is compatible with the currently used Python 3.10, so we can separate it from #11193.

- poetry: update to 2.1.3

Package(s) Affected
-------------------

- poetry: 2.1.3
- poetry-core: 2.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit poetry-core poetry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
