### PR TITLE
SRCS update Survey 20250917

### DIFF
--- a/app-games/pingus/spec
+++ b/app-games/pingus/spec
@@ -1,4 +1,4 @@
 VER=0.7.6
-SRCS="git::commit=tags/v$VER::https://gitlab.com/Pingus/pingus"
+SRCS="git::commit=tags/v$VER::https://github.com/Pingus/pingus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8592"

--- a/app-multimedia/cli-visualizer/spec
+++ b/app-multimedia/cli-visualizer/spec
@@ -1,5 +1,5 @@
 VER=1.8
 REL=2
-SRCS="tbl::https://github.com/dpayne/cli-visualizer/archive/v$VER.tar.gz"
+SRCS="tbl::https://web.archive.org/web/20200929213701/https://github.com/dpayne/cli-visualizer/archive/v$VER.tar.gz"
 CHKSUMS="sha256::927e4c18403c7a40397e8698ffefd1b37250be20fa0ec55fda9a82cf9cc8ba51"
 CHKUPDATE="anitya::id=230649"

--- a/app-multimedia/qmpdclient/autobuild/defines
+++ b/app-multimedia/qmpdclient/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="qmpdclient"
 PKGDES="A Qt4 client for MPD"
 PKGDEP="qt-4"
-PKGSEC="multimedia"
+PKGSEC=sound
 BUILDDEP="cmake"
 
 CMAKE_AFTER="-DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt4"

--- a/app-multimedia/qmpdclient/spec
+++ b/app-multimedia/qmpdclient/spec
@@ -1,5 +1,5 @@
 VER=1.2.2
-SRCS="tbl::https://dump.bitcheese.net/files/qmpdclient-$VER.tar.bz2"
-CHKSUMS="sha256::ed65705eaae8fb10fdce34ce20e010757a87423c2874479e1466e4368a866289"
-REL=2
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/ChaoticEnigma/qmpdclient"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8933"

--- a/app-network/quicktun/spec
+++ b/app-network/quicktun/spec
@@ -1,5 +1,5 @@
 VER=2.2.5
-REL=1
-SRCS="tbl::http://oss.ucis.nl/quicktun/src/quicktun-$VER.tgz"
-CHKSUMS="sha256::6c89c2f97309262857a2924273950e86f128408bced813fc0e1e85757529be36"
+REL=2
+SRCS="git::commit=tags/V$VER::https://github.com/UCIS/QuickTun"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230990"

--- a/app-network/slurm/spec
+++ b/app-network/slurm/spec
@@ -1,4 +1,5 @@
 VER=0.4.4
-SRCS="tbl::https://github.com/mattthias/slurm/archive/upstream/$VER.tar.gz"
-CHKSUMS="sha256::36cf8f5ff15c6b954d08efc4b399638c1e641bd57cf2993bda20171b607aeb88"
+REL=1
+SRCS="git::commit=tags/upstream/${VER}::https://github.com/mattthias/slurm.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=90583"

--- a/app-utils/cd-discid/spec
+++ b/app-utils/cd-discid/spec
@@ -1,6 +1,5 @@
 VER=1.4
-REL=2
-
-SRCS="tbl::http://linukz.org/download/cd-discid-$VER.tar.gz"
-CHKSUMS="sha256::ffd68cd406309e764be6af4d5cbcc309e132c13f3597c6a4570a1f218edd2c63"
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/taem/cd-discid.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=260"

--- a/app-utils/dieharder/spec
+++ b/app-utils/dieharder/spec
@@ -1,5 +1,5 @@
 VER=3.31.1
 REL=1
-SRCS="tbl::https://www.phy.duke.edu/~rgb/General/dieharder/dieharder-$VER.tgz"
+SRCS="tbl::http://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-$VER.tgz"
 CHKSUMS="sha256::6cff0ff8394c553549ac7433359ccfc955fb26794260314620dfa5e4cd4b727f"
 CHKUPDATE="anitya::id=21416"

--- a/app-utils/fakeroot/spec
+++ b/app-utils/fakeroot/spec
@@ -1,4 +1,5 @@
 VER=1.37
-SRCS="tbl::https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fakeroot/fakeroot_$VER.orig.tar.gz"
-CHKSUMS="sha256::9831cc912bc1da6dadac15699c5a07a82c00d6f0dd5c15ec02e20908dd527d3a"
+REL=1
+SRCS="git::commit=tags/upstream/$VER::https://salsa.debian.org/clint/fakeroot.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12048"

--- a/desktop-gnome/libgnomekbd/spec
+++ b/desktop-gnome/libgnomekbd/spec
@@ -1,4 +1,5 @@
 VER=3.28.1
-SRCS="tbl::https://ftp.acc.umu.se/pub/gnome/sources/libgnomekbd/${VER:0:4}/libgnomekbd-$VER.tar.xz"
-CHKSUMS="sha256::22dc59566d73c0065350f5a97340e62ecc7b08c4df19183804bb8be24c8fe870"
+REL=1
+SRCS="git::commit=$VER::https://gitlab.gnome.org/Archive/libgnomekbd.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228580"

--- a/desktop-themes/classic-plymouth/spec
+++ b/desktop-themes/classic-plymouth/spec
@@ -1,4 +1,4 @@
 VER=0git20141027
 REL=1
-SRCS="git::commit=::https://github.com/AOSC-Dev/Classic-Plymouth"
+SRCS="git::commit=9ff1e67ff9152a7d9ce73c1e5189b1449e6b2a3c::https://github.com/AOSC-Dev/Classic-Plymouth"
 CHKSUMS="SKIP"

--- a/lang-python/distlib/spec
+++ b/lang-python/distlib/spec
@@ -1,5 +1,5 @@
 VER=0.3.1
-REL=2
-SRCS="https://bitbucket.org/pypa/distlib/get/${VER}.tar.gz"
-CHKSUMS="sha256::01ed9bba4584498c239b604d89f23da1e1e6cfacdc4128ca18e16d0d1bde5595"
+REL=3
+SRCS="git::commit=tags/$VER::https://github.com/pypa/distlib.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=34504"

--- a/runtime-productivity/wv/spec
+++ b/runtime-productivity/wv/spec
@@ -1,5 +1,5 @@
 VER=1.2.9
-REL=2
-SRCS="tbl::https://www.abisource.com/downloads/wv/$VER/wv-$VER.tar.gz"
-CHKSUMS='sha256::4c730d3b325c0785450dd3a043eeb53e1518598c4f41f155558385dd2635c19d'
+REL=3
+SRCS="git::commit=tags/wv-${VER//./-}::https://github.com/AbiWord/wv"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5113"


### PR DESCRIPTION
Topic Description
-----------------

- cd-discid: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- slurm: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- qmpdclient: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- dieharder: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- quicktun: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- fakeroot: update SERCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- distlib: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- cli-visualizer: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- wv: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>
- pingus: update SRCS
    Signed-off-by: stydxm <stydxm@outlook.com>

... and 2 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libgnomekbd wv distlib fakeroot quicktun qmpdclient slurm cd-discid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
