### PR TITLE
fwupd: update to 2.0.14

### DIFF
--- a/app-admin/fwupd-efi/autobuild/defines
+++ b/app-admin/fwupd-efi/autobuild/defines
@@ -14,7 +14,7 @@ MESON_AFTER=(
 
 ABSPLITDBG=0
 # Upstream only supports these architectures.
-FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|riscv64|loongarch64|loongarch64_nosimd)"
 
 PKGBREAK="fwupd<=1.9.25"
 PKGREP="fwupd<=1.9.25"

--- a/app-admin/fwupd-efi/autobuild/patches/0001-Fix-build-error-of-LoongArch-in-gnu-efi-3.0.18.patch
+++ b/app-admin/fwupd-efi/autobuild/patches/0001-Fix-build-error-of-LoongArch-in-gnu-efi-3.0.18.patch
@@ -1,0 +1,164 @@
+From 2bc57d143e4cf9d7b2c72390cf56a29ac1112a5c Mon Sep 17 00:00:00 2001
+From: Xiaotian Wu <wuxiaotian@loongson.cn>
+Date: Mon, 1 Sep 2025 16:16:50 +0800
+Subject: [PATCH 1/2] Fix build error of LoongArch in gnu-efi-3.0.18
+
+In gnu-efi 3.0.18, LoongArch uses efi-app-loongarch64 and removes the PE header
+definition from crt0, resulting in the ImageBase address not being found.
+---
+ efi/lds/elf_loongarch64_efi.lds | 54 ++++++++++++---------------------
+ 1 file changed, 19 insertions(+), 35 deletions(-)
+
+diff --git a/efi/lds/elf_loongarch64_efi.lds b/efi/lds/elf_loongarch64_efi.lds
+index c7a77a3..5b96dcf 100644
+--- a/efi/lds/elf_loongarch64_efi.lds
++++ b/efi/lds/elf_loongarch64_efi.lds
+@@ -3,37 +3,39 @@ OUTPUT_ARCH(loongarch)
+ ENTRY(_start)
+ SECTIONS
+ {
+-  .text 0 : {
+-    *(.text.head)
+-    . = ALIGN(4096);
++  . = 0;
++  ImageBase = .;
++  /* .hash and/or .gnu.hash MUST come first! */
++  .hash : { *(.hash) }
++  .gnu.hash : { *(.gnu.hash) }
++  . = ALIGN(4096);
++  .eh_frame : { *(.eh_frame) }
++  .eh_frame_hdr : { *(.eh_frame_hdr) }
++  .gcc_except_table : { *(.gcc_except_table*) }
++  . = ALIGN(4096);
++  .text : {
+     _text = .;
+     *(.text)
+     *(.text.*)
+     *(.gnu.linkonce.t.*)
+     *(.plt)
+     . = ALIGN(16);
+-    _evtext = .;
+-    . = ALIGN(4096);
+     _etext = .;
+-  } =0
+-  _text_vsize = _evtext - _text;
++  }
+   _text_size = _etext - _text;
+   . = ALIGN(4096);
+   _reloc = .;
+   .reloc : {
+     *(.reloc)
+-    _evreloc = .;
+-    . = ALIGN(4096);
+     _ereloc = .;
+-  } =0
+-  _reloc_vsize = _evreloc - _reloc;
++  }
+   _reloc_size = _ereloc - _reloc;
+   . = ALIGN(65536);
+-  _data = .;
+   .dynamic  : { *(.dynamic) }
+   . = ALIGN(4096);
+   .data :
+   {
++   _data = .;
+    *(.sdata)
+    *(.data)
+    *(.data1)
+@@ -78,13 +80,11 @@ SECTIONS
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
++   *(.rel.local)
+    . = ALIGN(16);
+    _bss_end = .;
+-   _evdata = .;
+-   . = ALIGN(4096);
+    _edata = .;
+-  } =0
+-  _data_vsize = _evdata - _data;
++  }
+   _data_size = _edata - _data;
+ 
+   . = ALIGN(4096);
+@@ -107,11 +107,8 @@ SECTIONS
+   . = ALIGN(4096);
+   .rodata : {
+     *(.rodata*)
+-    _evrodata = .;
+-    . = ALIGN(4096);
+     _erodata = .;
+-  } =0
+-  _rodata_vsize = _evrodata - _rodata;
++  }
+   _rodata_size = _erodata - _rodata;
+   /*
+    * Note that _sbat must be the beginning of the data, and _esbat must be the
+@@ -129,7 +126,7 @@ SECTIONS
+     _esbat = .;
+     . = ALIGN(4096);
+     _epsbat = .;
+-  } =0
++  }
+   _sbat_size = _epsbat - _sbat;
+   _sbat_vsize = _esbat - _sbat;
+   . = ALIGN(4096);
+@@ -137,12 +134,9 @@ SECTIONS
+   {
+     _sbom = .;
+     *(.sbom)
+-    _esbom = .;
+-    . = ALIGN(4096);
+     _epsbom = .;
+-  } =0
++  }
+   _sbom_size = _epsbom - _sbom;
+-  _sbom_vsize = _esbom - _sbom;
+   _image_end = .;
+   _alldata_size = _image_end - _reloc;
+ 
+@@ -152,15 +146,6 @@ SECTIONS
+   .dynstr   : { *(.dynstr) }
+   . = ALIGN(4096);
+   .note.gnu.build-id : { *(.note.gnu.build-id) }
+-  . = ALIGN(4096);
+-  .hash : { *(.hash) }
+-  . = ALIGN(4096);
+-  .gnu.hash : { *(.gnu.hash) }
+-  . = ALIGN(4096);
+-  .eh_frame : { *(.eh_frame) }
+-  .eh_frame_hdr : { *(.eh_frame_hdr) }
+-  . = ALIGN(4096);
+-  .gcc_except_table : { *(.gcc_except_table*) }
+   /DISCARD/ :
+   {
+     *(.rela.reloc)
+@@ -168,4 +153,3 @@ SECTIONS
+   }
+   .comment 0 : { *(.comment) }
+ }
+-
+
+From bfbba16e8896713a490bb055fb2501bee012e76f Mon Sep 17 00:00:00 2001
+From: Xiaotian Wu <wuxiaotian@loongson.cn>
+Date: Mon, 1 Sep 2025 17:00:04 +0800
+Subject: [PATCH 2/2] Do not generate SIMD on LoongArch architecture
+
+---
+ efi/meson.build | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/efi/meson.build b/efi/meson.build
+index 747c2ef..76342cb 100644
+--- a/efi/meson.build
++++ b/efi/meson.build
+@@ -197,6 +197,9 @@ elif host_cpu == 'x86'
+                    '-mno-mmx',
+                    '-mno-red-zone',
+                    '-m32']
++elif host_cpu == 'loongarch64'
++  compile_args += ['-mno-lsx',
++                   '-mno-lasx']
+ # no special cases for aarch64 or arm
+ endif
+ 

--- a/app-admin/fwupd-efi/spec
+++ b/app-admin/fwupd-efi/spec
@@ -1,5 +1,5 @@
 VER=1.7
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd-efi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326081"

--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -11,9 +11,10 @@ PKGDEP__LOONGSON3="${PKGDEP/fwupd-efi/}"
 PKGDEP__PPC64EL="${PKGDEP/fwupd-efi/}"
 # FIXME: Valgrind is not yet available for LoongArch.
 BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/valgrind/}"
 
 MESON_AFTER=(
-    "-Ddocs=enabled"
+    "-Ddocs=disabled"
     "-Defi_binary=false"
     "-Dtests=false"
 )

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=2.0.13
+VER=2.0.14
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"

--- a/app-devel/gnu-efi/autobuild/build
+++ b/app-devel/gnu-efi/autobuild/build
@@ -1,5 +1,7 @@
-abinfo "Building..."
+abinfo "Building gnu-efi ..."
 make
 
-abinfo "Installing..."
-make PREFIX=/usr DESTDIR="$PKGDIR" install
+abinfo "Installing gnu-efi ..."
+make install\
+    PREFIX=/usr \
+    DESTDIR="$PKGDIR"

--- a/app-devel/gnu-efi/autobuild/defines
+++ b/app-devel/gnu-efi/autobuild/defines
@@ -6,4 +6,4 @@ ABSTRIP=0
 NOPARALLEL=1
 NOSTATIC=0
 
-FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64|loongarch64|loongarch64_nosimd)"

--- a/app-devel/gnu-efi/autobuild/prepare
+++ b/app-devel/gnu-efi/autobuild/prepare
@@ -1,2 +1,4 @@
-abinfo "Unsetting all pre-compiler, compiler, and linker flags ..."
-unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
+# ld: unrecognized option '-Wl,-O1,--sort-common,--as-needed'
+# and other errors.
+abinfo "Unsetting LDFLAGS ..."
+unset LDFLAGS

--- a/app-devel/gnu-efi/spec
+++ b/app-devel/gnu-efi/spec
@@ -1,5 +1,5 @@
 VER=3.0.18
-SRCS="tbl::https://download.sourceforge.net/gnu-efi/gnu-efi-$VER.tar.bz2"
+SRCS="tbl::https://sourceforge.net/projects/gnu-efi/files/gnu-efi-$VER.tar.bz2/download"
 CHKSUMS="sha256::7f212c96ee66547eeefb531267b641e5473d7d8529f0bd8ccdefd33cf7413f5c"
 CHKUPDATE="anitya::id=1202"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- fwupd-efi: support loongarch64_nosimd
- gnu-efi: support loongarch64_nosimd
    - Modify source url to comply with the AOSC Package Styling Manual.
    - Improve prepare script.
- fwupd: update to 2.0.14
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- fwupd: 2.0.14
- fwupd-efi: 1.7-2
- gnu-efi: 3.0.18-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnu-efi fwupd-efi fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
