### PR TITLE
boto3: update to 1.40.25

### DIFF
--- a/lang-python/boto3/spec
+++ b/lang-python/boto3/spec
@@ -1,4 +1,4 @@
-VER=1.20.26
+VER=1.40.25
 SRCS="tbl::https://pypi.io/packages/source/b/boto3/boto3-$VER.tar.gz"
-CHKSUMS="sha256::9c13f5c8fadf29088fac5feab849399169b6e8438c3b9a2310abdb7e5013ab65"
+CHKSUMS="sha256::debfa4b2c67492d53629a52c999d71cddc31041a8b62ca1a8b1fb60fb0712ee1"
 CHKUPDATE="anitya::id=29737"

--- a/lang-python/botocore/spec
+++ b/lang-python/botocore/spec
@@ -1,4 +1,4 @@
-VER=1.34.133
+VER=1.40.25
 SRCS="tbl::https://pypi.io/packages/source/b/botocore/botocore-$VER.tar.gz"
 CHKSUMS="sha256::5ea609aa4831a6589e32eef052a359ad8d7311733b4d86a9d35dab4bd3ec80ff"
 CHKUPDATE="anitya::id=29738"


### PR DESCRIPTION
Topic Description
-----------------

- boto3: update to 1.40.25
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- boto3: 1.40.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit boto3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
