### PR TITLE
git: update to 2.51.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,4 @@
-VER=2.50.1
+VER=2.51.0
 
 # Use this for stable releases.
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
@@ -8,5 +8,5 @@ SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 #REL=0.${RC}
 #SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::522d1635f8b62b484b0ce24993818aad3cab8e11ebb57e196bda38a3140ea915"
+CHKSUMS="sha256::3d531799d2cf2cac8e294ec6e3229e07bfca60dc6c783fe69e7712738bef7283"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.51.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- git: 2.51.0
- git-gui: 2.51.0
- gitk: 2.51.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
