### PR TITLE
pdal: update to 2.9.2

### DIFF
--- a/runtime-gis/pdal/spec
+++ b/runtime-gis/pdal/spec
@@ -1,5 +1,4 @@
-VER=2.8.4
-REL=2
+VER=2.9.2
 SRCS="git::commit=tags/$VER::https://github.com/PDAL/PDAL"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138228"


### PR DESCRIPTION
Topic Description
-----------------

- pdal: update to 2.9.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- pdal: 2.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pdal qgis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
