### PR TITLE
rocm: support mips

### DIFF
--- a/runtime-rocm/rocm-bandwidth-test/autobuild/defines
+++ b/runtime-rocm/rocm-bandwidth-test/autobuild/defines
@@ -17,4 +17,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongson3)"

--- a/runtime-rocm/rocm-bandwidth-test/spec
+++ b/runtime-rocm/rocm-bandwidth-test/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/RadeonOpenCompute/rocm_bandwidth_test"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231445"
+REL=1

--- a/runtime-rocm/rocm-clr/autobuild/defines
+++ b/runtime-rocm/rocm-clr/autobuild/defines
@@ -28,4 +28,4 @@ CMAKE_AFTER=(
     "-DHIP_COMMON_DIR=$SRCDIR/../HIP"
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongson3)"

--- a/runtime-rocm/rocm-clr/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
+++ b/runtime-rocm/rocm-clr/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
@@ -1,8 +1,8 @@
 diff --git a/hipamd/src/hip_graph_internal.cpp b/hipamd/src/hip_graph_internal.cpp
-index e88454e12..7c792b44e 100644
+index e88454e12..5c98e7f6d 100644
 --- a/hipamd/src/hip_graph_internal.cpp
 +++ b/hipamd/src/hip_graph_internal.cpp
-@@ -797,9 +797,29 @@ void GraphKernelArgManager::ReadBackOrFlush() {
+@@ -797,9 +797,33 @@ void GraphKernelArgManager::ReadBackOrFlush() {
        address dev_ptr =
            kernarg_graph_.back().kernarg_pool_addr_ + kernarg_graph_.back().kernarg_pool_size_;
        auto kSentinel = *reinterpret_cast<volatile unsigned char*>(dev_ptr - 1);
@@ -14,6 +14,8 @@ index e88454e12..7c792b44e 100644
 +      asm volatile("dbar 0");
 +#elif defined(__riscv)
 +      asm volatile("fence rw,rw");
++#elif defined(__mips64)
++      asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -26,6 +28,8 @@ index e88454e12..7c792b44e 100644
 +      asm volatile("dbar 0");
 +#elif defined(__riscv)
 +      asm volatile("fence rw,rw");
++#elif defined(__mips64)
++      asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -33,10 +37,10 @@ index e88454e12..7c792b44e 100644
      }
    }
 diff --git a/rocclr/device/rocm/rocvirtual.cpp b/rocclr/device/rocm/rocvirtual.cpp
-index cb170365d..80bf53a25 100755
+index cb170365d..7127e6859 100755
 --- a/rocclr/device/rocm/rocvirtual.cpp
 +++ b/rocclr/device/rocm/rocvirtual.cpp
-@@ -3464,9 +3464,29 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes,
+@@ -3464,9 +3464,33 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes,
            auto kSentinel = *reinterpret_cast<volatile int*>(dev().info().hdpMemFlushCntl);
          } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback &&
                     argSize != 0) {
@@ -48,6 +52,8 @@ index cb170365d..80bf53a25 100755
 +          asm volatile("dbar 0");
 +#elif defined(__riscv)
 +          asm volatile("fence rw,rw");
++#elif defined(__mips64)
++          asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -60,6 +66,8 @@ index cb170365d..80bf53a25 100755
 +          asm volatile("dbar 0");
 +#elif defined(__riscv)
 +          asm volatile("fence rw,rw");
++#elif defined(__mips64)
++          asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -80,10 +88,10 @@ index d6aa00c8d..99b5ae96a 100644
  
  #if defined(ATI_ARCH_ARM)
 diff --git a/rocclr/os/os.hpp b/rocclr/os/os.hpp
-index 8509cc362..be3dd1f54 100644
+index 8509cc362..09df9da15 100644
 --- a/rocclr/os/os.hpp
 +++ b/rocclr/os/os.hpp
-@@ -358,6 +358,13 @@ ALWAYSINLINE address Os::currentStackPtr() {
+@@ -358,6 +358,16 @@ ALWAYSINLINE address Os::currentStackPtr() {
  #elif defined(ATI_ARCH_ARM)
        "mov %0,sp"
        : "=r"(value)
@@ -94,6 +102,9 @@ index 8509cc362..be3dd1f54 100644
 +#elif defined(ATI_ARCH_RISCV)
 +      "mv %0,sp"
 +      : "=r"(value)
++#elif defined(__mips64)
++      "move %0, $29"
++       : "=r"(value)
  #else
        ""
  #endif

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -7,4 +7,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="clr"
 CHKUPDATE="anitya::id=369562"
-REL=1
+REL=2

--- a/runtime-rocm/rocm-cmake/autobuild/defines
+++ b/runtime-rocm/rocm-cmake/autobuild/defines
@@ -11,4 +11,4 @@ CMAKE_AFTER=(
     "-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm"
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-cmake/spec
+++ b/runtime-rocm/rocm-cmake/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-cmake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231446"
+REL=1

--- a/runtime-rocm/rocm-comgr/autobuild/defines
+++ b/runtime-rocm/rocm-comgr/autobuild/defines
@@ -20,4 +20,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -3,3 +3,4 @@ SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/ll
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"
 CHKUPDATE="anitya::id=231449"
+REL=1

--- a/runtime-rocm/rocm-core/autobuild/defines
+++ b/runtime-rocm/rocm-core/autobuild/defines
@@ -13,4 +13,4 @@ CMAKE_AFTER=(
     "-DROCM_VERSION=$PKGVER"
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"
+REL=1

--- a/runtime-rocm/rocm-device-libs/autobuild/defines
+++ b/runtime-rocm/rocm-device-libs/autobuild/defines
@@ -17,4 +17,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-device-libs/spec
+++ b/runtime-rocm/rocm-device-libs/spec
@@ -3,3 +3,4 @@ SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/ll
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/device-libs/"
 CHKUPDATE="anitya::id=231449"
+REL=1

--- a/runtime-rocm/rocm-llvm/autobuild/beyond
+++ b/runtime-rocm/rocm-llvm/autobuild/beyond
@@ -2,6 +2,13 @@ abinfo "Generating symlink folder to /usr/lib/rocm/llvm ..."
 ln -sfv ./lib/llvm "$PKGDIR"/usr/lib/rocm/llvm
 abinfo "Generating symlink to /usr/lib/rocm/bin ..."
 mkdir -pv "$PKGDIR"/usr/lib/rocm/bin/
+
+if ab_match_arch loongson3 ; then
+  abinfo "try impl amdclang ..."
+  ln -sfv ../clang++ "$PKGDIR"/usr/lib/rocm/llvm/bin/amdclang++
+  ln -sfv ../clang "$PKGDIR"/usr/lib/rocm/llvm/bin/amdclang
+fi
+
 ln -sfv ../llvm/bin/amdclang++ "$PKGDIR"/usr/lib/rocm/bin/amdclang++
 ln -sfv ../llvm/bin/amdclang "$PKGDIR"/usr/lib/rocm/bin/amdclang
 ln -sfv ../llvm/bin/clang++ "$PKGDIR"/usr/lib/rocm/bin/clang++

--- a/runtime-rocm/rocm-llvm/autobuild/defines
+++ b/runtime-rocm/rocm-llvm/autobuild/defines
@@ -21,8 +21,8 @@ LLVM_BASE_SET="clang;lld;compiler-rt;clang-tools-extra;openmp"
 _LLVM_BASE_RUNTIME_SET="libcxx;libcxxabi;libunwind"
 
 ABTYPE=cmakeninja
-CMAKE_AFTER=(
-    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm/lib/llvm'
+_CMAKE_BASE=(
+   '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm/lib/llvm'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DBUILD_SHARED_LIBS=ON'
     '-DLLVM_ENABLE_LIBCXX=ON'
@@ -40,6 +40,9 @@ CMAKE_AFTER=(
     '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
     '-DCMAKE_SKIP_RPATH=OFF'
     '-DLLVM_INCLUDE_TESTS=OFF'
+)
+CMAKE_AFTER=(
+    ${_CMAKE_BASE[@]}
     "-DLLVM_ENABLE_PROJECTS=${LLVM_BASE_SET}"
     "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
 )
@@ -48,5 +51,8 @@ CMAKE_AFTER__LOONGARCH64=(
     '-DCMAKE_C_FLAGS=-mcmodel=extreme'
     '-DCMAKE_CXX_FLAGS=-mcmodel=extreme'
 )
-
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+CMAKE_AFTER__LOONGSON3=(
+    ${_CMAKE_BASE[@]}
+    '-DLLVM_ENABLE_PROJECTS=clang;lld;compiler-rt;openmp'
+)
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0007-llvm-linker-extra.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0007-llvm-linker-extra.patch
@@ -1,13 +1,14 @@
 diff --git a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
-index 66d7569ee9ae..cc116724ab6b 100644
+index 66d7569ee9ae..23ad5f41b254 100644
 --- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
 +++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
-@@ -613,6 +613,8 @@ Expected<StringRef> linkDevice(ArrayRef<StringRef> InputFiles,
+@@ -613,6 +613,9 @@ Expected<StringRef> linkDevice(ArrayRef<StringRef> InputFiles,
    case Triple::ppc64:
    case Triple::ppc64le:
    case Triple::systemz:
 +  case Triple::loongarch64:
 +  case Triple::riscv64:
++  case Triple::mips64el:
      return generic::clang(InputFiles, Args);
    default:
      return createStringError(Triple.getArchName() +

--- a/runtime-rocm/rocm-llvm/autobuild/prepare
+++ b/runtime-rocm/rocm-llvm/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Overriding GNU config files ..."
+cp -v /usr/bin/config.* cmake/

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -4,3 +4,4 @@ CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"
 CHKUPDATE="anitya::id=231449"
 ENVREQ="total_mem_per_core=1"
+REL=1

--- a/runtime-rocm/rocm-rocprofiler-register/autobuild/defines
+++ b/runtime-rocm/rocm-rocprofiler-register/autobuild/defines
@@ -20,4 +20,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocm-rocprofiler-register/spec
+++ b/runtime-rocm/rocm-rocprofiler-register/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocprofiler-register"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378513"
+REL=1

--- a/runtime-rocm/rocminfo/autobuild/defines
+++ b/runtime-rocm/rocminfo/autobuild/defines
@@ -11,4 +11,4 @@ CMAKE_AFTER=(
     '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocminfo/spec
+++ b/runtime-rocm/rocminfo/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocminfo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231452"
+REL=2

--- a/runtime-rocm/rocr-runtime/autobuild/defines
+++ b/runtime-rocm/rocr-runtime/autobuild/defines
@@ -21,4 +21,4 @@ CMAKE_AFTER=(
     '-DCMAKE_LINKER_TYPE=LLD'
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64|loongson3)"

--- a/runtime-rocm/rocr-runtime/autobuild/patches/0001-support-arm64-loongarch64-riscv64.patch
+++ b/runtime-rocm/rocr-runtime/autobuild/patches/0001-support-arm64-loongarch64-riscv64.patch
@@ -12,10 +12,10 @@ index 177465c0..1d0166e6 100644
  namespace amd {
  namespace elf {
 diff --git a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
-index 0045289e..02ac2edf 100644
+index 0045289e..da85cfde 100644
 --- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
 +++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
-@@ -435,9 +435,29 @@ class GpuAgent : public GpuAgentInt {
+@@ -435,9 +435,33 @@ class GpuAgent : public GpuAgentInt {
    /// @brief Force a WC flush on PCIe devices by doing a write and then read-back
    __forceinline void PcieWcFlush(void *ptr, size_t size) const {
      if (!xgmi_cpu_gpu_) {
@@ -27,6 +27,8 @@ index 0045289e..02ac2edf 100644
 +        asm volatile("dbar 0");
 +#elif defined(__riscv)
 +        asm volatile("fence w, w");
++#elif defined(__mips64)
++	asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -39,6 +41,8 @@ index 0045289e..02ac2edf 100644
 +        asm volatile("dbar 0");
 +#elif defined(__riscv)
 +        asm volatile("fence rw, rw");
++#elif defined(__mips64)
++        asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -46,10 +50,10 @@ index 0045289e..02ac2edf 100644
      }
    }
 diff --git a/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp b/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
-index f8613dbb..293ce203 100644
+index f8613dbb..a2bd804a 100644
 --- a/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
 +++ b/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
-@@ -1665,7 +1665,17 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
+@@ -1665,7 +1665,19 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
    memcpy(&queue_slot[1], &slot_data[1], slot_size_b - sizeof(uint32_t));
    if (core::Runtime::runtime_singleton_->flag().dev_mem_queue() && !agent_->is_xgmi_cpu_gpu()) {
      // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -61,17 +65,19 @@ index f8613dbb..293ce203 100644
 +      asm volatile("dbar 0");
 +#elif defined(__riscv)
 +      asm volatile("fence w, w");
++#elif defined(__mips64)
++      asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
    }
    atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
-
+ 
 diff --git a/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp b/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
-index 36d21fa1..0dd14b2d 100644
+index 36d21fa1..de8bed56 100644
 --- a/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
 +++ b/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
-@@ -1274,7 +1274,17 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
+@@ -1274,7 +1274,19 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
    std::atomic_thread_fence(std::memory_order_release);
    if (core::Runtime::runtime_singleton_->flag().dev_mem_queue() && !queue_->needsPcieOrdering()) {
      // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -83,17 +89,19 @@ index 36d21fa1..0dd14b2d 100644
 +    asm volatile("dbar 0");
 +#elif defined(__riscv)
 +    asm volatile("fence w, w");
++#elif defined(__mips64)
++    asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
    }
    queue_buffer[index & queue_bitmask_].header = kDispatchPacketHeader;
-
+ 
 diff --git a/runtime/hsa-runtime/core/runtime/intercept_queue.cpp b/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
-index a86dabb3..b85db5ed 100644
+index a86dabb3..dcd0d196 100644
 --- a/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
 +++ b/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
-@@ -258,7 +258,17 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
+@@ -258,7 +258,19 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
        ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
        if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
          // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -105,13 +113,15 @@ index a86dabb3..b85db5ed 100644
 +        asm volatile("dbar 0");
 +#elif defined(__riscv)
 +        asm volatile("fence w, w");
++#elif defined(__mips64)
++        asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
        }
        atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                      std::memory_order_release);
-@@ -305,7 +315,17 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
+@@ -305,7 +317,19 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
        if (write_index != 0) {
          if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
            // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -123,13 +133,15 @@ index a86dabb3..b85db5ed 100644
 +          asm volatile("dbar 0");
 +#elif defined(__riscv)
 +          asm volatile("fence w,w");
++#elif defined(__mips64)
++          asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
          }
          atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                        std::memory_order_release);
-@@ -374,7 +394,17 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
+@@ -374,7 +398,19 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
      handler.first(&ring[i & mask], 1, i, handler.second, PacketWriter);
      if (Runtime::runtime_singleton_->flag().dev_mem_queue() && !needsPcieOrdering()) {
        // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -141,6 +153,8 @@ index a86dabb3..b85db5ed 100644
 +      asm volatile("dbar 0");
 +#elif defined(__riscv)
 +      asm volatile("fence w, w");
++#elif defined(__mips64)
++      asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
@@ -154,7 +168,7 @@ index 4d629798..efb0fc73 100644
 @@ -65,7 +65,7 @@
  #include <cpuid.h>
  #endif
-
+ 
 -#ifdef __GLIBC__
 +#if defined(__GLIBC__) && !defined(__riscv)
  #define ABS_ADDR(base, ptr) (ptr)
@@ -177,7 +191,7 @@ index 6c0de49a..e8fc7de8 100644
          os::YieldThread();
        } else {
 diff --git a/runtime/hsa-runtime/core/util/utils.h b/runtime/hsa-runtime/core/util/utils.h
-index 66c2028a..2e8bd00a 100644
+index 66c2028a..d976918b 100644
 --- a/runtime/hsa-runtime/core/util/utils.h
 +++ b/runtime/hsa-runtime/core/util/utils.h
 @@ -354,6 +354,7 @@ static __forceinline std::string& trim(std::string& s) { return ltrim(rtrim(s));
@@ -186,9 +200,9 @@ index 66c2028a..2e8bd00a 100644
  inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
 +#if defined(__x86_64__)
    static long cacheline_size = 0;
-
+ 
    if (!cacheline_size) {
-@@ -369,6 +370,15 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
+@@ -369,6 +370,17 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
      _mm_clflush((const void*)cur);
      cur += cacheline_size;
    } while (cur <= (const char*)lastline);
@@ -198,19 +212,21 @@ index 66c2028a..2e8bd00a 100644
 +  asm volatile("dbar 0");
 +#elif defined(__riscv)
 +  asm volatile("fence rw, rw");
++#elif defined(__mips64)
++  asm volatile("sync":::"memory");
 +#else
 +#error
 +#endif
  }
-
+ 
  }  // namespace rocr
 diff --git a/runtime/hsa-runtime/image/util.h b/runtime/hsa-runtime/image/util.h
 index 88cdf4cc..a28fc031 100644
 --- a/runtime/hsa-runtime/image/util.h
 +++ b/runtime/hsa-runtime/image/util.h
 @@ -74,9 +74,10 @@ namespace image {
-
-
+ 
+ 
  #if defined(__GNUC__)
 -#include "mm_malloc.h"
  #if defined(__i386__) || defined(__x86_64__)

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -2,4 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/rocm-$VER;rename=ROCR-Runtime::https://github.com/ROCm/ROCR-Runtime"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231453"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- rocm-cmake: enable mips
- rocm-bandwidth-test: enable mips
- rocm-clr: enable mips
- rocminfo: enable mips
- rocr-runtime: enable mips
- rocm-rocprofiler-register: enable mips
- rocm-comgr: enable mips
- rocm-device-libs: enable mips
- rocm-llvm: enable mips
- rocm-core: enable mips

Package(s) Affected
-------------------

- rocm-bandwidth-test: 6.4.3-1
- rocm-clr: 6.4.3-2
- rocm-cmake: 6.4.3-1
- rocm-comgr: 6.4.3-1
- rocm-core: 6.4.3-1
- rocm-device-libs: 6.4.3-1
- rocm-llvm: 6.4.3-1
- rocm-rocprofiler-register: 6.4.3-1
- rocminfo: 6.4.3-2
- rocr-runtime: 6.4.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-rocprofiler-register rocr-runtime rocminfo rocm-cmake rocm-clr rocm-bandwidth-test
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
