### PR TITLE
apt: update to 3.0.3

### DIFF
--- a/app-admin/apt/autobuild/postinst
+++ b/app-admin/apt/autobuild/postinst
@@ -13,7 +13,8 @@ if [ -f /etc/apt/apt.conf.d/99synaptic ]; then
 	rm -v /etc/apt/apt.conf.d/99synaptic
 fi
 
-if echo 42ef90bc5f1af50376edc9984cda013dbd7cb937d6129735890fa79f8b21f302 \
+if [ -f /etc/apt/trusted.gpg.d/aosc.gpg ] && \
+   echo 42ef90bc5f1af50376edc9984cda013dbd7cb937d6129735890fa79f8b21f302 \
     /etc/apt/trusted.gpg.d/aosc.gpg | \
     sha256sum --check --quiet; then
 	echo "Removing /etc/apt/trusted.gpg.d/aosc.gpg, which was previously introduced as a conffile ..."

--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,5 +1,4 @@
-VER=3.0.2
-REL=1
+VER=3.0.3
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"


### PR DESCRIPTION
Topic Description
-----------------

- apt: update to 3.0.3
    Fix up postinst, check if /etc/apt/trusted.gpg.d/aosc.gpg exists before
    checking for matching checksum.

Package(s) Affected
-------------------

- apt: 2:3.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
