### PR TITLE
maple-font: update to 7.6

### DIFF
--- a/desktop-fonts/maple-font/spec
+++ b/desktop-fonts/maple-font/spec
@@ -1,12 +1,12 @@
-VER=7.5
+VER=7.6
 SRCS="tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-Variable.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-TTF.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-CN-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-CN-unhinted.zip"
-CHKSUMS="sha256::2a9b0c9b1f76708f690fcc9a014c93b6c945b6af02a59ee21125b7799b742f15 \
-         sha256::495b9a8691f4a041dd378a318b6d57f819ac86751d3f599c6937a38bce6fdcbc \
-         sha256::2d496c8a5ac02daf3477d9a10e193c694489e9fa8d26193628b51086d5ee07a4 \
-         sha256::49fc3a94aa07f3c0441cb3115be876880c9d69ea6a8a5b72f41f97be9a3b598e \
-         sha256::3bd076e9e0a0cd48397fe836abe4c299c34245a0c4ee043c5653159626f3e085"
+CHKSUMS="sha256::f144b65cbfd14c87961dab4778bbfbff25a26f956feeb74ec8d0b9aa8b115f0d \
+         sha256::9f8922bcf45c23cd23123edd457dff48ac961e20628975e86388c457b7824922 \
+         sha256::eca12ce84b607dd3b60d92051a51c059d2332aa2836aaeda4531b4f071188a1c \
+         sha256::4278d1a16d385af1ad8282959b8e94d19d30226a7661505d07ff0b0f7ee67d69 \
+         sha256::f0f4b0fea1985e3a5a6b3c98f7d6ce4056ccf903a425f8b3ae6965f034c6c2af"
 CHKUPDATE="anitya::id=375863"


### PR DESCRIPTION
Topic Description
-----------------

- maple-font: update to 7.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- maple-font: 7.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit maple-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
