### PR TITLE
rhythmbox: update to 3.4.8

### DIFF
--- a/app-multimedia/rhythmbox/autobuild/defines
+++ b/app-multimedia/rhythmbox/autobuild/defines
@@ -5,8 +5,8 @@ PKGDEP="dconf desktop-file-utils gst-plugins-base-1-0 gst-plugins-good-1-0 \
         tdb totem-pl-parser webkit2gtk libdmapsharing libgpod check libgudev"
 PKGSUG="brasero grilo-plugins gst-libav-1-0 gst-plugins-bad-1-0 \
           gst-plugins-ugly-1-0 gvfs libgpod libmtp mako lirc"
-BUILDDEP="brasero gobject-introspection grilo intltool itstool \
-          libgpod libmtp vala lirc yelp-tools"
+BUILDDEP="brasero gobject-introspection grilo gtk-update-icon-cache intltool \
+          itstool libgpod libmtp vala lirc yelp-tools"
 PKGDES="An iTunes-like music player and manager"
 
 ABTYPE=meson

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,5 +1,4 @@
-VER=3.4.7
-REL=1
+VER=3.4.8
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
-CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
+CHKSUMS="sha256::2016a8a8d2a959c07a467ac9682c6ed605ba8883fb760410d68b68ab838df9f2"
 CHKUPDATE="anitya::id=9525"


### PR DESCRIPTION
Topic Description
-----------------

- rhythmbox: update to 3.4.8
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- rhythmbox: 3.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit rhythmbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
