### PR TITLE
fbset: use github source

### DIFF
--- a/app-utils/fbset/spec
+++ b/app-utils/fbset/spec
@@ -1,5 +1,5 @@
 VER=2.1
-SRCS="tbl::http://users.telenet.be/geertu/Linux/fbdev/fbset-$VER.tar.gz"
-CHKSUMS="sha256::40ff4ab0247b75138a0887ed40f81c1a6184f340b77126c16d074b1075b41c20"
-REL=1
+SRCS="git::commit=tags/upstream/$VER::https://github.com/sudipm-mukherjee/fbset"
+CHKSUMS="SKIP"
+REL=2
 CHKUPDATE="anitya::id=783"


### PR DESCRIPTION
Topic Description
-----------------

- fbset: use github source
    Upstream server returns 503 error.
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- fbset: 2.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fbset
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
