### PR TITLE
unifont: update to 17.0.01

### DIFF
--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -2,21 +2,20 @@ UPSTREAM_VER=2.12
 # Note: For use inside autobuild/.
 # Note: 2.12-rc1+unifont15.1.04 => 2.12~rc1+unifont15.1.04
 __GRUBVER=${UPSTREAM_VER/\-/~}
-__UNIFONTVER=16.0.01
+__UNIFONTVER=17.0.01
 RETROFONTVER=20200402
 
 # Taken from bootstrap.conf.
 GNULIB_REV=9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=8
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       git::commit=${GNULIB_REV};rename=gnulib::https://https.git.savannah.gnu.org/git/gnulib.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"
 CHKSUMS="SKIP \
          SKIP \
-         sha256::230a0959aa50778b68239c88ad3c2d53abde58be0932b14a379a3869118aca33 \
+         sha256::df6bd412669f8a4b56d3f43b0f1e026155eecd74b073473061f0633ad11b037e \
          sha256::1609e64c2672c1895808852a272a41a1d0a02084b86ad82a22edc9207a4f63fa"
 CHKUPDATE="anitya::id=1258"
 SUBDIR=.

--- a/desktop-fonts/unifont/spec
+++ b/desktop-fonts/unifont/spec
@@ -1,4 +1,4 @@
-VER=16.0.04
+VER=17.0.01
 SRCS="tbl::https://ftp.gnu.org/gnu/unifont/unifont-$VER/unifont-$VER.tar.gz"
-CHKSUMS="sha256::2bd4e4679757126f48e1bf2c1be40b09aa92162bfedda4683ce5fbc70a2a5972"
+CHKSUMS="sha256::234af86e7a0e851f020900db5ad0afc32691c248db362df9b2914cf50c42d940"
 CHKUPDATE="anitya::id=14916"


### PR DESCRIPTION
Topic Description
-----------------

- unifont: update to 17.0.01
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- unifont: 17.0.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit unifont grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
