### PR TITLE
udisks-2: update to 2.10.2

### DIFF
--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -1,5 +1,4 @@
-VER=2.10.1
-REL=1
+VER=2.10.2
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
-CHKSUMS="sha256::b75734ccf602540dedb4068bec206adcb508a4c003725e117ae8f994d92d8ece"
+CHKSUMS="sha256::6401c715d287ec84fe605e0cb90579e8da6c395bce5f42e419f205dd297e261f"
 CHKUPDATE="anitya::id=5028"

--- a/runtime-admin/libstoragemgmt/autobuild/defines
+++ b/runtime-admin/libstoragemgmt/autobuild/defines
@@ -1,8 +1,27 @@
 PKGNAME=libstoragemgmt
 PKGSEC=libs
 PKGDEP="libconfig libxml2 openssl perl pyudev pywbem six sqlite systemd yajl"
-BUILDDEP="check chrpath"
+BUILDDEP="check chrpath pbr pywbem"
 PKGDES="Storage array management library"
 
-AUTOTOOLS_AFTER="--with-python3 PYTHON=/usr/bin/python3"
-AUTOTOOLS_AFTER__RISCV64="$AUTOTOOLS_AFTER --without-mem-leak-test"
+AUTOTOOLS_AFTER=(
+	"--with-python3"
+	"PYTHON=/usr/bin/python3"
+)
+
+# NOTE valgrind is not available on the following architectures yet.
+# Memory leak tests requires valgrind.
+AUTOTOOLS_AFTER__LOONGARCH64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"--without-mem-leak-test"
+)
+
+AUTOTOOLS_AFTER__LOONGARCH64_NOSIMD=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"--without-mem-leak-test"
+)
+
+AUTOTOOLS_AFTER__RISCV64=(
+	"${AUTOTOOLS_AFTER[@]}"
+	"--without-mem-leak-test"
+)

--- a/runtime-admin/libstoragemgmt/spec
+++ b/runtime-admin/libstoragemgmt/spec
@@ -1,5 +1,5 @@
 VER=1.7.3
-REL=7
+REL=8
 SRCS="tbl::https://github.com/libstorage/libstoragemgmt/releases/download/$VER/libstoragemgmt-$VER.tar.gz"
 CHKSUMS="sha256::18e36665b645c1c41ad39fe8034e8f691104d72325881fb141e4bef97538ce80"
 CHKUPDATE="anitya::id=17306"

--- a/topics/udisks-2-2.10.2.toml
+++ b/topics/udisks-2-2.10.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "UDisks 2.10.2"
+
+[caution]
+default = "Fixes an out-of-bounds read vulnerability - CVE-2025-8067 (Severity: High)"
+zh_CN = "修复一处越界读取 (out-of-bounds read) 漏洞，漏洞编号 CVE-2025-8067（严重性：高）"
+
+[packages]
+"udisks-2" = "2.10.2"


### PR DESCRIPTION
Topic Description
-----------------

- udisks-2: update to 2.10.2
    Co-authored-by: billchenchina \(@billchenchina\) <billchenchina2001@gmail.com>

Package(s) Affected
-------------------

- udisks-2: 2.10.2

Security Update?
----------------

Yes, #12301

Build Order
-----------

```
#buildit libstoragemgmt udisks-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
