### PR TITLE
iosevka-fonts: update to 33.2.8

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.7
+VER=33.2.8
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::1ec79743bb88d3dbe204df44c288402285a9f91c760a98058fcf146afa08206c \
-         sha256::a9e3b3c702bfd5870a180eeba746efbfa2955e83e67bc531f13dbc11993bc85b \
-         sha256::18e68b7f59677d924379c5746373c7e90ab24b77cbf0ead12b1eb2dd9f605c3e \
-         sha256::c6dfcef8c0ca413fd0318c81fd62b08cac47cd1a3d7ee8dbf536f1a9cec66843 \
-         sha256::cd83a4017ab0e71634f2675a9d159b33c1556a5f9db543dfbc6e5da795f7c13c \
-         sha256::b26f1aad5b47600dbc622324c274c586f2d286186f5c54c1c7c34426dbb9a805 \
-         sha256::f8231d777ee4e76ad3abae31ca987eeaabd118efa56cbe697e5196c1f5a7f98b \
-         sha256::4643b7afd1c108a40446567b4c17ca0670aa7b4a04aebb906d2e83444fe44e9f \
-         sha256::b52ebaf70e70890e0b544f84240cc767a9f89f78cf9404b1bf036808f582347e \
-         sha256::0e0c3d564d7136d817f27662119eb09c0fba31d3eec0ec22eb3d2cb4b21833db \
-         sha256::af5842b56b423aa01ad7819e4a5a3e7df5cd5bcfbdfee6422c1f7fba4c0ab562 \
-         sha256::279e43c31ddcba95717666f516936a9736d034a41de88e1eaa2b9d4f849089a8 \
-         sha256::252de7db420754268164f277fb4a67d1bc56ccc2f80104b05038762241dd54b8 \
-         sha256::33f322f5966b9ba21829657a1be704998d702d4afaf0146b0faa283b15c5c0cd \
-         sha256::a3a679e352046dce8c73a4ed872c8e4f93461f70416a12c674065ced7925baf3 \
-         sha256::8f7ee9014b71717d410ae7ec20a3530c1f38d7ec4232aa09e5c6306ee77eab24 \
-         sha256::73935c382ea54a1ccb1d60c4ab32af9cd8e0ea65acd14660a94f9eab4dc1e0f2 \
-         sha256::ddd640fa509b2b4e1ae2a3346b534ade25ccbc35281e837df4fcda9fe2ef423b \
-         sha256::d5a1b1f2635dc5f2f98a2d3782bf82d80b66ca949ca240c5b723b6d01841f3fe \
-         sha256::279210d3ab1ddd7ac1766637ef80d00a0dc1e8601485be6b9673c27014a3d0e4 \
-         sha256::acebd04263c18b26f37c053e2a457f5e53086ea335d70789b707fa6bb15a73a9 \
-         sha256::cf83b268aa872bd4a47dc7c41a9df7374074568d8d4259e6e6a1e92639a9df7b \
-         sha256::721f93e907b9d7fd532c56e441670b8b0919e8cdfb6b6c236d5e0ba22f96d44d \
-         sha256::533496ae185a0c65feb3f0f8a20cc35b23f49f978b5033d3725d03deab86be1e \
+CHKSUMS="sha256::4bacf82337638fc12494bc8b24058e62988090e987d6b15c211cb7b1fd5fef6f \
+         sha256::7e2afc85bb3d45375bfcf0ea9eca9c5a6977fdcef4711879b95dba8d8f899528 \
+         sha256::281ccba978ec8a8f4cc805329457fc7d8bf60a5ee71ef2354ef32e346423f578 \
+         sha256::3b349d2d61434cf708161af0d507834d0c47f8910bff9f996ccf483d4797c6e1 \
+         sha256::311db6965b22b39ad3672b21941fb9351d8ec5e5cdfc05495bbcb2a87dbb7b9a \
+         sha256::b73837fe44ea520d3b1ffc413cf70f1188c52d6b99978cf0090a085cfc91ed6c \
+         sha256::d63c71e0ff7fd1b67f27fd5703b005cd7a1a6b50eccac9df3434654fa9f3986e \
+         sha256::0628cbf9489d535123143c212e4d8721894685abfa013e06ab7392fdf0f81567 \
+         sha256::c055577375834de812243214a090a1c5048c1261542e3672ceb2148c1cfc4a7a \
+         sha256::687f1facfdfc794ad409fa26f6f0b8139558196fcb98cc8b22ea84ef9e5976e8 \
+         sha256::82ad343f6a023366b9e38b460a4cd372487fc19e78c18507e18a6ba7732600e8 \
+         sha256::1b9d4a482650874c0b3df1e6cf746b195653a5a89a3ad8a5b1fb73963e928267 \
+         sha256::cdf57925f71e6e0c854d13903a37f12d8c5cb2508906d0217af4abb4e8dd3985 \
+         sha256::5ab8a207745d826843951e1595903a7dc4274b35643265186071f0e6b0d9a76c \
+         sha256::bb3c04e386a9a50d5d3c1d5f520499fc201d516932429b283309f0cee5ed5dfa \
+         sha256::2fe3f3a4dc1900dda0f9099ef3d04bf03689d40d786dcbd2da4fe54b86a1eebd \
+         sha256::233a3a9c8b7d4cfe51554322972a1127ba94813ce09e1a91564f3a73f1cdfff6 \
+         sha256::f7235d64d0cb15af302eeb1341656a11cec70ced4cf4e42d43f4d812cabf93ce \
+         sha256::b66e701600d3ef1bdbc6f1517e9d5533cb9e7ebe5f3b58d076e258fefbca58f2 \
+         sha256::570a9ad4d7c3968a9b9e4432e3ddb2c28864c6bdbbab80d0a46d967496fe4b91 \
+         sha256::ea88f55f1d3fbb98dead1df6dd4495b288bce0393d1740bc3bafa2f18a49be76 \
+         sha256::36de5f9f12a8bb4986e2ebe9b2d46659cf54cabdc01a65a6796a23e230d66ecb \
+         sha256::ab7d636dc3516b8844c7ec6b8654e93983f8219e96b8b7992d63b6d852b8b90a \
+         sha256::77867723253326a9bb0d5515971a08b11c977fca71fcea16b92691648d712abc \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.8
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
