### PR TITLE
oma: disable LTO for loongarch64-nosimd to avoid lsx generation

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -10,3 +10,6 @@ PKGREP="mirrormgr<=0.11.1"
 
 USECLANG=1
 PKGESS=1
+
+# FIXME: LTO will cause unexpected lsx generation
+NOLTO__LOONGARCH64_NOSIMD=1

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,5 @@
 VER=1.20.1
+REL=1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: disable LTO for loongarch64-nosimd to avoid lsx generation
    Signed-off-by: Xi Ruoyao <xry111@xry111.site>
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- oma: 1.20.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
