### PR TITLE
qt6ct: update to 0.10

### DIFF
--- a/app-utils/qt6ct/spec
+++ b/app-utils/qt6ct/spec
@@ -1,5 +1,4 @@
-VER=0.9
-REL=2
-SRCS="git::commit=tags/${VER}::https://github.com/trialuser02/qt6ct"
+VER=0.10
+SRCS="git::commit=tags/${VER}::https://www.opencode.net/trialuser/qt6ct.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=288166"


### PR DESCRIPTION
Topic Description
-----------------

- qt6ct: update to 0.10
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- qt6ct: 0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt6ct
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
