### PR TITLE
xwayland-satellite: update to 0.7

### DIFF
--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,4 +1,4 @@
-VER=0.6
+VER=0.7
 SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: update to 0.7
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- xwayland-satellite: 0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
