### PR TITLE
flameshot: update to 13.1.0

### DIFF
--- a/app-utils/flameshot/spec
+++ b/app-utils/flameshot/spec
@@ -1,5 +1,4 @@
-VER=12.1.0
-REL=1
+VER=13.1.0
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a"
+CHKSUMS="sha256::1d755a618bdcb3e739f691cea55ed2d432f93e521a504f95b74abed0c595f6f7"
 CHKUPDATE="anitya::id=16948"


### PR DESCRIPTION
Topic Description
-----------------

- flameshot: update to 13.1.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- flameshot: 13.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flameshot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
