### PR TITLE
NVIDIA Driver 580.76.05 Survey (Aug. 2025)

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=12.9.0
-MIN_DRIVER_VER=575.51.03
+UPSTREAM_VER=13.0.0
+MIN_DRIVER_VER=580.65.06
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::bbce2b760fe2096ca1c86f729e03bf377c1519add7b2755ecc4e9b0a9e07ee43"
+CHKSUMS__AMD64="sha256::c64969f35ad99bf3f9e8acb8e3d22355150c6ca07acc16a853778600a9b65ba6"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::f3b7ae71f95d11de0a03ccfa1c0aff7be336d2199b50b1a15b03695fd15a6409"
+CHKSUMS__ARM64="sha256::d956c956d0aef7270f26e6d8a9dbb2aeb3bd0d2214195c0e0e230a4cd37ff3d2"

--- a/runtime-display/libxnvctrl/spec
+++ b/runtime-display/libxnvctrl/spec
@@ -1,4 +1,4 @@
-VER=575.64.05
+VER=580.65.06
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,4 @@
-VER=575.64.05
+VER=580.76.05
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/01-utils/build
+++ b/runtime-display/nvidia/01-utils/build
@@ -113,10 +113,10 @@ install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
 install -Dvm755 "libnvidia-sandboxutils.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-sandboxutils.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.2" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.2
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.2" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.2
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.3" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.3
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.3" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.3
 install -Dvm644 "20_nvidia_xlib.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json
 install -Dvm644 "20_nvidia_xcb.json" \

--- a/runtime-display/nvidia/01-utils/build-optenv32
+++ b/runtime-display/nvidia/01-utils/build-optenv32
@@ -33,10 +33,10 @@ install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
 install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.2" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.2
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.2" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.2
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.3" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.3
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.3" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.3
 install -Dvm755 "libnvidia-egl-gbm.so.1.1.2" \
     "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.2
 

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=575.64.05
-SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::85f2b50f912261c1917a0b2cf7e1f9743affd008fdc0f209f4d5563f774d502d"
-SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::19113d544128b1b63b4cbe073c5a32a3401ce638011ec660f6c04a27804b86c0"
+VER=580.76.05
+SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
+CHKSUMS__AMD64="sha256::219be636b60931b021b2e8c1e0eff887363c731f8a940caa87bcc054d05d97fd"
+SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
+CHKSUMS__ARM64="sha256::34bd83b30cd559040c54cd3dd8d99f226a8a6d393d55180b2fcc5fe1012f1804"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/runtime-optenv32/libxnvctrl+32/spec
+++ b/runtime-optenv32/libxnvctrl+32/spec
@@ -1,4 +1,4 @@
-VER=575.64.05
+VER=580.65.06
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"


### PR DESCRIPTION
Topic Description
-----------------

- libxnvctrl+32: update to 580.76.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libxnvctrl: update to 580.76.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- cuda: update to 13.0.0+580.65.06
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 580.76.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 580.76.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 13.0.0+580.65.06
- libxnvctrl: 580.76.05
- nvidia: 580.76.05
- nvidia-firmware: 580.76.05
- nvidia-open: 580.76.05
- nvidia-utils: 580.76.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open cuda libxnvctrl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
