### PR TITLE
poetry-core: revert to 1.9.0

### DIFF
--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,4 +1,5 @@
-VER=2.1.3
+VER=1.9.0
+EPOCH=1
 SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
-CHKSUMS="sha256::0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4"
+CHKSUMS="sha256::fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"
 CHKUPDATE="anitya::id=71155"


### PR DESCRIPTION
Topic Description
-----------------

- poetry-core: revert to 1.9.0
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>

Package(s) Affected
-------------------

- poetry-core: 1.9.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit poetry-core
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
