### PR TITLE
clash-verge-rev: (arm64) use total_mem for ENVREQ

### DIFF
--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -2,6 +2,6 @@ VER=2.3.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
-ENVREQ__ARM64="total_mem_per_core=3"
+ENVREQ__ARM64="total_mem=60"
 ENVREQ__AMD64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem_per_core=3"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: \(arm64\) use total_mem for ENVREQ
    We simply do not have that many AArch64 buildbots with large enough RAM-
    to-core ratios.

Package(s) Affected
-------------------

- clash-verge-rev: 2.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
