### PR TITLE
nwg-look: remove useless dep

### DIFF
--- a/app-utils/nwg-look/autobuild/defines
+++ b/app-utils/nwg-look/autobuild/defines
@@ -5,4 +5,4 @@ BUILDDEP="go pkg-config"
 PKGDES="GTK 3 appearance editor for wlroots-based environments"
 
 # Note: Limited by upstream(xcur2png) support  
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+FAIL_ARCH="(loongarch64_nosimd|loongson3|riscv64|ppc64el)"

--- a/app-utils/nwg-look/autobuild/defines
+++ b/app-utils/nwg-look/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=nwg-look
 PKGSEC=utils
-PKGDEP="at-spi2-core atk cairo fontconfig freetype gdk-pixbuf glib glibc gtk-3 harfbuzz pango zlib"
+PKGDEP="at-spi2-core cairo fontconfig freetype gdk-pixbuf glib glibc gtk-3 harfbuzz pango zlib"
 BUILDDEP="go pkg-config"
 PKGDES="GTK 3 appearance editor for wlroots-based environments"
 

--- a/app-utils/nwg-look/spec
+++ b/app-utils/nwg-look/spec
@@ -1,5 +1,5 @@
 VER=1.0.6
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/nwg-piotr/nwg-look.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378332"


### PR DESCRIPTION
Topic Description
-----------------

- nwg-look: adjust fail_arch
- nwg-look: remove useless dep

Package(s) Affected
-------------------

- nwg-look: 1.0.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nwg-look
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
