### PR TITLE
wbg: update to 1.3.0

### DIFF
--- a/app-utils/wbg/autobuild/defines
+++ b/app-utils/wbg/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=wbg
 PKGSEC=utils
-PKGDEP="glibc libjpeg-turbo libpng libwebp pixman wayland"
+PKGDEP="glibc libjpeg-turbo libjxl libpng libwebp nanosvg pixman wayland"
 BUILDDEP="wayland-protocols meson ninja tllist"
 PKGDES="Wallpaper application for layer-shell Wayland compositors"
 
 ABTYPE=meson
+MESON_AFTER=('-Dsystem-nanosvg=enabled')

--- a/app-utils/wbg/spec
+++ b/app-utils/wbg/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.3.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/wbg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375605"


### PR DESCRIPTION
Topic Description
-----------------

- wbg: update to 1.3.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- wbg: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wbg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
