### PR TITLE
xfsprogs: update to 6.16.0

### DIFF
--- a/app-admin/xfsprogs/spec
+++ b/app-admin/xfsprogs/spec
@@ -1,4 +1,4 @@
-VER=6.15.0
+VER=6.16.0
 SRCS="https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-$VER.tar.xz"
-CHKSUMS="sha256::13b91f74beef8ad11137f7d9d71055573d91e961bc55bb0245956f69b84cd704"
+CHKSUMS="sha256::fa7ba8c35cb988e7d65b7e7630fe9d0e17e8d79799d3b98db7e19f2b9b150506"
 CHKUPDATE="anitya::id=5188"


### PR DESCRIPTION
Topic Description
-----------------

- xfsprogs: update to 6.16.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- xfsprogs: 6.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
