### PR TITLE
rustc: update to 1.89.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,7 +1,7 @@
 From c62e1c6dcc6eeb8db7619b6e30e00657b98f5162 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
-Subject: [PATCH] Add i486-unknown-linux-gnu compiler target
+Subject: [PATCH 1/4] Add i486-unknown-linux-gnu compiler target
 
 ---
  compiler/rustc_target/src/spec/mod.rs                     | 1 +
@@ -10,7 +10,7 @@ Subject: [PATCH] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 7a49f00407..b675552ff6 100644
+index 7a49f004072..b675552ff65 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
 @@ -1750,6 +1750,7 @@ supported_targets! {
@@ -23,7 +23,7 @@ index 7a49f00407..b675552ff6 100644
      ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
 diff --git a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 new file mode 100644
-index 0000000000..a57ef97626
+index 00000000000..a57ef976265
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 @@ -0,0 +1,8 @@

--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 5b726d1b6494e3a537cd633b3ade50c462b9be12 Mon Sep 17 00:00:00 2001
+From c62e1c6dcc6eeb8db7619b6e30e00657b98f5162 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 7234d1dc63..4d4d9469a6 100644
+index 7a49f00407..b675552ff6 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1737,6 +1737,7 @@ supported_targets! {
+@@ -1750,6 +1750,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -36,5 +36,5 @@ index 0000000000..a57ef97626
 +    base
 +}
 -- 
-2.49.0
+2.50.1
 

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,0 +1,45 @@
+From d775cc8d435c34ad5147161c5082775bc1a0f45b Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 7 Aug 2025 20:12:53 +0200
+Subject: [PATCH 2/4] ARCHLINUX: compiler: Swap primary and secondary lib dirs
+
+Arch Linux (editor's note: also AOSC OS) prefers "lib" over "lib64".
+---
+ compiler/rustc_target/src/lib.rs | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/compiler/rustc_target/src/lib.rs b/compiler/rustc_target/src/lib.rs
+index 91657fef803..34a13b255fc 100644
+--- a/compiler/rustc_target/src/lib.rs
++++ b/compiler/rustc_target/src/lib.rs
+@@ -53,20 +53,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
+     // If --libdir is set during configuration to the value other than
+     // "lib" (i.e., non-default), this value is used (see issue #16552).
+ 
++    const PRIMARY_LIB_DIR: &str = "lib";
++
+     #[cfg(target_pointer_width = "64")]
+-    const PRIMARY_LIB_DIR: &str = "lib64";
++    const SECONDARY_LIB_DIR: &str = "lib64";
+ 
+     #[cfg(target_pointer_width = "32")]
+-    const PRIMARY_LIB_DIR: &str = "lib32";
+-
+-    const SECONDARY_LIB_DIR: &str = "lib";
++    const SECONDARY_LIB_DIR: &str = "lib32";
+ 
+     match option_env!("CFG_LIBDIR_RELATIVE") {
+         None | Some("lib") => {
+             if sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR).exists() {
+                 PRIMARY_LIB_DIR.into()
+-            } else {
++            } else if sysroot.join(SECONDARY_LIB_DIR).join(RUST_LIB_DIR).exists() {
+                 SECONDARY_LIB_DIR.into()
++            } else {
++                PRIMARY_LIB_DIR.into()
+             }
+         }
+         Some(libdir) => libdir.into(),
+-- 
+2.50.1
+

--- a/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,0 +1,29 @@
+From 4558c3cef1db12eb171c992e12c88a53b79101ed Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 7 Aug 2025 19:01:26 +0200
+Subject: [PATCH 3/4] ARCHLINUX: bootstrap: Workaround for system stage0
+
+See: https://github.com/rust-lang/rust/issues/143735
+---
+ src/bootstrap/src/core/build_steps/compile.rs | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
+index f6efb23e8d8..1b9359f619e 100644
+--- a/src/bootstrap/src/core/build_steps/compile.rs
++++ b/src/bootstrap/src/core/build_steps/compile.rs
+@@ -807,7 +807,10 @@ impl Step for StdLink {
+                 let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
+             }
+ 
+-            builder.cp_link_r(&builder.initial_sysroot.join("lib"), &sysroot.join("lib"));
++            builder.cp_link_r(
++                &builder.initial_sysroot.join("lib/rustlib"),
++                &sysroot.join("lib/rustlib"),
++            );
+         } else {
+             if builder.download_rustc() {
+                 // Ensure there are no CI-rustc std artifacts.
+-- 
+2.50.1
+

--- a/lang-rust/rustc/autobuild/patches/0004-AOSCOS-bootstrap-temporarily-replace-lib64-with-lib.patch
+++ b/lang-rust/rustc/autobuild/patches/0004-AOSCOS-bootstrap-temporarily-replace-lib64-with-lib.patch
@@ -1,0 +1,44 @@
+From c86ce4ffc04573b293b1bd9892e904843c1ace04 Mon Sep 17 00:00:00 2001
+From: Henry Chen <chenx97@aosc.io>
+Date: Sat, 9 Aug 2025 22:48:09 +0800
+Subject: [PATCH 4/4] AOSCOS: bootstrap: temporarily replace lib64 with lib
+
+---
+ src/bootstrap/src/lib.rs | 21 ++++++++++++++-------
+ 1 file changed, 14 insertions(+), 7 deletions(-)
+
+diff --git a/src/bootstrap/src/lib.rs b/src/bootstrap/src/lib.rs
+index f44fe4548a1..417260c70ed 100644
+--- a/src/bootstrap/src/lib.rs
++++ b/src/bootstrap/src/lib.rs
+@@ -382,13 +382,20 @@ impl Build {
+         let in_tree_llvm_info = config.in_tree_llvm_info.clone();
+         let in_tree_gcc_info = config.in_tree_gcc_info.clone();
+ 
+-        let initial_target_libdir = command(&config.initial_rustc)
+-            .run_always()
+-            .args(["--print", "target-libdir"])
+-            .run_capture_stdout(&config)
+-            .stdout()
+-            .trim()
+-            .to_owned();
++        let initial_target_libdir = {
++            let s = command(&config.initial_rustc)
++                .run_always()
++                .args(["--print", "target-libdir"])
++                .run_capture_stdout(&config)
++                .stdout()
++                .trim()
++                .to_owned();
++            if s.contains("lib64") {
++                s.replace("lib64", "lib")
++            } else {
++                panic!("AOSCOS: No lib64 to be replaced. Please remove this patch.")
++            }
++        };
+ 
+         let initial_target_dir = Path::new(&initial_target_libdir)
+             .parent()
+-- 
+2.50.1
+

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,8 +1,8 @@
-VER=1.88.0
+VER=1.89.0
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::0c1dcbb4f762513d021e1a282c0ac58c0a423642b3a6bf581cafb5414df4193e"
+CHKSUMS="sha256::0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.89.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.89.0
    \(HEAD: c62e1c6dcc6eeb8db7619b6e30e00657b98f5162\).

Package(s) Affected
-------------------

- rustc: 1:1.89.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
