### PR TITLE
bash-pinyin-completion-rs: update to 0.3.2

### DIFF
--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,4 +1,4 @@
-VER=0.3.1
+VER=0.3.2
 SRCS="tbl::https://github.com/AOSC-Dev/bash-pinyin-completion-rs/archive/v$VER.tar.gz"
-CHKSUMS="sha256::053a15b7f0ccb00b11d67890c8483658de1152039738a2b87f2ea62c1da95393"
+CHKSUMS="sha256::3de1c978aae9deacc86cf4c20da4d01542de0a1338133320abde62ab534e2018"
 CHKUPDATE="anitya::id=376526"

--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,4 +1,4 @@
 VER=0.3.2
-SRCS="tbl::https://github.com/AOSC-Dev/bash-pinyin-completion-rs/archive/v$VER.tar.gz"
-CHKSUMS="sha256::3de1c978aae9deacc86cf4c20da4d01542de0a1338133320abde62ab534e2018"
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/bash-pinyin-completion-rs"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376526"


### PR DESCRIPTION
Topic Description
-----------------

- bash-pinyin-completion-rs: update to 0.3.2

Package(s) Affected
-------------------

- bash-pinyin-completion-rs: 0.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-pinyin-completion-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
