### PR TITLE
vscode: update to 1.104.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.103.1
+VER=1.104.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::0a2f1a6396600747e1bfb3ad7f57f30962bd8e0d8558cc79af4c64d4e6d4c61d"
-CHKSUMS__ARM64="sha256::44490e12c0273473c0fc8db3bd4b64649b7695600cd9d0a39a7a638781a74158"
+CHKSUMS__AMD64="sha256::dec5fe2e3a71a3fded60c7924a22967efc7a6ec608ad4f17e751cbc3cbde6c0a"
+CHKSUMS__ARM64="sha256::df14630c12e0cde57ac4e3e4d0b574644d95b9b5958aac21e559e8778e43341e"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.104.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.104.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
