### PR TITLE
ispc: update to 1.28.0

### DIFF
--- a/app-devel/ispc/spec
+++ b/app-devel/ispc/spec
@@ -1,5 +1,4 @@
-VER=1.27.0
+VER=1.28.0
 SRCS="git::commit=tags/v$VER::https://github.com/ispc/ispc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11544"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ispc: update to 1.28.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- ispc: 1.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ispc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
