### PR TITLE
libchewing: update to 0.10.3

### DIFF
--- a/runtime-i18n/libchewing/autobuild/defines
+++ b/runtime-i18n/libchewing/autobuild/defines
@@ -1,4 +1,10 @@
 PKGNAME=libchewing
 PKGSEC=libs
 PKGDEP="sqlite"
+BUILDDEP="rustc llvm"
 PKGDES="Intelligent Chinese phonetic input method"
+ABTYPE=cmakeninja
+CMAKE_AFTER="-DBUILD_TESTING=OFF"
+
+#FIXME: /usr/bin/ld: libchewing_capi.a: error adding symbols: file format not recognized
+USECLANG=1

--- a/runtime-i18n/libchewing/spec
+++ b/runtime-i18n/libchewing/spec
@@ -1,5 +1,4 @@
-VER=0.5.1
-SRCS="tbl::https://github.com/chewing/libchewing/releases/download/v$VER/libchewing-$VER.tar.bz2"
-CHKSUMS="sha256::9708c63415fa6034435c0f38100e7d30d0e1bac927f67bec6dfeb3fef016172b"
+VER=0.10.3
+SRCS="git::commit=tags/v$VER::https://github.com/chewing/libchewing"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1577"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libchewing: update to 0.10.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libchewing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
