### PR TITLE
uriparser: update to 0.9.9

### DIFF
--- a/runtime-web/uriparser/autobuild/defines
+++ b/runtime-web/uriparser/autobuild/defines
@@ -1,7 +1,12 @@
 PKGNAME=uriparser
 PKGSEC=libs
 PKGDEP="glibc"
-BUILDDEP="doxygen graphviz gtest"
-PKGDES="A strictly RFC 3986 compliant URI parsing library"
+BUILDDEP="gtest"
+PKGDES="RFC 3986 compliant URI parsing library"
 
 ABTYPE=cmakeninja
+
+CMAKE_AFTER=(
+    '-DURIPARSER_BUILD_DOCS=OFF'
+    '-DURIPARSER_BUILD_TESTS=OFF'
+)

--- a/runtime-web/uriparser/spec
+++ b/runtime-web/uriparser/spec
@@ -1,4 +1,4 @@
-VER=0.9.8
+VER=0.9.9
 SRCS="git::commit=tags/uriparser-$VER::https://github.com/uriparser/uriparser"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10160"


### PR DESCRIPTION
Topic Description
-----------------

- uriparser: update to 0.9.9
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uriparser: 0.9.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit uriparser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
