### PR TITLE
telegram-desktop: update to 6.0.2

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,12 +1,11 @@
-VER=5.16.6
-REL=1
+VER=6.0.2
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
 TDLIBVER=6d74326c5ce53aeb52496f157f0080d9b8515970
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::9b0ae00cec85d0c6735390cc453ed07f005da1d7927f2e77976037877bc1b594 \
+CHKSUMS="sha256::81e981079f2a056189783e25aac627b6709dd205b10ee3ef7465cae54245d362 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.0.2
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- telegram-desktop: 6.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
