### PR TITLE
systemd-boot-friend: update to 0.27.5

### DIFF
--- a/app-admin/systemd-boot-friend/autobuild/defines
+++ b/app-admin/systemd-boot-friend/autobuild/defines
@@ -6,10 +6,5 @@ PKGDES="Help systemd-boot to access OS kernel"
 
 USECLANG=1
 
-# FIXME: Segfaults during linkage.
-NOLTO__LOONGSON3=1
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGARCH64=1
-
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+# NOTE: Only supports architectures with UEFI
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|riscv64)"

--- a/app-admin/systemd-boot-friend/spec
+++ b/app-admin/systemd-boot-friend/spec
@@ -1,4 +1,4 @@
-VER=0.27.4
+VER=0.27.5
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

- systemd-boot-friend: update to 0.27.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- systemd-boot-friend: 0.27.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd-boot-friend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
