### PR TITLE
yubikey-manager: update to 5.7.2

### DIFF
--- a/app-devices/yubikey-manager/autobuild/defines
+++ b/app-devices/yubikey-manager/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=yubikey-manager
 PKGSEC=admin
-PKGDEP="click enum34 pcsclite ccid swig pyscard pyusb \
-        yubikey-personalization fido2 pyopenssl"
-BUILDDEP="setuptools"
+PKGDEP="click enum34 pcsclite ccid swig pyscard \
+        fido2 pyopenssl"
+BUILDDEP="setuptools-python3 poetry-core"
 PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"
 
 NOPYTHON2=1

--- a/app-devices/yubikey-manager/spec
+++ b/app-devices/yubikey-manager/spec
@@ -1,5 +1,4 @@
-VER=4.0.1
-SRCS="https://pypi.io/packages/source/y/yubikey-manager/yubikey-manager-${VER}.tar.gz"
-CHKSUMS="sha384::8619ca211172ab50fcb71eaa61f5ef59a2a0ff970172b9455dcea7de854aa683f00db8d781ab39f15cf97cbe00688dd5"
+VER=5.7.2
+SRCS="pypi::version=$VER::yubikey-manager"
+CHKSUMS="sha256::9aeb4035dcff8f6cb792e83f36e6a9152a9b5b65ac2c2e25e5f20d53c6064e62"
 CHKUPDATE="anitya::id=67946"
-REL=1

--- a/lang-python/fido2/spec
+++ b/lang-python/fido2/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-SRCS="https://github.com/Yubico/python-fido2/releases/download/$VER/fido2-$VER.tar.gz"
-CHKSUMS="sha384::ed01f83e8c3a4ca426a7c9baf41cc51b4290f729aa6b1508563d66486badc0fe4d7f42359a7d804c706f33fb09948e63"
+VER=2.0.0
+SRCS="pypi::version=$VER::fido2"
+CHKSUMS="sha256::3061cd05e73b3a0ef6afc3b803d57c826aa2d6a9732d16abd7277361f58e7964"
 CHKUPDATE="anitya::id=31676"
-REL=1

--- a/lang-python/pyscard/autobuild/build
+++ b/lang-python/pyscard/autobuild/build
@@ -1,5 +1,2 @@
-python2 setup.py build_ext
-python2 setup.py install --root="$PKGDIR" --optimize=1
-
 python3 setup.py build_ext
 python3 setup.py install --root="$PKGDIR" --optimize=1

--- a/lang-python/pyscard/autobuild/defines
+++ b/lang-python/pyscard/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=python
 PKGDEP="pcsclite python-3"
 BUILDDEP="swig setuptools-python3"
 PKGDES="A Python module for smart card support"
+ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/pyscard/autobuild/defines
+++ b/lang-python/pyscard/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=pyscard
 PKGSEC=python
-PKGDEP="pcsclite python-2 python-3"
-BUILDDEP="swig setuptools-python2 setuptools-python3"
+PKGDEP="pcsclite python-3"
+BUILDDEP="swig setuptools-python3"
 PKGDES="A Python module for smart card support"
+NOPYTHON2=1

--- a/lang-python/pyscard/spec
+++ b/lang-python/pyscard/spec
@@ -1,5 +1,4 @@
-VER=1.9.9
-SRCS="tbl::https://pypi.io/packages/source/p/pyscard/pyscard-$VER.tar.gz"
-CHKSUMS="sha256::e6bde541990183858740793806b1c7f4e798670519ae4c96145f35d5d7944c20"
-REL=3
+VER=2.3.0
+SRCS="pypi::version=$VER::pyscard"
+CHKSUMS="sha256::621928e217e3b1d3c791086bf0c9f307fc4ae004a9b1a430536acc1a6eb50003"
 CHKUPDATE="anitya::id=134670"


### PR DESCRIPTION
Topic Description
-----------------

pyscard: update to 2.3.0
fido2: update to 2.0.0
yubikey-manager: update to 5.7.2

Package(s) Affected
-------------------

pyscard: 2.3.0
fido2: 2.0.0
yubikey-manager: 5.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyscard fido2 yubikey-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

  - [ ] Architecture-independent `noarch`