### PR TITLE
blueprint-compiler: update to 0.18.0

### DIFF
--- a/app-devel/blueprint-compiler/spec
+++ b/app-devel/blueprint-compiler/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
+VER=0.18.0
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/jwestman/blueprint-compiler.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279929"


### PR DESCRIPTION
Topic Description
-----------------

- blueprint-compiler: update to 0.18.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- blueprint-compiler: 0.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit blueprint-compiler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
