### PR TITLE
Python 2 Purging Survey 20250808

### DIFF
--- a/app-devices/yubikey-manager/autobuild/defines
+++ b/app-devices/yubikey-manager/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=yubikey-manager
 PKGSEC=admin
-PKGDEP="click enum34 pcsclite ccid swig pyscard \
+PKGDEP="click pcsclite ccid swig pyscard \
         fido2 pyopenssl"
 BUILDDEP="setuptools-python3 poetry-core"
 PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"

--- a/app-devices/yubikey-manager/spec
+++ b/app-devices/yubikey-manager/spec
@@ -2,3 +2,5 @@ VER=5.7.2
 SRCS="pypi::version=$VER::yubikey-manager"
 CHKSUMS="sha256::9aeb4035dcff8f6cb792e83f36e6a9152a9b5b65ac2c2e25e5f20d53c6064e62"
 CHKUPDATE="anitya::id=67946"
+
+REL=1

--- a/desktop-gnome/gtk-2/autobuild/defines
+++ b/desktop-gnome/gtk-2/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=gtk-2
 PKGSEC=x11
-PKGDEP="at-spi2-core cairo gdk-pixbuf pango python-2 shared-mime-info"
+PKGDEP="at-spi2-core cairo gdk-pixbuf pango shared-mime-info"
+PKGSUG="python-3"
 BUILDDEP="gobject-introspection gtk-doc vim"
 BUILDDEP__RETRO="gtk-doc"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"

--- a/desktop-gnome/gtk-2/spec
+++ b/desktop-gnome/gtk-2/spec
@@ -1,5 +1,5 @@
 VER=2.24.33
-REL=4
+REL=5
 SRCS="https://download.gnome.org/sources/gtk+/${VER:0:4}/gtk+-$VER.tar.xz"
 CHKSUMS="sha256::ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtk+/${VER:0:4}/;pattern=gtk\+-(.+?).tar.xz"

--- a/lang-python/asn1crypto/autobuild/defines
+++ b/lang-python/asn1crypto/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=asn1crypto
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Python ASN.1 library"
 
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/asn1crypto/spec
+++ b/lang-python/asn1crypto/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-SRCS="tbl::https://pypi.io/packages/source/a/asn1crypto/asn1crypto-$VER.tar.gz"
-CHKSUMS="sha256::87620880a477123e01177a1f73d0f327210b43a3cdbd714efcd2fa49a8d7b384"
+VER=1.5.1
+SRCS="pypi::version=$VER::asn1crypto"
+CHKSUMS="sha256::13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"
 CHKUPDATE="anitya::id=13875"
-REL=1

--- a/lang-python/characteristic/autobuild/defines
+++ b/lang-python/characteristic/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=characteristic
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Service identity verification for pyOpenSSL"
 
+ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/characteristic/spec
+++ b/lang-python/characteristic/spec
@@ -1,5 +1,5 @@
 VER=14.3.0
-REL=7
-SRCS="tbl::https://pypi.python.org/packages/source/c/characteristic/characteristic-$VER.tar.gz"
+REL=8
+SRCS="pypi::version=$VER::characteristic"
 CHKSUMS="sha256::ded68d4e424115ed44e5c83c2a901a0b6157a959079d7591d92106ffd3ada380"
 CHKUPDATE="anitya::id=5488"

--- a/lang-python/cleo/autobuild/defines
+++ b/lang-python/cleo/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=cleo
 PKGSEC=python
-PKGDEP="clikit tomli rapidfuzz python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="clikit tomli rapidfuzz python-3"
+BUILDDEP="poetry-core"
 PKGDES="Cleo allows you to create beautiful and testable command-line interfaces"
 
+ABTYPE=pep517
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/cleo/spec
+++ b/lang-python/cleo/spec
@@ -1,5 +1,4 @@
-VER=2.0.1
-SRCS="tbl::https://pypi.io/packages/source/c/cleo/cleo-$VER.tar.gz"
-CHKSUMS="sha256::eb4b2e1f3063c11085cebe489a6e9124163c226575a3c3be69b2e51af4a15ec5"
+VER=2.2.1
+SRCS="pypi::version=$VER::cleo"
+CHKSUMS="sha256::d9db0fa3a194efb9caadfe1e718bf48cc48f08b7b1ee8381526ecc67c58856c4"
 CHKUPDATE="anitya::id=21160"
-REL=1

--- a/lang-python/clikit/autobuild/defines
+++ b/lang-python/clikit/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=clikit
 PKGSEC=python
-PKGDEP="pastel pylev python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="pastel pylev python-3"
+BUILDDEP="poetry-core"
 PKGDES="A group of utilities to build beautiful and testable command line interfaces"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/clikit/spec
+++ b/lang-python/clikit/spec
@@ -1,5 +1,5 @@
 VER=0.6.2
-SRCS="https://pypi.io/packages/source/c/clikit/clikit-$VER.tar.gz"
+SRCS="pypi::version=$VER::clikit"
 CHKSUMS="sha256::442ee5db9a14120635c5990bcdbfe7c03ada5898291f0c802f77be71569ded59"
 CHKUPDATE="anitya::id=21159"
-REL=2
+REL=3

--- a/lang-python/configparser/autobuild/beyond
+++ b/lang-python/configparser/autobuild/beyond
@@ -1,1 +1,0 @@
-rm "$PKGDIR"/usr/lib/python2.7/site-packages/backports/__init__.py*

--- a/lang-python/configparser/autobuild/defines
+++ b/lang-python/configparser/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=configparser
-PKGSEC=python
-PKGDEP="python-2"
-BUILDDEP="setuptools"
-PKGDES="Brings the updated configparser from Python 3.5 to Python 2"
-
-ABHOST=noarch
-PKGEPOCH=1
-NOPYTHON3=1

--- a/lang-python/configparser/spec
+++ b/lang-python/configparser/spec
@@ -1,5 +1,0 @@
-VER=3.7.3
-REL=2
-SRCS="tbl::https://pypi.io/packages/source/c/configparser/configparser-$VER.tar.gz"
-CHKSUMS="sha256::27594cf4fc279f321974061ac69164aaebd2749af962ac8686b20503ac0bcf2d"
-CHKUPDATE="anitya::id=7020"

--- a/lang-python/constantly/autobuild/defines
+++ b/lang-python/constantly/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=constantly
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3 versioneer"
 PKGDES="Symbolic constants in Python"
 
+ABTYPE=pep517
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/constantly/spec
+++ b/lang-python/constantly/spec
@@ -1,5 +1,4 @@
-VER=15.1.0
-REL=3
-SRCS="tbl::https://pypi.io/packages/source/c/constantly/constantly-$VER.tar.gz"
-CHKSUMS="sha256::586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+VER=23.10.4
+SRCS="pypi::version=$VER::constantly"
+CHKSUMS="sha256::aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd"
 CHKUPDATE="anitya::id=19031"

--- a/lang-python/cryptography/autobuild/defines
+++ b/lang-python/cryptography/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=cryptography
 PKGDES="Exposes cryptographic recipes and primitives to Python developers"
 PKGSEC=python
-PKGDEP="asn1crypto cffi enum34 idna ipaddress pyasn1 six openssl"
-BUILDDEP="setuptools setuptools-rust appdirs wheel rustc llvm typing-extensions"
+PKGDEP="asn1crypto cffi idna ipaddress pyasn1 six openssl"
+BUILDDEP="setuptools-python3 setuptools-rust appdirs wheel rustc llvm typing-extensions"
 
 NOPYTHON2=1
 ABTYPE=python

--- a/lang-python/entrypoints/autobuild/defines
+++ b/lang-python/entrypoints/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=entrypoints
 PKGSEC=python
-PKGDEP="configparser"
-BUILDDEPS="setuptools"
+PKGDEP="python-3"
+BUILDDEPS="flit-core"
 PKGDES="Discover and load entry points from installed packages"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/entrypoints/spec
+++ b/lang-python/entrypoints/spec
@@ -1,5 +1,4 @@
-VER=0.3
-REL=4
-SRCS="tbl::https://pypi.io/packages/source/e/entrypoints/entrypoints-$VER.tar.gz"
-CHKSUMS="sha256::c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+VER=0.4
+SRCS="pypi::version=$VER::entrypoints"
+CHKSUMS="sha256::b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"
 CHKUPDATE="anitya::id=12081"

--- a/lang-python/enum34/autobuild/defines
+++ b/lang-python/enum34/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=enum34
-PKGSEC=python
-PKGDEP="python-2"
-BUILDDEP="setuptools"
-PKGDES="Enum backport for Python 2.x"
-
-NOPYTHON3=1
-ABHOST=noarch

--- a/lang-python/enum34/spec
+++ b/lang-python/enum34/spec
@@ -1,5 +1,0 @@
-VER=1.1.10
-REL=1
-SRCS="tbl::https://pypi.python.org/packages/source/e/enum34/enum34-$VER.tar.gz"
-CHKSUMS="sha256::cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"
-CHKUPDATE="anitya::id=8176"

--- a/lang-python/functools32/autobuild/defines
+++ b/lang-python/functools32/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=functools32
-PKGSEC=python
-PKGDEP="python-2"
-BUILDDEP="setuptools-python2"
-PKGDES="Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy"
-
-ABHOST=noarch
-NOPYTHON3=1

--- a/lang-python/functools32/spec
+++ b/lang-python/functools32/spec
@@ -1,5 +1,0 @@
-VER=3.2.3+2
-SRCS="tbl::https://pypi.io/packages/source/f/functools32/functools32-${VER/+/-}.tar.gz"
-CHKSUMS="sha256::f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
-CHKUPDATE="anitya::id=11225"
-REL=1

--- a/lang-python/html5lib-python/autobuild/defines
+++ b/lang-python/html5lib-python/autobuild/defines
@@ -1,8 +1,11 @@
 PKGNAME=html5lib-python
 PKGSEC=python
-PKGDEP="six webencodings python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="six webencodings python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="A Python HTML parser/tokenizer based on the WHATWG HTML5 spec"
 
 ABHOST=noarch
+ABTYPE=python
 PKGEPOCH=1
+
+NOPYTHON2=1

--- a/lang-python/html5lib-python/spec
+++ b/lang-python/html5lib-python/spec
@@ -1,5 +1,5 @@
 VER=1.1
-REL=2
-SRCS="tbl::https://github.com/html5lib/html5lib-python/archive/$VER.tar.gz"
-CHKSUMS="sha256::66e9e24a53c10c27abb6be8a3cf2cf55824c6ea1cef8570a633cb223ec46e894"
+REL=3
+SRCS="pypi::version=$VER::html5lib"
+CHKSUMS="sha256::b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
 CHKUPDATE="anitya::id=8053"

--- a/lang-python/hyper-h2/autobuild/defines
+++ b/lang-python/hyper-h2/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=hyper-h2
 PKGSEC=python
-PKGDEP="python-3 python-hpack hyperframe enum34"
-BUILDDEP="setuptools"
+PKGDEP="python-3 python-hpack hyperframe"
+BUILDDEP="setuptools-python3"
 PKGDES="HTTP/2 State-Machine based protocol implementation"
 
 NOPYTHON2=1

--- a/lang-python/hyperlink/autobuild/defines
+++ b/lang-python/hyperlink/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=hyperlink
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="A featureful, correct URL for Python"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/hyperlink/spec
+++ b/lang-python/hyperlink/spec
@@ -1,5 +1,4 @@
-VER=19.0.0
-SRCS="tbl::https://github.com/python-hyper/hyperlink/archive/v$VER.tar.gz"
-CHKSUMS="sha256::277c33e9b74ea6aaac8c133e9e40e8d1f4b807cb4f78ad5be111c3be860aad74"
-REL=3
+VER=21.0.0
+SRCS="pypi::version=$VER::hyperlink"
+CHKSUMS="sha256::427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b"
 CHKUPDATE="anitya::id=19142"

--- a/lang-python/incremental/autobuild/defines
+++ b/lang-python/incremental/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=incremental
 PKGSEC=python
-PKGDEP="click python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="tomli packaging python-3"
+BUILDDEP="hatchling"
 PKGDES="A small library that versions your Python projects"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/incremental/spec
+++ b/lang-python/incremental/spec
@@ -1,5 +1,4 @@
-VER=17.5.0
-REL=4
-SRCS="tbl::https://pypi.io/packages/source/i/incremental/incremental-$VER.tar.gz"
-CHKSUMS="sha256::7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3"
+VER=24.7.2
+SRCS="pypi::version=$VER::incremental"
+CHKSUMS="sha256::fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9"
 CHKUPDATE="anitya::id=19663"

--- a/lang-python/ipaddress/autobuild/defines
+++ b/lang-python/ipaddress/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=ipaddress
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="IPv4/IPv6 manipulation library"
 
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/ipaddress/spec
+++ b/lang-python/ipaddress/spec
@@ -1,5 +1,5 @@
 VER=1.0.23
-SRCS="tbl::https://pypi.io/packages/source/i/ipaddress/ipaddress-$VER.tar.gz"
+SRCS="pypi::version=$VER::ipaddress"
 CHKSUMS="sha256::b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"
-REL=3
+REL=4
 CHKUPDATE="anitya::id=6374"

--- a/lang-python/jsonschema-specifications/autobuild/defines
+++ b/lang-python/jsonschema-specifications/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=jsonschema-specifications
+PKGSEC=python
+PKGDEP="referencing python-3"
+BUILDDEP="hatchling hatch-vcs"
+PKGDES="The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+
+ABTYPE=pep517
+ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/jsonschema-specifications/spec
+++ b/lang-python/jsonschema-specifications/spec
@@ -1,0 +1,4 @@
+VER=2025.4.1
+SRCS="pypi::version=$VER::jsonschema-specifications"
+CHKSUMS="sha256::630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"
+CHKUPDATE="anitya::id=316377"

--- a/lang-python/jsonschema/autobuild/defines
+++ b/lang-python/jsonschema/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=jsonschema
 PKGSEC=python
-PKGDEP="attrs functools32 pyrsistent six"
-BUILDDEP="setuptools setuptools-scm"
+PKGDEP="attrs jsonschema-specifications referencing rpds-py python-3"
+BUILDDEP="hatchling hatch-vcs hatch-fancy-pypi-readme"
 PKGDES="An implementation of JSON Schema validation for Python"
 
+ABTYPE=pep517
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/jsonschema/spec
+++ b/lang-python/jsonschema/spec
@@ -1,5 +1,4 @@
-VER=3.2.0
-SRCS="tbl::https://pypi.io/packages/source/j/jsonschema/jsonschema-$VER.tar.gz"
-CHKSUMS="sha256::c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+VER=4.25.0
+SRCS="pypi::version=$VER::jsonschema"
+CHKSUMS="sha256::e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f"
 CHKUPDATE="anitya::id=3898"
-REL=1

--- a/lang-python/lockfile/autobuild/defines
+++ b/lang-python/lockfile/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=lockfile
 PKGSEC=python
 PKGDES="A platform-independent file locking module for Python"
-PKGDEP="python-3 python-2 pbr"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3 pbr"
+BUILDDEP="setuptools-python3"
 
 ABHOST=noarch
 ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/lockfile/spec
+++ b/lang-python/lockfile/spec
@@ -1,5 +1,5 @@
 VER=0.12.2
-SRCS="https://pypi.io/packages/source/l/lockfile/lockfile-${VER}.tar.gz"
+SRCS="pypi::version=$VER::lockfile"
 CHKSUMS="sha256::6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"
 CHKUPDATE="anitya::id=89384"
-REL=2
+REL=3

--- a/lang-python/maturin/autobuild/defines
+++ b/lang-python/maturin/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=maturin
 PKGSEC=python
 PKGDES="A tool for building Rust binaries as Python packages"
-PKGDEP="python-3 typing-extensions patchelf bzip2 xz"
-BUILDDEP="rustc llvm"
+PKGDEP="python-3"
+PKGSUG="zig patchelf"
+BUILDDEP="setuptools-python3 setuptools-rust tomli rustc llvm"
 
 # FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
 NOLTO__LOONGSON3=1

--- a/lang-python/maturin/spec
+++ b/lang-python/maturin/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.9.3
 SRCS="git::commit=tags/v$VER::https://github.com/PyO3/maturin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=42653"

--- a/lang-python/pastel/autobuild/beyond
+++ b/lang-python/pastel/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo "Removing tests site-package ..."
-rm -rv "$PKGDIR"/usr/lib/python$ABPY2VER/site-packages/tests
-rm -rv "$PKGDIR"/usr/lib/python$ABPY3VER/site-packages/tests

--- a/lang-python/pastel/autobuild/defines
+++ b/lang-python/pastel/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=pastel
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="poetry-core"
 PKGDES="Python module that brings colors to your terminal"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/pastel/spec
+++ b/lang-python/pastel/spec
@@ -1,5 +1,4 @@
-VER=0.2.0
+VER=0.2.1
 SRCS="pypi::version=$VER::pastel"
-CHKSUMS="sha256::46155fc523bdd4efcd450bbcb3f2b94a6e3b25edc0eb493e081104ad09e1ca36"
+CHKSUMS="sha256::e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"
 CHKUPDATE="anitya::id=21161"
-REL=2

--- a/lang-python/pkginfo/autobuild/defines
+++ b/lang-python/pkginfo/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=pkginfo
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Query metadatdata from sdists/bdists/installed packages"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/pkginfo/spec
+++ b/lang-python/pkginfo/spec
@@ -1,5 +1,4 @@
-VER=1.5.0.1
-SRCS="tbl::https://pypi.io/packages/source/p/pkginfo/pkginfo-$VER.tar.gz"
-CHKSUMS="sha256::7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb"
+VER=1.12.1.2
+SRCS="pypi::version=$VER::pkginfo"
+CHKSUMS="sha256::5cd957824ac36f140260964eba3c6be6442a8359b8c48f4adf90210f33a04b7b"
 CHKUPDATE="anitya::id=11017"
-REL=2

--- a/lang-python/ply/autobuild/defines
+++ b/lang-python/ply/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=ply
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Implementation of lex and yacc parsing tools"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/ply/spec
+++ b/lang-python/ply/spec
@@ -1,5 +1,5 @@
 VER=3.11
-REL=4
+REL=5
 SRCS="pypi::version=$VER::ply"
 CHKSUMS="sha256::00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
 CHKUPDATE="anitya::id=20112"

--- a/lang-python/pyrsistent/autobuild/defines
+++ b/lang-python/pyrsistent/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=pyrsistent
-PKGSEC=python
-PKGDEP="python-3"
-BUILDDEP="python-build python-installer wheel hypothesis-python"
-PKGDES="Persistent/Functional/Immutable data structures for Python"
-
-NOPYTHON2=1
-ABTYPE=pep517

--- a/lang-python/pyrsistent/spec
+++ b/lang-python/pyrsistent/spec
@@ -1,4 +1,0 @@
-VER=0.20.0
-SRCS="tbl::https://pypi.io/packages/source/p/pyrsistent/pyrsistent-$VER.tar.gz"
-CHKSUMS="sha256::4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4"
-CHKUPDATE="anitya::id=19676"

--- a/lang-python/pyscss/autobuild/defines
+++ b/lang-python/pyscss/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME=pyscss
 PKGDES="a Scss compiler for Python"
-PKGDEP="python-2 python-3 six pathlib enum34"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3 six pathlib"
+BUILDDEP="setuptools-python3"
 PKGSEC=python
+
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/pyscss/spec
+++ b/lang-python/pyscss/spec
@@ -1,5 +1,4 @@
-VER=1.3.7
-SRCS="git::commit=tags/$VER::https://github.com/Kronuz/pyScss/"
+VER=1.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/Kronuz/pyScss/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=87682"
-REL=2

--- a/lang-python/python-msgpack/autobuild/defines
+++ b/lang-python/python-msgpack/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME="python-msgpack"
 PKGSEC="python"
-PKGDEP="python-2 python-3"
-BUILDDEP="cython setuptools-python2 setuptools-python3"
+PKGDEP="python-3"
+BUILDDEP="cython setuptools-python3"
 PKGDES="MessagePack serializer implementation for Python"
+
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/python-msgpack/spec
+++ b/lang-python/python-msgpack/spec
@@ -1,5 +1,4 @@
-VER=1.0.2
-REL=2
+VER=1.1.1
 SRCS="pypi::version=$VER::msgpack"
-CHKSUMS="sha256::fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984"
+CHKSUMS="sha256::77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd"
 CHKUPDATE="anitya::id=21831"

--- a/lang-python/referencing/autobuild/defines
+++ b/lang-python/referencing/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=referencing
+PKGSEC=python
+PKGDEP="attrs rpds-py typing-extensions python-3"
+BUILDDEP="hatchling hatch-vcs"
+PKGDES="An implementation-agnostic implementation of JSON reference resolution"
+
+ABTYPE=pep517
+ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/referencing/spec
+++ b/lang-python/referencing/spec
@@ -1,0 +1,4 @@
+VER=0.36.2
+SRCS="pypi::version=$VER::referencing"
+CHKSUMS="sha256::df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"
+CHKUPDATE="anitya::id=304263"

--- a/lang-python/rpds-py/autobuild/defines
+++ b/lang-python/rpds-py/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=rpds-py
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="maturin cargo llvm"
+PKGDES="Python bindings to Rust's persistent data structures (rpds)"
+
+ABTYPE=pep517
+
+NOPYTHON2=1
+
+# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/lang-python/rpds-py/spec
+++ b/lang-python/rpds-py/spec
@@ -1,0 +1,4 @@
+VER=0.27.0
+SRCS="pypi::version=$VER::rpds-py"
+CHKSUMS="sha256::8b23cf252f180cda89220b378d917180f29d313cd6a07b2431c0d3b776aae86f"
+CHKUPDATE="anitya::id=330423"

--- a/lang-python/service-identity/autobuild/defines
+++ b/lang-python/service-identity/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=service-identity
 PKGSEC=python
-PKGDEP="attrs characteristic idna pyasn1-modules pyopenssl python-3"
+PKGDEP="attrs idna pyasn1-modules pyopenssl python-3"
 BUILDDEP="hatch-fancy-pypi-readme hatch-vcs hatchling"
 PKGDES="Service identity verification for pyOpenSSL"
 

--- a/lang-python/service-identity/spec
+++ b/lang-python/service-identity/spec
@@ -1,4 +1,4 @@
 VER=24.2.0
-SRCS="tbl::https://pypi.io/packages/source/s/service_identity/service_identity-$VER.tar.gz"
+SRCS="pypi::version=$VER::service_identity"
 CHKSUMS="sha256::b8683ba13f0d39c6cd5d625d2c5f65421d6d707b013b375c355751557cbe8e09"
 CHKUPDATE="anitya::id=199618"

--- a/lang-python/setuptools-python3/spec
+++ b/lang-python/setuptools-python3/spec
@@ -1,4 +1,4 @@
-VER=75.8.0
+VER=80.9.0
 SRCS="git::commit=tags/v$VER::https://github.com/pypa/setuptools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4021"

--- a/lang-python/trove-classifiers/spec
+++ b/lang-python/trove-classifiers/spec
@@ -1,4 +1,4 @@
-VER=2024.1.31
+VER=2025.8.6.13
 SRCS="git::commit=$VER::https://github.com/pypa/trove-classifiers.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88298"

--- a/lang-python/webencodings/autobuild/defines
+++ b/lang-python/webencodings/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=webencodings
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools setuptools-python2"
+BUILDDEP="setuptools-python3"
 PKGDES="Character encoding aliases for legacy web content"
 
 ABHOST=noarch

--- a/lang-python/wsproto/autobuild/defines
+++ b/lang-python/wsproto/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=wsproto
 PKGSEC=python
-PKGDEP="python-3 python-2 hyper-h11 enum34 setuptools"
+PKGDEP="hyper-h11 python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Sans-IO WebSocket protocol implementation"
 
+ABTYPE=python
 ABHOST=noarch
-BUILDDEP="setuptools-python2"
+
+NOPYTHON2=1

--- a/lang-python/wsproto/spec
+++ b/lang-python/wsproto/spec
@@ -1,5 +1,4 @@
-VER=1.0.0
-SRCS="https://pypi.io/packages/source/w/wsproto/wsproto-$VER.tar.gz"
-CHKSUMS="sha256::868776f8456997ad0d9720f7322b746bbe9193751b5b290b7f924659377c8c38"
+VER=1.2.0
+SRCS="pypi::version=$VER::wsproto"
+CHKSUMS="sha256::ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065"
 CHKUPDATE="anitya::id=18173"
-REL=2

--- a/lang-python/zope-interface/autobuild/defines
+++ b/lang-python/zope-interface/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=zope-interface
 PKGSEC=python
-PKGDEP="python-3 python-2"
-BUILDDEP="python-build python-installer setuptools wheel setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer setuptools-python3 wheel"
 PKGDES="An object interfaces implementation for Python"
 
 ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/zope-interface/spec
+++ b/lang-python/zope-interface/spec
@@ -1,5 +1,5 @@
 VER=7.2
-SRCS="tbl::https://pypi.io/packages/source/z/zope.interface/zope.interface-$VER.tar.gz"
+SRCS="pypi::version=$VER::zope.interface"
 CHKSUMS="sha256::8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe"
 CHKUPDATE="anitya::id=4112"
-REL=1
+REL=2

--- a/runtime-common/protobuf/autobuild/defines
+++ b/runtime-common/protobuf/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=protobuf
 PKGSEC=libs
-PKGDEP="gcc-runtime python-2 python-3 zlib abseil-cpp"
+PKGDEP="gcc-runtime python-3 zlib abseil-cpp"
 PKGDEP__RETRO="gcc-runtime zlib abseil-cpp"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -10,7 +10,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools-python3"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"

--- a/runtime-common/protobuf/spec
+++ b/runtime-common/protobuf/spec
@@ -1,5 +1,4 @@
-VER=25.2
-REL=2
-SRCS="https://github.com/protocolbuffers/protobuf/archive/v$VER/protobuf-$VER.tar.gz"
-CHKSUMS="sha256::8ff511a64fc46ee792d3fe49a5a1bcad6f7dc50dfbba5a28b0e5b979c17f9871"
+VER=32.0
+SRCS="git::commit=tags/v$VER::https://github.com/protocolbuffers/protobuf.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3715"

--- a/runtime-cryptography/gpgme/autobuild/beyond
+++ b/runtime-cryptography/gpgme/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Remove Python 2 support"
+rm -rf "$PKGDIR"/usr/lib/python2.7/

--- a/runtime-cryptography/gpgme/autobuild/defines
+++ b/runtime-cryptography/gpgme/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gpgme
 PKGSEC=libs
-PKGDEP="gnupg libassuan libgpg-error python-2 python-3"
+PKGDEP="gnupg libassuan libgpg-error python-3"
 PKGDEP__RETRO="gnupg libgpg-error"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/runtime-cryptography/gpgme/autobuild/defines.stage2
+++ b/runtime-cryptography/gpgme/autobuild/defines.stage2
@@ -1,6 +1,6 @@
 PKGNAME=gpgme
 PKGSEC=libs
-PKGDEP="gnupg libgpg-error python-2 python-3"
+PKGDEP="gnupg libgpg-error python-3"
 PKGDEP__RETRO="gnupg libgpg-error"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/runtime-cryptography/gpgme/spec
+++ b/runtime-cryptography/gpgme/spec
@@ -1,4 +1,4 @@
-VER=1.24.2
+VER=1.24.3
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$VER.tar.bz2"
-CHKSUMS="sha256::e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581"
+CHKSUMS="sha256::bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd"
 CHKUPDATE="anitya::id=1239"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-2: purge python 2 support
- gpgme: update to 1.24.3; purge python 2 support
- protobuf: update to 32.0; purge python 2 support
- python-msgpack: update to 1.1.1; switch to pep517; purge python 2 support
- setuptools-python3: update to 80.9.0
- trove-classifiers: update to 2025.8.6.13
- zope-interface: drop python 2 support; switch to pypi SRCS
- asn1crypto: update to 1.5.1; switch to pypi SRCS; purge python 2 support
- characteristic: purge python 2 support; switch to pypi SRCS
- service-identity: switch to pypi SRCS; clean PKGDEP

... and 27 more commits

Package(s) Affected
-------------------

- asn1crypto: 1.5.1
- characteristic: 14.3.0-8
- cleo: 2.2.1
- clikit: 0.6.2-3
- constantly: 23.10.4
- cryptography: 40.0.0
- entrypoints: 0.4
- gpgme: 1.24.3
- gtk-2: 2.24.33-5
- html5lib-python: 1:1.1-3
- hyper-h2: 4.0.0-1
- hyperlink: 21.0.0
- incremental: 24.7.2
- ipaddress: 1.0.23-4
- jsonschema: 4.25.0
- jsonschema-specifications: 2025.4.1
- lockfile: 0.12.2-3
- maturin: 1.9.3
- pastel: 0.2.1
- pkginfo: 1.12.1.2
- ply: 3.11-5
- protobuf: 32.0
- pyscss: 1.4.0
- python-msgpack: 1.1.1
- referencing: 0.36.2
- rpds-py: 0.27.0
- service-identity: 24.2.0
- setuptools-python3: 80.9.0
- trove-classifiers: 2025.8.6.13
- webencodings: 0.5.1
- wsproto: 1.2.0
- yubikey-manager: 5.7.2-1
- zope-interface: 7.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit webencodings ply pkginfo pastel lockfile ipaddress incremental hyperlink html5lib-python maturin rpds-py referencing jsonschema-specifications jsonschema yubikey-manager cryptography hyper-h2 pyscss wsproto constantly entrypoints clikit cleo service-identity characteristic asn1crypto zope-interface trove-classifiers setuptools-python3 python-msgpack protobuf gpgme gtk-2
```

Test Build(s) Done
------------------

