### PR TITLE
tinyxml2: update to 11.0.0

### DIFF
--- a/app-multimedia/kodi/spec
+++ b/app-multimedia/kodi/spec
@@ -1,5 +1,5 @@
 VER=21.2
-REL=2
+REL=3
 PERIPHERAL_JOYSTICK_VER=20.1.0-Nexus
 CODE=Omega
 # Note: Take commit from branch with the corresponding codename.

--- a/runtime-common/tinyxml2/autobuild/defines
+++ b/runtime-common/tinyxml2/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=tinyxml2
 PKGSEC=libs
-PKGDEP="gcc-runtime"
+PKGDEP="gcc-runtime glibc"
 PKGDES="A C++ XML parser library"
-
-ABTYPE=meson
-MESON_AFTER=(
-    -Dtests=false
+PKGBREAK="kodi<=1:21.2-2"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-Dtinyxml2_BUILD_TESTING=OFF'
+    '-Dtinyxml2_SHARED_LIBS=ON'
 )

--- a/runtime-common/tinyxml2/spec
+++ b/runtime-common/tinyxml2/spec
@@ -1,4 +1,4 @@
-VER=10.0.0
+VER=11.0.0
 SRCS="git::commit=tags/$VER::https://github.com/leethomason/tinyxml2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4976"


### PR DESCRIPTION
Topic Description
-----------------

- tinyxml2: update to 11.0.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>
- kodi: rebuild for tinyxml2 update

Package(s) Affected
-------------------

- tinyxml2: 11.0.0
- kodi: 1:21.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tinyxml2 kodi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
