### PR TITLE
zellij: update to 0.43.0

### DIFF
--- a/app-utils/zellij/autobuild/defines
+++ b/app-utils/zellij/autobuild/defines
@@ -2,10 +2,10 @@ PKGNAME=zellij
 PKGSEC=utils
 PKGDEP="glibc gcc-runtime"
 BUILDDEP="rustc llvm"
-PKGDES="A terminal workspace and a terminal multiplexer"
+PKGDES="Terminal workspace and multiplexer"
 
 USECLANG=1
+ABTYPE=rust
 
-# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local
-# symbol; recompile with -fPIC
-NOLTO__LOONGSON3=1
+# FIXME: ld.lld: error: undefined symbol: OPENSSL_cleanse
+NOLTO__LOONGARCH64=1

--- a/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
+++ b/app-utils/zellij/autobuild/patches/0001-chore-update-wasmtime-to-30.0.2.patch
@@ -1,39 +1,29 @@
-From 1e52abcaa68d574ca7ff6dfadf6c29c12fdedfe6 Mon Sep 17 00:00:00 2001
+From a12c22fdce3a58bbae377e95d6e086ce0bfdbf8a Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
-Date: Fri, 21 Mar 2025 03:27:32 -0700
+Date: Wed, 6 Aug 2025 20:19:36 -0700
 Subject: [PATCH 1/2] chore: update wasmtime to 30.0.2
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- Cargo.lock                              | 257 +++++++++++-------------
+ Cargo.lock                              | 232 +++++++++++++-----------
  zellij-server/Cargo.toml                |   6 +-
  zellij-server/src/plugins/plugin_map.rs |  15 +-
- 3 files changed, 129 insertions(+), 149 deletions(-)
+ 3 files changed, 132 insertions(+), 121 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 204fd5cc..ef55c939 100644
+index 22ae60e6..7e8ae288 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -34,18 +34,6 @@ version = "1.0.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
- 
--[[package]]
--name = "ahash"
--version = "0.8.11"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
--dependencies = [
-- "cfg-if",
-- "once_cell",
-- "version_check",
+@@ -43,7 +43,7 @@ dependencies = [
+  "cfg-if",
+  "once_cell",
+  "version_check",
 - "zerocopy 0.7.34",
--]
--
++ "zerocopy 0.7.35",
+ ]
+ 
  [[package]]
- name = "aho-corasick"
- version = "0.7.20"
-@@ -725,20 +713,35 @@ dependencies = [
+@@ -914,20 +914,35 @@ dependencies = [
   "libc",
  ]
  
@@ -73,7 +63,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "serde",
   "serde_derive",
-@@ -746,11 +749,12 @@ dependencies = [
+@@ -935,11 +950,12 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen"
@@ -88,7 +78,7 @@ index 204fd5cc..ef55c939 100644
   "cranelift-bforest",
   "cranelift-bitset",
   "cranelift-codegen-meta",
-@@ -759,8 +763,9 @@ dependencies = [
+@@ -948,8 +964,9 @@ dependencies = [
   "cranelift-entity",
   "cranelift-isle",
   "gimli 0.31.1",
@@ -97,9 +87,9 @@ index 204fd5cc..ef55c939 100644
   "log",
 + "pulley-interpreter",
   "regalloc2",
-  "rustc-hash",
+  "rustc-hash 2.1.0",
   "serde",
-@@ -770,33 +775,35 @@ dependencies = [
+@@ -959,33 +976,35 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen-meta"
@@ -143,7 +133,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "cranelift-bitset",
   "serde",
-@@ -805,9 +812,9 @@ dependencies = [
+@@ -994,9 +1013,9 @@ dependencies = [
  
  [[package]]
  name = "cranelift-frontend"
@@ -155,7 +145,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "cranelift-codegen",
   "log",
-@@ -817,15 +824,15 @@ dependencies = [
+@@ -1006,15 +1025,15 @@ dependencies = [
  
  [[package]]
  name = "cranelift-isle"
@@ -175,23 +165,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "cranelift-codegen",
   "libc",
-@@ -1514,15 +1521,6 @@ version = "0.11.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
- 
--[[package]]
--name = "hashbrown"
--version = "0.14.5"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
--dependencies = [
-- "ahash",
--]
--
- [[package]]
- name = "hashbrown"
- version = "0.15.2"
-@@ -2795,13 +2793,12 @@ dependencies = [
+@@ -3259,13 +3278,12 @@ dependencies = [
  
  [[package]]
  name = "pulley-interpreter"
@@ -207,25 +181,24 @@ index 204fd5cc..ef55c939 100644
   "wasmtime-math",
  ]
  
-@@ -2833,7 +2830,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
- dependencies = [
-  "rand_chacha 0.9.0",
-  "rand_core 0.9.0",
-- "zerocopy 0.8.17",
-+ "zerocopy",
- ]
+@@ -4921,16 +4939,6 @@ version = "0.2.87"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
  
+-[[package]]
+-name = "wasm-encoder"
+-version = "0.221.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+-dependencies = [
+- "leb128",
+- "wasmparser 0.221.3",
+-]
+-
  [[package]]
-@@ -2872,7 +2869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
- dependencies = [
-  "getrandom 0.3.1",
-- "zerocopy 0.8.17",
-+ "zerocopy",
- ]
- 
- [[package]]
-@@ -4094,14 +4091,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ name = "wasm-encoder"
+ version = "0.224.0"
+@@ -4938,14 +4946,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
  dependencies = [
   "leb128",
@@ -243,7 +216,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "bitflags 2.5.0",
   "hashbrown 0.15.2",
-@@ -4110,33 +4107,22 @@ dependencies = [
+@@ -4954,33 +4962,22 @@ dependencies = [
   "serde",
  ]
  
@@ -282,7 +255,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "addr2line 0.24.2",
   "anyhow",
-@@ -4148,7 +4134,7 @@ dependencies = [
+@@ -4992,7 +4989,7 @@ dependencies = [
   "encoding_rs",
   "fxprof-processed-profile",
   "gimli 0.31.1",
@@ -291,7 +264,7 @@ index 204fd5cc..ef55c939 100644
   "indexmap 2.7.1",
   "ittapi",
   "libc",
-@@ -4171,8 +4157,8 @@ dependencies = [
+@@ -5015,8 +5012,8 @@ dependencies = [
   "sptr",
   "target-lexicon",
   "trait-variant",
@@ -302,7 +275,7 @@ index 204fd5cc..ef55c939 100644
   "wasmtime-asm-macros",
   "wasmtime-cache",
   "wasmtime-component-macro",
-@@ -4192,18 +4178,18 @@ dependencies = [
+@@ -5036,18 +5033,18 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-asm-macros"
@@ -325,7 +298,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "base64 0.21.0",
-@@ -4221,9 +4207,9 @@ dependencies = [
+@@ -5065,9 +5062,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-macro"
@@ -337,7 +310,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "proc-macro2",
-@@ -4236,15 +4222,15 @@ dependencies = [
+@@ -5080,15 +5077,15 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-component-util"
@@ -357,7 +330,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4257,19 +4243,20 @@ dependencies = [
+@@ -5101,19 +5098,20 @@ dependencies = [
   "itertools 0.12.1",
   "log",
   "object 0.36.7",
@@ -381,7 +354,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "cpp_demangle",
-@@ -4286,17 +4273,17 @@ dependencies = [
+@@ -5130,17 +5128,17 @@ dependencies = [
   "serde_derive",
   "smallvec",
   "target-lexicon",
@@ -403,7 +376,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "cc",
-@@ -4309,10 +4296,11 @@ dependencies = [
+@@ -5153,10 +5151,11 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-debug"
@@ -417,7 +390,7 @@ index 204fd5cc..ef55c939 100644
   "object 0.36.7",
   "rustix 0.38.44",
   "wasmtime-versioned-export-macros",
-@@ -4320,9 +4308,9 @@ dependencies = [
+@@ -5164,9 +5163,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-jit-icache-coherence"
@@ -429,7 +402,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "cfg-if",
-@@ -4332,24 +4320,24 @@ dependencies = [
+@@ -5176,24 +5175,24 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-math"
@@ -460,7 +433,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4358,9 +4346,9 @@ dependencies = [
+@@ -5202,9 +5201,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wasi"
@@ -472,7 +445,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4380,25 +4368,38 @@ dependencies = [
+@@ -5224,25 +5223,38 @@ dependencies = [
   "thiserror 1.0.61",
   "tokio",
   "tracing",
@@ -515,7 +488,7 @@ index 204fd5cc..ef55c939 100644
   "wasmtime-cranelift",
   "wasmtime-environ",
   "winch-codegen",
-@@ -4406,9 +4407,9 @@ dependencies = [
+@@ -5250,9 +5262,9 @@ dependencies = [
  
  [[package]]
  name = "wasmtime-wit-bindgen"
@@ -527,7 +500,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4435,7 +4436,7 @@ dependencies = [
+@@ -5279,7 +5291,7 @@ dependencies = [
   "leb128",
   "memchr",
   "unicode-width 0.2.0",
@@ -536,7 +509,7 @@ index 204fd5cc..ef55c939 100644
  ]
  
  [[package]]
-@@ -4551,9 +4552,9 @@ dependencies = [
+@@ -5395,9 +5407,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle"
@@ -548,7 +521,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -4566,9 +4567,9 @@ dependencies = [
+@@ -5410,9 +5422,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-generate"
@@ -560,7 +533,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "heck 0.5.0",
-@@ -4581,9 +4582,9 @@ dependencies = [
+@@ -5425,9 +5437,9 @@ dependencies = [
  
  [[package]]
  name = "wiggle-macro"
@@ -572,7 +545,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -4624,9 +4625,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+@@ -5468,9 +5480,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
  
  [[package]]
  name = "winch-codegen"
@@ -584,7 +557,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -4635,7 +4636,7 @@ dependencies = [
+@@ -5479,7 +5491,7 @@ dependencies = [
   "smallvec",
   "target-lexicon",
   "thiserror 1.0.61",
@@ -593,7 +566,7 @@ index 204fd5cc..ef55c939 100644
   "wasmtime-cranelift",
   "wasmtime-environ",
  ]
-@@ -4893,9 +4894,9 @@ dependencies = [
+@@ -5671,9 +5683,9 @@ dependencies = [
  
  [[package]]
  name = "wit-parser"
@@ -605,7 +578,7 @@ index 204fd5cc..ef55c939 100644
  dependencies = [
   "anyhow",
   "id-arena",
-@@ -4906,7 +4907,7 @@ dependencies = [
+@@ -5684,7 +5696,7 @@ dependencies = [
   "serde_derive",
   "serde_json",
   "unicode-xid",
@@ -614,43 +587,35 @@ index 204fd5cc..ef55c939 100644
  ]
  
  [[package]]
-@@ -5132,33 +5133,13 @@ dependencies = [
-  "uuid",
- ]
+@@ -5937,11 +5949,11 @@ dependencies = [
  
--[[package]]
--name = "zerocopy"
--version = "0.7.34"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
--dependencies = [
-- "zerocopy-derive 0.7.34",
--]
--
  [[package]]
  name = "zerocopy"
- version = "0.8.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
- dependencies = [
-- "zerocopy-derive 0.8.17",
--]
--
--[[package]]
--name = "zerocopy-derive"
 -version = "0.7.34"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
--dependencies = [
-- "proc-macro2",
-- "quote",
-- "syn 2.0.96",
-+ "zerocopy-derive",
++version = "0.7.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
++checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+ dependencies = [
+- "zerocopy-derive 0.7.34",
++ "zerocopy-derive 0.7.35",
  ]
  
  [[package]]
+@@ -5955,9 +5967,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zerocopy-derive"
+-version = "0.7.34"
++version = "0.7.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
++checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
 diff --git a/zellij-server/Cargo.toml b/zellij-server/Cargo.toml
-index c42ff874..9511ee7a 100644
+index 5477211b..0e8e2a6c 100644
 --- a/zellij-server/Cargo.toml
 +++ b/zellij-server/Cargo.toml
 @@ -45,11 +45,11 @@ unicode-width = { workspace = true }
@@ -677,7 +642,7 @@ index c42ff874..9511ee7a 100644
  [features]
  singlepass = ["wasmtime/winch"]
 diff --git a/zellij-server/src/plugins/plugin_map.rs b/zellij-server/src/plugins/plugin_map.rs
-index 6716dffd..c923c778 100644
+index a92c291a..79bd9080 100644
 --- a/zellij-server/src/plugins/plugin_map.rs
 +++ b/zellij-server/src/plugins/plugin_map.rs
 @@ -10,8 +10,7 @@ use std::{
@@ -690,7 +655,7 @@ index 6716dffd..c923c778 100644
  };
  
  use crate::{thread_bus::ThreadSenders, ClientId};
-@@ -316,7 +315,7 @@ pub struct PluginEnv {
+@@ -320,7 +319,7 @@ pub struct PluginEnv {
  pub struct VecDequeInputStream(pub Arc<Mutex<VecDeque<u8>>>);
  
  impl StdinStream for VecDequeInputStream {
@@ -699,7 +664,7 @@ index 6716dffd..c923c778 100644
          Box::new(self.clone())
      }
  
-@@ -325,7 +324,7 @@ impl StdinStream for VecDequeInputStream {
+@@ -329,7 +328,7 @@ impl StdinStream for VecDequeInputStream {
      }
  }
  
@@ -708,7 +673,7 @@ index 6716dffd..c923c778 100644
      fn read(&mut self, size: usize) -> StreamResult<Bytes> {
          let mut inner = self.0.lock().unwrap();
          let len = std::cmp::min(size, inner.len());
-@@ -334,7 +333,7 @@ impl HostInputStream for VecDequeInputStream {
+@@ -338,7 +337,7 @@ impl HostInputStream for VecDequeInputStream {
  }
  
  #[async_trait::async_trait]
@@ -717,7 +682,7 @@ index 6716dffd..c923c778 100644
      async fn ready(&mut self) {}
  }
  
-@@ -347,7 +346,7 @@ impl<T> Clone for WriteOutputStream<T> {
+@@ -351,7 +350,7 @@ impl<T> Clone for WriteOutputStream<T> {
  }
  
  impl<T: Write + Send + 'static> StdoutStream for WriteOutputStream<T> {
@@ -726,7 +691,7 @@ index 6716dffd..c923c778 100644
          Box::new((*self).clone())
      }
  
-@@ -356,7 +355,7 @@ impl<T: Write + Send + 'static> StdoutStream for WriteOutputStream<T> {
+@@ -360,7 +359,7 @@ impl<T: Write + Send + 'static> StdoutStream for WriteOutputStream<T> {
      }
  }
  
@@ -735,7 +700,7 @@ index 6716dffd..c923c778 100644
      fn write(&mut self, bytes: Bytes) -> StreamResult<()> {
          self.0
              .lock()
-@@ -379,7 +378,7 @@ impl<T: Write + Send + 'static> HostOutputStream for WriteOutputStream<T> {
+@@ -383,7 +382,7 @@ impl<T: Write + Send + 'static> HostOutputStream for WriteOutputStream<T> {
  }
  
  #[async_trait::async_trait]
@@ -745,5 +710,5 @@ index 6716dffd..c923c778 100644
  }
  
 -- 
-2.49.0
+2.50.1
 

--- a/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
+++ b/app-utils/zellij/autobuild/patches/0002-chore-update-nix-to-0.27-to-support-loongarch64.patch
@@ -1,23 +1,24 @@
-From f9b12fbc26b9b5761d4795e478c4c7413d7fc979 Mon Sep 17 00:00:00 2001
+From 0e4d80fe2ca35e21127fbd87652a996035614cb1 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 21 Mar 2025 03:27:12 -0700
 Subject: [PATCH 2/2] chore: update nix to >=0.27 to support loongarch64
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
- Cargo.lock                           | 35 ++++--------------
- Cargo.toml                           |  2 +-
- zellij-client/src/lib.rs             | 17 ++++-----
- zellij-client/src/os_input_output.rs | 24 ++++++-------
- zellij-server/src/os_input_output.rs | 54 +++++++++++++++++-----------
- zellij-server/src/pty.rs             | 35 ++++++++++++++----
- 6 files changed, 90 insertions(+), 77 deletions(-)
+ Cargo.lock                                    | 25 +++------
+ Cargo.toml                                    |  2 +-
+ zellij-client/src/lib.rs                      | 17 +++---
+ zellij-client/src/os_input_output.rs          | 24 ++++-----
+ .../src/web_client/server_listener.rs         |  4 +-
+ zellij-server/src/os_input_output.rs          | 54 ++++++++++++-------
+ zellij-server/src/pty.rs                      | 35 +++++++++---
+ 7 files changed, 93 insertions(+), 68 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index ef55c939..997790d1 100644
+index 7e8ae288..856caebb 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2078,7 +2078,7 @@ version = "1.1.8"
+@@ -2514,7 +2514,7 @@ version = "1.1.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
  dependencies = [
@@ -26,7 +27,7 @@ index ef55c939..997790d1 100644
   "winapi",
  ]
  
-@@ -2238,19 +2238,6 @@ dependencies = [
+@@ -2699,19 +2699,6 @@ dependencies = [
   "rand 0.8.5",
  ]
  
@@ -46,7 +47,7 @@ index ef55c939..997790d1 100644
  [[package]]
  name = "nix"
  version = "0.29.0"
-@@ -3566,7 +3553,7 @@ dependencies = [
+@@ -4245,7 +4232,7 @@ dependencies = [
   "libc",
   "log",
   "memmem",
@@ -55,24 +56,7 @@ index ef55c939..997790d1 100644
   "num-derive",
   "num-traits",
   "ordered-float",
-@@ -4074,16 +4061,6 @@ version = "0.2.87"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
- 
--[[package]]
--name = "wasm-encoder"
--version = "0.221.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
--dependencies = [
-- "leb128",
-- "wasmparser 0.221.3",
--]
--
- [[package]]
- name = "wasm-encoder"
- version = "0.224.0"
-@@ -4986,7 +4963,7 @@ dependencies = [
+@@ -5777,7 +5764,7 @@ dependencies = [
   "log",
   "miette",
   "names",
@@ -81,16 +65,16 @@ index ef55c939..997790d1 100644
   "rand 0.8.5",
   "regex",
   "ssh2",
-@@ -5009,7 +4986,7 @@ dependencies = [
+@@ -5808,7 +5795,7 @@ dependencies = [
   "libc",
   "log",
   "mio 0.7.14",
 - "nix 0.23.1",
 + "nix",
-  "notify-debouncer-full",
+  "notify",
   "regex",
-  "serde",
-@@ -5046,7 +5023,7 @@ dependencies = [
+  "rmp-serde",
+@@ -5853,7 +5840,7 @@ dependencies = [
   "lazy_static",
   "libc",
   "log",
@@ -99,41 +83,41 @@ index ef55c939..997790d1 100644
   "notify-debouncer-full",
   "prost",
   "regex",
-@@ -5113,7 +5090,7 @@ dependencies = [
-  "log",
+@@ -5922,7 +5909,7 @@ dependencies = [
   "log4rs",
   "miette",
+  "names",
 - "nix 0.23.1",
 + "nix",
+  "notify",
   "openssl-sys",
   "percent-encoding",
-  "prost",
 diff --git a/Cargo.toml b/Cargo.toml
-index e48dfa2c..02394a61 100644
+index 5a70e54c..a14d0aa6 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -67,7 +67,7 @@ lazy_static = { version = "1.4.0", default-features = false }
+@@ -72,7 +72,7 @@ lazy_static = { version = "1.4.0", default-features = false }
  libc = { version = "0.2", default-features = false, features = ["std"] }
  log = { version = "0.4.17", default-features = false }
  miette = { version = "5.7.0", default-features = false, features = ["fancy"] }
 -nix = { version = "0.23.1", default-features = false }
 +nix = { version = "0.29.0", default-features = false, features = ["fs", "process", "signal", "term", "user"]  }
- notify-debouncer-full = { version = "0.1.0", default-features = false }
+ notify-debouncer-full = { version = "0.3.1", default-features = false }
+ notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
  prost = { version = "0.11.9", default-features = false, features = ["std", "prost-derive"] }
- regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
 diff --git a/zellij-client/src/lib.rs b/zellij-client/src/lib.rs
-index 3256ada1..ebca605d 100644
+index 0f326f8f..a3444ac3 100644
 --- a/zellij-client/src/lib.rs
 +++ b/zellij-client/src/lib.rs
-@@ -11,6 +11,7 @@ mod stdin_handler;
- use log::info;
+@@ -14,6 +14,7 @@ use log::info;
  use std::env::current_exe;
  use std::io::{self, Write};
+ use std::net::{IpAddr, Ipv4Addr};
 +use std::os::unix::io::AsFd;
  use std::path::Path;
  use std::process::Command;
  use std::sync::{Arc, Mutex};
-@@ -187,7 +188,7 @@ pub fn start_client(
+@@ -241,7 +242,7 @@ pub fn start_client(
      let take_snapshot = "\u{1b}[?1049h";
      let bracketed_paste = "\u{1b}[?2004h";
      let enter_kitty_keyboard_mode = "\u{1b}[>1u";
@@ -142,7 +126,7 @@ index 3256ada1..ebca605d 100644
  
      if !is_a_reconnect {
          // we don't do this for a reconnect because our controlling terminal already has the
-@@ -215,7 +216,7 @@ pub fn start_client(
+@@ -269,7 +270,7 @@ pub fn start_client(
          .theme_config(config_options.theme.as_ref())
          .unwrap_or_else(|| os_input.load_palette().into());
  
@@ -151,7 +135,7 @@ index 3256ada1..ebca605d 100644
      let client_attributes = ClientAttributes {
          size: full_screen_ws,
          style: Style {
-@@ -286,7 +287,7 @@ pub fn start_client(
+@@ -358,7 +359,7 @@ pub fn start_client(
  
      let mut command_is_executing = CommandIsExecuting::new();
  
@@ -160,7 +144,7 @@ index 3256ada1..ebca605d 100644
      let _ = os_input
          .get_stdout_writer()
          .write(bracketed_paste.as_bytes())
-@@ -307,7 +308,7 @@ pub fn start_client(
+@@ -379,7 +380,7 @@ pub fn start_client(
          let send_client_instructions = send_client_instructions.clone();
          let os_input = os_input.clone();
          Box::new(move |info| {
@@ -169,7 +153,7 @@ index 3256ada1..ebca605d 100644
                  handle_panic(info, &send_client_instructions);
              }
          })
-@@ -368,7 +369,7 @@ pub fn start_client(
+@@ -436,7 +437,7 @@ pub fn start_client(
                          let os_api = os_input.clone();
                          move || {
                              os_api.send_to_server(ClientToServerMsg::TerminalResize(
@@ -178,7 +162,7 @@ index 3256ada1..ebca605d 100644
                              ));
                          }
                      }),
-@@ -422,7 +423,7 @@ pub fn start_client(
+@@ -490,7 +491,7 @@ pub fn start_client(
          .unwrap();
  
      let handle_error = |backtrace: String| {
@@ -187,7 +171,7 @@ index 3256ada1..ebca605d 100644
          let goto_start_of_last_line = format!("\u{1b}[{};{}H", full_screen_ws.rows, 1);
          let restore_snapshot = "\u{1b}[?1049l";
          os_input.disable_mouse().non_fatal();
-@@ -541,7 +542,7 @@ pub fn start_client(
+@@ -609,7 +610,7 @@ pub fn start_client(
              },
              ClientInstruction::QueryTerminalSize => {
                  os_input.send_to_server(ClientToServerMsg::TerminalResize(
@@ -196,7 +180,7 @@ index 3256ada1..ebca605d 100644
                  ));
              },
              ClientInstruction::WriteConfigToDisk { config } => {
-@@ -579,7 +580,7 @@ pub fn start_client(
+@@ -667,7 +668,7 @@ pub fn start_client(
  
          os_input.disable_mouse().non_fatal();
          info!("{}", exit_msg);
@@ -206,7 +190,7 @@ index 3256ada1..ebca605d 100644
          let exit_kitty_keyboard_mode = "\u{1b}[<1u";
          if !explicitly_disable_kitty_keyboard_protocol {
 diff --git a/zellij-client/src/os_input_output.rs b/zellij-client/src/os_input_output.rs
-index 8f7d8817..65f1dc6a 100644
+index 941892da..415f607c 100644
 --- a/zellij-client/src/os_input_output.rs
 +++ b/zellij-client/src/os_input_output.rs
 @@ -12,7 +12,7 @@ use nix::sys::termios;
@@ -250,9 +234,9 @@ index 8f7d8817..65f1dc6a 100644
      };
  
      // fallback to default values when rows/cols == 0: https://github.com/zellij-org/zellij/issues/1551
-@@ -92,13 +92,13 @@ pub struct ClientOsInputOutput {
+@@ -98,13 +98,13 @@ impl std::fmt::Debug for ClientOsInputOutput {
  /// Zellij client requires.
- pub trait ClientOsApi: Send + Sync {
+ pub trait ClientOsApi: Send + Sync + std::fmt::Debug {
      /// Returns the size of the terminal associated to file descriptor `fd`.
 -    fn get_terminal_size_using_fd(&self, fd: RawFd) -> Size;
 +    fn get_terminal_size_using_fd(&self, fd: BorrowedFd) -> Size;
@@ -267,7 +251,7 @@ index 8f7d8817..65f1dc6a 100644
      /// Returns the writer that allows writing to standard output.
      fn get_stdout_writer(&self) -> Box<dyn io::Write>;
      /// Returns a BufReader that allows to read from STDIN line by line, also locks STDIN
-@@ -133,13 +133,13 @@ pub trait ClientOsApi: Send + Sync {
+@@ -139,13 +139,13 @@ pub trait ClientOsApi: Send + Sync + std::fmt::Debug {
  }
  
  impl ClientOsApi for ClientOsInputOutput {
@@ -284,7 +268,7 @@ index 8f7d8817..65f1dc6a 100644
          match &self.orig_termios {
              Some(orig_termios) => {
                  let orig_termios = orig_termios.lock().unwrap();
-@@ -322,7 +322,7 @@ impl Clone for Box<dyn ClientOsApi> {
+@@ -328,7 +328,7 @@ impl Clone for Box<dyn ClientOsApi> {
  }
  
  pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
@@ -293,8 +277,30 @@ index 8f7d8817..65f1dc6a 100644
      let orig_termios = current_termios.map(|termios| Arc::new(Mutex::new(termios)));
      let reading_from_stdin = Arc::new(Mutex::new(None));
      Ok(ClientOsInputOutput {
+diff --git a/zellij-client/src/web_client/server_listener.rs b/zellij-client/src/web_client/server_listener.rs
+index 04ad6e04..dd205033 100644
+--- a/zellij-client/src/web_client/server_listener.rs
++++ b/zellij-client/src/web_client/server_listener.rs
+@@ -5,6 +5,8 @@ use crate::web_client::types::{ClientConnectionBus, ConnectionTable, SessionMana
+ use crate::web_client::utils::terminal_init_messages;
+ 
+ use std::{
++    io,
++    os::unix::io::AsFd,
+     path::PathBuf,
+     sync::{Arc, Mutex},
+ };
+@@ -59,7 +61,7 @@ pub fn zellij_server_listener(
+ 
+                     reload_config_from_disk(&mut config, &mut config_options, &config_file_path);
+ 
+-                    let full_screen_ws = os_input.get_terminal_size_using_fd(0);
++                    let full_screen_ws = os_input.get_terminal_size_using_fd(io::stdin().as_fd());
+                     let mut sent_init_messages = false;
+ 
+                     let palette = config
 diff --git a/zellij-server/src/os_input_output.rs b/zellij-server/src/os_input_output.rs
-index c6e4de78..5f39005c 100644
+index a85fab6f..7a46f311 100644
 --- a/zellij-server/src/os_input_output.rs
 +++ b/zellij-server/src/os_input_output.rs
 @@ -1,6 +1,10 @@
@@ -464,7 +470,7 @@ index c6e4de78..5f39005c 100644
              _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
          }
      }
-@@ -818,7 +832,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -845,7 +859,7 @@ impl ServerOsApi for ServerOsInputOutput {
          terminal_id: u32,
          run_command: RunCommand,
          quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
@@ -473,7 +479,7 @@ index c6e4de78..5f39005c 100644
          let default_editor = None; // no need for a default editor when running an explicit command
          self.orig_termios
              .lock()
-@@ -836,7 +850,7 @@ impl ServerOsApi for ServerOsInputOutput {
+@@ -863,7 +877,7 @@ impl ServerOsApi for ServerOsInputOutput {
                  self.terminal_id_to_raw_fd
                      .lock()
                      .to_anyhow()?
@@ -482,7 +488,7 @@ index c6e4de78..5f39005c 100644
                  Ok((pid_primary, pid_secondary))
              })
              .with_context(|| format!("failed to rerun command in terminal id {}", terminal_id))
-@@ -879,7 +893,7 @@ impl Clone for Box<dyn ServerOsApi> {
+@@ -906,7 +920,7 @@ impl Clone for Box<dyn ServerOsApi> {
  }
  
  pub fn get_server_os_input() -> Result<ServerOsInputOutput, nix::Error> {
@@ -492,7 +498,7 @@ index c6e4de78..5f39005c 100644
          log::warn!("Starting a server without a controlling terminal, using the default termios configuration.");
      }
 diff --git a/zellij-server/src/pty.rs b/zellij-server/src/pty.rs
-index 450f0b0b..ca16cad0 100644
+index 88bfee7d..d84c4e5a 100644
 --- a/zellij-server/src/pty.rs
 +++ b/zellij-server/src/pty.rs
 @@ -14,7 +14,11 @@ use async_std::{
@@ -506,9 +512,9 @@ index 450f0b0b..ca16cad0 100644
 +    path::PathBuf,
 +};
  use zellij_utils::{
-     data::{Event, FloatingPaneCoordinates, OriginatingPlugin},
+     data::{Direction, Event, FloatingPaneCoordinates, OriginatingPlugin},
      errors::prelude::*,
-@@ -987,7 +991,7 @@ impl Pty {
+@@ -938,7 +942,7 @@ impl Pty {
                  }
              }
          });
@@ -517,7 +523,7 @@ index 450f0b0b..ca16cad0 100644
              .bus
              .os_input
              .as_mut()
-@@ -996,6 +1000,7 @@ impl Pty {
+@@ -947,6 +951,7 @@ impl Pty {
                  os_input.spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())
              })
              .with_context(err_context)?;
@@ -525,7 +531,7 @@ index 450f0b0b..ca16cad0 100644
          let terminal_bytes = task::spawn({
              let err_context =
                  |terminal_id: u32| format!("failed to run async task for terminal {terminal_id}");
-@@ -1235,7 +1240,7 @@ impl Pty {
+@@ -1187,7 +1192,7 @@ impl Pty {
                                  terminal_id,
                                  starts_held,
                                  Some(command.clone()),
@@ -534,7 +540,7 @@ index 450f0b0b..ca16cad0 100644
                              )))
                          },
                          Err(err) => {
-@@ -1263,7 +1268,12 @@ impl Pty {
+@@ -1215,7 +1220,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -548,7 +554,7 @@ index 450f0b0b..ca16cad0 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1294,7 +1304,12 @@ impl Pty {
+@@ -1246,7 +1256,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -562,7 +568,7 @@ index 450f0b0b..ca16cad0 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1317,7 +1332,12 @@ impl Pty {
+@@ -1269,7 +1284,12 @@ impl Pty {
                  {
                      Ok((terminal_id, pid_primary, child_fd)) => {
                          self.id_to_child_pid.insert(terminal_id, child_fd);
@@ -576,7 +582,7 @@ index 450f0b0b..ca16cad0 100644
                      },
                      Err(err) => match err.downcast_ref::<ZellijError>() {
                          Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-@@ -1422,7 +1442,7 @@ impl Pty {
+@@ -1374,7 +1394,7 @@ impl Pty {
                          }
                      }
                  });
@@ -585,7 +591,7 @@ index 450f0b0b..ca16cad0 100644
                      .bus
                      .os_input
                      .as_mut()
-@@ -1431,6 +1451,7 @@ impl Pty {
+@@ -1383,6 +1403,7 @@ impl Pty {
                          os_input.re_run_command_in_terminal(id, run_command, quit_cb)
                      })
                      .with_context(err_context)?;
@@ -594,5 +600,5 @@ index 450f0b0b..ca16cad0 100644
                      let err_context =
                          |pane_id| format!("failed to run async task for pane {pane_id:?}");
 -- 
-2.49.0
+2.50.1
 

--- a/app-utils/zellij/spec
+++ b/app-utils/zellij/spec
@@ -1,4 +1,4 @@
-VER=0.42.2
+VER=0.43.0
 SRCS="git::commit=tags/v${VER}::https://github.com/zellij-org/zellij"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=300087"


### PR DESCRIPTION
Topic Description
-----------------

- zellij: update to 0.43.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zellij: 0.43.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit zellij
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
