### PR TITLE
gsoap: fix build

### DIFF
--- a/runtime-network/gsoap/autobuild/defines
+++ b/runtime-network/gsoap/autobuild/defines
@@ -6,4 +6,6 @@ PKGDES="Development toolkit for Web Services and XML data bindings for C & C++"
 # Note: flag controling whether create shared libraries or not is established
 # by Fedora patch.
 # Reference link: https://src.fedoraproject.org/rpms/gsoap/blob/577958/f/gsoap-libtool.patch
-AUTOTOOLS_AFTER="--disable-static"
+AUTOTOOLS_AFTER=(
+    "--enable-ipv6"
+)

--- a/runtime-network/gsoap/autobuild/patches/0001-Fedora-gsoap-libtool.patch
+++ b/runtime-network/gsoap/autobuild/patches/0001-Fedora-gsoap-libtool.patch
@@ -1,8 +1,8 @@
 diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
---- gsoap-2.8.orig/configure.ac	2020-06-30 21:02:21.000000000 +0200
-+++ gsoap-2.8/configure.ac	2020-07-21 22:24:34.231537804 +0200
-@@ -16,8 +16,7 @@
- AM_PROG_LEX
+--- gsoap-2.8.orig/configure.ac	2022-12-04 22:03:49.000000000 +0100
++++ gsoap-2.8/configure.ac	2022-12-21 06:11:12.732737406 +0100
+@@ -15,8 +15,7 @@
+ AM_PROG_LEX([noyywrap])
  AC_PROG_YACC
  AC_PROG_CPP
 -AC_PROG_RANLIB
@@ -11,7 +11,7 @@ diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
  AC_PROG_LN_S
  AC_PROG_AWK
  AC_PROG_INSTALL
-@@ -307,15 +306,15 @@
+@@ -303,15 +302,15 @@
      WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lgnutls -lgcrypt -lgpg-error -lz"
      SAMPLE_INCLUDES=
      SAMPLE_SSL_LIBS="-lgnutls -lgcrypt -lgpg-error -lz"
@@ -30,7 +30,7 @@ diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
    fi
    if test -n "$ZLIB"; then
      WSDL2H_EXTRA_FLAGS="-I${ZLIB}/include ${WSDL2H_EXTRA_FLAGS}"
-@@ -334,7 +333,7 @@
+@@ -330,7 +329,7 @@
    WSDL2H_EXTRA_FLAGS=
    SAMPLE_SSL_LIBS=
    SAMPLE_INCLUDES=
@@ -40,8 +40,8 @@ diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
  AM_CONDITIONAL([WITH_OPENSSL], [test "x$with_openssl" = "xyes" -a "x$with_gnutls" != "xyes"])
  AC_SUBST(WSDL2H_EXTRA_FLAGS)
 diff -ur gsoap-2.8.orig/gsoap/Makefile.am gsoap-2.8/gsoap/Makefile.am
---- gsoap-2.8.orig/gsoap/Makefile.am	2020-06-30 21:02:23.000000000 +0200
-+++ gsoap-2.8/gsoap/Makefile.am	2020-07-21 22:24:34.231537804 +0200
+--- gsoap-2.8.orig/gsoap/Makefile.am	2022-12-04 22:03:49.000000000 +0100
++++ gsoap-2.8/gsoap/Makefile.am	2022-12-21 06:11:12.733737409 +0100
 @@ -34,20 +34,30 @@
  dom_cpp.cpp: dom.cpp
  	$(LN_S) -f $(top_srcdir)/gsoap/dom.cpp dom_cpp.cpp
@@ -87,8 +87,8 @@ diff -ur gsoap-2.8.orig/gsoap/Makefile.am gsoap-2.8/gsoap/Makefile.am
  BUILT_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp stdsoap2_ck.c stdsoap2_ck_cpp.cpp stdsoap2_ssl.c stdsoap2_ssl_cpp.cpp
  
 diff -ur gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am gsoap-2.8/gsoap/samples/autotest/Makefile.am
---- gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am	2020-06-30 21:02:24.000000000 +0200
-+++ gsoap-2.8/gsoap/samples/autotest/Makefile.am	2020-07-21 22:24:34.231537804 +0200
+--- gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am	2022-12-04 22:03:49.000000000 +0100
++++ gsoap-2.8/gsoap/samples/autotest/Makefile.am	2022-12-21 06:11:12.733737409 +0100
 @@ -14,7 +14,7 @@
  WSDLINPUT=$(top_srcdir)/gsoap/samples/autotest/examples.wsdl
  SOAPHEADER=$(top_srcdir)/gsoap/samples/autotest/examples.h
@@ -99,8 +99,8 @@ diff -ur gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am gsoap-2.8/gsoap/sampl
  $(SOAP_CPP_SRC) : $(WSDLINPUT)
  	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
 diff -ur gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am gsoap-2.8/gsoap/samples/databinding/Makefile.am
---- gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am	2020-06-30 21:02:25.000000000 +0200
-+++ gsoap-2.8/gsoap/samples/databinding/Makefile.am	2020-07-21 22:24:34.232537807 +0200
+--- gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am	2022-12-04 22:03:50.000000000 +0100
++++ gsoap-2.8/gsoap/samples/databinding/Makefile.am	2022-12-21 06:11:12.733737409 +0100
 @@ -14,7 +14,7 @@
  WSDLINPUT=$(top_srcdir)/gsoap/samples/databinding/address.xsd
  SOAPHEADER=$(top_srcdir)/gsoap/samples/databinding/address.h
@@ -111,8 +111,8 @@ diff -ur gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am gsoap-2.8/gsoap/sa
  $(SOAP_CPP_SRC) : $(WSDLINPUT)
  	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
 diff -ur gsoap-2.8.orig/gsoap/samples/Makefile.defines gsoap-2.8/gsoap/samples/Makefile.defines
---- gsoap-2.8.orig/gsoap/samples/Makefile.defines	2020-06-30 21:02:25.000000000 +0200
-+++ gsoap-2.8/gsoap/samples/Makefile.defines	2020-07-21 22:24:34.232537807 +0200
+--- gsoap-2.8.orig/gsoap/samples/Makefile.defines	2022-12-04 22:03:50.000000000 +0100
++++ gsoap-2.8/gsoap/samples/Makefile.defines	2022-12-21 06:11:12.734737411 +0100
 @@ -13,13 +13,13 @@
  SOAP_C_CORE=soapC.c
  SOAP_C_CLIENT=soapClient.c $(SOAP_C_CORE)

--- a/runtime-network/gsoap/spec
+++ b/runtime-network/gsoap/spec
@@ -2,4 +2,4 @@ VER=2.8.124
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/gsoap_$VER.zip"
 CHKSUMS="sha256::4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636"
 CHKUPDATE="anitya::id=1260"
-REL=1
+REL=2


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Update Fedora gsoap-libtool patch.
- Remove unrecognized options: --disable-static, and add ipv6 support.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
gsoap: 2.8.124-1
 
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit gsoap
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
