### PR TITLE
keyring: remove unnecessary ABSPLITDBG=0

### DIFF
--- a/lang-python/keyring/autobuild/defines
+++ b/lang-python/keyring/autobuild/defines
@@ -17,7 +17,6 @@ PKGDES="Store and access your passwords safely"
 
 ABHOST=noarch
 
-ABSPLITDBG=0
 NOPYTHON2=1
 
 ABTYPE=python


### PR DESCRIPTION
Topic Description
-----------------

- keyring: remove unnecessary \`ABSPLITDBG=0\`

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

