### PR TITLE
q: update to 0.19.8

### DIFF
--- a/app-network/q/autobuild/build
+++ b/app-network/q/autobuild/build
@@ -1,6 +1,0 @@
-abinfo "Building q ..."
-go build -ldflags "-s -w -buildid= -linkmode external \
-    -X main.version=$PKGVER \
-    -X main.commit=$commit \
-    -X main.date=$date" \
-    -o "$PKGDIR"/usr/bin/q

--- a/app-network/q/autobuild/defines
+++ b/app-network/q/autobuild/defines
@@ -4,5 +4,4 @@ PKGDES="Command line DNS client with support for multiple protocols"
 PKGDEP="gcc-runtime"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
-ABSPLITDBG=0
+ABTYPE=gomod

--- a/app-network/q/autobuild/prepare
+++ b/app-network/q/autobuild/prepare
@@ -1,3 +1,9 @@
 abinfo "Setting build information ..."
-export commit=$(git rev-parse --short HEAD)
-export date=$(git show -s --format=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' HEAD)
+COMMIT=$(git rev-parse --short HEAD)
+DATE=$(git show -s --format=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' HEAD)
+
+GO_LDFLAGS=(
+    "-X 'main.version=$PKGVER'"
+    "-X 'main.commit=$COMMIT'"
+    "-X 'main.date=$DATE'"
+)

--- a/app-network/q/spec
+++ b/app-network/q/spec
@@ -1,5 +1,4 @@
-VER=0.19.2
+VER=0.19.8
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/natesales/q.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376437"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- q: update to 0.19.8

Package(s) Affected
-------------------

- q: 0.19.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit q
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
