### PR TITLE
putty: update to 0.83

### DIFF
--- a/app-network/putty/spec
+++ b/app-network/putty/spec
@@ -1,4 +1,4 @@
-VER=0.81
+VER=0.83
 SRCS="tbl::https://the.earth.li/~sgtatham/putty/$VER/putty-$VER.tar.gz"
-CHKSUMS="sha256::cb8b00a94f453494e345a3df281d7a3ed26bb0dd7e36264f145206f8857639fe"
+CHKSUMS="sha256::718777c13d63d0dff91fe03162bc2a05b4dfc8b0827634cd60b51cefdff631c6"
 CHKUPDATE="anitya::id=5749"


### PR DESCRIPTION
Topic Description
-----------------

- putty: update to 0.83

Package(s) Affected
-------------------

- putty: 0.83

Security Update?
----------------

No

Build Order
-----------

```
#buildit putty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
