### PR TITLE
httpx-go:update to 1.7.1

### DIFF
--- a/app-utils/httpx-go/spec
+++ b/app-utils/httpx-go/spec
@@ -1,4 +1,4 @@
-VER=1.7.0
+VER=1.7.1
 SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/httpx.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328160"


### PR DESCRIPTION
Topic Description
-----------------

- httpx-go:update to 1.7.1

Package(s) Affected
-------------------

- httpx-go: 1.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpx-go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
