### PR TITLE
sshfs: update to 3.7.3

### DIFF
--- a/app-network/sshfs/spec
+++ b/app-network/sshfs/spec
@@ -1,4 +1,4 @@
-VER=3.6.0
+VER=3.7.3
 SRCS="tbl::https://github.com/libfuse/sshfs/releases/download/sshfs-$VER/sshfs-$VER.tar.xz"
-CHKSUMS="sha256::1679b5543a6db2e93e06dbcdc9247b35df64c3148e2c30f80764f4813bd6c270"
+CHKSUMS="sha256::5218ce7bdd2ce0a34137a0d7798e0f6d09f0e6d21b1e98ee730a18b0699c2e99"
 CHKUPDATE="anitya::id=11058"


### PR DESCRIPTION
Topic Description
-----------------

- sshfs: update to 3.7.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sshfs: 3.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit sshfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
