### PR TITLE
qgis: update to 3.44.2

### DIFF
--- a/app-gis/qgis/autobuild/defines
+++ b/app-gis/qgis/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=qgis
 PKGSEC=science
-PKGDEP="proj geos gdal libzip exiv2 pdal qtkeychain qca gsl sip \
+PKGDEP="proj geos gdal libzip exiv2 pdal qtkeychain qca gsl sip jinja2 psycopg2 \
 	pyqt5 pyqt-builder qwt5 qscintilla libspatialindex postgresql-runtime-17"
 PKGDES="Geographic Information System (GIS) software"
 

--- a/app-gis/qgis/spec
+++ b/app-gis/qgis/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=3_42_3
-VER=${UPSTREAM_VER//_/.}
-SRCS="git::commit=tags/final-${UPSTREAM_VER}::https://github.com/qgis/QGIS.git"
+VER=3.44.2
+SRCS="git::commit=tags/final-${VER//./_}::https://github.com/qgis/QGIS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5779"


### PR DESCRIPTION
Topic Description
-----------------

- qgis: update to 3.44.2
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- qgis: 3.44.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qgis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
