### PR TITLE
xfsprogs: update to 6.15.0

### DIFF
--- a/app-admin/xfsprogs/spec
+++ b/app-admin/xfsprogs/spec
@@ -1,4 +1,4 @@
-VER=6.14.0
+VER=6.15.0
 SRCS="https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-$VER.tar.xz"
-CHKSUMS="sha256::fa5ab77f8b5169ce48dd8de09446ad7e29834a05b8f52012bae411cf53ec1f58"
+CHKSUMS="sha256::13b91f74beef8ad11137f7d9d71055573d91e961bc55bb0245956f69b84cd704"
 CHKUPDATE="anitya::id=5188"


### PR DESCRIPTION
Topic Description
-----------------

- xfsprogs: update to 6.15.0

Package(s) Affected
-------------------

- xfsprogs: 6.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
