### PR TITLE
rnote: update to 0.13.1

### DIFF
--- a/app-doc/rnote/spec
+++ b/app-doc/rnote/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
+VER=0.13.1
 SRCS="git::commit=tags/v$VER::https://github.com/flxzt/rnote.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375549"


### PR DESCRIPTION
Topic Description
-----------------

- rnote: update to 0.13.1
    Signed-off-by: wxiwnd <wxiwnd@outlook.com>

Package(s) Affected
-------------------

- rnote: 0.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rnote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
