### PR TITLE
musicfox: update to 4.6.6

### DIFF
--- a/app-multimedia/musicfox/spec
+++ b/app-multimedia/musicfox/spec
@@ -1,5 +1,4 @@
-VER=4.6.2
+VER=4.6.6
 SRCS="git::commit=tags/v$VER::https://github.com/go-musicfox/go-musicfox"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376106"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- musicfox: update to 4.6.6

Package(s) Affected
-------------------

- musicfox: 4.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit musicfox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
