### PR TITLE
kea: update to 3.0.1

### DIFF
--- a/app-network/kea/spec
+++ b/app-network/kea/spec
@@ -1,5 +1,4 @@
-VER=2.6.3
-REL=1
-SRCS="tbl::https://ftp.isc.org/isc/kea/${VER}/kea-${VER}.tar.gz"
-CHKSUMS="sha256::00241a5955ffd3d215a2c098c4527f9d7f4b203188b276f9a36250dd3d9dd612"
+VER=3.0.1
+SRCS="tbl::https://ftp.isc.org/isc/kea/${VER}/kea-${VER}.tar.xz"
+CHKSUMS="sha256::ec84fec4bb7f6b9d15a82e755a571e9348eb4d6fbc62bb3f6f1296cd7a24c566"
 CHKUPDATE="anitya::id=12915"


### PR DESCRIPTION
Topic Description
-----------------

- kea: update to 3.0.1

Package(s) Affected
-------------------

- kea: 3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
