### PR TITLE
box64: enable box32 support in build

### DIFF
--- a/app-emulation/box64/autobuild/alternatives
+++ b/app-emulation/box64/autobuild/alternatives
@@ -1,1 +1,2 @@
 alternative /usr/lib/binfmt.d/emu-x86_64.conf /usr/lib/binfmt.alternatives/box64.conf 70
+alternative /usr/lib/binfmt.d/emu-i386.conf /usr/lib/binfmt.alternatives/box32.conf 70

--- a/app-emulation/box64/autobuild/beyond
+++ b/app-emulation/box64/autobuild/beyond
@@ -1,6 +1,9 @@
 abinfo "Setting executable bits on shared objects ..."
 chmod -v +x "$PKGDIR/usr/lib/box64-x86_64-linux-gnu/"*
+chmod -v +x "$PKGDIR/usr/lib/box64-i386-linux-gnu/"*
+
 abinfo "Moving binfmt configuration to /usr/lib/binfmt.alternatives ..."
 mkdir -v "$PKGDIR/usr/lib/binfmt.alternatives/"
 mv -v "$PKGDIR/etc/binfmt.d/box64.conf" "$PKGDIR/usr/lib/binfmt.alternatives/"
+mv -v "$PKGDIR/etc/binfmt.d/box32.conf" "$PKGDIR/usr/lib/binfmt.alternatives/"
 rm -rv "$PKGDIR/etc/binfmt.d/"

--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -9,6 +9,8 @@ ABTYPE="cmakeninja"
 CMAKE_AFTER=(
     "-DCI=ON"
     "-DWITH_MOLD=ON"
+    "-DBOX32=ON"
+    "-DBOX32_BINFMT=ON"
 )
 
 CMAKE_AFTER__ARM64=(

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,5 @@
 VER=0.3.6
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: emable box32 support in build

Package(s) Affected
-------------------

- box64: 0.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
