### PR TITLE
intel-oneapi-basekit: update to 2025.2.1

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2025.2.0
-PKG_URL=bd1d0273-a931-4f7e-ab76-6a2a67d646c7
-PKG_CODE=592
+VER=2025.2.1
+PKG_URL=3b7a16b3-a7b0-460f-be16-de0d64fa6b1e
+PKG_CODE=44
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha384::176c5400c7f7df83d19ac03e3f8d9f11a10c7b6e44f641ca3129fae3b4aac65541185bb6501451a57df664e4f6031eb0"
+CHKSUMS="sha384::70c259c5a113e0ade58d3b3c33e5917ff2e2057a1ac52772323d241c90b8885b386bd328d6e94a7a3f06ee3c2ca52106"
 CHKUPDATE="anitya::id=372585"

--- a/app-devel/opencl-registry-api/autobuild/defines
+++ b/app-devel/opencl-registry-api/autobuild/defines
@@ -7,6 +7,4 @@ PKGDES="OpenCL (Open Computing Language) header files"
 ABHOST=noarch
 ABTYPE=cmakeninja
 
-# FIXME: API changes in version 2024.10.24 break intel-compute-runtime.
-# The version must stay at 2024.05.08 until intel-compute-runtime supports the new API.
 PKGEPOCH=1

--- a/app-devel/opencl-registry-api/spec
+++ b/app-devel/opencl-registry-api/spec
@@ -1,4 +1,4 @@
-VER=2024.10.24
+VER=2025.07.22
 SRCS="git::commit=tags/v$VER;rename=OpenCL-Headers::https://github.com/KhronosGroup/OpenCL-Headers \
       git::commit=tags/v$VER;rename=OpenCL-CLHPP::https://github.com/KhronosGroup/OpenCL-CLHPP"
 CHKSUMS="SKIP \

--- a/runtime-common/level-zero/spec
+++ b/runtime-common/level-zero/spec
@@ -1,4 +1,4 @@
-VER=1.23.1
+VER=1.24.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/oneapi-src/level-zero.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229539"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=25.27.34303.5
+VER=25.31.34666.3
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- opencl-registry-api: update to 2025.07.22
- intel-compute-runtime: update to 25.31.34666.3
- level-zero: update to 1.24.1
- intel-oneapi-basekit: update to 2025.2.1

Package(s) Affected
-------------------

- intel-compute-runtime: 25.31.34666.3
- intel-oneapi-basekit: 2025.2.1
- level-zero: 1.24.1
- opencl-registry-api: 1:2025.07.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencl-registry-api level-zero intel-compute-runtime intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
