### PR TITLE
zfs: rework DKMS installation/removal

### DIFF
--- a/app-admin/zfs/autobuild/defines
+++ b/app-admin/zfs/autobuild/defines
@@ -7,3 +7,6 @@ ABTYPE=self
 
 PKGBREAK="spl<=0.7.13"
 PKGREP="spl<=0.7.13"
+
+# Note: No guarantee for RC kernels.
+PKGBREAK="linux+kernel+rc"

--- a/app-admin/zfs/autobuild/postinst
+++ b/app-admin/zfs/autobuild/postinst
@@ -1,6 +1,6 @@
 unset ARCH
 
-if systemd-detect-virt -q --container; then
+if test -d /usr/lib/modules; then
     for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
         if [ -f "/usr/lib/modules/${i}/modules.dep" -a -f "/usr/lib/modules/${i}/modules.order" -a -f "/usr/lib/modules/${i}/modules.builtin" ]; then
             echo -e "\033[36m**\033[0m\tBuilding zfs kernel modules for $i ..."

--- a/app-admin/zfs/autobuild/prerm
+++ b/app-admin/zfs/autobuild/prerm
@@ -1,2 +1,3 @@
 unset ARCH
 dkms remove zfs/@ZFSVER@ --all || true > /dev/null
+dkms uninstall zfs/@ZFSVER@ --all || true > /dev/null

--- a/app-admin/zfs/autobuild/triggers
+++ b/app-admin/zfs/autobuild/triggers
@@ -1,0 +1,1 @@
+activate-noawait initrd-update

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,5 @@
 VER=2.3.4
+REL=1
 SRCS="tbl::https://github.com/openzfs/zfs/releases/download/zfs-$VER/zfs-$VER.tar.gz"
 CHKSUMS="sha256::9ec397cf360133161a1180035f3e7d6962186ed2b3457953a28d45aa883fa495"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: rework DKMS installation/removal
    - Run postinst \(DKMS\) before dracut trigger.
    - Remove a bogus systemd-detect-virt check \(it's not necessary and was
    written backwards, damn it\).
    - Actually remove the module files from the kernel trees.
    - Add breakage for linux+kernel+rc, as OpenZFS tend not to be able to keep
    up with RC kernels \(nor did we tend to update zfs so frequently\).

Package(s) Affected
-------------------

- zfs: 2.3.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
