### PR TITLE
topics: TUM for uv-0.8.6

### DIFF
--- a/topics/uv-0.8.6.toml
+++ b/topics/uv-0.8.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "uv 0.8.6"
+
+[caution]
+default = "Fixes a vulnerability that enables malicious ZIP content to be extracted via package installers due to parsing differentials - CVE-2025-54368 (Severity: Medium)"
+zh_CN = "修复一处利用解析实现差异导致某些组件包安装器解压有害 ZIP 内容的漏洞，漏洞编号 CVE-2025-54368（严重性：中）"
+
+[packages]
+"uv" = "0.8.6"


### PR DESCRIPTION
Topic Description
-----------------

- topics: TUM for uv-0.8.6
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- uv: 0.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
