### PR TITLE
ntfs-3g: fix build

### DIFF
--- a/app-admin/ntfs-3g/autobuild/beyond
+++ b/app-admin/ntfs-3g/autobuild/beyond
@@ -3,23 +3,20 @@ export LIBNTFS_3G_CFLAGS="-I${PKGDIR}/usr/include"
 export LIBNTFS_3G_LIBS="-pthread -L${PKGDIR}/usr/lib -lntfs-3g"
 
 abinfo "Configuring, building, and installing the system compression plugin ..."
-(
-    cd "$SRCDIR"/../ntfs-3g-system-compression-1.0
+cd "$SRCDIR"/../ntfs-3g-system-compression-1.0
+autoreconf -fvi
+./configure --prefix=/usr
+make
+make install DESTDIR="$PKGDIR"
+
+for i in dedup onedrive; do
+    abinfo "Configuring, building, and installing the $i plugin ..."
+    cd "$SRCDIR"/../$i
+    ab_apply_patches "$SRCDIR"/autobuild/patches/*.$i
     autoreconf -fvi
     ./configure --prefix=/usr
     make
     make install DESTDIR="$PKGDIR"
-)
-
-for i in dedup onedrive; do
-    abinfo "Configuring, building, and installing the $i plugin ..."
-    (
-        cd "$SRCDIR"/../$i
-        autoreconf -fvi
-        ./configure --prefix=/usr
-        make
-        make install DESTDIR="$PKGDIR"
-    )
 done
 
 abinfo "Creating mount.ntfs symlink to ease mounting ..."

--- a/app-admin/ntfs-3g/autobuild/defines
+++ b/app-admin/ntfs-3g/autobuild/defines
@@ -3,12 +3,15 @@ PKGSEC=admin
 PKGDEP="util-linux fuse gnutls attr libgcrypt libconfig"
 PKGDES="NTFS filesystem driver and utilities"
 
-AUTOTOOLS_AFTER="--disable-static \
-                 --disable-ldconfig \
-                 --with-fuse=external \
-                 --exec-prefix=/usr \
-                 --enable-posix-acls \
-                 --enable-crypto \
-                 --enable-extras \
-                 --enable-quarantined"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--disable-static"
+    "--disable-ldconfig"
+    "--with-fuse=external"
+    "--exec-prefix=/usr"
+    "--enable-posix-acls"
+    "--enable-crypto"
+    "--enable-extras"
+    "--enable-quarantined"
+)
 PKGEPOCH=1

--- a/app-admin/ntfs-3g/autobuild/patches/0003-fix-add-missing-header.patch
+++ b/app-admin/ntfs-3g/autobuild/patches/0003-fix-add-missing-header.patch
@@ -1,0 +1,24 @@
+From ab6a5fd82e113d6814ed474c076e30b6c4ac4e2c Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Mon, 11 Aug 2025 21:08:14 +0800
+Subject: [PATCH 3/3] fix: add missing header
+
+---
+ include/ntfs-3g/ntfstime.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/ntfs-3g/ntfstime.h b/include/ntfs-3g/ntfstime.h
+index f3a89dd..f069371 100644
+--- a/include/ntfs-3g/ntfstime.h
++++ b/include/ntfs-3g/ntfstime.h
+@@ -29,6 +29,7 @@
+ #endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
++#include <time.h>
+ #endif
+ #ifdef HAVE_GETTIMEOFDAY
+ #include <sys/time.h>
+-- 
+2.50.1
+

--- a/app-admin/ntfs-3g/autobuild/patches/0004-fix-add-missing-header.dedup
+++ b/app-admin/ntfs-3g/autobuild/patches/0004-fix-add-missing-header.dedup
@@ -1,0 +1,25 @@
+From d43117243d7975404aca4f8e32581e48fa1325d9 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Mon, 11 Aug 2025 21:15:30 +0800
+Subject: [PATCH] fix: add missing header
+
+---
+ src/dedup.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/dedup.c b/src/dedup.c
+index 673d60b..49a7f7f 100644
+--- a/src/dedup.c
++++ b/src/dedup.c
+@@ -87,6 +87,8 @@
+ #include <ntfs-3g/security.h>
+ #include <ntfs-3g/plugin.h>
+ #include <ntfs-3g/misc.h>
++#include <stdlib.h>
++#include <ctype.h>
+ 
+ #define CKHR_MAGIC const_cpu_to_le32(0x72686b43) /* "Ckhr" */
+ #define SMAP_MAGIC const_cpu_to_le32(0x70616d53) /* "Smap" */
+-- 
+2.50.1
+

--- a/app-admin/ntfs-3g/autobuild/preinst
+++ b/app-admin/ntfs-3g/autobuild/preinst
@@ -1,1 +1,0 @@
-rm -f /usr/bin/mkntfs.*

--- a/app-admin/ntfs-3g/autobuild/prepare
+++ b/app-admin/ntfs-3g/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -D_FILE_OFFSET_BITS=64"

--- a/app-admin/ntfs-3g/spec
+++ b/app-admin/ntfs-3g/spec
@@ -1,5 +1,6 @@
 VER=2022.10.3
-SRCS="tbl::https://tuxera.com/opensource/ntfs-3g_ntfsprogs-$VER.tgz \
+REL=1
+SRCS="tbl::https://download.tuxera.com/opensource/ntfs-3g_ntfsprogs-$VER.tgz \
       tbl::https://github.com/ebiggers/ntfs-3g-system-compression/releases/download/v1.0/ntfs-3g-system-compression-1.0.tar.gz \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/dedup.zip \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/onedrive.zip"


### PR DESCRIPTION
Topic Description
-----------------

- ntfs-3g: fix build
    - Change source url.
    - Drop unused prepare, preinst scripts.
    - Improve defines, beyond scripts.

Package(s) Affected
-------------------

- ntfs-3g: 1:2022.10.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ntfs-3g
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
