### PR TITLE
openipmi: new, 2.0.37

### DIFF
--- a/app-utils/openipmi/autobuild/conffiles
+++ b/app-utils/openipmi/autobuild/conffiles
@@ -1,0 +1,2 @@
+/etc/ipmi/lan.conf
+/etc/ipmi/ipmisim1.emu

--- a/app-utils/openipmi/autobuild/defines
+++ b/app-utils/openipmi/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="openipmi"
+PKGDEP="net-snmp python-3 swig popt"
+PKGSEC="utils"
+PKGDES="Intelligent Platform Management Interface (IPMI) toolkit and libraries"
+ABTYPE="autotools"

--- a/app-utils/openipmi/autobuild/patches/0001-swig-python-use-python3.patch
+++ b/app-utils/openipmi/autobuild/patches/0001-swig-python-use-python3.patch
@@ -1,0 +1,45 @@
+From 4f67049e60daf490f674c7962eb1230d2874c60b Mon Sep 17 00:00:00 2001
+From: Camber Huang <camber@poi.science>
+Date: Fri, 15 Aug 2025 10:31:51 +0800
+Subject: [PATCH] swig/python: use python3
+
+Signed-off-by: Camber Huang <camber@poi.science>
+---
+ swig/python/openipmigui.py | 2 +-
+ swig/python/sample.py      | 2 +-
+ swig/python/sample2.py     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/swig/python/openipmigui.py b/swig/python/openipmigui.py
+index e874c87c..7b5df368 100755
+--- a/swig/python/openipmigui.py
++++ b/swig/python/openipmigui.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # openipmigui.py
+ #
+diff --git a/swig/python/sample.py b/swig/python/sample.py
+index 32604a67..c82f5a21 100755
+--- a/swig/python/sample.py
++++ b/swig/python/sample.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ 
+ # sample
+ #
+diff --git a/swig/python/sample2.py b/swig/python/sample2.py
+index 92ccdc4b..b86e75f9 100755
+--- a/swig/python/sample2.py
++++ b/swig/python/sample2.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ 
+ # sample2
+ #
+-- 
+2.39.5 (Apple Git-154)
+

--- a/app-utils/openipmi/spec
+++ b/app-utils/openipmi/spec
@@ -1,0 +1,4 @@
+VER=2.0.37
+SRCS="tbl::https://sourceforge.net/projects/openipmi/files/OpenIPMI%202.0%20Library/OpenIPMI-$VER.tar.gz/download"
+CHKSUMS="sha256::c62d38f5da7df4299ac3a652508e959537752440181e34c76b2aecebd7f301b9"
+CHKUPDATE="anitya::id=2549"


### PR DESCRIPTION
Topic Description
-----------------

- openipmi: new, 2.0.37
    Signed-off-by: Camber Huang <camber@aosc.io>

Package(s) Affected
-------------------

- openipmi: 2.0.37

Security Update?
----------------

No

Build Order
-----------

```
#buildit openipmi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
