### PR TITLE
xarchiver: update to 0.5.4.26

### DIFF
--- a/app-utils/xarchiver/spec
+++ b/app-utils/xarchiver/spec
@@ -1,5 +1,4 @@
-VER=0.5.4.15
-REL=1
+VER=0.5.4.26
 SRCS="tbl::https://github.com/ib/xarchiver/archive/$VER.tar.gz"
-CHKSUMS="sha256::2a18f5a8932516ecc5c50152ff6ce77bc3f58a0b221d6db9c70d089cf90d7182"
+CHKSUMS="sha256::58e4fb2c1fb8421573a31cf3b4dfec301076d61f48ac5720df632986c87e9573"
 CHKUPDATE="anitya::id=5157"


### PR DESCRIPTION
Topic Description
-----------------

- xarchiver: update to 0.5.4.26
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- xarchiver: 0.5.4.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit xarchiver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
