### PR TITLE
oma: update to 1.21.0

### DIFF
--- a/app-admin/oma/autobuild/beyond
+++ b/app-admin/oma/autobuild/beyond
@@ -3,7 +3,10 @@ mkdir -pv "$SRCDIR"/completions
 COMPLETE=bash "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/oma.bash
 COMPLETE=zsh "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/_oma
 COMPLETE=fish "$PKGDIR"/usr/bin/oma > "$SRCDIR"/completions/oma.fish
-"$PKGDIR"/usr/bin/oma generate-manpages
+# FIXME: Replace with a more generative routine.
+for genlang in en_US zh_CN zh_TW; do
+	env LANG="${genlang}" "$PKGDIR"/usr/bin/oma generate-manpages
+done
 
 abinfo "Installing command-not-found handler shell script to /etc/bashrc.d ..."
 mkdir -pv "$PKGDIR"/etc/bashrc.d
@@ -22,8 +25,17 @@ cp -v "$SRCDIR"/data/command-not-found/command-not-found.fish \
 
 abinfo "Installing man to /usr/share/man/man1 ..."
 mkdir -pv "$PKGDIR"/usr/share/man/man1
-cp -v "$SRCDIR"/man/*.1 \
-	"$PKGDIR"/usr/share/man/man1
+mv -v "$SRCDIR"/man/en_US/* \
+	"$SRCDIR"/man/
+rm -rv "$SRCDIR"/man/en_US
+# FIXME: Replace with a more generative routine.
+for manlang in zh_CN zh_TW; do
+	mkdir -pv "$PKGDIR"/usr/share/man/${manlang}/man1
+	cp -av "$SRCDIR"/man/${manlang}/* \
+		"$PKGDIR"/usr/share/man/${manlang}/man1
+done
+cp -av "$SRCDIR"/man/*.1 \
+	"$PKGDIR"/usr/share/man/man1/
 
 abinfo "Installing Policykit config file ..."
 mkdir -pv "$PKGDIR"/usr/share/polkit-1/actions

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,5 +1,4 @@
-VER=1.20.1
-REL=2
+VER=1.21.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.21.0.toml
+++ b/topics/oma-1.21.0.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.21.0"
+zh_CN = "小熊猫包管理 (oma) 1.21.0"
+
+[caution]
+default = "With localized help messages and man pages, as well as protection against removal of currently running kernels, fixes for the why command, OSC 9;4 terminal progress reporting, and more"
+zh_CN = "新增帮助信息及手册本地化，以及使用中内核保护功能、why 命令修复及 OSC 9;4 终端进度反馈等新特性"
+
+[packages]
+oma = "1.21.0"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.21.0

Package(s) Affected
-------------------

- oma: 1.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`



