### PR TITLE
luajit: add loongarch64_nosimd build config

### DIFF
--- a/lang-lua/luajit/autobuild/defines
+++ b/lang-lua/luajit/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 PKGDES="Just-in-time compiler and drop-in replacement for Lua 5.1"
 
 AB_FLAGS_O3=1
-FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|i486|loongson2f|loongson3|loongarch64)"
+FAIL_ARCH="!(amd64|armv4|armv6hf|armv7hf|arm64|i486|loongson2f|loongson3|loongarch64|loongarch64_nosimd)"

--- a/lang-lua/luajit/spec
+++ b/lang-lua/luajit/spec
@@ -4,9 +4,12 @@ CHKUPDATE="anitya::id=6444"
 # Upstream shows no interest in adding new arch
 # Note: loongson/LuaJIT don't do tag either
 VER__LOONGARCH64=v2.1.ROLLING+git20250605
+VER__LOONGARCH64_NOSIMD="${VER__LOONGARCH64}"
 SRCS__LOONGARCH64="git::commit=02579d06dba72769949b0e8660c875a6d20eb6b3::https://github.com/loongson/LuaJIT.git"
+SRCS__LOONGARCH64_NOSIMD="${SRCS__LOONGARCH64}"
 # FIXME: Anitya don't handle the "don't do release" and "don't do tag" kind of project well
 CHKUPDATE__LOONGARCH64="github::repo=loongson/LuaJIT"
+CHKUPDATE__LOONGARCH64_NOSIMD="${CHKUPDATE__LOONGARCH64}"
 
 CHKSUMS="SKIP"
 REL=1


### PR DESCRIPTION
Topic Description
-----------------

- luajit: add loongarch64_nosimd build config
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- luajit: 2.1.0b3+git20250528-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit luajit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
