### PR TITLE
deskflow: update to 1.23.0

### DIFF
--- a/app-utils/deskflow/autobuild/defines
+++ b/app-utils/deskflow/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=deskflow
 PKGSEC=utils
 PKGDES="Share mouse and keyboard between multiple devices"
 PKGDEP="glib pugixml qt-6 libei libtomlplusplus libportal libnotify"
+
+ABTYPE=cmakeninja

--- a/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
+++ b/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
@@ -1,4 +1,4 @@
-From d55ea69a7423d3c0ea49523de11d311b79356493 Mon Sep 17 00:00:00 2001
+From 000aa13d78fb5881d5f7ff1ce7a1efb555e49a09 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 9 May 2025 00:22:30 +0800
 Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
@@ -7,48 +7,44 @@ As required by the Styling Manual.
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- src/lib/common/Settings.cpp            |   3 -
- src/lib/common/Settings.h              |   4 -
- src/lib/gui/CMakeLists.txt             |   2 -
- src/lib/gui/MainWindow.cpp             |  20 ----
- src/lib/gui/MainWindow.h               |   3 -
- src/lib/gui/Messages.cpp               |  16 ----
- src/lib/gui/Messages.h                 |   2 -
- src/lib/gui/VersionChecker.cpp         | 127 -------------------------
- src/lib/gui/VersionChecker.h           |  38 --------
- src/lib/gui/dialogs/SettingsDialog.cpp |   3 -
- src/lib/gui/dialogs/SettingsDialog.ui  |   8 --
- 11 files changed, 226 deletions(-)
- delete mode 100644 src/lib/gui/VersionChecker.cpp
- delete mode 100644 src/lib/gui/VersionChecker.h
+ src/lib/common/Settings.cpp            |  3 ---
+ src/lib/common/Settings.h              |  4 ----
+ src/lib/gui/CMakeLists.txt             |  2 --
+ src/lib/gui/MainWindow.cpp             | 18 ------------------
+ src/lib/gui/MainWindow.h               |  3 ---
+ src/lib/gui/Messages.cpp               | 18 ------------------
+ src/lib/gui/Messages.h                 |  2 --
+ src/lib/gui/dialogs/SettingsDialog.cpp |  3 ---
+ src/lib/gui/dialogs/SettingsDialog.ui  |  8 --------
+ 9 files changed, 61 deletions(-)
 
 diff --git a/src/lib/common/Settings.cpp b/src/lib/common/Settings.cpp
-index 4af5f7b8..742cd282 100644
+index ee9ffc94e..64b837444 100644
 --- a/src/lib/common/Settings.cpp
 +++ b/src/lib/common/Settings.cpp
-@@ -113,9 +113,6 @@ QVariant Settings::defaultValue(const QString &key)
+@@ -112,9 +112,6 @@ QVariant Settings::defaultValue(const QString &key)
    if (key == Daemon::Elevate)
-     return instance()->isNativeMode();
+     return Settings::isNativeMode();
  
 -  if (key == Core::UpdateUrl)
 -    return kUrlUpdateCheck;
 -
    if (key == Server::ExternalConfigFile)
-     return QStringLiteral("%1/%2.conf").arg(instance()->settingsPath(), kAppId);
+     return QStringLiteral("%1/%2-server.conf").arg(Settings::settingsPath(), kAppId);
  
 diff --git a/src/lib/common/Settings.h b/src/lib/common/Settings.h
-index 524b8324..fe394ce7 100644
+index c3bc87a48..2f55d1f99 100644
 --- a/src/lib/common/Settings.h
 +++ b/src/lib/common/Settings.h
-@@ -49,7 +49,6 @@ public:
+@@ -48,7 +48,6 @@ public:
+     inline static const auto ProcessMode = QStringLiteral("core/processMode");
      inline static const auto ScreenName = QStringLiteral("core/screenName");
-     inline static const auto StopOnDeskSwitch = QStringLiteral("core/stopOnDeskSwitch");
      inline static const auto StartedBefore = QStringLiteral("core/startedBefore");
 -    inline static const auto UpdateUrl = QStringLiteral("core/updateUrl");
    };
    struct Daemon
    {
-@@ -61,7 +60,6 @@ public:
+@@ -60,7 +59,6 @@ public:
    struct Gui
    {
      inline static const auto Autohide = QStringLiteral("gui/autoHide");
@@ -56,15 +52,15 @@ index 524b8324..fe394ce7 100644
      inline static const auto CloseReminder = QStringLiteral("gui/closeReminder");
      inline static const auto CloseToTray = QStringLiteral("gui/closeToTray");
      inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
-@@ -167,7 +165,6 @@ private:
+@@ -165,7 +163,6 @@ private:
+     , Settings::Core::ProcessMode
      , Settings::Core::ScreenName
      , Settings::Core::StartedBefore
-     , Settings::Core::StopOnDeskSwitch
 -    , Settings::Core::UpdateUrl
      , Settings::Daemon::Command
      , Settings::Daemon::Elevate
      , Settings::Daemon::LogFile
-@@ -175,7 +172,6 @@ private:
+@@ -173,7 +170,6 @@ private:
      , Settings::Log::Level
      , Settings::Log::ToFile
      , Settings::Gui::Autohide
@@ -73,7 +69,7 @@ index 524b8324..fe394ce7 100644
      , Settings::Gui::CloseToTray
      , Settings::Gui::LogExpanded
 diff --git a/src/lib/gui/CMakeLists.txt b/src/lib/gui/CMakeLists.txt
-index 01bf8cfb..fcfba4fe 100644
+index 01bf8cfb7..fcfba4fe9 100644
 --- a/src/lib/gui/CMakeLists.txt
 +++ b/src/lib/gui/CMakeLists.txt
 @@ -42,8 +42,6 @@ add_library(${target} STATIC
@@ -86,11 +82,11 @@ index 01bf8cfb..fcfba4fe 100644
    config/Screen.cpp
    config/Screen.h
 diff --git a/src/lib/gui/MainWindow.cpp b/src/lib/gui/MainWindow.cpp
-index 5b0d730e..a996a787 100644
+index 71b987008..a98de39eb 100644
 --- a/src/lib/gui/MainWindow.cpp
 +++ b/src/lib/gui/MainWindow.cpp
-@@ -302,8 +302,6 @@ void MainWindow::connectSlots()
-   connect(m_actionStartCore, &QAction::triggered, this, &MainWindow::startCore);
+@@ -324,8 +324,6 @@ void MainWindow::connectSlots()
+   connect(m_actionRestartCore, &QAction::triggered, this, &MainWindow::resetCore);
    connect(m_actionStopCore, &QAction::triggered, this, &MainWindow::stopCore);
  
 -  connect(&m_versionChecker, &VersionChecker::updateFound, this, &MainWindow::versionCheckerUpdateFound);
@@ -98,7 +94,7 @@ index 5b0d730e..a996a787 100644
  // Mac os tray will only show a menu
  #ifndef Q_OS_MAC
    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
-@@ -400,12 +398,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
+@@ -409,12 +407,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
    isVisible() ? hide() : showAndActivate();
  }
  
@@ -111,13 +107,11 @@ index 5b0d730e..a996a787 100644
  void MainWindow::coreProcessError(CoreProcess::Error error)
  {
    if (error == CoreProcess::Error::AddressMissing) {
-@@ -604,18 +596,6 @@ void MainWindow::serverConnectionConfigureClient(const QString &clientName)
+@@ -634,16 +626,6 @@ void MainWindow::open()
+   const auto kCriticalDialogDelay = 100;
+   QTimer::singleShot(kCriticalDialogDelay, this, &messages::raiseCriticalDialog);
  
- void MainWindow::open()
- {
--
 -  if (!Settings::value(Settings::Gui::AutoUpdateCheck).isValid()) {
--    showAndActivate();
 -    Settings::setValue(Settings::Gui::AutoUpdateCheck, messages::showUpdateCheckOption(this));
 -  }
 -
@@ -127,11 +121,11 @@ index 5b0d730e..a996a787 100644
 -    qDebug() << "update check disabled";
 -  }
 -
-   m_coreProcess.applyLogLevel();
- 
    if (Settings::value(Settings::Core::StartedBefore).toBool()) {
+     if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
+       return;
 diff --git a/src/lib/gui/MainWindow.h b/src/lib/gui/MainWindow.h
-index ab828e5b..08dd738d 100644
+index 0e1705a01..8c305587f 100644
 --- a/src/lib/gui/MainWindow.h
 +++ b/src/lib/gui/MainWindow.h
 @@ -17,7 +17,6 @@
@@ -142,7 +136,7 @@ index ab828e5b..08dd738d 100644
  #include "gui/core/ClientConnection.h"
  #include "gui/core/CoreProcess.h"
  #include "gui/core/ServerConnection.h"
-@@ -103,7 +102,6 @@ private:
+@@ -97,7 +96,6 @@ private:
    void coreProcessError(CoreProcess::Error error);
    void coreConnectionStateChanged(CoreProcess::ConnectionState state);
    void coreProcessStateChanged(CoreProcess::ProcessState state);
@@ -150,7 +144,7 @@ index ab828e5b..08dd738d 100644
    void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
    void serverConnectionConfigureClient(const QString &clientName);
  
-@@ -172,7 +170,6 @@ private:
+@@ -164,7 +162,6 @@ private:
    inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
    inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
  
@@ -159,10 +153,10 @@ index ab828e5b..08dd738d 100644
    bool m_saveOnExit = true;
    deskflow::gui::core::WaylandWarnings m_waylandWarnings;
 diff --git a/src/lib/gui/Messages.cpp b/src/lib/gui/Messages.cpp
-index e55b6e94..c6d5fff3 100644
+index a8a285f3d..b5523a65e 100644
 --- a/src/lib/gui/Messages.cpp
 +++ b/src/lib/gui/Messages.cpp
-@@ -293,20 +293,4 @@ void showWaylandLibraryError(QWidget *parent)
+@@ -286,24 +286,6 @@ void showWaylandLibraryError(QWidget *parent)
    );
  }
  
@@ -171,227 +165,56 @@ index e55b6e94..c6d5fff3 100644
 -  QMessageBox message(parent);
 -  message.addButton(QObject::tr("No thanks"), QMessageBox::RejectRole);
 -  const auto checkButton = message.addButton(QObject::tr("Check for updates"), QMessageBox::AcceptRole);
--  message.setText(QString(
--                      "<p>Would you like to check for updates when %1 starts?</p>"
--                      "<p>Checking for updates requires an Internet connection.</p>"
--                      "<p>URL: <pre>%2</pre></p>"
--  )
--                      .arg(kAppName, Settings::value(Settings::Core::UpdateUrl).toString()));
+-  message.setText(
+-      QObject::tr(
+-          "<p>Would you like to check for updates when %1 starts?</p>"
+-          "<p>Checking for updates requires an Internet connection.</p>"
+-          "<p>URL: <pre>%2</pre></p>"
+-      )
+-          .arg(kAppName, Settings::value(Settings::Core::UpdateUrl).toString())
+-  );
 -
 -  message.exec();
 -  return message.clickedButton() == checkButton;
 -}
 -
- } // namespace deskflow::gui::messages
+ bool showDaemonOffline(QWidget *parent)
+ {
+   QMessageBox message(parent);
 diff --git a/src/lib/gui/Messages.h b/src/lib/gui/Messages.h
-index 1f1eb8df..f20b5a5c 100644
+index f035e2092..339eb8dfb 100644
 --- a/src/lib/gui/Messages.h
 +++ b/src/lib/gui/Messages.h
-@@ -47,6 +47,4 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
+@@ -47,8 +47,6 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
  
  void showWaylandLibraryError(QWidget *parent);
  
 -bool showUpdateCheckOption(QWidget *parent);
 -
+ bool showDaemonOffline(QWidget *parent);
+ 
  } // namespace deskflow::gui::messages
-diff --git a/src/lib/gui/VersionChecker.cpp b/src/lib/gui/VersionChecker.cpp
-deleted file mode 100644
-index 763413e3..00000000
---- a/src/lib/gui/VersionChecker.cpp
-+++ /dev/null
-@@ -1,127 +0,0 @@
--/*
-- * Deskflow -- mouse and keyboard sharing utility
-- * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
-- * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
-- */
--
--#include "VersionChecker.h"
--
--#include "common/Settings.h"
--
--#include <QLocale>
--#include <QNetworkAccessManager>
--#include <QNetworkReply>
--#include <QNetworkRequest>
--#include <QProcess>
--#include <QRegularExpression>
--#include <memory>
--
--VersionChecker::VersionChecker(QObject *parent) : QObject(parent), m_network{new QNetworkAccessManager(this)}
--{
--  connect(m_network, &QNetworkAccessManager::finished, this, &VersionChecker::replyFinished, Qt::UniqueConnection);
--}
--
--void VersionChecker::checkLatest() const
--{
--  const QString url = Settings::value(Settings::Core::UpdateUrl).toString();
--  qDebug("checking for updates at: %s", qPrintable(url));
--  auto request = QNetworkRequest(url);
--  auto userAgent = QString("%1 %2 on %3").arg(kAppName, kVersion, QSysInfo::prettyProductName());
--  request.setHeader(QNetworkRequest::UserAgentHeader, userAgent);
--  request.setRawHeader("X-Deskflow-Version", kVersion);
--  request.setRawHeader("X-Deskflow-Language", QLocale::system().name().toStdString().c_str());
--  m_network->get(request);
--}
--
--void VersionChecker::replyFinished(QNetworkReply *reply)
--{
--  const auto httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
--  if (reply->error() != QNetworkReply::NoError) {
--    qWarning("version check server error: %s", qPrintable(reply->errorString()));
--    qWarning("error checking for updates, http status: %d", httpStatus);
--    return;
--  }
--
--  qDebug("version check server success, http status: %d", httpStatus);
--
--  const auto newestVersion = QString(reply->readAll());
--  reply->deleteLater();
--  qDebug("version check response: %s", qPrintable(newestVersion));
--
--  if (newestVersion.isEmpty()) {
--    qWarning() << "version check is response is empty";
--    return;
--  }
--
--  if (compareVersions(kVersion, newestVersion) > 0) {
--    qWarning().noquote() //
--        << QStringLiteral("current version %1 out of date, update available: %2").arg(kVersion, newestVersion);
--    Q_EMIT updateFound(newestVersion);
--  } else {
--    qDebug().noquote() << QStringLiteral("current version %1 is upto date").arg(kVersion);
--  }
--}
--
--int VersionChecker::getStageVersion(QString stage)
--{
--  const char *stableName = "stable";
--  const char *rcName = "rc";
--  const char *betaName = "beta";
--
--  // use max int for stable so it's always the highest value.
--  const int stableValue = INT_MAX;
--  const int rcValue = 2;
--  const int betaValue = 1;
--  const int otherValue = 0;
--
--  if (stage.isEmpty() || stage == stableName) {
--    return stableValue;
--  } else if (stage.startsWith(rcName, Qt::CaseInsensitive)) {
--    static QRegularExpression re("\\d*", QRegularExpression::CaseInsensitiveOption);
--    auto match = re.match(stage);
--    if (match.hasMatch()) {
--      // return the rc value plus the rc number (e.g. 2 + 1)
--      // this should be ok since stable is max int.
--      return rcValue + match.captured(1).toInt();
--    }
--  } else if (stage == betaName) {
--    return betaValue;
--  }
--
--  return otherValue;
--}
--
--int VersionChecker::compareVersions(const QString &left, const QString &right)
--{
--  if (left.compare(right) == 0)
--    return 0; // versions are same.
--
--  QStringList leftParts = left.split("-");
--  QStringList rightParts = right.split("-");
--
--  QString leftNumber = leftParts.at(0);
--  QString rightNumber = rightParts.at(0);
--
--  QStringList leftNumberParts = leftNumber.split(".");
--  QStringList rightNumberParts = rightNumber.split(".");
--
--  auto leftStagePart = leftParts.size() > 1 ? leftParts.at(1) : "";
--  auto rightStagePart = rightParts.size() > 1 ? rightParts.at(1) : "";
--
--  const int leftMajor = leftNumberParts.at(0).toInt();
--  const int leftMinor = leftNumberParts.at(1).toInt();
--  const int leftPatch = leftNumberParts.at(2).toInt();
--  const int leftStage = getStageVersion(leftStagePart);
--
--  const int rightMajor = rightNumberParts.at(0).toInt();
--  const int rightMinor = rightNumberParts.at(1).toInt();
--  const int rightPatch = rightNumberParts.at(2).toInt();
--  const int rightStage = getStageVersion(rightStagePart);
--
--  const bool rightWins =
--      (rightMajor > leftMajor) || ((rightMajor >= leftMajor) && (rightMinor > leftMinor)) ||
--      ((rightMajor >= leftMajor) && (rightMinor >= leftMinor) && (rightPatch > leftPatch)) ||
--      ((rightMajor >= leftMajor) && (rightMinor >= leftMinor) && (rightPatch >= leftPatch) && (rightStage > leftStage));
--
--  return rightWins ? 1 : -1;
--}
-diff --git a/src/lib/gui/VersionChecker.h b/src/lib/gui/VersionChecker.h
-deleted file mode 100644
-index 7c014ae2..00000000
---- a/src/lib/gui/VersionChecker.h
-+++ /dev/null
-@@ -1,38 +0,0 @@
--/*
-- * Deskflow -- mouse and keyboard sharing utility
-- * SPDX-FileCopyrightText: (C) 2012 Symless Ltd.
-- * SPDX-License-Identifier: GPL-2.0-only WITH LicenseRef-OpenSSL-Exception
-- */
--
--#pragma once
--
--#include <QObject>
--#include <QString>
--#include <memory>
--
--class QNetworkAccessManager;
--class QNetworkReply;
--
--class VersionChecker : public QObject
--{
--  Q_OBJECT
--public:
--  explicit VersionChecker(QObject *parent = nullptr);
--  void checkLatest() const;
--public slots:
--  void replyFinished(QNetworkReply *reply);
--signals:
--  void updateFound(const QString &version);
--
--private:
--  static int compareVersions(const QString &left, const QString &right);
--
--  /**
--   * \brief Converts a string stage to a integer value
--   * \param stage The string containing the stage version
--   * \return An integer representation of the stage, the higher the number the
--   * more recent the version
--   */
--  static int getStageVersion(QString stage);
--  QNetworkAccessManager *m_network = nullptr;
--};
 diff --git a/src/lib/gui/dialogs/SettingsDialog.cpp b/src/lib/gui/dialogs/SettingsDialog.cpp
-index 37d2ff6c..9afff967 100644
+index 2dd47cbf0..2fa2d1a52 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.cpp
 +++ b/src/lib/gui/dialogs/SettingsDialog.cpp
-@@ -154,7 +154,6 @@ void SettingsDialog::accept()
-   Settings::setValue(Settings::Core::StopOnDeskSwitch, ui->cbStopOnDeskSwitch->isChecked());
+@@ -133,7 +133,6 @@ void SettingsDialog::accept()
+   Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
    Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
    Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
 -  Settings::setValue(Settings::Gui::AutoUpdateCheck, ui->cbAutoUpdate->isChecked());
    Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
    Settings::setValue(Settings::Security::Certificate, ui->lineTlsCertPath->text());
    Settings::setValue(Settings::Security::KeySize, ui->comboTlsKeyLength->currentText().toInt());
-@@ -189,7 +188,6 @@ void SettingsDialog::loadFromConfig()
+@@ -167,7 +166,6 @@ void SettingsDialog::loadFromConfig()
+   ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
    ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
-   ui->cbStopOnDeskSwitch->setChecked(Settings::value(Settings::Core::StopOnDeskSwitch).toBool());
    ui->cbElevateDaemon->setChecked(Settings::value(Settings::Daemon::Elevate).toBool());
 -  ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
  
    const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
    ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);
-@@ -278,7 +276,6 @@ void SettingsDialog::updateControls()
+@@ -258,7 +256,6 @@ void SettingsDialog::updateControls()
    ui->comboLogLevel->setEnabled(writable);
    ui->cbLogToFile->setEnabled(writable);
    ui->cbAutoHide->setEnabled(writable);
@@ -400,7 +223,7 @@ index 37d2ff6c..9afff967 100644
    ui->lineTlsCertPath->setEnabled(writable);
    ui->comboTlsKeyLength->setEnabled(writable);
 diff --git a/src/lib/gui/dialogs/SettingsDialog.ui b/src/lib/gui/dialogs/SettingsDialog.ui
-index b370c985..ad5b598e 100644
+index 1ff603b05..55a7d1721 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.ui
 +++ b/src/lib/gui/dialogs/SettingsDialog.ui
 @@ -84,13 +84,6 @@
@@ -417,7 +240,7 @@ index b370c985..ad5b598e 100644
            <item>
             <widget class="QCheckBox" name="cbCloseToTray">
              <property name="text">
-@@ -607,7 +600,6 @@
+@@ -612,7 +605,6 @@
    <tabstop>cbPreventSleep</tabstop>
    <tabstop>cbLanguageSync</tabstop>
    <tabstop>cbScrollDirection</tabstop>
@@ -426,5 +249,5 @@ index b370c985..ad5b598e 100644
    <tabstop>cbAutoHide</tabstop>
    <tabstop>rbIconColorful</tabstop>
 -- 
-2.49.0
+2.50.1
 

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -1,4 +1,4 @@
-VER=1.21.2
+VER=1.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"


### PR DESCRIPTION
Topic Description
-----------------

- deskflow: update to 1.23.0

Package(s) Affected
-------------------

- deskflow: 1.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
