### PR TITLE
racket: update to 8.18

### DIFF
--- a/lang-lisp/racket/autobuild/build
+++ b/lang-lisp/racket/autobuild/build
@@ -1,0 +1,17 @@
+# FIXME: Upstream hacks generated `configure` script which breaks autobuild's
+# autotools default `AUTOTOOLS_DEF` arguments.
+abinfo "Building racket ..."
+cd "$SRCDIR"
+./configure \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --libdir=/usr/lib \
+    --bindir=/usr/bin \
+    --mandir=/usr/share/man \
+    "${AUTOTOOLS_AFTER[@]}"
+
+make
+
+abinfo "Installing racket ..."
+make install DESTDIR="$PKGDIR"

--- a/lang-lisp/racket/autobuild/build
+++ b/lang-lisp/racket/autobuild/build
@@ -1,8 +1,7 @@
 # FIXME: Upstream hacks generated `configure` script which breaks autobuild's
 # autotools default `AUTOTOOLS_DEF` arguments.
 abinfo "Building racket ..."
-cd "$SRCDIR"
-./configure \
+"$SRCDIR"/configure \
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var \

--- a/lang-lisp/racket/autobuild/defines
+++ b/lang-lisp/racket/autobuild/defines
@@ -4,9 +4,6 @@ PKGDEP="gtk-3 libffi glibc"
 BUILDDEP="ncurses lz4 zlib urw-fonts"
 PKGDES="A full-spectrum programming language"
 
-RECONF=0
-ABTYPE=autotools
-
 AUTOTOOLS_AFTER__PPC64EL=(
     '--enable-pb'
     '--enable-mach=tpb64l'

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=8.17
+VER=8.18
 SRCS="tbl::https://download.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::44431395138f7b8c5e67d416ff063b8fb6ce056f4c4f0fda27b7b1ec58bfa33b"
+CHKSUMS="sha256::65477c71ec1a978a6ee4db582b9b47b1a488029d7a42e358906de154a6e5905c"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 8.18
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- racket: 8.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
