### PR TITLE
maiatrac3plus: fix build error

### DIFF
--- a/app-multimedia/maiatrac3plus/autobuild/build
+++ b/app-multimedia/maiatrac3plus/autobuild/build
@@ -1,4 +1,9 @@
-cmake . ${CMAKE_DEF} -DMIPS=ON # quirk: disable x86 specific flags
+abinfo "Run cmake..."
+cmake "$SRCDIR" ${CMAKE_DEF[@]} -DMIPS=ON # quirk: disable x86 specific flags
+
+abinfo "Run make..."
 make -j${ABMK}
-install -Dm755 "$SRCDIR"/lib/libat3plusdecoder.so \
-               "$PKGDIR"/usr/lib/libat3plusdecoder.so
+
+abinfo "Run install..."
+install -D -v -m 755 "$SRCDIR"/lib/libat3plusdecoder.so \
+                     "$PKGDIR"/usr/lib/libat3plusdecoder.so

--- a/app-multimedia/maiatrac3plus/spec
+++ b/app-multimedia/maiatrac3plus/spec
@@ -1,6 +1,6 @@
 VER=20130616
 SUBDIR="maiatrac3plus/MaiAT3PlusDecoder"
-REL=2
+REL=3
 SRCS="git::commit=95c34f2651b0988a8ed762692925eb22700e9b42::https://github.com/emulibraries/maiatrac3plus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230935"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Fix build MIGRATE_TO_ARRAY error.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
maiatrac3plus: 20130616-2
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit maiatrac3plus
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
