### PR TITLE
fastfetch: detect cpu name and frequency on loongson3 via /proc/cpuinfo

### DIFF
--- a/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
+++ b/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
@@ -1,0 +1,39 @@
+From 3c98703a464209b56f0d38b2b869cf985e714da2 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Mon, 4 Aug 2025 10:17:45 +0800
+Subject: [PATCH] AOSCOS: LOONGSON3: CPU (Linux): detect cpu via /proc/cpuinfo
+ on loongson3
+
+---
+ src/detection/cpu/cpu_linux.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/detection/cpu/cpu_linux.c b/src/detection/cpu/cpu_linux.c
+index 46ab37b7..9761f46c 100644
+--- a/src/detection/cpu/cpu_linux.c
++++ b/src/detection/cpu/cpu_linux.c
+@@ -297,7 +297,8 @@ static const char* parseCpuInfo(
+             (cpuMHz->length == 0 && ffParsePropLine(line, "clock :", cpuMHz)) ||
+             (cpu->name.length == 0 && ffParsePropLine(line, "cpu :", &cpu->name)) ||
+             #elif __mips__ || __mips
+-            (cpu->name.length == 0 && ffParsePropLine(line, "cpu model :", &cpu->name)) ||
++            (cpu->name.length == 0 && ffParsePropLine(line, "model name :", &cpu->name)) ||
++            (cpuMHz->length == 0 && ffParsePropLine(line, "CPU MHz :", cpuMHz)) ||
+             #elif __loongarch__
+             (cpu->name.length == 0 && ffParsePropLine(line, "Model Name :", &cpu->name)) ||
+             (cpuMHz->length == 0 && ffParsePropLine(line, "CPU MHz :", cpuMHz)) ||
+@@ -633,6 +634,12 @@ FF_MAYBE_UNUSED static void detectSocName(FFCPUResult* cpu)
+         for (const char* p = model; *p; ++p)
+             ffStrbufAppendC(&cpu->name, (char) toupper(*p));
+     }
++    #if __mips__ || __mips
++    else if (ffStrEquals(vendor, "loongson"))
++    {
++        ffStrbufSetStatic(&cpu->vendor, "Loongson");
++    }
++    #endif
+     else
+     {
+         ffStrbufSetS(&cpu->name, model);
+--
+2.50.1

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,5 @@
 VER=2.49.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: detect cpu name and frequency on loongson3 via /proc/cpuinfo
    - Track patches at AOSC-Tracking/fastfetch @ aosc/2.49.0
    \(HEAD: 3c98703a464209b56f0d38b2b869cf985e714da2\).

Package(s) Affected
-------------------

- fastfetch: 2.49.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

