### PR TITLE
telegram-desktop: update to 6.1.3

### DIFF
--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From 32c53db1ec49b42ba17f6728fca2822ed8b453b9 Mon Sep 17 00:00:00 2001
+From 0c8413f88e9ad2ab06c1a7a3d2158c7fb5a57223 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 01/13] fix(window.style): set default window width to 360px

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From aacf40717bfd501d0374e8d4434af7cc65e32a54 Mon Sep 17 00:00:00 2001
+From 62d7478f1e15632e023474e7fec5a10420596fba Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 02/13] fix(core_settings.h): use system window decoration by

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 4ad3d9247e8efc560188c32c2ed7a4f0df128c6d Mon Sep 17 00:00:00 2001
+From 57ecfccb077557aa8c2dfad908453a243b547336 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 03/13] fix(ui): fix build with Qt 5

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From c8bd79ec79167a76192e7be285766b3022770d14 Mon Sep 17 00:00:00 2001
+From a949da6a9ad00303fa2b04b038e50b911e49d094 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 04/13] fix(core/launcher.cpp): revert to old HiDPI handling

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From 356027ef8b33d5a3a5dc290ba808b0984e026679 Mon Sep 17 00:00:00 2001
+From 4793226eb8cfe9710e8fd027d48b2a69ed35a869 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 05/13] fix(settings): use system fonts by default

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 13b2e2f8b04ef5c93ecb0fbb9c7b987ccb0153d7 Mon Sep 17 00:00:00 2001
+From 7ee0e218255643e6ab4fdde85c98f5fad67dbff5 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 06/13] Remove the confusing "Default" option from selectable

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From 93b130c8a1d63e7700cbbf6d024b0e13bf28fd06 Mon Sep 17 00:00:00 2001
+From b880e72810976d4b494996690339d0f231d36de5 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 07/13] fix(lib_tl): add missing cstring include

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From c834fec9d03688fa567c96e3c1bb58bcfe1df7ea Mon Sep 17 00:00:00 2001
+From a7185b55867aecd93643594c19ca5435b9ebee0a Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 08/13] fix(lib_webview): add missing cstdint include

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,4 +1,4 @@
-From 31d02d13659fb2194044a0283017c6c68c832859 Mon Sep 17 00:00:00 2001
+From 1efab5d4513d335888a930ca31820c90d0cf87cf Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
 Subject: [PATCH 09/13] fix(current_geo_location_linux): add missing

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,4 +1,4 @@
-From 7c4268f115355ecffe3bfdb85c3d7ec46c1a674b Mon Sep 17 00:00:00 2001
+From aecdd037f9241d98475c3492f50bb5e9e60313a9 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
 Subject: [PATCH 10/13] fix(core_settings.h): enable video hardware

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,4 +1,4 @@
-From ffa8b279cf689fc961c8760bcf37aeea61be4db6 Mon Sep 17 00:00:00 2001
+From 7c96df63ffd37d362e6c28cb8959b37f9125924d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
 Subject: [PATCH 11/13] fix(cmake): disable CMP0160 to workaround KF5 cmake

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,4 +1,4 @@
-From 7aa5f1294a453582be8833b5f29a934a3f69e783 Mon Sep 17 00:00:00 2001
+From 0daca95d120c41ed75950d9398c8b2bc5289ae5b Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 3 Jul 2025 19:04:36 -0700
 Subject: [PATCH 12/13] fix(credits_amount.h): include cmath for std::floor

--- a/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 2de3af9bb6e85f93b0ebafc46ca9c7d866fe8828 Mon Sep 17 00:00:00 2001
+From c1271847216ea61e19b5794601629e7f8d1acb63 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 28 Aug 2025 02:08:09 -0700
 Subject: [PATCH 13/13] fix(lib_webview): fix build with Qt 5
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  2 files changed, 36 insertions(+)
 
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-index fb03b6e889..3f0d733883 100644
+index 77fd81908a..072c98ab8d 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 @@ -126,7 +126,12 @@ bool HttpServer::Private::processRedirect(
@@ -24,7 +24,7 @@ index fb03b6e889..3f0d733883 100644
 +	*connection = QObject::connect(reply, &QNetworkReply::finished, socket, [
 +#endif
  		=, 
- 		replyGuard = std::make_unique<Guard>([=] {
+ 		replyGuard = std::make_unique<Guard>(crl::guard(reply, [=] {
  			reply->deleteLater();
 @@ -155,7 +160,13 @@ bool HttpServer::Private::processRedirect(
  		socket->write("Cache-Control: no-store\r\n");

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,12 +1,11 @@
-VER=6.1.1
-REL=1
+VER=6.1.3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
-OWTVER=62321fd7128ab2650b459d4195781af8185e46b5
-TDLIBVER=5c77c4692c28eb48a68ef1c1eeb1b1d732d507d3
+OWTVER=5c5c71258777d0196dbb3a09cc37d2f56ead28ab
+TDLIBVER=6dca40bdaac8b5e66c7a793727bf3f81e9711f70
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::07274d7b0038e5e6d127fb6568283594d8a735ea086c662eeee73713bd73ca04 \
+CHKSUMS="sha256::1c6a531abf106d5f4b6d9179fc802f93cb8ab62630cc07e73d64688780125869 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.1.3
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 6.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
