### PR TITLE
criu: support loongarch64_nosimd

### DIFF
--- a/app-admin/criu/autobuild/defines
+++ b/app-admin/criu/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=criu
 PKGSEC=admin
-PKGDEP="python-3 protobuf libnl libbsd nftables libnet gnutls protobuf-c"
+PKGDEP="python-3 protobuf libnl libbsd nftables libnet gnutls protobuf"
 BUILDDEP="perl xmlto asciidoc libcap"
 PKGDES="Checkpoint and restore in user space"
 
@@ -9,4 +9,4 @@ MAKE_AFTER="RUNDIR=/run/criu \
 NOLTO=1
 
 # See Makefile `Supported Architectures`
-FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|loongson3)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|loongarch64_nosimd|loongson3)"

--- a/app-admin/criu/spec
+++ b/app-admin/criu/spec
@@ -1,5 +1,5 @@
 VER=3.19
-REL=1
-SRCS="tbl::http://github.com/checkpoint-restore/criu/archive/v$VER/criu-$VER.tar.gz"
-CHKSUMS="sha256::990cdd147cb670a5d5d14216c2b5c2fc2b9a53ef19396569a6413807ba2a6aa2"
+REL=2
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/checkpoint-restore/criu.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=366"


### PR DESCRIPTION
Topic Description
-----------------

- criu: support loongarch64_nosimd

Package(s) Affected
-------------------

- criu: 3.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit criu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
