### PR TITLE
kddockwidgets: update to 2.2.5

### DIFF
--- a/runtime-desktop/kddockwidgets/autobuild/defines
+++ b/runtime-desktop/kddockwidgets/autobuild/defines
@@ -1,7 +1,5 @@
 PKGNAME=kddockwidgets
 PKGSEC=libs
 PKGDEP="qt-5"
-BUILDDEP="cmake ninja extra-cmake-modules doxygen"
-PKGDES="A Qt dock widget library suitable for replacing QDockWidget"
-
-CMAKE_AFTER="-DKDDockWidgets_DOCS=true"
+BUILDDEP="extra-cmake-modules"
+PKGDES="Qt dock widget library suitable for replacing QDockWidget"

--- a/runtime-desktop/kddockwidgets/spec
+++ b/runtime-desktop/kddockwidgets/spec
@@ -1,5 +1,4 @@
-VER="1.3.1"
-REL=2
-SRCS="https://github.com/KDAB/KDDockWidgets/releases/download/v${VER}/kddockwidgets-${VER}.tar.gz"
-CHKSUMS="sha256::5b1a532590ce4bf01147450f946d7460754d0424487ce4eb4f563d1b8e8c4449"
+VER=2.2.5
+SRCS="git::commit=tags/v$VER::https://github.com/KDAB/KDDockWidgets"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230450"


### PR DESCRIPTION
Topic Description
-----------------

- kddockwidgets: update to 2.2.5
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- kddockwidgets: 2.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit kddockwidgets
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
