### PR TITLE
rocm: update to 6.4.3

### DIFF
--- a/runtime-rocm/rocm-bandwidth-test/spec
+++ b/runtime-rocm/rocm-bandwidth-test/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocm_bandwidth_test"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231445"

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER};rename=clr::https://github.com/ROCm/clr.git \
       git::commit=tags/rocm-${VER};rename=HIP::https://github.com/ROCm/HIP.git \
       git::commit=tags/rocm-${VER};rename=llvm-project::https://github.com/ROCm/llvm-project"

--- a/runtime-rocm/rocm-cmake/spec
+++ b/runtime-rocm/rocm-cmake/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-cmake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231446"

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"

--- a/runtime-rocm/rocm-device-libs/spec
+++ b/runtime-rocm/rocm-device-libs/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/device-libs/"

--- a/runtime-rocm/rocm-half/spec
+++ b/runtime-rocm/rocm-half/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/half"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378431"

--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLAS-common.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378524"

--- a/runtime-rocm/rocm-hipblas/spec
+++ b/runtime-rocm/rocm-hipblas/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLAS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378433"

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipBLASLt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378523"

--- a/runtime-rocm/rocm-hipcub/spec
+++ b/runtime-rocm/rocm-hipcub/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/hipCUB"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378522"

--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipFFT.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378521"

--- a/runtime-rocm/rocm-hipfort/spec
+++ b/runtime-rocm/rocm-hipfort/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipfort.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378520"

--- a/runtime-rocm/rocm-hipify/spec
+++ b/runtime-rocm/rocm-hipify/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/HIPIFY.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378519"

--- a/runtime-rocm/rocm-hiprand/spec
+++ b/runtime-rocm/rocm-hiprand/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipRAND.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378518"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipSPARSE.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378517"

--- a/runtime-rocm/rocm-llama-cpp/spec
+++ b/runtime-rocm/rocm-llama-cpp/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
-SRCS="git::commit=b5956::https://github.com/ggml-org/llama.cpp.git"
+VER=6.4.3
+SRCS="git::commit=b6122::https://github.com/ggml-org/llama.cpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328681"

--- a/runtime-rocm/rocm-llvm/autobuild/defines
+++ b/runtime-rocm/rocm-llvm/autobuild/defines
@@ -17,7 +17,7 @@ USECLANG=1
 # Note: Keep libclang_rt.builtins.a, Compiling for GPU environment
 NOSTATIC=0
 
-LLVM_BASE_SET="clang;lld;compiler-rt;clang-tools-extra;mlir;openmp;flang"
+LLVM_BASE_SET="clang;lld;compiler-rt;clang-tools-extra;openmp"
 _LLVM_BASE_RUNTIME_SET="libcxx;libcxxabi;libunwind"
 
 ABTYPE=cmakeninja

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0008-llvm-loongarch64-la664.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0008-llvm-loongarch64-la664.patch
@@ -1,0 +1,78 @@
+From b88d699f9a8877d77af0a87d4955af40420142ee Mon Sep 17 00:00:00 2001
+From: Ami-zhang <zhanglimin@loongson.cn>
+Date: Mon, 29 Apr 2024 16:58:15 +0800
+Subject: [PATCH] [LoongArch] Support la664
+
+A new ProcessorModel called `la664` is defined in LoongArch.td
+to support `-march/-mtune=la664`.
+---
+ .../llvm/TargetParser/LoongArchTargetParser.def       |  2 ++
+ .../include/llvm/TargetParser/LoongArchTargetParser.h |  3 +++
+ llvm/lib/Target/LoongArch/LoongArch.td                |  7 +++++++
+ llvm/lib/TargetParser/Host.cpp                        |  2 ++
+ 8 files changed, 43 insertions(+)
+
+diff --git a/llvm/include/llvm/TargetParser/LoongArchTargetParser.def b/llvm/include/llvm/TargetParser/LoongArchTargetParser.def
+index b20d124953f88..101a48cbd5399 100644
+--- a/llvm/include/llvm/TargetParser/LoongArchTargetParser.def
++++ b/llvm/include/llvm/TargetParser/LoongArchTargetParser.def
+@@ -10,6 +10,7 @@ LOONGARCH_FEATURE("+lasx", FK_LASX)
+ LOONGARCH_FEATURE("+lbt", FK_LBT)
+ LOONGARCH_FEATURE("+lvz", FK_LVZ)
+ LOONGARCH_FEATURE("+ual", FK_UAL)
++LOONGARCH_FEATURE("+frecipe", FK_FRECIPE)
+
+ #undef LOONGARCH_FEATURE
+
+@@ -19,5 +20,6 @@ LOONGARCH_FEATURE("+ual", FK_UAL)
+
+ LOONGARCH_ARCH("loongarch64", AK_LOONGARCH64, FK_64BIT | FK_FP32 | FK_FP64 | FK_UAL)
+ LOONGARCH_ARCH("la464", AK_LA464, FK_64BIT | FK_FP32 | FK_FP64 | FK_LSX | FK_LASX | FK_UAL)
++LOONGARCH_ARCH("la664", AK_LA664, FK_64BIT | FK_FP32 | FK_FP64 | FK_LSX | FK_LASX | FK_UAL | FK_FRECIPE)
+
+ #undef LOONGARCH_ARCH
+diff --git a/llvm/include/llvm/TargetParser/LoongArchTargetParser.h b/llvm/include/llvm/TargetParser/LoongArchTargetParser.h
+index 028844187584b..c0bb15a5163b1 100644
+--- a/llvm/include/llvm/TargetParser/LoongArchTargetParser.h
++++ b/llvm/include/llvm/TargetParser/LoongArchTargetParser.h
+@@ -46,6 +46,9 @@ enum FeatureKind : uint32_t {
+
+   // Allow memory accesses to be unaligned.
+   FK_UAL = 1 << 8,
++
++  // Floating-point approximate reciprocal instructions are available.
++  FK_FRECIPE = 1 << 9,
+ };
+
+ struct FeatureInfo {
+diff --git a/llvm/lib/Target/LoongArch/LoongArch.td b/llvm/lib/Target/LoongArch/LoongArch.td
+index 8a628157c6018..70bc1a582cd3e 100644
+--- a/llvm/lib/Target/LoongArch/LoongArch.td
++++ b/llvm/lib/Target/LoongArch/LoongArch.td
+@@ -151,6 +151,13 @@ def : ProcessorModel<"la464", NoSchedModel, [Feature64Bit,
+                                              FeatureExtLVZ,
+                                              FeatureExtLBT]>;
+
++def : ProcessorModel<"la664", NoSchedModel, [Feature64Bit,
++                                             FeatureUAL,
++                                             FeatureExtLASX,
++                                             FeatureExtLVZ,
++                                             FeatureExtLBT,
++                                             FeatureFrecipe]>;
++
+ //===----------------------------------------------------------------------===//
+ // Define the LoongArch target.
+ //===----------------------------------------------------------------------===//
+diff --git a/llvm/lib/TargetParser/Host.cpp b/llvm/lib/TargetParser/Host.cpp
+index 82c1731f58f0a..7b5dfc67660d6 100644
+--- a/llvm/lib/TargetParser/Host.cpp
++++ b/llvm/lib/TargetParser/Host.cpp
+@@ -1562,6 +1562,8 @@ StringRef sys::getHostCPUName() {
+   switch (processor_id & 0xf000) {
+   case 0xc000: // Loongson 64bit, 4-issue
+     return "la464";
++  case 0xd000: // Loongson 64bit, 6-issue
++    return "la664";
+   // TODO: Others.
+   default:
+     break;

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0009-llvm-loongarch64-support-la64v10-v11.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0009-llvm-loongarch64-support-la64v10-v11.patch
@@ -1,0 +1,134 @@
+From 12205c317a1bbd29792939186d67d8470c7c16af Mon Sep 17 00:00:00 2001
+From: Ami-zhang <zhanglimin@loongson.cn>
+Date: Tue, 25 Jun 2024 17:18:20 +0800
+Subject: [PATCH] [LoongArch] Support -march=la64v1.0 and -march=la64v1.1
+
+The newly added strings `la64v1.0` and `la64v1.1` in `-march`
+are as described in LoongArch toolchains conventions (see [1]).
+
+The target-cpu/feature attributes are forwarded to compiler when
+specifying particular `-march` parameter. The default cpu `loongarch64`
+is returned when archname is `la64v1.0` or `la64v1.1`.
+
+In addition, this commit adds `la64v1.0`/`la64v1.1` to "__loongarch_arch"
+and adds definition for macro "__loongarch_frecipe".
+
+[1]: https://github.com/loongson/la-toolchain-conventions
+---
+ clang/lib/Basic/Targets/LoongArch.cpp         | 23 +++++++++++++++-
+ clang/lib/Basic/Targets/LoongArch.h           |  2 ++
+ .../lib/Driver/ToolChains/Arch/LoongArch.cpp  | 10 +++++--
+ .../TargetParser/LoongArchTargetParser.cpp    | 11 ++++++++
+ 6 files changed, 88 insertions(+), 7 deletions(-)
+
+diff --git a/clang/lib/Basic/Targets/LoongArch.cpp b/clang/lib/Basic/Targets/LoongArch.cpp
+index 75f71a337b7a4..cb3fd12c48ddb 100644
+--- a/clang/lib/Basic/Targets/LoongArch.cpp
++++ b/clang/lib/Basic/Targets/LoongArch.cpp
+@@ -200,7 +200,24 @@ void LoongArchTargetInfo::getTargetDefines(const LangOptions &Opts,
+
+   // Define __loongarch_arch.
+   StringRef ArchName = getCPU();
+-  Builder.defineMacro("__loongarch_arch", Twine('"') + ArchName + Twine('"'));
++  if (ArchName == "loongarch64") {
++    if (HasFeatureLSX) {
++      // TODO: As more features of the V1.1 ISA are supported, a unified "v1.1"
++      // arch feature set will be used to include all sub-features belonging to
++      // the V1.1 ISA version.
++      if (HasFeatureFrecipe)
++        Builder.defineMacro("__loongarch_arch",
++                            Twine('"') + "la64v1.1" + Twine('"'));
++      else
++        Builder.defineMacro("__loongarch_arch",
++                            Twine('"') + "la64v1.0" + Twine('"'));
++    } else {
++      Builder.defineMacro("__loongarch_arch",
++                          Twine('"') + ArchName + Twine('"'));
++    }
++  } else {
++    Builder.defineMacro("__loongarch_arch", Twine('"') + ArchName + Twine('"'));
++  }
+
+   // Define __loongarch_tune.
+   StringRef TuneCPU = getTargetOpts().TuneCPU;
+@@ -216,6 +233,8 @@ void LoongArchTargetInfo::getTargetDefines(const LangOptions &Opts,
+     Builder.defineMacro("__loongarch_simd_width", "128");
+     Builder.defineMacro("__loongarch_sx", Twine(1));
+   }
++  if (HasFeatureFrecipe)
++    Builder.defineMacro("__loongarch_frecipe", Twine(1));
+
+   StringRef ABI = getABI();
+   if (ABI == "lp64d" || ABI == "lp64f" || ABI == "lp64s")
+@@ -291,6 +310,8 @@ bool LoongArchTargetInfo::handleTargetFeatures(
+       HasFeatureLASX = true;
+     else if (Feature == "-ual")
+       HasUnalignedAccess = false;
++    else if (Feature == "+frecipe")
++      HasFeatureFrecipe = true;
+   }
+   return true;
+ }
+diff --git a/clang/lib/Basic/Targets/LoongArch.h b/clang/lib/Basic/Targets/LoongArch.h
+index 5fc223483951e..c668ca7eca047 100644
+--- a/clang/lib/Basic/Targets/LoongArch.h
++++ b/clang/lib/Basic/Targets/LoongArch.h
+@@ -29,6 +29,7 @@ class LLVM_LIBRARY_VISIBILITY LoongArchTargetInfo : public TargetInfo {
+   bool HasFeatureF;
+   bool HasFeatureLSX;
+   bool HasFeatureLASX;
++  bool HasFeatureFrecipe;
+
+ public:
+   LoongArchTargetInfo(const llvm::Triple &Triple, const TargetOptions &)
+@@ -37,6 +38,7 @@ class LLVM_LIBRARY_VISIBILITY LoongArchTargetInfo : public TargetInfo {
+     HasFeatureF = false;
+     HasFeatureLSX = false;
+     HasFeatureLASX = false;
++    HasFeatureFrecipe = false;
+     LongDoubleWidth = 128;
+     LongDoubleAlign = 128;
+     LongDoubleFormat = &llvm::APFloat::IEEEquad();
+diff --git a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+index 4a2b9efc9ffad..b149d48d97fe8 100644
+--- a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
++++ b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+@@ -253,8 +253,14 @@ std::string loongarch::postProcessTargetCPUString(const std::string &CPU,
+ std::string loongarch::getLoongArchTargetCPU(const llvm::opt::ArgList &Args,
+                                              const llvm::Triple &Triple) {
+   std::string CPU;
++  std::string Arch;
+   // If we have -march, use that.
+-  if (const Arg *A = Args.getLastArg(options::OPT_march_EQ))
+-    CPU = A->getValue();
++  if (const Arg *A = Args.getLastArg(options::OPT_march_EQ)) {
++    Arch = A->getValue();
++    if (Arch == "la64v1.0" || Arch == "la64v1.1")
++      CPU = llvm::LoongArch::getDefaultArch(Triple.isLoongArch64());
++    else
++      CPU = Arch;
++  }
+   return postProcessTargetCPUString(CPU, Triple);
+ }
+diff --git a/llvm/lib/TargetParser/LoongArchTargetParser.cpp b/llvm/lib/TargetParser/LoongArchTargetParser.cpp
+index 772d24c5ce3de..8e86d18de2ad9 100644
+--- a/llvm/lib/TargetParser/LoongArchTargetParser.cpp
++++ b/llvm/lib/TargetParser/LoongArchTargetParser.cpp
+@@ -44,6 +44,17 @@ bool LoongArch::getArchFeatures(StringRef Arch,
+       return true;
+     }
+   }
++
++  if (Arch == "la64v1.0" || Arch == "la64v1.1") {
++    Features.push_back("+64bit");
++    Features.push_back("+d");
++    Features.push_back("+lsx");
++    Features.push_back("+ual");
++    if (Arch == "la64v1.1")
++      Features.push_back("+frecipe");
++    return true;
++  }
++
+   return false;
+ }
+

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocBLAS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241713"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocFFT.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378516"

--- a/runtime-rocm/rocm-rocmlir/spec
+++ b/runtime-rocm/rocm-rocmlir/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocMLIR"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378515"

--- a/runtime-rocm/rocm-rocprim/spec
+++ b/runtime-rocm/rocm-rocprim/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocPRIM"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378514"

--- a/runtime-rocm/rocm-rocprofiler-register/spec
+++ b/runtime-rocm/rocm-rocprofiler-register/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocprofiler-register"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378513"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocRAND.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378511"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocSOLVER.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378510"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rocSPARSE.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378508"

--- a/runtime-rocm/rocm-roctracer/spec
+++ b/runtime-rocm/rocm-roctracer/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/roctracer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378506"

--- a/runtime-rocm/rocm-smi-lib/spec
+++ b/runtime-rocm/rocm-smi-lib/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm_smi_lib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138206"

--- a/runtime-rocm/rocminfo/spec
+++ b/runtime-rocm/rocminfo/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocminfo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,4 +1,4 @@
-VER=6.4.2
+VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-llama-cpp: update to 6.4.3
- rocm-hiprand: update to 6.4.3
- rocm-hipblas: update to 6.4.3
- rocm-rocsolver: update to 6.4.3
- rocm-hipsparse: update to 6.4.3
- rocm-hipfft: update to 6.4.3
- rocm-rocsparse: update to 6.4.3
- rocm-rccl: update to 6.4.3
- rocm-rocrand: update to 6.4.3
- rocm-rocfft: update to 6.4.2

... and 21 more commits

Package(s) Affected
-------------------

- rocm-bandwidth-test: 6.4.3
- rocm-clr: 6.4.3
- rocm-cmake: 6.4.3
- rocm-comgr: 6.4.3
- rocm-core: 6.4.3
- rocm-device-libs: 6.4.3
- rocm-half: 6.4.3
- rocm-hipblas: 6.4.3
- rocm-hipblas-common: 6.4.3
- rocm-hipblaslt: 6.4.3
- rocm-hipcub: 6.4.3
- rocm-hipfft: 6.4.3
- rocm-hipfort: 6.4.3
- rocm-hipify: 6.4.3
- rocm-hiprand: 6.4.3
- rocm-hipsparse: 6.4.3
- rocm-llama-cpp: 6.4.3
- rocm-llvm: 6.4.3
- rocm-rccl: 6.4.3
- rocm-rocblas: 6.4.3
- rocm-rocfft: 6.4.3
- rocm-rocmlir: 6.4.3
- rocm-rocprim: 6.4.3
- rocm-rocprofiler-register: 6.4.3
- rocm-rocrand: 6.4.3
- rocm-rocsolver: 6.4.3
- rocm-rocsparse: 6.4.3
- rocm-roctracer: 6.4.3
- rocm-smi-lib: 6.4.3
- rocminfo: 6.4.3
- rocr-runtime: 6.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-rocprofiler-register rocr-runtime rocminfo rocm-cmake rocm-clr rocm-bandwidth-test rocm-half rocm-smi-lib rocm-hipify rocm-rocprim rocm-hipcub rocm-rocmlir rocm-hipfort rocm-roctracer rocm-hipblas-common rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand rocm-rccl rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver rocm-hipblas rocm-hiprand rocm-llama-cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
