### PR TITLE
vscode: update to 1.103.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.103.0
+VER=1.103.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::46c4b9c83e5ea7ae1fbdcac679c39de878c50c1ec3bc73a7fc2e384823b559ae"
-CHKSUMS__ARM64="sha256::86f17a8a3a7a82977a40995eccad33e8386d9c56f49289aa393b7de6d6fdeb9f"
+CHKSUMS__AMD64="sha256::0a2f1a6396600747e1bfb3ad7f57f30962bd8e0d8558cc79af4c64d4e6d4c61d"
+CHKSUMS__ARM64="sha256::44490e12c0273473c0fc8db3bd4b64649b7695600cd9d0a39a7a638781a74158"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.103.1

Package(s) Affected
-------------------

- vscode: 1.103.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
