### PR TITLE
sssd: update to 2.11.1

### DIFF
--- a/app-admin/sssd/autobuild/beyond
+++ b/app-admin/sssd/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Handling directories..."
+mv -v "$PKGDIR"/usr/etc/* "$PKGDIR"/etc
+rm -rv "$PKGDIR"/usr/etc

--- a/app-admin/sssd/autobuild/defines
+++ b/app-admin/sssd/autobuild/defines
@@ -6,18 +6,17 @@ PKGRECOM="autofs"
 BUILDDEP="docbook-xsl doxygen autofs"
 PKGDES="A daemon to manage identity, authentication and authorization for centrally-managed systems"
 
-AUTOTOOLS_AFTER="--enable-pammoddir=/usr/lib/security \
-                 --enable-pac-responder \
-                 --with-initscript=systemd  \
-                 --with-os=fedora \
-                 --with-pid-path=/run \
-                 --without-python2-bindings \
-                 --with-python3-bindings  \
-                 --with-syslog=journald \
-                 --with-autofs \
-                 --without-selinux \
-                 --with-oidc-child=no \
-                 --without-semanage"
+AUTOTOOLS_AFTER=("--enable-pammoddir=/usr/lib/security"
+                 "--enable-pac-responder"
+                 "--with-initscript=systemd"
+                 "--with-os=fedora"
+                 "--with-pid-path=/run"
+                 "--without-python2-bindings"
+                 "--with-python3-bindings"
+                 "--with-syslog=journald"
+                 "--with-autofs"
+                 "--without-selinux"
+                 "--with-oidc-child=no")
 ABSHADOW=0
 # FIXME: race condition upon make install
 NOPARALLEL=1

--- a/app-admin/sssd/autobuild/postinst
+++ b/app-admin/sssd/autobuild/postinst
@@ -1,1 +1,2 @@
+abinfo "Handling permissions..."
 chmod u=rwX,go-rwx -R /etc/sssd

--- a/app-admin/sssd/autobuild/prepare
+++ b/app-admin/sssd/autobuild/prepare
@@ -1,4 +1,0 @@
-abinfo "Arch Linux: Tweaking logrotate config (/var/run => /run) ..."
-sed -e 's#/var/run/#/run/#' \
-    -i "$SRCDIR"/src/examples/logrotate
-

--- a/app-admin/sssd/spec
+++ b/app-admin/sssd/spec
@@ -1,5 +1,4 @@
-VER=2.9.5
-REL=2
+VER=2.11.1
 SRCS="git::commit=tags/$VER::https://github.com/SSSD/sssd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12810"


### PR DESCRIPTION
Topic Description
-----------------

- sssd: update to 2.11.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- sssd: 2.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit sssd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
