### PR TITLE
msmtp: update to 1.8.30

### DIFF
--- a/app-web/msmtp/spec
+++ b/app-web/msmtp/spec
@@ -1,4 +1,4 @@
-VER=1.8.29
+VER=1.8.30
 SRCS="tbl::https://marlam.de/msmtp/releases/msmtp-${VER}.tar.xz"
-CHKSUMS="sha256::13a78f3c6034b33008a7f2474fdddd0deaf7db6da89d0791d3d75eae721220d7"
+CHKSUMS="sha256::f826a3c500c4dfeed814685097cead9b2b3dca5a2ec3897967cb9032570fa9ab"
 CHKUPDATE="anitya::id=2024"


### PR DESCRIPTION
Topic Description
-----------------

- msmtp: update to 1.8.30
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- msmtp: 1.8.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit msmtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
