### PR TITLE
libkate: update to 0.4.3

### DIFF
--- a/runtime-multimedia/libkate/autobuild/defines
+++ b/runtime-multimedia/libkate/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libkate
 PKGSEC=libs
-PKGDEP="liboggz libpng python-2"
+PKGDEP="glibc libogg libpng wxpython"
 PKGDES="A karaoke and text codec for embedding in ogg"
 
-RECONF=0
+ABSHADOW=0

--- a/runtime-multimedia/libkate/spec
+++ b/runtime-multimedia/libkate/spec
@@ -1,5 +1,4 @@
-VER=0.4.1
-REL=1
-SRCS="tbl::https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libkate/libkate-$VER.tar.gz"
-CHKSUMS="sha256::c40e81d5866c3d4bf744e76ce0068d8f388f0e25f7e258ce0c8e76d7adc87b68"
+VER=0.4.3
+SRCS="git::commit=tags/kate-$VER::https://gitlab.xiph.org/xiph/kate.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230927"


### PR DESCRIPTION
Topic Description
-----------------

- libkate: update to 0.4.3

Package(s) Affected
-------------------

- libkate: 0.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libkate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
