### PR TITLE
poetry: update to 2.1.3

### DIFF
--- a/lang-python/fastjsonschema/autobuild/defines
+++ b/lang-python/fastjsonschema/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=fastjsonschema
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Fast JSON schema validator for Python"
+
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/fastjsonschema/spec
+++ b/lang-python/fastjsonschema/spec
@@ -1,0 +1,4 @@
+VER=2.21.1
+SRCS="pypi::version=${VER}::fastjsonschema"
+CHKSUMS="sha256::794d4f0a58f848961ba16af7b9c85a3e88cd360df008c59aac6fc5ae9323b5d4"
+CHKUPDATE="anitya::id=25966"

--- a/lang-python/findpython/autobuild/defines
+++ b/lang-python/findpython/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=findpython
+PKGSEC=python
+PKGDEP="python-3 packaging platformdirs"
+BUILDDEP="pdm-backend"
+PKGDES="Utility to find Python versions in system"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/findpython/spec
+++ b/lang-python/findpython/spec
@@ -1,0 +1,4 @@
+VER=0.7.0
+SRCS="pypi::version=${VER}::findpython"
+CHKSUMS="sha256::8b31647c76352779a3c1a0806699b68e6a7bdc0b5c2ddd9af2a07a0d40c673dc"
+CHKUPDATE="anitya::id=275615"

--- a/lang-python/pbs-installer/autobuild/defines
+++ b/lang-python/pbs-installer/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pbs-installer
+PKGSEC=python
+PKGDEP="python-3 httpx zstandard"
+BUILDDEP="pdm-backend"
+PKGDES="Installer for Python Build Standalone"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/pbs-installer/spec
+++ b/lang-python/pbs-installer/spec
@@ -1,0 +1,4 @@
+VER=2025.7.12
+SRCS="pypi::version=${VER}::pbs-installer"
+CHKSUMS="sha256::343b8905e1da3cd4b03b68d630086330dde1814294963b77d2664b18b5002ac6"
+CHKUPDATE="anitya::id=363037"

--- a/lang-python/pdm-backend/autobuild/defines
+++ b/lang-python/pdm-backend/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=pdm-backend
+PKGSEC=python
+PKGDEP="python-3"
+PKGDES="Python build backend used by PDM"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/pdm-backend/spec
+++ b/lang-python/pdm-backend/spec
@@ -1,0 +1,4 @@
+VER=2.4.5
+SRCS="pypi::version=${VER}::pdm-backend"
+CHKSUMS="sha256::56c019c440308adad5d057c08cbb777e65f43b991a3b0920749781258972fe5b"
+CHKUPDATE="anitya::id=306904"

--- a/lang-python/poetry-core/spec
+++ b/lang-python/poetry-core/spec
@@ -1,5 +1,5 @@
-VER=1.9.0
+VER=2.1.3
 EPOCH=1
 SRCS="tbl::https://github.com/python-poetry/poetry-core/releases/download/${VER}/poetry_core-${VER}.tar.gz"
-CHKSUMS="sha256::fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"
+CHKSUMS="sha256::0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4"
 CHKUPDATE="anitya::id=71155"

--- a/lang-python/poetry/autobuild/defines
+++ b/lang-python/poetry/autobuild/defines
@@ -1,10 +1,12 @@
 PKGNAME=poetry
 PKGSEC=python
-PKGDEP="cachecontrol cachy cleo clikit html5lib-python jsonschema pexpect \
-	pkginfo pyparsing pyrsistent toolbelt requests shellingham tomlkit \
-	crashtest pexpect packaging virtualenv keyring poetry-core lockfile \
-	platformdirs dulwich tomli pyproject-hooks python-2 python-3"
-BUILDDEP="setuptools python-build python-installer setuptools-python2"
-PKGDES="Python dependency management and packaging made easy"
+PKGDEP="python-3 poetry-core cachecontrol cleo dulwich fastjsonschema \
+	keyring python-build python-installer packaging pkginfo platformdirs \
+	pyproject-hooks requests toolbelt shellingham tomlkit \
+	trove-classifiers virtualenv findpython pbs-installer crashtest"
+BUILDDEP="setuptools"
+PKGDES="Python dependency management and packaging tool"
 
 ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/poetry/spec
+++ b/lang-python/poetry/spec
@@ -1,5 +1,4 @@
-VER=1.8.3
-SRCS="https://pypi.io/packages/source/p/poetry/poetry-$VER.tar.gz"
-CHKSUMS="sha256::67f4eb68288eab41e841cc71a00d26cf6bdda9533022d0189a145a34d0a35f48"
+VER=2.1.3
+SRCS="pypi::version=${VER}::poetry"
+CHKSUMS="sha256::f2c9bd6790b19475976d88ea4553bcc3533c0dc73f740edc4fffe9e2add50594"
 CHKUPDATE="anitya::id=32514"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- poetry: update to 2.1.3
    \(cherry picked from commit e5ccd08071950b092611bcea1ae6e7e0ae7ecf81\)
- findpython: new, 0.7.0
    \(cherry picked from commit f33f4b316b652ac8372319273c12868f1b6636b4\)
- fastjsonschema: new, 2.21.1
    \(cherry picked from commit b245e8f99d9d1d21d4a0dffebb78d30197d69f56\)
- pdm-backend: new, 2.4.5
    \(cherry picked from commit 22a9b46e6d94806168f037e743e1ff441db045ea\)
- pbs-installer: new, 2025.7.12
    \(cherry picked from commit 791b2a99c3516d06f23ba5420e882cbc72230985\)
- poetry-core: update to 2.1.3

Package(s) Affected
-------------------

- fastjsonschema: 2.21.1
- findpython: 0.7.0
- pbs-installer: 2025.7.12
- pdm-backend: 2.4.5
- poetry: 2.1.3
- poetry-core: 2.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit poetry-core pbs-installer pdm-backend fastjsonschema findpython poetry
```

Test Build(s) Done
------------------

