### PR TITLE
zsh-autosuggestions: new, 0.7.1

### DIFF
--- a/app-shells/zsh-autosuggestions/autobuild/build
+++ b/app-shells/zsh-autosuggestions/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building..."
+make
+
+abinfo "Installing..."
+install -Dvm644 "$SRCDIR"/"$PKGNAME".zsh "$SRCDIR"/"$PKGNAME".plugin.zsh \
+	-t "$PKGDIR"/usr/share/"$PKGNAME"

--- a/app-shells/zsh-autosuggestions/autobuild/defines
+++ b/app-shells/zsh-autosuggestions/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=zsh-autosuggestions
+PKGSEC=misc
+PKGDEP="zsh"
+PKGDES="Fish-like autosuggestions for zsh"
+
+ABHOST=noarch

--- a/app-shells/zsh-autosuggestions/spec
+++ b/app-shells/zsh-autosuggestions/spec
@@ -1,0 +1,4 @@
+VER=0.7.1
+SRCS="git::commit=v$VER::https://github.com/zsh-users/zsh-autosuggestions"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17241"


### PR DESCRIPTION
Topic Description
-----------------

- zsh-autosuggestions: new, 0.7.1

Package(s) Affected
-------------------

- zsh-autosuggestions: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zsh-autosuggestions
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
