### PR TITLE
tauri-cli: update to 2.7.1

### DIFF
--- a/lang-rust/tauri-cli/autobuild/build
+++ b/lang-rust/tauri-cli/autobuild/build
@@ -1,5 +1,5 @@
-abinfo "Building ..."
+abinfo "Building tauri-cli ..."
 cargo build --release -p tauri-cli
 
-abinfo "Installing ..."
+abinfo "Installing tauri-cli ..."
 install -Dvm755 "$SRCDIR"/target/release/cargo-tauri -t "$PKGDIR"/usr/bin/

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -4,5 +4,4 @@ PKGSEC=devel
 PKGDEP="bzip2 gcc-runtime glibc xz"
 BUILDDEP="rustc llvm"
 
-# FIXME: ld.lld: error: undefined hidden symbol: ring_core_0_17_8_OPENSSL_ia32cap_P
-NOLTO=1
+USECLANG=1

--- a/lang-rust/tauri-cli/spec
+++ b/lang-rust/tauri-cli/spec
@@ -1,4 +1,4 @@
-VER=2.4.1
+VER=2.7.1
 SRCS="git::commit=tags/tauri-cli-v$VER::https://github.com/tauri-apps/tauri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371844"


### PR DESCRIPTION
Topic Description
-----------------

- tauri-cli: update to 2.7.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- tauri-cli: 2.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tauri-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
