### PR TITLE
dracut-ng: fix luks boot

### DIFF
--- a/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
@@ -1,7 +1,7 @@
 From 59c5fe4ef236aae3c79683672a76ef16fdfc8038 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 23 Jan 2025 11:45:36 +0800
-Subject: [PATCH 1/5] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
+Subject: [PATCH 1/6] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
  to amdgpu, loongson, and radeon
 
 If we are using mips64el (assumed to be MIPS-based Loongson), only install

--- a/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
@@ -1,19 +1,21 @@
-From 4492c6c8ee6f191d3753bf37048641c3f30e2125 Mon Sep 17 00:00:00 2001
+From f44bbdb641a645dfc220b097c61cc56129a18049 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:55:49 +0800
-Subject: [PATCH 2/5] AOSCOS: LOONGSON3: 01systemd-crypsetup: remove TPM2
+Subject: [PATCH 2/6] AOSCOS: LOONGSON3: 11systemd-crypsetup: remove TPM2
  dependency
 
 There is just no way that we will get TPM2 on MIPS-based Loongson 3
 systems - and it saves almost 10MiB post-XZ.
 
+Co-authored-by: Kaiyang Wu <origincode@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  modules.d/11systemd-cryptsetup/module-setup.sh | 8 +++++++-
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/modules.d/11systemd-cryptsetup/module-setup.sh b/modules.d/11systemd-cryptsetup/module-setup.sh
-index 0a89ef20..1fb0d1bf 100755
+index 0a89ef20..c74b4fd1 100755
 --- a/modules.d/11systemd-cryptsetup/module-setup.sh
 +++ b/modules.d/11systemd-cryptsetup/module-setup.sh
 @@ -31,7 +31,13 @@ depends() {
@@ -22,12 +24,12 @@ index 0a89ef20..1fb0d1bf 100755
      elif [[ ! ${hostonly-} ]]; then
 -        for module in fido2 pkcs11 tpm2-tss; do
 +        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
-+            modules="fido pkcs11 tpm2-tss"
++            modules=(fido pkcs11 tpm2-tss)
 +        else
 +            # MIPS64: No chance for TPM2 on these platforms.
-+            modules=""
++            modules=()
 +        fi
-+        for module in "$modules"; do
++        for module in ${modules[@]}; do
              module_check $module > /dev/null 2>&1
              if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then
                  deps+=" $module"

--- a/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
@@ -1,7 +1,7 @@
-From 564a31a4ba34114a0761763c6d45ac6522c78a1e Mon Sep 17 00:00:00 2001
+From 8adf8561997a7a8f42a4f34f27b96f4d039087af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:56:34 +0800
-Subject: [PATCH 3/5] AOSCOS: LOONGSON3: 90kernel-modules: minimise default
+Subject: [PATCH 3/6] AOSCOS: LOONGSON3: 70kernel-modules: minimise default
  kernel drivers
 
 Make sure that only drivers that were likely needed at early-boot were
@@ -10,6 +10,7 @@ included as part of the initramfs.
 Saves about 5MiB post-XZ.
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  modules.d/70kernel-modules/module-setup.sh | 89 ++++++++++++++--------
  1 file changed, 59 insertions(+), 30 deletions(-)

--- a/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-FROMLIST-feat-decompress-kernel-modules-and-firmware.patch
@@ -1,7 +1,7 @@
-From a2524047524cb8352fa99779ff849405201f9063 Mon Sep 17 00:00:00 2001
+From 4b06c400364c5305bb6e04086c5a0db11034a7c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:58:49 +0800
-Subject: [PATCH 4/5] FROMLIST: feat: decompress kernel modules and firmware
+Subject: [PATCH 4/6] FROMLIST: feat: decompress kernel modules and firmware
  before final compression
 
 Decompress all kernel modules and firmware (if compressed), this allows

--- a/app-admin/dracut-ng/autobuild/patches/0005-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
@@ -1,7 +1,7 @@
-From b0214e3c5a5d50972040aeea821f2a1e7c77e9db Mon Sep 17 00:00:00 2001
+From 17d06d00528ad4c2525ee2513697706201865e0a Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 1 Mar 2025 00:54:31 +0800
-Subject: [PATCH 5/5] fix(90kernel-modules): Explicitly include
+Subject: [PATCH 5/6] fix(70kernel-modules): Explicitly include
  xhci-pci-renesas
 
 Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends
@@ -45,6 +45,8 @@ keyboard and a mouse being detected only after the initrd switched root:
 [   11.652409] hid-generic 0003:1532:0114.0002: input,hidraw1: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input1
 [   11.653054] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.2/0003:1532:0114.0003/input/input15
 [   11.703768] hid-generic 0003:1532:0114.0003: input,hidraw2: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input2
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  modules.d/70kernel-modules/module-setup.sh | 8 +++++++-
  1 file changed, 7 insertions(+), 1 deletion(-)

--- a/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-revert-efaee44-hostonly_cmdline-should-continue-to-d.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-revert-efaee44-hostonly_cmdline-should-continue-to-d.patch
@@ -1,0 +1,23 @@
+From 44a55fa1dcfe0ebeb6d48f5263870229d556a5ea Mon Sep 17 00:00:00 2001
+From: Jo Zzsi <jozzsicsataban@gmail.com>
+Date: Tue, 12 Aug 2025 07:17:52 -0400
+Subject: [PATCH 6/6] revert(efaee44): hostonly_cmdline should continue to
+ default to yes
+
+Despite the Fedora setting, let's keep the default to yes
+for distributions that do not whish to overwrite the default.
+---
+ dracut.conf.d/hostonly/10-hostonly.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/dracut.conf.d/hostonly/10-hostonly.conf b/dracut.conf.d/hostonly/10-hostonly.conf
+index c5bd9b22..72fc9299 100644
+--- a/dracut.conf.d/hostonly/10-hostonly.conf
++++ b/dracut.conf.d/hostonly/10-hostonly.conf
+@@ -1,3 +1,2 @@
+ # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
+ hostonly="yes"
+-hostonly_cmdline=no
+-- 
+2.50.1
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,4 +1,5 @@
 VER=108
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: fix luks boot
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- dracut-ng: 108-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
