### PR TITLE
pinentry: move gtk-2 from PKGDEP to PKGSUG

### DIFF
--- a/app-utils/pinentry/autobuild/defines
+++ b/app-utils/pinentry/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=pinentry
 PKGSEC=utils
-PKGDEP="libassuan libcap ncurses libsecret pcre2 gtk-2"
-BUILDDEP="gcr qt-5 qt-6"
-PKGSUG="gcr qt-5 qt-6"
-PKGDES="A collection of simple PIN or passphrase entry dialogs"
+PKGDEP="libassuan libcap ncurses libsecret pcre2"
+BUILDDEP="gcr gtk-2 qt-5 qt-6"
+PKGSUG="gcr gtk-2 qt-5 qt-6"
+PKGDES="Helpers for displaying PIN or passphrase entry dialogs"
 
 AUTOTOOLS_AFTER=(
     '--enable-pinentry-curses'

--- a/app-utils/pinentry/autobuild/overrides/usr/bin/pinentry
+++ b/app-utils/pinentry/autobuild/overrides/usr/bin/pinentry
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run user-defined and site-defined pre-exec hooks.
+[[ -r "${XDG_CONFIG_HOME:-$HOME/.config}"/pinentry/preexec ]] && \
+	. "${XDG_CONFIG_HOME:-$HOME/.config}"/pinentry/preexec
+[[ -r /etc/pinentry/preexec ]] && . /etc/pinentry/preexec
+
+# Guess preferred backend based on environment.
+backends=(curses tty)
+if [[ -n "$DISPLAY" || "$XDG_SESSION_TYPE" == "wayland" ]]; then
+	backends=(qt qt5 gtk-2 curses tty)
+fi
+
+for backend in "${backends[@]}"; do
+	lddout=$(ldd "/usr/bin/pinentry-$backend" 2>/dev/null) || continue
+	[[ "$lddout" == *'not found'* ]] && continue
+	exec "/usr/bin/pinentry-$backend" "$@"
+done
+
+echo "Error: No suitable pinentry backend found" >&2
+exit 1

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,4 +1,5 @@
 VER=1.3.2
+REL=1
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e"
 CHKUPDATE="anitya::id=3643"


### PR DESCRIPTION
Topic Description
-----------------

- pinentry: move gtk-2 from PKGDEP to PKGSUG
    - Add a auto-select pinentry backend script
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- pinentry: 1.3.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
