### PR TITLE
vscode: update to 1.103.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.102.2
+VER=1.103.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::2e035c295ca28f0eebc99d39e3b4f602b30eb4af0b65d94b7b35d0eb7bf7f0ea"
-CHKSUMS__ARM64="sha256::e5262b8c4a53bcb56519c8c7f362f5fce3e9e988ff1b97b224af7edad5ef657e"
+CHKSUMS__AMD64="sha256::46c4b9c83e5ea7ae1fbdcac679c39de878c50c1ec3bc73a7fc2e384823b559ae"
+CHKSUMS__ARM64="sha256::86f17a8a3a7a82977a40995eccad33e8386d9c56f49289aa393b7de6d6fdeb9f"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.103.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.103.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
