### PR TITLE
js-102: add loongarch64_nosimd defines

### DIFF
--- a/lang-js/js-102/autobuild/defines
+++ b/lang-js/js-102/autobuild/defines
@@ -22,6 +22,8 @@ AUTOTOOLS_AFTER="--disable-debug
 AUTOTOOLS_AFTER__LOONGARCH64=" \
                  ${AUTOTOOLS_AFTER} \
                  --enable-linker=bfd"
+AUTOTOOLS_AFTER__LOONGARCH64_NOSIMD=" \
+                 ${AUTOTOOLS_AFTER__LOONGARCH64}"
 AUTOTOOLS_AFTER__LOONGSON3=" \
                  ${AUTOTOOLS_AFTER} \
                  --target=mips64el-aosc-linux-gnuabi64 \


### PR DESCRIPTION
Topic Description
-----------------

- js-102: add loongarch64_nosimd defines
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- js-102: 102.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit js-102
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
