### PR TITLE
feeluown: update to 4.1.15

### DIFF
--- a/app-multimedia/feeluown-bilibili/spec
+++ b/app-multimedia/feeluown-bilibili/spec
@@ -1,4 +1,4 @@
-VER=0.5.0
+VER=0.5.1
 SRCS="git::commit=tags/v${VER}::https://github.com/feeluown/feeluown-bilibili"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268765"

--- a/app-multimedia/feeluown-netease/spec
+++ b/app-multimedia/feeluown-netease/spec
@@ -1,4 +1,4 @@
-VER=1.0.3
+VER=1.0.4
 SRCS="git::commit=tags/v${VER}::https://github.com/feeluown/feeluown-netease"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33792"

--- a/app-multimedia/feeluown-qqmusic/spec
+++ b/app-multimedia/feeluown-qqmusic/spec
@@ -1,4 +1,4 @@
-VER=1.0.5
+VER=1.0.11
 SRCS="git::commit=tags/v$VER::https://github.com/feeluown/feeluown-qqmusic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33797"

--- a/app-multimedia/feeluown/spec
+++ b/app-multimedia/feeluown/spec
@@ -1,4 +1,4 @@
-VER=4.1.10
+VER=4.1.15
 SRCS="git::commit=tags/v$VER::https://github.com/feeluown/FeelUOwn"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=33791"


### PR DESCRIPTION
Topic Description
-----------------

- feeluown-netease: update to 1.0.4
- feeluown-bilibili: update to 0.5.1
- feeluown-qqmusic: update to 1.0.11
- feeluown: update to 4.1.15
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- feeluown: 1:4.1.15
- feeluown-bilibili: 0.5.1
- feeluown-netease: 1.0.4
- feeluown-qqmusic: 1.0.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit feeluown feeluown-bilibili feeluown-qqmusic feeluown-netease
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
