### PR TITLE
NVIDIA Driver 575.64.05 Survey (Aug. 2025)

### DIFF
--- a/runtime-display/libxnvctrl/spec
+++ b/runtime-display/libxnvctrl/spec
@@ -1,5 +1,4 @@
-VER=565.57.01
-REL=1
+VER=575.64.05
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,4 @@
-VER=575.64
+VER=575.64.05
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=575.64
+VER=575.64.05
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::eb01bcfe73b06c7d24b6083c27e6414f6979542f06e65601421b64ccc0ad68b1"
+CHKSUMS__AMD64="sha256::85f2b50f912261c1917a0b2cf7e1f9743affd008fdc0f209f4d5563f774d502d"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::b878fc7c1d6c4897d7d0d599104d5e64dd4b41091fec9d233d5dc47900921b5d"
+CHKSUMS__ARM64="sha256::19113d544128b1b63b4cbe073c5a32a3401ce638011ec660f6c04a27804b86c0"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/runtime-optenv32/libxnvctrl+32/spec
+++ b/runtime-optenv32/libxnvctrl+32/spec
@@ -1,4 +1,4 @@
-VER=565.57.01
+VER=575.64.05
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"


### PR DESCRIPTION
Topic Description
-----------------

- libxnvctrl+32: update to 575.64.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libxnvctrl: update to 575.64.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 575.64.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 575.64.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libxnvctrl: 575.64.05
- nvidia: 575.64.05
- nvidia-firmware: 575.64.05
- nvidia-open: 575.64.05
- nvidia-utils: 575.64.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open libxnvctrl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
