### PR TITLE
atop: update to 2.12.0

### DIFF
--- a/app-utils/atop/spec
+++ b/app-utils/atop/spec
@@ -1,4 +1,4 @@
-VER=2.11.0
+VER=2.12.0
 SRCS="tbl::https://atoptool.nl/download/atop-$VER.tar.gz"
-CHKSUMS="sha256::9b94c666602efff7bf402ecce706c347f38c39cb63498f9d39626861e5646e20"
+CHKSUMS="sha256::0d09ecc90c14e6ef41c22e3c57c142c3e4fb9cf3c94379077a33c961d5343086"
 CHKUPDATE="anitya::id=135"


### PR DESCRIPTION
Topic Description
-----------------

- atop: update to 2.12.0

Package(s) Affected
-------------------

- atop: 2.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit atop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
