### PR TITLE
loonggpu-kernel-dkms: Add patches for backlight and 6.17-rc1 compatibility

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
@@ -1,7 +1,7 @@
 From 2e20048c55fa5ec168f5a44f4f5733c7e2703346 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:15 +0800
-Subject: [PATCH 01/38] chore: initialise a gitignore file
+Subject: [PATCH 01/46] chore: initialise a gitignore file
 
 Just to make my life easier.
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
@@ -1,7 +1,7 @@
 From f50458a8b381bb6b5858ad27b8ab51982d7655db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:29:59 +0800
-Subject: [PATCH 02/38] loonggpu: include: use video aperture helpers for Linux
+Subject: [PATCH 02/46] loonggpu: include: use video aperture helpers for Linux
  >= 6.13.
 
 Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
@@ -1,7 +1,7 @@
 From c8c543febf29491562e32a6c21805ca2af963c2f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:34:47 +0800
-Subject: [PATCH 03/38] loonggpu: pass string literal parameter to
+Subject: [PATCH 03/46] loonggpu: pass string literal parameter to
  MODULE_IMPORT_NS for Linux >= 6.13
 
 With commit cdd30ebb1b9f ("module: Convert symbol namespace to string

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
@@ -1,7 +1,7 @@
 From d78344d1e4534a20fbe9a9691fb20c86fa605701 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 11:51:25 +0800
-Subject: [PATCH 04/38] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
+Subject: [PATCH 04/46] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
  option
 
 This option is marked deprecated and causes a warning during DKMS builds.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
@@ -1,7 +1,7 @@
 From 37c11b5b83ccc184e10bdea24dc4c8ed02474d1d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:35 +0800
-Subject: [PATCH 05/38] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
+Subject: [PATCH 05/46] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
  unused variable i
 
 A variable `i' was defined under multiple functions, triggering

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
@@ -1,7 +1,7 @@
 From fb033217bfa7ca1b3b900ba448bd96688910b164 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:30:31 +0800
-Subject: [PATCH 06/38] loonggpu: gsgpu_vm: move struct definition to
+Subject: [PATCH 06/46] loonggpu: gsgpu_vm: move struct definition to
  include/gsgpu_vm.h
 
 Move struct definition to header so that non-static functions may access

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
@@ -1,7 +1,7 @@
 From 960d2e37e3a0b833b7f5ce34fb4d80a22e6b0c7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:33:02 +0800
-Subject: [PATCH 07/38] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
+Subject: [PATCH 07/46] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
 
 Lots of functions in this driver were missing prototype definitions,
 triggering a large number of `-Wmissing-prototypes' warnings.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 6 Feb 2025 18:12:15 +0800
-Subject: [PATCH 08/38] AOSCOS: loonggpu: remove driver date
+Subject: [PATCH 08/46] AOSCOS: loonggpu: remove driver date
 
 Following upstream changes.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,7 +1,7 @@
 From 535a3a5be05a569abe24eaa21ee6236a44744f3e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:03:46 +0800
-Subject: [PATCH 09/38] loonggpu: Remove unused fbdev_list field in
+Subject: [PATCH 09/46] loonggpu: Remove unused fbdev_list field in
  gsgpu_framebuffer
 
 This field is referred nowhere.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
@@ -1,7 +1,7 @@
 From 67052920d0d65c559f3d91cc1087dd7794eb9018 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:21:48 +0800
-Subject: [PATCH 10/38] loonggpu: Remove the unused gsgpu_fbdev_total_size
+Subject: [PATCH 10/46] loonggpu: Remove the unused gsgpu_fbdev_total_size
  function
 
 It's referred nowhere.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,7 +1,7 @@
 From 6505d6bb76b24f59444420c3105d20052cf02c23 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:27:04 +0800
-Subject: [PATCH 11/38] loonggpu: Improve fbdev object-test helper
+Subject: [PATCH 11/46] loonggpu: Improve fbdev object-test helper
 
 Follow the change of our reference implementation, allowing us to
 remove struct gsgpu_fbdev later.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,7 +1,7 @@
 From 84c8becebd2d7d1429b514a9b887b785fc98dcaf Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:34:42 +0800
-Subject: [PATCH 12/38] loonggpu: Remove struct gsgpu_fbdev and add some clean
+Subject: [PATCH 12/46] loonggpu: Remove struct gsgpu_fbdev and add some clean
  up code
 
 Both data fields in struct gsgpu_fbdev, the framebuffer and the

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,7 +1,7 @@
 From a169f227222a60a30f99c4640de9823f6dbacfff Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:50:01 +0800
-Subject: [PATCH 13/38] loonggpu: Move fbdev cleanup code into fb_destroy
+Subject: [PATCH 13/46] loonggpu: Move fbdev cleanup code into fb_destroy
  callback
 
 Fbdev calls struct fb_ops.fb_destroy after cleaning up the final

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,7 +1,7 @@
 From 9b5968d63571d2beff31fe0fbadd6b98540c7473 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:59:39 +0800
-Subject: [PATCH 14/38] loonggpu: Remove redundant info->par assignment
+Subject: [PATCH 14/46] loonggpu: Remove redundant info->par assignment
 
 It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
 kernel version is).

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,7 +1,7 @@
 From 3d6e1f3088cddf98c0bc419812908fdc14534ee1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:19:37 +0800
-Subject: [PATCH 15/38] loonggpu: Remove test for !screen_base in fbdev probing
+Subject: [PATCH 15/46] loonggpu: Remove test for !screen_base in fbdev probing
 
 The screen_base field comes from the fbdev BO and contains the fbdev
 framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,7 +1,7 @@
 From fd00f34c73088c7a838276c85a188a441549bbb1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:21:28 +0800
-Subject: [PATCH 16/38] loonggpu: Correctly clean up failed display probing
+Subject: [PATCH 16/46] loonggpu: Correctly clean up failed display probing
 
 Improve the fbdev probing function to fully clean up if it failed.
 Allows to remove special cases from fb_destroy as well.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,7 +1,7 @@
 From 83ef7728a8f023468e5c0aa4ec907b442ddd7d54 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:10:14 +0800
-Subject: [PATCH 17/38] loonggpu: Remove load callback from kms_driver
+Subject: [PATCH 17/46] loonggpu: Remove load callback from kms_driver
 
 The ".load" callback in "struct drm_driver" is deprecated. In order to
 remove the callback, we have to manually call "gsgpu_driver_load_kms"

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,7 +1,7 @@
 From 6a2e84785264b6dfc36a910b86fa7acd1b54d114 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
-Subject: [PATCH 18/38] loonggpu: Implement client-based fbdev emulation
+Subject: [PATCH 18/46] loonggpu: Implement client-based fbdev emulation
 
 Implement fbdev emulation on top of struct drm_client and its helpers.
 Replaces ad-hoc interfaces for restoring and closing fbdev emulation with

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,7 +1,7 @@
 From 09c4bae40f4d1191a3d8a8caab81a70f8c5d35c3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
-Subject: [PATCH 19/38] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+Subject: [PATCH 19/46] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
  call
 
 It's not needed anymore as now the generic drm_client_register() calls

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,7 +1,7 @@
 From 443a5275c42e8833079eb621775b7faf144e7b7c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
-Subject: [PATCH 20/38] loonggpu: Disable outputs when releasing fbdev client
+Subject: [PATCH 20/46] loonggpu: Disable outputs when releasing fbdev client
 
 Following up the reference implementation change to avoid potential
 errors.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,7 +1,7 @@
 From 5d470d0074d8db599d7aaf3334b56c9a51d266f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
-Subject: [PATCH 21/38] loonggpu: Run DRM default client setup
+Subject: [PATCH 21/46] loonggpu: Run DRM default client setup
 
 Rework fbdev probing to support fbdev_probe in struct drm_driver
 and remove the old fb_probe callback. Provide an initializer macro

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
@@ -1,7 +1,7 @@
 From 0871ad4bb96b29174dd0cb86b4758bd77592b376 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:36:09 +0800
-Subject: [PATCH 22/38] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
+Subject: [PATCH 22/46] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
 
 A comment in Kbuild says "using EXTRA_CFLAGS for compatibility with
 kernel older than 2.6.24" which does not make any sense for loonggpu: we

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
@@ -1,7 +1,7 @@
 From 8a7019df11c908bddbcc0ded58a6a38ce557318d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:59:23 +0800
-Subject: [PATCH 23/38] AOSCOS: loonggpu: Adapt for drm_sched_init struct
+Subject: [PATCH 23/46] AOSCOS: loonggpu: Adapt for drm_sched_init struct
  params
 
 Since kernel commit 796a9f55a8d1 ("drm/sched: Use struct for

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
@@ -1,7 +1,7 @@
 From 7b7a3db4e073f207cff231791a11d6a11a80c2cb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:07:26 +0800
-Subject: [PATCH 24/38] AOSCOS: loonggpu: Adapt for renaming of from_timer to
+Subject: [PATCH 24/46] AOSCOS: loonggpu: Adapt for renaming of from_timer to
  timer_container_of
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
@@ -1,7 +1,7 @@
 From 51778b8977329840486c9c0c3d7b65a9917461dd Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:15:51 +0800
-Subject: [PATCH 25/38] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
+Subject: [PATCH 25/46] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
  to timer_delete_sync
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,7 +1,7 @@
 From 5a01159f90249c17dd9acafe01b42ddd27f06e15 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 22 Jun 2025 16:05:51 +0800
-Subject: [PATCH 26/38] loonggpu: bridge: Adapt for recent kernel API changes
+Subject: [PATCH 26/46] loonggpu: bridge: Adapt for recent kernel API changes
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,7 +1,7 @@
 From cbfbdeabb1ae75c3979ddb0f8c35d1d7c01685f2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
-Subject: [PATCH 27/38] loonggpu: Remove the check against moving pinned BOs
+Subject: [PATCH 27/46] loonggpu: Remove the check against moving pinned BOs
 
 The check is already in the generic code.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
@@ -1,7 +1,7 @@
 From f24dbfb4d81ab70a5919f9281d349accdebcf2e2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
-Subject: [PATCH 28/38] loonggpu: Remove dead code
+Subject: [PATCH 28/46] loonggpu: Remove dead code
 
 The body of this if statement is obviously unreachable.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,7 +1,7 @@
 From 3f819995623623251838683cd761144fcd961d0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
-Subject: [PATCH 29/38] loonggpu: NFC: Clean up gsgpu_bo_move
+Subject: [PATCH 29/46] loonggpu: NFC: Clean up gsgpu_bo_move
 
 Just use goto to deduplicate some identical code, and wrap a long line
 to make the flow more similar to the reference implementation.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
@@ -1,7 +1,7 @@
 From c9a04e21d03f0385b57a074d8018e4011e3ec9df Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
-Subject: [PATCH 30/38] loonggpu: Handle tt moves properly
+Subject: [PATCH 30/46] loonggpu: Handle tt moves properly
 
 It seems required since a TTM move refactoring in 2020.  Following up the
 reference implementation change (and several changes after that).

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
@@ -1,7 +1,7 @@
 From 95174f237cc75370e7c99a69ab8779e2b263324a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
-Subject: [PATCH 31/38] loonggpu: Use multihop
+Subject: [PATCH 31/46] loonggpu: Use multihop
 
 Remove the code to move resources directly between
 SYSTEM and VRAM in favour of using the core ttm mulithop code.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,7 +1,7 @@
 From 859801da3ffd26fdc27a5a6f77484c9137a100f5 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
-Subject: [PATCH 32/38] loonggpu: Drop the unused no_wait_gpu parameter of
+Subject: [PATCH 32/46] loonggpu: Drop the unused no_wait_gpu parameter of
  gsgpu_move_blit
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,7 +1,7 @@
 From fef5eeb09edd5421ab852efc8e1bff0db0030e80 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
-Subject: [PATCH 33/38] loonggpu: Drop lg_ttm_tt_bind
+Subject: [PATCH 33/46] loonggpu: Drop lg_ttm_tt_bind
 
 Get rid of the ttm_tt_populate usage: this symbol is only exported if
 DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
@@ -1,7 +1,7 @@
 From 17d2c2dec632865fbb4bde88ac66e838153ace10 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:09:20 +0800
-Subject: [PATCH 34/38] loonggpu: Make the mode parameter of the mode_valid
+Subject: [PATCH 34/46] loonggpu: Make the mode parameter of the mode_valid
  callback of bridge_phy_cfg_funcs a pointer to const
 
 Fix a -Wdiscarded-qualifiers warning.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,7 +1,7 @@
 From f2f40bb47d116791d979df9fd1e6f09b5210bc0f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
-Subject: [PATCH 35/38] loonggpu: Remove an invalid "const" qualifier
+Subject: [PATCH 35/46] loonggpu: Remove an invalid "const" qualifier
 
 You obviously cannot sprintf things into a const char array!
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,7 +1,7 @@
 From 45ca1bad62a6824155b08fdbe627bb0a74d49763 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
-Subject: [PATCH 36/38] loonggpu: Fix the parameter order of a kmalloc_array
+Subject: [PATCH 36/46] loonggpu: Fix the parameter order of a kmalloc_array
  call
 
 The element size should be the second parameter.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,7 +1,7 @@
 From 5d88458aaf0edfb43d7674b8afa674e80406ea8e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
-Subject: [PATCH 37/38] loonggpu: Handle the different drm_client_setup.h
+Subject: [PATCH 37/46] loonggpu: Handle the different drm_client_setup.h
  location in 6.12
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,7 +1,7 @@
 From aedb6d4c922ba8a8d3019cbf29bc5b9a79b76022 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 13 Aug 2025 12:38:30 +0800
-Subject: [PATCH 38/38] loonggpu: Handle the error from gsgpu_driver_load_kms
+Subject: [PATCH 38/46] loonggpu: Handle the error from gsgpu_driver_load_kms
  correctly
 
 With a 4KiB-page kernel, gsgpu_gart_init will fail because it requires

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
@@ -1,0 +1,31 @@
+From b5446a8767e99c4d35fb5e9057a8eda188d791c2 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 20:06:53 +0800
+Subject: [PATCH 39/46] loonggpu: Adapt for drm_get_format_info() API change
+
+Link: https://git.kernel.org/torvalds/c/0e7d5874fb6b
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_fb.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index 936c36b..eedbe38 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -122,7 +122,12 @@ static int gsgpufb_create_pinned_object(struct drm_fb_helper *fb_helper,
+ 	int height = mode_cmd->height;
+ 	u32 cpp;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	info = drm_get_format_info(adev->ddev, mode_cmd->pixel_format,
++				   mode_cmd->modifier[0]);
++#else
+ 	info = drm_get_format_info(adev->ddev, mode_cmd);
++#endif
+ 	cpp = info->cpp[0];
+ 
+ 	/* need to align pitch with crtc limits */
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
@@ -1,0 +1,51 @@
+From 2d8b77ff31988dec54db98bff35d6315b9815b57 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 20:12:24 +0800
+Subject: [PATCH 40/46] loonggpu: Adapt for .fb_create API change
+
+Link: https://git.kernel.org/torvalds/c/81112eaac559
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_display.c   | 1 +
+ include/gsgpu_display.h | 9 +++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/gsgpu/gsgpu_display.c b/gsgpu/gsgpu_display.c
+index 8bcc5a2..69980f5 100644
+--- a/gsgpu/gsgpu_display.c
++++ b/gsgpu/gsgpu_display.c
+@@ -305,6 +305,7 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ struct drm_framebuffer *
+ gsgpu_display_user_framebuffer_create(struct drm_device *dev,
+ 				       struct drm_file *file_priv,
++				       GSGPU_FB_CREATE_DRM_FORMAT_INFO
+ 				       const struct drm_mode_fb_cmd2 *mode_cmd)
+ {
+ 	struct drm_gem_object *obj;
+diff --git a/include/gsgpu_display.h b/include/gsgpu_display.h
+index 46523aa..eb3f0ca 100644
+--- a/include/gsgpu_display.h
++++ b/include/gsgpu_display.h
+@@ -1,10 +1,19 @@
+ #ifndef __GSGPU_DISPLAY_H__
+ #define __GSGPU_DISPLAY_H__
+ 
++#include <linux/version.h>
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++#define GSGPU_FB_CREATE_DRM_FORMAT_INFO const struct drm_format_info *info,
++#else
++#define GSGPU_FB_CREATE_DRM_FORMAT_INFO
++#endif
++
+ uint32_t gsgpu_display_supported_domains(struct gsgpu_device *adev);
+ struct drm_framebuffer *
+ gsgpu_display_user_framebuffer_create(struct drm_device *dev,
+ 				       struct drm_file *file_priv,
++				       GSGPU_FB_CREATE_DRM_FORMAT_INFO
+ 				       const struct drm_mode_fb_cmd2 *mode_cmd);
+ int gsgpu_display_crtc_page_flip_target(struct drm_crtc *crtc,
+                                 struct drm_framebuffer *fb,
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
@@ -1,0 +1,33 @@
+From 0a1e7a25605f1df7048e5f4dd105a9e38fd201f8 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 20:15:46 +0800
+Subject: [PATCH 41/46] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
+ change
+
+Link: https://git.kernel.org/torvalds/c/a34cc7bf1034
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_display.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/gsgpu/gsgpu_display.c b/gsgpu/gsgpu_display.c
+index 69980f5..05e760f 100644
+--- a/gsgpu/gsgpu_display.c
++++ b/gsgpu/gsgpu_display.c
+@@ -293,7 +293,13 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ {
+ 	int ret;
+ 	rfb->base.obj[0] = obj;
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	drm_helper_mode_fill_fb_struct(dev, &rfb->base, NULL, mode_cmd);
++#else
+ 	drm_helper_mode_fill_fb_struct(dev, &rfb->base, mode_cmd);
++#endif
++
+ 	ret = drm_framebuffer_init(dev, &rfb->base, &gsgpu_fb_funcs);
+ 	if (ret) {
+ 		rfb->base.obj[0] = NULL;
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
@@ -1,0 +1,132 @@
+From 1b821f27321c039151ff82fe9f8bd0e06210c9b8 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 20:24:55 +0800
+Subject: [PATCH 42/46] loonggpu: Pass along the format info from .fb_create()
+ to drm_helper_mode_fill_fb_struct()
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_display.c |  8 +++++++-
+ gsgpu/gsgpu_fb.c      | 24 +++++++++++++++++-------
+ include/gsgpu_mode.h  |  2 ++
+ 3 files changed, 26 insertions(+), 8 deletions(-)
+
+diff --git a/gsgpu/gsgpu_display.c b/gsgpu/gsgpu_display.c
+index 05e760f..6fb765c 100644
+--- a/gsgpu/gsgpu_display.c
++++ b/gsgpu/gsgpu_display.c
+@@ -288,6 +288,7 @@ uint32_t gsgpu_display_supported_domains(struct gsgpu_device *adev)
+ 
+ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ 				    struct gsgpu_framebuffer *rfb,
++				    GSGPU_FB_CREATE_DRM_FORMAT_INFO
+ 				    const struct drm_mode_fb_cmd2 *mode_cmd,
+ 				    struct drm_gem_object *obj)
+ {
+@@ -295,7 +296,7 @@ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ 	rfb->base.obj[0] = obj;
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+-	drm_helper_mode_fill_fb_struct(dev, &rfb->base, NULL, mode_cmd);
++	drm_helper_mode_fill_fb_struct(dev, &rfb->base, info, mode_cmd);
+ #else
+ 	drm_helper_mode_fill_fb_struct(dev, &rfb->base, mode_cmd);
+ #endif
+@@ -341,7 +342,12 @@ gsgpu_display_user_framebuffer_create(struct drm_device *dev,
+ 		return ERR_PTR(-ENOMEM);
+ 	}
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	ret = gsgpu_display_framebuffer_init(dev, gsgpu_fb, info, mode_cmd, obj);
++#else
+ 	ret = gsgpu_display_framebuffer_init(dev, gsgpu_fb, mode_cmd, obj);
++#endif
++
+ 	if (ret) {
+ 		kfree(gsgpu_fb);
+ 		lg_drm_gem_object_put(obj);
+diff --git a/gsgpu/gsgpu_fb.c b/gsgpu/gsgpu_fb.c
+index eedbe38..8488433 100644
+--- a/gsgpu/gsgpu_fb.c
++++ b/gsgpu/gsgpu_fb.c
+@@ -108,12 +108,12 @@ int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int cpp, bool tiled)
+ }
+ 
+ static int gsgpufb_create_pinned_object(struct drm_fb_helper *fb_helper,
++					GSGPU_FB_CREATE_DRM_FORMAT_INFO
+ 					struct drm_mode_fb_cmd2 *mode_cmd,
+ 					struct drm_gem_object **gobj_p)
+ {
+ 	struct gsgpu_device *adev = fb_helper->dev->dev_private;
+ 	struct drm_gem_object *gobj = NULL;
+-	const struct drm_format_info *info;
+ 	struct gsgpu_bo *abo = NULL;
+ 	bool fb_tiled = false; /* useful for testing */
+ 	u32 tiling_flags = 0, domain;
+@@ -122,11 +122,9 @@ static int gsgpufb_create_pinned_object(struct drm_fb_helper *fb_helper,
+ 	int height = mode_cmd->height;
+ 	u32 cpp;
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+-	info = drm_get_format_info(adev->ddev, mode_cmd->pixel_format,
+-				   mode_cmd->modifier[0]);
+-#else
+-	info = drm_get_format_info(adev->ddev, mode_cmd);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
++	const struct drm_format_info *info =
++		drm_get_format_info(adev->ddev, mode_cmd);
+ #endif
+ 	cpp = info->cpp[0];
+ 
+@@ -213,7 +211,16 @@ int gsgpu_driver_fbdev_probe(struct drm_fb_helper *helper,
+ 	mode_cmd.pixel_format = drm_mode_legacy_fb_format(sizes->surface_bpp,
+ 							  sizes->surface_depth);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	const struct drm_format_info *format_info =
++		drm_get_format_info(adev->ddev, mode_cmd.pixel_format,
++				    mode_cmd.modifier[0]);
++	ret = gsgpufb_create_pinned_object(helper, format_info, &mode_cmd,
++					   &gobj);
++#else
+ 	ret = gsgpufb_create_pinned_object(helper, &mode_cmd, &gobj);
++#endif
++
+ 	if (ret) {
+ 		DRM_ERROR("failed to create fbcon object %d\n", ret);
+ 		return ret;
+@@ -228,7 +235,10 @@ int gsgpu_driver_fbdev_probe(struct drm_fb_helper *helper,
+ 	}
+ 
+ 	ret = gsgpu_display_framebuffer_init(adev->ddev, to_gsgpu_framebuffer(fb),
+-					      &mode_cmd, gobj);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++					     format_info,
++#endif
++					     &mode_cmd, gobj);
+ 	if (ret) {
+ 		DRM_ERROR("failed to initialize framebuffer %d\n", ret);
+ 		goto err_kfree;
+diff --git a/include/gsgpu_mode.h b/include/gsgpu_mode.h
+index be2e123..b08b967 100644
+--- a/include/gsgpu_mode.h
++++ b/include/gsgpu_mode.h
+@@ -12,6 +12,7 @@
+ 
+ #include "gsgpu_irq.h"
+ #include "gsgpu_dc_irq.h"
++#include "gsgpu_display.h"
+ 
+ struct gsgpu_bo;
+ struct gsgpu_device;
+@@ -156,6 +157,7 @@ int gsgpu_display_get_crtc_scanoutpos(struct drm_device *dev,
+ 
+ int gsgpu_display_framebuffer_init(struct drm_device *dev,
+ 				   struct gsgpu_framebuffer *rfb,
++				   GSGPU_FB_CREATE_DRM_FORMAT_INFO
+ 				   const struct drm_mode_fb_cmd2 *mode_cmd,
+ 				   struct drm_gem_object *obj);
+ 
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
@@ -1,0 +1,176 @@
+From 97ce999696fd7372e983b480a333666f23633723 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 23:18:18 +0800
+Subject: [PATCH 43/46] loonggpu: Pass DRM client ID to drm_sched_job_init
+
+Adapt for upstream API change.
+
+I'm really unsure if I missed a call site where an ID should be used
+instead of 0.
+
+Link: https://git.kernel.org/torvalds/c/2956554823ce
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_cs.c        | 3 ++-
+ gsgpu/gsgpu_job.c       | 4 ++--
+ gsgpu/gsgpu_ttm.c       | 6 +++---
+ gsgpu/gsgpu_ttm_buddy.c | 4 ++--
+ gsgpu/gsgpu_vm.c        | 6 +++---
+ include/gsgpu_helper.h  | 6 ++++--
+ include/gsgpu_job.h     | 2 +-
+ 7 files changed, 17 insertions(+), 14 deletions(-)
+
+diff --git a/gsgpu/gsgpu_cs.c b/gsgpu/gsgpu_cs.c
+index c465623..5e40281 100644
+--- a/gsgpu/gsgpu_cs.c
++++ b/gsgpu/gsgpu_cs.c
+@@ -1184,7 +1184,8 @@ static int gsgpu_cs_submit(struct gsgpu_cs_parser *p,
+ 	job = p->job;
+ 	p->job = NULL;
+ 
+-	r = lg_drm_sched_job_init(&job->base, entity, 1, p->filp);
++	r = lg_drm_sched_job_init(&job->base, entity, 1, p->filp,
++				  p->filp->client_id);
+ 	if (r)
+ 		goto error_unlock;
+ 
+diff --git a/gsgpu/gsgpu_job.c b/gsgpu/gsgpu_job.c
+index b94d369..41f51d3 100644
+--- a/gsgpu/gsgpu_job.c
++++ b/gsgpu/gsgpu_job.c
+@@ -108,7 +108,7 @@ void gsgpu_job_free(struct gsgpu_job *job)
+ }
+ 
+ int gsgpu_job_submit(struct gsgpu_job *job, struct drm_sched_entity *entity,
+-		      void *owner, struct dma_fence **f)
++		      void *owner, struct dma_fence **f, u64 client_id)
+ {
+ 	enum drm_sched_priority priority;
+ 	struct gsgpu_ring *ring;
+@@ -117,7 +117,7 @@ int gsgpu_job_submit(struct gsgpu_job *job, struct drm_sched_entity *entity,
+ 	if (!f)
+ 		return -EINVAL;
+ 
+-	r = lg_drm_sched_job_init(&job->base, entity, 1, owner);
++	r = lg_drm_sched_job_init(&job->base, entity, 1, owner, client_id);
+ 	if (r)
+ 		return r;
+ 	lg_drm_sched_job_arm(&job->base);
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index 95ccd5e..2cd63c0 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -1814,7 +1814,7 @@ static int gsgpu_map_buffer(struct ttm_buffer_object *bo,
+ 		goto error_free;
+ 
+ 	r = gsgpu_job_submit(job, &adev->mman.entity,
+-			      GSGPU_FENCE_OWNER_UNDEFINED, &fence);
++			      GSGPU_FENCE_OWNER_UNDEFINED, &fence, 0);
+ 	if (r)
+ 		goto error_free;
+ 
+@@ -1886,7 +1886,7 @@ int gsgpu_copy_buffer(struct gsgpu_ring *ring, uint64_t src_offset,
+ 		r = gsgpu_job_submit_direct(job, ring, fence);
+ 	else
+ 		r = gsgpu_job_submit(job, &adev->mman.entity,
+-				      GSGPU_FENCE_OWNER_UNDEFINED, fence);
++				      GSGPU_FENCE_OWNER_UNDEFINED, fence, 0);
+ 	if (r)
+ 		goto error_free;
+ 
+@@ -1978,7 +1978,7 @@ int gsgpu_fill_buffer(struct gsgpu_bo *bo,
+ 	gsgpu_ring_pad_ib(ring, &job->ibs[0]);
+ 	WARN_ON(job->ibs[0].length_dw > num_dw);
+ 	r = gsgpu_job_submit(job, &adev->mman.entity,
+-			      GSGPU_FENCE_OWNER_UNDEFINED, fence);
++			      GSGPU_FENCE_OWNER_UNDEFINED, fence, 0);
+ 	if (r)
+ 		goto error_free;
+ 
+diff --git a/gsgpu/gsgpu_ttm_buddy.c b/gsgpu/gsgpu_ttm_buddy.c
+index b636b15..71158e8 100644
+--- a/gsgpu/gsgpu_ttm_buddy.c
++++ b/gsgpu/gsgpu_ttm_buddy.c
+@@ -204,7 +204,7 @@ static int gsgpu_ttm_map_buffer(struct ttm_buffer_object *bo,
+ 	}
+ 
+ 	r = gsgpu_job_submit(job, &adev->mman.entity,
+-			     GSGPU_FENCE_OWNER_UNDEFINED, &fence);
++			     GSGPU_FENCE_OWNER_UNDEFINED, &fence, 0);
+ 	if (r)
+ 		gsgpu_job_free(job);
+ 
+@@ -269,7 +269,7 @@ static int gsgpu_ttm_fill_mem(struct gsgpu_ring *ring, uint32_t src_data,
+ 	gsgpu_ring_pad_ib(ring, &job->ibs[0]);
+ 	WARN_ON(job->ibs[0].length_dw > num_dw);
+ 	r = gsgpu_job_submit(job, &adev->mman.entity,
+-			     GSGPU_FENCE_OWNER_UNDEFINED, fence);
++			     GSGPU_FENCE_OWNER_UNDEFINED, fence, 0);
+ 	if (r)
+ 		gsgpu_job_free(job);
+ 
+diff --git a/gsgpu/gsgpu_vm.c b/gsgpu/gsgpu_vm.c
+index b369090..9de32fe 100644
+--- a/gsgpu/gsgpu_vm.c
++++ b/gsgpu/gsgpu_vm.c
+@@ -312,7 +312,7 @@ static int gsgpu_vm_clear_bo(struct gsgpu_device *ldev,
+ 	if (r)
+ 		goto error_free;
+ 
+-	r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_UNDEFINED, &fence);
++	r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_UNDEFINED, &fence, 0);
+ 	if (r)
+ 		goto error_free;
+ 
+@@ -930,7 +930,7 @@ restart:
+ 		gsgpu_ring_pad_ib(ring, params.ib);
+ 		gsgpu_sync_resv(ldev, &job->sync, resv, GSGPU_SYNC_ALWAYS, GSGPU_FENCE_OWNER_VM, false);
+ 		WARN_ON(params.ib->length_dw > ndw);
+-		r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_VM, &fence);
++		r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_VM, &fence, 0);
+ 		if (r)
+ 			goto error;
+ 
+@@ -1187,7 +1187,7 @@ static int gsgpu_vm_bo_update_mapping(struct gsgpu_device *ldev,
+ 
+ 	gsgpu_ring_pad_ib(ring, params.ib);
+ 	WARN_ON(params.ib->length_dw > ndw);
+-	r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_VM, &f);
++	r = gsgpu_job_submit(job, &vm->entity, GSGPU_FENCE_OWNER_VM, &f, 0);
+ 	if (r)
+ 		goto error_free;
+ 
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index 8cb4fa3..8fa0bf7 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -1174,9 +1174,11 @@ static inline void lg_ring_sched_thread_unpark(struct gsgpu_ring *ring)
+ 
+ static inline int lg_drm_sched_job_init(struct drm_sched_job *job,
+ 					struct drm_sched_entity *entity,
+-					u32 credits, void *owner)
++					u32 credits, void *owner, u64 client_id)
+ {
+-#if defined(LG_DRM_SCHED_JOB_INIT_HAS_CREDITS)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	return drm_sched_job_init(job, entity, credits, owner, client_id);
++#elif defined(LG_DRM_SCHED_JOB_INIT_HAS_CREDITS)
+ 	return drm_sched_job_init(job, entity, credits, owner);
+ #else
+ 	return drm_sched_job_init(job, entity, owner);
+diff --git a/include/gsgpu_job.h b/include/gsgpu_job.h
+index eed859c..5b4d3ab 100644
+--- a/include/gsgpu_job.h
++++ b/include/gsgpu_job.h
+@@ -43,7 +43,7 @@ int gsgpu_job_alloc_with_ib(struct gsgpu_device *adev, unsigned size,
+ void gsgpu_job_free_resources(struct gsgpu_job *job);
+ void gsgpu_job_free(struct gsgpu_job *job);
+ int gsgpu_job_submit(struct gsgpu_job *job, struct drm_sched_entity *entity,
+-		      void *owner, struct dma_fence **f);
++		      void *owner, struct dma_fence **f, u64 client_id);
+ int gsgpu_job_submit_direct(struct gsgpu_job *job, struct gsgpu_ring *ring,
+ 			     struct dma_fence **fence);
+ 
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
@@ -1,0 +1,31 @@
+From eaf52006639d5e39fa24879d86f00629b3db0f0f Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 23:20:01 +0800
+Subject: [PATCH 44/46] loonggpu: Adapt for the rename of
+ DRM_GPU_SCHED_STAT_NOMINAL to DRM_GPU_SCHED_STAT_RESET
+
+Link: https://git.kernel.org/torvalds/c/0a5dc1b67ef5
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/gsgpu_helper.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index 8fa0bf7..e21d402 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -422,7 +422,11 @@ static inline int lg_atomic_read_drm_open_count(struct drm_device *dev)
+ 
+ #if defined(LG_DRM_SCHED_BACKEND_OPS_TIMEDOUT_JOB_RET_SCHED_STAT)
+ #define lg_gsgpu_job_timedout_ret enum drm_gpu_sched_stat
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++#define LG_DRM_GPU_SCHED_STAT_NOMINAL DRM_GPU_SCHED_STAT_RESET
++#else
+ #define LG_DRM_GPU_SCHED_STAT_NOMINAL DRM_GPU_SCHED_STAT_NOMINAL
++#endif
+ #else
+ #define lg_gsgpu_job_timedout_ret void
+ #define LG_DRM_GPU_SCHED_STAT_NOMINAL
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
@@ -1,0 +1,104 @@
+From dfba9f4e909cf8d30265a3aa38850eea4d98cd74 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 15 Aug 2025 23:23:20 +0800
+Subject: [PATCH 45/46] loonggpu: Don't directly use ttm_bo_get
+
+Adapt for upstream API change which made this function internal.
+
+Link: https://git.kernel.org/torvalds/c/9ec1ac835e48
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_gem.c    | 9 ++-------
+ gsgpu/gsgpu_object.c | 8 +++-----
+ include/gsgpu.h      | 2 ++
+ 3 files changed, 7 insertions(+), 12 deletions(-)
+
+diff --git a/gsgpu/gsgpu_gem.c b/gsgpu/gsgpu_gem.c
+index 637c4d5..17c36a6 100644
+--- a/gsgpu/gsgpu_gem.c
++++ b/gsgpu/gsgpu_gem.c
+@@ -81,12 +81,11 @@ void gsgpu_gem_object_free(struct drm_gem_object *gobj)
+ 
+ 	if (robj) {
+ 		gsgpu_mn_unregister(robj);
+-		gsgpu_bo_unref(&robj);
++		ttm_bo_put(&robj->tbo);
+ 	}
+ }
+ 
+-#if !defined(LG_DRM_DRIVER_HAS_GEM_FREE)
+-static const struct drm_gem_object_funcs gsgpu_gem_object_funcs = {
++const struct drm_gem_object_funcs gsgpu_gem_object_funcs = {
+ 	.free = gsgpu_gem_object_free,
+ 	.open = gsgpu_gem_object_open,
+ 	.close = gsgpu_gem_object_close,
+@@ -96,7 +95,6 @@ static const struct drm_gem_object_funcs gsgpu_gem_object_funcs = {
+ 	.mmap = gsgpu_gem_object_mmap,
+ 	.vm_ops = &gsgpu_gem_vm_ops,
+ };
+-#endif
+ 
+ int gsgpu_gem_object_create(struct gsgpu_device *adev, unsigned long size,
+ 			     int alignment, u32 initial_domain,
+@@ -142,9 +140,6 @@ retry:
+ 		return r;
+ 	}
+ 	*obj = &lg_gbo_to_gem_obj(bo);
+-#if !defined(LG_DRM_DRIVER_HAS_GEM_FREE)
+-	(*obj)->funcs = &gsgpu_gem_object_funcs;
+-#endif
+ 	return 0;
+ }
+ 
+diff --git a/gsgpu/gsgpu_object.c b/gsgpu/gsgpu_object.c
+index 9504920..f7073ff 100644
+--- a/gsgpu/gsgpu_object.c
++++ b/gsgpu/gsgpu_object.c
+@@ -438,6 +438,7 @@ static int gsgpu_bo_do_create(struct gsgpu_device *adev,
+ 	if (bo == NULL)
+ 		return -ENOMEM;
+ 	drm_gem_private_object_init(adev->ddev, &lg_gbo_to_gem_obj(bo), size);
++	bo->tbo.base.funcs = &gsgpu_gem_object_funcs;
+ 	INIT_LIST_HEAD(&bo->shadow_list);
+ 	INIT_LIST_HEAD(&bo->va);
+ 	bo->preferred_domains = bp->preferred_domain ? bp->preferred_domain :
+@@ -794,7 +795,7 @@ struct gsgpu_bo *gsgpu_bo_ref(struct gsgpu_bo *bo)
+ 	if (bo == NULL)
+ 		return NULL;
+ 
+-	ttm_bo_get(&bo->tbo);
++	drm_gem_object_get(&bo->tbo.base);
+ 	return bo;
+ }
+ 
+@@ -806,13 +807,10 @@ struct gsgpu_bo *gsgpu_bo_ref(struct gsgpu_bo *bo)
+  */
+ void gsgpu_bo_unref(struct gsgpu_bo **bo)
+ {
+-	struct ttm_buffer_object *tbo;
+-
+ 	if ((*bo) == NULL)
+ 		return;
+ 
+-	tbo = &((*bo)->tbo);
+-	ttm_bo_put(tbo);
++	drm_gem_object_put(&(*bo)->tbo.base);
+ 	*bo = NULL;
+ }
+ 
+diff --git a/include/gsgpu.h b/include/gsgpu.h
+index 06b8ef9..20e6760 100644
+--- a/include/gsgpu.h
++++ b/include/gsgpu.h
+@@ -290,6 +290,8 @@ struct gsgpu_cs_post_dep {
+ #define gem_to_gsgpu_bo(gobj) container_of((gobj), struct gsgpu_bo, gem_base)
+ #endif
+ 
++extern const struct drm_gem_object_funcs gsgpu_gem_object_funcs;
++
+ void gsgpu_gem_object_free(struct drm_gem_object *obj);
+ int gsgpu_gem_object_open(struct drm_gem_object *obj,
+ 				struct drm_file *file_priv);
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,0 +1,119 @@
+From aaee8cb5d7f879ba4cd2cb268a8591f99735b729 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 16 Aug 2025 19:15:10 +0800
+Subject: [PATCH 46/46] loonggpu: backlight: Get PWM correctly and skip GPIO
+ for now
+
+This should make backlight control at least usable with AOSC 6.16.1-rc1
+kernel.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_backlight.c   | 32 +++++++++++++++++++++++++++++---
+ include/gsgpu_backlight.h |  7 +++++++
+ 2 files changed, 36 insertions(+), 3 deletions(-)
+
+diff --git a/gsgpu/gsgpu_backlight.c b/gsgpu/gsgpu_backlight.c
+index 8b97512..f45d0c4 100644
+--- a/gsgpu/gsgpu_backlight.c
++++ b/gsgpu/gsgpu_backlight.c
+@@ -10,8 +10,12 @@
+ 
+ static bool gsgpu_backlight_get_hw_status(struct gsgpu_backlight *ls_bl)
+ {
++#ifdef LG_GPIO_WORKS
+ 	return (gpio_get_value(GPIO_LCD_VDD) && gpio_get_value(GPIO_LCD_EN)
+ 		&& pwm_is_enabled(ls_bl->pwm));
++#else
++	return pwm_is_enabled(ls_bl->pwm);
++#endif
+ }
+ 
+ static void gsgpu_backlight_enable(struct gsgpu_backlight *ls_bl)
+@@ -146,10 +150,23 @@ static int gsgpu_backlight_hw_request_init(struct gsgpu_backlight *ls_bl)
+ 	bool pwm_enable_default;
+ 	struct pwm_state state;
+ 	struct gsgpu_device *adev = ls_bl->driver_private;
+-	char pwm_name[16];
+ 
+-	sprintf(pwm_name, "pwm%d", ls_bl->pwm_id);
+-	ls_bl->pwm = lg_pwm_request(adev->ddev->dev, pwm_name, ls_bl->pwm_id, "Loongson_bl");
++	if (ls_bl->pwm_id != 3) {
++		DRM_ERROR("Must use PWM3 for backlight\n");
++		goto ERROR_PWM;
++	}
++
++	/*
++	 * Note that we must patch the kernel ACPI initialization code to
++	 * register the name gsgpu_backlight using pwm_add_table to make
++	 * this work.  We cannot call pwm_add_table in this module as
++	 * pwm_add_table is only intended for board initialization and not
++	 * exported.  Even some dirty hack might allow us to call it from a
++	 * module, doing so would still cause a deadlock.
++	 *
++	 * See https://github.com/AOSC-Tracking/linux/commit/6ce646344dfb.
++	 */
++	ls_bl->pwm = pwm_get(adev->ddev->dev, "gsgpu_backlight");
+ 
+ 	if (IS_ERR(ls_bl->pwm)) {
+ 		DRM_ERROR("Failed to get the pwm chip\n");
+@@ -171,6 +188,12 @@ static int gsgpu_backlight_hw_request_init(struct gsgpu_backlight *ls_bl)
+ 	if (pwm_enable_default)
+ 		pwm_enable(ls_bl->pwm);
+ 
++	/*
++	 * FIXME: The LCD backlight enable/disable and LCD power
++	 * enable/disable support is removed for now.  The upstream
++	 * kernel seems not able to find GPIO_LCD_VDD and GPIO_LCD_EN.
++	 */
++#ifdef LG_GPIO_WORKS
+ 	ret = gpio_request(GPIO_LCD_VDD, "GPIO_VDD");
+ 	if (ret) {
+ 		DRM_ERROR("EN request error!\n");
+@@ -186,15 +209,18 @@ static int gsgpu_backlight_hw_request_init(struct gsgpu_backlight *ls_bl)
+ 	/* gpio init */
+ 	gpio_direction_output(GPIO_LCD_VDD, 1);
+ 	gpio_direction_output(GPIO_LCD_EN, 1);
++#endif
+ 
+ 	gsgpu_backlight_power(ls_bl, 0);
+ 
+ 	return ret;
+ 
++#ifdef LG_GPIO_WORKS
+ ERROR_EN:
+ 	gpio_free(GPIO_LCD_VDD);
+ ERROR_VDD:
+ 	lg_pwm_free(ls_bl->pwm);
++#endif
+ ERROR_PWM:
+ 	return -ENODEV;
+ }
+diff --git a/include/gsgpu_backlight.h b/include/gsgpu_backlight.h
+index 8ecc610..178c225 100644
+--- a/include/gsgpu_backlight.h
++++ b/include/gsgpu_backlight.h
+@@ -34,6 +34,7 @@ struct gsgpu_backlight {
+ 	void (*power)(struct gsgpu_backlight *ls_bl, bool enable);
+ };
+ 
++#ifdef LG_GPIO_WORKS
+ #define BACKLIGHT_DEFAULT_METHOD_CLOSE(ls_bl)\
+ 	do { \
+ 		ls_bl->hw_enabled = false;\
+@@ -65,6 +66,12 @@ struct gsgpu_backlight {
+ 		BACKLIGHT_DEFAULT_METHOD_OPEN(ls_bl);\
+ 		ls_bl->hw_enabled = true; \
+ 	} while (0)
++#else /* LG_GPIO_WORKS */
++#define BACKLIGHT_DEFAULT_METHOD_CLOSE(ls_bl)
++#define BACKLIGHT_DEFAULT_METHOD_FORCE_CLOSE(ls_bl)
++#define BACKLIGHT_DEFAULT_METHOD_OPEN(ls_bl)
++#define BACKLIGHT_DEFAULT_METHOD_FORCE_OPEN(ls_bl)
++#endif
+ 
+ int gsgpu_backlight_register(struct drm_connector *connector);
+ int gsgpu_late_register(struct drm_connector *connector);
+-- 
+2.50.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=3
+REL=4
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

loonggpu-kernel-dkms: Add patches for backlight and 6.17-rc1 compatibility

Tracking AOSC patches at
https://github.com/AOSC-Tracking/loonggpu-kernel-dkms, current HEAD is aaee8cb5d7f879ba4cd2cb268a8591f99735b729.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1.0.1~alpha~lnd25.5-4`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
