### PR TITLE
telegram-desktop: fix taskbar icon on both Qt 5 and Qt 6

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0013-Fix-desktop-file-name-on-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-Fix-desktop-file-name-on-Qt-5.patch
@@ -1,15 +1,95 @@
-From d0e73422d952c5c061f8c85bc4294291fb3d421e Mon Sep 17 00:00:00 2001
+From 0034f9f12ad34c108d8c031da993a8389e2d8d24 Mon Sep 17 00:00:00 2001
 From: Kirikaze Chiyuki <me@chyk.ink>
-Date: Sun, 27 Jul 2025 16:15:27 +0800
+Date: Mon, 4 Aug 2025 09:53:59 +0800
 Subject: [PATCH] Fix desktop file name on Qt 5
 
-- Fixed missing task selector icon on Wayland
+The target Qt version of Telegram Desktop code is Qt 6. commit 0534a2f aligns the behavior of desktopFileName to Qt 6. However, AOSC OS is still using Qt 5 to compile Telegram Desktop, so conditional compilation fixes are introduced in this patch.
 ---
- Telegram/SourceFiles/platform/linux/specific_linux.cpp | 9 ++++++++-
- 1 file changed, 8 insertions(+), 1 deletion(-)
+ .../platform/linux/integration_linux.cpp      |  5 +++
+ .../platform/linux/main_window_linux.cpp      |  6 +++
+ .../linux/notifications_manager_linux.cpp     |  6 +++
+ .../platform/linux/specific_linux.cpp         | 37 +++++++++++++++++++
+ 4 files changed, 54 insertions(+)
 
+diff --git a/Telegram/SourceFiles/platform/linux/integration_linux.cpp b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+index 0bb06f550..1a223a122 100644
+--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+@@ -17,6 +17,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #endif
+ #include "base/random.h"
+ 
++#include <QtGlobal>
+ #include <QtCore/QAbstractEventDispatcher>
+ 
+ #include <gio/gio.hpp>
+@@ -86,7 +87,11 @@ public:
+ 
+ Application::Application()
+ : Gio::impl::ApplicationImpl(this) {
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	const auto appId = QGuiApplication::desktopFileName().toStdString();
++#else
++	const auto appId = QGuiApplication::desktopFileName().chopped(8).toStdString();
++#endif
+ 	if (Gio::Application::id_is_valid(appId)) {
+ 		set_application_id(appId);
+ 	}
+diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+index f70a8959f..3e673314b 100644
+--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+@@ -35,6 +35,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "base/platform/linux/base_linux_xcb_utilities.h"
+ #endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION
+ 
++#include <QtGlobal>
+ #include <QtCore/QSize>
+ #include <QtCore/QMimeData>
+ #include <QtGui/QWindow>
+@@ -174,9 +175,14 @@ void MainWindow::updateUnityCounter() {
+ 		return hash;
+ 	};
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	const auto launcherUrl = "application://"
+ 		+ QGuiApplication::desktopFileName().toStdString()
+ 		+ ".desktop";
++#else
++	const auto launcherUrl = "application://"
++		+ QGuiApplication::desktopFileName().toStdString();
++#endif
+ 
+ 	const auto counterSlice = std::min(Core::App().unreadBadge(), 9999);
+ 
+diff --git a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+index f73fceab0..ca06e0b2f 100644
+--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+@@ -26,6 +26,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "base/weak_ptr.h"
+ #include "window/notifications_utilities.h"
+ 
++#include <QtGlobal>
+ #include <QtCore/QBuffer>
+ #include <QtCore/QVersionNumber>
+ #include <QtGui/QGuiApplication>
+@@ -676,8 +677,13 @@ void Manager::Private::showNotification(
+ 			"category",
+ 			GLib::Variant::new_string("im.received"));
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 		hints.insert_value("desktop-entry", GLib::Variant::new_string(
+ 			QGuiApplication::desktopFileName().toStdString()));
++#else
++		hints.insert_value("desktop-entry", GLib::Variant::new_string(
++			QGuiApplication::desktopFileName().chopped(8).toStdString()));
++#endif
+ 	}
+ 
+ 	const auto imageKey = GetImageKey();
 diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
-index 1710805..b2af33a 100644
+index 171080535..bc68355c0 100644
 --- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
 @@ -27,6 +27,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -20,22 +100,103 @@ index 1710805..b2af33a 100644
  #include <QtWidgets/QApplication>
  #include <QtWidgets/QSystemTrayIcon>
  #include <QtCore/QStandardPaths>
-@@ -693,8 +694,14 @@ void start() {
- 			return u"org.telegram.desktop._%1"_q.arg(
+@@ -236,9 +237,14 @@ bool GenerateDesktopFile(
+ 	if (!QDir(targetPath).exists()) QDir().mkpath(targetPath);
+ 
+ 	const auto sourceFile = u":/misc/org.telegram.desktop.desktop"_q;
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	const auto targetFile = targetPath
+ 		+ QGuiApplication::desktopFileName()
+ 		+ u".desktop"_q;
++#else
++	const auto targetFile = targetPath
++		+ QGuiApplication::desktopFileName();
++#endif
+ 
+ 	const auto sourceText = [&] {
+ 		QFile source(sourceFile);
+@@ -400,9 +406,15 @@ bool GenerateServiceFile(bool silent = false) {
+ 	const auto targetPath = QStandardPaths::writableLocation(
+ 		QStandardPaths::GenericDataLocation) + u"/dbus-1/services/"_q;
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	const auto targetFile = targetPath
+ 		+ QGuiApplication::desktopFileName()
+ 		+ u".service"_q;
++#else
++	const auto targetFile = targetPath
++		+ QGuiApplication::desktopFileName().chopped(8)
++		+ u".service"_q;
++#endif
+ 
+ 	DEBUG_LOG(("App Info: placing D-Bus service file to %1").arg(targetPath));
+ 	if (!QDir(targetPath).exists()) QDir().mkpath(targetPath);
+@@ -410,10 +422,18 @@ bool GenerateServiceFile(bool silent = false) {
+ 	auto target = GLib::KeyFile::new_();
+ 	constexpr auto group = "D-BUS Service";
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	target.set_string(
+ 		group,
+ 		"Name",
+ 		QGuiApplication::desktopFileName().toStdString());
++#else
++	target.set_string(
++		group,
++		"Name",
++		QGuiApplication::desktopFileName().chopped(8)
++		.toStdString());
++#endif
+ 
+ 	QStringList exec;
+ 	exec.append(executable);
+@@ -583,10 +603,16 @@ void AutostartToggle(bool enabled, Fn<void(bool)> done) {
+ 			+ u"/autostart/"_q;
+ 
+ 		if (!enabled) {
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 			return QFile::remove(
+ 				autostart
+ 					+ QGuiApplication::desktopFileName()
+ 					+ u".desktop"_q);
++#else
++			return QFile::remove(
++				autostart + QGuiApplication::desktopFileName()
++				);
++#endif
+ 		}
+ 
+ 		return GenerateDesktopFile(
+@@ -694,7 +720,11 @@ void start() {
  				Core::Launcher::Instance().instanceHash().constData());
  		}
--
+ 
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-+		// Qt 6
  		return u"org.telegram.desktop"_q;
 +#else
-+		// Qt 5 requires full desktop file name
-+		// fix for task selector icon on Wayland
 +		return u"org.telegram.desktop.desktop"_q;
 +#endif
  	}());
  
  	LOG(("App ID: %1").arg(QGuiApplication::desktopFileName()));
+@@ -779,10 +809,17 @@ QImage DefaultApplicationIcon() {
+ }
+ 
+ QString ApplicationIconName() {
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	static const auto Result = KSandbox::isSnap()
+ 		? u"snap.%1."_q.arg(qEnvironmentVariable("SNAP_INSTANCE_NAME"))
+ 		: QGuiApplication::desktopFileName().remove(
+ 		u"._"_q + Core::Launcher::Instance().instanceHash());
++#else
++	static const auto Result = KSandbox::isSnap()
++		? u"snap.%1."_q.arg(qEnvironmentVariable("SNAP_INSTANCE_NAME"))
++		: QGuiApplication::desktopFileName().chopped(8).remove(
++		u"._"_q + Core::Launcher::Instance().instanceHash());
++#endif
+ 	return Result;
+ }
+ 
 -- 
 2.50.1
 

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=6.0.2
+REL=1
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
 TDLIBVER=6d74326c5ce53aeb52496f157f0080d9b8515970


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: fix taskbar icon on both Qt 5 and Qt 6

The target Qt version of Telegram Desktop code is Qt 6. commit 0534a2f aligns the behavior of desktopFileName to Qt 6. However, AOSC OS is still using Qt 5 to compile Telegram Desktop, so conditional compilation fixes are introduced in this patch.

Package(s) Affected
-------------------

- telegram-desktop: 6.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
