### PR TITLE
ostree: update to 2025.6

### DIFF
--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,4 @@
-VER=2025.5
+VER=2025.6
 SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
-CHKSUMS="sha256::a2ddd454ba0e620e08fb7324dec8bdbb6d03360f531313691b42e19b59db6c88"
+CHKSUMS="sha256::6750627df600f28c8ef2c7f443a9d72aef7061a342cde234162ebdf850a7e575"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: update to 2025.6
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- ostree: 2025.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
