### PR TITLE
clash-verge-rev: update to 2.4.1

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-feat-src-assets-add-XDG-.desktop-entry.patch
@@ -1,4 +1,4 @@
-From 709aa94b8ca74d83efbdc3631b269e0008bd45cd Mon Sep 17 00:00:00 2001
+From c13e298107be2a2f559be9296ac500341a7c7030 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 16:28:51 +0800
 Subject: [PATCH 01/23] feat(src/assets): add XDG .desktop entry

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 1a1285e12e9d3bb28f029871f442814f1dc300a8 Mon Sep 17 00:00:00 2001
+From fce7e6680ad3db0c7ec60fd35a09b58578e94bb5 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 02/23] fix(tauri.conf.json): disable bundle distribution
@@ -8,11 +8,11 @@ Subject: [PATCH 02/23] fix(tauri.conf.json): disable bundle distribution
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index f382c739..1ce85a3e 100755
+index 19e3f5f3..53656148 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.4.0",
+   "version": "2.4.1",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-scripts-use-ABI2-New-World-Mihomo-binary-for-loo.patch
@@ -1,4 +1,4 @@
-From 990bc87198d07023280286aca9ab8f29cc69c55d Mon Sep 17 00:00:00 2001
+From 8722dcaeba0e8e1bb50137700f677f8fda477ceb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 22 Mar 2024 17:26:12 +0800
 Subject: [PATCH 03/23] fix(scripts): use ABI2 (New-World) Mihomo binary for

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-feat-drop-clash-meta-alpha-support.patch
@@ -1,4 +1,4 @@
-From 9ed8cc8ea42f84646129eaa45f04e56a3218b0bf Mon Sep 17 00:00:00 2001
+From 455319a959b6a451b2919fbb29161134f0c67a45 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 04/23] feat: drop clash-meta-alpha support

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-fix-check.mjs-do-not-fetch-Mihomo-Clash-Meta-binarie.patch
@@ -1,4 +1,4 @@
-From ad726c2a14562c7c9e795e9560a56ed6da112729 Mon Sep 17 00:00:00 2001
+From 63f9b7f28c87ea55e86720f757d4682e42c2a03b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 23 Mar 2024 11:45:21 +0800
 Subject: [PATCH 05/23] fix(check.mjs): do not fetch Mihomo (Clash Meta)

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-fix-src-tauri-tauri.conf.json-disable-Mihomo-Clash-M.patch
@@ -1,4 +1,4 @@
-From 2eca9ad6f32f3dcd789a3b2fdf90ca041a202e03 Mon Sep 17 00:00:00 2001
+From f05a6851c047df6a463b2e977bb57df2c825cc08 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 06/23] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
@@ -9,7 +9,7 @@ Subject: [PATCH 06/23] fix(src-tauri/tauri.conf.json): disable Mihomo (Clash
  1 file changed, 1 deletion(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 1ce85a3e..33215677 100755
+index 53656148..93ebc2ce 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-fix-check.mjs-do-not-check-Mihomo-Clash-Meta-platfor.patch
@@ -1,4 +1,4 @@
-From 53a3453ddc958c1949533aa42649db7de7f274ca Mon Sep 17 00:00:00 2001
+From be902f365894f199a4135be2decd27a606936cf8 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:36:28 +0800
 Subject: [PATCH 07/23] fix(check.mjs): do not check Mihomo (Clash Meta)

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-create-any-bundle-package.patch
@@ -1,4 +1,4 @@
-From 87c37acec457b267d58ceb78525fc52f61828e84 Mon Sep 17 00:00:00 2001
+From ca9ec59925947a94299c2b163677d46bbbbdc738 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:49:46 +0800
 Subject: [PATCH 08/23] Do not create any bundle package

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-check-update-feature.patch
@@ -1,4 +1,4 @@
-From 046a13c5f6484aa57b3d35c44524772b9fd2149c Mon Sep 17 00:00:00 2001
+From 28a943f771a02c3053b283b031c2d51c51d00fcf Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 09/23] Drop check update feature
@@ -66,7 +66,7 @@ index 74e9e736..00000000
 -  );
 -};
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index d3d7fa46..bc783b52 100644
+index 918582bb..a6d2f676 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
 @@ -9,7 +9,6 @@ import {
@@ -74,10 +74,10 @@ index d3d7fa46..bc783b52 100644
    exportDiagnosticInfo,
  } from "@/services/cmds";
 -import { check as checkUpdate } from "@tauri-apps/plugin-updater";
- import { useVerge } from "@/hooks/use-verge";
  import { version } from "@root/package.json";
  import { DialogRef } from "@/components/base";
-@@ -19,7 +18,6 @@ import { HotkeyViewer } from "./mods/hotkey-viewer";
+ import { SettingList, SettingItem } from "./mods/setting-comp";
+@@ -18,7 +17,6 @@ import { HotkeyViewer } from "./mods/hotkey-viewer";
  import { MiscViewer } from "./mods/misc-viewer";
  import { ThemeViewer } from "./mods/theme-viewer";
  import { LayoutViewer } from "./mods/layout-viewer";
@@ -85,7 +85,7 @@ index d3d7fa46..bc783b52 100644
  import { BackupViewer } from "./mods/backup-viewer";
  import { LiteModeViewer } from "./mods/lite-mode-viewer";
  import { TooltipIcon } from "@/components/base/base-tooltip-icon";
-@@ -39,22 +37,9 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -37,22 +35,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -108,7 +108,7 @@ index d3d7fa46..bc783b52 100644
  
    const onExportDiagnosticInfo = useCallback(async () => {
      await exportDiagnosticInfo();
-@@ -74,7 +59,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -72,7 +57,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -116,7 +116,7 @@ index d3d7fa46..bc783b52 100644
        <BackupViewer ref={backupRef} />
        <LiteModeViewer ref={liteModeRef} />
  
-@@ -109,8 +93,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -107,8 +91,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
  
        <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
  
@@ -162,7 +162,7 @@ index 34660f4e..1fc4069a 100644
  
        <SettingItem label={t("Language")}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index cfe17d8f..4514069f 100644
+index ac939581..acc3ca7c 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
 @@ -17,7 +17,6 @@ import iconDark from "@/assets/image/icon_dark.svg?react";
@@ -173,7 +173,7 @@ index cfe17d8f..4514069f 100644
  import { useCustomTheme } from "@/components/layout/use-custom-theme";
  import getSystem from "@/utils/get-system";
  import "dayjs/locale/ru";
-@@ -567,7 +566,6 @@ const Layout = () => {
+@@ -566,7 +565,6 @@ const Layout = () => {
                  />
                  <LogoSvg fill={isDark ? "white" : "black"} />
                </div>

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From be10f31b9b714e51f9b55270318b2b9bedc22012 Mon Sep 17 00:00:00 2001
+From c7dcf93d5641a1b1aee2c016d23ac46d69d6b770 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 10/23] Set core binary name as mihomo
@@ -126,10 +126,10 @@ index a34cb3ca..bf1cc1ae 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index 2d2a3330..8350ac38 100644
+index 66382845..0446e09e 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
-@@ -347,7 +347,7 @@ impl IVerge {
+@@ -353,7 +353,7 @@ impl IVerge {
  
      pub fn template() -> Self {
          Self {
@@ -139,10 +139,10 @@ index 2d2a3330..8350ac38 100644
              theme_mode: Some("system".into()),
              #[cfg(not(target_os = "windows"))]
 diff --git a/src-tauri/src/enhance/chain.rs b/src-tauri/src/enhance/chain.rs
-index 2fb7e951..7e568a9a 100644
+index 9f9b0e8b..0647eeb1 100644
 --- a/src-tauri/src/enhance/chain.rs
 +++ b/src-tauri/src/enhance/chain.rs
-@@ -108,8 +108,8 @@ impl ChainSupport {
+@@ -158,8 +158,8 @@ impl ChainSupport {
                  (self, core.as_str()),
                  (ChainSupport::All, _)
                      | (ChainSupport::Clash, "clash")

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From d765703ae20fc39827f74f8d34b2780c57c9085a Mon Sep 17 00:00:00 2001
+From 5b1460540e68baa3ab73cdee624d5cbd44db1d18 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 11/23] feat: always not portable

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,4 +1,4 @@
-From 6750d765d63ce80292bb76c97cab35db18dd127d Mon Sep 17 00:00:00 2001
+From c0e6aa8aea0e7927c88883940101e525abd2469c Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 12/23] Set service install/uninstall script path to
@@ -9,12 +9,12 @@ Subject: [PATCH 12/23] Set service install/uninstall script path to
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index cb684702..f9e690f3 100644
+index facefd0e..1e6583a1 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -230,9 +230,11 @@ pub fn reinstall_service() -> Result<()> {
+@@ -235,9 +235,11 @@ pub async fn reinstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
- pub fn uninstall_service() -> Result<()> {
+ pub async fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, true, "uninstall service");
 +    use std::path::Path;
      use users::get_effective_uid;
@@ -25,9 +25,9 @@ index cb684702..f9e690f3 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -270,9 +272,11 @@ pub fn uninstall_service() -> Result<()> {
+@@ -275,9 +277,11 @@ pub async fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
- pub fn install_service() -> Result<()> {
+ pub async fn install_service() -> Result<()> {
      logging!(info, Type::Service, true, "install service");
 +    use std::path::Path;
      use users::get_effective_uid;

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-Unset-all-release-profile.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-Unset-all-release-profile.patch
@@ -1,4 +1,4 @@
-From 7513e00ef23c0314a2dd54c944a404d2148a2629 Mon Sep 17 00:00:00 2001
+From 9bfb1ffc039fd6f8181e147e9cfaf3deb768da90 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:52:29 +0800
 Subject: [PATCH 13/23] Unset all release profile
@@ -8,10 +8,10 @@ Subject: [PATCH 13/23] Unset all release profile
  1 file changed, 7 deletions(-)
 
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 5b385104..a22703af 100755
+index c4b80ffa..5ff9d01d 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -111,13 +111,6 @@ custom-protocol = ["tauri/custom-protocol"]
+@@ -116,13 +116,6 @@ custom-protocol = ["tauri/custom-protocol"]
  verge-dev = []
  tokio-trace = ["console-subscriber"]
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0014-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0014-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 58dcaee76df0be24a2df99ee963c6c003a0245cf Mon Sep 17 00:00:00 2001
+From 17955e9eb10abf02b85398aa7582c37539884375 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 14/23] Do not use gcc

--- a/app-proxy/clash-verge-rev/autobuild/patches/0015-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0015-Drop-Upgrade-core-button.patch
@@ -1,4 +1,4 @@
-From 8c0884617736271bdf697ac480deb88fbd5927a9 Mon Sep 17 00:00:00 2001
+From 98f61b09864e875c8983971c3ba19ab695340ef2 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 15/23] Drop "Upgrade core" button

--- a/app-proxy/clash-verge-rev/autobuild/patches/0016-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0016-ppc64el-Use-rollup-wasm-node-to-fix-build-on-POWER8.patch
@@ -1,4 +1,4 @@
-From 149c42c84dc87d05b96d36ad040c7fbf0378691c Mon Sep 17 00:00:00 2001
+From bef2821f325e4a462856e7e6cd8c64df47a73df5 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 12:09:38 +0800
 Subject: [PATCH 16/23] (ppc64el) Use `@rollup/wasm-node` to fix build on
@@ -9,11 +9,11 @@ Subject: [PATCH 16/23] (ppc64el) Use `@rollup/wasm-node` to fix build on
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/package.json b/package.json
-index 7af821e5..d13849ce 100644
+index 4ec265ae..93312233 100644
 --- a/package.json
 +++ b/package.json
 @@ -106,5 +106,10 @@
-     "vite-plugin-svgr": "^4.3.0"
+     "vite-plugin-svgr": "^4.5.0"
    },
    "type": "module",
 -  "packageManager": "pnpm@9.13.2"

--- a/app-proxy/clash-verge-rev/autobuild/patches/0017-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0017-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From fd7a672d221456f75e623a28337c0313497daae5 Mon Sep 17 00:00:00 2001
+From 9b293fc288dca69e9b5ac265f52bf4419fc13f39 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 17/23] Do not sidecar mihomo program
@@ -8,7 +8,7 @@ Subject: [PATCH 17/23] Do not sidecar mihomo program
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index 05d371d8..b13da577 100644
+index 4b8ad96c..380c4b4d 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
 @@ -263,7 +263,7 @@ impl CoreManager {

--- a/app-proxy/clash-verge-rev/autobuild/patches/0018-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0018-Fix-if-mihomo-geoip-file-src_path-is-symlink.patch
@@ -1,39 +1,56 @@
-From 0d09640ac21b70d9a7d8a3cfc1437f1de68bbc2a Mon Sep 17 00:00:00 2001
+From b25cb91c9dffd2e46e3234ec9348dfb210e49b0b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 8 Apr 2025 12:32:41 +0800
 Subject: [PATCH 18/23] Fix if mihomo geoip file `src_path` is symlink
 
 ---
- src-tauri/src/utils/init.rs | 30 +++++++++++++++++-------------
- 1 file changed, 17 insertions(+), 13 deletions(-)
+ src-tauri/src/utils/init.rs | 51 +++++++++++++++----------------------
+ 1 file changed, 21 insertions(+), 30 deletions(-)
 
 diff --git a/src-tauri/src/utils/init.rs b/src-tauri/src/utils/init.rs
-index d2e97a81..769425bd 100644
+index 33f0adbd..e6563996 100644
 --- a/src-tauri/src/utils/init.rs
 +++ b/src-tauri/src/utils/init.rs
-@@ -13,7 +13,7 @@ use log4rs::{
+@@ -13,7 +13,10 @@ use log4rs::{
+     config::{Appender, Logger, Root},
+     encode::pattern::PatternEncoder,
  };
- use std::{
-     fs::{self, DirEntry},
--    path::PathBuf,
+-use std::{path::PathBuf, str::FromStr};
++use std::{
 +    path::{Path, PathBuf},
-     str::FromStr,
- };
++    str::FromStr,
++};
  use tauri_plugin_shell::ShellExt;
-@@ -322,21 +322,16 @@ pub fn init_resources() -> Result<()> {
+ use tokio::fs;
+ use tokio::fs::DirEntry;
+@@ -403,7 +406,7 @@ pub async fn init_resources() -> Result<()> {
      // copy the resource file
      // if the source file is newer than the destination file, copy it over
      for file in file_list.iter() {
 -        let src_path = res_dir.join(file);
 +        let mut src_path = res_dir.join(file);
          let dest_path = app_dir.join(file);
-         log::debug!(target: "app", "src_path: {src_path:?}, dest_path: {dest_path:?}");
+         logging!(
+             debug,
+@@ -414,27 +417,12 @@ pub async fn init_resources() -> Result<()> {
+             dest_path
+         );
  
--        let handle_copy = |dest: &PathBuf| {
--            match fs::copy(&src_path, dest) {
--                Ok(_) => log::debug!(target: "app", "resources copied '{file}'"),
+-        let handle_copy = |src: PathBuf, dest: PathBuf, file: String| async move {
+-            match fs::copy(&src, &dest).await {
+-                Ok(_) => {
+-                    logging!(debug, Type::Setup, true, "resources copied '{}'", file);
+-                }
 -                Err(err) => {
--                    log::error!(target: "app", "failed to copy resources '{file}' to '{dest:?}', {err}")
+-                    logging!(
+-                        error,
+-                        Type::Setup,
+-                        true,
+-                        "failed to copy resources '{}' to '{:?}', {}",
+-                        file,
+-                        dest,
+-                        err
+-                    );
 -                }
 -            };
 -        };
@@ -42,34 +59,43 @@ index d2e97a81..769425bd 100644
 +        }
  
          if src_path.exists() && !dest_path.exists() {
--            handle_copy(&dest_path);
-+            copy(&src_path, &dest_path, &file);
+-            handle_copy(src_path.clone(), dest_path.clone(), file.to_string()).await;
++            copy(&src_path, &dest_path, &file).await;
              continue;
          }
  
-@@ -346,14 +341,14 @@ pub fn init_resources() -> Result<()> {
+@@ -444,7 +432,7 @@ pub async fn init_resources() -> Result<()> {
          match (src_modified, dest_modified) {
              (Ok(src_modified), Ok(dest_modified)) => {
                  if src_modified > dest_modified {
--                    handle_copy(&dest_path);
-+                    copy(&src_path, &dest_path, &file);
+-                    handle_copy(src_path.clone(), dest_path.clone(), file.to_string()).await;
++                    copy(&src_path, &dest_path, &file).await;
                  } else {
-                     log::debug!(target: "app", "skipping resource copy '{file}'");
+                     logging!(
+                         debug,
+@@ -456,14 +444,8 @@ pub async fn init_resources() -> Result<()> {
                  }
              }
              _ => {
-                 log::debug!(target: "app", "failed to get modified '{file}'");
--                handle_copy(&dest_path);
-+                copy(&src_path, &dest_path, &file);
+-                logging!(
+-                    debug,
+-                    Type::Setup,
+-                    true,
+-                    "failed to get modified '{}'",
+-                    file
+-                );
+-                handle_copy(src_path.clone(), dest_path.clone(), file.to_string()).await;
++                log::debug!(target: "app", "failed to get modified '{file}'");
++                copy(&src_path, &dest_path, &file).await;
              }
          };
      }
-@@ -361,6 +356,15 @@ pub fn init_resources() -> Result<()> {
+@@ -471,6 +453,15 @@ pub async fn init_resources() -> Result<()> {
      Ok(())
  }
  
-+fn copy(src_path: &Path, dest: &Path, file: &str) {
-+    match fs::copy(src_path, dest) {
++async fn copy(src_path: &Path, dest: &Path, file: &str) {
++    match fs::copy(src_path, dest).await {
 +        Ok(_) => log::debug!(target: "app", "resources copied '{file}'"),
 +        Err(err) => {
 +            log::error!(target: "app", "failed to copy resources '{file}' to '{dest:?}', {err}")

--- a/app-proxy/clash-verge-rev/autobuild/patches/0019-fix-components-drop-update-checker.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0019-fix-components-drop-update-checker.patch
@@ -1,4 +1,4 @@
-From 32ee953c671da606b6fe1035859fb4a560b56ff5 Mon Sep 17 00:00:00 2001
+From e55aea88b38f77f0432481a17046318494638d0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:43:15 +0800
 Subject: [PATCH 19/23] fix(components): drop update checker
@@ -10,7 +10,7 @@ Subject: [PATCH 19/23] fix(components): drop update checker
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
-index 0e35132c..22a70941 100644
+index 58bee02c..5b2ac8c4 100644
 --- a/src/components/home/system-info-card.tsx
 +++ b/src/components/home/system-info-card.tsx
 @@ -64,36 +64,6 @@ export const SystemInfoCard = () => {
@@ -101,7 +101,7 @@ index 0e35132c..22a70941 100644
              {t("Verge Version")}
 diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
 deleted file mode 100644
-index 91ea4ae1..00000000
+index e4780be7..00000000
 --- a/src/components/setting/mods/update-viewer.tsx
 +++ /dev/null
 @@ -1,169 +0,0 @@
@@ -250,7 +250,7 @@ index 91ea4ae1..00000000
 -      <Box sx={{ height: "calc(100% - 10px)", overflow: "auto" }}>
 -        <ReactMarkdown
 -          components={{
--            a: ({ node, ...props }) => {
+-            a: ({ ...props }) => {
 -              const { children } = props;
 -              return (
 -                <a {...props} target="_blank">

--- a/app-proxy/clash-verge-rev/autobuild/patches/0020-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0020-fix-drop-Open-Core-Dir-function.patch
@@ -1,28 +1,28 @@
-From 35f7e0ee297db2c3149cd1dcf5d58a24f486f6c2 Mon Sep 17 00:00:00 2001
+From cd1fbc6034c158a5e4efdc968a83e6eb0aa5ac7e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 20/23] fix: drop Open Core Dir function
 
 This is useless for our users as it would just open /usr/bin.
 ---
- src-tauri/src/cmd/app.rs                      |  8 -------
- src-tauri/src/core/tray/mod.rs                | 21 +++----------------
+ src-tauri/src/cmd/app.rs                      |  8 ---
+ src-tauri/src/core/tray/mod.rs                | 58 +++++++------------
  src-tauri/src/lib.rs                          |  1 -
- .../setting/setting-verge-advanced.tsx        |  3 ---
- src/services/cmds.ts                          |  6 ------
- 5 files changed, 3 insertions(+), 36 deletions(-)
+ .../setting/setting-verge-advanced.tsx        |  3 -
+ src/services/cmds.ts                          |  6 --
+ 5 files changed, 21 insertions(+), 55 deletions(-)
 
 diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
-index cb8fd6a2..db914791 100644
+index 44b2cecf..cf0a891c 100644
 --- a/src-tauri/src/cmd/app.rs
 +++ b/src-tauri/src/cmd/app.rs
-@@ -13,14 +13,6 @@ pub fn open_app_dir() -> CmdResult<()> {
+@@ -13,14 +13,6 @@ pub async fn open_app_dir() -> CmdResult<()> {
      wrap_err!(open::that(app_dir))
  }
  
 -/// 打开核心所在目录
 -#[tauri::command]
--pub fn open_core_dir() -> CmdResult<()> {
+-pub async fn open_core_dir() -> CmdResult<()> {
 -    let core_dir = wrap_err!(tauri::utils::platform::current_exe())?;
 -    let core_dir = core_dir.parent().ok_or("failed to get core dir")?;
 -    wrap_err!(open::that(core_dir))
@@ -30,19 +30,27 @@ index cb8fd6a2..db914791 100644
 -
  /// 打开日志目录
  #[tauri::command]
- pub fn open_logs_dir() -> CmdResult<()> {
+ pub async fn open_logs_dir() -> CmdResult<()> {
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index 74ebf61b..e8214210 100644
+index 64445b4c..e4bfa811 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -660,14 +660,6 @@ fn create_tray_menu(
+@@ -617,7 +617,6 @@ async fn create_tray_menu(
+     let lightweight_mode_text = t("LightWeight Mode").await;
+     let copy_env_text = t("Copy Env").await;
+     let conf_dir_text = t("Conf Dir").await;
+-    let core_dir_text = t("Core Dir").await;
+     let logs_dir_text = t("Logs Dir").await;
+     let open_dir_text = t("Open Dir").await;
+     let restart_clash_text = t("Restart Clash Core").await;
+@@ -712,14 +711,6 @@ async fn create_tray_menu(
          None::<&str>,
      )?;
  
 -    let open_core_dir = &MenuItem::with_id(
 -        app_handle,
 -        "open_core_dir",
--        t("Core Dir"),
+-        core_dir_text,
 -        true,
 -        None::<&str>,
 -    )?;
@@ -50,38 +58,76 @@ index 74ebf61b..e8214210 100644
      let open_logs_dir = &MenuItem::with_id(
          app_handle,
          "open_logs_dir",
-@@ -681,7 +673,7 @@ fn create_tray_menu(
+@@ -733,7 +724,7 @@ async fn create_tray_menu(
          "open_dir",
-         t("Open Dir"),
+         open_dir_text,
          true,
 -        &[open_app_dir, open_core_dir, open_logs_dir],
 +        &[open_app_dir, open_logs_dir],
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -779,15 +771,8 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
-             feat::toggle_tun_mode(None);
-         }
-         "copy_env" => feat::copy_clash_env(),
--        "open_app_dir" => {
--            let _ = cmd::open_app_dir();
--        }
--        "open_core_dir" => {
--            let _ = cmd::open_core_dir();
--        }
--        "open_logs_dir" => {
--            let _ = cmd::open_logs_dir();
--        }
-+        "open_app_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_app_dir()),
-+        "open_logs_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_logs_dir()),
-         "restart_clash" => feat::restart_clash_core(),
-         "restart_app" => feat::restart_app(),
-         "entry_lightweight_mode" => {
+@@ -818,35 +809,28 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+                     return;
+                 }
+ 
+-                if crate::module::lightweight::is_in_lightweight_mode() {
+-                    log::info!(target: "app", "当前在轻量模式，正在退出");
+-                    crate::module::lightweight::exit_lightweight_mode().await; // Await async function
+-                }
+-                let result = WindowManager::show_main_window().await; // Await async function
+-                log::info!(target: "app", "窗口显示结果: {result:?}");
+-            }
+-            "system_proxy" => {
+-                feat::toggle_system_proxy().await; // Await async function
+-            }
+-            "tun_mode" => {
+-                feat::toggle_tun_mode(None).await; // Await async function
++            if crate::module::lightweight::is_in_lightweight_mode() {
++                log::info!(target: "app", "当前在轻量模式，正在退出");
++                crate::module::lightweight::exit_lightweight_mode();
+             }
+-            "copy_env" => feat::copy_clash_env().await, // Await async function
+-            "open_app_dir" => {
+-                let _ = cmd::open_app_dir().await; // Await async function
+-            }
+-            "open_core_dir" => {
+-                let _ = cmd::open_core_dir().await; // Await async function
+-            }
+-            "open_logs_dir" => {
+-                let _ = cmd::open_logs_dir().await; // Await async function
++            let result = WindowManager::show_main_window().await;
++            log::info!(target: "app", "窗口显示结果: {result:?}");
++        }
++        "system_proxy" => {
++            feat::toggle_system_proxy();
++        }
++        "tun_mode" => {
++            feat::toggle_tun_mode(None);
++        }
++        "copy_env" => feat::copy_clash_env().await,
++        "open_app_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_app_dir().await),
++        "open_logs_dir" => crate::logging_error!(Type::Cmd, true, cmd::open_logs_dir().await),
++        "restart_clash" => feat::restart_clash_core().await,
++        "restart_app" => feat::restart_app().await,
++        "entry_lightweight_mode" => {
++            if !should_handle_tray_click() {
++                return;
+             }
+-            "restart_clash" => feat::restart_clash_core().await, // Await async function
+-            "restart_app" => feat::restart_app().await,          // Await async function
+-            "entry_lightweight_mode" => {
+-                if !should_handle_tray_click() {
+-                    return;
+-                }
+ 
+                 let was_lightweight = crate::module::lightweight::is_in_lightweight_mode();
+                 if was_lightweight {
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 92f63ea1..dac13347 100644
+index 65d95de7..c156d737 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -298,7 +298,6 @@ mod app_init {
+@@ -145,7 +145,6 @@ mod app_init {
              cmd::open_app_dir,
              cmd::open_logs_dir,
              cmd::open_web_url,
@@ -90,7 +136,7 @@ index 92f63ea1..dac13347 100644
              cmd::get_network_interfaces,
              cmd::get_system_hostname,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index bc783b52..905df326 100644
+index a6d2f676..1b5120f5 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
 @@ -4,7 +4,6 @@ import { Typography } from "@mui/material";
@@ -101,7 +147,7 @@ index bc783b52..905df326 100644
    openLogsDir,
    openDevTools,
    exportDiagnosticInfo,
-@@ -89,8 +88,6 @@ const SettingVergeAdvanced = ({ onError }: Props) => {
+@@ -87,8 +86,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          }
        />
  
@@ -111,7 +157,7 @@ index bc783b52..905df326 100644
  
        <SettingItem onClick={openDevTools} label={t("Open Dev Tools")} />
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index 8f14c418..121a0344 100644
+index cfc0efb4..e3a8813c 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
 @@ -504,12 +504,6 @@ export async function openAppDir() {

--- a/app-proxy/clash-verge-rev/autobuild/patches/0021-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0021-fix-disable-GeoData-update.patch
@@ -1,4 +1,4 @@
-From 6684863f2d43e27f8ee078f3415a332cac09fda2 Mon Sep 17 00:00:00 2001
+From b914d5a5c9f9ad5f7e082ddf2c2165cba5105813 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 21/23] fix: disable GeoData update
@@ -9,12 +9,12 @@ We handle this via mihomo-rules-dat.
  1 file changed, 9 deletions(-)
 
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index 102ba1ed..c2f03e4c 100644
+index d9b3d17d..2c78e791 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
-@@ -67,14 +67,6 @@ const SettingClash = ({ onError }: Props) => {
-   const onChangeVerge = (patch: Partial<IVergeConfig>) => {
-     mutateVerge({ ...verge, ...patch }, false);
+@@ -60,14 +60,6 @@ const SettingClash = ({ onError }: Props) => {
+   const onChangeData = (patch: Partial<IConfigData>) => {
+     mutateClash((old) => ({ ...old!, ...patch }), false);
    };
 -  const onUpdateGeo = async () => {
 -    try {
@@ -27,7 +27,7 @@ index 102ba1ed..c2f03e4c 100644
  
    // 实现DNS设置开关处理函数
    const handleDnsToggle = useLockFn(async (enable: boolean) => {
-@@ -261,7 +253,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -254,7 +246,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0022-fix-remove-unused-code.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0022-fix-remove-unused-code.patch
@@ -1,4 +1,4 @@
-From 844f1d643b70c9e266e1a18769f6cf4c6929deeb Mon Sep 17 00:00:00 2001
+From ee1393b83e507d37c8d7dee5cc5e113afa1e8a5a Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Wed, 9 Jul 2025 15:55:53 +0800
 Subject: [PATCH 22/23] fix: remove unused code
@@ -187,7 +187,7 @@ index f2f8faf7..af18705b 100644
      name: "enableLoopback",
      func: resolveEnableLoopback,
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index f9e690f3..92cbd277 100644
+index 1e6583a1..444e0b6d 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
 @@ -7,7 +7,6 @@ use crate::{
@@ -198,7 +198,7 @@ index f9e690f3..92cbd277 100644
      path::PathBuf,
      process::Command as StdCommand,
      time::{SystemTime, UNIX_EPOCH},
-@@ -92,9 +91,7 @@ impl ServiceState {
+@@ -96,9 +95,7 @@ impl ServiceState {
  #[derive(Debug, Deserialize, Serialize, Clone)]
  pub struct ResponseBody {
      pub core_type: Option<String>,
@@ -208,9 +208,9 @@ index f9e690f3..92cbd277 100644
  }
  
  #[derive(Debug, Deserialize, Serialize, Clone)]
-@@ -747,26 +744,16 @@ pub(super) async fn start_with_existing_service(config_file: &PathBuf) -> Result
+@@ -752,26 +749,16 @@ pub(super) async fn start_with_existing_service(config_file: &PathBuf) -> Result
  
-     let clash_core = Config::verge().latest_ref().get_valid_clash_core();
+     let clash_core = Config::verge().await.latest_ref().get_valid_clash_core();
  
 -    let bin_ext = if cfg!(windows) { ".exe" } else { "" };
 -    let clash_bin = format!("{clash_core}{bin_ext}");

--- a/app-proxy/clash-verge-rev/autobuild/patches/0023-fix-edit-mihomo-path.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0023-fix-edit-mihomo-path.patch
@@ -1,4 +1,4 @@
-From fc410874add0a7b5fd4a006ec1cd54a5f14924da Mon Sep 17 00:00:00 2001
+From 16ad39aa74c74d7f2311eaf87ebf7d50d239ce7e Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Wed, 27 Aug 2025 00:38:46 +0800
 Subject: [PATCH 23/23] fix: edit mihomo path
@@ -9,7 +9,7 @@ Subject: [PATCH 23/23] fix: edit mihomo path
  2 files changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index 8350ac38..1aa1be95 100644
+index 0446e09e..5975a6c7 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
 @@ -234,7 +234,7 @@ pub struct IVergeTheme {
@@ -20,7 +20,7 @@ index 8350ac38..1aa1be95 100644
 +    pub const VALID_CLASH_CORES: &'static [&'static str] = &["mihomo", "mihomo-alpha"];
  
      /// 验证并修正配置文件中的clash_core值
-     pub fn validate_and_fix_config() -> Result<()> {
+     pub async fn validate_and_fix_config() -> Result<()> {
 @@ -253,10 +253,10 @@ impl IVerge {
                      warn,
                      Type::Config,
@@ -56,7 +56,7 @@ index 8350ac38..1aa1be95 100644
  
      fn get_system_language() -> String {
 diff --git a/src-tauri/src/core/core.rs b/src-tauri/src/core/core.rs
-index b13da577..42f8d739 100644
+index 380c4b4d..a998d614 100644
 --- a/src-tauri/src/core/core.rs
 +++ b/src-tauri/src/core/core.rs
 @@ -445,7 +445,7 @@ impl CoreManager {

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.4.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.4.1

Package(s) Affected
-------------------

- clash-verge-rev: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
