### PR TITLE
vscodium: update to 1.103.15539

### DIFF
--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -2,9 +2,7 @@ PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
 PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-# FIXME: rustc depends on llvm-20 while our default llvm is llvm-18.
-# Invalid attribute group entry (Producer: 'LLVM20.1.6' Reader: 'LLVM 18.1.8')
-BUILDDEP="jq llvm-20 make nodejs pkg-config rustc"
+BUILDDEP="jq llvm make nodejs pkg-config rustc"
 PKGPROV="codium"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.102.14746
+VER=1.103.15539
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.103.15539
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscodium: 1.103.15539

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
