### PR TITLE
autoconf-archive: update to 2024.10.16

### DIFF
--- a/app-devel/autoconf-archive/spec
+++ b/app-devel/autoconf-archive/spec
@@ -1,4 +1,4 @@
-VER=2023.02.20
+VER=2024.10.16
 SRCS="tbl::https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-$VER.tar.xz"
-CHKSUMS="sha256::71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33"
+CHKSUMS="sha256::7bcd5d001916f3a50ed7436f4f700e3d2b1bade3ed803219c592d62502a57363"
 CHKUPDATE="anitya::id=142"


### PR DESCRIPTION
Topic Description
-----------------

- autoconf-archive: update to 2024.10.16
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- autoconf-archive: 2024.10.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit autoconf-archive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
