### PR TITLE
aosc-os-presets-desktop: enable smbd.socket instead of smbd.service for security

### DIFF
--- a/runtime-data/aosc-os-presets-desktop/autobuild/build
+++ b/runtime-data/aosc-os-presets-desktop/autobuild/build
@@ -16,7 +16,7 @@ enable saned.socket
 enable accounts-daemon.service
 
 # Network services
-enable smbd.service
+enable smbd.socket
 enable avahi-dnsconfd.service
 EOF
 

--- a/runtime-data/aosc-os-presets-desktop/spec
+++ b/runtime-data/aosc-os-presets-desktop/spec
@@ -1,2 +1,2 @@
-VER=6
+VER=7
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-presets-desktop: enable smbd.socket instead of smbd.service for security
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- aosc-os-presets-desktop: 7

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-presets-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
