### PR TITLE
kitty: update to 0.42.2

### DIFF
--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,4 +1,4 @@
-VER=0.41.1
+VER=0.42.2
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::e30150fad1bcc885a7adbd87380696ef7b67a62a38f74634efbc05c3745f26aa"
+CHKSUMS="sha256::719796b6f67f81d212e80a5dcd51ba84cff54e009f32a728108f6854f00306a1"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.42.2
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- kitty: 0.42.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
