### PR TITLE
libtiff: disable RECONF due to recent GNU server unavailability

### DIFF
--- a/runtime-imaging/libtiff/autobuild/defines
+++ b/runtime-imaging/libtiff/autobuild/defines
@@ -6,3 +6,8 @@ PKGDES="Library for manipulation of TIFF images"
 
 # Note: For compatibility with Debian applications.
 AUTOTOOLS_AFTER="--enable-ld-version-script --disable-docs"
+
+# FIXME: Set RECONF=0 to avoid bootstrap script which attempts to
+#        download dependencies from GNU servers which is currently
+#        unavailable.
+RECONF=0

--- a/runtime-imaging/libtiff/autobuild/prepare
+++ b/runtime-imaging/libtiff/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Generating Autotools scripts ..."
+autoreconf -fvi

--- a/runtime-imaging/libtiff/spec
+++ b/runtime-imaging/libtiff/spec
@@ -1,5 +1,5 @@
 VER=4.4.0
-REL=3
+REL=4
 SRCS="tbl::https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
 CHKSUMS="sha256::917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed"
 CHKUPDATE="anitya::id=1738"


### PR DESCRIPTION
Topic Description
-----------------

- libtiff: disable RECONF due to recent GNU server unavailability
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libtiff: 4.4.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtiff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
