### PR TITLE
iosevka-fonts: update to 33.2.9

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.2.8
+VER=33.2.9
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::4bacf82337638fc12494bc8b24058e62988090e987d6b15c211cb7b1fd5fef6f \
-         sha256::7e2afc85bb3d45375bfcf0ea9eca9c5a6977fdcef4711879b95dba8d8f899528 \
-         sha256::281ccba978ec8a8f4cc805329457fc7d8bf60a5ee71ef2354ef32e346423f578 \
-         sha256::3b349d2d61434cf708161af0d507834d0c47f8910bff9f996ccf483d4797c6e1 \
-         sha256::311db6965b22b39ad3672b21941fb9351d8ec5e5cdfc05495bbcb2a87dbb7b9a \
-         sha256::b73837fe44ea520d3b1ffc413cf70f1188c52d6b99978cf0090a085cfc91ed6c \
-         sha256::d63c71e0ff7fd1b67f27fd5703b005cd7a1a6b50eccac9df3434654fa9f3986e \
-         sha256::0628cbf9489d535123143c212e4d8721894685abfa013e06ab7392fdf0f81567 \
-         sha256::c055577375834de812243214a090a1c5048c1261542e3672ceb2148c1cfc4a7a \
-         sha256::687f1facfdfc794ad409fa26f6f0b8139558196fcb98cc8b22ea84ef9e5976e8 \
-         sha256::82ad343f6a023366b9e38b460a4cd372487fc19e78c18507e18a6ba7732600e8 \
-         sha256::1b9d4a482650874c0b3df1e6cf746b195653a5a89a3ad8a5b1fb73963e928267 \
-         sha256::cdf57925f71e6e0c854d13903a37f12d8c5cb2508906d0217af4abb4e8dd3985 \
-         sha256::5ab8a207745d826843951e1595903a7dc4274b35643265186071f0e6b0d9a76c \
-         sha256::bb3c04e386a9a50d5d3c1d5f520499fc201d516932429b283309f0cee5ed5dfa \
-         sha256::2fe3f3a4dc1900dda0f9099ef3d04bf03689d40d786dcbd2da4fe54b86a1eebd \
-         sha256::233a3a9c8b7d4cfe51554322972a1127ba94813ce09e1a91564f3a73f1cdfff6 \
-         sha256::f7235d64d0cb15af302eeb1341656a11cec70ced4cf4e42d43f4d812cabf93ce \
-         sha256::b66e701600d3ef1bdbc6f1517e9d5533cb9e7ebe5f3b58d076e258fefbca58f2 \
-         sha256::570a9ad4d7c3968a9b9e4432e3ddb2c28864c6bdbbab80d0a46d967496fe4b91 \
-         sha256::ea88f55f1d3fbb98dead1df6dd4495b288bce0393d1740bc3bafa2f18a49be76 \
-         sha256::36de5f9f12a8bb4986e2ebe9b2d46659cf54cabdc01a65a6796a23e230d66ecb \
-         sha256::ab7d636dc3516b8844c7ec6b8654e93983f8219e96b8b7992d63b6d852b8b90a \
-         sha256::77867723253326a9bb0d5515971a08b11c977fca71fcea16b92691648d712abc \
+CHKSUMS="sha256::227d28c890f659e89e43031352ebc118e4c58314f561e3315106fb485afb46ab \
+         sha256::30c8b78e5b06a06a5e1c19dca04ae87727b1226990a681827635f0574101c905 \
+         sha256::2e381da9dbb910ab956f4a202bb449829886194fa854dcde875fd58a016e09d9 \
+         sha256::220c38bd5cff9251708cd356e0db9d11b2a70dabd12263f03f4ae8e5246dd893 \
+         sha256::52cf1342c2c92ef81989f7136a92e1dad7e293b22bdc62a67b6c93d5ef59e529 \
+         sha256::1e115fe7f8370be7218baa44e82edacf5a35ef20c27f940abc163b513db52be5 \
+         sha256::925bfcdbab519c83689ed085473faebc64a4a40ce5efb4e1e594bb440bd4cec4 \
+         sha256::72897ffab0ea210c97015db070c385f001a57b014ff13cdaa2423b5680e5c3d9 \
+         sha256::dea6480cffa8eb301b6fafde0b8b242fbbd7d44df0bfdd5792777eba2ff3e8fe \
+         sha256::2d9db57a16bd9ab3348b584535995dbd1b4b28a403519c885bd405d4d33e9511 \
+         sha256::4c440bf3d07a24592686d63ac552ba984e7ce429d12018f7319e1517ab0c3fcb \
+         sha256::d84bf31cda0811e5c0783a010388482230713118033ff0f1d510dd48fc883c4e \
+         sha256::6930b84500ad97deaa78528448131b00014a08dd808926fdf70a1d90861611d1 \
+         sha256::22ff41b7dd211967b803b2148b2584849c27d453bf45ba96d0e74120d892660b \
+         sha256::11b82ecb25c45cd001a460ef1b26fd19d18dcef380c69bb6402992a1234ad9f3 \
+         sha256::474e950512088b2dd3b87afadd9dc3eaa3d55d4f553ac88898b314e275901d20 \
+         sha256::7cfdfffa4e9e70df2f792001693e1e3273fbed89cfbf473f880fa6a54e4f340a \
+         sha256::2dfdb60455724aca395109386fe773f2bd01d2a275f74894cef2f1892f113656 \
+         sha256::ee462d5151a798ba7c7b93fa8d2fc873ad2f3d6337a91b5987e085c11dbbc5ae \
+         sha256::e954d7421d675b2e0caf29da7409c4fed6135b6b1bb0cfc894dfd3ca0295ea5d \
+         sha256::1dc5b8e759a2f748ec0e4cb341d63c79ac828565bc21ba39e145fcd17bffd68f \
+         sha256::8979d8f1f597699b6f914b9f7d9312b78f6fe5d5b9bda5bcd2a696adc43f4f30 \
+         sha256::8bb9f6e4be75bec3a613e04701ebb3da26125fdfc5f067ee1ddbe004c472f1e6 \
+         sha256::37cf4487b4dd30b564f99c0692a1d8e5af189fcda0728cc58d4d8af7386f4657 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.2.9
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- iosevka-fonts: 33.2.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
