### PR TITLE
fuzzel: update to 1.13.0

### DIFF
--- a/app-utils/fuzzel/autobuild/defines
+++ b/app-utils/fuzzel/autobuild/defines
@@ -1,8 +1,13 @@
 PKGNAME=fuzzel
 PKGSEC=x11
-PKGDEP="cairo fcft fontconfig glibc libpng libxkbcommon pixman wayland"
-BUILDDEP="wayland-protocols scdoc meson nanosvg ninja tllist"
-PKGDES="A Wayland-native application launcher"
+PKGDEP="cairo fcft fontconfig glibc libpng libxkbcommon nanosvg pixman wayland"
+BUILDDEP="wayland-protocols scdoc meson ninja tllist"
+PKGDES="Wayland-native application launcher"
 
 ABTYPE=meson
-MESON_AFTER="-Dsystem-nanosvg=enabled"
+MESON_AFTER=(
+    '-Denable-cairo=enabled'
+    '-Dpng-backend=libpng'
+    '-Dsvg-backend=nanosvg'
+    '-Dsystem-nanosvg=enabled'
+)

--- a/app-utils/fuzzel/spec
+++ b/app-utils/fuzzel/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
+VER=1.13.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fuzzel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=190841"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- fuzzel: update to 1.13.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fuzzel: 1.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuzzel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
