### PR TITLE
icewm: update to 3.9.0

### DIFF
--- a/desktop-wm/icewm/autobuild/defines
+++ b/desktop-wm/icewm/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=icewm
 PKGSEC=x11
 PKGDES="A lightweighted window manager for the X Window System"
-PKGDEP="gdk-pixbuf-xlib x11-lib x11-font x11-app fribidi libsndfile aosc-xdg-menu"
+PKGDEP="x11-lib x11-font x11-app fribidi aosc-xdg-menu imlib2"
 PKGDEP__RETRO="gdk-pixbuf-xlib x11-lib x11-app fribidi aosc-xdg-menu"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/desktop-wm/icewm/spec
+++ b/desktop-wm/icewm/spec
@@ -1,4 +1,4 @@
-VER=3.6.0
+VER=3.9.0
 SRCS="tbl::https://github.com/ice-wm/icewm/releases/download/${VER}/icewm-${VER}.tar.lz"
-CHKSUMS="sha256::979fafd3a3371f73cbafe592e2be052475637ac4bb4385bb132331fd6924bc76"
+CHKSUMS="sha256::1323527a9a49db66e9ce7b08e6ec43c87700243432fc6679681df367c67b2dc0"
 CHKUPDATE="anitya::id=1358"


### PR DESCRIPTION
Topic Description
-----------------

- icewm: update to 3.9.0
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- icewm: 3.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit icewm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
