### PR TITLE
ttyd 1.7.7 Survey

### DIFF
--- a/app-utils/ttyd/spec
+++ b/app-utils/ttyd/spec
@@ -1,5 +1,4 @@
-VER=1.6.3
-SRCS="tbl::https://github.com/tsl0922/ttyd/archive/$VER.tar.gz"
-CHKSUMS="sha256::1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9"
+VER=1.7.7
+SRCS="git::commit=tags/$VER::https://github.com/tsl0922/ttyd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13890"
-REL=1

--- a/runtime-web/libwebsockets/autobuild/defines
+++ b/runtime-web/libwebsockets/autobuild/defines
@@ -8,3 +8,6 @@ NOSTATIC=0
 NOLTO=1
 
 PKGBREAK="ddnet<=11.0.3 ttyd<=1.3.0"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=('-DLWS_WITH_LIBUV=ON')

--- a/runtime-web/libwebsockets/spec
+++ b/runtime-web/libwebsockets/spec
@@ -1,5 +1,4 @@
-VER=4.3.3
+VER=4.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/warmcat/libwebsockets"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11181"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ttyd: update to 1.7.7
    Signed-off-by: stydxm <stydxm@outlook.com>
- libwebsockets: update to 4.4.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- libwebsockets: build with libuv
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libwebsockets ttyd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
