### PR TITLE
openfortivpn: update to 1.23.1

### DIFF
--- a/app-network/openfortivpn/autobuild/defines
+++ b/app-network/openfortivpn/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=openfortivpn
 PKGSEC=net
 PKGDEP="openssl ppp systemd"
-PKGDES="A Fortinet-compatible VPN client"
+PKGDES="Fortinet-compatible VPN client"
+
+ABTYPE=autotools

--- a/app-network/openfortivpn/spec
+++ b/app-network/openfortivpn/spec
@@ -1,5 +1,4 @@
-VER=1.18.0
-SRCS="tbl::https://github.com/adrienverge/openfortivpn/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::01f4c5d97113d55d469b8078d1b2a8966ee1dfd231574322b36ec48c897c5ae9"
+VER=1.23.1
+SRCS="git::commit=tags/v$VER::https://github.com/adrienverge/openfortivpn"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7491"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- openfortivpn: update to 1.23.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- openfortivpn: 1.23.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openfortivpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
