### PR TITLE
linux-firmware: update to 20250829+debian20250808+1

### DIFF
--- a/runtime-kernel/linux-firmware/01-nonfree/build
+++ b/runtime-kernel/linux-firmware/01-nonfree/build
@@ -68,3 +68,16 @@ ln -sv brcmfmac43456-sdio.AP6256.txt \
 
 abinfo "Compressing AP6256 firmware blob"
 xz -C crc32 "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43456-sdio.bin
+
+# FIXME: https://github.com/AlmaLinux/raspberry-pi/issues/17
+abinfo "De-compressing .txt configuration for Raspberry Pi 3 Model B ..."
+cd "$PKGDIR"/usr/lib/firmware/brcm
+xz -dvvv brcmfmac43430-sdio.raspberrypi,3-model-b.txt.xz
+
+abinfo "Re-creating symlinks for Raspberry Pi Zero (1, 2) ..."
+rm -v "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-2-w.txt.xz \
+      "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.txt.xz
+ln -sv brcmfmac43430-sdio.raspberrypi,3-model-b.txt \
+    "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-2-w.txt
+ln -sv brcmfmac43430-sdio.raspberrypi,3-model-b.txt \
+    "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.txt 

--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,19 +1,19 @@
-UPSTREAM_VER=20250425
-DEBIANVER=20241210-1~bpo12+1
+UPSTREAM_VER=20250829
+DEBIANVER=20250808-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 # When using a stable tag.
 #SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=8d82acd29b5c115f0b75b17907ebce712c6f2e22::https://gitlab.com/kernel-firmware/linux-firmware.git \
-      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
-      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/4b356e134e8333d073bd3802d767a825adec3807/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
+SRCS="git::commit=910c190740916a9969ad5105137fb88ae4ce34c8::https://gitlab.com/kernel-firmware/linux-firmware.git \
+      file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
+      file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
-      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/BCM4345C5.hcd \
+      file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/6b6f053f6089e08dd2a675cda1ec813de2e842e2/brcm/BCM4345C5.hcd \
       tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free-firmware/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz"
 CHKSUMS="SKIP \
          sha256::ddf83f2100885b166be52d21c8966db164fdd4e1d816aca2acc67ee9cc28d726 \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::22187c54c6259e768e32c9ec97df2eb0121b75a4243b9e819c87fa07272f03f6"
+         sha256::0fc198d42bbfac7060f01445d976c05de2ce13214e1a7521e6dfe4a7a6caa124"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20250829+debian20250808+1
    - Refresh Raspberry Pi-specific firmware blobs.
    - Notable changes from the main linux-firmware.git tree:
    AI:
    - Intel...
    - Update NPU firmware found on Meteor Lake, Arrow Lake, and Lunar Lake
    - VPU 37xx: 20250627\*MTL_CLIENT_SILICON-NVR+NN-deployment\*2fc7252521edea4e75ec14e475a72ba6f0f92685\*2fc7252521edea4e75ec14e475a72ba6f0f92685\*2fc7252521e
    - VPU 40xx: Jun 27 2025\*NPU40xx\*ci_tag_ud202528_vpu_rc_20250626_1901\*2fc7252521edea4e75ec14e475a72ba6f0f92685
    Audio:
    - Cirrus...
    - CS35L41...
    - Add firmware for HDA codec found on Acer and HP Agusta laptops
    - Fix firmware links for several ASUS \(consumer and commercial\)
    laptops and NUC models
    - Update firmware for Dell Oasis
    - CS35L56: Update firmware for "smart amplifiers" found on ASUS, Dell,
    Lenovo laptops, with additions for new Lenovo models
    - Intel...
    - Update topology file for Digital Microphone Array
    - Qualcomm...
    - Add Audio topology for QCS6490 RB3Gen2
    - Realtek...
    - Add patch firmware for RT1321 MCU
    Graphics:
    - AMD...
    - DCN 3.2.0, 4.0.1: Update firmware to 0.1.10.0
    - DCN 3.2.0, 4.0.1: Update DMCUB firmware to 0.1.17.0
    - DCN 3.1.4, DCN 3.1.5, DCN 3.2.1, DCN 3.5, DCN 3.5.1, DCN 4.0.1, and
    Yellow Carp...
    - Update DMCUB firmware to 0.1.24.0
    - Update SSC from 0.0125 to 0.125
    - \(DCN 3.1.4\) "Fix a boot option" \(37001ea471\)
    - Add DCN 3.6, GC 11.5.3, PSP 14.0.5, and SDMA 6.1.3 firmware
    - Update GC 11.5.1 microcode
    - Update ISP firmware for ISP 4.1.1
    - Imagination...
    - Add firmware for Imagination Technologies BXS-4-64 GPU
    - Intel...
    - Battlemage...
    - Update GuC firmware to v70.45.2
    - Add fan_control firmware v203.0.0.0
    - Lunar Lake: Update GuC firmware to v70.45.2
    - DG2: Update GuC firmware to v70.45.2
    - Lunar Lake: Update GSC firmware to v104.0.5.1429
    - Panther Lake: Introduce firmware...
    - GuC v70.47.0
    - HuC v10.3.3
    - Add firmware for Xe3LPD DMC v2.29
    - NVIDIA...
    - Add GSP-RM version 570.144 firmware images
    - Qualcomm...
    - Add firmware for GPUs based on the arch10.10, arch10.12, arch11.8,
    arch12.8, and arch13.8 architectures
    Multimedia:
    - Amphion...
    - Update VPU decoder firmware to 1.10.0, encoder firmware to 1.4.5
    - Chips&Media...
    - K3: Update wave521c video IP firmware
    - NXP i.MX9: Add wave633c codec IP firmware
    - Intel...
    - Add firmware binary files for Intel IPU7 \(Lunar Lake\)
    - MediaTek...
    - MT8189: Add System Companion Processor \(SCP\) firmware \(1.0.0\)
    - MT8196: Add Video Companion Processor \(VCP\) firmware \(1.0.0\)
    - Qualcomm...
    - SM8650: Add firmware binary \(VPU\)
    Networking \(wired\):
    - Intel...
    - Intel\(R\) Ethernet Connection E800 Series...
    - Update firmware to 1.3.55.0, adding support for E825-C
    - Update wireless_edge package to 1.3.23, adding support for E825-C
    - Realtek...
    - RTL8153A: Update firmware to rtl8153a-4 v3 06/12/25
    Networking \(modem\):
    - Qualcomm...
    - Add Qualcomm SDX61 firmware for Foxconn vendor
    Platform:
    - AMD...
    - Platform Management Framework: Update Trusted Application \(PMF-TA\)
    firmware to v3.1
    - Add Microcode update for Family 19h, 1ah
    - MediaTek...
    - MT8186: Update SCP firmware to 0.1.0
    - Qualcomm...
    - QCM6490: Add QUPv3 firmware
    - QCS615...
    - "Due to the TZ upgrade on QCS615, it is required firmware to use
    Sectools v2 for signing. Therefore, the venus_s2.mbn file is added."
    - Update GPU firmware
    - QCS8300: Add QUPv3 firmware
    - SC8280XP: Update firmware for Lenovo ThinkPad X13s
    - Fixes "some charging issues found"
    - SCM8550: Update firmware binary to VIDEO.VPU.3.1-0092
    - SM8750: Add firmware
    - X1E80100: Add CDSP firmware
    - X1P42100 \(Snapdragon X1 Plus\): Update GPU firmware
    - qcom/gen71500_gmu.bin: v4.06.04
    - qcom/gen71500_sqe.fw: v1.81
    - qcom/x1p42100/gen71500_zap.mbn: v0.13
    Wi-Fi and Bluetooth:
    - Broadcom...
    - AP6212: Add Khadas VIM SDIO Wi-Fi configuration \(matching
    brcmfmac43455-sdio.AW-CM256SM.txt\)
    - AP6212, AP6356S: Add firmware for NanoPi devices
    - AP6254: Add NVRAM file for the Wi-Fi/Bluetooth module found on Radxa
    Rock Pi X Single Board Computer
    - Intel...
    - Garfield Peak2 \(AX211\), Filmore Peak2 \(BE201\)...
    - Update firmware to 23.150.0.4
    - Gale Peak2 \(BE200\), Garfield Peak2 \(AX211\)...
    - Update firmware to 23.150.0.4
    - Johnson Peak2 \(AX203\), Typhoon Peak2 \(AX210\)...
    - Update firmware to 23.150.0.4
    - Gale Peak2 \(BE200\), Harrison Peak1 \(AX101\), Thunder Peak2 \(9260\),
    Jefferson Peak2 \(9560\), Harrison Peak2 \(HrP2\), Cyclone Peak2 \(CcP2\)...
    - Update firmware to 23.140.0.5
    - 7265D: Update firmware to 29.9ef079ed.0
    - 8000C, 8265: Update firmware to 36.c8e8e144.0
    - Bz/gl: Update firmware for core97-84 release
    - cc/Qu/QuZ: Update firmware for core97-84 release
    - ty/So/Ma: Update firmware for core97-84 release
    - MediaTek...
    - MT7916...
    - Update Wi-Fi firmware to 20240823
    - MT7921...
    - Update Bluetooth firmware to 20250625154126
    - Update Wi-Fi firmware \(MCU: 20250625153620a, RAM: 20250625153044\)
    - MT7922...
    - Update Bluetooth firmware to 20250523103438
    - Update Wi-Fi firmware \(MCU: 20250523103150a, RAM: 20250523103106\)
    - MT7925...
    - Update Bluetooth firmware to 20250526153203
    - Update Wi-Fi firmware \(MCU: 20250526152947a, RAM: 20250526152808\)
    - MT7981...
    - Update Wi-Fi firmware to 20240823
    - MT7986...
    - Update Wi-Fi firmware to 20240823
    - Qualcomm...
    - WCN6855 hw2.0@nfa765: Add firmware
    - WLAN.HSP.1.1-04685-QCAHSPSWPL_V1_V2_SILICONZ_IOE-1
    - WCN6855: Add support for "hw2.1 with NFA firmware variant"
    - WCN7850 hw2.0: Update firmware version to
    WLAN.HMT.1.1.c5-00284.1-QCAHMTSWPL_V1.0_V2.0_SILICONZ-3
    - WCN785x: Update btusb firmware to 2.0.0-00799-5
    - Realtek...
    - RTL8127A: Add firmware
    - RTL8822C: Update Bluetooth controller firmware \(USB: 0x28D7_7C20,
    UART: 0x25D7_7C20\)
    - RTL8852BT...
    - Update firmware to v0.29.127.0
    - "Support scan offload with extra OP chan"
    - RTL8852B...
    - Update firmware to v0.29.128.0
    - "Support scan offload with extra OP chan"
    - RTL8852C: Update firmware to v0.27.129.4
    - Add tables for dynamic antenna TXPWR
    - Fix WoW - TCP keep alive wakeup issue
    - Fix potential security issues
    - "Initially add regd information"
    - "Fix WoWLAN resume flow issues"
    - "Fix loss of group addressed frames on non-transmitted BSSID"
    - RTL8922A: Update firmware to v0.35.80.3
    - Accepts "larger beacon loss count setting to prevent disconnection"
    - "Update RF TSSI mechanism and its format, and fix potential
    security issues"
    - "Fix EHT/HE 20M RX throughput unstable"
    - "Initially add regd information"
    - "Fix loss of group addressed frames on non-transmitted BSSID, and
    allow beacon mode to use data rates other than 6 Mbps"

Package(s) Affected
-------------------

- firmware-free: 20250829+debian20250808+1
- firmware-nonfree: 20250829+debian20250808+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
