### PR TITLE
xray: update to 25.8.31

### DIFF
--- a/app-proxy/xray/autobuild/defines
+++ b/app-proxy/xray/autobuild/defines
@@ -6,6 +6,3 @@ BUILDDEP="go"
 
 ABTYPE=gomod
 GO_PACKAGES=("main")
-GO_LDFLAGS=(
-    "-X github.com/xtls/xray-core/core.build=$(git rev-parse --short HEAD)"
-)

--- a/app-proxy/xray/autobuild/prepare
+++ b/app-proxy/xray/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS=(
+    "-X github.com/xtls/xray-core/core.build=$(git rev-parse --short HEAD)"
+)

--- a/app-proxy/xray/spec
+++ b/app-proxy/xray/spec
@@ -1,4 +1,4 @@
-VER=25.8.3
+VER=25.8.31
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/XTLS/Xray-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"

--- a/runtime-data/v2ray-rules-dat/autobuild/defines
+++ b/runtime-data/v2ray-rules-dat/autobuild/defines
@@ -5,3 +5,4 @@ PKGDES="Enhanced edition of V2Ray rules dat files"
 
 ABSPLITDBG=0
 ABHOST=noarch
+ABTYPE=self

--- a/runtime-data/v2ray-rules-dat/spec
+++ b/runtime-data/v2ray-rules-dat/spec
@@ -1,6 +1,6 @@
-VER=202501302211
+VER=202508312212
 SRCS="file::rename=geoip.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geoip.dat \
       file::rename=geosite.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geosite.dat"
-CHKSUMS="sha256::5604fafbdb9b4faed9f88b6c7a318f14c95d8e179a9bf15cd470420779a5f476 \
-         sha256::53188eae8c03c76590d047982cd91a4080c1c6d9b768062f2c44311c32335314"
+CHKSUMS="sha256::a663a7af78e587523d257cf9d4eafa6f0cd5fb4d5fbfdb62d014ffb86f341bac \
+         sha256::276bc29ab6140f469a08e3125f9ff15e8e5242f301c2912677a49f68238bbf26"
 CHKUPDATE="anitya::id=375331"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray-rules-dat: update to 202508312212
- xray: update to 25.8.31
    - Improve defines script.
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- v2ray-rules-dat: 202508312212
- xray: 25.8.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray-rules-dat xray
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
