### PR TITLE
emacs: update to 30.2

### DIFF
--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,4 +1,4 @@
-VER=30.1
+VER=30.2
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
-CHKSUMS="sha256::54404782ea5de37e8fcc4391fa9d4a41359a4ba9689b541f6bc97dd1ac283f6c"
+CHKSUMS="sha256::1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d"
 CHKUPDATE="anitya::id=675"


### PR DESCRIPTION
Topic Description
-----------------

- emacs: update to 30.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- emacs: 30.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit emacs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
