### PR TITLE
tailscale: install completions

### DIFF
--- a/app-network/tailscale/autobuild/beyond
+++ b/app-network/tailscale/autobuild/beyond
@@ -1,5 +1,17 @@
-abinfo "Installing tailscaled service files"
+abinfo "Installing tailscaled service files..."
+
 install -Dvm644 "${SRCDIR}/cmd/tailscaled/tailscaled.service" \
 	-t "${PKGDIR}/usr/lib/systemd/system"
 install -Dvm644 "${SRCDIR}/cmd/tailscaled/tailscaled.defaults" \
 	"${PKGDIR}/etc/default/tailscaled"
+
+
+abinfo "Installing tailscale completions..."
+
+"$SRCDIR"/tailscale completion bash > "$SRCDIR"/tailscale.bash
+"$SRCDIR"/tailscale completion zsh > "$SRCDIR"/_tailscale
+"$SRCDIR"/tailscale completion fish > "$SRCDIR"/tailscale.fish
+
+install -Dvm0644 "$SRCDIR"/tailscale.bash -t "$PKGDIR"/usr/share/bash-completion/completions/
+install -Dvm0644 "$SRCDIR"/_tailscale -t "$PKGDIR"/usr/share/zsh/site-functions/
+install -Dvm0644 "$SRCDIR"/tailscale.fish -t "$PKGDIR"/usr/share/fish/vendor_completions.d/

--- a/app-network/tailscale/spec
+++ b/app-network/tailscale/spec
@@ -2,3 +2,4 @@ VER=1.86.2
 SRCS="git::commit=tags/v${VER}::https://github.com/tailscale/tailscale"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141585"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- tailscale: install completions

Package(s) Affected
-------------------

- tailscale: 1.86.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tailscale
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
