### PR TITLE
oma: update to 1.20.0~rc.4

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME="oma"
 PKGDES="Default package management interface"
-PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp \
-        nettle openssl systemd xz glibc ripgrep zstd \
-        aosc-os-repository-data aosc-os-keyring"
-PKGDEP__LOONGSON3="${PKGDEP/gmp/} openssl"
-BUILDDEP="rustc llvm-20"
+PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp nettle openssl \
+        systemd xz glibc ripgrep zstd aosc-os-repository-data \
+        aosc-os-repository-template aosc-os-keyring"
+BUILDDEP="rustc llvm"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"
 PKGREP="mirrormgr<=0.11.1"
@@ -19,8 +18,5 @@ USECLANG=1
 #   deb ${mirror}/debs stable bsp-loongarch64-nosimd
 #   deb [arch=all] ${mirror} debs stable main
 CARGO_AFTER__LOONGARCH64_NOSIMD="--no-default-features --features aosc,generic"
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGSON3=1
 
 PKGESS=1

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.19.2
+VER=1.20.0~rc.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~rc.1
+VER=1.20.0~rc.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~rc.2
+VER=1.20.0~rc.3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~rc.3
+VER=1.20.0~rc.4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/runtime-data/aosc-os-repository-data/autobuild/build
+++ b/runtime-data/aosc-os-repository-data/autobuild/build
@@ -1,3 +1,4 @@
 abinfo "Installing repository data..."
-mkdir -pv "$PKGDIR"/usr/share/distro-repository-data/
-cp -v *.yml "$PKGDIR"/usr/share/distro-repository-data/
+mkdir -pv "$PKGDIR"/usr/share/repository-data/
+install -Dvm644 "$SRCDIR"/*.toml \
+    "$PKGDIR"/usr/share/repository-data/

--- a/runtime-data/aosc-os-repository-data/autobuild/defines
+++ b/runtime-data/aosc-os-repository-data/autobuild/defines
@@ -3,3 +3,6 @@ PKGSEC=misc
 PKGDES="AOSC OS repository and mirrors configuration data"
 
 ABHOST=noarch
+
+# Note: Only oma 1.20 and above is compatible with >= 20250808.
+PKGBREAK="oma<=1.19.2"

--- a/runtime-data/aosc-os-repository-data/autobuild/overrides/etc/repository-data/comps.toml
+++ b/runtime-data/aosc-os-repository-data/autobuild/overrides/etc/repository-data/comps.toml
@@ -1,0 +1,7 @@
+# Configuration for custom components, template as follows:
+#
+#   [some-comp]
+#   description.default = "Description or pretty name for the component"
+#   description.zh_CN = "本地化后的包组简介或名称"
+#
+# The header (in brackets `[]') is taken as the name of the component.

--- a/runtime-data/aosc-os-repository-data/autobuild/overrides/etc/repository-data/mirrors.toml
+++ b/runtime-data/aosc-os-repository-data/autobuild/overrides/etc/repository-data/mirrors.toml
@@ -1,0 +1,18 @@
+# Configuration for custom mirrors, template as follows:
+#
+#   [some-mirror]
+#   description.default = "Description or pretty name for the mirror"
+#   description.zh_CN = "本地化后的镜像简介或名称"
+#   url = "https://localhost:8888/anthon/"
+#
+# The header (in brackets `[]') defines the ID of the custom mirror.
+# Custom mirror ID must be unique (including to ones defined by in this
+# configuration file or to ones defined by internal system metadata, which
+# are shipped with `aosc-os-repository-data').
+#
+# The `description' field may be localised - after the dot `.' goes the
+# locale code without encoding (i.e., "en_US", not "en_US.UTF-8") and
+# `default' corresponds to "not localised."
+#
+# The `url' field is used to define the root directory of your mirror,
+# where the `debs' directory resides.

--- a/runtime-data/aosc-os-repository-data/spec
+++ b/runtime-data/aosc-os-repository-data/spec
@@ -1,4 +1,4 @@
-VER=20250423
+VER=20250808
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-os-repository-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230634"

--- a/runtime-data/aosc-os-repository-template/autobuild/build
+++ b/runtime-data/aosc-os-repository-template/autobuild/build
@@ -1,0 +1,24 @@
+abinfo "Creating directory for installing repository configuration template ..."
+mkdir -pv "$PKGDIR"/usr/share/repository-data
+
+if ab_match_arch loongarch64_nosimd; then
+    abinfo "Generating repository template for AOSC OS (LoongArch64, No SIMD) ..."
+    cat > "$PKGDIR"/usr/share/repository-data/template.toml << EOF
+[[config]]
+components = ["bsp-loongarch64-nosimd"]
+signed-by = ["/usr/share/keyrings/aosc-archive-keyring.gpg"]
+architectures = ["loongarch64"]
+
+[[config]]
+components = ["main"]
+signed-by = ["/usr/share/keyrings/aosc-archive-keyring.gpg"]
+architectures = ["all"]
+EOF
+else
+    abinfo "Generating repository template for AOSC OS (mainline) ..."
+    cat > "$PKGDIR"/usr/share/repository-data/template.toml << EOF
+[[config]]
+components = ["main"]
+signed-by = ["/usr/share/keyrings/aosc-archive-keyring.gpg"]
+EOF
+fi

--- a/runtime-data/aosc-os-repository-template/autobuild/defines
+++ b/runtime-data/aosc-os-repository-template/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=aosc-os-repository-template
+PKGSEC=misc
+PKGDEP=""
+PKGDES="AOSC OS repository configuration template"
+
+# Note: Architecture-specific data.
+ABSPLITDBG=0
+
+ABTYPE=self

--- a/runtime-data/aosc-os-repository-template/spec
+++ b/runtime-data/aosc-os-repository-template/spec
@@ -1,0 +1,2 @@
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.20.0\~rc.4

Package(s) Affected
-------------------

- oma: 1.20.0\~rc.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-repository-data:-pkgbreak aosc-os-repository-template oma aosc-os-repository-data
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



