### PR TITLE
deno: update to 2.4.5

### DIFF
--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.4.4
+VER=2.4.5
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=137.2.1
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::5031957355e777ac1ba5b5a4160ba801f693c6dfc77c58d622f6d60422d07be3 \
+CHKSUMS="sha256::a6bba626d08813c114bfcc862e69fd7202eecda97df9f349abf6cc4e38fe4e40 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.4.5
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
