### PR TITLE
telegram-desktop: update to 6.1.1

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From f5e7c46e53c66342cd4c5871993689a4f28ade86 Mon Sep 17 00:00:00 2001
+From 32c53db1ec49b42ba17f6728fca2822ed8b453b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 01/12] fix(window.style): set default window width to 360px
+Subject: [PATCH 01/13] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index acdda31299..899bcb5827 100644
+index a18a471533..a72dbf3989 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
@@ -31,5 +31,5 @@ index acdda31299..899bcb5827 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From 194e15bdcdcbf9d8b94e7cb2b37220c34b9e8015 Mon Sep 17 00:00:00 2001
+From aacf40717bfd501d0374e8d4434af7cc65e32a54 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 02/12] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 02/13] fix(core_settings.h): use system window decoration by
  default
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 02/12] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 8ce8d72818..a116d04020 100644
+index 9ee26fea74..98f480a3c3 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1037,7 +1037,7 @@ private:
+@@ -1044,7 +1044,7 @@ private:
  	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
@@ -22,5 +22,5 @@ index 8ce8d72818..a116d04020 100644
  	rpl::variable<bool> _systemDarkModeEnabled = true;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From cdcfccf854f70b896b654d57e7a2b8e5a123c340 Mon Sep 17 00:00:00 2001
+From 4ad3d9247e8efc560188c32c2ed7a4f0df128c6d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 03/12] fix(ui): fix build with Qt 5
+Subject: [PATCH 03/13] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---
@@ -38,7 +38,7 @@ index 2fba82e0da..0538f8d7e7 100644
  		return _type;
  	}
 diff --git a/Telegram/lib_webview/CMakeLists.txt b/Telegram/lib_webview/CMakeLists.txt
-index 4bf3d98ecc..072da88f0a 100644
+index 4b9450934b..522208bd89 100644
 --- a/Telegram/lib_webview/CMakeLists.txt
 +++ b/Telegram/lib_webview/CMakeLists.txt
 @@ -7,6 +7,7 @@
@@ -68,5 +68,5 @@ index 24274c3794..a57c4fab1f 100644
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From d90a2ff31a4c5d5f4b29765c6cdd8f3e0a129c81 Mon Sep 17 00:00:00 2001
+From c8bd79ec79167a76192e7be285766b3022770d14 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 04/12] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 04/13] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst
@@ -28,5 +28,5 @@ index e844acf9ee..adb4b80fb6 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,14 +1,14 @@
-From a72244ae434989c343e1dac1ab0b293b47914846 Mon Sep 17 00:00:00 2001
+From 356027ef8b33d5a3a5dc290ba808b0984e026679 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 05/12] fix(settings): use system fonts by default
+Subject: [PATCH 05/13] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index a116d04020..ad75558a52 100644
+index 98f480a3c3..7fdf581191 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
 @@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -19,7 +19,7 @@ index a116d04020..ad75558a52 100644
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1071,7 +1072,7 @@ private:
+@@ -1078,7 +1079,7 @@ private:
  	rpl::variable<bool> _storiesClickTooltipHidden = false;
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;
@@ -29,5 +29,5 @@ index a116d04020..ad75558a52 100644
  	std::optional<bool> _weatherInCelsius;
  	QByteArray _tonsiteStorageToken;
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 360bb552a3fcdaae7bf7859983bbc921cae21453 Mon Sep 17 00:00:00 2001
+From 13b2e2f8b04ef5c93ecb0fbb9c7b987ccb0153d7 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 06/12] Remove the confusing "Default" option from selectable
+Subject: [PATCH 06/13] Remove the confusing "Default" option from selectable
  fonts
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 06/12] Remove the confusing "Default" option from selectable
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
-index 97f65b65d9..9eff4830c3 100644
+index a891c422f1..585c3a7934 100644
 --- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 +++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 @@ -532,7 +532,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
@@ -45,5 +45,5 @@ index 97f65b65d9..9eff4830c3 100644
  		std::swap(result[2], *nowIt);
  		++skip;
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From 852ee247a623e54af0d842ae052a75f9ecc6e65d Mon Sep 17 00:00:00 2001
+From 93b130c8a1d63e7700cbbf6d024b0e13bf28fd06 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 07/12] fix(lib_tl): add missing cstring include
+Subject: [PATCH 07/13] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -21,5 +21,5 @@ index 5eadf62a93..961f7febe0 100644
  
  namespace tl {
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From 3f286d01e9fa4b7890f1cd33e7ff62c93cb2dfa6 Mon Sep 17 00:00:00 2001
+From c834fec9d03688fa567c96e3c1bb58bcfe1df7ea Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 08/12] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 08/13] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -21,5 +21,5 @@ index 4a92fe3020..3cf6125358 100644
  #include <rpl/never.h>
  #include <rpl/producer.h>
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,7 +1,7 @@
-From 4e025fb57c6d29c22746b51aeeb70d6e5117061d Mon Sep 17 00:00:00 2001
+From 31d02d13659fb2194044a0283017c6c68c832859 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
-Subject: [PATCH 09/12] fix(current_geo_location_linux): add missing
+Subject: [PATCH 09/13] fix(current_geo_location_linux): add missing
  QGuiApplication include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -22,5 +22,5 @@ index 7015af7398..d48fc7025a 100644
  namespace Platform {
  namespace {
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,7 +1,7 @@
-From 3528d978865341d1efa3f30bd353937bcd4cbba4 Mon Sep 17 00:00:00 2001
+From 7c4268f115355ecffe3bfdb85c3d7ec46c1a674b Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
-Subject: [PATCH 10/12] fix(core_settings.h): enable video hardware
+Subject: [PATCH 10/13] fix(core_settings.h): enable video hardware
  acceleration by default
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -10,10 +10,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index ad75558a52..e9fb514bff 100644
+index 7fdf581191..0b6386477a 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1053,11 +1053,7 @@ private:
+@@ -1060,11 +1060,7 @@ private:
  	rpl::variable<Media::OrderMode> _playerOrderMode;
  	bool _macWarnBeforeQuit = true;
  	std::vector<uint64> _accountsOrder;
@@ -26,5 +26,5 @@ index ad75558a52..e9fb514bff 100644
  		= HistoryView::DoubleClickQuickAction();
  	bool _translateButtonEnabled = false;
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,7 +1,7 @@
-From f6010f4edaeccba592619bed208dbd5e82d35abc Mon Sep 17 00:00:00 2001
+From ffa8b279cf689fc961c8760bcf37aeea61be4db6 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
-Subject: [PATCH 11/12] fix(cmake): disable CMP0160 to workaround KF5 cmake
+Subject: [PATCH 11/13] fix(cmake): disable CMP0160 to workaround KF5 cmake
  errors
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -27,5 +27,5 @@ index fc7b239b03..d9f278a357 100644
  
  include(cmake/validate_special_target.cmake)
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,7 +1,7 @@
-From 6fb69e2cb3c037fea9d29319d25deb81689088da Mon Sep 17 00:00:00 2001
+From 7aa5f1294a453582be8833b5f29a934a3f69e783 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 3 Jul 2025 19:04:36 -0700
-Subject: [PATCH 12/12] fix(credits_amount.h): include cmath for std::floor
+Subject: [PATCH 12/13] fix(credits_amount.h): include cmath for std::floor
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
@@ -22,5 +22,5 @@ index 098266d887..a5d329c417 100644
  #include "base/basic_types.h"
  
 -- 
-2.50.0
+2.51.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
@@ -1,0 +1,106 @@
+From 2de3af9bb6e85f93b0ebafc46ca9c7d866fe8828 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Thu, 28 Aug 2025 02:08:09 -0700
+Subject: [PATCH 13/13] fix(lib_webview): fix build with Qt 5
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../linux/webview_linux_http_server.cpp       | 20 +++++++++++++++++++
+ .../linux/webview_linux_webkitgtk.cpp         | 16 +++++++++++++++
+ 2 files changed, 36 insertions(+)
+
+diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
+index fb03b6e889..3f0d733883 100644
+--- a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
++++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
+@@ -126,7 +126,12 @@ bool HttpServer::Private::processRedirect(
+ 	request.setRawHeader("Referer", "http://desktop-app-resource/page.html");
+ 
+ 	const auto reply = manager.get(request);
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	QObject::connect(reply, &QNetworkReply::finished, socket, [
++#else
++	QMetaObject::Connection * const connection = new QMetaObject::Connection;
++	*connection = QObject::connect(reply, &QNetworkReply::finished, socket, [
++#endif
+ 		=, 
+ 		replyGuard = std::make_unique<Guard>([=] {
+ 			reply->deleteLater();
+@@ -155,7 +160,13 @@ bool HttpServer::Private::processRedirect(
+ 		socket->write("Cache-Control: no-store\r\n");
+ 		socket->write("\r\n");
+ 		socket->write(input);
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 	}, Qt::SingleShotConnection);
++#else
++		QObject::disconnect(*connection);
++		delete connection;
++	});
++#endif
+ 
+ 	return true;
+ }
+@@ -179,9 +190,18 @@ HttpServer::HttpServer(
+ 				socket,
+ 				&QObject::deleteLater);
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 			QObject::connect(socket, &QIODevice::readyRead, socket, [=] {
+ 				_private->handleRequest(socket);
+ 			}, Qt::SingleShotConnection);
++#else
++			QMetaObject::Connection * const connection = new QMetaObject::Connection;
++			*connection = QObject::connect(socket, &QIODevice::readyRead, socket, [=] {
++				_private->handleRequest(socket);
++				QObject::disconnect(*connection);
++				delete connection;
++			});
++#endif
+ 		}
+ 	});
+ }
+diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
+index 5027a4c0db..44ab526918 100644
+--- a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
++++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
+@@ -716,21 +716,37 @@ void Instance::dataRequest(
+ 		socket->write("HTTP/1.1 ");
+ 		socket->write(partial ? "206 Partial Content\r\n" : "200 OK\r\n");
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 		const auto mime = QByteArray(stream->mime());
++#else
++		const auto mime = QByteArray(stream->mime().c_str());
++#endif
+ 		socket->write("Content-Type: " + mime + "\r\n");
+ 		socket->write("Accept-Ranges: bytes\r\n");
+ 		socket->write("Cache-Control: no-store\r\n");
+ 		socket->write("Content-Length: "
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 			+ QByteArray::number(requestedLimit)
++#else
++			+ QByteArray::number((qlonglong)requestedLimit)
++#endif
+ 			+ "\r\n");
+ 
+ 		if (partial) {
+ 			socket->write("Content-Range: bytes "
++#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+ 				+ QByteArray::number(requestedOffset)
+ 				+ '-'
+ 				+ QByteArray::number(requestedOffset + requestedLimit - 1)
+ 				+ '/'
+ 				+ QByteArray::number(total)
++#else
++				+ QByteArray::number((qlonglong)requestedOffset)
++				+ '-'
++				+ QByteArray::number((qlonglong)(requestedOffset + requestedLimit - 1))
++				+ '/'
++				+ QByteArray::number((qlonglong)total)
++#endif
+ 				+ "\r\n");
+ 		}
+ 
+-- 
+2.51.0
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,12 +1,11 @@
-VER=6.0.2
-REL=1
+VER=6.1.1
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
-TDLIBVER=6d74326c5ce53aeb52496f157f0080d9b8515970
+TDLIBVER=5c77c4692c28eb48a68ef1c1eeb1b1d732d507d3
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::81e981079f2a056189783e25aac627b6709dd205b10ee3ef7465cae54245d362 \
+CHKSUMS="sha256::07274d7b0038e5e6d127fb6568283594d8a735ea086c662eeee73713bd73ca04 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -10,7 +10,7 @@ CHKSUMS="sha256::07274d7b0038e5e6d127fb6568283594d8a735ea086c662eeee73713bd73ca0
          SKIP"
 SUBDIR="tdesktop-$VER-full"
 CHKUPDATE="anitya::id=16951"
-ENVREQ__ARM64="total_mem_per_core=3"
+ENVREQ__ARM64="total_mem=60"
 ENVREQ__LOONGARCH64="total_mem_per_core=4"
 ENVREQ__LOONGSON3="total_mem_per_core=4"
 ENVREQ__PPC64EL="total_mem_per_core=4"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: lower ENVREQ__ARM64 to total_mem=60
- telegram-desktop: update to 6.1.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- telegram-desktop: 6.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
