### PR TITLE
doggo: new, 1.0.5

### DIFF
--- a/app-network/doggo/autobuild/defines
+++ b/app-network/doggo/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=doggo
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="Command-line DNS client"
+ABTYPE=gomod
+GO_LDFLAGS=("-X" "main.buildVersion=$PKGVER")
+GO_PACKAGES=("cmd/doggo")

--- a/app-network/doggo/spec
+++ b/app-network/doggo/spec
@@ -1,0 +1,4 @@
+VER=1.0.5
+SRCS="git::commit=tags/v$VER::https://github.com/mr-karan/doggo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373317"


### PR DESCRIPTION
Topic Description
-----------------

- doggo: new, 1.0.5

Package(s) Affected
-------------------

- doggo: 1.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit doggo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
