### PR TITLE
systemd: enable all sysrq keys

### DIFF
--- a/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
 From e465cda1339757e9003ab1ee1ea8081c7774440b Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 1/4] AOSCOS: sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 1/5] AOSCOS: sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
@@ -22,5 +22,5 @@ index 153f747342..5e409a8256 100644
  #AllowHybridSleep=yes
  #SuspendState=mem standby freeze
 -- 
-2.49.0
+2.51.0
 

--- a/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
@@ -1,7 +1,7 @@
 From 661c8b462339315f9b4034e540bab3b368025614 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 12 Aug 2024 22:19:25 +0800
-Subject: [PATCH 2/4] AOSCOS: fix: do not tint terminal by default
+Subject: [PATCH 2/5] AOSCOS: fix: do not tint terminal by default
 
 Let's face it, it's weird and we have much better ways to notify the user
 about a system running in a container. Change the default behavior (tint by
@@ -26,5 +26,5 @@ index 4e38e60775..adb2f06617 100644
                  log_debug_errno(cache, "Failed to parse $SYSTEMD_TINT_BACKGROUND, leaving background tinting enabled: %m");
  
 -- 
-2.49.0
+2.51.0
 

--- a/app-admin/systemd/autobuild/patches/0003-AOSCOS-mount-setup.c-do-not-sleep-during-boot.patch
+++ b/app-admin/systemd/autobuild/patches/0003-AOSCOS-mount-setup.c-do-not-sleep-during-boot.patch
@@ -1,7 +1,7 @@
 From f8f95c4a3e6d41553be5e5ed93b91b985ff70f93 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 10 Nov 2024 13:38:51 +0800
-Subject: [PATCH 3/4] AOSCOS: mount-setup.c: do not sleep during boot
+Subject: [PATCH 3/5] AOSCOS: mount-setup.c: do not sleep during boot
 
 To make the user happy.
 
@@ -28,5 +28,5 @@ index 73be3b5dce..133cc98ab5 100644
                          return 0;
                  }
 -- 
-2.49.0
+2.51.0
 

--- a/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
+++ b/app-admin/systemd/autobuild/patches/0004-exec-credential-try-forking-again-without-CLONE_NEWN.patch
@@ -1,7 +1,7 @@
 From 68b24c60fe9d3c77aed57697ea07838579f92285 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 28 Dec 2024 16:06:22 +0800
-Subject: [PATCH 4/4] exec-credential: try forking again without CLONE_NEWNS
+Subject: [PATCH 4/5] exec-credential: try forking again without CLONE_NEWNS
 
 QEMU user emulation currently does not support CLONE_NEWS, fork()ing
 with it will result in an EINVAL, rendering the system unbootable with
@@ -29,5 +29,5 @@ index 6ab3edbb54..9ddf2d6540 100644
                  _cleanup_(rmdir_and_freep) char *u = NULL; /* remove the temporary workspace if we can */
                  _cleanup_free_ char *t = NULL;
 -- 
-2.49.0
+2.51.0
 

--- a/app-admin/systemd/autobuild/patches/0005-AOSCOS-allow-all-sysrq-keys-except-memory-dump.patch
+++ b/app-admin/systemd/autobuild/patches/0005-AOSCOS-allow-all-sysrq-keys-except-memory-dump.patch
@@ -1,0 +1,28 @@
+From 924fd05342ff2e3df1620339aacfe193d8682c46 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Tue, 2 Sep 2025 03:33:38 +0000
+Subject: [PATCH 5/5] AOSCOS: allow all sysrq keys except memory dump
+
+so our user can debug and recover from a broken system even when they didn't know the system would break.
+---
+ sysctl.d/50-default.conf | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/sysctl.d/50-default.conf b/sysctl.d/50-default.conf
+index 69de91a2bc..78913226c6 100644
+--- a/sysctl.d/50-default.conf
++++ b/sysctl.d/50-default.conf
+@@ -16,7 +16,9 @@
+ # Use kernel.sysrq = 1 to allow all keys.
+ # See https://docs.kernel.org/admin-guide/sysrq.html for a list
+ # of values and keys.
+-kernel.sysrq = 16
++# Only disable debugging dumps
++# 502 = 0b1_1111_0110
++kernel.sysrq = 502
+ 
+ # Append the PID to the core filename
+ kernel.core_uses_pid = 1
+-- 
+2.51.0
+

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=257.6
 
 # Use this for stable releases.
-# REL=1
+REL=1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 

--- a/topics/systemd-enable-all-sysrq.toml
+++ b/topics/systemd-enable-all-sysrq.toml
@@ -1,0 +1,12 @@
+security = false
+
+[name]
+default = "systemd default SysRq config update"
+zh_CN = "systemd SysRq 默认设置更新"
+
+[caution]
+default = "Enabled all except debugging dump Magic SysRq keys by default"
+zh_CN = "默认启用除调试转储以外的所有 SysRq 组合键"
+
+[packages]
+systemd = "1:257.6-1"


### PR DESCRIPTION
Topic Description
-----------------

- systemd: enable all sysrq keys

Package(s) Affected
-------------------

- systemd: 1:257.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
