### PR TITLE
bash-startup: update to v0.8.0

### DIFF
--- a/runtime-data/bash-startup/spec
+++ b/runtime-data/bash-startup/spec
@@ -1,5 +1,4 @@
-VER=0.7.2
-REL=1
+VER=v0.8.0
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/bash-config"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226642"


### PR DESCRIPTION
Topic Description
-----------------

- bash-startup: update to v0.8.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bash-startup: 2:v0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-startup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
