### PR TITLE
libgdiplus: update to 6.2

### DIFF
--- a/lang-dotnet/libgdiplus/autobuild/defines
+++ b/lang-dotnet/libgdiplus/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libgdiplus
 PKGSEC=libs
 PKGDEP="libtiff cairo giflib glib libexif pango"
 PKGDES="An open source implementation of the GDI+ API"
+
+ABTYPE=autotools

--- a/lang-dotnet/libgdiplus/autobuild/prepare
+++ b/lang-dotnet/libgdiplus/autobuild/prepare
@@ -1,1 +1,0 @@
-export LDFLAGS="${LDFLAGS} -lX11 -lpangoft2-1.0"

--- a/lang-dotnet/libgdiplus/spec
+++ b/lang-dotnet/libgdiplus/spec
@@ -1,4 +1,4 @@
-VER=6.1
-SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/mono/libgdiplus"
+VER=6.2
+SRCS="git::commit=tags/$VER::https://gitlab.winehq.org/mono/libgdiplus.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6440"


### PR DESCRIPTION
Topic Description
-----------------

- libgdiplus: update to 6.2
    - Drop unused prepare script.
    - Change upstream to winehq.

Package(s) Affected
-------------------

- libgdiplus: 6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgdiplus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
