### PR TITLE
[Draft] rocm: refresh patches llvm-mc

### DIFF
--- a/runtime-rocm/rocm-clr/autobuild/defines
+++ b/runtime-rocm/rocm-clr/autobuild/defines
@@ -28,4 +28,4 @@ CMAKE_AFTER=(
     "-DHIP_COMMON_DIR=$SRCDIR/../HIP"
 )
 
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/runtime-rocm/rocm-clr/autobuild/patch
+++ b/runtime-rocm/rocm-clr/autobuild/patch
@@ -5,5 +5,5 @@ abinfo "Apply CLR patch..."
 cd "$SRCDIR"
 ab_apply_patches "$SRCDIR"/autobuild/patches/0001-HIPAMD-DISABLE-glibcxx_assert.patch
 ab_apply_patches "$SRCDIR"/autobuild/patches/0002-support-arm64-loongarch64-riscv64.patch
-ab_apply_patches "$SRCDIR"/autobuild/patches/0004-rewrite-hip-embed-pch.patch
+ab_apply_patches "$SRCDIR"/autobuild/patches/0004-replace-llvm-mc.patch
 ab_apply_patches "$SRCDIR"/autobuild/patches/*.patch."${CROSS:-$ARCH}"

--- a/runtime-rocm/rocm-clr/autobuild/patches/0004-replace-llvm-mc.patch
+++ b/runtime-rocm/rocm-clr/autobuild/patches/0004-replace-llvm-mc.patch
@@ -38,3 +38,27 @@ index 6c92d4388..2ebfc0b8d 100755
    $LLVM_DIR/bin/clang $tmp/hiprtc_header.o -o $rtc_shared_lib_out -shared &&
    $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++14 -nogpulib -nogpuinc -emit-llvm -c -o $tmp/tmp.bc --cuda-device-only -D__HIPCC_RTC__ --offload-arch=gfx906 -x hip-cpp-output $tmp/hiprtc &&
    rm -rf $tmp
+diff --git a/hipamd/src/hiprtc/CMakeLists.txt b/hipamd/src/hiprtc/CMakeLists.txt
+index 367d4feaa..aa1f62f26 100644
+--- a/hipamd/src/hiprtc/CMakeLists.txt
++++ b/hipamd/src/hiprtc/CMakeLists.txt
+@@ -134,7 +134,7 @@ add_to_config(_versionInfo HIP_VERSION_GITHASH)
+ include(HIPRTC RESULT_VARIABLE HIPRTC_CMAKE)
+ # Requires clang and llvm-mc to create this library.
+ find_program(clang clang HINTS ${ROCM_PATH}/llvm/bin ${ROCM_PATH})
+-find_program(llvm-mc llvm-mc HINTS ${ROCM_PATH}/llvm/bin ${ROCM_PATH})
++find_package(LLVM REQUIRED CONFIG)
+ set(HIPRTC_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/hip_rtc_gen")
+ set(HIPRTC_GEN_HEADER "${HIPRTC_GEN_DIR}/hipRTC_header.h")
+ set(HIPRTC_GEN_MCIN "${HIPRTC_GEN_DIR}/hipRTC_header.mcin")
+@@ -184,8 +184,8 @@ add_custom_command(
+   DEPENDS ${clang} ${HIPRTC_GEN_HEADER})
+ add_custom_command(
+   OUTPUT ${HIPRTC_GEN_OBJ}
+-  COMMAND ${llvm-mc} -o ${HIPRTC_GEN_OBJ} ${HIPRTC_GEN_MCIN} --filetype=obj
+-  DEPENDS ${llvm-mc} ${HIPRTC_GEN_PREPROCESSED} ${HIPRTC_GEN_MCIN})
++  COMMAND ${clang} -target ${LLVM_TARGET_TRIPLE} -o ${HIPRTC_GEN_OBJ} -x assembler ${HIPRTC_GEN_MCIN} -c
++  DEPENDS ${clang} ${HIPRTC_GEN_PREPROCESSED} ${HIPRTC_GEN_MCIN})
+
+ # Create hiprtc-builtins library.
+ add_library(hiprtc-builtins ${HIPRTC_GEN_OBJ})

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -7,4 +7,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="clr"
 CHKUPDATE="anitya::id=369562"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- rocm-clr: refresh patches llvm-mc

Package(s) Affected
-------------------

- rocm-clr: 6.4.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-clr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
