### PR TITLE
eza: update to 0.23.1

### DIFF
--- a/app-utils/eza/spec
+++ b/app-utils/eza/spec
@@ -1,4 +1,4 @@
-VER=0.23.0
+VER=0.23.1
 SRCS="git::commit=tags/v$VER::https://github.com/eza-community/eza"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369474"


### PR DESCRIPTION
Topic Description
-----------------

- eza: update to 0.23.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- eza: 0.23.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit eza
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
