### PR TITLE
vala: update to 0.56.18

### DIFF
--- a/app-devel/vala/spec
+++ b/app-devel/vala/spec
@@ -1,5 +1,4 @@
-VER=0.56.17
-REL=1
+VER=0.56.18
 SRCS="https://download.gnome.org/sources/vala/${VER:0:4}/vala-$VER.tar.xz"
-CHKSUMS="sha256::26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a"
+CHKSUMS="sha256::f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382"
 CHKUPDATE="anitya::id=5065"


### PR DESCRIPTION
Topic Description
-----------------

- vala: update to 0.56.18
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vala: 0.56.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit vala
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
