### PR TITLE
libgnome-keyring: fix SRCS link

### DIFF
--- a/desktop-gnome/libgnome-keyring/autobuild/defines
+++ b/desktop-gnome/libgnome-keyring/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libgnome-keyring
 PKGDES="GNOME Keyring library"
 PKGSEC=gnome
-PKGDEP="glib libgcrypt dbus"
+PKGDEP="glib libgcrypt dbus gnome-common"
 BUILDDEP="intltool gobject-introspection vala"
 
 ABSHADOW=no

--- a/desktop-gnome/libgnome-keyring/spec
+++ b/desktop-gnome/libgnome-keyring/spec
@@ -1,5 +1,5 @@
 VER=3.12.0
-REL=5
-SRCS="tbl::https://ftp.acc.umu.se/pub/gnome/sources/libgnome-keyring/3.12/libgnome-keyring-$VER.tar.xz"
-CHKSUMS="sha256::c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783"
+REL=6
+SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.gnome.org/Archive/libgnome-keyring.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228577"


### PR DESCRIPTION
Topic Description
-----------------

- libgnome-keyring: fix SRCS link
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libgnome-keyring: 3.12.0-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgnome-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
