### PR TITLE
nss: update to 3.114

### DIFF
--- a/runtime-cryptography/nss/spec
+++ b/runtime-cryptography/nss/spec
@@ -1,4 +1,4 @@
-VER=3.113
+VER=3.114
 SRCS="https://archive.mozilla.org/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::acef06b512d3bd81c87a63b3c8653d258bb689d2191fc0e64decf5a1efa01c0f"
+CHKSUMS="sha256::cac3c0d67028804fb316e9695f81749fa4dc118e731d674b4c4c347bd849c2f1"
 CHKUPDATE="anitya::id=2503"


### PR DESCRIPTION
Topic Description
-----------------

- nss: update to 3.114
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- nss: 3.114

Security Update?
----------------

No

Build Order
-----------

```
#buildit nss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
