### PR TITLE
mise: update to 2025.8.9

### DIFF
--- a/app-devel/mise/spec
+++ b/app-devel/mise/spec
@@ -1,5 +1,4 @@
-VER=2025.5.6
+VER=2025.8.9
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/mise.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376460"
-REL=1

--- a/app-utils/usage/spec
+++ b/app-utils/usage/spec
@@ -1,4 +1,4 @@
-VER=2.1.1
+VER=2.2.2
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/usage.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376568"


### PR DESCRIPTION
Topic Description
-----------------

- usage: update to 2.2.2
- mise: update to 2025.8.9

Package(s) Affected
-------------------

- mise: 2025.8.9
- usage: 2.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit usage mise
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
