### PR TITLE
rocm-base: metapackage support arm64

### DIFF
--- a/meta-bases/rocm-base/autobuild/defines
+++ b/meta-bases/rocm-base/autobuild/defines
@@ -10,4 +10,4 @@ ABSPLITDBG=0
 
 PKGPROV="rocm"
 
-FAIL_ARCH="!(amd64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/meta-bases/rocm-base/spec
+++ b/meta-bases/rocm-base/spec
@@ -1,2 +1,2 @@
-VER=2
+VER=3
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- rocm-base: metapackage support arm64

Package(s) Affected
-------------------

- rocm-base: 3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
