### PR TITLE
Attempt to resolve various conditions we need "oma purge loonggpu-driver"

### DIFF
--- a/runtime-display/loonggl/autobuild/build
+++ b/runtime-display/loonggl/autobuild/build
@@ -24,3 +24,11 @@ ln -sv ../../../loonggpu/dri/gsgpu_dri.so \
 abinfo "Creating a symlink to libglapidispatch ..."
 ln -sv loonggpu/libglapidispatch.so.0 \
     "$PKGDIR"/usr/lib/libglapidispatch.so.0
+
+# When glvnd tries libEGL_loonggpu.so, if the kernel loonggpu driver isn't
+# loaded, libEGL_loonggpu.so just crashes instead of returning the error
+# to glvnd gracefully.  Fix it so glvnd can try the next driver (maybe
+# llvmpipe or iris).
+abinfo "Apply a mystical fix for error handling ..."
+printf "\xff\xd7\xff\x53" | dd if=/dev/stdin of="$PKGDIR"/usr/lib/loonggpu/libEGL_loonggpu.so.0.0.0 bs=1 count=4 oseek=149792 conv=notrunc
+printf "\x9f\xec\xff\x43\xff\xab\x2e\x56\x00\x28\x00\x50" | dd if=/dev/stdin of="$PKGDIR"/usr/lib/loonggpu/libEGL_loonggpu.so.0.0.0 bs=1 count=12 oseek=149748 conv=notrunc

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=1.0.1-alpha-lnd25.5
+REL=1
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/postinst.in
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/postinst.in
@@ -2,7 +2,7 @@ VER=%PKGVER%
 unset ARCH
 
 echo "Installing LoongGPU kernel modules..."
-for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+for i in `ls /usr/lib/modules | grep -Ev 'extramodules|-4k$'`; do
 	if [ -f "/usr/lib/modules/${i}/modules.dep" -a \
 	     -f "/usr/lib/modules/${i}/modules.order" -a \
 	     -f "/usr/lib/modules/${i}/modules.builtin" ]; then

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=5
+REL=6
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- loonggl: Apply a mystical binary patch
- loonggpu-kernel-dkms: Don't register for 4-KiB-page kernel.

Package(s) Affected
-------------------

- loonggl: `1.0.1~alpha~lnd25.5-1`
- loonggpu-kernel-dkms: `1.0.1~alpha~lnd25.5-6`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggl loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

