### PR TITLE
wiliwili: update to 1.5.2

### DIFF
--- a/app-multimedia/wiliwili/autobuild/defines
+++ b/app-multimedia/wiliwili/autobuild/defines
@@ -1,15 +1,19 @@
 PKGNAME="wiliwili"
 PKGSEC="video"
 PKGDES="A desktop client for Bilibili"
-PKGDEP="curl dbus gcc-runtime libwebp mpv opencc zlib hicolor-icon-theme"
-BUILDDEP="extra-cmake-modules"
-ABTYPE=cmake
+PKGDEP="curl dbus fmt gcc-runtime glibc hicolor-icon-theme libwebp mpv opencc \
+        openssl sdl2 tinyxml2 zlib"
+ABTYPE=cmakeninja
 
 CMAKE_AFTER=(
         '-DINSTALL=ON'
         '-DPLATFORM_DESKTOP=ON'
         '-DGLFW_BUILD_WAYLAND=ON'
         '-DGLFW_BUILD_X11=ON'
+        '-DUSE_EGL=ON'
         '-DUSE_SYSTEM_CURL=ON'
         '-DUSE_SYSTEM_OPENCC=ON'
+        '-DUSE_SYSTEM_FMT=ON'
+        '-DUSE_SYSTEM_TINYXML2=ON'
+        '-DUSE_SYSTEM_SDL2=ON'
 )

--- a/app-multimedia/wiliwili/spec
+++ b/app-multimedia/wiliwili/spec
@@ -1,4 +1,4 @@
-VER=1.5.1
+VER=1.5.2
 SRCS="git::commit=tags/v$VER::https://github.com/xfangfang/wiliwili.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376456"


### PR DESCRIPTION
Topic Description
-----------------

- wiliwili: update to 1.5.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- wiliwili: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit wiliwili
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
