### PR TITLE
cava: update to 0.10.6

### DIFF
--- a/app-multimedia/cava/spec
+++ b/app-multimedia/cava/spec
@@ -1,4 +1,4 @@
-VER=0.10.5
+VER=0.10.6
 SRCS="git::commit=tags/$VER::https://github.com/karlstav/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17019"


### PR DESCRIPTION
Topic Description
-----------------

- cava: update to 0.10.6
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- cava: 0.10.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
