### PR TITLE
lighttpd: update to 1.4.81

### DIFF
--- a/app-network/lighttpd/spec
+++ b/app-network/lighttpd/spec
@@ -1,5 +1,4 @@
-VER=1.4.76
+VER=1.4.81
 SRCS="tbl::https://download.lighttpd.net/lighttpd/releases-${VER%.*}.x/lighttpd-$VER.tar.xz"
-CHKSUMS="sha256::8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011"
+CHKSUMS="sha256::d7d42c3fd2fd94b63c915aa7d18f4da3cac5937ddba33e909f81cf50842a5840"
 CHKUPDATE="anitya::id=1817"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- lighttpd: update to 1.4.81
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lighttpd: 1.4.81

Security Update?
----------------

No

Build Order
-----------

```
#buildit lighttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
