### PR TITLE
xviewer: update to 3.4.11

### DIFF
--- a/app-imaging/xviewer/spec
+++ b/app-imaging/xviewer/spec
@@ -1,4 +1,4 @@
-VER=3.4.6
+VER=3.4.11
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/xviewer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13328"


### PR DESCRIPTION
Topic Description
-----------------

- xviewer: update to 3.4.11
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- xviewer: 3.4.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit xviewer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
