### PR TITLE
caddy: update to 2.10.2

### DIFF
--- a/app-web/caddy/autobuild/defines
+++ b/app-web/caddy/autobuild/defines
@@ -4,6 +4,4 @@ PKGDES="Fast and extensible multi-platform HTTP/1-2-3 web server with automatic 
 PKGDEP="glibc"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
-ABSPLITDBG=0
 ABTYPE=gomod

--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,5 +1,5 @@
-VER=2.10.0
+VER=2.10.2
 SRCS="tbl::https://github.com/caddyserver/caddy/releases/download/v${VER}/caddy_${VER}_buildable-artifact.tar.gz"
-CHKSUMS="sha256::3f19cc5f163898d67abf46e2d42e9d31fffe11ee01a0b912c4b4ece907ebfe0b"
+CHKSUMS="sha256::f25ba47638690436a15b9f60b22c95deb560ab16105eb7382fb2dacd77fb819d"
 CHKUPDATE="anitya::id=15601"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- caddy: update to 2.10.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- caddy: 2.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit caddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
