### PR TITLE
fnott: update to 1.8.0

### DIFF
--- a/app-utils/fnott/autobuild/defines
+++ b/app-utils/fnott/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=fnott
 PKGSEC=utils
-PKGDEP="dbus fcft fontconfig glibc libpng pixman wayland"
-BUILDDEP="meson nanosvg scdoc tllist wayland-protocols"
+PKGDEP="dbus fcft fontconfig glibc libpng nanosvg pixman wayland"
+BUILDDEP="meson scdoc tllist wayland-protocols"
 PKGDES="Keyboard-driven Wayland notification daemon"
 
 ABTYPE=meson

--- a/app-utils/fnott/spec
+++ b/app-utils/fnott/spec
@@ -1,5 +1,4 @@
-VER=1.7.1
+VER=1.8.0
 SRCS="git::commit=tags/${VER}::https://codeberg.org/dnkl/fnott"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375603"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- fnott: update to 1.8.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- fnott: 1.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fnott
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
