### PR TITLE
gnupg: add pinentry dependency

### DIFF
--- a/app-cryptography/gnupg/autobuild/defines
+++ b/app-cryptography/gnupg/autobuild/defines
@@ -3,11 +3,10 @@ PKGSEC=libs
 PKGDES="Complete and free implementation of the OpenGPG standard"
 
 PKGDEP="openldap libusb bzip2 libksba libgcrypt \
-        libassuan readline npth zlib libgpg-error gnutls sqlite"
+        libassuan readline npth zlib libgpg-error gnutls sqlite pinentry"
 PKGDEP__RETRO="bzip2 libgpg-error libgcrypt libassuan libksba \
-         npth readline"
+         npth readline pinentry"
 # gnupg has no library dependency on pinentry, but relies on it to enter passphrase
-PKGSUG="pinentry"
 BUILDDEP="transfig"
 
 # Do NOT let gnupg try to regenerate version string from git

--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,5 @@
 VER=2.4.8
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
 CHKSUMS="sha256::b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616"
 CHKUPDATE="anitya::id=1215"


### PR DESCRIPTION
Topic Description
-----------------

- gnupg: add pinentry dependency

Package(s) Affected
-------------------

- gnupg: 2:2.4.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnupg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
