### PR TITLE
cinny-desktop: update to 4.10.0

### DIFF
--- a/app-web/cinny-desktop/spec
+++ b/app-web/cinny-desktop/spec
@@ -1,4 +1,4 @@
-VER=4.9.1
+VER=4.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/cinnyapp/cinny-desktop"
 CHKSUMS="SKIP"
 SUBDIR="cinny-desktop/src-tauri"


### PR DESCRIPTION
Topic Description
-----------------

- cinny-desktop: update to 4.10.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- cinny-desktop: 4.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinny-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
