### PR TITLE
intel-graphics-compiler: update to 2.16.0

### DIFF
--- a/app-devel/intel-graphics-compiler/autobuild/beyond
+++ b/app-devel/intel-graphics-compiler/autobuild/beyond
@@ -1,4 +1,4 @@
-LLVM_MAJOR_VER=14
+LLVM_MAJOR_VER=15
 
 mv -v "${PKGDIR}"/usr/include/opencl-c{,-base}.h "${PKGDIR}"/usr/include/igc
 mkdir -pv "${PKGDIR}"/usr/share/doc/"${PKGNAME}"

--- a/app-devel/intel-graphics-compiler/autobuild/defines
+++ b/app-devel/intel-graphics-compiler/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="gcc-runtime glibc zlib"
 BUILDDEP="mako pyyaml"
 PKGDES="An LLVM based compiler for OpenCL targeting Intel Gen graphics hardware architecture"
 
-LLVM_VER=14.0.6
+LLVM_VER=15.0.7
 ABTYPE=cmakeninja
 CMAKE_AFTER=" \
     -DCCLANG_FROM_SYSTEM=OFF \

--- a/app-devel/intel-graphics-compiler/autobuild/prepare
+++ b/app-devel/intel-graphics-compiler/autobuild/prepare
@@ -5,7 +5,7 @@ export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic"
 git config --local user.name "AOSC Maintainers"
 git config --local user.email "maintainers@aosc.io"
 
-LLVM_VER=14.0.6
+LLVM_VER=15.0.7
 mv -v "${SRCDIR}"/../llvm-project-"${LLVM_VER}".src "${SRCDIR}"/../llvm-project
 cd "${SRCDIR}"/../llvm-project
 
@@ -15,11 +15,6 @@ do
     patch -p1 -t -s -N -i "$file"
 done
 rm -v "${SRCDIR}"/../opencl-clang/patches/clang/*.patch
-for file in "${SRCDIR}"/external/llvm/releases/14.0.0/patches_external/*.patch
-do
-    patch -p1 -t -s -N -i "$file"
-done
-rm -v "${SRCDIR}"/external/llvm/releases/14.0.0/patches_external/*.patch
 
 mkdir "${SRCDIR}"/../llvm-project/.git
 ln -sv "${SRCDIR}"/../SPIRV-LLVM-Translator-IGC "${SRCDIR}"/../llvm-project/llvm/projects/llvm-spirv

--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,9 +1,9 @@
-VER=2.14.1
-LLVM_VER=14.0.6
-OPENCL_CLANG_VER=14.0.1
-SPIRV_LLVM_TRANSLATOR_VER=14.0.7
-VS_INTRINSICS_VER=0.22.1
-SPIRV_TOOLS_VER=1.3.290.0
+VER=2.16.0
+LLVM_VER=15.0.7
+OPENCL_CLANG_VER=15.0.2
+SPIRV_LLVM_TRANSLATOR_VER=15.0.15
+VS_INTRINSICS_VER=0.23.1
+SPIRV_TOOLS_VER=1.4.321.0
 
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \
       tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-"${LLVM_VER}"/llvm-project-"${LLVM_VER}".src.tar.xz \
@@ -13,7 +13,7 @@ SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/intel/intel-grap
       git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Tools::https://github.com/KhronosGroup/SPIRV-Tools.git \
       git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Headers::https://github.com/KhronosGroup/SPIRV-Headers.git"
 CHKSUMS="SKIP \
-         sha256::8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a \
+         sha256::8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6 \
          SKIP \
          SKIP \
          SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- intel-graphics-compiler: update to 2.16.0

Package(s) Affected
-------------------

- intel-graphics-compiler: 2.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-graphics-compiler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
