### PR TITLE
tinty: update to 0.29.0

### DIFF
--- a/app-utils/tinty/spec
+++ b/app-utils/tinty/spec
@@ -1,4 +1,4 @@
-VER=0.27.0
+VER=0.29.0
 SRCS="git::commit=tags/v${VER}::https://github.com/tinted-theming/tinty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377749"


### PR DESCRIPTION
Topic Description
-----------------

- tinty: update to 0.29.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- tinty: 0.29.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tinty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
