### PR TITLE
hwdata: do not ship modprobe blacklist

### DIFF
--- a/runtime-data/hwdata/autobuild/build
+++ b/runtime-data/hwdata/autobuild/build
@@ -1,5 +1,7 @@
 abinfo "Configuring hwdata ..."
-"$SRCDIR"/configure
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    --disable-blacklist
 
 abinfo "Installing hwdata ..."
 make DESTDIR="$PKGDIR" install

--- a/runtime-data/hwdata/spec
+++ b/runtime-data/hwdata/spec
@@ -1,4 +1,5 @@
 VER=0.398
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/vcrhonek/hwdata"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13577"


### PR DESCRIPTION
Topic Description
-----------------

- hwdata: do not ship modprobe blacklist
    There is no need and it saves a dracut trigger.

Package(s) Affected
-------------------

- hwdata: 0.398-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hwdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
