### PR TITLE
binutils: fix LoongArch relaxation issues

### DIFF
--- a/app-devel/binutils/01-main/patches/0001-AOSCOS-libiberty-append-O2-to-cpp-invocations.patch
+++ b/app-devel/binutils/01-main/patches/0001-AOSCOS-libiberty-append-O2-to-cpp-invocations.patch
@@ -1,7 +1,7 @@
 From cd62ffbadd6f485764d89509b50c95d6cf2c417e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 2 Feb 2025 23:52:54 +0800
-Subject: [PATCH 1/3] AOSCOS: libiberty: append -O2 to cpp invocations
+Subject: [PATCH 1/6] AOSCOS: libiberty: append -O2 to cpp invocations
 
 Lest libiberty would fail to build with errors related to undefined
 references to `LONG_MIN'.
@@ -95,5 +95,5 @@ index f83b42fb0d5..533ae9734fa 100755
  ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
  ac_compiler_gnu=$ac_cv_c_compiler_gnu
 -- 
-2.49.0
+2.50.1
 

--- a/app-devel/binutils/01-main/patches/0002-AOSCOS-bfd-arm64-powerpc-ppc64-ppc64el-set-common-pa.patch
+++ b/app-devel/binutils/01-main/patches/0002-AOSCOS-bfd-arm64-powerpc-ppc64-ppc64el-set-common-pa.patch
@@ -1,7 +1,7 @@
 From 072457058d06965a634c35c44b6ecc3c62609e56 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 2 Feb 2025 23:59:57 +0800
-Subject: [PATCH 2/3] AOSCOS: bfd: (arm64, powerpc, ppc64, ppc64el) set common
+Subject: [PATCH 2/6] AOSCOS: bfd: (arm64, powerpc, ppc64, ppc64el) set common
  page size to 64KiB
 
 According to Fedora's binutils spec, "On ppc64 and aarch64 (arm64), we
@@ -55,5 +55,5 @@ index 65182f49070..ec33409cd4a 100644
  #define bfd_elfNN_bfd_is_target_special_symbol	\
    elfNN_aarch64_is_target_special_symbol
 -- 
-2.49.0
+2.50.1
 

--- a/app-devel/binutils/01-main/patches/0003-BACKPORT-FROMLIST-LoongArch-Batch-delete-bytes-at-th.patch
+++ b/app-devel/binutils/01-main/patches/0003-BACKPORT-FROMLIST-LoongArch-Batch-delete-bytes-at-th.patch
@@ -1,7 +1,7 @@
 From f2710729038d3c96a64d49184789e3f13d87a07c Mon Sep 17 00:00:00 2001
 From: WANG Xuerui <git@xen0n.name>
 Date: Sat, 14 Jun 2025 14:15:51 +0000
-Subject: [PATCH 3/3] BACKPORT: FROMLIST: LoongArch: Batch-delete bytes at the
+Subject: [PATCH 3/6] BACKPORT: FROMLIST: LoongArch: Batch-delete bytes at the
  end of each relax trip
 
 Previously, memmove and reloc/symbol adjustments happened at each
@@ -576,5 +576,5 @@ index a04f00d1b84..af15eb1e55b 100644
  }
  
 -- 
-2.49.0
+2.50.1
 

--- a/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Allow-to-relax-instructions-into-.patch
+++ b/app-devel/binutils/01-main/patches/0004-BACKPORT-LoongArch-Allow-to-relax-instructions-into-.patch
@@ -1,0 +1,549 @@
+From 45adf3a7551639ea3cca19e621122241b2581195 Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <git@xen0n.name>
+Date: Sun, 6 Jul 2025 09:06:20 +0800
+Subject: [PATCH 4/6] BACKPORT: LoongArch: Allow to relax instructions into
+ NOPs after handling alignment
+
+Right now, LoongArch linker relaxation is 2-pass, since after alignment
+is done, byte deletion can no longer happen. However, as the alignment
+pass also shrinks text sections, new relaxation chances may well be
+created after alignment is done. Although at this point we can no longer
+delete unused instructions without disturbing alignment, we can still
+replace them with NOPs; popular LoongArch micro-architectures can
+eliminate NOPs during execution, so we can expect a (very) slight
+performance improvement from those late-created relaxation chances.
+
+To achieve this, the number of relax passes is raised to 3 for
+LoongArch, and every relaxation handler except loongarch_relax_align is
+migrated to a new helper loongarch_relax_delete_or_nop, that either
+deletes bytes or fills the bytes to be "deleted" with NOPs, depending on
+whether the containing section already has undergone alignment. Also,
+since no byte can be deleted during this relax pass, in the pass the
+pending_delete_ops structure is no longer allocated, and
+loongarch_calc_relaxed_addr(x) degrades to the trivial "return x" in
+this case.
+
+In addition, previously when calculating distances to symbols, an
+extra segment alignment must be considered, because alignment may
+increase distance between sites. However in the newly added 3rd pass
+code size can no longer increase for "closed" sections, so we can skip
+the adjustment for them to allow for a few more relaxation chances.
+
+A simple way to roughly measure this change's effectiveness is to check
+how many pcalau12i + addi.d pairs are relaxed into pcaddi's. Taking a
+Firefox 140.0.2 test build of mine as an example:
+
+Before: 47842 pcaddi's in libxul.so
+After: 48089
+
+This is a 0.5% increase, which is kind of acceptable for a peephole
+optimization like this; of which 9 are due to the "relax"ed symbol
+distance treatment.
+
+Signed-off-by: WANG Xuerui <git@xen0n.name>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ bfd/elfnn-loongarch.c                         | 218 ++++++++++++------
+ ld/emultempl/loongarchelf.em                  |   2 +-
+ .../ld-loongarch-elf/ld-loongarch-elf.exp     |   1 +
+ .../ld-loongarch-elf/relax-after-alignment.d  |  30 +++
+ .../ld-loongarch-elf/relax-after-alignment.s  |  49 ++++
+ 5 files changed, 227 insertions(+), 73 deletions(-)
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-after-alignment.s
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index af15eb1e55b..d97ff197b78 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -173,6 +173,10 @@ loongarch_elf_new_section_hook (bfd *abfd, asection *sec)
+ #define loongarch_elf_hash_table(p)					\
+     ((struct loongarch_elf_link_hash_table *) ((p)->hash))		\
+ 
++/* During linker relaxation, indicates whether the section has already
++   undergone alignment processing and no more byte deletion is permitted.  */
++#define loongarch_sec_closed_for_deletion(sec) ((sec)->sec_flg0)
++
+ #define MINUS_ONE ((bfd_vma) 0 - 1)
+ 
+ #define sec_addr(sec) ((sec)->output_section->vma + (sec)->output_offset)
+@@ -4776,7 +4780,10 @@ loongarch_calc_relaxed_addr (struct bfd_link_info *info, bfd_vma offset)
+   struct pending_delete_op *op;
+   splay_tree_node node;
+ 
+-  BFD_ASSERT (pdops != NULL);
++  if (!pdops)
++    /* Currently this means we are past the stages where byte deletion could
++       possibly happen.  */
++    return offset;
+ 
+   /* Find the op that starts just before the given address.  */
+   node = splay_tree_predecessor (pdops, (splay_tree_key)offset);
+@@ -4801,9 +4808,9 @@ loongarch_calc_relaxed_addr (struct bfd_link_info *info, bfd_vma offset)
+ 
+ static void
+ loongarch_relax_delete_bytes (bfd *abfd,
+-			  bfd_vma addr,
+-			  size_t count,
+-			  struct bfd_link_info *link_info)
++			      bfd_vma addr,
++			      size_t count,
++			      struct bfd_link_info *link_info)
+ {
+   struct loongarch_elf_link_hash_table *htab
+       = loongarch_elf_hash_table (link_info);
+@@ -4854,6 +4861,34 @@ loongarch_relax_delete_bytes (bfd *abfd,
+     }
+ }
+ 
++static void
++loongarch_relax_delete_or_nop (bfd *abfd,
++			       asection *sec,
++			       bfd_vma addr,
++			       size_t count,
++			       struct bfd_link_info *link_info)
++{
++  struct bfd_elf_section_data *data = elf_section_data (sec);
++  bfd_byte *contents = data->this_hdr.contents;
++
++  BFD_ASSERT (count % 4 == 0);
++
++  if (!loongarch_sec_closed_for_deletion (sec))
++    {
++      /* Deletions are still possible within the section.  */
++      loongarch_relax_delete_bytes (abfd, addr, count, link_info);
++      return;
++    }
++
++  /* We can no longer delete bytes in the section after enforcing alignment.
++     But as the resulting shrinkage may open up a few more relaxation chances,
++     allowing unnecessary instructions to be replaced with NOPs instead of
++     being removed altogether may still benefit performance to a lesser
++     extent.  */
++  for (; count; addr += 4, count -= 4)
++    bfd_put (32, abfd, LARCH_NOP, contents + addr);
++}
++
+ static void
+ loongarch_relax_perform_deletes (bfd *abfd, asection *sec,
+ 				 struct bfd_link_info *link_info)
+@@ -5112,7 +5147,7 @@ loongarch_tls_perform_trans (bfd *abfd, asection *sec,
+ 	bfd_put (32, abfd, LARCH_NOP, contents + rel->r_offset);
+ 	/* link with -relax option will delete NOP.  */
+ 	if (!info->disable_target_specific_optimizations)
+-	  loongarch_relax_delete_bytes (abfd, rel->r_offset, 4, info);
++	  loongarch_relax_delete_or_nop (abfd, sec, rel->r_offset, 4, info);
+ 	return true;
+ 
+       case R_LARCH_TLS_IE_PC_HI20:
+@@ -5227,7 +5262,7 @@ loongarch_relax_tls_le (bfd *abfd, asection *sec, asection *sym_sec,
+ 	    if (symval < 0x800)
+ 	      {
+ 		rel->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+-		loongarch_relax_delete_bytes (abfd, rel->r_offset,
++		loongarch_relax_delete_or_nop (abfd, sec, rel->r_offset,
+ 		    4, link_info);
+ 	      }
+ 	    break;
+@@ -5252,8 +5287,8 @@ loongarch_relax_tls_le (bfd *abfd, asection *sec, asection *sym_sec,
+ 	  case R_LARCH_TLS_LE64_LO20:
+ 	  case R_LARCH_TLS_LE64_HI12:
+ 	    rel->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+-	    loongarch_relax_delete_bytes (abfd, rel->r_offset,
+-					  4, link_info);
++	    loongarch_relax_delete_or_nop (abfd, sec, rel->r_offset,
++					   4, link_info);
+ 	    break;
+ 
+ 	  case R_LARCH_TLS_LE_LO12:
+@@ -5316,17 +5351,22 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
+-  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-					       sec->output_section,
+-					       sym_sec->output_section))
+-    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							: max_alignment;
+-
+-  if (symval > pc)
+-    pc -= (max_alignment > 4 ? max_alignment : 0);
+-  else if (symval < pc)
+-    pc += (max_alignment > 4 ? max_alignment : 0);
++  /* If pc and symbol not in the same segment, add/sub segment alignment if the
++     section has not undergone alignment processing because distances may grow
++     after alignment.  */
++  if (!loongarch_sec_closed_for_deletion (sec))
++    {
++      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++						   sec->output_section,
++						   sym_sec->output_section))
++	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++							  : max_alignment;
++
++      if (symval > pc)
++	pc -= (max_alignment > 4 ? max_alignment : 0);
++      else if (symval < pc)
++	pc += (max_alignment > 4 ? max_alignment : 0);
++    }
+ 
+   const uint32_t pcaddi = LARCH_OP_PCADDI;
+ 
+@@ -5353,7 +5393,7 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec, asection *sym_sec,
+ 				 R_LARCH_PCREL20_S2);
+   rel_lo->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+ 
+-  loongarch_relax_delete_bytes (abfd, rel_lo->r_offset, 4, info);
++  loongarch_relax_delete_or_nop (abfd, sec, rel_lo->r_offset, 4, info);
+ 
+   return true;
+ }
+@@ -5381,17 +5421,22 @@ loongarch_relax_call36 (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
+-  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-					       sec->output_section,
+-					       sym_sec->output_section))
+-    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							: max_alignment;
+-
+-  if (symval > pc)
+-    pc -= (max_alignment > 4 ? max_alignment : 0);
+-  else if (symval < pc)
+-    pc += (max_alignment > 4 ? max_alignment : 0);
++  /* If pc and symbol not in the same segment, add/sub segment alignment if the
++     section has not undergone alignment processing because distances may grow
++     after alignment.  */
++  if (!loongarch_sec_closed_for_deletion (sec))
++    {
++      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++						   sec->output_section,
++						   sym_sec->output_section))
++	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++							  : max_alignment;
++
++      if (symval > pc)
++	pc -= (max_alignment > 4 ? max_alignment : 0);
++      else if (symval < pc)
++	pc += (max_alignment > 4 ? max_alignment : 0);
++    }
+ 
+   /* Is pcalau12i + addi.d insns?  */
+   if (!LARCH_INSN_JIRL (jirl)
+@@ -5413,7 +5458,7 @@ loongarch_relax_call36 (bfd *abfd, asection *sec, asection *sym_sec,
+   /* Adjust relocations.  */
+   rel->r_info = ELFNN_R_INFO (ELFNN_R_SYM (rel->r_info), R_LARCH_B26);
+   /* Delete jirl instruction.  */
+-  loongarch_relax_delete_bytes (abfd, rel->r_offset + 4, 4, info);
++  loongarch_relax_delete_or_nop (abfd, sec, rel->r_offset + 4, 4, info);
+   return true;
+ }
+ 
+@@ -5445,17 +5490,22 @@ loongarch_relax_pcala_ld (bfd *abfd, asection *sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
+-  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-					       sec->output_section,
+-					       sym_sec->output_section))
+-    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							: max_alignment;
+-
+-  if (symval > pc)
+-    pc -= (max_alignment > 4 ? max_alignment : 0);
+-  else if (symval < pc)
+-    pc += (max_alignment > 4 ? max_alignment : 0);
++  /* If pc and symbol not in the same segment, add/sub segment alignment if the
++     section has not undergone alignment processing because distances may grow
++     after alignment.  */
++  if (!loongarch_sec_closed_for_deletion (sec))
++    {
++      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++						   sec->output_section,
++						   sym_sec->output_section))
++	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++							  : max_alignment;
++
++      if (symval > pc)
++	pc -= (max_alignment > 4 ? max_alignment : 0);
++      else if (symval < pc)
++	pc += (max_alignment > 4 ? max_alignment : 0);
++    }
+ 
+   if ((ELFNN_R_TYPE (rel_lo->r_info) != R_LARCH_GOT_PC_LO12)
+       || (LARCH_GET_RD (ld) != rd)
+@@ -5488,8 +5538,9 @@ bfd_elfNN_loongarch_set_data_segment_info (struct bfd_link_info *info,
+     loongarch_elf_hash_table (info)->data_segment_phase = data_segment_phase;
+ }
+ 
+-/* Implement R_LARCH_ALIGN by deleting excess alignment NOPs.
+-   Once we've handled an R_LARCH_ALIGN, we can't relax anything else.  */
++/* Honor R_LARCH_ALIGN requests by deleting excess alignment NOPs.
++   Once we've handled an R_LARCH_ALIGN, we can't relax anything else by deleting
++   bytes, or alignment will be disrupted.  */
+ static bool
+ loongarch_relax_align (bfd *abfd, asection *sec, asection *sym_sec,
+ 			Elf_Internal_Rela *rel,
+@@ -5530,9 +5581,9 @@ loongarch_relax_align (bfd *abfd, asection *sec, asection *sym_sec,
+       return false;
+     }
+ 
+-  /* Once we've handled an R_LARCH_ALIGN in a section,
+-     we can't relax anything else in this section.  */
+-  sec->sec_flg0 = true;
++  /* Once we've handled an R_LARCH_ALIGN in a section, we can't relax anything
++     else by deleting bytes, or alignment will be disrupted.  */
++  loongarch_sec_closed_for_deletion (sec) = true;
+   rel->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+ 
+   /* If skipping more bytes than the specified maximum,
+@@ -5577,17 +5628,22 @@ loongarch_relax_tls_ld_gd_desc (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
+-  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-					       sec->output_section,
+-					       sym_sec->output_section))
+-    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							: max_alignment;
+-
+-  if (symval > pc)
+-    pc -= (max_alignment > 4 ? max_alignment : 0);
+-  else if (symval < pc)
+-    pc += (max_alignment > 4 ? max_alignment : 0);
++  /* If pc and symbol not in the same segment, add/sub segment alignment if the
++     section has not undergone alignment processing because distances may grow
++     after alignment.  */
++  if (!loongarch_sec_closed_for_deletion (sec))
++    {
++      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++						   sec->output_section,
++						   sym_sec->output_section))
++	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++							  : max_alignment;
++
++      if (symval > pc)
++	pc -= (max_alignment > 4 ? max_alignment : 0);
++      else if (symval < pc)
++	pc += (max_alignment > 4 ? max_alignment : 0);
++    }
+ 
+   const uint32_t pcaddi = LARCH_OP_PCADDI;
+ 
+@@ -5630,7 +5686,7 @@ loongarch_relax_tls_ld_gd_desc (bfd *abfd, asection *sec, asection *sym_sec,
+     }
+   rel_lo->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+ 
+-  loongarch_relax_delete_bytes (abfd, rel_lo->r_offset, 4, info);
++  loongarch_relax_delete_or_nop (abfd, sec, rel_lo->r_offset, 4, info);
+ 
+   return true;
+ }
+@@ -5674,15 +5730,25 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+   if (htab->layout_mutating_for_relr)
+     return true;
+ 
++  /* Definition of LoongArch linker relaxation passes:
++
++     - Pass 0: relaxes everything except R_LARCH_ALIGN, byte deletions are
++	       performed; skipped if disable_target_specific_optimizations.
++     - Pass 1: handles alignment, byte deletions are performed.  Sections with
++	       R_LARCH_ALIGN relocations are marked closed for further byte
++	       deletion in order to not disturb alignment.  This pass is NOT
++	       skipped even if disable_target_specific_optimizations is true.
++     - Pass 2: identical to Pass 0, but replacing relaxed insns with NOP in case
++	       the containing section is closed for deletion; skip condition
++	       also same as Pass 0.  */
++  bool is_alignment_pass = info->relax_pass == 1;
+   if (bfd_link_relocatable (info)
+-      || sec->sec_flg0
+       || sec->reloc_count == 0
+       || (sec->flags & SEC_RELOC) == 0
+       || (sec->flags & SEC_HAS_CONTENTS) == 0
+       /* The exp_seg_relro_adjust is enum phase_enum (0x4).  */
+       || *(htab->data_segment_phase) == 4
+-      || (info->disable_target_specific_optimizations
+-	  && info->relax_pass == 0))
++      || (info->disable_target_specific_optimizations && !is_alignment_pass))
+     return true;
+ 
+   struct bfd_elf_section_data *data = elf_section_data (sec);
+@@ -5718,7 +5784,10 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+       htab->max_alignment = max_alignment;
+     }
+ 
+-  splay_tree pdops = pending_delete_ops_new (abfd);
++  splay_tree pdops = NULL;
++  if (!loongarch_sec_closed_for_deletion (sec))
++    pdops = pending_delete_ops_new (abfd);
++
+   htab->pending_delete_ops = pdops;
+ 
+   for (unsigned int i = 0; i < sec->reloc_count; i++)
+@@ -5760,7 +5829,13 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	}
+ 
+       relax_func_t relax_func = NULL;
+-      if (info->relax_pass == 0)
++      if (is_alignment_pass)
++	{
++	  if (r_type != R_LARCH_ALIGN)
++	    continue;
++	  relax_func = loongarch_relax_align;
++	}
++      else
+ 	{
+ 	  switch (r_type)
+ 	    {
+@@ -5814,10 +5889,6 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 		continue;
+ 	    }
+ 	}
+-      else if (info->relax_pass == 1 && r_type == R_LARCH_ALIGN)
+-	relax_func = loongarch_relax_align;
+-      else
+-	continue;
+ 
+       /* Four kind of relocations:
+ 	 Normal: symval is the symbol address.
+@@ -5956,9 +6027,12 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 				    info, again, max_alignment);
+     }
+ 
+-  loongarch_relax_perform_deletes (abfd, sec, info);
+-  htab->pending_delete_ops = NULL;
+-  splay_tree_delete (pdops);
++  if (pdops)
++    {
++      loongarch_relax_perform_deletes (abfd, sec, info);
++      htab->pending_delete_ops = NULL;
++      splay_tree_delete (pdops);
++    }
+ 
+   return true;
+ }
+diff --git a/ld/emultempl/loongarchelf.em b/ld/emultempl/loongarchelf.em
+index de64b1d30de..c43bbb29941 100644
+--- a/ld/emultempl/loongarchelf.em
++++ b/ld/emultempl/loongarchelf.em
+@@ -58,7 +58,7 @@ larch_elf_before_allocation (void)
+ 	ENABLE_RELAXATION;
+     }
+ 
+-  link_info.relax_pass = 2;
++  link_info.relax_pass = 3;
+ }
+ 
+ static void
+diff --git a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+index 7e5fdfa66a0..d4a9c8d50b2 100644
+--- a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
++++ b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+@@ -45,6 +45,7 @@ if [istarget "loongarch64-*-*"] {
+     run_dump_test "underflow_s_5_20"
+     run_dump_test "tls-le-norelax"
+     run_dump_test "tls-le-relax"
++    run_dump_test "relax-after-alignment"
+     run_dump_test "relax-medium-call"
+     run_dump_test "relax-medium-call-1"
+     run_dump_test "check_got_relax"
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
+new file mode 100644
+index 00000000000..844c518e9c7
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
+@@ -0,0 +1,30 @@
++#name: additional relaxation chances after alignment processing
++#as:
++#ld: --defsym _start=0
++#objdump: -d --no-show-raw-insn
++
++.*:\s+file format .*
++
++
++Disassembly of section \.text:
++
++0000000120000400 <before>:
++\s*120000400:\s+pcalau12i\s+\$t0, 512
++\s*[0-9a-f]+:\s+addi\.d\s+\$t0, \$t0, 1024
++\s*[0-9a-f]+:\s+pcaddi\s+\$t0, 524286
++\s*[0-9a-f]+:\s+nop\s*
++\s*\.\.\.
++\s*120000c00:\s+pcaddi\s+\$t0, 523776
++\s*\.\.\.
++
++0000000120200400 <target>:
++\s*120200400:\s+break\s+0x0
++
++0000000120200404 <after>:
++\s*\.\.\.
++\s*1203ffbfc:\s+pcaddi\s+\$t0, -523775
++\s*\.\.\.
++\s*120400400:\s+pcaddi\s+\$t0, -524288
++\s*[0-9a-f]+:\s+nop\s*
++\s*[0-9a-f]+:\s+pcalau12i\s+\$t0, -512
++\s*[0-9a-f]+:\s+addi\.d\s+\$t0, \$t0, 1024
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-after-alignment.s b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.s
+new file mode 100644
+index 00000000000..24d29ecb257
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.s
+@@ -0,0 +1,49 @@
++# 0x0 pre-relax, 0x400 post-relax
++# all addresses are additionally offset by 0x120000000 without `ld -shared`
++before:
++    la.pcrel $t0, target  # too far; should stay as pcalau12i + addi.d
++    la.pcrel $t0, target  # furthest reach of relax pass 2
++
++# 0x10 pre-relax, 0x410 post-relax
++.rept 508
++.word 0
++.endr
++
++# 0x800 {pre,post}-relax
++# 255 nops + R_LARCH_ALIGN before relaxation
++# none of the aligning nops should remain after relax pass 1
++.p2align 10
++
++# 0xbfc pre-relax, 0xc00 post-relax
++    la.pcrel $t0, target  # should become single pcaddi in relax pass 0
++
++# 0xc04 {pre,post}-relax
++.rept 523775
++.word 0
++.endr
++
++# 0x200400 {pre,post}-relax
++target:
++    break 0
++
++# 0x200404 {pre,post}-relax
++after:
++.rept 523774
++.word 0
++.endr
++
++# 0x3ffbfc {pre,post}-relax
++    la.pcrel $t0, target  # should become single pcaddi in relax pass 0
++
++# 255 nops + R_LARCH_ALIGN before relaxation
++# none of the aligning nops should remain after relax pass 1
++.p2align 10
++
++# 0x400000 pre-relax, 0x3ffc00 post-relax
++.rept 512
++.word 0
++.endr
++
++# 0x400800 pre-relax, 0x400400 post-relax
++    la.pcrel $t0, target  # furthest reach of relax pass 2
++    la.pcrel $t0, target  # too far; should stay as pcalau12i + addi.d
+-- 
+2.50.1
+

--- a/app-devel/binutils/01-main/patches/0005-BACKPORT-LoongArch-Un-skip-cross-segment-alignment-c.patch
+++ b/app-devel/binutils/01-main/patches/0005-BACKPORT-LoongArch-Un-skip-cross-segment-alignment-c.patch
@@ -1,0 +1,179 @@
+From f0e962bcc3e220d4ff0d73d46838992819267282 Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <git@xen0n.name>
+Date: Fri, 11 Jul 2025 15:49:07 +0800
+Subject: [PATCH 5/6] BACKPORT: LoongArch: Un-skip cross-segment alignment
+ compensation during relax pass 2
+
+It turned out wrong to skip compensating for segment alignment if the
+current section is closed for deletion, as my recent system update with
+binutils trunk revealed link failures of many high-profile packages such
+as ffmpeg, numpy and wxGTK -- the dreaded "relocation truncated to fit"
+errors regarding improperly produced R_LARCH_PCREL20_S2.
+
+As it's near 2.45 branching time, revert the problematic change and
+XFAIL the original test case for now.
+
+Suggested-by: Xi Ruoyao <xry111@xry111.site>
+Signed-off-by: WANG Xuerui <git@xen0n.name>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ bfd/elfnn-loongarch.c                         | 108 +++++++-----------
+ .../ld-loongarch-elf/relax-after-alignment.d  |   1 +
+ 2 files changed, 45 insertions(+), 64 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index d97ff197b78..e3e8406519b 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -5351,22 +5351,17 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment if the
+-     section has not undergone alignment processing because distances may grow
+-     after alignment.  */
+-  if (!loongarch_sec_closed_for_deletion (sec))
+-    {
+-      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-						   sec->output_section,
+-						   sym_sec->output_section))
+-	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							  : max_alignment;
+-
+-      if (symval > pc)
+-	pc -= (max_alignment > 4 ? max_alignment : 0);
+-      else if (symval < pc)
+-	pc += (max_alignment > 4 ? max_alignment : 0);
+-    }
++  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
++  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++					       sec->output_section,
++					       sym_sec->output_section))
++    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++						      : max_alignment;
++
++  if (symval > pc)
++    pc -= (max_alignment > 4 ? max_alignment : 0);
++  else if (symval < pc)
++    pc += (max_alignment > 4 ? max_alignment : 0);
+ 
+   const uint32_t pcaddi = LARCH_OP_PCADDI;
+ 
+@@ -5421,22 +5416,17 @@ loongarch_relax_call36 (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment if the
+-     section has not undergone alignment processing because distances may grow
+-     after alignment.  */
+-  if (!loongarch_sec_closed_for_deletion (sec))
+-    {
+-      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-						   sec->output_section,
+-						   sym_sec->output_section))
+-	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							  : max_alignment;
+-
+-      if (symval > pc)
+-	pc -= (max_alignment > 4 ? max_alignment : 0);
+-      else if (symval < pc)
+-	pc += (max_alignment > 4 ? max_alignment : 0);
+-    }
++  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
++  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++					       sec->output_section,
++					       sym_sec->output_section))
++    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++						      : max_alignment;
++
++  if (symval > pc)
++    pc -= (max_alignment > 4 ? max_alignment : 0);
++  else if (symval < pc)
++    pc += (max_alignment > 4 ? max_alignment : 0);
+ 
+   /* Is pcalau12i + addi.d insns?  */
+   if (!LARCH_INSN_JIRL (jirl)
+@@ -5490,22 +5480,17 @@ loongarch_relax_pcala_ld (bfd *abfd, asection *sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment if the
+-     section has not undergone alignment processing because distances may grow
+-     after alignment.  */
+-  if (!loongarch_sec_closed_for_deletion (sec))
+-    {
+-      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-						   sec->output_section,
+-						   sym_sec->output_section))
+-	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							  : max_alignment;
+-
+-      if (symval > pc)
+-	pc -= (max_alignment > 4 ? max_alignment : 0);
+-      else if (symval < pc)
+-	pc += (max_alignment > 4 ? max_alignment : 0);
+-    }
++  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
++  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++					       sec->output_section,
++					       sym_sec->output_section))
++    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++						      : max_alignment;
++
++  if (symval > pc)
++    pc -= (max_alignment > 4 ? max_alignment : 0);
++  else if (symval < pc)
++    pc += (max_alignment > 4 ? max_alignment : 0);
+ 
+   if ((ELFNN_R_TYPE (rel_lo->r_info) != R_LARCH_GOT_PC_LO12)
+       || (LARCH_GET_RD (ld) != rd)
+@@ -5628,22 +5613,17 @@ loongarch_relax_tls_ld_gd_desc (bfd *abfd, asection *sec, asection *sym_sec,
+     symval = sec_addr (sec)
+ 	     + loongarch_calc_relaxed_addr (info, symval - sec_addr (sec));
+ 
+-  /* If pc and symbol not in the same segment, add/sub segment alignment if the
+-     section has not undergone alignment processing because distances may grow
+-     after alignment.  */
+-  if (!loongarch_sec_closed_for_deletion (sec))
+-    {
+-      if (!loongarch_two_sections_in_same_segment (info->output_bfd,
+-						   sec->output_section,
+-						   sym_sec->output_section))
+-	max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
+-							  : max_alignment;
+-
+-      if (symval > pc)
+-	pc -= (max_alignment > 4 ? max_alignment : 0);
+-      else if (symval < pc)
+-	pc += (max_alignment > 4 ? max_alignment : 0);
+-    }
++  /* If pc and symbol not in the same segment, add/sub segment alignment.  */
++  if (!loongarch_two_sections_in_same_segment (info->output_bfd,
++					       sec->output_section,
++					       sym_sec->output_section))
++    max_alignment = info->maxpagesize > max_alignment ? info->maxpagesize
++						      : max_alignment;
++
++  if (symval > pc)
++    pc -= (max_alignment > 4 ? max_alignment : 0);
++  else if (symval < pc)
++    pc += (max_alignment > 4 ? max_alignment : 0);
+ 
+   const uint32_t pcaddi = LARCH_OP_PCADDI;
+ 
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
+index 844c518e9c7..08def250998 100644
+--- a/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
++++ b/ld/testsuite/ld-loongarch-elf/relax-after-alignment.d
+@@ -2,6 +2,7 @@
+ #as:
+ #ld: --defsym _start=0
+ #objdump: -d --no-show-raw-insn
++#xfail: *-*-*
+ 
+ .*:\s+file format .*
+ 
+-- 
+2.50.1
+

--- a/app-devel/binutils/01-main/patches/0006-FROMLIST-LoongArch-Fix-symbol-size-after-relaxation.patch
+++ b/app-devel/binutils/01-main/patches/0006-FROMLIST-LoongArch-Fix-symbol-size-after-relaxation.patch
@@ -1,0 +1,244 @@
+From 527a57784e259e825e5bae4d7da26c4b746da574 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 6 Aug 2025 12:19:22 +0800
+Subject: [PATCH 6/6] FROMLIST: LoongArch: Fix symbol size after relaxation
+
+There's a logic error in loongarch_relax_perform_deletes: when there's
+not any delete operation of which the start address is strictly smaller
+than the symbol address, splay_tree_predecessor() will return nullptr
+and the symbol size will be unchanged even if some bytes of it are
+removed.
+
+Make the logic more complete to fix this issue.  Also factor out the
+symbol size adjustment logic into a function to avoid code bloating.
+
+Tested-by: WANG Xuerui <git@xen0n.name>
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+
+Link: https://sourceware.org/pipermail/binutils/2025-August/143197.html
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ bfd/elfnn-loongarch.c                         | 102 ++++++++++--------
+ .../ld-loongarch-elf/ld-loongarch-elf.exp     |   2 +
+ .../ld-loongarch-elf/relax-sym-size-1.d       |   7 ++
+ .../ld-loongarch-elf/relax-sym-size-1.s       |   8 ++
+ .../ld-loongarch-elf/relax-sym-size-2.d       |   7 ++
+ .../ld-loongarch-elf/relax-sym-size-2.s       |  19 ++++
+ 6 files changed, 102 insertions(+), 43 deletions(-)
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-sym-size-1.d
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-sym-size-1.s
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-sym-size-2.d
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-sym-size-2.s
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index e3e8406519b..1c0668266f8 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -4889,6 +4889,60 @@ loongarch_relax_delete_or_nop (bfd *abfd,
+     bfd_put (32, abfd, LARCH_NOP, contents + addr);
+ }
+ 
++/* If some bytes in a symbol is deleted, we need to adjust its size.  */
++static void
++loongarch_relax_resize_symbol (bfd_size_type *size, bfd_vma orig_value,
++			       splay_tree pdops)
++{
++  splay_tree_key key = (splay_tree_key)orig_value;
++  bfd_vma orig_end = orig_value + *size;
++  splay_tree_node node = splay_tree_predecessor (pdops, key);
++
++  if (node)
++    {
++      bfd_vma addr = (bfd_vma)node->key;
++      struct pending_delete_op *op = (struct pending_delete_op *)node->value;
++
++      /* This shouldn't happen unless people write something really insane like
++	     .reloc ., R_LARCH_ALIGN, 60
++	     .rept 15
++	     1: nop
++	     .endr
++	     .set x, 1b
++	     .size x, . - 1b
++	 But let's just try to make it "work" anyway.  */
++      if (orig_value < addr + op->size)
++	{
++	  bfd_size_type n_deleted = op->size - (orig_value - addr);
++	  if (n_deleted >= *size)
++	    {
++	      *size = 0;
++	      return;
++	    }
++
++	  *size -= n_deleted;
++	}
++    }
++
++  node = splay_tree_lookup (pdops, key);
++  if (!node)
++    node = splay_tree_successor (pdops, key);
++
++  for (; node; node = splay_tree_successor (pdops, node->key))
++    {
++      bfd_vma addr = (bfd_vma)node->key;
++      struct pending_delete_op *op = (struct pending_delete_op *)node->value;
++
++      if (addr >= orig_end)
++	return;
++
++      if (orig_end < addr + op->size)
++	*size -= orig_end - addr;
++      else
++	*size -= op->size;
++    }
++}
++
+ static void
+ loongarch_relax_perform_deletes (bfd *abfd, asection *sec,
+ 				 struct bfd_link_info *link_info)
+@@ -4977,30 +5031,8 @@ loongarch_relax_perform_deletes (bfd *abfd, asection *sec,
+ 	    sym->st_value
+ 		= loongarch_calc_relaxed_addr (link_info, orig_value);
+ 
+-	  /* If the symbol *spans* some deleted bytes, that is its *end* is in
+-	     the moved bytes but its *start* isn't, then we must adjust its
+-	     size.
+-
+-	     This test needs to use the original value of st_value, otherwise
+-	     we might accidentally decrease size when deleting bytes right
+-	     before the symbol.  */
+-	  bfd_vma sym_end = orig_value + sym->st_size;
+-	  if (sym_end <= toaddr)
+-	    {
+-	      splay_tree_node node = splay_tree_predecessor (
+-		  pdops, (splay_tree_key)orig_value);
+-	      for (; node; node = splay_tree_successor (pdops, node->key))
+-		{
+-		  bfd_vma addr = (bfd_vma)node->key;
+-		  struct pending_delete_op *op
+-		      = (struct pending_delete_op *)node->value;
+-
+-		  if (addr >= sym_end)
+-		    break;
+-		  if (orig_value <= addr && sym_end > addr)
+-		    sym->st_size -= op->size;
+-		}
+-	    }
++	  if (orig_value + sym->st_size <= toaddr)
++	    loongarch_relax_resize_symbol (&sym->st_size, orig_value, pdops);
+ 	}
+     }
+ 
+@@ -5047,29 +5079,13 @@ loongarch_relax_perform_deletes (bfd *abfd, asection *sec,
+ 	{
+ 	  bfd_vma orig_value = sym_hash->root.u.def.value;
+ 
+-	  /* As above, adjust the value.  */
++	  /* As above, adjust the value and size.  */
+ 	  if (orig_value <= toaddr)
+ 	    sym_hash->root.u.def.value
+ 		= loongarch_calc_relaxed_addr (link_info, orig_value);
+ 
+-	  /* As above, adjust the size if needed.  */
+-	  bfd_vma sym_end = orig_value + sym_hash->size;
+-	  if (sym_end <= toaddr)
+-	    {
+-	      splay_tree_node node = splay_tree_predecessor (
+-		  pdops, (splay_tree_key)orig_value);
+-	      for (; node; node = splay_tree_successor (pdops, node->key))
+-		{
+-		  bfd_vma addr = (bfd_vma)node->key;
+-		  struct pending_delete_op *op
+-		      = (struct pending_delete_op *)node->value;
+-
+-		  if (addr >= sym_end)
+-		    break;
+-		  if (orig_value <= addr && sym_end > addr)
+-		    sym_hash->size -= op->size;
+-		}
+-	    }
++	  if (orig_value + sym_hash->size <= toaddr)
++	    loongarch_relax_resize_symbol (&sym_hash->size, orig_value, pdops);
+ 	}
+     }
+ }
+diff --git a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+index d4a9c8d50b2..39967aac6b9 100644
+--- a/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
++++ b/ld/testsuite/ld-loongarch-elf/ld-loongarch-elf.exp
+@@ -48,6 +48,8 @@ if [istarget "loongarch64-*-*"] {
+     run_dump_test "relax-after-alignment"
+     run_dump_test "relax-medium-call"
+     run_dump_test "relax-medium-call-1"
++    run_dump_test "relax-sym-size-1"
++    run_dump_test "relax-sym-size-2"
+     run_dump_test "check_got_relax"
+ }
+ 
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.d b/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.d
+new file mode 100644
+index 00000000000..eec989f68be
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.d
+@@ -0,0 +1,7 @@
++#source: relax-sym-size-1.s
++#ld:
++#readelf: -s
++
++#...
++ *[0-9]+: [0-9a-z]+ +8 .* _start
++#...
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.s b/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.s
+new file mode 100644
+index 00000000000..c70ac7176bd
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-sym-size-1.s
+@@ -0,0 +1,8 @@
++.p2align 2
++bar:
++  nop
++.globl _start
++_start:
++  la.pcrel $a0, bar
++  ret
++.size _start, . - _start
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.d b/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.d
+new file mode 100644
+index 00000000000..1388099d37f
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.d
+@@ -0,0 +1,7 @@
++#source: relax-sym-size-2.s
++#ld:
++#readelf: -s
++
++#...
++ *[0-9]+: [0-9a-z]+ +64 .* _start
++#...
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.s b/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.s
+new file mode 100644
+index 00000000000..e02e16b7d26
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-sym-size-2.s
+@@ -0,0 +1,19 @@
++bar:
++  nop
++.p2align 6
++
++.reloc ., R_LARCH_ALIGN, 60
++.rept 15
++  1: nop
++.endr
++  la.pcrel $a0, bar
++  ret
++
++.reloc ., R_LARCH_ALIGN, 60
++.rept 15
++  2: nop
++.endr
++
++.globl _start
++.set _start, 1b
++.size _start, 2b - 1b
+-- 
+2.50.1
+

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,4 +1,5 @@
 VER=2.44
+REL=1
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: fix LoongArch relaxation issues
    Backported fixes:
    f9dba9898f4 FROMLIST: LoongArch: Fix symbol size after relaxation
    f0e962bcc3e BACKPORT: LoongArch: Un-skip cross-segment alignment compensation during relax pass 2
    45adf3a7551 BACKPORT: LoongArch: Allow to relax instructions into NOPs after handling alignment
    Track patches at AOSC-Tracking/binutils-gdb @ aosc/aosc/binutils-2_44
    \(HEAD: 527a57784e259e825e5bae4d7da26c4b746da574\).

Package(s) Affected
-------------------

- binutils: 2.44-1
- binutils+cross-amd64: 2.44-1
- binutils+cross-arm-none-eabi: 2.44-1
- binutils+cross-arm64: 2.44-1
- binutils+cross-loongarch64: 2.44-1
- binutils+cross-loongson3: 2.44-1
- binutils+cross-ppc64el: 2.44-1
- binutils+cross-riscv64: 2.44-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
