### PR TITLE
 vscodium: update to 1.104.16282

### DIFF
--- a/app-editors/vscodium/autobuild/patches/0004-fix-patch-vscode-to-use-tsc-instead-of-tsgo.patch
+++ b/app-editors/vscodium/autobuild/patches/0004-fix-patch-vscode-to-use-tsc-instead-of-tsgo.patch
@@ -1,0 +1,43 @@
+From 0c3c06c7813a2fd7a466fabc8c9a4cab0fb0f580 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Wed, 24 Sep 2025 21:14:08 +0800
+Subject: [PATCH] fix: patch vscode to use tsc instead of tsgo
+
+---
+ patches/tsgo-to-tsc.patch | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+ create mode 100644 patches/tsgo-to-tsc.patch
+
+diff --git a/patches/tsgo-to-tsc.patch b/patches/tsgo-to-tsc.patch
+new file mode 100644
+index 0000000..9f9fffd
+--- /dev/null
++++ b/patches/tsgo-to-tsc.patch
+@@ -0,0 +1,24 @@
++diff --git a/package.json b/package.json
++index 49249fb..257b552 100644
++--- a/package.json
+++++ b/package.json
++@@ -18,7 +18,7 @@
++     "preinstall": "node build/npm/preinstall.js",
++     "postinstall": "node build/npm/postinstall.js",
++     "compile": "node ./node_modules/gulp/bin/gulp.js compile",
++-    "compile-check-ts-native": "tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck",
+++    "compile-check-ts-native": "tsc --project ./src/tsconfig.json --noEmit --skipLibCheck",
++     "watch": "npm-run-all -lp watch-client watch-extensions",
++     "watchd": "deemon npm run watch",
++     "watch-webd": "deemon npm run watch-web",
++@@ -44,8 +44,8 @@
++     "download-builtin-extensions-cg": "node build/lib/builtInExtensionsCG.js",
++     "monaco-compile-check": "tsc -p src/tsconfig.monaco.json --noEmit",
++     "tsec-compile-check": "node node_modules/tsec/bin/tsec -p src/tsconfig.tsec.json",
++-    "vscode-dts-compile-check": "tsgo --project src/tsconfig.vscode-dts.json && tsgo --project src/tsconfig.vscode-proposed-dts.json",
++-    "valid-layers-check": "node build/checker/layersChecker.js && tsgo --project build/checker/tsconfig.browser.json && tsgo --project build/checker/tsconfig.worker.json && tsgo --project build/checker/tsconfig.node.json && tsgo --project build/checker/tsconfig.electron-browser.json && tsgo --project build/checker/tsconfig.electron-main.json && tsgo --project build/checker/tsconfig.electron-utility.json",
+++    "vscode-dts-compile-check": "tsc --project src/tsconfig.vscode-dts.json && tsc --project src/tsconfig.vscode-proposed-dts.json",
+++    "valid-layers-check": "node build/checker/layersChecker.js && tsc --project build/checker/tsconfig.browser.json && tsc --project build/checker/tsconfig.worker.json && tsc --project build/checker/tsconfig.node.json && tsc --project build/checker/tsconfig.electron-browser.json && tsc --project build/checker/tsconfig.electron-main.json && tsc --project build/checker/tsconfig.electron-utility.json",
++     "define-class-fields-check": "node build/lib/propertyInitOrderChecker.js && tsc -p src/tsconfig.defineClassFields.json",
++     "update-distro": "node build/npm/update-distro.mjs",
++     "web": "echo 'npm run web' is replaced by './scripts/code-server' or './scripts/code-web'",
+-- 
+2.51.0
+

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.103.25610
+VER=1.104.06114
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.104.06114
+VER=1.104.16282
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.104.16282
- vscodium: update to 1.104.06114
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscodium: 1.104.16282

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
