### PR TITLE
maple-font: update to 7.7

### DIFF
--- a/desktop-fonts/maple-font/spec
+++ b/desktop-fonts/maple-font/spec
@@ -1,12 +1,12 @@
-VER=7.6
+VER=7.7
 SRCS="tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-Variable.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-TTF.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-CN-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-CN-unhinted.zip"
-CHKSUMS="sha256::f144b65cbfd14c87961dab4778bbfbff25a26f956feeb74ec8d0b9aa8b115f0d \
-         sha256::9f8922bcf45c23cd23123edd457dff48ac961e20628975e86388c457b7824922 \
-         sha256::eca12ce84b607dd3b60d92051a51c059d2332aa2836aaeda4531b4f071188a1c \
-         sha256::4278d1a16d385af1ad8282959b8e94d19d30226a7661505d07ff0b0f7ee67d69 \
-         sha256::f0f4b0fea1985e3a5a6b3c98f7d6ce4056ccf903a425f8b3ae6965f034c6c2af"
+CHKSUMS="sha256::5a8736d2eca43d0aece94aca28aa0540d644c2d416582ba8e433b6f991cce4a4 \
+         sha256::60793a95a5032b40d5fd734fdbc06a7aba1e9f80a328a1ed8a8fb2f0372650e4 \
+         sha256::6e237b3c671d9dce2f6e32c027c80ff7e8e6b94f19989010190f653e2d3bbe8b \
+         sha256::b39143c70724a1b7c8deb67b64c12464f86de23770cdd9c87811fd1b9383d6ee \
+         sha256::b8cb09527237cf1cfff6db395d8dee861e522b50932bb31f6559c54b78619202"
 CHKUPDATE="anitya::id=375863"


### PR DESCRIPTION
Topic Description
-----------------

- maple-font: update to 7.7
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- maple-font: 7.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit maple-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
