### PR TITLE
heimdall: fix build error

### DIFF
--- a/app-devices/heimdall/autobuild/build
+++ b/app-devices/heimdall/autobuild/build
@@ -1,7 +1,11 @@
-cmake . ${CMAKE_DEF}
+abinfo "Running CMake ..."
+cmake "$SRCDIR" ${CMAKE_DEF[@]}
+
+abinfo "Building Heimdall ..."
 make
 
-install -d "$PKGDIR"/usr/bin
-install -Dm755 bin/* "$PKGDIR"/usr/bin/
-install -Dm644 heimdall/60-heimdall.rules \
+abinfo "Installing Heimdall..."
+install -dv "$PKGDIR"/usr/bin
+install -Dvm0755 "$SRCDIR"/bin/* "$PKGDIR"/usr/bin/
+install -Dvm0644 "$SRCDIR"/heimdall/60-heimdall.rules \
     "$PKGDIR"/usr/lib/udev/rules.d/60-heimdall.rules

--- a/app-devices/heimdall/spec
+++ b/app-devices/heimdall/spec
@@ -1,5 +1,5 @@
 VER=1.4.2
-REL=4
+REL=5
 SRCS="tbl::https://github.com/Benjamin-Dobell/Heimdall/archive/v$VER.tar.gz"
 CHKSUMS="sha256::589bef88f2597c8a84fe6fafbe928ddc9687438b5b54edd917d7df48c7e3eff8"
 CHKUPDATE="anitya::id=1308"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Fix build MIGRATE_TO_ARRAY error.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
heimdall: 1.4.2-4
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit heimdall
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
