### PR TITLE
dmenu: update to 5.4

### DIFF
--- a/app-utils/dmenu/spec
+++ b/app-utils/dmenu/spec
@@ -1,4 +1,4 @@
-VER=5.3
+VER=5.4
 SRCS="tbl::https://dl.suckless.org/tools/dmenu-$VER.tar.gz"
-CHKSUMS="sha256::1a8f53e6fd2d749839ec870c5e27b3e14da5c3eeacbfcb945d159e1d5433795f"
+CHKSUMS="sha256::8fbace2a0847aa80fe861066b118252dcc7b4ca0a0a8f3a93af02da8fb6cd453"
 CHKUPDATE="anitya::id=442"


### PR DESCRIPTION
Topic Description
-----------------

- dmenu: update to 5.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- dmenu: 5.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dmenu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
