### PR TITLE
fcitx5-pinyin-moegirl: update to 20250909

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250810
+VER=20250909
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::3eeb96e37faebbd55ab32df7296d4829bdae2b69a1f0cfd5f5f542569d50665d
-         sha256::fd8bffda48a0b6936f9d694761324131494c5798b9b68b5e68b883274903a198
+CHKSUMS="sha256::c2d30b8e01dbd484647341bf4791c3945fabeffa2847d5f1805b61dcba3eef0b
+         sha256::c2cc6d8933a0f7fcb3764853b8bc1d7cb7afd0c0335d6203f7a6ead40c8937a9
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20250909

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20250909
- rime-pinyin-moegirl: 20250909

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
