### PR TITLE
pcl:update to 1.15.1

### DIFF
--- a/runtime-imaging/pcl/spec
+++ b/runtime-imaging/pcl/spec
@@ -1,5 +1,4 @@
-VER=1.15.0
-REL=1
+VER=1.15.1
 SRCS="git::commit=tags/pcl-$VER::https://github.com/PointCloudLibrary/pcl"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=2606"
+CHKUPDATE="anitya::id=141386"


### PR DESCRIPTION
Topic Description
-----------------

- pcl: update to 1.15.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pcl: 1.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
