### PR TITLE
blender: enable OpenImageDenoise on AArch64

### DIFF
--- a/app-creativity/blender/autobuild/defines
+++ b/app-creativity/blender/autobuild/defines
@@ -7,7 +7,7 @@ PKGDEP="boost desktop-file-utils ffmpeg fftw freetype glew \
 	materialx alembic \
         ptex requests shared-mime-info xdg-utils libcl python-3 llvm libharu"
 PKGDEP__AMD64="${PKGDEP} embree openimagedenoise openpgl"
-PKGDEP__ARM64="${PKGDEP} embree"
+PKGDEP__ARM64="${PKGDEP} embree openimagedenoise"
 BUILDDEP="cmake jack"
 BUILDDEP__AMD64="${BUILDDEP} cuda"
 BUILDDEP__ARM64="${BUILDDEP} cuda"

--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -1,5 +1,5 @@
 VER=4.0.2
-REL=3
+REL=4
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
 CHKSUMS="sha256::aaa0e729da7591cfbf45772af76345977daaa7b11a0af35d98f9313e246077a3"
 CHKUPDATE="anitya::id=201"

--- a/runtime-imaging/openimagedenoise/autobuild/defines
+++ b/runtime-imaging/openimagedenoise/autobuild/defines
@@ -6,4 +6,4 @@ BUILDDEP="ispc"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER="-DPYTHON_EXECUTABLE=/usr/bin/python3"
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64)"

--- a/runtime-imaging/openimagedenoise/spec
+++ b/runtime-imaging/openimagedenoise/spec
@@ -1,5 +1,4 @@
-VER=1.4.3
-REL=1
+VER=2.3.0
 SRCS="tbl::https://github.com/OpenImageDenoise/oidn/releases/download/v${VER}/oidn-${VER}.src.tar.gz"
-CHKSUMS="sha256::3276e252297ebad67a999298d8f0c30cfb221e166b166ae5c955d88b94ad062a"
+CHKSUMS="sha256::cce3010962ec84e0ba1acd8c9055a3d8de402fedb1b463517cfeb920a276e427"
 CHKUPDATE="anitya::id=19531"


### PR DESCRIPTION
Topic Description
-----------------

- blender: enable OIDN for ARM64
- openimagedenoise: update to 2.3.0, build on ARM64

Package(s) Affected
-------------------

- blender: 4.0.2-4
- openimagedenoise: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit openimagedenoise blender
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
