### PR TITLE
fcitx: add libxkbcommon as PKGDEP

### DIFF
--- a/app-i18n/fcitx/autobuild/beyond
+++ b/app-i18n/fcitx/autobuild/beyond
@@ -1,6 +1,11 @@
 abinfo "Dropping .desktop entries ..."
 rm -rv "$PKGDIR"/usr/share/applications
 
+abinfo "Moving autostart .desktop entries ..."
+mkdir -pv "$PKGDIR"/etc/xdg/autostart
+mv -v "$PKGDIR"/usr/etc/xdg/autostart/fcitx-autostart.desktop "$PKGDIR"/etc/xdg/autostart/fcitx-autostart.desktop
+rm -rv "$PKGDIR"/usr/etc
+
 if ab_match_archgroup retro; then
     abinfo "Tweaking autostart to use the light UI ..."
     sed -e 's|Exec=fcitx-autostart|Exec=fcitx -u fcitx-light-ui|g' \

--- a/app-i18n/fcitx/autobuild/defines
+++ b/app-i18n/fcitx/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=fcitx
 PKGDES="An input method framework with extension support"
 PKGSEC=x11
 PKGDEP="pango dbus-glib icu shared-mime-info hicolor-icon-theme \
-        desktop-file-utils xkeyboard-config imchooser"
+        desktop-file-utils xkeyboard-config imchooser libxkbcommon"
 PKGDEP__RETRO="cairo dbus-glib xkeyboard-config libxkbcommon \
                iso-codes json-c"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"

--- a/app-i18n/fcitx/spec
+++ b/app-i18n/fcitx/spec
@@ -1,4 +1,5 @@
 VER=4.2.9.9
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8004"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx: add libxkbcommon as PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- fcitx: 4.2.9.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
