### PR TITLE
wezterm: update to 20240203+110809+5046fc22+git20250909

### DIFF
--- a/app-utils/wezterm/spec
+++ b/app-utils/wezterm/spec
@@ -1,5 +1,6 @@
-VER=20240203+110809+5046fc22+git20250731
-SRCS="git::commit=6a493f88fab06a792308e0c704790390fd3c6232;copy-repo=true::https://github.com/wez/wezterm"
+VER=20240203+110809+5046fc22+git20250909
+REL=1
+SRCS="git::commit=bf9a2aeebacec19fd07b55234d626f006b22d369;copy-repo=true::https://github.com/wez/wezterm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235427"
 

--- a/app-utils/wezterm/spec
+++ b/app-utils/wezterm/spec
@@ -1,5 +1,5 @@
 VER=20240203+110809+5046fc22+git20250731
-SRCS="git::commit=6a493f88fab06a792308e0c704790390fd3c6232::https://github.com/wez/wezterm"
+SRCS="git::commit=6a493f88fab06a792308e0c704790390fd3c6232;copy-repo=true::https://github.com/wez/wezterm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235427"
 


### PR DESCRIPTION
Topic Description
-----------------

- wezterm: update to 20240203+110809+5046fc22+git20250909
- wezterm: copy git repo metadata to fix version display

Package(s) Affected
-------------------

- wezterm: 20240203+110809+5046fc22+git20250909-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wezterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
