### PR TITLE
viddy: new, 1.3.0

### DIFF
--- a/app-utils/viddy/autobuild/defines
+++ b/app-utils/viddy/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=viddy
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="cargo llvm"
+PKGDES="Alternative watch(1) implementation with diff highlighting and output history"
+
+ABTYPE=rust
+# Note: Default ldflags break the build, work around by forcing clang with USECLANG=1
+USECLANG=1

--- a/app-utils/viddy/spec
+++ b/app-utils/viddy/spec
@@ -1,0 +1,5 @@
+VER=1.3.0
+# Note: `copy-repo=true` is required to get git tags information for in-app version display
+SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/sachaos/viddy"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=382076"


### PR DESCRIPTION
Topic Description
-----------------

- viddy: new, 1.3.0

Package(s) Affected
-------------------

- viddy: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit viddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
