### PR TITLE
busybox: update to 1.37.0-1

### DIFF
--- a/app-utils/busybox/autobuild/patches/0002-remove-CBQ-support.patch
+++ b/app-utils/busybox/autobuild/patches/0002-remove-CBQ-support.patch
@@ -1,0 +1,60 @@
+From 6c547b7c4cfc3b10b1bd9aecb0a4b6b3b8c20a97 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Tue, 5 Aug 2025 18:06:38 +0000
+Subject: [PATCH] remove CBQ support
+
+---
+ networking/tc.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/networking/tc.c b/networking/tc.c
+index 3a79fd2..ecf7d61 100644
+--- a/networking/tc.c
++++ b/networking/tc.c
+@@ -231,6 +231,12 @@ static int cbq_parse_opt(int argc, char **argv, struct nlmsghdr *n)
+ 	return 0;
+ }
+ #endif
++#ifndef TCA_CBQ_MAX
++/*
++ * Linux v6.8-rc1~131^2~60^2^2 removed the uapi definitions for CBQ.
++ * See <A HREF="https://git.kernel.org/linus/33241dca48626">https://git.kernel.org/linus/33241dca48626</A>
++ */
++#else
+ static int cbq_print_opt(struct rtattr *opt)
+ {
+ 	struct rtattr *tb[TCA_CBQ_MAX+1];
+@@ -322,6 +328,7 @@ static int cbq_print_opt(struct rtattr *opt)
+  done:
+ 	return 0;
+ }
++#endif
+ 
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+@@ -372,8 +379,10 @@ static FAST_FUNC int print_qdisc(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
++#ifdef TCA_CBQ_MAX
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			cbq_print_opt(tb[TCA_OPTIONS]);
++#endif
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -442,9 +451,11 @@ static FAST_FUNC int print_class(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
++#ifdef TCA_CBQ_MAX
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+ 			cbq_print_opt(tb[TCA_OPTIONS]);
++#endif
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);
+-- 
+2.50.1
+

--- a/app-utils/busybox/autobuild/patches/0003-ALPINE-tar-fix-TOCTOU-symlink-race-condition.patch
+++ b/app-utils/busybox/autobuild/patches/0003-ALPINE-tar-fix-TOCTOU-symlink-race-condition.patch
@@ -1,0 +1,31 @@
+From efaed86d21f882cd0a616484bde76d252ced6631 Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@ariadne.space>
+Date: Tue, 5 Aug 2025 09:21:11 -0700
+Subject: [PATCH] tar: fix TOCTOU symlink race condition
+
+Signed-off-by: Ariadne Conill <ariadne@ariadne.space>
+---
+ archival/libarchive/data_extract_all.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/archival/libarchive/data_extract_all.c b/archival/libarchive/data_extract_all.c
+index 8a69711c1..88bf96392 100644
+--- a/archival/libarchive/data_extract_all.c
++++ b/archival/libarchive/data_extract_all.c
+@@ -143,9 +143,11 @@ void FAST_FUNC data_extract_all(archive_handle_t *archive_handle)
+ 	case S_IFREG: {
+ 		/* Regular file */
+ 		char *dst_nameN;
+-		int flags = O_WRONLY | O_CREAT | O_EXCL;
++		int flags = O_WRONLY | O_CREAT | O_NOFOLLOW;
+ 		if (archive_handle->ah_flags & ARCHIVE_O_TRUNC)
+-			flags = O_WRONLY | O_CREAT | O_TRUNC;
++			flags |= O_TRUNC;
++		else
++			flags |= O_EXCL;
+ 		dst_nameN = dst_name;
+ #ifdef ARCHIVE_REPLACE_VIA_RENAME
+ 		if (archive_handle->ah_flags & ARCHIVE_REPLACE_VIA_RENAME)
+-- 
+2.50.1
+

--- a/app-utils/busybox/spec
+++ b/app-utils/busybox/spec
@@ -1,4 +1,5 @@
 VER=1.37.0
+REL=1
 SRCS="tbl::https://busybox.net/downloads/busybox-$VER.tar.bz2"
 CHKSUMS="sha256::3311dff32e746499f4df0d5df04d7eb396382d7e108bb9250e7b519b837043a4"
 CHKUPDATE="anitya::id=230"

--- a/topics/busybox-1.37.0-1.toml
+++ b/topics/busybox-1.37.0-1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "BusyBox 1.37.0 Security Update"
+zh_CN = "BusyBox 1.37.0 安全更新"
+
+[caution]
+default = "Fixes a TOCTOU (Time-Of-Check to Time-of-Use) race condition vulnerability (severity: high)"
+zh_CN = "修复一处 TOCTOU（检查到使用时间）竞态条件漏洞（严重性：高）"
+
+[packages]
+"busybox" = "1.37.0-1"


### PR DESCRIPTION
Topic Description
-----------------

- busybox: update to 1.37.0-1

Package(s) Affected
-------------------

- busybox: 1.37.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit busybox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
