### PR TITLE
ansible: update to 2.19.2

### DIFF
--- a/app-admin/ansible/spec
+++ b/app-admin/ansible/spec
@@ -1,4 +1,4 @@
-VER=2.12.1
+VER=2.19.2
 SRCS="tbl::https://github.com/ansible/ansible/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::69b3cdeb56513fffad95bee5323f4f96a04d5bcc9236d9897cf603eb2a50959c"
+CHKSUMS="sha256::cb3feaf0edb3e3e70a4483f4990edb5935066d87de9d99a65bfdef5db9b4976c"
 CHKUPDATE="anitya::id=6097"


### PR DESCRIPTION
Topic Description
-----------------

- ansible: update to 2.19.2
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- ansible: 2.19.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ansible
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
