### PR TITLE
pcre2: update to 10.46

### DIFF
--- a/runtime-common/pcre2/spec
+++ b/runtime-common/pcre2/spec
@@ -1,5 +1,4 @@
-VER=10.44
+VER=10.46
 SRCS="git::commit=tags/pcre2-$VER::https://github.com/PCRE2Project/pcre2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5832"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pcre2: update to 10.46
    Co-authored-by: billchenchina \(@billchenchina\) <billchenchina2001@gmail.com>

Package(s) Affected
-------------------

- pcre2: 10.46

Security Update?
----------------

Yes, CVE-2025-58050

Build Order
-----------

```
#buildit pcre2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
