### PR TITLE
lact: preserve VCS metadata to display the correct commit hash

### DIFF
--- a/app-admin/lact/spec
+++ b/app-admin/lact/spec
@@ -1,4 +1,5 @@
 VER=0.8.1
-SRCS="git::commit=tags/v$VER::https://github.com/ilya-zlobintsev/LACT"
+REL=1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ilya-zlobintsev/LACT"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372202"


### PR DESCRIPTION
Topic Description
-----------------

- lact: preserve VCS metadata to display the correct commit hash

Package(s) Affected
-------------------

- lact: 0.8.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lact
```

Test Build(s) Done
------------------

