### PR TITLE
unixbench: update to 6.0.0

### DIFF
--- a/app-benchmarks/unixbench/spec
+++ b/app-benchmarks/unixbench/spec
@@ -1,5 +1,4 @@
-VER=5.1.3
-REL=2
+VER=6.0.0
 SRCS="tbl::https://github.com/kdlucas/byte-unixbench/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3a6bb00f270a5329682dff20fd2c1ab5332ef046eb54a96a0d7bd371005d31a3"
+CHKSUMS="sha256::c151d28b6f4f3f40faad19e877c1ab06fbd4b3da006ccfa26b36200c741fc3ba"
 CHKUPDATE="anitya::id=226943"


### PR DESCRIPTION
Topic Description
-----------------

- unixbench: update to 6.0.0
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- unixbench: 6.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit unixbench
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
