### PR TITLE
aide: update to 0.19.2

### DIFF
--- a/app-utils/aide/autobuild/defines
+++ b/app-utils/aide/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=aide
 PKGSEC=utils
-PKGDEP="elfutils mhash"
+PKGDEP="elfutils"
 PKGDES="File integrity checker and intrusion detector"
 
-AUTOTOOLS_AFTER="--with-mhash --with-posix-acl --with-xattr \
+AUTOTOOLS_AFTER="--with-posix-acl --with-xattr \
                  --with-zlib --with-e2fsattrs --disable-static"
 ABSHADOW=no

--- a/app-utils/aide/spec
+++ b/app-utils/aide/spec
@@ -1,4 +1,3 @@
-VER=0.16.2
+VER=0.19.2
 SRCS="tbl::https://github.com/aide/aide/releases/download/v$VER/aide-$VER.tar.gz"
-CHKSUMS='sha256::17f998ae6ae5afb9c83578e4953115ab8a2705efc50dee5c6461cef3f521b797'
-CHKUPDATE="anitya::id=10341"
+CHKSUMS="sha256::23762b05f46111edeb3c8a05016c8731c01bdb8c1f91be48c156c31ab85e74c4"

--- a/topics/aide-0.19.2.toml
+++ b/topics/aide-0.19.2.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "AIDE 0.19.2"
+zh_CN = "AIDE 0.19.2"
+
+[caution]
+default = "Fixes an improper output neutralization vulnerability - CVE-2025-54389 (Severity: Medium); Fixes a null pointer dereference vulnerability - CVE-2025-54409 (Severity: Medium)"
+zh_CN = "修复一处输出无害化处理不当漏洞，漏洞编号 CVE-2025-54389（严重性：中）；修复一处空指针解引用漏洞，漏洞编号 CVE-2025-54409（严重性：中）"
+
+[packages]
+"aide" = "0.19.2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add aide-0.19.2
- aide: update to 0.19.2

Package(s) Affected
-------------------

- aide: 0.19.2

Security Update?
----------------

**Yes**

[CVE-2025-54389](https://nvd.nist.gov/vuln/detail/CVE-2025-54389), [CVE-2025-54409](https://nvd.nist.gov/vuln/detail/CVE-2025-54409)

Build Order
-----------

```
#buildit aide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
