### PR TITLE
ibus-chewing: update to 2.1.7

### DIFF
--- a/app-i18n/ibus-chewing/autobuild/build
+++ b/app-i18n/ibus-chewing/autobuild/build
@@ -1,7 +1,0 @@
-cmake . -DCMAKE_INSTALL_PREFIX=/usr \
-        -DSYSCONF_INSTALL_DIR=/usr/share \
-        -DLIBEXEC_DIR=/usr/lib/ibus
-make
-make translations
-
-make DESTDIR="$PKGDIR" install

--- a/app-i18n/ibus-chewing/autobuild/defines
+++ b/app-i18n/ibus-chewing/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ibus-chewing
 PKGSEC=x11
-PKGDEP="ibus libchewing gtk-2"
-BUILDDEP="swig gob2 cmake cmake-fedora"
+PKGDEP="ibus libchewing gtk-4 libadwaita"
+BUILDDEP="swig gob2 cmake-fedora"
 PKGDES="Chinese Chewing Engine for IBus Framework"
-
+ABTYPE=meson

--- a/app-i18n/ibus-chewing/spec
+++ b/app-i18n/ibus-chewing/spec
@@ -1,5 +1,4 @@
-VER=1.6.1
-REL=2
-SRCS="git::commit=tags/$VER::https://github.com/definite/ibus-chewing"
+VER=2.1.7
+SRCS="git::commit=tags/v$VER::https://github.com/definite/ibus-chewing"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228880"


### PR DESCRIPTION
Topic Description
-----------------

- ibus-chewing: update to 2.1.7
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ibus-chewing: 2.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit ibus-chewing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
