### PR TITLE
snapper: update to 0.13.0

### DIFF
--- a/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
+++ b/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
@@ -1,13 +1,11 @@
 diff --git a/scripts/Makefile.am b/scripts/Makefile.am
-index 1f8176c..b5df671 100644
+index 48a37965..77628748 100644
 --- a/scripts/Makefile.am
 +++ b/scripts/Makefile.am
-@@ -17,6 +17,6 @@ endif
- EXTRA_DIST = snapper-hourly bash-completion.bash zsh-completion.zsh $(pam_snapper_SCRIPTS)
+@@ -19,4 +19,4 @@ endif
+ EXTRA_DIST = snapper-hourly $(pam_snapper_SCRIPTS)
  
  install-data-local:
 -	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper
 +	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/snapper
- 	install -D --mode a+r,u+w bash-completion.bash $(DESTDIR)/usr/share/bash-completion/completions/snapper
- 	install -D --mode a+r,u+w zsh-completion.zsh $(DESTDIR)/usr/share/zsh/site-functions/_snapper
 

--- a/app-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
+++ b/app-admin/snapper/autobuild/patches/0004-Arch-Linux-use-usr-path.patch
@@ -1,5 +1,6 @@
-diff --git a/data/org.opensuse.Snapper.service b/data/org.opensuse.Snapper.service
-index 6a08a25..2e0d2ef 100644
+diff --git a/data/org.opensuse.Snapper.service
+b/data/org.opensuse.Snapper.service
+index 6a08a258..2e0d2ef1 100644
 --- a/data/org.opensuse.Snapper.service
 +++ b/data/org.opensuse.Snapper.service
 @@ -1,6 +1,6 @@
@@ -10,3 +11,4 @@ index 6a08a25..2e0d2ef 100644
 +Exec=/usr/bin/snapperd
  User=root
  SystemdService=snapperd.service
+

--- a/app-admin/snapper/spec
+++ b/app-admin/snapper/spec
@@ -1,4 +1,4 @@
-VER=0.12.2
+VER=0.13.0
 SRCS="git::commit=tags/v${VER}::https://github.com/openSUSE/snapper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4843"


### PR DESCRIPTION
Topic Description
-----------------

- snapper: update to 0.13.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- snapper: 0.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
