### PR TITLE
bash-pinyin-completion-rs: update to 0.3.1

### DIFF
--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,4 +1,4 @@
-VER=0.2.3
+VER=0.3.0
 SRCS="tbl::https://github.com/AOSC-Dev/bash-pinyin-completion-rs/archive/v$VER.tar.gz"
-CHKSUMS="sha256::53cb5dc97fe13fefe0d3c8d165e4167e60639a0cd1f7dae81cf70b075b1e9829"
+CHKSUMS="sha256::9c7a5a0f4c4ca29953461fa159c5fa832a490c1198085bf433ee0c8cbf7b5b09"
 CHKUPDATE="anitya::id=376526"

--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
+VER=0.3.1
 SRCS="tbl::https://github.com/AOSC-Dev/bash-pinyin-completion-rs/archive/v$VER.tar.gz"
-CHKSUMS="sha256::9c7a5a0f4c4ca29953461fa159c5fa832a490c1198085bf433ee0c8cbf7b5b09"
+CHKSUMS="sha256::053a15b7f0ccb00b11d67890c8483658de1152039738a2b87f2ea62c1da95393"
 CHKUPDATE="anitya::id=376526"


### PR DESCRIPTION
Topic Description
-----------------

- bash-pinyin-completion-rs: upgrade to 0.3.0
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>

Package(s) Affected
-------------------

- bash-pinyin-completion-rs: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-pinyin-completion-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
