### PR TITLE
lfortran: update to 0.55.0

### DIFF
--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.54.0
+VER=0.55.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::a46c44f8398ed0d14ca051a08982a3001642449c06a3be1c30944c3e027bbf51"
+CHKSUMS="sha256::62050b78a52f8d04061bb8b20f0774a22f6409250d97f9558a9b1c9ae9e762d5"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.55.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.55.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
