### PR TITLE
newflasher: update to 58

### DIFF
--- a/app-devices/newflasher/autobuild/patches/0001-Disable-build-time-strippping.patch
+++ b/app-devices/newflasher/autobuild/patches/0001-Disable-build-time-strippping.patch
@@ -1,5 +1,7 @@
---- newflasher-52/makefile	2021-10-01 17:14:44.000000000 +0000
-+++ newflasher-52.nostrip/makefile	2022-07-24 03:59:58.662513657 +0000
+diff --git a/makefile b/makefile
+index 7cb9623..3a6111d 100644
+--- a/makefile
++++ b/makefile
 @@ -1,20 +1,12 @@
 -ARMCC=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-gcc
 -ARMSTRIP=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-strip
@@ -21,39 +23,39 @@
  INSTALL=install
  
  DESTDIR=
-@@ -55,31 +47,26 @@
+@@ -55,31 +47,26 @@ newflasher.exe: libs newflasher.c version.h
  	sed "s/@VERSION@/$(VERSION)/" newflasher.rc.in >newflasher.rc
  	${WINDRES} newflasher.rc -O coff -o newflasher.res
  	${CCWIN} ${CROSS_CFLAGS} -static newflasher.c newflasher.res -o newflasher.exe -lsetupapi -lz -lexpat
 -	${CCWINSTRIP} newflasher.exe
  
  newflasher.x64: libs newflasher.c version.h
- 	@cd zlib-1.2.11 && CC=gcc ./configure --static && make clean && make
+ 	@cd zlib-1.3.1 && CC=gcc ./configure --static && make clean && make
  	@cd expat-2.2.9 && CC="gcc -fPIC" ./configure --enable-static --disable-shared && make clean && make
  	${CC} ${CROSS_CFLAGS} -static newflasher.c -o newflasher.x64 -lz -lexpat
 -	${STRIP} newflasher.x64
  
  newflasher.i386: libs newflasher.c version.h
- 	@cd zlib-1.2.11 && CC="gcc -m32" ./configure --static && make clean && make
+ 	@cd zlib-1.3.1 && CC="gcc -m32" ./configure --static && make clean && make
  	@cd expat-2.2.9 && CC="gcc -m32 -fPIC" ./configure --enable-static --disable-shared && make clean && make
  	${CC} ${CROSS_CFLAGS} -m32 -static newflasher.c -o newflasher.i386 -lz -lexpat
 -	${STRIP} newflasher.i386
  
  newflasher.arm32: libs newflasher.c version.h
- 	@cd zlib-1.2.11 && CC=${ARMCC} ./configure --static && make clean && make
+ 	@cd zlib-1.3.1 && CC=${ARMCC} ./configure --static && make clean && make
  	@cd expat-2.2.9 && CC="${ARMCC} -fPIC" ./configure --enable-static --disable-shared --host=arm-linux-gnueabi && make clean && make
  	${ARMCC} ${CROSS_CFLAGS} -static newflasher.c -o newflasher.arm32 -lz -lexpat
 -	${ARMSTRIP} newflasher.arm32
  
  newflasher.arm64: libs newflasher.c version.h
- 	@cd zlib-1.2.11 && CC=${ARMCC64} ./configure --static && make clean && make
+ 	@cd zlib-1.3.1 && CC=${ARMCC64} ./configure --static && make clean && make
  	@cd expat-2.2.9 && CC="${ARMCC64} -fPIC" ./configure --enable-static --disable-shared --host=aarch64-linux-gnu && make clean && make
  	${ARMCC64} ${CROSS_CFLAGS} -static newflasher.c -o newflasher.arm64 -lz -lexpat
 -	${ARMSTRIP64} newflasher.arm64
  
  newflasher.arm64_pie:
  	@echo "Building Android pie binary"
-@@ -94,7 +81,7 @@
+@@ -97,7 +84,7 @@ newflasher.spec:
  .PHONY: install
  install: newflasher newflasher.1.gz
  	$(INSTALL) -o root -g root -d $(DESTDIR)/usr/bin

--- a/app-devices/newflasher/spec
+++ b/app-devices/newflasher/spec
@@ -1,4 +1,4 @@
-VER=52
-SRCS="tbl::https://github.com/newflasher/newflasher/archive/$VER.tar.gz"
-CHKSUMS="sha256::9388f20d5f56b3aeed9a8950de06cfc31cffd4307d52d7059ea9286564f416ba"
+VER=58
+SRCS="git::commit=tags/$VER::https://github.com/newflasher/newflasher"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226910"


### PR DESCRIPTION
Topic Description
-----------------

- newflasher: update to 58
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- newflasher: 58

Security Update?
----------------

No

Build Order
-----------

```
#buildit newflasher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
