### PR TITLE
kstars: update to 3.7.8

### DIFF
--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,5 +1,4 @@
-VER=3.7.5
-REL=1
+VER=3.7.8
 SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
-CHKSUMS="sha256::2fd87255f76016515f33a3328d1e1b51af3a1473db560ef10563d8f18487517c"
+CHKSUMS="sha256::55b3aef29ec1aba50906bd393d565e8a7e0b5b3a5d2e8e3cdfc1b58d718d2c0c"
 CHKUPDATE="anitya::id=229035"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.7.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kstars: 1:3.7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
