### PR TITLE
containers-common: update to 0.64.2+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2

### DIFF
--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.63.1
+UPSTREAM_VER=0.64.2
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.64.2+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- containers-common: 0.64.2+image5.34.3+shortnames2025.03.19+skopeo1.18.0+storage1.57.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
