### PR TITLE
dune: update to 3.19.1

### DIFF
--- a/lang-ocaml/dune/autobuild/build
+++ b/lang-ocaml/dune/autobuild/build
@@ -1,34 +1,44 @@
-# Script adapted from Arch Linux community/dune.
-# https://github.com/archlinux/svntogit-community/blob/4cca5149bd5dd0c4211dac5e9be1c9bcd18b51dc/trunk/PKGBUILD
-
-## If $PKGDIR is placed under $SRCDIR, dune will search abdist and think the
-## installed executable as a dune file, and refuse to install.
-_SRCDIR="$SRCDIR"/dune-"$PKGVER"
-pushd "$_SRCDIR"
-
 abinfo "Building Dune's core executable ..."
-./configure --libdir /usr/lib/ocaml
-make dune.exe
+"$SRCDIR"/configure \
+    --libdir="$(ocamlc -where)"
+ocaml "$SRCDIR"/boot/bootstrap.ml \
+    --verbose
 
 abinfo "Building Dune packages ..."
-DUNE_RELEASE_PKGS="dune,dune-action-plugin,dune-build-info,dune-configurator,dune-glob,dune-private-libs,dune-site,dyn,stdune,ordering,xdg,fiber"
-"$_SRCDIR"/dune.exe build \
-    -p $DUNE_RELEASE_PKGS \
-    --profile dune-bootstrap
+# Note: Ensure `dune` is last, otherwise it will install error:
+# * Error: Invalid dune file
+DUNE_RELEASE_PKGS=(
+    'dune-build-info'
+    'dune-private-libs'
+    'dune-configurator'
+    'dune-action-plugin'
+    'dune-glob'
+    'dune-site'
+    'dune-rpc'
+    'dyn'
+    'ordering'
+    'xdg'
+    'stdune'
+    'ocamlc-loc'
+    'chrome-trace'
+    'dune'
+)
+_DUNE_RELEASE_PKGS=$(IFS=','; echo "${DUNE_RELEASE_PKGS[*]}")
 
-abinfo "Installing Dune and related file..."
-for _pkg in ${DUNE_RELEASE_PKGS//,/ }; do
-    abinfo "Installing component ${_pkg} ..."
-    DESTDIR="$PKGDIR" \
-    "$_SRCDIR"/dune.exe install "$_pkg" \
-        --prefix "/usr" \
-        --libdir=$(ocamlfind printconf destdir)
+"$SRCDIR"/dune.exe build \
+    --profile dune-bootstrap \
+    --verbose \
+    -p "${_DUNE_RELEASE_PKGS}"
+
+abinfo "Installing Dune and related files ..."
+for pkg in ${DUNE_RELEASE_PKGS[@]}; do
+    abinfo "Installing component ${pkg} ..."
+    "$SRCDIR"/dune.exe install \
+        --prefix "$PKGDIR"/usr \
+        --libdir "$PKGDIR"/"$(ocamlfind printconf destdir)" \
+        "${pkg}"
 done
 
-abinfo "Fixing documentation directories ..."
-for i in doc man; do
-    mkdir -pv "$PKGDIR"/usr/share
-    mv -v "$PKGDIR"/usr/{,share/}$i
-done
-
-popd
+abinfo "Correcting directories ..."
+mv -v "$PKGDIR"/usr/{,share/}doc
+mv -v "$PKGDIR"/usr/{,share/}man

--- a/lang-ocaml/dune/autobuild/defines
+++ b/lang-ocaml/dune/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=ocaml
 PKGDEP="findlib ocaml"
 PKGDES="A composable build system for OCaml"
 
+ABTYPE=self
 NOSTATIC=0

--- a/lang-ocaml/dune/autobuild/prepare
+++ b/lang-ocaml/dune/autobuild/prepare
@@ -1,4 +1,4 @@
-if ! ab_match_archgroup ocaml-native; then
-    abinfo "Disabling ELF filter and debug symbol stripper for ${CROSS:-$ARCH} ..."
-    export ABSTRIP=0 ABSPLITDBG=0
-fi
+# This allows 'dune --version' to output the correct version instead of "n/a".
+abinfo "Setting dune version ..."
+sed -i "/^(name dune)/a (version $PKGVER)" \
+    "$SRCDIR"/dune-project

--- a/lang-ocaml/dune/spec
+++ b/lang-ocaml/dune/spec
@@ -1,6 +1,4 @@
-VER=3.4.1
-REL=3
-SRCS="tbl::https://github.com/ocaml/dune/archive/$VER/dune-$VER.tar.gz"
-CHKSUMS="sha256::dc260f7f723b17cec104d394d904b402a0b0108d2d3241fe7596e6d473502cef"
+VER=3.19.1
+SRCS="git::commit=tags/$VER::https://github.com/ocaml/dune.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16017"
-SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- dune: update to 3.19.1
    - Modify source url to comply with the AOSC Package Styling Manual.
    - Improve build script.

Package(s) Affected
-------------------

- dune: 3.19.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dune
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
