### PR TITLE
libcamera: update to 0.5.2

### DIFF
--- a/runtime-devices/libcamera/autobuild/beyond
+++ b/runtime-devices/libcamera/autobuild/beyond
@@ -3,7 +3,3 @@ if [[ -e "$PKGDIR"/usr/lib/libcamera ]]; then
     abinfo 'Fixing permissions problem for signed IPA modules ...'
     find "$PKGDIR"/usr/lib/libcamera -type f -exec chmod -v 755 {} +
 fi
-
-abinfo "Moving documentations to /usr/share/doc/libcamera ..."
-mv -v "$PKGDIR"/usr/share/doc/libcamera-"$PKGVER" \
-      "$PKGDIR"/usr/share/doc/libcamera

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -2,9 +2,9 @@ PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
-        elfutils libunwind gstreamer glib gnutls qt-6 openssl"
+        elfutils libunwind gstreamer glib gnutls qt-6 openssl libevent gtest"
 PKGDEP__ARM64="${PKGDEP} libpisp"
-BUILDDEP="doxygen jinja2 ply pyyaml sphinx texlive graphviz gtest"
+BUILDDEP="jinja2 ply pyyaml"
 PKGBREAK="pipewire<=1.4.1"
 
 # Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
@@ -14,7 +14,7 @@ PKGBREAK="pipewire<=1.4.1"
 MESON_AFTER=(
     '-Dandroid=disabled'
     '-Dcam=enabled'
-    '-Ddocumentation=enabled'
+    '-Ddocumentation=disabled'
     '-Ddoc_werror=false'
     '-Dgstreamer=enabled'
     '-Dlc-compliance=enabled'

--- a/runtime-devices/libcamera/autobuild/defines.stage2
+++ b/runtime-devices/libcamera/autobuild/defines.stage2
@@ -2,8 +2,8 @@ PKGNAME=libcamera
 PKGSEC=libs
 PKGDES="A cross-platform camera support library"
 PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
-        elfutils libunwind gstreamer glib gnutls openssl"
-BUILDDEP="doxygen jinja2 ply pyyaml sphinx texlive graphviz gtest"
+        elfutils libunwind gstreamer glib gnutls openssl libevent gtest"
+BUILDDEP="jinja2 ply pyyaml"
 
 PKGBREAK="pipewire<=1.4.1"
 
@@ -14,7 +14,7 @@ PKGBREAK="pipewire<=1.4.1"
 MESON_AFTER=(
     '-Dandroid=disabled'
     '-Dcam=enabled'
-    '-Ddocumentation=enabled'
+    '-Ddocumentation=disabled'
     '-Ddoc_werror=false'
     '-Dgstreamer=enabled'
     '-Dlc-compliance=enabled'

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.5.1
+VER=0.5.2
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.5.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libcamera: 0.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
