### PR TITLE
oma: update to 1.20.0~ci~test11

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test7
+VER=1.20.0~ci~test8
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test3
+VER=1.20.0~ci~test4
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test5
+VER=1.20.0~ci~test6
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test2
+VER=1.20.0~ci~test3
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test1
+VER=1.20.0~ci~test2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test10
+VER=1.20.0~ci~test11
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test4
+VER=1.20.0~ci~test5
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.19.2
+VER=1.20.0~ci~test1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test8
+VER=1.20.0~ci~test9
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test6
+VER=1.20.0~ci~test7
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.20.0~ci~test9
+VER=1.20.0~ci~test10
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.20.0\~ci~test11

Package(s) Affected
-------------------

- oma: 1.20.0\~ci~test11

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`



