### PR TITLE
darktable: update to 5.2.1

### DIFF
--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,4 +1,4 @@
-VER=5.2.0
+VER=5.2.1
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=392"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: update to 5.2.1

Package(s) Affected
-------------------

- darktable: 1:5.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
