### PR TITLE
breezy: fix missing PKGREP and PKGBREAK

### DIFF
--- a/app-vcs/breezy/autobuild/defines
+++ b/app-vcs/breezy/autobuild/defines
@@ -5,6 +5,8 @@ PKGDEP="python-3 configobj dulwich urllib3 pyyaml patiencediff merge3 tzlocal fa
 PKGSUG="fastimport dulwich"
 BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-rust setuptools-gettext llvm-20 cython"
 PKGDES="Command line tools for the Breezy distributed version control system"
+PKGREP="bzr<=2.7.0-2"
+PKGBREAK="bzr<=2.7.0-2"
 
 ABTYPE=pep517
 NOPYTHON2=1

--- a/app-vcs/breezy/spec
+++ b/app-vcs/breezy/spec
@@ -1,4 +1,5 @@
 VER=3.3.12
+REL=1
 SRCS="tbl::https://github.com/breezy-team/breezy/archive/refs/tags/brz-$VER.tar.gz"
 CHKSUMS="sha256::9ce8a3af9f45ea85761bf8a924e719cb5b20dff3e3edb1220b5c99bb37a3e46f"
 CHKUPDATE="anitya::id=235155"


### PR DESCRIPTION
Topic Description
-----------------

- breezy: fix missing PKGREP and PKGBREAK

Package(s) Affected
-------------------

- breezy: 3.3.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit breezy
```

Test Build(s) Done
------------------

