### PR TITLE
libodfgen: update to 0.1.8

### DIFF
--- a/runtime-productivity/libodfgen/autobuild/defines
+++ b/runtime-productivity/libodfgen/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=libodfgen
 PKGSEC=libs
-PKGDEP="libwpd zlib librevenge"
-BUILDDEP="doxygen"
+PKGDEP="libwpd zlib librevenge boost"
 PKGDES="Library for generating documents in Open Document Format"
 
 ABSHADOW=no

--- a/runtime-productivity/libodfgen/spec
+++ b/runtime-productivity/libodfgen/spec
@@ -1,5 +1,5 @@
-VER=0.1.6
-REL=2
-SRCS="tbl::https://sourceforge.net/projects/libwpd/files/libodfgen/libodfgen-$VER/libodfgen-$VER.tar.gz"
-CHKSUMS="sha256::33a32799d0d871f53a9774f444aa165f184d57c5bc5c93ea1947a24f94b9acf2"
+VER=0.1.8
+SRCS="git::commit=tags/libodfgen-$VER::git://git.code.sf.net/p/libwpd/libodfgen"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15131"
+ENVREQ="total_mem_per_core=1"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: bump REL
    Signed-off-by: stydxm <stydxm@outlook.com>
- libodfgen: update to 0.1.8
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libodfgen libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
