### PR TITLE
syncthing: update to 2.0.6

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,4 +1,4 @@
-VER=2.0.3
+VER=2.0.6
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::80ef0589c3949b2b48ae703106e4ce95474a111625923fb7d568f73c2537fe5d"
+CHKSUMS="sha256::e17ea11091a8c9d29b99a09f93005f66a199ef4843a2be277c14361edef5953a"
 CHKUPDATE="anitya::id=11814"


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 2.0.6
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- syncthing: 2.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
