### PR TITLE
wine-emukit: update wine to 10.12+gecko2.47.4+mono10.1.0

### DIFF
--- a/app-emulation/wine-emukit/autobuild/defines
+++ b/app-emulation/wine-emukit/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=utils
 # Note: systemd-binfmt is needed for binfmt_misc.
 PKGDEP="systemd"
 PKGDEP__LOONGARCH64="${PKGDEP} latx"
+PKGDEP__ARM64="${PKGDEP} box64"
+PKGDEP__PPC64EL="${PKGDEP} box64"
+PKGDEP__RISCV64="${PKGDEP} box64"
 PKGDES="Compatibility layer for running programs designed for Microsoft Windows (x86 emulated runtime)"
 
 # Note: This is a binary package, disabling stripping.
@@ -11,8 +14,8 @@ ABSTRIP=0
 # Note: Man pages have already been compresssed once.
 ABMANCOMPRESS=0
 
-# Note: Only allow architectures with x86 emulation runtime (EmuKit).
-FAIL_ARCH="!(loongarch64)"
+# Note: Only allow architectures with x86 emulation runtime (EmuKit and box64).
+FAIL_ARCH="!(loongarch64|arm64|ppc64el|riscv64)"
 
 # Note: Sync with main `wine' package.
 PKGEPOCH=2

--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,8 +1,8 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.1.0
-WINE_VER=9.13
+__MONO_VER=10.1.0
+WINE_VER=10.12
 VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="file::rename=wine.deb::https://repo.aosc.io/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::ab7b87934e0891c081a1e4299e0dc14265bea99b41c1926de746c9b93cf63083"
+CHKSUMS="sha256::25a9616fbcbbc5fe99f54037017d084a8a7b51b04ccc8c619f24052454a68cb2"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: update wine to 10.12+gecko2.47.4+mono10.1.0
- wine-emukit: add support for other architectures(arm64,ppc64el,riscv64)

Package(s) Affected
-------------------

- wine: 2:9.13+gecko2.47.4+mono9.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
