### PR TITLE
osu-lazer: update to 2025.816.0

### DIFF
--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,4 +1,5 @@
-VER=2025.724.0
-SRCS="git::commit=tags/$VER::https://github.com/ppy/osu"
+UPSTREAM_VER=2025.816.0-lazer
+VER=${UPSTREAM_VER/-lazer/}
+SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/ppy/osu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2025.816.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- osu-lazer: 2025.816.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
