### PR TITLE
gpgme: cherry-pick qt-6 support

### DIFF
--- a/runtime-cryptography/gpgme/autobuild/defines
+++ b/runtime-cryptography/gpgme/autobuild/defines
@@ -10,7 +10,7 @@ PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
 PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP="doxygen graphviz qt-5 swig"
+BUILDDEP="doxygen graphviz qt-5 qt-6 swig"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -28,28 +28,31 @@ PKGDES="A C wrapper library for GnuPG"
 #
 # By default we use SYS_getdents on Linux to optimize fd closing
 # before an exec.  This option allows to switch this optimization off.
-AUTOTOOLS_AFTER="--disable-glibtest \
-                 --disable-w32-glib \
-                 --enable-languages=cl,cpp,python,qt \
-                 --enable-build-timestamp \
-                 --disable-gpgconf-test \
-                 --disable-gpg-test \
-                 --disable-gpgsm-test \
-                 --disable-g13-test \
-                 --enable-largefile \
-                 --disable-fd-passing \
-                 --enable-linux-getdents"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-languages=cl"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    "--disable-glibtest"
+    "--disable-w32-glib"
+    "--enable-languages=cl,cpp,python,qt5,qt6"
+    "--enable-build-timestamp"
+    "--disable-gpgconf-test"
+    "--disable-gpg-test"
+    "--disable-gpgsm-test"
+    "--disable-g13-test"
+    "--enable-largefile"
+    "--disable-fd-passing"
+    "--enable-linux-getdents"
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    "--enable-languages=cl"
+)
+AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO[@]}"
+AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO[@]}"
 
 PKGBREAK="kde-runtime<=16.08.3 kdepimlibs4<=1:4.14.10 \
           balsa<=2.5.2-0 claws-mail<=3.14.1 fwupd<=0.7.5 \

--- a/runtime-cryptography/gpgme/autobuild/defines.stage2
+++ b/runtime-cryptography/gpgme/autobuild/defines.stage2
@@ -21,7 +21,6 @@ PKGDES="A C wrapper library for GnuPG"
 
 AUTOTOOLS_AFTER="--disable-fd-passing --disable-gpgsm-test"
 PKGBREAK="kde-runtime<=16.08.3 kdepimlibs4<=1:4.14.10 \
-          kde-runtime<=16.08.3 kdepimlibs4<=1:4.14.10 \
           balsa<=2.5.2-0 claws-mail<=3.14.1 fwupd<=0.7.5 \
           geany-plugins<=1.29 gmime<=2.6.20-3 gpgmepp<=16.08.3 \
           kdepimlibs<=16.04.0 kdepimlibs4<=1:4.14.10-1 libcryptui<=3.12.2-2 \

--- a/runtime-cryptography/gpgme/spec
+++ b/runtime-cryptography/gpgme/spec
@@ -1,4 +1,5 @@
 VER=1.24.3
+REL=1
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$VER.tar.bz2"
 CHKSUMS="sha256::bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd"
 CHKUPDATE="anitya::id=1239"


### PR DESCRIPTION
Topic Description
-----------------

- gpgme: cherry-pick qt-6 support
    - use bash arrays when possible
    - fix a small mistake for stage2

Package(s) Affected
-------------------

- gpgme: 1.24.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpgme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
