### PR TITLE
clash-verge-rev: update to 2.4.0

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -8,7 +8,7 @@ PKGDES="A GUI configuration manager for the Clash rule-based proxy"
 
 PKGPROV="clash-verge"
 
-# FIXME: Vite not supported on loongson3, riscv64.
+# FIXME: Vite not supported.
 FAIL_ARCH="(loongson3|riscv64)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero

--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,4 +1,4 @@
-From d48e8ef6fc5334b7dc3c89cd0cdb0dc84f7c0048 Mon Sep 17 00:00:00 2001
+From 709aa94b8ca74d83efbdc3631b269e0008bd45cd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
 Subject: [PATCH 01/23] feat(src/assets): add XDG .desktop entry
@@ -29,5 +29,5 @@ index 00000000..1dc4106e
 +Comment=A graphical rule-based proxy manager
 +Comment[zh_CN]=图形化代理服务规则管理器
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From b57d2b8b402031bb3c8d6e0afa578213cae9ba11 Mon Sep 17 00:00:00 2001
+From 1a1285e12e9d3bb28f029871f442814f1dc300a8 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 02/23] fix(tauri.conf.json): disable bundle distribution
@@ -8,11 +8,11 @@ Subject: [PATCH 02/23] fix(tauri.conf.json): disable bundle distribution
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 894d62a2..81ad957f 100755
+index f382c739..1ce85a3e 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.3.1",
+   "version": "2.4.0",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,
@@ -21,5 +21,5 @@ index 894d62a2..81ad957f 100755
      "icon": [
        "icons/32x32.png",
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,4 +1,4 @@
-From 0974e05f1fef7972b1e36f13a4edc15291d9bc8f Mon Sep 17 00:00:00 2001
+From 990bc87198d07023280286aca9ab8f29cc69c55d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
 Subject: [PATCH 03/23] fix(scripts): use ABI2 (New-World) Mihomo binary for
@@ -11,7 +11,7 @@ and abi2 (new-world) binaries.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index fd7a9cd0..1da884a5 100644
+index 8b1f383d..facf7da7 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -71,7 +71,7 @@ const META_ALPHA_MAP = {
@@ -24,5 +24,5 @@ index fd7a9cd0..1da884a5 100644
  
  // Fetch the latest alpha release version from the version.txt file
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
@@ -1,4 +1,4 @@
-From 6c2b1b87c325af4adbadf5235cb07e30b1342dfd Mon Sep 17 00:00:00 2001
+From 9ed8cc8ea42f84646129eaa45f04e56a3218b0bf Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 04/23] feat: drop clash-meta-alpha support
@@ -8,10 +8,10 @@ Subject: [PATCH 04/23] feat: drop clash-meta-alpha support
  1 file changed, 1 deletion(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 18a4b914..8e27425c 100644
+index 1b44236f..012ca2dc 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -23,7 +23,6 @@ import { showNotice } from "@/services/noticeService";
+@@ -27,7 +27,6 @@ import { showNotice } from "@/services/noticeService";
  
  const VALID_CORE = [
    { name: "Mihomo", core: "verge-mihomo", chip: "Release Version" },
@@ -20,5 +20,5 @@ index 18a4b914..8e27425c 100644
  
  export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,4 +1,4 @@
-From f999072f1985e9ba4cd3eeb0600cbd232ce4449d Mon Sep 17 00:00:00 2001
+From ad726c2a14562c7c9e795e9560a56ed6da112729 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
 Subject: [PATCH 05/23] fix(check.mjs): do not fetch Mihomo (Clash Meta)
@@ -10,7 +10,7 @@ We use a system copy for this purpose.
  1 file changed, 13 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 1da884a5..156035f9 100644
+index facf7da7..e5b29146 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -487,19 +487,6 @@ const resolveWinSysproxy = () =>
@@ -34,5 +34,5 @@ index 1da884a5..156035f9 100644
    { name: "service", func: resolveService, retry: 5 },
    { name: "install", func: resolveInstall, retry: 5 },
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,4 +1,4 @@
-From deb3d7b26537c556cbdd8551bc8ae58476a0f135 Mon Sep 17 00:00:00 2001
+From 2eca9ad6f32f3dcd789a3b2fdf90ca041a202e03 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 06/23] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
@@ -9,7 +9,7 @@ Subject: [PATCH 06/23] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 81ad957f..a1d7df07 100755
+index 1ce85a3e..33215677 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@
@@ -21,5 +21,5 @@ index 81ad957f..a1d7df07 100755
      "category": "DeveloperTool",
      "shortDescription": "Clash Verge Rev",
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,4 +1,4 @@
-From 53208d3f32f8ef3ae74c8727736d27aa1a7c2f6d Mon Sep 17 00:00:00 2001
+From 53a3453ddc958c1949533aa42649db7de7f274ca Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:36:28 +0800
 Subject: [PATCH 07/23] fix(check.mjs): do not check Mihomo (Clash Meta)
@@ -9,7 +9,7 @@ Subject: [PATCH 07/23] fix(check.mjs): do not check Mihomo (Clash Meta)
  1 file changed, 15 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 156035f9..9a17ed90 100644
+index e5b29146..49ec5987 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -148,21 +148,6 @@ async function getLatestReleaseVersion() {
@@ -35,5 +35,5 @@ index 156035f9..9a17ed90 100644
   * core info
   */
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
@@ -1,4 +1,4 @@
-From 63a85ae5348306ab4d63410e4c74efa622c62ca0 Mon Sep 17 00:00:00 2001
+From 87c37acec457b267d58ceb78525fc52f61828e84 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:49:46 +0800
 Subject: [PATCH 08/23] Do not create any bundle package
@@ -48,5 +48,5 @@ index 398bff03..318d0af8 100644
 +  "identifier": "io.github.clash-verge-rev.clash-verge-rev"
  }
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
@@ -1,4 +1,4 @@
-From da055072f7f01892e789ce6b2b638202d56bb4b2 Mon Sep 17 00:00:00 2001
+From 046a13c5f6484aa57b3d35c44524772b9fd2149c Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 09/23] Drop check update feature
@@ -66,7 +66,7 @@ index 74e9e736..00000000
 -  );
 -};
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 02fc8423..8c6fe4a7 100644
+index d3d7fa46..bc783b52 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
 @@ -9,7 +9,6 @@ import {
@@ -108,7 +108,7 @@ index 02fc8423..8c6fe4a7 100644
  
    const onExportDiagnosticInfo = useCallback(async () => {
      await exportDiagnosticInfo();
-@@ -68,7 +53,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -74,7 +59,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -116,7 +116,7 @@ index 02fc8423..8c6fe4a7 100644
        <BackupViewer ref={backupRef} />
        <LiteModeViewer ref={liteModeRef} />
  
-@@ -103,8 +87,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -109,8 +93,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
  
        <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
  
@@ -162,10 +162,10 @@ index 34660f4e..1fc4069a 100644
  
        <SettingItem label={t("Language")}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index 5be8eb4c..26a401bd 100644
+index cfe17d8f..4514069f 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -16,7 +16,6 @@ import iconDark from "@/assets/image/icon_dark.svg?react";
+@@ -17,7 +17,6 @@ import iconDark from "@/assets/image/icon_dark.svg?react";
  import { useThemeMode, useEnableLog } from "@/services/states";
  import { LayoutItem } from "@/components/layout/layout-item";
  import { LayoutTraffic } from "@/components/layout/layout-traffic";
@@ -173,7 +173,7 @@ index 5be8eb4c..26a401bd 100644
  import { useCustomTheme } from "@/components/layout/use-custom-theme";
  import getSystem from "@/utils/get-system";
  import "dayjs/locale/ru";
-@@ -550,7 +549,6 @@ const Layout = () => {
+@@ -567,7 +566,6 @@ const Layout = () => {
                  />
                  <LogoSvg fill={isDark ? "white" : "black"} />
                </div>
@@ -182,5 +182,5 @@ index 5be8eb4c..26a401bd 100644
  
              <List className="the-menu">
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From 6e74012bab5f9a3c5737243404ed476d16008f69 Mon Sep 17 00:00:00 2001
+From be10f31b9b714e51f9b55270318b2b9bedc22012 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 10/23] Set core binary name as mihomo
@@ -48,7 +48,7 @@ index 49aafdb9..ce35f689 100644
    zip.addLocalFolder(configDir, ".config");
  
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 9a17ed90..9382fbd2 100644
+index 49ec5987..f2f8faf7 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -160,8 +160,8 @@ function clashMetaAlpha() {
@@ -74,7 +74,7 @@ index 9a17ed90..9382fbd2 100644
      zipFile,
      downloadURL,
 diff --git a/src-tauri/packages/windows/installer.nsi b/src-tauri/packages/windows/installer.nsi
-index 15a2689e..c8585b2f 100644
+index a34cb3ca..bf1cc1ae 100644
 --- a/src-tauri/packages/windows/installer.nsi
 +++ b/src-tauri/packages/windows/installer.nsi
 @@ -444,35 +444,35 @@ FunctionEnd
@@ -126,7 +126,7 @@ index 15a2689e..c8585b2f 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index 9510228e..160cd499 100644
+index 2d2a3330..8350ac38 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
 @@ -347,7 +347,7 @@ impl IVerge {
@@ -154,10 +154,10 @@ index 2fb7e951..7e568a9a 100644
              None => true,
          }
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 8e27425c..1e3ff139 100644
+index 012ca2dc..8e95945d 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -22,7 +22,7 @@ import { closeAllConnections, upgradeCore } from "@/services/api";
+@@ -26,7 +26,7 @@ import {
  import { showNotice } from "@/services/noticeService";
  
  const VALID_CORE = [
@@ -166,7 +166,7 @@ index 8e27425c..1e3ff139 100644
  ];
  
  export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
-@@ -40,7 +40,7 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+@@ -44,7 +44,7 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
      close: () => setOpen(false),
    }));
  
@@ -176,5 +176,5 @@ index 8e27425c..1e3ff139 100644
    const onCoreChange = useLockFn(async (core: string) => {
      if (core === clash_core) return;
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From d2046a6ceb5b2c4a5237020761558b641957e53d Mon Sep 17 00:00:00 2001
+From d765703ae20fc39827f74f8d34b2780c57c9085a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 11/23] feat: always not portable
@@ -8,7 +8,7 @@ Subject: [PATCH 11/23] feat: always not portable
  1 file changed, 10 deletions(-)
 
 diff --git a/src-tauri/src/utils/dirs.rs b/src-tauri/src/utils/dirs.rs
-index 5669a5db..cc1196f8 100644
+index 225de7df..dabdc847 100644
 --- a/src-tauri/src/utils/dirs.rs
 +++ b/src-tauri/src/utils/dirs.rs
 @@ -22,16 +22,6 @@ pub static PROFILE_YAML: &str = "profiles.yaml";
@@ -29,5 +29,5 @@ index 5669a5db..cc1196f8 100644
      Ok(())
  }
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,4 +1,4 @@
-From 83b35408b6f0ae589121af95c5b1c3529e230074 Mon Sep 17 00:00:00 2001
+From 6750d765d63ce80292bb76c97cab35db18dd127d Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 12/23] Set service install/uninstall script path to
@@ -9,12 +9,12 @@ Subject: [PATCH 12/23] Set service install/uninstall script path to
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 6815180f..cc7504e3 100644
+index cb684702..f9e690f3 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -230,9 +230,11 @@ pub async fn reinstall_service() -> Result<()> {
+@@ -230,9 +230,11 @@ pub fn reinstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
- pub async fn uninstall_service() -> Result<()> {
+ pub fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, true, "uninstall service");
 +    use std::path::Path;
      use users::get_effective_uid;
@@ -25,9 +25,9 @@ index 6815180f..cc7504e3 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -270,9 +272,11 @@ pub async fn uninstall_service() -> Result<()> {
+@@ -270,9 +272,11 @@ pub fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
- pub async fn install_service() -> Result<()> {
+ pub fn install_service() -> Result<()> {
      logging!(info, Type::Service, true, "install service");
 +    use std::path::Path;
      use users::get_effective_uid;
@@ -39,5 +39,5 @@ index 6815180f..cc7504e3 100644
      if !install_path.exists() {
          bail!(format!("installer not found: {install_path:?}"));
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-Unset-all-release-profile.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-Unset-all-release-profile.patch
@@ -1,4 +1,4 @@
-From 7c735a2d85027354b75a4cb5d92951669c107e53 Mon Sep 17 00:00:00 2001
+From 7513e00ef23c0314a2dd54c944a404d2148a2629 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:52:29 +0800
 Subject: [PATCH 13/23] Unset all release profile
@@ -8,12 +8,12 @@ Subject: [PATCH 13/23] Unset all release profile
  1 file changed, 7 deletions(-)
 
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 080451f8..4962b2e5 100755
+index 5b385104..a22703af 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -108,13 +108,6 @@ default = ["custom-protocol"]
- custom-protocol = ["tauri/custom-protocol"]
+@@ -111,13 +111,6 @@ custom-protocol = ["tauri/custom-protocol"]
  verge-dev = []
+ tokio-trace = ["console-subscriber"]
  
 -[profile.release]
 -panic = "abort"
@@ -26,5 +26,5 @@ index 080451f8..4962b2e5 100755
  incremental = true
  codegen-units = 256 # 增加编译单元，提升编译速度
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0014-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0014-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From f854a4e79de2c681f3edee8657b3541a9008a336 Mon Sep 17 00:00:00 2001
+From 58dcaee76df0be24a2df99ee963c6c003a0245cf Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 14/23] Do not use gcc
@@ -20,5 +20,5 @@ index beb596d4..00000000
 -[target.armv7-unknown-linux-gnueabihf]
 -linker = "arm-linux-gnueabihf-gcc"
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0015-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0015-Drop-Upgrade-core-button.patch
@@ -1,27 +1,25 @@
-From 1fd2df81bd57c3b10779dc25e22f2315b6f6cc35 Mon Sep 17 00:00:00 2001
+From 8c0884617736271bdf697ac480deb88fbd5927a9 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 15/23] Drop "Upgrade core" button
 
 ---
- .../setting/mods/clash-core-viewer.tsx        | 30 +------------------
- src/services/api.ts                           |  6 ----
- 2 files changed, 1 insertion(+), 35 deletions(-)
+ .../setting/mods/clash-core-viewer.tsx        | 29 -------------------
+ 1 file changed, 29 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 1e3ff139..1d23a35d 100644
+index 8e95945d..21da1cd8 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -18,7 +18,7 @@ import {
-   ListItemText,
- } from "@mui/material";
+@@ -20,7 +20,6 @@ import {
  import { changeClashCore, restartCore } from "@/services/cmds";
--import { closeAllConnections, upgradeCore } from "@/services/api";
-+import { closeAllConnections } from "@/services/api";
+ import {
+   closeAllConnections,
+-  upgradeCore,
+   forceRefreshClashConfig,
+ } from "@/services/cmds";
  import { showNotice } from "@/services/noticeService";
- 
- const VALID_CORE = [
-@@ -80,22 +80,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+@@ -86,22 +85,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
      }
    });
  
@@ -44,7 +42,7 @@ index 1e3ff139..1d23a35d 100644
    return (
      <BaseDialog
        open={open}
-@@ -103,18 +87,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
+@@ -109,18 +92,6 @@ export const ClashCoreViewer = forwardRef<DialogRef>((props, ref) => {
          <Box display="flex" justifyContent="space-between">
            {t("Clash Core")}
            <Box>
@@ -63,23 +61,6 @@ index 1e3ff139..1d23a35d 100644
              <LoadingButton
                variant="contained"
                size="small"
-diff --git a/src/services/api.ts b/src/services/api.ts
-index cebaec84..beadb96c 100644
---- a/src/services/api.ts
-+++ b/src/services/api.ts
-@@ -62,12 +62,6 @@ export const updateGeoData = async () => {
-   return instance.post("/configs/geo");
- };
- 
--/// Upgrade clash core
--export const upgradeCore = async () => {
--  const instance = await getAxios();
--  return instance.post("/upgrade");
--};
--
- /// Get current rules
- export const getRules = async () => {
-   const instance = await getAxios();
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0016-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0016-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
@@ -1,4 +1,4 @@
-From 8b8f6b7ed7d9d5411a83cbbd76bad8473f18af2e Mon Sep 17 00:00:00 2001
+From 149c42c84dc87d05b96d36ad040c7fbf0378691c Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 12:09:38 +0800
 Subject: [PATCH 16/23] (ppc64el) Use `@rollup/wasm-node` to fix build on
@@ -9,11 +9,11 @@ Subject: [PATCH 16/23] (ppc64el) Use `@rollup/wasm-node` to fix build on
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/package.json b/package.json
-index d1ab192e..29de7140 100644
+index 7af821e5..d13849ce 100644
 --- a/package.json
 +++ b/package.json
-@@ -112,5 +112,10 @@
-     "endOfLine": "lf"
+@@ -106,5 +106,10 @@
+     "vite-plugin-svgr": "^4.3.0"
    },
    "type": "module",
 -  "packageManager": "pnpm@9.13.2"
@@ -25,5 +25,5 @@ index d1ab192e..29de7140 100644
 +  }
  }
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0017-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0017-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From 94ef9cb2275d54b94f5baeec0c02593c4ef2eb19 Mon Sep 17 00:00:00 2001
+From fd7a672d221456f75e623a28337c0313497daae5 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 17/23] Do not sidecar mihomo program
@@ -8,10 +8,10 @@ Subject: [PATCH 17/23] Do not sidecar mihomo program
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index 70a7748b..23a02784 100644
+index 05d371d8..b13da577 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
-@@ -260,7 +260,7 @@ impl CoreManager {
+@@ -263,7 +263,7 @@ impl CoreManager {
          // 使用子进程运行clash验证配置
          let output = app_handle
              .shell()
@@ -20,7 +20,7 @@ index 70a7748b..23a02784 100644
              .args(["-t", "-d", app_dir_str, "-f", config_path])
              .output()
              .await?;
-@@ -456,7 +456,7 @@ impl CoreManager {
+@@ -756,7 +756,7 @@ impl CoreManager {
  
          let (mut rx, child) = app_handle
              .shell()
@@ -30,5 +30,5 @@ index 70a7748b..23a02784 100644
                  "-d",
                  dirs::path_to_str(&config_dir)?,
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0018-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0018-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
@@ -1,4 +1,4 @@
-From d3ca1cb202b88611f3c4c5f8f9b400955f0d8a89 Mon Sep 17 00:00:00 2001
+From 0d09640ac21b70d9a7d8a3cfc1437f1de68bbc2a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 8 Apr 2025 12:32:41 +0800
 Subject: [PATCH 18/23] Fix if mihomo geoip file `src_path` is symlink
@@ -8,7 +8,7 @@ Subject: [PATCH 18/23] Fix if mihomo geoip file `src_path` is symlink
  1 file changed, 17 insertions(+), 13 deletions(-)
 
 diff --git a/src-tauri/src/utils/init.rs b/src-tauri/src/utils/init.rs
-index 3c42986d..ee9cd4a0 100644
+index d2e97a81..769425bd 100644
 --- a/src-tauri/src/utils/init.rs
 +++ b/src-tauri/src/utils/init.rs
 @@ -13,7 +13,7 @@ use log4rs::{
@@ -20,7 +20,7 @@ index 3c42986d..ee9cd4a0 100644
      str::FromStr,
  };
  use tauri_plugin_shell::ShellExt;
-@@ -320,21 +320,16 @@ pub fn init_resources() -> Result<()> {
+@@ -322,21 +322,16 @@ pub fn init_resources() -> Result<()> {
      // copy the resource file
      // if the source file is newer than the destination file, copy it over
      for file in file_list.iter() {
@@ -47,7 +47,7 @@ index 3c42986d..ee9cd4a0 100644
              continue;
          }
  
-@@ -344,14 +339,14 @@ pub fn init_resources() -> Result<()> {
+@@ -346,14 +341,14 @@ pub fn init_resources() -> Result<()> {
          match (src_modified, dest_modified) {
              (Ok(src_modified), Ok(dest_modified)) => {
                  if src_modified > dest_modified {
@@ -64,7 +64,7 @@ index 3c42986d..ee9cd4a0 100644
              }
          };
      }
-@@ -359,6 +354,15 @@ pub fn init_resources() -> Result<()> {
+@@ -361,6 +356,15 @@ pub fn init_resources() -> Result<()> {
      Ok(())
  }
  
@@ -81,5 +81,5 @@ index 3c42986d..ee9cd4a0 100644
  #[cfg(target_os = "windows")]
  pub fn init_scheme() -> Result<()> {
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0019-fix-components-drop-update-checker.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0019-fix-components-drop-update-checker.patch
@@ -1,4 +1,4 @@
-From bb336d18af11a51bcb9352076a58bdfdf1e8d4e1 Mon Sep 17 00:00:00 2001
+From 32ee953c671da606b6fe1035859fb4a560b56ff5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:43:15 +0800
 Subject: [PATCH 19/23] fix(components): drop update checker
@@ -275,5 +275,5 @@ index 91ea4ae1..00000000
 -  );
 -});
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0020-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0020-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From e54e5948667a4fd17f2205a29776df8b5704b328 Mon Sep 17 00:00:00 2001
+From 35f7e0ee297db2c3149cd1dcf5d58a24f486f6c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 20/23] fix: drop Open Core Dir function
@@ -6,14 +6,14 @@ Subject: [PATCH 20/23] fix: drop Open Core Dir function
 This is useless for our users as it would just open /usr/bin.
 ---
  src-tauri/src/cmd/app.rs                      |  8 -------
- src-tauri/src/core/tray/mod.rs                | 22 +++----------------
+ src-tauri/src/core/tray/mod.rs                | 21 +++----------------
  src-tauri/src/lib.rs                          |  1 -
  .../setting/setting-verge-advanced.tsx        |  3 ---
- src/services/cmds.ts                          |  6 -----
- 5 files changed, 3 insertions(+), 37 deletions(-)
+ src/services/cmds.ts                          |  6 ------
+ 5 files changed, 3 insertions(+), 36 deletions(-)
 
 diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
-index f44928ce..2c7b7205 100644
+index cb8fd6a2..db914791 100644
 --- a/src-tauri/src/cmd/app.rs
 +++ b/src-tauri/src/cmd/app.rs
 @@ -13,14 +13,6 @@ pub fn open_app_dir() -> CmdResult<()> {
@@ -32,12 +32,12 @@ index f44928ce..2c7b7205 100644
  #[tauri::command]
  pub fn open_logs_dir() -> CmdResult<()> {
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index 62414efa..0343b7a5 100644
+index 74ebf61b..e8214210 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -840,15 +840,6 @@ fn create_tray_menu(
-     )
-     .unwrap();
+@@ -660,14 +660,6 @@ fn create_tray_menu(
+         None::<&str>,
+     )?;
  
 -    let open_core_dir = &MenuItem::with_id(
 -        app_handle,
@@ -45,22 +45,21 @@ index 62414efa..0343b7a5 100644
 -        t("Core Dir"),
 -        true,
 -        None::<&str>,
--    )
--    .unwrap();
+-    )?;
 -
      let open_logs_dir = &MenuItem::with_id(
          app_handle,
          "open_logs_dir",
-@@ -863,7 +854,7 @@ fn create_tray_menu(
+@@ -681,7 +673,7 @@ fn create_tray_menu(
          "open_dir",
          t("Open Dir"),
          true,
 -        &[open_app_dir, open_core_dir, open_logs_dir],
 +        &[open_app_dir, open_logs_dir],
-     )
-     .unwrap();
+     )?;
  
-@@ -965,15 +956,8 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+     let restart_clash = &MenuItem::with_id(
+@@ -779,15 +771,8 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
              feat::toggle_tun_mode(None);
          }
          "copy_env" => feat::copy_clash_env(),
@@ -79,10 +78,10 @@ index 62414efa..0343b7a5 100644
          "restart_app" => feat::restart_app(),
          "entry_lightweight_mode" => {
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 961d898c..5aa20228 100644
+index 92f63ea1..dac13347 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -225,7 +225,6 @@ pub fn run() {
+@@ -298,7 +298,6 @@ mod app_init {
              cmd::open_app_dir,
              cmd::open_logs_dir,
              cmd::open_web_url,
@@ -91,7 +90,7 @@ index 961d898c..5aa20228 100644
              cmd::get_network_interfaces,
              cmd::get_system_hostname,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 8c6fe4a7..269f1776 100644
+index bc783b52..905df326 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
 @@ -4,7 +4,6 @@ import { Typography } from "@mui/material";
@@ -102,7 +101,7 @@ index 8c6fe4a7..269f1776 100644
    openLogsDir,
    openDevTools,
    exportDiagnosticInfo,
-@@ -83,8 +82,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -89,8 +88,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
          }
        />
  
@@ -112,10 +111,10 @@ index 8c6fe4a7..269f1776 100644
  
        <SettingItem onClick={openDevTools} label={t("Open Dev Tools")} />
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index 5f2cbc87..959287a4 100644
+index 8f14c418..121a0344 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
-@@ -157,12 +157,6 @@ export async function openAppDir() {
+@@ -504,12 +504,6 @@ export async function openAppDir() {
    );
  }
  
@@ -129,5 +128,5 @@ index 5f2cbc87..959287a4 100644
    return invoke<void>("open_logs_dir").catch((err) =>
      showNotice("error", err?.message || err.toString()),
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0021-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0021-fix-disable-GeoData-update.patch
@@ -1,27 +1,18 @@
-From 42260ac21454ad918f94dcb5bb12c3262cd88768 Mon Sep 17 00:00:00 2001
+From 6684863f2d43e27f8ee078f3415a332cac09fda2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 21/23] fix: disable GeoData update
 
 We handle this via mihomo-rules-dat.
 ---
- src/components/setting/setting-clash.tsx | 10 ----------
- src/services/api.ts                      |  6 ------
- 2 files changed, 16 deletions(-)
+ src/components/setting/setting-clash.tsx | 9 ---------
+ 1 file changed, 9 deletions(-)
 
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index a56bf3ce..5a2e87c2 100644
+index 102ba1ed..c2f03e4c 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
-@@ -3,7 +3,6 @@ import { TooltipIcon } from "@/components/base/base-tooltip-icon";
- import { useClash } from "@/hooks/use-clash";
- import { useListen } from "@/hooks/use-listen";
- import { useVerge } from "@/hooks/use-verge";
--import { updateGeoData } from "@/services/api";
- import { invoke_uwp_tool } from "@/services/cmds";
- import { showNotice } from "@/services/noticeService";
- import getSystem from "@/utils/get-system";
-@@ -65,14 +64,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -67,14 +67,6 @@ const SettingClash = ({ onError }: Props) => {
    const onChangeVerge = (patch: Partial<IVergeConfig>) => {
      mutateVerge({ ...verge, ...patch }, false);
    };
@@ -36,7 +27,7 @@ index a56bf3ce..5a2e87c2 100644
  
    // 实现DNS设置开关处理函数
    const handleDnsToggle = useLockFn(async (enable: boolean) => {
-@@ -256,7 +247,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -261,7 +253,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  
@@ -44,23 +35,6 @@ index a56bf3ce..5a2e87c2 100644
      </SettingList>
    );
  };
-diff --git a/src/services/api.ts b/src/services/api.ts
-index beadb96c..5ee0bac0 100644
---- a/src/services/api.ts
-+++ b/src/services/api.ts
-@@ -56,12 +56,6 @@ export const getClashConfig = async () => {
-   return instance.get("/configs") as Promise<IConfigData>;
- };
- 
--/// Update geo data
--export const updateGeoData = async () => {
--  const instance = await getAxios();
--  return instance.post("/configs/geo");
--};
--
- /// Get current rules
- export const getRules = async () => {
-   const instance = await getAxios();
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0022-fix-remove-unused-code.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0022-fix-remove-unused-code.patch
@@ -1,4 +1,4 @@
-From 851cf24e128867ee74f90800f5f973dd2d12ecad Mon Sep 17 00:00:00 2001
+From 844f1d643b70c9e266e1a18769f6cf4c6929deeb Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Wed, 9 Jul 2025 15:55:53 +0800
 Subject: [PATCH 22/23] fix: remove unused code
@@ -6,10 +6,11 @@ Subject: [PATCH 22/23] fix: remove unused code
 ---
  scripts/prebuild.mjs          | 143 ----------------------------------
  src-tauri/src/core/service.rs |  13 ----
- 2 files changed, 156 deletions(-)
+ src-tauri/src/utils/dirs.rs   |  14 ----
+ 3 files changed, 170 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 9382fbd2..b6d0749f 100644
+index f2f8faf7..af18705b 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -148,122 +148,6 @@ async function getLatestReleaseVersion() {
@@ -186,7 +187,7 @@ index 9382fbd2..b6d0749f 100644
      name: "enableLoopback",
      func: resolveEnableLoopback,
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index cc7504e3..78c2b836 100644
+index f9e690f3..92cbd277 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
 @@ -7,7 +7,6 @@ use crate::{
@@ -207,9 +208,9 @@ index cc7504e3..78c2b836 100644
  }
  
  #[derive(Debug, Deserialize, Serialize, Clone)]
-@@ -748,26 +745,16 @@ pub(super) async fn start_with_existing_service(config_file: &PathBuf) -> Result
+@@ -747,26 +744,16 @@ pub(super) async fn start_with_existing_service(config_file: &PathBuf) -> Result
  
-     let clash_core = Config::verge().latest().get_valid_clash_core();
+     let clash_core = Config::verge().latest_ref().get_valid_clash_core();
  
 -    let bin_ext = if cfg!(windows) { ".exe" } else { "" };
 -    let clash_bin = format!("{clash_core}{bin_ext}");
@@ -234,6 +235,31 @@ index cc7504e3..78c2b836 100644
      });
  
      // log::info!(target:"app", "启动服务参数: {:?}", payload);
+diff --git a/src-tauri/src/utils/dirs.rs b/src-tauri/src/utils/dirs.rs
+index dabdc847..b547eaad 100644
+--- a/src-tauri/src/utils/dirs.rs
++++ b/src-tauri/src/utils/dirs.rs
+@@ -192,20 +192,6 @@ pub fn service_path() -> Result<PathBuf> {
+     Ok(res_dir.join("clash-verge-service.exe"))
+ }
+ 
+-pub fn service_log_file() -> Result<PathBuf> {
+-    use chrono::Local;
+-
+-    let log_dir = app_logs_dir()?.join("service");
+-
+-    let local_time = Local::now().format("%Y-%m-%d-%H%M").to_string();
+-    let log_file = format!("{local_time}.log");
+-    let log_file = log_dir.join(log_file);
+-
+-    let _ = std::fs::create_dir_all(&log_dir);
+-
+-    Ok(log_file)
+-}
+-
+ pub fn path_to_str(path: &PathBuf) -> Result<&str> {
+     let path_str = path
+         .as_os_str()
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0023-fix-edit-mihomo-path.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0023-fix-edit-mihomo-path.patch
@@ -1,14 +1,15 @@
-From edc91f71efb38cfa8a178f1d73615772b8451f30 Mon Sep 17 00:00:00 2001
+From fc410874add0a7b5fd4a006ec1cd54a5f14924da Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
-Date: Thu, 10 Jul 2025 02:30:20 +0800
+Date: Wed, 27 Aug 2025 00:38:46 +0800
 Subject: [PATCH 23/23] fix: edit mihomo path
 
 ---
  src-tauri/src/config/verge.rs | 12 ++++++------
- 1 file changed, 6 insertions(+), 6 deletions(-)
+ src-tauri/src/core/core.rs    |  2 +-
+ 2 files changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index 160cd499..43ad221b 100644
+index 8350ac38..1aa1be95 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
 @@ -234,7 +234,7 @@ pub struct IVergeTheme {
@@ -54,6 +55,19 @@ index 160cd499..43ad221b 100644
      }
  
      fn get_system_language() -> String {
+diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
+index b13da577..42f8d739 100644
+--- a/src-tauri/src/core/core.rs
++++ b/src-tauri/src/core/core.rs
+@@ -445,7 +445,7 @@ impl CoreManager {
+             child_guard.as_ref().map(|child| child.pid())
+         };
+ 
+-        let target_processes = ["verge-mihomo", "verge-mihomo-alpha"];
++        let target_processes = ["mihomo", "mihomo-alpha"];
+ 
+         // 并行查找所有目标进程
+         let mut process_futures = Vec::new();
 -- 
-2.50.1
+2.51.0
 

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,7 +1,5 @@
-VER=2.3.1
+VER=2.4.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
-ENVREQ__ARM64="total_mem=60"
-ENVREQ__AMD64="total_mem_per_core=3"
-ENVREQ__LOONGARCH64="total_mem_per_core=3"
+ENVREQ="total_mem=60"

--- a/app-proxy/clash-verge-service/autobuild/defines
+++ b/app-proxy/clash-verge-service/autobuild/defines
@@ -7,4 +7,4 @@ PKGSEC="net"
 USECLANG=1
 
 # clash-verge-rev does not support architecture
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="loongson3"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.4.0

Package(s) Affected
-------------------

- clash-verge-rev: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
