### PR TITLE
llvm-21: new, 21.1.6

### DIFF
--- a/app-devel/llvm-21/01-runtime/build
+++ b/app-devel/llvm-21/01-runtime/build
@@ -1,0 +1,74 @@
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+abinfo "Removing certain search path in PATH to avoid issues ..."
+# LLVM will not be able to find Python 3 otherwise
+PATH="${PATH/:\/bin/}"
+PATH="${PATH/:\/sbin/}"
+
+CPP_TRIPLE="$(basename /usr/include/c++/*.*/*-aosc-linux-*)"
+if [[ "$USECLANG" = '1' ]]; then
+    abinfo "Selecting ${CPP_TRIPLE} for Clang ..."
+    clang -target "${CPP_TRIPLE}" -v
+    export CFLAGS="${CFLAGS} -target ${CPP_TRIPLE}"
+    export CXXFLAGS="${CXXFLAGS} -target ${CPP_TRIPLE}"
+    # only clang will have this idiotic issue
+    if ab_match_arch riscv64; then
+        abinfo 'Setting -D__LONG_WIDTH__=64 to workaround a Clang bug ...'
+        export CFLAGS="${CFLAGS} -D__LONG_WIDTH__=64"
+        export CXXFLAGS="${CXXFLAGS} -D__LONG_WIDTH__=64"
+    fi
+fi
+
+if ab_match_arch loongarch64; then
+    abinfo "Adding -mcmodel=medium for compiler-rt ..."
+    export CFLAGS="${CFLAGS} -mcmodel=medium"
+    export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
+fi
+
+# Remove this when uleb128 relocation support is landed
+if ab_match_arch riscv64; then
+    abinfo "Stripping debug symbols from libc_nonshared.a for ULEB128 relocation ..."
+    strip --strip-debug /usr/lib/libc_nonshared.a
+fi
+
+abinfo "Running CMake for LLVM ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-${PKGVER%%.*} \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
+    -DCMAKE_SKIP_RPATH=NO \
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
+
+# FIXME: LLVM builds break with Ninja due to an unidentified race condition.
+# Fallback to GNU Make for now.
+#
+# Ref: https://github.com/llvm/llvm-project/issues/87553
+abinfo "Building LLVM ..."
+make
+
+abinfo "Installing LLVM to a temporary installation directory ..."
+make install \
+    DESTDIR="$SRCDIR"/fakeroot
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib
+cp -Pv \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so* \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+# Note: not all targets have libunwind, libcxx and libcxxabi
+for i in "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*; do
+    if [ -e "$i" ]; then
+        cp -Pv "$i" \
+            "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+    fi
+done
+
+abinfo "Installing version-specific runtime libraries to the default location ..."
+cd "$PKGDIR"/usr/lib
+# The major sover must match the first segment of PKGVER to be considered
+# version-specific
+ln -sv llvm-"${PKGVER%%.*}"/lib/*.so."${PKGVER%%.*}"* .
+ln -sv llvm-"${PKGVER%%.*}"/lib/libLLVM-"${PKGVER%%.*}".so .

--- a/app-devel/llvm-21/01-runtime/build.stage2
+++ b/app-devel/llvm-21/01-runtime/build.stage2
@@ -1,0 +1,44 @@
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+abinfo "Removing certain search path in PATH to avoid issues ..."
+# LLVM will not be able to find Python 3 otherwise
+PATH="${PATH/:\/bin/}"
+PATH="${PATH/:\/sbin/}"
+
+CPP_TRIPLE="$(basename /usr/include/c++/*.*/*-aosc-linux-*)"
+
+abinfo "Running CMake for LLVM ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-${PKGVER%%.*} \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
+    -DCMAKE_SKIP_RPATH=NO \
+    -DCMAKE_SKIP_INSTALL_RPATH=NO
+
+# FIXME: LLVM builds break with Ninja due to an unidentified race condition.    
+# Fallback to GNU Make for now.
+#
+# Ref: https://github.com/llvm/llvm-project/issues/87553
+abinfo "Building LLVM ..."
+make
+
+abinfo "Installing LLVM to a temporary installation directory ..."
+make install \
+    DESTDIR="$SRCDIR"/fakeroot
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib
+cp -Pv \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so* \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/libc++*.so* \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+
+abinfo "Installing version-specific runtime libraries to the default location ..."
+cd "$PKGDIR"/usr/lib
+# The major sover must match the first segment of PKGVER to be considered
+# version-specific
+ln -sv llvm-"${PKGVER%%.*}"/lib/*.so."${PKGVER%%.*}"* .
+ln -sv llvm-"${PKGVER%%.*}"/lib/libLLVM-"${PKGVER%%.*}".so .

--- a/app-devel/llvm-21/01-runtime/defines
+++ b/app-devel/llvm-21/01-runtime/defines
@@ -1,0 +1,102 @@
+PKGNAME=llvm-runtime-21
+PKGSEC=libs
+PKGDEP="gcc-runtime libedit libffi ncurses zlib"
+BUILDDEP="swig doxygen ocaml findlib llvm"
+BUILDDEP__RETRO="llvm"
+BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, version 21)"
+
+AB_FLAGS_O3=1
+# Note: For size.
+AB_FLAGS_O3__RETRO=0
+
+# FIXME: We simply do not have (that many) machines with enough RAM.
+NOLTO=1
+
+USECLANG=1
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+# Figure out which feature/module to enable
+_LLVM_MIN_SET="clang" # for Afterglow and other new ports
+_LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
+_LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang;libclc" # for main-T1 arch (e.g. amd64, arm64 ...)
+
+_LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
+_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;offload;openmp"
+_LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET}"
+
+CMAKE_AFTER=(
+    '-DLLVM_BUILD_LLVM_DYLIB=ON'
+    '-DLLVM_DYLIB_EXPORT_ALL=ON'
+    '-DLLVM_LINK_LLVM_DYLIB=ON'
+    '-DLLVM_ENABLE_RTTI=ON'
+    '-DLLVM_ENABLE_FFI=ON'
+    '-DLLVM_BUILD_DOCS=OFF'
+    '-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF'
+    "-DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi)"
+    '-DLLVM_BINUTILS_INCDIR=/usr/include'
+    '-DLLVM_INSTALL_UTILS=ON'
+    '-DLLVM_INCLUDE_TESTS=OFF'
+    '-DLLVM_USE_LINKER=lld'
+    '-DINSTALL_WITH_TOOLCHAIN=ON'
+)
+CMAKE_AFTER__BASE=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+CMAKE_AFTER__FULL=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER__FULL[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__LOONGARCH64[@]}"
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+
+CMAKE_AFTER__RETRO=(
+    "${CMAKE_AFTER[@]}"
+    '-DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET}'
+    '-DLLVM_USE_LINKER=bfd'
+)
+
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-21/01-runtime/defines.stage2
+++ b/app-devel/llvm-21/01-runtime/defines.stage2
@@ -1,0 +1,105 @@
+PKGNAME=llvm-runtime-21
+PKGSEC=libs
+PKGDEP="gcc-runtime libedit libffi ncurses zlib"
+BUILDDEP=""
+BUILDDEP__RETRO=""
+BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, version 21)"
+
+AB_FLAGS_O3=1
+# Note: For size.
+AB_FLAGS_O3__RETRO=0
+
+# FIXME: We simply do not have (that many) machines with enough RAM.
+NOLTO=1
+
+# Note: For bootstrapping.
+USECLANG=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+# Figure out which feature/module to enable
+_LLVM_MIN_SET="clang" # for Afterglow and other new ports
+_LLVM_BASE_SET="${_LLVM_MIN_SET};lld" # for main-T2 arch (e.g. loongson3, riscv64 ...)
+_LLVM_FULL_SET="${_LLVM_BASE_SET}" # for main-T1 arch (e.g. amd64, arm64 ...)
+
+_LLVM_BASE_RUNTIME_SET=""
+_LLVM_FULL_RUNTIME_SET=""
+_LLVM_BASE_RUNTIME_SET__LOONGARCH64=""
+# FIXME: Runtime libraries does not build without lld.
+_LLVM_BASE_RUNTIME_SET__LOONGSON3=""
+
+CMAKE_AFTER=(
+    '-DLLVM_BUILD_LLVM_DYLIB=ON'
+    '-DLLVM_DYLIB_EXPORT_ALL=ON'
+    '-DLLVM_LINK_LLVM_DYLIB=ON'
+    '-DLLVM_ENABLE_RTTI=ON'
+    '-DLLVM_ENABLE_FFI=ON'
+    '-DLLVM_BUILD_DOCS=OFF'
+    '-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF'
+    "-DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi)"
+    '-DLLVM_BINUTILS_INCDIR=/usr/include'
+    '-DLLVM_INSTALL_UTILS=ON'
+    '-DLLVM_INCLUDE_TESTS=OFF'
+    '-DLLVM_USE_LINKER=bfd'
+    '-DINSTALL_WITH_TOOLCHAIN=ON'
+)
+CMAKE_AFTER__BASE=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+CMAKE_AFTER__FULL=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER__FULL[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__LOONGARCH64[@]}"
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+
+CMAKE_AFTER__RETRO=(
+    "${CMAKE_AFTER[@]}"
+    '-DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET}'
+    '-DLLVM_USE_LINKER=bfd'
+)
+
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-21/01-runtime/patch
+++ b/app-devel/llvm-21/01-runtime/patch
@@ -1,0 +1,5 @@
+cd "$SRCDIR"/..
+abinfo "Applying patches for LLVM full workspace ..."
+ab_apply_patches "$SRCDIR/autobuild/patches/"*.patch
+ab_reverse_patches "$SRCDIR/autobuild/patches/"*.rpatch
+cd "$SRCDIR"

--- a/app-devel/llvm-21/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,0 +1,25 @@
+From c1c0017102e03650a21c5b969a8ff3b0e353f21b Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:48:08 -0800
+Subject: [PATCH 1/6] Fix fuzzer objects building when LTO is enabled
+
+---
+ compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/CMakeLists.txt b/compiler-rt/lib/fuzzer/CMakeLists.txt
+index 6db24610df1f..201b880cfbb1 100644
+--- a/compiler-rt/lib/fuzzer/CMakeLists.txt
++++ b/compiler-rt/lib/fuzzer/CMakeLists.txt
+@@ -147,7 +147,7 @@ if(OS_NAME MATCHES "Android|Linux|Fuchsia" AND
+     set(cxx_${arch}_merge_dir "${CMAKE_CURRENT_BINARY_DIR}/cxx_${arch}_merge.dir")
+     file(MAKE_DIRECTORY ${cxx_${arch}_merge_dir})
+     add_custom_command(TARGET clang_rt.${name}-${arch} POST_BUILD
+-      COMMAND ${CMAKE_CXX_COMPILER} ${target_cflags} -Wl,--whole-archive "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" -Wl,--no-whole-archive ${dir}/lib/libc++.a -r -o ${name}.o
++      COMMAND ${CMAKE_CXX_COMPILER} ${target_cflags} -flto -Wl,--whole-archive "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" -Wl,--no-whole-archive ${dir}/lib/libc++.a -r -o ${name}.o
+       COMMAND ${CMAKE_OBJCOPY} --localize-hidden ${name}.o
+       COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>"
+       COMMAND ${CMAKE_AR} qcs "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" ${name}.o
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,0 +1,30 @@
+From 120abd17e1ee0c56780a3952556e9510aecd2cce Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:49:26 -0800
+Subject: [PATCH 2/6] Add stub for mips64 LLDB impl
+
+---
+ .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+index 08f19d374e28..a042dd3dd677 100644
+--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
++++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+@@ -32,7 +32,12 @@ public:
+   // given thread.
+   static std::unique_ptr<NativeRegisterContextLinux>
+   CreateHostNativeRegisterContextLinux(const ArchSpec &target_arch,
+-                                       NativeThreadLinux &native_thread);
++                                       NativeThreadLinux &native_thread)
++#ifdef __mips64
++  { llvm_unreachable("mips64 unsupported"); }
++#else
++  ;
++#endif
+ 
+   // Determine the architecture of the thread given by its ID.
+   static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,0 +1,32 @@
+From 655dcfdd892ba425aae4325dbed7c8402dc4d704 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:52:51 -0800
+Subject: [PATCH 3/6] Add stub for lldb arch functions on loongson3
+
+---
+ .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+index a042dd3dd677..ee4901aa7cd3 100644
+--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
++++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+@@ -40,7 +40,15 @@ public:
+ #endif
+ 
+   // Determine the architecture of the thread given by its ID.
++#ifdef __mips64
++  static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid) {
++    return llvm::createStringError(
++        llvm::inconvertibleErrorCode(),
++        "Architecture does not support this function");
++  }
++#else
+   static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
++#endif
+ 
+   // Invalidates cached values in register context data structures
+   virtual void InvalidateAllRegisters(){}
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
@@ -1,0 +1,24 @@
+From 24deae6b210e658d8fbe4a3a3f242e018ce874b6 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:53:18 -0800
+Subject: [PATCH 4/6] HACK: force enable cacheflush function
+
+---
+ compiler-rt/lib/builtins/clear_cache.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/builtins/clear_cache.c b/compiler-rt/lib/builtins/clear_cache.c
+index eb58452d624e..fd6c6c1ae6bb 100644
+--- a/compiler-rt/lib/builtins/clear_cache.c
++++ b/compiler-rt/lib/builtins/clear_cache.c
+@@ -43,6 +43,7 @@ uintptr_t GetCurrentProcess(void);
+ #endif
+ 
+ #if defined(__linux__) && defined(__mips__)
++#define __USE_MISC
+ #include <sys/cachectl.h>
+ #include <sys/syscall.h>
+ #include <unistd.h>
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/01-runtime/patches/0005-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0005-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,0 +1,498 @@
+From fd18d71bbba908eb85de54fee58a347446066ba7 Mon Sep 17 00:00:00 2001
+From: Adrian Cruceru <cruceruadrian@gmail.com>
+Date: Mon, 25 May 2020 20:58:30 +0200
+Subject: [PATCH 5/6] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
+ nightly target.
+
+Code is guarded via defines to enable only if 'RUST_SGX' is present.
+
+Main logic is in libunwind/src/AddressSpace.hpp
+We use 6 symbols to figure out where eh_frame / eh_frame_hdr is at runtime when loaded in an SGX enclave. (EH symbols + IMAGE base)
+These are set by 'fortanix-sgx-tools'.
+
+As notes:
+- Target above at the moment uses a pre-compiled libunwind.a from forked repo.
+- Goal of these changes is to use official llvm with patch.
+- Changes in rust-lang to use this are planned if/when this is accepted.
+- Ticket: fortanix/rust-sgx#174
+- Original ported changes: llvm/llvm-project@release/5.x...fortanix:release/5.x
+---
+ libunwind/CMakeLists.txt             |   2 +-
+ libunwind/README_RUST_SGX.md         |  22 +++++
+ libunwind/docs/BuildingLibunwind.rst |   5 ++
+ libunwind/src/AddressSpace.hpp       |  27 ++++++
+ libunwind/src/CMakeLists.txt         |  59 ++++++++++---
+ libunwind/src/RWMutex.hpp            |   2 +-
+ libunwind/src/UnwindRustSgx.c        | 125 +++++++++++++++++++++++++++
+ libunwind/src/UnwindRustSgx.h        |  84 ++++++++++++++++++
+ libunwind/src/config.h               |   4 +
+ 9 files changed, 318 insertions(+), 12 deletions(-)
+ create mode 100644 libunwind/README_RUST_SGX.md
+ create mode 100644 libunwind/src/UnwindRustSgx.c
+ create mode 100644 libunwind/src/UnwindRustSgx.h
+
+diff --git a/libunwind/CMakeLists.txt b/libunwind/CMakeLists.txt
+index 5f4b0902d522..ab56070307cc 100644
+--- a/libunwind/CMakeLists.txt
++++ b/libunwind/CMakeLists.txt
+@@ -273,7 +273,7 @@ if (LIBUNWIND_ENABLE_ASSERTIONS)
+ 
+   # On Release builds cmake automatically defines NDEBUG, so we
+   # explicitly undefine it:
+-  if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  if ((NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG") AND (NOT RUST_SGX))
+     add_compile_flags(-UNDEBUG)
+   endif()
+ else()
+diff --git a/libunwind/README_RUST_SGX.md b/libunwind/README_RUST_SGX.md
+new file mode 100644
+index 000000000000..c5d6eb4772bc
+--- /dev/null
++++ b/libunwind/README_RUST_SGX.md
+@@ -0,0 +1,22 @@
++# Libunwind customizations for linking with x86_64-fortanix-unknown-sgx Rust target.
++
++## Description
++### Initial Fork
++Initial Fork has been made from 5.0 release of llvm (commit: 6a075b6de4)
++### Detailed Description
++#### Header files that we do not include for this target
++1. pthread.h
++#### Library that we do not link to for this target.
++1. pthread (Locks used by libunwind is provided by rust stdlib for this target)
++
++## Building unwind for rust-sgx target
++### Generate Make files:
++* `cd where you want to build libunwind`
++* `mkdir build`
++* `cd build`
++* `cmake -DCMAKE_BUILD_TYPE="RELEASE" -DRUST_SGX=1 -G "Unix Makefiles" -DLLVM_ENABLE_WARNINGS=1 -DLIBUNWIND_ENABLE_PEDANTIC=0 -DLLVM_PATH=<path/to/llvm> <path/to/libunwind>`
++* `"DEBUG"` could be used instead of `"RELEASE"` to enable debug logs of libunwind.
++
++### Build:
++* `make unwind_static`
++* `build/lib/` will have the built library.
+diff --git a/libunwind/docs/BuildingLibunwind.rst b/libunwind/docs/BuildingLibunwind.rst
+index c231587fd502..830513e3a808 100644
+--- a/libunwind/docs/BuildingLibunwind.rst
++++ b/libunwind/docs/BuildingLibunwind.rst
+@@ -131,3 +131,8 @@ libunwind specific options
+ 
+   Path where built libunwind libraries should be installed. If a relative path,
+   relative to ``CMAKE_INSTALL_PREFIX``.
++
++.. option:: LIBUNWIND_ENABLE_RUST_SGX:BOOL
++
++  **Default**: ``OFF``
++
+diff --git a/libunwind/src/AddressSpace.hpp b/libunwind/src/AddressSpace.hpp
+index 5551c7d4bef1..9f0a611f5d25 100644
+--- a/libunwind/src/AddressSpace.hpp
++++ b/libunwind/src/AddressSpace.hpp
+@@ -94,6 +94,7 @@ namespace libunwind {
+ //   __eh_frame_hdr_start = SIZEOF(.eh_frame_hdr) > 0 ? ADDR(.eh_frame_hdr) : 0;
+ //   __eh_frame_hdr_end = SIZEOF(.eh_frame_hdr) > 0 ? . : 0;
+ 
++#if !defined(RUST_SGX)
+ extern char __eh_frame_start;
+ extern char __eh_frame_end;
+ 
+@@ -102,6 +103,15 @@ extern char __eh_frame_hdr_start;
+ extern char __eh_frame_hdr_end;
+ #endif
+ 
++#elif defined(RUST_SGX)
++extern "C" char IMAGE_BASE;
++extern "C" uint64_t EH_FRM_HDR_OFFSET;
++extern "C" uint64_t EH_FRM_HDR_LEN;
++extern "C" uint64_t EH_FRM_OFFSET;
++extern "C" uint64_t EH_FRM_LEN;
++#endif
++
++
+ #elif defined(_LIBUNWIND_ARM_EHABI) && defined(_LIBUNWIND_IS_BAREMETAL)
+ 
+ // When statically linked on bare-metal, the symbols for the EH table are looked
+@@ -487,6 +497,10 @@ static int findUnwindSectionsByPhdr(struct dl_phdr_info *pinfo,
+ #endif  // defined(_LIBUNWIND_USE_DL_ITERATE_PHDR)
+ 
+ 
++#if defined(RUST_SGX)
++extern "C" char IMAGE_BASE;
++#endif
++    
+ inline bool LocalAddressSpace::findUnwindSections(pint_t targetAddr,
+                                                   UnwindInfoSections &info) {
+ #ifdef __APPLE__
+@@ -520,6 +534,8 @@ inline bool LocalAddressSpace::findUnwindSections(pint_t targetAddr,
+ #elif defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND) && defined(_LIBUNWIND_IS_BAREMETAL)
+   info.dso_base = 0;
+   // Bare metal is statically linked, so no need to ask the dynamic loader
++
++#if !defined(RUST_SGX)
+   info.dwarf_section_length = (size_t)(&__eh_frame_end - &__eh_frame_start);
+   info.dwarf_section =        (uintptr_t)(&__eh_frame_start);
+   _LIBUNWIND_TRACE_UNWINDING("findUnwindSections: section %p length %p",
+@@ -530,6 +546,17 @@ inline bool LocalAddressSpace::findUnwindSections(pint_t targetAddr,
+   _LIBUNWIND_TRACE_UNWINDING("findUnwindSections: index section %p length %p",
+                              (void *)info.dwarf_index_section, (void *)info.dwarf_index_section_length);
+ #endif
++
++#elif defined(RUST_SGX)
++  info.dwarf_section =        (uintptr_t)EH_FRM_OFFSET + (uintptr_t)(&IMAGE_BASE);
++  info.dwarf_section_length = (uintptr_t)EH_FRM_LEN;
++#if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
++  info.dwarf_index_section =        (uintptr_t)EH_FRM_HDR_OFFSET + (uintptr_t)(&IMAGE_BASE);
++  info.dwarf_index_section_length = (uintptr_t)EH_FRM_HDR_LEN;
++#endif
++
++#endif
++  
+   if (info.dwarf_section_length)
+     return true;
+ #elif defined(_LIBUNWIND_ARM_EHABI) && defined(_LIBUNWIND_IS_BAREMETAL)
+diff --git a/libunwind/src/CMakeLists.txt b/libunwind/src/CMakeLists.txt
+index 71663a22cdf4..ba4a77880f72 100644
+--- a/libunwind/src/CMakeLists.txt
++++ b/libunwind/src/CMakeLists.txt
+@@ -1,5 +1,9 @@
+ # Get sources
+ 
++enable_language(C CXX ASM)
++
++set(CMAKE_POSITION_INDEPENDENT_CODE ON)
++
+ set(LIBUNWIND_CXX_SOURCES
+     libunwind.cpp
+     Unwind-EHABI.cpp
+@@ -18,14 +22,6 @@ set(LIBUNWIND_C_SOURCES
+     Unwind-sjlj.c
+     Unwind-wasm.c
+     )
+-set_source_files_properties(${LIBUNWIND_C_SOURCES}
+-                            PROPERTIES
+-                              # We need to set `-fexceptions` here so that key
+-                              # unwinding functions, like
+-                              # _UNWIND_RaiseException, are not marked as
+-                              # `nounwind`, which breaks LTO builds of
+-                              # libunwind.  See #56825 and #120657 for context.
+-                              COMPILE_FLAGS "-std=c99 -fexceptions")
+ 
+ set(LIBUNWIND_ASM_SOURCES
+     UnwindRegistersRestore.S
+@@ -65,6 +61,49 @@ if (MSVC_IDE)
+   source_group("Header Files" FILES ${LIBUNWIND_HEADERS})
+ endif()
+ 
++if (RUST_SGX)
++    # Compile Flags
++    add_definitions(-DRUST_SGX)
++    add_definitions(-D__NO_STRING_INLINES)
++    add_definitions(-D__NO_MATH_INLINES)
++    add_definitions(-D_LIBUNWIND_IS_BAREMETAL)
++    # Can't use add_definitions because CMake will reorder these arguments
++    list(APPEND LIBUNWIND_COMPILE_FLAGS -U_FORTIFY_SOURCE)
++    list(APPEND LIBUNWIND_COMPILE_FLAGS -D_FORTIFY_SOURCE=0)
++
++    list(APPEND LIBUNWIND_COMPILE_FLAGS -fno-stack-protector)
++    list(APPEND LIBUNWIND_COMPILE_FLAGS -ffreestanding)
++    list(APPEND LIBUNWIND_COMPILE_FLAGS -fexceptions)
++    # Avoid too new relocation types being emitted, which might prevent linking
++    # on older platforms.
++    #
++    # See https://github.com/rust-lang/rust/issues/34978
++    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
++        list(APPEND LIBUNWIND_COMPILE_FLAGS -Wa,-mrelax-relocations=no)
++    else()
++        list(APPEND LIBUNWIND_COMPILE_FLAGS)
++    endif()
++
++    # Sources
++    list(APPEND LIBUNWIND_HEADERS   UnwindRustSgx.h)
++    list(APPEND LIBUNWIND_C_SOURCES UnwindRustSgx.c)
++endif()
++
++
++set_source_files_properties(${LIBUNWIND_C_SOURCES}
++                            PROPERTIES
++                              # We need to set `-fexceptions` here so that key
++                              # unwinding functions, like
++                              # _UNWIND_RaiseException, are not marked as
++                              # `nounwind`, which breaks LTO builds of
++                              # libunwind.  See #56825 and #120657 for context.
++                              COMPILE_FLAGS "-std=c99 -fexceptions")
++
++# See add_asm_sources() in compiler-rt for explanation of this workaround.
++if((APPLE AND CMAKE_VERSION VERSION_LESS 3.19) OR (MINGW AND CMAKE_VERSION VERSION_LESS 3.17))
++  set_source_files_properties(${LIBUNWIND_ASM_SOURCES} PROPERTIES LANGUAGE C)
++endif()
++
+ set(LIBUNWIND_SOURCES
+     ${LIBUNWIND_CXX_SOURCES}
+     ${LIBUNWIND_C_SOURCES}
+@@ -75,11 +114,11 @@ if (NOT APPLE)
+   add_library_flags_if(LIBUNWIND_HAS_DL_LIB dl)
+ endif()
+ 
+-if (LIBUNWIND_ENABLE_THREADS AND NOT APPLE)
++if (LIBUNWIND_ENABLE_THREADS AND NOT APPLE AND (NOT RUST_SGX))
+     add_library_flags_if(LIBUNWIND_HAS_PTHREAD_LIB pthread)
+ endif()
+ 
+-if (LIBUNWIND_ENABLE_THREADS)
++if (LIBUNWIND_ENABLE_THREADS AND (NOT RUST_SGX))
+   add_compile_flags_if(LIBUNWIND_WEAK_PTHREAD_LIB -DLIBUNWIND_USE_WEAK_PTHREAD=1)
+ endif()
+ 
+diff --git a/libunwind/src/RWMutex.hpp b/libunwind/src/RWMutex.hpp
+index 344d35641f07..65bd849aabb3 100644
+--- a/libunwind/src/RWMutex.hpp
++++ b/libunwind/src/RWMutex.hpp
+@@ -15,7 +15,7 @@
+ 
+ #if defined(_WIN32)
+ #include <windows.h>
+-#elif !defined(_LIBUNWIND_HAS_NO_THREADS)
++#elif !defined(_LIBUNWIND_HAS_NO_THREADS) && !defined(RUST_SGX)
+ #include <pthread.h>
+ #if defined(__ELF__) && defined(_LIBUNWIND_LINK_PTHREAD_LIB)
+ #pragma comment(lib, "pthread")
+diff --git a/libunwind/src/UnwindRustSgx.c b/libunwind/src/UnwindRustSgx.c
+new file mode 100644
+index 000000000000..9be7c1b54e6f
+--- /dev/null
++++ b/libunwind/src/UnwindRustSgx.c
+@@ -0,0 +1,125 @@
++//===--------------------- UnwindRustSgx.c ----------------------------------===//
++//
++////                     The LLVM Compiler Infrastructure
++////
++//// This file is dual licensed under the MIT and the University of Illinois Open
++//// Source Licenses. See LICENSE.TXT for details.
++////
++////
++////===----------------------------------------------------------------------===//
++
++#define _GNU_SOURCE
++#include <link.h>
++
++#include <elf.h>
++#include <stdarg.h>
++#include <stdio.h>
++#include <stddef.h>
++#include "UnwindRustSgx.h"
++
++#define max_log 256
++
++__attribute__((weak)) struct _IO_FILE *stderr  = (struct _IO_FILE *)-1;
++
++static int vwrite_err(const char *format, va_list ap)
++{
++    int len = 0;
++#ifndef NDEBUG
++    char s[max_log];
++    s[0]='\0';
++    len = vsnprintf(s, max_log, format, ap);
++    __rust_print_err((uint8_t *)s, len);
++#endif
++    return len;
++}
++
++static int write_err(const char *format, ...)
++{
++    int ret;
++    va_list args;
++        va_start(args, format);
++    ret = vwrite_err(format, args);
++    va_end(args);
++
++
++    return ret;
++}
++
++__attribute__((weak)) int fprintf (FILE *__restrict __stream,
++            const char *__restrict __format, ...)
++{
++
++    int ret;
++    if (__stream != stderr) {
++        write_err("Rust SGX Unwind supports only writing to stderr\n");
++        return -1;
++    } else {
++        va_list args;
++        ret = 0;
++        va_start(args, __format);
++        ret += vwrite_err(__format, args);
++        va_end(args);
++    }
++
++    return ret;
++}
++
++__attribute__((weak)) int fflush (FILE *__stream)
++{
++    // We do not need to do anything here.
++    return 0;
++}
++
++__attribute__((weak)) void __assert_fail(const char * assertion,
++                                       const char * file,
++                           unsigned int line,
++                           const char * function)
++{
++    write_err("%s:%d %s %s\n", file, line, function, assertion);
++    abort();
++}
++
++// We do not report stack over flow detected.
++// Calling write_err uses more stack due to the way we have implemented it.
++// With possible enabling of stack probes, we should not
++// get into __stack_chk_fail() at all.
++__attribute__((weak))  void __stack_chk_fail() {
++    abort();
++}
++
++/*
++ * Below are defined for all executibles compiled for
++ * x86_64-fortanix-unknown-sgx rust target.
++ * Ref: rust/src/libstd/sys/sgx/abi/entry.S
++ */
++
++struct libwu_rs_alloc_meta {
++    size_t alloc_size;
++    // Should we put a signatre guard before ptr for oob access?
++    unsigned char ptr[0];
++};
++
++#define META_FROM_PTR(__PTR) (struct libwu_rs_alloc_meta *) \
++    ((unsigned char *)__PTR - offsetof(struct libwu_rs_alloc_meta, ptr))
++
++void *libuw_malloc(size_t size)
++{
++    struct libwu_rs_alloc_meta *meta;
++    size_t alloc_size = size + sizeof(struct libwu_rs_alloc_meta);
++    meta = (void *)__rust_c_alloc(alloc_size, sizeof(size_t));
++    if (!meta) {
++        return NULL;
++    }
++    meta->alloc_size = alloc_size;
++    return (void *)meta->ptr;
++}
++
++void libuw_free(void *p)
++{
++    struct libwu_rs_alloc_meta *meta;
++    if (!p) {
++        return;
++    }
++    meta = META_FROM_PTR(p);
++    __rust_c_dealloc((unsigned char *)meta, meta->alloc_size, sizeof(size_t));
++}
+diff --git a/libunwind/src/UnwindRustSgx.h b/libunwind/src/UnwindRustSgx.h
+new file mode 100644
+index 000000000000..8155b8e74ffa
+--- /dev/null
++++ b/libunwind/src/UnwindRustSgx.h
+@@ -0,0 +1,84 @@
++//===--------------------- UnwindRustSgx.h ----------------------------------===//
++//
++////                     The LLVM Compiler Infrastructure
++////
++//// This file is dual licensed under the MIT and the University of Illinois Open
++//// Source Licenses. See LICENSE.TXT for details.
++////
++////
++////===----------------------------------------------------------------------===//
++
++#if !defined(UNWIND_RUST_SGX_H)
++#define UNWIND_RUST_SGX_H
++
++#ifdef RUST_SGX
++
++#undef _GNU_SOURCE
++#define _GNU_SOURCE
++#include <link.h>
++#include <stdarg.h>
++#include <string.h>
++#include <stdint.h>
++
++// We have to use RWLock from rust repo, it is defined in:
++// src/libstd/sys/sgx/rwlock.rs.
++// rwlock.rs has a compile time check to ensure the size and alignment matches
++// the Rust definition.
++typedef struct {
++  void *opaque;
++} RWLock;
++
++#define RWLOCK_INIT                                                            \
++  { (void *)0 }
++
++// These are the functions exposed by SGX-Rust.
++// The rust changes are available at:
++#ifdef __cplusplus
++extern "C"  {
++#endif
++    int __rust_rwlock_rdlock(RWLock *rwlock);
++    int __rust_rwlock_wrlock(RWLock *rwlock);
++    int __rust_rwlock_unlock(RWLock *rwlock);
++    unsigned char *__rust_c_alloc(size_t, size_t);
++    void __rust_c_dealloc(unsigned char *, size_t, size_t);
++    __attribute__((noreturn)) void __rust_abort(void);
++    unsigned char *__rust_encl_address(size_t);
++
++#ifndef NDEBUG
++    void __rust_print_err(uint8_t *m, int s);
++#endif
++
++#ifdef __cplusplus
++}
++#endif
++
++#define abort __rust_abort
++
++#undef pthread_rwlock_t
++#undef pthread_rwlock_rdlock
++#undef pthread_rwlock_wrlock
++#undef pthread_rwlock_unlock
++#undef PTHREAD_RWLOCK_INITIALIZER
++
++#define pthread_rwlock_t RWLock
++#define pthread_rwlock_rdlock __rust_rwlock_rdlock
++#define pthread_rwlock_wrlock __rust_rwlock_wrlock
++#define pthread_rwlock_unlock __rust_rwlock_unlock
++#define PTHREAD_RWLOCK_INITIALIZER RWLOCK_INIT
++
++#define malloc libuw_malloc
++#define free libuw_free
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++void *libuw_malloc(size_t size);
++void libuw_free(void *p);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
++#endif
+diff --git a/libunwind/src/config.h b/libunwind/src/config.h
+index deb5a4d4d73d..5337be4b3d50 100644
+--- a/libunwind/src/config.h
++++ b/libunwind/src/config.h
+@@ -20,6 +20,10 @@
+ 
+ #include <__libunwind_config.h>
+ 
++#ifdef RUST_SGX
++#include "UnwindRustSgx.h"
++#endif
++
+ // Platform specific configuration defines.
+ #ifdef __APPLE__
+   #if defined(FOR_DYLD)
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/01-runtime/patches/0006-compiler-rt-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0006-compiler-rt-Disable-installing-of-custom-libcxx.patch
@@ -1,0 +1,41 @@
+From f2158d0ed4ef52d3054a835f0f6e96d4930a80a8 Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 12 Apr 2025 15:25:26 +0800
+Subject: [PATCH 6/6] [compiler-rt] Disable installing of custom libcxx
+
+e7bad34475e2 ([compiler-rt] Use installed libc++(abi) for tests
+instead of build tree, 2024-11-06) removed 'INSTALL_COMMAND ""' line.
+After that, CMake will install files to locations like
+$DESTDIR/var/cache/acbs/build/acbs.p8hoyk2z/llvm-project-20.1.2.src/llvm/
+build/runtimes/runtimes-bins/compiler-rt/lib/fuzzer/libcxx_fuzzer_x86_64.
+
+Link: https://github.com/llvm/llvm-project/issues/135476
+Fixes: e7bad34475e2 ("[compiler-rt] Use installed libc++(abi) for tests instead of build tree")
+Signed-off-by: xtex <xtex@aosc.io>
+---
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index fb2aee8e42ee..8c6f579207cb 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -663,7 +663,6 @@ macro(add_custom_libcxx name prefix)
+     CMAKE_SHARED_LINKER_FLAGS
+     CMAKE_MODULE_LINKER_FLAGS
+     CMAKE_EXE_LINKER_FLAGS
+-    CMAKE_INSTALL_PREFIX
+     CMAKE_MAKE_PROGRAM
+     CMAKE_LINKER
+     CMAKE_AR
+@@ -733,6 +732,7 @@ macro(add_custom_libcxx name prefix)
+                -DLLVM_INCLUDE_TESTS=OFF
+                -DLLVM_INCLUDE_DOCS=OFF
+                ${LIBCXX_CMAKE_ARGS}
++    INSTALL_COMMAND ""
+     STEP_TARGETS configure build
+     BUILD_ALWAYS 1
+     USES_TERMINAL_CONFIGURE 1
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/02-compiler/beyond
+++ b/app-devel/llvm-21/02-compiler/beyond
@@ -1,0 +1,47 @@
+##### Control part variables
+LLVM_SUFFIX="-${PKGVER%%.*}"
+
+abinfo "Generating postinst scripts ..."
+printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/bin/llvm-config 80' \
+    "$LLVM_SUFFIX" \
+    >> "$SRCDIR/autobuild/postinst"
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
+    BIN="$(basename $i)"
+    [[ "$BIN" == 'llvm-config' || "$BIN" == "clang$LLVM_SUFFIX" ]] || \
+        printf " --slave /usr/bin/$BIN $BIN /usr/lib/llvm%s/bin/$BIN" \
+            "$LLVM_SUFFIX" \
+            >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
+    BIN="$(basename $i)"
+    printf " --slave /usr/lib/cmake/$BIN ${BIN}-cmake /usr/lib/llvm%s/lib/cmake/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/include/*; do
+    ! [[ "$i" =~ .*unwind.* ]] || continue
+    ! [[ "$i" =~ .*clc ]] || continue
+    ! [[ "$i" =~ .*c\+\+ ]] || continue
+    BIN="$(basename $i)"
+    printf " --slave /usr/include/$BIN ${BIN}-include /usr/lib/llvm%s/include/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
+    OMP_LIB="$(basename $i)"
+    printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+cat << EOF > "$SRCDIR/autobuild/postrm"
+if [ "\$1" != "upgrade" ]; then
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
+fi
+EOF
+
+abinfo "Final postinst script:"
+cat "$SRCDIR/autobuild/postinst"

--- a/app-devel/llvm-21/02-compiler/build
+++ b/app-devel/llvm-21/02-compiler/build
@@ -1,0 +1,94 @@
+llvm_ir_strip () {
+    mkdir -pv "$SRCDIR"/strip-tmp
+    cat << 'EOF' > "$SRCDIR"/strip-tmp/build.ninja
+rule ir-strip
+  command = TMPDIR="$$(mktemp -d)" && cd "$$TMPDIR" && llvm-ar x "$in" && for i in *.o; do if llvm-bcanalyzer "$$i" > /dev/null; then echo "-- Removing debug markers in $$i"; opt --strip-debug "$$i" -o "$$i"; fi done && llvm-ar rcs "$out" *.o && rm -rf "$$TMPDIR"
+  description = Stripping $in ...
+
+EOF
+    abinfo "Removing installed LTO archives ..."
+    rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+    abinfo "Generating stripping scripts ..."
+    for i in "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/*.a; do
+        local outfile="$(basename "$i")"
+        printf "build $PKGDIR/usr/lib/llvm-${PKGVER%%.*}/lib/$outfile: ir-strip $i\n\n" >> "$SRCDIR"/strip-tmp/build.ninja
+    done
+    abinfo "Executing LLVM IR stripping scripts ..."
+    ninja -C "$SRCDIR"/strip-tmp/
+}
+
+abinfo "Installing all files from LLVM ..."
+mkdir -pv "$PKGDIR"
+cp -arv "$SRCDIR"/fakeroot/* \
+    "$PKGDIR"/
+
+if [[ "$NOLTO" = 0 ]]; then
+    abinfo "Preparing for LLVM IR strip in LTO archives ..."
+    llvm_ir_strip
+else
+    abinfo "Dropping executable bit from static libraries ..."
+    chmod -v 644 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+fi
+
+abinfo "Installing clang-analyzer ..."
+install -dvm755 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer
+for prog in scan-build scan-view; do
+    cp -rfv "$SRCDIR"/../clang/tools/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/
+    ln -sfv ../lib/clang-analyzer/$prog/bin/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/bin/
+done
+ln -sfv ../../../bin/clang \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/scan-build/
+
+abinfo "Dropping runtime libraries ..."
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so*
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so
+# FIXME: Broken ld.lld => no extra runtime library may be built.
+if ! ab_match_arch loongson3; then
+    rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*
+fi
+
+abinfo "Stripping static libraries ..."
+strip \
+    --verbose \
+    --strip-debug \
+    --enable-deterministic-archives \
+    --remove-section=.comment \
+    --remove-section=.note \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+abinfo "Making compatible version symlinks ..."
+ln -sv "${PKGVER%%.*}" \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+# FIXME: Chromium would fail to detect Clang prefix unless a full absolute
+# path to the compilers were set. Debian creates a symlink:
+#
+#   /usr/lib/clang/${PKGVER%%.*}
+#       => /usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}
+#
+# to counteract this - not sure if needed anywhere else but create this
+# symlink just to be safe.
+abinfo "Making Clang prefix symlinks ..."
+mkdir -pv "$PKGDIR"/usr/lib/clang
+ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
+    "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}
+
+abinfo "Creating versioned executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cd "$PKGDIR"/usr/bin
+for i in ../lib/llvm-${PKGVER%%.*}/bin/*; do 
+    ln -sv $i $(basename $i)-${PKGVER%%.*}
+done
+# Note: Remove double-suffixed executables.
+rm -v "$PKGDIR"/usr/bin/*-${PKGVER%%.*}-${PKGVER%%.*}
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-21/02-compiler/build.stage2
+++ b/app-devel/llvm-21/02-compiler/build.stage2
@@ -1,0 +1,48 @@
+abinfo "Installing all files from LLVM ..."
+mkdir -pv "$PKGDIR"
+cp -arv "$SRCDIR"/fakeroot/* \
+    "$PKGDIR"/
+
+abinfo "Dropping executable bit from static libraries ..."
+chmod -v 644 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+abinfo "Installing clang-analyzer ..."
+install -dvm755 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer
+for prog in scan-build scan-view; do
+    cp -rfv "$SRCDIR"/../clang/tools/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/
+done
+ln -sfv ../../../bin/clang \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/scan-build/
+
+abinfo "Dropping runtime libraries ..."
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so*
+# Note: not all targets have libunwind, libcxx and libcxxabi.
+for i in "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*; do
+    if [ -e "$i" ]; then
+        rm -v $i
+    fi
+done
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so
+
+abinfo "Making compatible version symlinks ..."
+ln -sv "${PKGVER%%.*}" \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+abinfo "Stripping static libraries ..."
+strip \
+    --verbose \
+    --strip-debug \
+    --enable-deterministic-archives \
+    --remove-section=.comment \
+    --remove-section=.note \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-21/02-compiler/defines
+++ b/app-devel/llvm-21/02-compiler/defines
@@ -1,0 +1,16 @@
+PKGNAME=llvm-21
+PKGSEC=devel
+PKGDEP="gcc llvm-runtime-21 perl python-3"
+BUILDDEP="pypsutil setuptools"
+PKGDES="Low Level Virtual Machine Infrastructure (version 21)"
+
+NOSTATIC=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+PKGPROV="clang"
+
+PKGBREAK="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"
+PKGREP="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"

--- a/app-devel/llvm-21/02-compiler/defines.stage2
+++ b/app-devel/llvm-21/02-compiler/defines.stage2
@@ -1,0 +1,15 @@
+PKGNAME=llvm-21
+PKGSEC=devel
+PKGDEP="gcc llvm-runtime-21"
+PKGDES="Low Level Virtual Machine Infrastructure (version 21)"
+
+NOSTATIC=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+PKGPROV="clang"
+
+PKGBREAK="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"
+PKGREP="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"

--- a/app-devel/llvm-21/spec
+++ b/app-devel/llvm-21/spec
@@ -1,0 +1,13 @@
+VER=21.1.6
+
+# Use tarball-based source when possible
+SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
+SUBDIR="llvm-project-$VER.src/llvm"
+# Use git-based source when the upstream hasn't uploaded their own tarball yet
+#SRCS="git::commit=tags/llvmorg-${VER}::https://github.com/llvm/llvm-project.git"
+#SUBDIR="llvm-21/llvm"
+
+CHKSUMS="sha256::ae67086eb04bed7ca11ab880349b5f1ab6f50e1b88cda376eaf8a845b935762b"
+CHKUPDATE="anitya::id=1830"
+
+ENVREQ="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-21: new, 21.1.6
    - Remove PSTL runtime. \[^1\]
    - Drop MIPS patch for LLDB LinuxSignal. \[^2\]
    - Enable Clang build for all stage3 recipes.
    - Add comments about non-default options.
    - Clean up CMake options and refactor as arrays.
    - Enable INSTALL_WITH_TOOLCHAIN to install libLTO.so and LLVMgold.so. \[^3\]
    - Track patches at AOSC-Tracking/llvm-project @ aosc/llvmorg-21.1.6
    \(HEAD: f2158d0ed4ef52d3054a835f0f6e96d4930a80a8\).
    \[^1\]: https://discourse.llvm.org/t/rfc-removing-pstl/86807
    \[^2\]: https://github.com/llvm/llvm-project/commit/8877b913ae88c6ae43e859316489fe0469293131
    \[^3\]: https://github.com/llvm/llvm-project/commit/b9ec4ab6ac4f3ae8603da8bfbf10bc0ec104e0b7

Package(s) Affected
-------------------

- llvm-21: 21.1.6
- llvm-runtime-21: 21.1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-21
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
