### PR TITLE
cloud-init: update to 25.2

### DIFF
--- a/app-admin/cloud-init/spec
+++ b/app-admin/cloud-init/spec
@@ -1,4 +1,4 @@
-VER=24.4.1
+VER=25.2
 SRCS="git::commit=tags/$VER::https://github.com/canonical/cloud-init"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11545"


### PR DESCRIPTION
Topic Description
-----------------

- cloud-init: update to 25.2

Package(s) Affected
-------------------

- cloud-init: 25.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cloud-init
```

Test Build(s) Done
------------------

