### PR TITLE
libgsystem: drop, orphaned

### DIFF
--- a/app-admin/ostree/autobuild/defines
+++ b/app-admin/ostree/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ostree
 PKGSEC=admin
-PKGDEP="avahi curl fuse gpgme libarchive libgsystem util-linux"
+PKGDEP="avahi curl fuse gpgme libarchive util-linux"
 BUILDDEP="bison dracut docbook-xsl"
 PKGDES="Tool for managing bootable, immutable filesystem trees"
 

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,5 @@
 VER=2025.4
+REL=1
 SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
 CHKSUMS="sha256::014d12d19ea664fae53fe147d3d2c0b7465a3c37e099c87d289df908adeb5669"
 CHKUPDATE="anitya::id=10899"

--- a/desktop-cinnamon/cinnamon-desktop/autobuild/defines
+++ b/desktop-cinnamon/cinnamon-desktop/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=cinnamon-desktop 
 PKGSEC=Cinnamon
-PKGDEP="desktop-base gdk-pixbuf gtk-3 libgsystem accountsservice pulseaudio"
+PKGDEP="desktop-base gdk-pixbuf gtk-3 accountsservice pulseaudio"
 BUILDDEP="gnome-common gobject-introspection intltool"
 PKGDES="Library with common API for various Cinnamon modules"
 

--- a/desktop-cinnamon/cinnamon-desktop/spec
+++ b/desktop-cinnamon/cinnamon-desktop/spec
@@ -1,4 +1,5 @@
 VER=5.8.0
+REL=1
 SRCS="tbl::https://github.com/linuxmint/cinnamon-desktop/archive/$VER.tar.gz"
 CHKSUMS="sha256::53080bd27527a8271d659e143a8d3b333d9b85efc82b77e571075f9cf8d3287c"
 CHKUPDATE="anitya::id=6387"

--- a/desktop-gnome/gnome-shell/autobuild/defines
+++ b/desktop-gnome/gnome-shell/autobuild/defines
@@ -4,9 +4,8 @@ PKGDEP="accountsservice gcr gjs gnome-bluetooth gnome-menus upower \
         gnome-session gnome-settings-daemon gsettings-desktop-schemas \
         libcanberra libcroco libsecret mutter network-manager-applet \
         telepathy-logger telepathy-mission-control unzip gstreamer-1-0 \
-        evolution-data-server libgsystem python-3 gnome-autoar \
-        gnome-control-center gtk-4 xdg-desktop-portal-gnome \
-        gtk-update-icon-cache"
+        evolution-data-server python-3 gnome-autoar gnome-control-center \
+        gtk-4 xdg-desktop-portal-gnome gtk-update-icon-cache"
 BUILDDEP="appstream-glib gobject-introspection gtk-doc intltool \
           sassc asciidoc"
 PKGDES="The default GNOME desktop interface"

--- a/desktop-gnome/gnome-shell/spec
+++ b/desktop-gnome/gnome-shell/spec
@@ -1,5 +1,5 @@
 VER=42.4
-REL=3
+REL=4
 SRCS="https://download.gnome.org/sources/gnome-shell/${VER%%.*}/gnome-shell-$VER.tar.xz"
 CHKSUMS="sha256::875ff2970ea9fb7a05506e32a0d50dc917f41b4ca37134b41377f9c82873c54e"
 CHKUPDATE="anitya::id=5409"

--- a/desktop-gnome/libgsystem/autobuild/defines
+++ b/desktop-gnome/libgsystem/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=libgsystem
-PKGSEC=libs
-PKGDEP="attr glib systemd"
-BUILDDEP="gobject-introspection gtk-doc"
-PKGDES="'Copylib' for system service modules using GLib with GCC"
-
-PKGEPOCH=1
-ABSHADOW=no
-AUTOTOOLS_AFTER="--enable-gtk-doc --with-systemd-journal"

--- a/desktop-gnome/libgsystem/autobuild/prepare
+++ b/desktop-gnome/libgsystem/autobuild/prepare
@@ -1,4 +1,0 @@
-sed -e 's|attr/xattr|sys/xattr|g' \
-    -i "$SRCDIR"/configure.ac
-
-NOCONFIGURE=1 ./autogen.sh

--- a/desktop-gnome/libgsystem/spec
+++ b/desktop-gnome/libgsystem/spec
@@ -1,5 +1,0 @@
-VER=2015.2
-REL=1
-SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/Archive/libgsystem"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=229570"

--- a/groups/glib-rebuilds
+++ b/groups/glib-rebuilds
@@ -69,7 +69,6 @@ runtime-vcs/libgit2-glib
 desktop-gnome/libgnome-keyring
 runtime-virtualization/libgovirt
 desktop-gnome/libgrss
-desktop-gnome/libgsystem
 desktop-gnome/libgtop
 runtime-admin/libgudev
 runtime-virtualization/libguestfs


### PR DESCRIPTION
Topic Description
-----------------

- libgsystem: drop, orphaned
    Signed-off-by: Ilikara <3435193369@qq.com>
- cinnamon-desktop: remove unused dependency libgsystem
    Signed-off-by: Ilikara <3435193369@qq.com>
- gnome-shell: remove unused dependency libgsystem
    Signed-off-by: Ilikara <3435193369@qq.com>
- ostree: remove unused dependency libgsystem
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- ostree: 2025.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree  gnome-shell  cinnamon-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
