### PR TITLE
cups: update to 2.4.13

### DIFF
--- a/app-admin/cups/spec
+++ b/app-admin/cups/spec
@@ -1,4 +1,4 @@
-VER=2.4.12
+VER=2.4.13
 SRCS="git::commit=tags/v$VER::https://github.com/OpenPrinting/cups"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380"

--- a/runtime-optenv32/cups+32/autobuild/defines
+++ b/runtime-optenv32/cups+32/autobuild/defines
@@ -15,6 +15,7 @@ AUTOTOOLS_AFTER=(
     '--enable-libusb'
     '--with-ondemand=upstart'
     '--enable-debug'
+    '--with-dnssd=no'
 )
 
 # FIXME: Missing templates?

--- a/runtime-optenv32/cups+32/spec
+++ b/runtime-optenv32/cups+32/spec
@@ -1,4 +1,4 @@
-VER=2.4.11
+VER=2.4.13
 SRCS="git::commit=tags/v$VER::https://github.com/OpenPrinting/cups"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380"

--- a/topics/cups-2.4.13.toml
+++ b/topics/cups-2.4.13.toml
@@ -1,0 +1,14 @@
+security = true
+must_match_all = false
+
+[name]
+default = "CUPS Printing System 2.4.13"
+zh_CN = "CUPS 打印系统 2.4.13"
+
+[caution]
+default = "Fixes two security vulnerabilities - CVE-2025-58060, CVE-2025-58364 (one of critical severity)"
+zh_CN = "修复两个安全漏洞，漏洞编号 CVE-2025-58060, CVE-2025-58364（含一个严重漏洞）"
+
+[packages]
+"cups" = "2.4.13"
+"cups+32" = "2.4.13"


### PR DESCRIPTION
Topic Description
-----------------

- cups: update to 2.4.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cups: 2.4.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
