### PR TITLE
Python 2 Purging Survey 20250807

### DIFF
--- a/app-admin/rtslib-fb/autobuild/defines
+++ b/app-admin/rtslib-fb/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=rtslib-fb
 PKGSEC=python
-PKGDEP="python-2 python-3 pyudev six"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3 pyudev six"
+BUILDDEP="hatchling hatch-vcs"
 PKGDES="Python API for in-kernel LIO target"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/app-admin/rtslib-fb/spec
+++ b/app-admin/rtslib-fb/spec
@@ -1,5 +1,4 @@
-VER=2.1.75
-SRCS="tbl::https://github.com/open-iscsi/rtslib-fb/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::1a4a560eb85f64d088393c0d18d2205421d20239ff95bed4b1ccbab72fe2aadb"
+VER=2.2.3
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/open-iscsi/rtslib-fb.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=38954"
-REL=1

--- a/lang-python/pathlib2/autobuild/defines
+++ b/lang-python/pathlib2/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=pathlib2
-PKGSEC=python
-PKGDEP="scandir six"
-BUILDDEP="setuptools-python2"
-PKGDES="Provide a backport of standard pathlib module for Python 2.x"
-
-ABHOST=noarch
-NOPYTHON3=1

--- a/lang-python/pathlib2/spec
+++ b/lang-python/pathlib2/spec
@@ -1,5 +1,0 @@
-VER=2.3.5
-SRCS="tbl::https://pypi.io/packages/source/p/pathlib2/pathlib2-$VER.tar.gz"
-CHKSUMS="sha256::6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
-CHKUPDATE="anitya::id=218492"
-REL=1

--- a/lang-python/poetry-core/autobuild/defines
+++ b/lang-python/poetry-core/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=poetry-core
 PKGSEC=python
 PKGDES="Poetry PEP 517 Build Backend"
-PKGDEP="python-3 pathlib2"
+PKGDEP="python-3"
 BUILDDEP="python-build python-installer setuptools"
 
 ABTYPE=pep517

--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=1
+VER=2.1.3
 SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
-CHKSUMS="sha256::fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"
+CHKSUMS="sha256::0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4"
 CHKUPDATE="anitya::id=71155"

--- a/lang-python/pyasn1/autobuild/defines
+++ b/lang-python/pyasn1/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=pyasn1
 PKGDES="ASN.1 library for Python"
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/pyasn1/spec
+++ b/lang-python/pyasn1/spec
@@ -1,5 +1,4 @@
-VER=0.4.8
+VER=0.6.1
 SRCS="tbl::https://pypi.io/packages/source/p/pyasn1/pyasn1-$VER.tar.gz"
-CHKSUMS="sha256::aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
-REL=3
+CHKSUMS="sha256::6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"
 CHKUPDATE="anitya::id=44489"

--- a/lang-python/pylev/autobuild/defines
+++ b/lang-python/pylev/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=pylev
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="A pure Python Levenshtein implementation that's not freaking GPL'd"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/pylev/spec
+++ b/lang-python/pylev/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
+VER=1.4.0
 SRCS="tbl::https://pypi.io/packages/source/p/pylev/pylev-$VER.tar.gz"
-CHKSUMS="sha256::063910098161199b81e453025653ec53556c1be7165a9b7c50be2f4d57eae1c3"
+CHKSUMS="sha256::9e77e941042ad3a4cc305dcdf2b2dec1aec2fbe3dd9015d2698ad02b173006d1"
 CHKUPDATE="anitya::id=19802"
-REL=2

--- a/lang-python/pysocks/autobuild/defines
+++ b/lang-python/pysocks/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=pysocks
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="SOCKS4, SOCKS5 or HTTP proxy for Python"
 
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/pysocks/spec
+++ b/lang-python/pysocks/spec
@@ -1,5 +1,4 @@
-VER=1.6.8
-REL=5
+VER=1.7.1
 SRCS="tbl::https://pypi.io/packages/source/P/PySocks/PySocks-$VER.tar.gz"
-CHKSUMS="sha256::3fe52c55890a248676fd69dc9e3c4e811718b777834bcaab7a8125cf9deac672"
+CHKSUMS="sha256::3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"
 CHKUPDATE="anitya::id=10673"

--- a/lang-python/python-hpack/autobuild/defines
+++ b/lang-python/python-hpack/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=python-hpack
 PKGSEC=python
-PKGDEP="python-3 python-2"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="HTTP/2 Header Encoding for Python"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/python-hpack/spec
+++ b/lang-python/python-hpack/spec
@@ -1,5 +1,4 @@
-VER=4.0.0
+VER=4.1.0
 SRCS="https://pypi.io/packages/source/h/hpack/hpack-$VER.tar.gz"
-CHKSUMS="sha256::fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"
+CHKSUMS="sha256::ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"
 CHKUPDATE="anitya::id=19034"
-REL=2

--- a/lang-python/scandir/autobuild/defines
+++ b/lang-python/scandir/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=scandir
-PKGSEC=python
-PKGDEP="python-2"
-BUILDDEP="setuptools"
-PKGDES="Better directory iterator and faster os.walk() for Python 2.x"
-
-NOPYTHON3=1
-ABHOST=noarch

--- a/lang-python/scandir/spec
+++ b/lang-python/scandir/spec
@@ -1,4 +1,0 @@
-VER=1.10.0
-SRCS="tbl::https://pypi.io/packages/source/s/scandir/scandir-$VER.tar.gz"
-CHKSUMS="sha256::4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"
-CHKUPDATE="anitya::id=231391"

--- a/lang-python/secretstorage/autobuild/defines
+++ b/lang-python/secretstorage/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=secretstorage
 PKGSEC=python
-PKGDEP="python-2 python-3 dbus-python pycryptodome cryptography"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3 dbus-python pycryptodome cryptography jeepney"
 PKGDES="Securely store passwords and other private data using the SecretService DBus API"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/secretstorage/spec
+++ b/lang-python/secretstorage/spec
@@ -1,5 +1,4 @@
-VER=3.3.0
-REL=3
+VER=3.3.3
 SRCS="https://pypi.io/packages/source/S/SecretStorage/SecretStorage-$VER.tar.gz"
-CHKSUMS="sha256::30cfdef28829dad64d6ea1ed08f8eff6aa115a77068926bcc9f5225d5a3246aa"
+CHKSUMS="sha256::2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"
 CHKUPDATE="anitya::id=4020"

--- a/lang-python/service-identity/autobuild/defines
+++ b/lang-python/service-identity/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=service-identity
 PKGSEC=python
-PKGDEP="attrs characteristic idna pyasn1-modules pyopenssl python-2 \
-	python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="attrs characteristic idna pyasn1-modules pyopenssl python-3"
+BUILDDEP="hatch-fancy-pypi-readme hatch-vcs hatchling"
 PKGDES="Service identity verification for pyOpenSSL"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/service-identity/spec
+++ b/lang-python/service-identity/spec
@@ -1,5 +1,4 @@
-VER=18.1.0
-REL=4
+VER=24.2.0
 SRCS="tbl::https://pypi.io/packages/source/s/service_identity/service_identity-$VER.tar.gz"
-CHKSUMS="sha256::0858a54aabc5b459d1aafa8a518ed2081a285087f349fe3e55197989232e2e2d"
+CHKSUMS="sha256::b8683ba13f0d39c6cd5d625d2c5f65421d6d707b013b375c355751557cbe8e09"
 CHKUPDATE="anitya::id=199618"

--- a/lang-python/shellingham/autobuild/defines
+++ b/lang-python/shellingham/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=shellingham
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3 wheel"
 PKGDES="Tool to detect surrounding (currently used) shell"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/shellingham/spec
+++ b/lang-python/shellingham/spec
@@ -2,4 +2,4 @@ VER=1.5.4
 SRCS="tbl::https://pypi.io/packages/source/s/shellingham/shellingham-$VER.tar.gz"
 CHKSUMS="sha256::8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
 CHKUPDATE="anitya::id=72819"
-REL=1
+REL=2

--- a/lang-python/six/autobuild/defines
+++ b/lang-python/six/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=six
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGDES="Python 2 and 3 compatibility utilities"
 
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/six/spec
+++ b/lang-python/six/spec
@@ -1,4 +1,4 @@
-VER=1.16.0
+VER=1.17.0
 SRCS="tbl::https://pypi.io/packages/source/s/six/six-$VER.tar.gz"
-CHKSUMS="sha256::1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+CHKSUMS="sha256::ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
 CHKUPDATE="anitya::id=4027"

--- a/lang-python/tomlkit/autobuild/defines
+++ b/lang-python/tomlkit/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=tomlkit
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="poetry-core"
 PKGDES="Style preserving TOML library"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/tomlkit/spec
+++ b/lang-python/tomlkit/spec
@@ -1,5 +1,4 @@
-VER=0.7.0
-REL=3
+VER=0.13.3
 SRCS="https://pypi.io/packages/source/t/tomlkit/tomlkit-$VER.tar.gz"
-CHKSUMS="sha256::ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"
+CHKSUMS="sha256::430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1"
 CHKUPDATE="anitya::id=19609"

--- a/lang-python/toolbelt/autobuild/defines
+++ b/lang-python/toolbelt/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=toolbelt
 PKGSEC=python
-PKGDEP="requests python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="requests python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="A toolbelt of useful classes and functions to be used with python-requests"
 
 ABHOST=noarch
 ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/toolbelt/spec
+++ b/lang-python/toolbelt/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-SRCS="tbl::https://github.com/requests/toolbelt/archive/$VER.tar.gz"
-CHKSUMS="sha256::0a052d9b5595718b7ec79c201e45e123dd3b9c6d659561479f24b7a2a85bbe81"
+SRCS="git::commit=tags/$VER::https://github.com/requests/toolbelt.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5665"
-REL=1
+REL=2

--- a/lang-python/webencodings/autobuild/defines
+++ b/lang-python/webencodings/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=webencodings
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 BUILDDEP="setuptools setuptools-python2"
 PKGDES="Character encoding aliases for legacy web content"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/webencodings/spec
+++ b/lang-python/webencodings/spec
@@ -1,5 +1,4 @@
-VER=0.5
-REL=5
+VER=0.5.1
 SRCS="tbl::https://pypi.io/packages/source/w/webencodings/webencodings-$VER.tar.gz"
-CHKSUMS="sha256::a5c55ee93b24e740fe951c37b5c228dccc1f171450e188555a775261cce1b904"
+CHKSUMS="sha256::b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
 CHKUPDATE="anitya::id=231400"


### PR DESCRIPTION
Topic Description
-----------------

- pyasn1: update to 0.6.1; purge python 2 support
- pylev: update to 1.4.0; purge python 2 support
- pysocks: update to 1.7.1; purge python 2 support
- python-hpack: purge python 2 support; switch to pep517; update to 4.1.0
- scandir: drop, orphaned
- pathlib2: drop, orphaned
- poetry-core: update to 2.1.3; drop pathlib2 dep
- secretstorage: purge python 2 support; switch to pep517; update to 3.3.3
- service-identity: purge python 2 support; switch to pep517; update to 24.2.0
- shellingham: purge python 2 support; switch to pep517

... and 5 more commits

Package(s) Affected
-------------------

- poetry-core: 2.1.3
- pyasn1: 0.6.1
- pylev: 1.4.0
- pysocks: 1.7.1
- python-hpack: 4.1.0
- rtslib-fb: 2.2.3
- secretstorage: 3.3.3
- service-identity: 24.2.0
- shellingham: 1.5.4-2
- six: 1.17.0
- tomlkit: 0.13.3
- toolbelt: 1.0.0-2
- webencodings: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtslib-fb webencodings toolbelt tomlkit six shellingham service-identity secretstorage poetry-core python-hpack pysocks pylev pyasn1
```

Test Build(s) Done
------------------

