### PR TITLE
llvm-runtime+wasi: update to 20.1.8

### DIFF
--- a/runtime-wasi/llvm-runtime+wasi/autobuild/defines
+++ b/runtime-wasi/llvm-runtime+wasi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=llvm-runtime+wasi
 PKGSEC=libs
 PKGDEP="libc+wasi"
-BUILDDEP="cmake ninja python-3 llvm-18"
+BUILDDEP="cmake ninja python-3 llvm-20"
 PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, WASI)"
 
 CMAKE_AFTER="-DLLVM_ENABLE_RTTI=OFF \

--- a/runtime-wasi/llvm-runtime+wasi/spec
+++ b/runtime-wasi/llvm-runtime+wasi/spec
@@ -1,10 +1,9 @@
 # Version must match ../../app-devel/llvm
-VER=18.1.8
-REL=2
+VER=20.1.8
 __WASI_SDK_REF="wasi-sdk-23"
 SRCS="https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz \
       file::rename=wasi-sdk.cmake::https://cdn.jsdelivr.net/gh/WebAssembly/wasi-sdk@${__WASI_SDK_REF}/wasi-sdk.cmake"
 SUBDIR="llvm-project-$VER.src/llvm"
-CHKSUMS="sha256::0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a \
+CHKSUMS="sha256::6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d \
          sha256::22a5ee26eb8367ac9d35a9431f4ac0a8e64dcb372bfd55be8665d35200d70917"
 CHKUPDATE="anitya::id=1830"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-runtime+wasi: update to 20.1.8
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- llvm-runtime+wasi: 20.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-runtime+wasi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
