### PR TITLE
drop gdl and gdlmm

### DIFF
--- a/app-creativity/inkscape/autobuild/defines
+++ b/app-creativity/inkscape/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=graphics
 PKGDEP="desktop-file-utils gc gsl gtkmm gtkspell hicolor-icon-theme \
         imagemagick libcdr libxslt lxml murrine numpy poppler popt python-3 \
         libsoup libwpg libvisio openjpeg potrace scour double-conversion \
-        gtkmm-3 gdlmm tinycss2"
+        gtkmm-3 tinycss2"
 BUILDDEP="boost cmake intltool dos2unix"
 PKGSUG="texlive"
 PKGDES="Vector graphics editor using the SVG file format"

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=1_4_2
 VER=${UPSTREAM_VER//_/.}
-REL=1
+REL=2
 SRCS="git::commit=tags/INKSCAPE_${UPSTREAM_VER}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/desktop-gnome/gdl/autobuild/defines
+++ b/desktop-gnome/gdl/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=gdl
-PKGSEC=gnome
-PKGDEP="gtk-3"
-BUILDDEP="gobject-introspection gtk-doc intltool"
-PKGDES="GNOME Docking Library"
-
-AUTOTOOLS_AFTER="--enable-gtk-doc"

--- a/desktop-gnome/gdl/spec
+++ b/desktop-gnome/gdl/spec
@@ -1,4 +1,0 @@
-VER=3.40.0
-SRCS="tbl::https://download.gnome.org/sources/gdl/${VER:0:4}/gdl-$VER.tar.xz"
-CHKSUMS="sha256::3641d4fd669d1e1818aeff3cf9ffb7887fc5c367850b78c28c775eba4ab6a555"
-CHKUPDATE="anitya::id=1624"

--- a/desktop-gnome/gdlmm/autobuild/defines
+++ b/desktop-gnome/gdlmm/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=gdlmm
-PKGSEC=gnome
-PKGDEP="gdl gtkmm-3"
-BUILDDEP="mm-common"
-PKGDES="C++ bindings for the GDL library"
-
-ABSHADOW=0

--- a/desktop-gnome/gdlmm/spec
+++ b/desktop-gnome/gdlmm/spec
@@ -1,5 +1,0 @@
-VER=3.7.3
-REL=4
-SRCS="tbl::https://download.gnome.org/sources/gdlmm/${VER:0:3}/gdlmm-$VER.tar.xz"
-CHKSUMS="sha256::e280ed9233877b63ad0a0c8fb04d2c35dc6a29b3312151ee21a15b5932fef79b"
-CHKUPDATE="anitya::id=227734"


### PR DESCRIPTION
Topic Description
-----------------

- gdl: drop, orphaned
    Signed-off-by: ilikara <3435193369@qq.com>
- gdlmm: drop, orphaned
    Signed-off-by: ilikara <3435193369@qq.com>
- inkscape: remove unused dependency gdlmm
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- inkscape: 1.4.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit inkscape
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
