### PR TITLE
rtl-sdr: new, 2.0.2

### DIFF
--- a/app-devices/rtl-sdr/autobuild/beyond
+++ b/app-devices/rtl-sdr/autobuild/beyond
@@ -1,0 +1,9 @@
+abinfo "Installing udev rules ..."
+install -Dvm644 "$SRCDIR"/rtl-sdr.rules \
+    "$PKGDIR"/usr/lib/udev/rules.d/10-rtl-sdr.rules
+
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/debian/*.1 -t "$PKGDIR"/usr/share/man/man1/
+
+abinfo "Installing modprobe blacklist ..."
+install -vDm644 "$SRCDIR"/debian/rtl-sdr-blacklist.conf "$PKGDIR"/usr/lib/modprobe.d/rtlsdr.conf

--- a/app-devices/rtl-sdr/autobuild/defines
+++ b/app-devices/rtl-sdr/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="rtl-sdr"
+PKGDES="Driver for Realtek RTL2832U that enables general-purpose, software-defined radio (SDR)"
+PKGDEP="glibc libusb"
+BUILDDEP="cmake"
+PKGSEC="hamradio"

--- a/app-devices/rtl-sdr/spec
+++ b/app-devices/rtl-sdr/spec
@@ -1,0 +1,4 @@
+VER=2.0.2
+SRCS="git::commit=tags/v${VER}::https://gitea.osmocom.org/sdr/rtl-sdr.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17786"


### PR DESCRIPTION
Topic Description
-----------------

- rtl-sdr: new, 2.0.2

Package(s) Affected
-------------------

- rtl-sdr: 2.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtl-sdr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
