### PR TITLE
aosc-os-presets-desktop: Don't enable avahi-daemon.service by default

### DIFF
--- a/runtime-data/aosc-os-presets-desktop/autobuild/build
+++ b/runtime-data/aosc-os-presets-desktop/autobuild/build
@@ -17,7 +17,6 @@ enable accounts-daemon.service
 
 # Network services
 enable smbd.service
-enable avahi-daemon.service
 enable avahi-dnsconfd.service
 EOF
 

--- a/runtime-data/aosc-os-presets-desktop/spec
+++ b/runtime-data/aosc-os-presets-desktop/spec
@@ -1,2 +1,2 @@
-VER=5
+VER=6
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

systemd-resolved already has the mDNS transponder functionality, and it's enabled by default.  Thus having systemd-resolved running together with avahi-daemon will cause a conflict.

The conflict is a contribute factor of the very annoying "avahi-daemon keeps reporting a conflict and bump the ID in the host name" issue, but that issue is not solely caused by the conflict (i.e. it even happens without the conflict).  Considering this issue is still not fixed (nor even understood) after years it was reported, to me we should just keep using the systemd mDNS transponder and disable avahi by default.

If a user must use avahi they need to at least set MulticastDNS=no in systemd/resolved.conf.d/ and if they still hit the annoying issue I guess we've no way to help them.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
aosc-os-presets-desktop: `6`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit aosc-os-presets-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
