### PR TITLE
kicad: update to 9.0.4

### DIFF
--- a/app-electronics/kicad/autobuild/defines
+++ b/app-electronics/kicad/autobuild/defines
@@ -8,18 +8,26 @@ BUILDDEP="cmake breezy swig glm llvm po4a asciidoctor"
 ABTYPE=cmakeninja
 # FIXME: Set -DKICAD_USE_EGL once we enable EGL support in wxWidgets.
 # Currently blocked by bugs in SuperSlicer.
-CMAKE_AFTER="-DKICAD_SCRIPTING_WXPYTHON=ON \
-             -DKICAD_INSTALL_DEMOS=ON \
-             -DKICAD_BUILD_QA_TESTS=OFF \
-             -DKICAD_SPICE=OFF \
-             -DKICAD_BUILD_I18N=ON \
-             -DKICAD_USE_EGL=OFF \
-             -DKICAD_USE_BUNDLED_GLEW=OFF \
-             -DKICAD_DRC_PROTO=OFF \
-             -DKICAD_BUILD_PEGTL_DEBUG_TOOL=OFF \
-             -DKICAD_BUILD_PNS_DEBUG_TOOL=OFF \
-             -DKICAD_GAL_PROFILE=OFF \
-             -DKICAD_USE_SENTRY=OFF"
+CMAKE_AFTER=(
+        "-DKICAD_SCRIPTING_WXPYTHON=ON"
+        "-DKICAD_INSTALL_DEMOS=ON"
+        "-DKICAD_BUILD_QA_TESTS=OFF"
+        "-DKICAD_SPICE=OFF"
+        "-DKICAD_BUILD_I18N=ON"
+        "-DKICAD_USE_EGL=OFF"
+        "-DKICAD_USE_BUNDLED_GLEW=OFF"
+        "-DKICAD_DRC_PROTO=OFF"
+        "-DKICAD_BUILD_PEGTL_DEBUG_TOOL=OFF"
+        "-DKICAD_BUILD_PNS_DEBUG_TOOL=OFF"
+        "-DKICAD_GAL_PROFILE=OFF"
+        "-DKICAD_USE_SENTRY=OFF"
+        "-DKICAD_UPDATE_CHECK=OFF"
+        "-DKICAD_WAYLAND=ON"
+)
 
 PKGREP="kicad-i18n<=4.0.0"
 PKGBREAK="kicad-i18n<=4.0.0"
+
+# Note: Current loongarch64_nosimd machines does not have a graphics
+#       performance that is enough for PCB designing.
+FAIL_ARCH="(loongarch64_nosimd)"

--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -1,5 +1,4 @@
-VER=9.0.3
-REL=2
+VER=9.0.4
 SRCS="git::commit=tags/$VER;rename=kicad-$VER::https://gitlab.com/kicad/code/kicad \
       git::commit=tags/$VER;rename=kicad-footprints-$VER::https://gitlab.com/kicad/libraries/kicad-footprints \
       git::commit=tags/$VER;rename=kicad-symbols-$VER::https://gitlab.com/kicad/libraries/kicad-symbols \


### PR DESCRIPTION
Topic Description
-----------------

- kicad: update to 9.0.4
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- kicad: 9.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
