### PR TITLE
pacman: update to 7.0.0

### DIFF
--- a/app-admin/pacman/autobuild/defines
+++ b/app-admin/pacman/autobuild/defines
@@ -9,4 +9,3 @@ PKGBREAK="bash-completion<=1:2.10"
 
 AUTOTOOLS_AFTER="--enable-doc"
 ABSHADOW=0
-

--- a/app-admin/pacman/spec
+++ b/app-admin/pacman/spec
@@ -1,5 +1,4 @@
-VER=6.0.1
-SRCS="tbl::https://sources.archlinux.org/other/pacman/pacman-$VER.tar.xz"
-CHKSUMS="sha256::0db61456e56aa49e260e891c0b025be210319e62b15521f29d3e93b00d3bf731"
+VER=7.0.0
+SRCS="git::commit=tags/v${VER}::https://gitlab.archlinux.org/pacman/pacman.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7244"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pacman: update to 7.0.0

Package(s) Affected
-------------------

- pacman: 1:7.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pacman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
