### PR TITLE
easytier: update to 2.4.3

### DIFF
--- a/app-network/easytier/autobuild/defines
+++ b/app-network/easytier/autobuild/defines
@@ -6,6 +6,16 @@ BUILDDEP="rustc llvm"
 
 ABTYPE=rust
 
+# NOTE: Autobuild4 now adds --workspace by default.
+# LINK: https://github.com/AOSC-Dev/autobuild4/commit/c566af6
+# Use -p to specify members.
+CARGO_AFTER=(
+    '-p'
+    'easytier'
+    '-p'
+    'easytier-web'
+)
+
 # FIXME: 
 # error[E0432]: unresolved imports `self::encode::Encode','self::decode::Decode'
 NOLTO=1

--- a/app-network/easytier/spec
+++ b/app-network/easytier/spec
@@ -1,4 +1,4 @@
-VER=2.4.2
+VER=2.4.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/EasyTier/EasyTier"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377832"


### PR DESCRIPTION
Topic Description
-----------------

- easytier: update to 2.4.3
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- easytier: 2.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit easytier
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
