### PR TITLE
malcontent: add defines.stage2 and disable tests

### DIFF
--- a/runtime-desktop/malcontent/autobuild/defines.stage2
+++ b/runtime-desktop/malcontent/autobuild/defines.stage2
@@ -1,12 +1,12 @@
 PKGNAME=malcontent
 PKGSEC=libs
-PKGDEP="accountsservice dbus desktop-file-utils flatpak gtk-3 polkit"
+PKGDEP="accountsservice dbus desktop-file-utils glib gtk-3 polkit"
 BUILDDEP="appstream-glib gobject-introspection gtk-doc"
 PKGDES="Implements content accessibility restrictions to non-administrator accounts"
 
 MESON_AFTER=(
     '-Dinstalled_tests=false'
-    '-Dui=enabled'
+    '-Dui=disabled'
     '-Duse_system_libmalcontent=false'
     '-Dprivileged_group=wheel'
 )

--- a/runtime-desktop/malcontent/autobuild/patches/0001-AOSCOS-fix-libmalcontent-disable-tests.patch
+++ b/runtime-desktop/malcontent/autobuild/patches/0001-AOSCOS-fix-libmalcontent-disable-tests.patch
@@ -1,0 +1,25 @@
+From 51a5fd4eecca1a3fb61952824f70ab66e466b78e Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 29 May 2025 15:58:46 +0800
+Subject: [PATCH] AOSCOS: fix(libmalcontent): disable tests
+
+We do not currently run unit tests and it requires glib-testing, which we
+do not maintain.
+---
+ libmalcontent/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/libmalcontent/meson.build b/libmalcontent/meson.build
+index 2f36420..0de2a31 100644
+--- a/libmalcontent/meson.build
++++ b/libmalcontent/meson.build
+@@ -76,5 +76,3 @@ libmalcontent_gir = gnome.generate_gir(libmalcontent,
+   install: true,
+   dependencies: libmalcontent_dep,
+ )
+-
+-subdir('tests')
+\ No newline at end of file
+-- 
+2.49.0
+

--- a/runtime-desktop/malcontent/spec
+++ b/runtime-desktop/malcontent/spec
@@ -1,5 +1,5 @@
 VER=0.10.5
-REL=1
+REL=2
 SRCS="https://gitlab.freedesktop.org/pwithnall/malcontent/-/archive/$VER/malcontent-$VER.tar.gz"
 CHKSUMS="sha256::f4c120c223c1a6ef6ea14e8f66d471cd20bb1a8033dcaf81720b3294b6dab830"
 CHKUPDATE="anitya::id=230451"


### PR DESCRIPTION
Topic Description
-----------------

- malcontent: add defines.stage2 and disable tests
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- malcontent: 0.10.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit malcontent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
