### PR TITLE
chezscheme: new, 10.2.0

### DIFF
--- a/lang-lisp/chezscheme/autobuild/build
+++ b/lang-lisp/chezscheme/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Configuring..."
+# parameters were taken from Arch Linux
+./configure --installprefix=/usr --threads \
+            --installschemename=chez \
+            --installscriptname=chez-script \
+            --kernelobj
+
+abinfo "Building chezscheme..."
+make
+
+abinfo "Installing..."
+make install DESTDIR="$PKGDIR"
+

--- a/lang-lisp/chezscheme/autobuild/defines
+++ b/lang-lisp/chezscheme/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=chezsheceme
+PKGVER=10.2.0
+PKGSEC=lisp
+PKGDEP="ncurses"
+BUILDDEP="ncurses x11-lib"
+PKGDES="Compiler and run-time system for the language of the Revised^6 Report on Scheme (R6RS), with numerous extensions"
+
+ABTYPE=self
+

--- a/lang-lisp/chezscheme/spec
+++ b/lang-lisp/chezscheme/spec
@@ -1,0 +1,5 @@
+VER=10.2.0
+ 
+SRCS="tbl::https://github.com/cisco/ChezScheme/releases/download/v$VER/csv$VER.tar.gz"
+CHKSUMS="sha256::b795916d4cfed59240c5f44b1b507a8657efd28e62e72e134d03486e9f3e374a"
+


### PR DESCRIPTION
Topic Description
-----------------

chezscheme: new, 10.2.0

Package(s) Affected
-------------------

chezscheme

Security Update?
----------------

No 

Build Order
-----------


```
#buildit chezscheme
```

Test Build(s) Done
------------------

**Primary Architectures**



- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

