### PR TITLE
ncbi-blast+: update to 2.17.0

### DIFF
--- a/app-scientific/ncbi-blast+/autobuild/build
+++ b/app-scientific/ncbi-blast+/autobuild/build
@@ -1,0 +1,22 @@
+abinfo "Building ncbi-blast+ ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    --with-dll \
+    --with-bin-release \
+    --with-mt \
+    --with-libuv \
+    --with-lmdb \
+    --with-lzo \
+    --with-nghttp2 \
+    --with-pcre2 \
+    --with-perl \
+    --with-python \
+    --with-sqlite3 \
+    --with-z \
+    --with-zstd
+
+abinfo "Configuring ncbi-blast+ ..."
+make
+
+abinfo "Installing ncbi-blast+ ..."
+make prefix="$PKGDIR"/usr install

--- a/app-scientific/ncbi-blast+/autobuild/defines
+++ b/app-scientific/ncbi-blast+/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=ncbi-blast+
 PKGSEC=science
 PKGDES="NCBI Blast+ for Basic Local Alignment Search Tool running on your machine."
+PKGDEP="boost mbedtls"
+BUILDDEP="config"
 
-RECONF=0
-AUTOTOOLS_STRICT=0
-ABSHADOW=0
+#FIXME: ncbi-blast-2.17.0+-src/c++/src/util/compress/zlib_cloudflare/deflate.c:149:2: error: #error "Only 64-bit Intel and ARM architectures are supported" 
+FAIL_ARCH="!(amd64|arm64)"
+ABTYPE=self

--- a/app-scientific/ncbi-blast+/autobuild/patches/0001-feature-enable-debug.patch
+++ b/app-scientific/ncbi-blast+/autobuild/patches/0001-feature-enable-debug.patch
@@ -1,9 +1,0 @@
-diff --git a/configure b/configure
-index 82053df..cf6ceea 100755
---- a/configure
-+++ b/configure
-@@ -1,3 +1,3 @@
- #!/bin/sh
- srcdir=`dirname $0`
--exec $srcdir/configure.orig --without-debug --with-strip --with-openmp --with-mt --without-vdb --without-gnutls --without-gcrypt --with-build-root=$srcdir/ReleaseMT --with-experimental=Int8GI ${1+"$@"}
-+exec $srcdir/configure.orig --with-openmp --with-mt --without-vdb --without-gnutls --without-gcrypt --with-build-root=$srcdir/ReleaseMT --with-experimental=Int8GI ${1+"$@"}

--- a/app-scientific/ncbi-blast+/autobuild/prepare
+++ b/app-scientific/ncbi-blast+/autobuild/prepare
@@ -1,1 +1,0 @@
-export AUTOTOOLS_DEF="--prefix=$PKGDIR/usr"

--- a/app-scientific/ncbi-blast+/spec
+++ b/app-scientific/ncbi-blast+/spec
@@ -1,5 +1,5 @@
-VER=2.13.0
+VER=2.17.0
 SRCS="tbl::https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${VER}/ncbi-blast-${VER}+-src.tar.gz"
 SUBDIR="ncbi-blast-${VER}+-src/c++"
-CHKSUMS="sha256::89553714d133daf28c477f83d333794b3c62e4148408c072a1b4620e5ec4feb2"
+CHKSUMS="sha256::502057a88e9990e34e62758be21ea474cc0ad68d6a63a2e37b2372af1e5ea147"
 CHKUPDATE="anitya::id=21036"


### PR DESCRIPTION
Topic Description
-----------------

- ncbi-blast+: update to 2.17.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ncbi-blast+: 2.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncbi-blast+
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
