### PR TITLE
rofi: update to 2.0.0

### DIFF
--- a/app-utils/rofi/autobuild/defines
+++ b/app-utils/rofi/autobuild/defines
@@ -8,8 +8,10 @@ PKGCONFL="rofi-wayland"
 
 ABTYPE=meson
 MESON_AFTER=(
-    -Ddrun=true
-    -Dwindow=true
-    -Dcheck=disabled
-    -Dimdkit=true
+    '-Ddrun=true'
+    '-Dwindow=true'
+    '-Dcheck=disabled'
+    '-Dimdkit=true'
+    '-Dwayland=enabled'
+    '-Dxcb=enabled'
 )

--- a/app-utils/rofi/spec
+++ b/app-utils/rofi/spec
@@ -1,8 +1,4 @@
-VER=1.7.9.1
-REL=1
-# FIXME: Release tarball version and tag version are mismatching for
-# 1.7.9/1.7.9.1, use $VER when the problem is resolved.
-TAG_VER=1.7.9
-SRCS="tbl::https://github.com/davatorium/rofi/releases/download/$TAG_VER/rofi-$VER.tar.xz"
-CHKSUMS="sha256::04c128f8c56f043cd229545285ee773322d0eafaffad100b8604338108c5f5ec"
+VER=2.0.0
+SRCS="tbl::https://github.com/davatorium/rofi/releases/download/$VER/rofi-$VER.tar.xz"
+CHKSUMS="sha256::6a55ee27f189ef9a1435cea329b146805b5dc830d8abc7a08c50a971521a8d8d"
 CHKUPDATE="anitya::id=10146"


### PR DESCRIPTION
Topic Description
-----------------

- rofi: update to 2.0.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- rofi: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rofi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
