### PR TITLE
libvips: update to 8.17.1

### DIFF
--- a/runtime-imaging/libvips/autobuild/defines
+++ b/runtime-imaging/libvips/autobuild/defines
@@ -5,14 +5,14 @@ PKGDEP="gcc-runtime glibc glib expat zlib libarchive fftw cfitsio cgif \
         libimagequant libexif libjpeg-turbo libpng libwebp pango fontconfig \
         libtiff librsvg cairo lcms2 openexr openjpeg highway nifti matio"
 PKGRECOM="imagemagick openslide libheif libjxl poppler python-3"
-BUILDDEP="imagemagick openslide libdicom libheif libjxl poppler vala gtk-doc \
-	doxygen"
+BUILDDEP="imagemagick openslide libdicom libheif libjxl poppler vala gi-docgen"
 
+ABTYPE=meson
 MESON_AFTER=(
     '-Dexamples=false'
-    '-Ddoxygen=true'
-    '-Dgtk_doc=true'
-    '-Dvapi=true'
+    '-Ddocs=false'
+    # FIXME: temporarily disabled due to libvips/libvips#4654
+    # '-Dvapi=true'
     '-Dnifti-prefix-dir=/usr'
     '-Dpdfium=disabled'
     '-Dquantizr=disabled'

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,4 @@
-VER=8.16.1
-REL=3
+VER=8.17.1
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: update to 8.17.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libvips: 8.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
