### PR TITLE
cpu-x: update to 5.4.0

### DIFF
--- a/app-utils/cpu-x/autobuild/defines
+++ b/app-utils/cpu-x/autobuild/defines
@@ -6,4 +6,23 @@ PKGDEP="cairomm gcc-runtime glib glibc glibmm gtkmm-3 libcl libcpuid \
 BUILDDEP="gettext opencl-registry-api vulkan-headers"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
 
-CMAKE_AFTER="-DWITH_OPENCL=ON"
+ABTYPE=cmakeninja
+
+CMAKE_AFTER=(
+    '-DWITH_DMIDECODE=ON'
+    '-DWITH_GETTEXT=ON'
+    '-DWITH_GTK=ON'
+    '-DWITH_LIBCPUID=ON'
+    '-DWITH_LIBEGL=ON'
+    '-DWITH_LIBPCI=ON'
+    '-DWITH_LIBPROCPS=ON'
+    '-DWITH_LIBSTATGRAB=ON'
+    '-DWITH_NCURSES=ON'
+    '-DWITH_OPENCL=ON'
+    '-DWITH_VULKAN=ON'
+)
+
+CMAKE_AFTER__AMD64=(
+    '${CMAKE_AFTER[@]}'
+    '-DWITH_BANDWIDTH=ON'
+)

--- a/app-utils/cpu-x/spec
+++ b/app-utils/cpu-x/spec
@@ -1,4 +1,4 @@
-VER=5.3.1
+VER=5.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/TheTumultuousUnicornOfDarkness/CPU-X"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137672"

--- a/runtime-common/libcpuid/spec
+++ b/runtime-common/libcpuid/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=0.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/anrieff/libcpuid"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241811"


### PR DESCRIPTION
Topic Description
-----------------

- cpu-x: update to 5.4.0
    - Add missing ABTYPE
    - Explicitly set the build options to ON
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>
- libcpuid: update to 0.8.1

Package(s) Affected
-------------------

- cpu-x: 5.4.0
- libcpuid: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcpuid cpu-x
```

Test Build(s) Done
------------------

