### PR TITLE
vkmark: update to 2025.01

### DIFF
--- a/app-benchmarks/vkmark/spec
+++ b/app-benchmarks/vkmark/spec
@@ -1,4 +1,4 @@
-VER=2017.08+git20230412
-SRCS="git::commit=ab6e6f34077722d5ae33f6bd40b18ef9c0e99a15::https://github.com/vkmark/vkmark.git"
+VER=2025.01
+SRCS="git::commit=tags/${VER}::https://github.com/vkmark/vkmark.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15696"


### PR DESCRIPTION
Topic Description
-----------------

- vkmark: update to 2025.01
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- vkmark: 2025.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkmark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
