### PR TITLE
rust-bindgen: update to 0.72.0

### DIFF
--- a/lang-rust/rust-bindgen/spec
+++ b/lang-rust/rust-bindgen/spec
@@ -1,4 +1,4 @@
-VER=0.69.4
+VER=0.72.0
 SRCS="git::commit=tags/v$VER::https://github.com/rust-lang/rust-bindgen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17910"


### PR DESCRIPTION
Topic Description
-----------------

- rust-bindgen: update to 0.72.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rust-bindgen: 0.72.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rust-bindgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
