### PR TITLE
llvm-20: update PKGBREAK and PKGREP

### DIFF
--- a/app-devel/llvm-20/01-runtime/defines
+++ b/app-devel/llvm-20/01-runtime/defines
@@ -125,5 +125,5 @@ CMAKE_AFTER__M68K="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__POWERPC="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__PPC64="${CMAKE_AFTER__RETRO}"
 
-PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1"
-PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1"
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-20/01-runtime/defines.stage2
+++ b/app-devel/llvm-20/01-runtime/defines.stage2
@@ -112,5 +112,5 @@ CMAKE_AFTER__M68K="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__POWERPC="${CMAKE_AFTER__RETRO}"
 CMAKE_AFTER__PPC64="${CMAKE_AFTER__RETRO}"
 
-PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1"
-PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1"
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,10 +1,11 @@
 VER=20.1.8
+REL=1
 SRCS="git::commit=tags/llvmorg-${VER}::https://github.com/llvm/llvm-project.git"
 SUBDIR="llvm-20/llvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1830"
 # Note: Prefer larger RAM.
-ENVREQ__ARM64="total_mem_per_core=1.5"
+ENVREQ__ARM64="total_mem=60"
 # Note: Prefer 3C5000 (or faster) build hosts.
 ENVREQ__LOONGARCH64="core=16"
 ENVREQ__LOONGARCH64_NOSIMD="${ENVREQ__LOONGARCH64}"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-20: update PKGBREAK and PKGREP
    ... because llvm-runtime-18<=18.1.8-10 was the default provider of llvm library
    symlinks like LLVMgold.so and libclang.so
- mc: remove patches which no longer need
    Add "zip" to \`BUILDDEP\` solves \`HAVE_ZIPINFO\` check.
    Extfs \`s3+\` was ported into Python 3.
- mc: update SRCS url
- autobahn: add patch to use CFLAGS
- txaio: update to 25.6.1; purge Python 2 support
- diff-match-patch: update to 20241021
- dblatex: drop, orphaned
- click-plugins: drop, orphaned
    It does not offer any mechanism for building a package now.
- cjkwrap: drop, orphaned
- blessings: purge Python 2 support

... and 24 more commits

Package(s) Affected
-------------------

- llvm-20: 20.1.8-1
- llvm-runtime-20: 20.1.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
