### PR TITLE
feh: update to 3.11

### DIFF
--- a/app-imaging/feh/spec
+++ b/app-imaging/feh/spec
@@ -1,4 +1,4 @@
-VER=3.10.3
+VER=3.11
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::5426e2799770217af1e01c2e8c182d9ca8687d84613321d8ab4a66fe4041e9c8"
+CHKSUMS="sha256::e35597564fd7ad6106127fbbf2f2bb92ea264e75b0fcbffc054db43c933dbd2a"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

- feh: update to 3.11
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- feh: 3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit feh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
