### PR TITLE
chezmoi: update to 2.65.0

### DIFF
--- a/app-utils/chezmoi/autobuild/defines
+++ b/app-utils/chezmoi/autobuild/defines
@@ -4,8 +4,5 @@ PKGSEC=utils
 PKGDEP="git glibc"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols
-# from Go executables.
-ABSPLITDBG=0
 ABTYPE=gomod
 GO_BUILD_AFTER=(-tags "noupgrade")

--- a/app-utils/chezmoi/spec
+++ b/app-utils/chezmoi/spec
@@ -1,4 +1,4 @@
-VER=2.64.0
+VER=2.65.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/twpayne/chezmoi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232604"


### PR DESCRIPTION
Topic Description
-----------------

- chezmoi: update to 2.65.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- chezmoi: 2.65.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit chezmoi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
