### PR TITLE
glib: update to 2.84.4

### DIFF
--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,5 +1,4 @@
-VER=2.84.0
-REL=3
+VER=2.84.4
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
-CHKSUMS="sha256::f8823600cb85425e2815cfad82ea20fdaa538482ab74e7293d58b3f64a5aff6a"
+CHKSUMS="sha256::8a9ea10943c36fc117e253f80c91e477b673525ae45762942858aef57631bb90"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib: update to 2.84.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- glib: 2.84.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
