### PR TITLE
egl-wayland: update to 1.1.20

### DIFF
--- a/runtime-display/egl-wayland/spec
+++ b/runtime-display/egl-wayland/spec
@@ -1,4 +1,4 @@
-VER=1.1.19
+VER=1.1.20
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/egl-wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17778"


### PR DESCRIPTION
Topic Description
-----------------

- egl-wayland: update to 1.1.20
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- egl-wayland: 1.1.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit egl-wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
