### PR TITLE
aosc-os-keyring: install keyring to /usr/share/keyrings

### DIFF
--- a/runtime-data/aosc-os-keyring/autobuild/build
+++ b/runtime-data/aosc-os-keyring/autobuild/build
@@ -1,5 +1,8 @@
-# FIXME: We will transition to a signature-matched APT sources
-# configuration on a later date.
 abinfo "Installing keys ..."
-install -Dvm644 "$SRCDIR"/*.gpg \
-   -t "$PKGDIR"/etc/apt/trusted.gpg.d/
+install -Dvm644 "$SRCDIR"/aosc-os-2024-10-06-ed25519-F54DE04F93DFEDBA123FC2933AE2C2BE062E9F06.gpg \
+    "$PKGDIR"/usr/share/keyrings/aosc-archive-keyring.gpg
+
+abinfo "Creating a compatibility symlink for trusted.gpg.d ..."
+mkdir -pv "$PKGDIR"/etc/apt/trusted.gpg.d
+ln -sv ../../../usr/share/keyrings/aosc-archive-keyring.gpg \
+    "$PKGDIR"/etc/apt/trusted.gpg.d/aosc-os-2024-10-06-ed25519-F54DE04F93DFEDBA123FC2933AE2C2BE062E9F06.gpg

--- a/runtime-data/aosc-os-keyring/spec
+++ b/runtime-data/aosc-os-keyring/spec
@@ -1,8 +1,7 @@
 VER=20241006
-SRCS="file::use-url-name=true::https://repo.aosc.io/pubkeys/aosc-os-2017-02-14-nistp521-156C7480EDD3052155E18CFCA54D903CC4CB9CD1.gpg \
-      file::use-url-name=true::https://repo.aosc.io/pubkeys/aosc-os-2024-10-06-ed25519-F54DE04F93DFEDBA123FC2933AE2C2BE062E9F06.gpg"
-CHKSUMS="sha256::42ef90bc5f1af50376edc9984cda013dbd7cb937d6129735890fa79f8b21f302 \
-         sha256::6a8cfbcaeb9fd16a729fa1fe086fc58cddd0e714873aa336efa9983c845ed305"
+REL=1
+SRCS="file::use-url-name=true::https://repo.aosc.io/pubkeys/aosc-os-2024-10-06-ed25519-F54DE04F93DFEDBA123FC2933AE2C2BE062E9F06.gpg"
+CHKSUMS="sha256::6a8cfbcaeb9fd16a729fa1fe086fc58cddd0e714873aa336efa9983c845ed305"
 # Note: No way to track version update, this should be coordinated
 # amongst maintainers.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-keyring: install keyring to /usr/share/keyrings
    Also drop the old 2017 key.

Package(s) Affected
-------------------

- aosc-os-keyring: 20241006-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
