### PR TITLE
pushpkg: update to 20250806

### DIFF
--- a/app-devel/pushpkg/autobuild/build
+++ b/app-devel/pushpkg/autobuild/build
@@ -1,8 +1,9 @@
-abinfo "Installing pushpkg, completions and LICENSE ..."
-install -Dvm755 "$SRCDIR"/pushpkg "$PKGDIR"/usr/bin/pushpkg
-install -Dvm644 "$SRCDIR"/pushpkg.bash \
-        "$PKGDIR"/usr/share/bash-completion/completions/pushpkg.bash
-install -Dvm644 "$SRCDIR"/pushpkg.fish \
-        "$PKGDIR"/usr/share/fish/vendor_completions.d/pushpkg.fish
-install -Dvm644 "$SRCDIR"/{README.md,COPYING} \
-        -t "$PKGDIR"/usr/share/doc/$PKGNAME/
+abinfo "Installing pushpkg ..."
+install -Dvm755 "$SRCDIR"/pushpkg \
+    "$PKGDIR"/usr/bin/pushpkg
+
+abinfo "Installing completions ..."
+install -Dvm644 "$SRCDIR"/completions/pushpkg.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/pushpkg.bash
+install -Dvm644 "$SRCDIR"/completions/pushpkg.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/pushpkg.fish

--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,13 +1,4 @@
-VER=0+git20250528
-__COMMIT="ec2a6ce198b38ebe065c500a959c24acad8ba263"
-SRCS="file::rename=pushpkg::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/pushpkg \
-      file::rename=pushpkg.bash::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.bash \
-      file::rename=pushpkg.fish::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/completions/pushpkg.fish \
-      file::rename=COPYING::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/COPYING \
-      file::rename=README.md::https://cdn.jsdelivr.net/gh/AOSC-Dev/scriptlets@${__COMMIT}/pushpkg/README.md"
-CHKSUMS="sha256::55edcedb332ac81d4092d31f795cea3c226b9afef048f6c025dbfb994c0a19af \
-         sha256::48101ed7b8c871f8d315e889816e31502682290b3ca03f8075409247b7a4724e \
-         sha256::9a7d8167284bbe2e36b6fe3f7e5bbe4e125a89685a9213db9caa83512ec48026 \
-         sha256::992c720940396663b52389eea4c6a7409dd26b55ab3bfcd3a17f5da8b6d2a3c9 \
-         sha256::c62c3891a4629143a7dd9ec135e0c12a5f4287fe705f01832ad1bd478195e014"
-SUBDIR="."
+VER=20250806
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/pushpkg"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=380490"


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to 20250806
    - Use unified Git source.
    - Let Autobuild handle documentation and license files.

Package(s) Affected
-------------------

- pushpkg: 1:20250802

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
