### PR TITLE
 qtcreator: add loongarch64_nosimd build config

### DIFF
--- a/app-devel/qtcreator/autobuild/defines
+++ b/app-devel/qtcreator/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="cmake gdb git go litehtml llvm qt-6 rustc-demangle \
         syntax-highlighting valgrind"
 # FIXME: Valgrind is not yet available.
 PKGDEP__LOONGARCH64="${PKGDEP/valgrind/}"
+PKGDEP__LOONGARCH64_NOSIMD="${PKGDEP__LOONGARCH64}"
 PKGDEP__RISCV64="${PKGDEP/valgrind/}"
 PKGSUG="breezy mercurial"
 BUILDDEP="${PKGSUG}"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: add loongarch64_nosimd build config
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- qtcreator: 16.0.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
