### PR TITLE
nvidia-open: update to 580.65.06

### DIFF
--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,4 @@
-VER=575.64
+VER=580.65.06
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-open: update to 580.65.06
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- nvidia-open: 580.65.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia-open
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
