### PR TITLE
element-desktop: update to 1.11.111

### DIFF
--- a/app-web/element-desktop/autobuild/build
+++ b/app-web/element-desktop/autobuild/build
@@ -41,5 +41,5 @@ install -dvm755 "$PKGDIR"/usr/bin
 ln -sv ../lib/element/element-desktop "$PKGDIR"/usr/bin/element-desktop
 
 abinfo "Installing application icon ..."
-install -Dvm644 "$SRCDIR"/element-desktop/res/img/element.png \
-    -t "$PKGDIR"/usr/share/pixmaps/
+install -Dvm644 "$SRCDIR"/element-desktop/build/icon.png \
+    "$PKGDIR"/usr/share/pixmaps/element.png

--- a/app-web/element-desktop/autobuild/patches/0001-Disable-update-check.patch.deferred
+++ b/app-web/element-desktop/autobuild/patches/0001-Disable-update-check.patch.deferred
@@ -1,4 +1,4 @@
-From 833520e8582af6e71b300f766cdd0f45ce4d4b15 Mon Sep 17 00:00:00 2001
+From 5a80fb1ed4565338edff64fe10ebca3b033ecc11 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Tue, 29 Apr 2025 00:42:26 -0700
 Subject: [PATCH 1/2] Disable update check
@@ -20,5 +20,5 @@ index fba31cf..6e22ad8 100644
      "default_server_config": {
          "m.homeserver": {
 -- 
-2.49.0
+2.51.0
 

--- a/app-web/element-desktop/autobuild/patches/0002-Do-not-build-deb.patch.deferred
+++ b/app-web/element-desktop/autobuild/patches/0002-Do-not-build-deb.patch.deferred
@@ -1,4 +1,4 @@
-From 8faf67123e9017c544fd2df231b99bf9a160c27f Mon Sep 17 00:00:00 2001
+From 9eaa034aa3690510b139797ff640874854a3a917 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Tue, 29 Apr 2025 03:48:10 -0700
 Subject: [PATCH 2/2] Do not build deb
@@ -9,18 +9,18 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/electron-builder.ts b/electron-builder.ts
-index 6e48290..eefbfc7 100644
+index d2fd537..06a7f71 100644
 --- a/electron-builder.ts
 +++ b/electron-builder.ts
-@@ -97,7 +97,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
+@@ -91,7 +91,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
          electron_protocol: DEFAULT_PROTOCOL_SCHEME,
      },
      linux: {
 -        target: ["tar.gz", "deb"],
 +        target: ["tar.gz"],
          category: "Network;InstantMessaging;Chat",
-         maintainer: "support@element.io",
-         icon: "build/icons",
+         icon: "build/icon.png",
+         executableName: pkg.name, // element-desktop or element-desktop-nightly
 -- 
-2.49.0
+2.51.0
 

--- a/app-web/element-desktop/spec
+++ b/app-web/element-desktop/spec
@@ -1,4 +1,4 @@
-VER=1.11.110
+VER=1.11.111
 SRCS="git::commit=tags/v$VER;rename=element-web::https://github.com/element-hq/element-web \
       git::commit=tags/v$VER;rename=element-desktop::https://github.com/element-hq/element-desktop"
 CHKSUMS="SKIP SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- element-desktop: update to 1.11.111
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- element-desktop: 1.11.111

Security Update?
----------------

No

Build Order
-----------

```
#buildit element-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
