### PR TITLE
gitea: new, 1.24.5

### DIFF
--- a/app-vcs/gitea/autobuild/beyond
+++ b/app-vcs/gitea/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Installing gitea config file ..."
+install -dv "$PKGDIR"/etc/gitea
+install -Dvm644 "$SRCDIR"/custom/conf/app.example.ini \
+    "$PKGDIR"/etc/gitea/app.ini

--- a/app-vcs/gitea/autobuild/build
+++ b/app-vcs/gitea/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Building the Gitea backend ..."
+make backend                                                    
+abinfo "Installing gitea binary ..."
+install -Dvm755 gitea "$PKGDIR"/usr/bin/gitea

--- a/app-vcs/gitea/autobuild/conffiles
+++ b/app-vcs/gitea/autobuild/conffiles
@@ -1,0 +1,1 @@
+/etc/gitea/app.ini

--- a/app-vcs/gitea/autobuild/defines
+++ b/app-vcs/gitea/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=gitea
+PKGSEC=vcs
+PKGDES="Web-based Git repository hosting service"
+PKGDEP="git linux-pam openssh"
+PKGSUG="mariadb memcached postgresql sqlite"
+BUILDDEP="go nodejs"

--- a/app-vcs/gitea/autobuild/overrides/usr/lib/systemd/system/gitea.service
+++ b/app-vcs/gitea/autobuild/overrides/usr/lib/systemd/system/gitea.service
@@ -1,0 +1,54 @@
+# Adapted from Arch Linux.
+# Original systemd service file  can be found here:
+# https://gitlab.archlinux.org/archlinux/packaging/packages/gitea/-/blob/main/gitea.service
+
+[Unit]
+Description=Gitea (Git with a cup of tea)
+After=network.target
+After=mysqld.service
+After=postgresql.service
+After=memcached.service
+After=redis.service
+
+[Service]
+User=gitea
+Group=gitea
+Type=simple
+WorkingDirectory=~
+RuntimeDirectory=gitea
+LogsDirectory=gitea
+StateDirectory=gitea
+Environment=USER=gitea HOME=/var/lib/gitea GITEA_WORK_DIR=/var/lib/gitea
+ExecStart=/usr/bin/gitea web -c /etc/gitea/app.ini
+Restart=always
+RestartSec=2s
+ReadWritePaths=/etc/gitea/app.ini
+AmbientCapabilities=
+CapabilityBoundingSet=
+LockPersonality=true
+#Required by commit search
+#MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+#SecureBits=noroot-locked
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+[Install]
+WantedBy=multi-user.target

--- a/app-vcs/gitea/autobuild/overrides/usr/lib/sysusers.d/gitea.conf
+++ b/app-vcs/gitea/autobuild/overrides/usr/lib/sysusers.d/gitea.conf
@@ -1,0 +1,1 @@
+u! gitea - "Gitea daemon user" /var/lib/gitea /bin/bash

--- a/app-vcs/gitea/autobuild/overrides/usr/lib/tmpfiles.d/gitea.conf
+++ b/app-vcs/gitea/autobuild/overrides/usr/lib/tmpfiles.d/gitea.conf
@@ -1,0 +1,10 @@
+d /var/lib/gitea 0750
+d /var/lib/gitea/attachments 0750
+d /var/lib/gitea/data 0750
+d /var/lib/gitea/indexers 0750
+d /var/lib/gitea/repos 0750
+d /var/lib/gitea/tmp 0750
+Z /var/lib/gitea - gitea gitea
+d /var/log/gitea 0750 gitea gitea
+z /etc/gitea 0755 root gitea
+z /etc/gitea/app.ini 0660 root gitea

--- a/app-vcs/gitea/autobuild/postinst
+++ b/app-vcs/gitea/autobuild/postinst
@@ -1,0 +1,2 @@
+systemd-sysusers gitea.conf
+systemd-tmpfiles --create gitea.conf

--- a/app-vcs/gitea/autobuild/prepare
+++ b/app-vcs/gitea/autobuild/prepare
@@ -1,0 +1,13 @@
+abinfo "Setting build tags ..."
+export TAGS="bindata sqlite sqlite_unlock_notify pam"
+
+abinfo "Setting build flags ..."
+if ab_match_arch loongson3; then
+    export EXTRA_GOFLAGS="-mod=readonly -modcacherw"
+else
+    export EXTRA_GOFLAGS="-buildmode=pie -mod=readonly -modcacherw"
+fi
+export LDFLAGS="-linkmode=external -compressdwarf=false -X 'code.gitea.io/gitea/modules/setting.AppWorkPath=/var/lib/gitea/' -X 'code.gitea.io/gitea/modules/setting.CustomConf=/etc/gitea/app.ini'"
+
+abinfo "Gathering build deps ..."
+make deps-backend deps-tools

--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,0 +1,4 @@
+VER=1.24.5
+SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v1.24.5/gitea-src-1.24.5.tar.gz"
+CHKSUMS="sha256::835118a9b92ee8854a7b3113d3a09670a36ea8882bb9c779303f4812c4687aeb"
+CHKUPDATE="anitya::id=13537"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: new, 1.24.5

Package(s) Affected
-------------------

- gitea: 1.24.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
