### PR TITLE
nvidia: update to 580.65.06

### DIFF
--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=575.64
+VER=580.65.06
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::eb01bcfe73b06c7d24b6083c27e6414f6979542f06e65601421b64ccc0ad68b1"
+CHKSUMS__AMD64="sha256::04b10867af585e765cfbfdcf39ed5f4bd112375bebab0172eaa187c6aa5024ff"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::b878fc7c1d6c4897d7d0d599104d5e64dd4b41091fec9d233d5dc47900921b5d"
+CHKSUMS__ARM64="sha256::e02acdc0d20d4a541aa5026bfddb1b9b4fc6bc64ae3b04ff9cb9c892700cf9c4"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia: update to 580.65.06
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- nvidia: 580.65.06
- nvidia-firmware: 580.65.06
- nvidia-utils: 580.65.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
