### PR TITLE
tauri-cli: update to 2.8.0

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.12.7
+VER=4.12.8
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/lang-rust/tauri-cli/autobuild/build
+++ b/lang-rust/tauri-cli/autobuild/build
@@ -1,5 +1,0 @@
-abinfo "Building tauri-cli ..."
-cargo build --release -p tauri-cli
-
-abinfo "Installing tauri-cli ..."
-install -Dvm755 "$SRCDIR"/target/release/cargo-tauri -t "$PKGDIR"/usr/bin/

--- a/lang-rust/tauri-cli/autobuild/defines
+++ b/lang-rust/tauri-cli/autobuild/defines
@@ -5,3 +5,4 @@ PKGDEP="bzip2 gcc-runtime glibc xz"
 BUILDDEP="rustc llvm"
 
 USECLANG=1
+CARGO_AFTER="-p tauri-cli"

--- a/lang-rust/tauri-cli/spec
+++ b/lang-rust/tauri-cli/spec
@@ -1,4 +1,4 @@
-VER=2.7.1
+VER=2.8.0
 SRCS="git::commit=tags/tauri-cli-v$VER::https://github.com/tauri-apps/tauri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371844"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.12.8
- tauri-cli: use rust template to build
- tauri-cli: update to 2.8.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- autobuild4: 4.12.8
- tauri-cli: 2.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 tauri-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
