### PR TITLE
protobuf: downgrade to 25.2

### DIFF
--- a/runtime-common/protobuf/spec
+++ b/runtime-common/protobuf/spec
@@ -1,4 +1,9 @@
-VER=32.0
+VER=25.2
+EPOCH=1
+# Note: the stable repo doesn't accept same-name uploads, which becomes
+# problematic when only the EPOCH changes.
+# Please remove this note when we do a version upgrade
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/protocolbuffers/protobuf.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3715"


### PR DESCRIPTION
Topic Description
-----------------

- protobuf: downgrade to 25.2
    Apparently lots of reverse dependencies aren't ready for the new
    APIs.

Package(s) Affected
-------------------

- protobuf: 25.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit protobuf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
