### PR TITLE
svt-av1: update to 3.1.0

### DIFF
--- a/runtime-multimedia/svt-av1/autobuild/defines
+++ b/runtime-multimedia/svt-av1/autobuild/defines
@@ -4,9 +4,6 @@ PKGDEP="glibc"
 BUILDDEP="nasm"
 PKGSEC=libs
 
-CMAKE_AFTER=(
-	"-DBUILD_SHARED_LIBS=ON"
-	"-DNATIVE=OFF"
-)
+ABTYPE=cmakeninja
 
 PKGBREAK="ffmpeg<=7.1-6 gstreamer<=1.26.0 libavif<=0.11.1-3"

--- a/runtime-multimedia/svt-av1/spec
+++ b/runtime-multimedia/svt-av1/spec
@@ -1,4 +1,4 @@
-VER=3.0.2
+VER=3.1.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/AOMediaCodec/SVT-AV1"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=24271"


### PR DESCRIPTION
Topic Description
-----------------

- svt-av1: update to 3.1.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- svt-av1: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit svt-av1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
