### PR TITLE
fcitx5-pinyin-moegirl: update to 20250810

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250711
+VER=20250810
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::923760b2ae67fbbae33c1ad73a3adbd77f892cf2de5cd405bfdba1978352b333
-         sha256::82cfc985d49e2c59012af05d551c64dd186a9643a1972d7cc383f3eb7186f35e
+CHKSUMS="sha256::3eeb96e37faebbd55ab32df7296d4829bdae2b69a1f0cfd5f5f542569d50665d
+         sha256::fd8bffda48a0b6936f9d694761324131494c5798b9b68b5e68b883274903a198
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250810

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250810
- rime-pinyin-moegirl: 20250810

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
