### PR TITLE
niri: update to 25.08

### DIFF
--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -9,8 +9,3 @@ BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"
 USECLANG=1
 ABTYPE=rust
-
-# FIXME: ld.lld is not yet available for loongson3.
-# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
-# recompile with -fPIC
-NOLTO__LOONGSON3=1

--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -9,3 +9,4 @@ BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"
 USECLANG=1
 ABTYPE=rust
+FAIL_ARCH="(loongarch64_nosimd)"

--- a/desktop-wm/niri/autobuild/prepare
+++ b/desktop-wm/niri/autobuild/prepare
@@ -1,0 +1,7 @@
+if [ -d "$SRCDIR/autobuild/patches" ]; then
+    abinfo "Patches detected, marking commit hash as modified ..."
+    export NIRI_BUILD_COMMIT="modified"
+else
+    abinfo "No patch detected, marking a clean commit hash ..."
+    export NIRI_BUILD_COMMIT=$(git rev-parse --short HEAD)
+fi

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,4 +1,5 @@
 VER=25.08
-SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
+# Note: copy-repo is required for the build system to detect commit hash
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,4 +1,4 @@
-VER=25.05.1
+VER=25.08
 SRCS="git::commit=tags/v$VER::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372826"


### PR DESCRIPTION
Topic Description
-----------------

- niri: update to 25.08
    Co-authored-by: Alan Lin \(@miwu04\) <mail@alanlin.icu>

Package(s) Affected
-------------------

- niri: 25.08

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
