### PR TITLE
autofs: backport upstream patches to fix build error

### DIFF
--- a/app-admin/autofs/autobuild/patches/0001-BACKPORT-Update-configure-script.patch
+++ b/app-admin/autofs/autobuild/patches/0001-BACKPORT-Update-configure-script.patch
@@ -1,0 +1,257 @@
+From a63b1cbfca1a2802d4c89d40e34b52564a56f947 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 01/19] BACKPORT: Update configure script.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ configure | 92 +++++++++++++++++++++++++++----------------------------
+ 1 file changed, 46 insertions(+), 46 deletions(-)
+
+diff --git a/configure b/configure
+index d9b94b3..3dc07f6 100755
+--- a/configure
++++ b/configure
+@@ -2437,8 +2437,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ # for pkg-config macros
+-# pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
+-# serial 11 (pkg-config-0.29.1)
++# pkg.m4 - Macros to locate and use pkg-config.   -*- Autoconf -*-
++# serial 12 (pkg-config-0.29.2)
+ 
+ 
+ 
+@@ -3706,8 +3706,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ pkg_failed=no
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for systemd" >&5
+-printf %s "checking for systemd... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libsystemd" >&5
++printf %s "checking for libsystemd... " >&6; }
+ 
+ if test -n "$systemd_CFLAGS"; then
+     pkg_cv_systemd_CFLAGS="$systemd_CFLAGS"
+@@ -3747,7 +3747,7 @@ fi
+ 
+ 
+ if test $pkg_failed = yes; then
+-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+ if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+@@ -3756,12 +3756,12 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        systemd_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libsystemd" 2>&1`
++                systemd_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libsystemd" 2>&1`
+         else
+-	        systemd_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libsystemd" 2>&1`
++                systemd_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libsystemd" 2>&1`
+         fi
+-	# Put the nasty error message in config.log where it belongs
+-	echo "$systemd_PKG_ERRORS" >&5
++        # Put the nasty error message in config.log where it belongs
++        echo "$systemd_PKG_ERRORS" >&5
+ 
+ 
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sm_notify in -lsystemd" >&5
+@@ -3807,7 +3807,7 @@ fi
+ 
+ 
+ elif test $pkg_failed = untried; then
+-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sm_notify in -lsystemd" >&5
+@@ -3853,8 +3853,8 @@ fi
+ 
+ 
+ else
+-	systemd_CFLAGS=$pkg_cv_systemd_CFLAGS
+-	systemd_LIBS=$pkg_cv_systemd_LIBS
++        systemd_CFLAGS=$pkg_cv_systemd_CFLAGS
++        systemd_LIBS=$pkg_cv_systemd_LIBS
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+ 
+@@ -3997,8 +3997,8 @@ fi
+ if test "x$with_libtirpc" = "xyes"; then
+ 
+ pkg_failed=no
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for TIRPC" >&5
+-printf %s "checking for TIRPC... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libtirpc" >&5
++printf %s "checking for libtirpc... " >&6; }
+ 
+ if test -n "$TIRPC_CFLAGS"; then
+     pkg_cv_TIRPC_CFLAGS="$TIRPC_CFLAGS"
+@@ -4038,7 +4038,7 @@ fi
+ 
+ 
+ if test $pkg_failed = yes; then
+-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+ if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+@@ -4047,14 +4047,14 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        TIRPC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtirpc" 2>&1`
++                TIRPC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtirpc" 2>&1`
+         else
+-	        TIRPC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtirpc" 2>&1`
++                TIRPC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtirpc" 2>&1`
+         fi
+-	# Put the nasty error message in config.log where it belongs
+-	echo "$TIRPC_PKG_ERRORS" >&5
++        # Put the nasty error message in config.log where it belongs
++        echo "$TIRPC_PKG_ERRORS" >&5
+ 
+-	as_fn_error $? "Package requirements (libtirpc) were not met:
++        as_fn_error $? "Package requirements (libtirpc) were not met:
+ 
+ $TIRPC_PKG_ERRORS
+ 
+@@ -4065,9 +4065,9 @@ Alternatively, you may set the environment variables TIRPC_CFLAGS
+ and TIRPC_LIBS to avoid the need to call pkg-config.
+ See the pkg-config man page for more details." "$LINENO" 5
+ elif test $pkg_failed = untried; then
+-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+ printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+ is in your PATH or set the PKG_CONFIG environment variable to the full
+@@ -4080,8 +4080,8 @@ See the pkg-config man page for more details.
+ To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+ See \`config.log' for more details" "$LINENO" 5; }
+ else
+-	TIRPC_CFLAGS=$pkg_cv_TIRPC_CFLAGS
+-	TIRPC_LIBS=$pkg_cv_TIRPC_LIBS
++        TIRPC_CFLAGS=$pkg_cv_TIRPC_CFLAGS
++        TIRPC_LIBS=$pkg_cv_TIRPC_LIBS
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+ 
+@@ -4812,8 +4812,8 @@ fi
+ # LDAP SASL auth needs libxml and Kerberos
+ 
+ pkg_failed=no
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XML" >&5
+-printf %s "checking for XML... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libxml-2.0" >&5
++printf %s "checking for libxml-2.0... " >&6; }
+ 
+ if test -n "$XML_CFLAGS"; then
+     pkg_cv_XML_CFLAGS="$XML_CFLAGS"
+@@ -4853,7 +4853,7 @@ fi
+ 
+ 
+ if test $pkg_failed = yes; then
+-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+ if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+@@ -4862,21 +4862,21 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        XML_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libxml-2.0" 2>&1`
++                XML_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libxml-2.0" 2>&1`
+         else
+-	        XML_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libxml-2.0" 2>&1`
++                XML_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libxml-2.0" 2>&1`
+         fi
+-	# Put the nasty error message in config.log where it belongs
+-	echo "$XML_PKG_ERRORS" >&5
++        # Put the nasty error message in config.log where it belongs
++        echo "$XML_PKG_ERRORS" >&5
+ 
+-	HAVE_LIBXML=0
++        HAVE_LIBXML=0
+ elif test $pkg_failed = untried; then
+-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+-	HAVE_LIBXML=0
++        HAVE_LIBXML=0
+ else
+-	XML_CFLAGS=$pkg_cv_XML_CFLAGS
+-	XML_LIBS=$pkg_cv_XML_LIBS
++        XML_CFLAGS=$pkg_cv_XML_CFLAGS
++        XML_LIBS=$pkg_cv_XML_LIBS
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+ 
+@@ -5079,8 +5079,8 @@ fi
+ 
+ 
+ pkg_failed=no
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for NSL" >&5
+-printf %s "checking for NSL... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libnsl" >&5
++printf %s "checking for libnsl... " >&6; }
+ 
+ if test -n "$NSL_CFLAGS"; then
+     pkg_cv_NSL_CFLAGS="$NSL_CFLAGS"
+@@ -5120,7 +5120,7 @@ fi
+ 
+ 
+ if test $pkg_failed = yes; then
+-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+ if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+@@ -5129,12 +5129,12 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        NSL_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libnsl" 2>&1`
++                NSL_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libnsl" 2>&1`
+         else
+-	        NSL_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libnsl" 2>&1`
++                NSL_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libnsl" 2>&1`
+         fi
+-	# Put the nasty error message in config.log where it belongs
+-	echo "$NSL_PKG_ERRORS" >&5
++        # Put the nasty error message in config.log where it belongs
++        echo "$NSL_PKG_ERRORS" >&5
+ 
+ 
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for yp_match in -lnsl" >&5
+@@ -5181,7 +5181,7 @@ fi
+ NSL_CFLAGS=""
+ 
+ elif test $pkg_failed = untried; then
+-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ 
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for yp_match in -lnsl" >&5
+@@ -5228,8 +5228,8 @@ fi
+ NSL_CFLAGS=""
+ 
+ else
+-	NSL_CFLAGS=$pkg_cv_NSL_CFLAGS
+-	NSL_LIBS=$pkg_cv_NSL_LIBS
++        NSL_CFLAGS=$pkg_cv_NSL_CFLAGS
++        NSL_LIBS=$pkg_cv_NSL_LIBS
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+ 
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0002-BACKPORT-autofs-5.1.9-fix-ldap_parse_page_control-ch.patch
+++ b/app-admin/autofs/autobuild/patches/0002-BACKPORT-autofs-5.1.9-fix-ldap_parse_page_control-ch.patch
@@ -1,0 +1,60 @@
+From 599c3b5c15b35a8a8fdbbb671310485289addee8 Mon Sep 17 00:00:00 2001
+From: David Disseldorp <ddiss@suse.de>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 02/19] BACKPORT: autofs-5.1.9 - fix ldap_parse_page_control()
+ check
+
+The final @cookie parameter should be a struct berval ** type. The
+check currently fails when -Werror=incompatible-pointer-types is set:
+
+conftest.c: In function 'main':
+conftest.c:54:47: error: passing argument 4 of 'ldap_parse_page_control'
+from incompatible pointer type [-Werror=incompatible-pointer-types]
+   54 |       ret = ldap_parse_page_control(ld,clp,ct,c);
+      |                                               ^
+      |                                               |
+      |                                               struct berval *
+In file included from /usr/include/lber_types.h:24,
+                 from /usr/include/lber.h:29,
+                 from /usr/include/ldap.h:30,
+                 from conftest.c:45:
+/usr/include/ldap.h:2155:25: note: expected 'struct berval **' but
+argument is of type 'struct berval *'
+ 2155 | ldap_parse_page_control LDAP_P((
+
+Signed-off-by: David Disseldorp <ddiss@suse.de>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ aclocal.m4 | 2 +-
+ configure  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/aclocal.m4 b/aclocal.m4
+index 1046d72..fa18eb1 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -424,7 +424,7 @@ AC_LINK_IFELSE(
+       #include <ldap.h> ]],
+    [[ LDAP *ld;
+       ber_int_t *ct;
+-      struct berval *c;
++      struct berval **c;
+       int ret;
+       LDAPControl **clp;
+       ret = ldap_parse_page_control(ld,clp,ct,c); ]])],
+diff --git a/configure b/configure
+index 3dc07f6..22ac5e1 100755
+--- a/configure
++++ b/configure
+@@ -5653,7 +5653,7 @@ main (void)
+ {
+  LDAP *ld;
+       ber_int_t *ct;
+-      struct berval *c;
++      struct berval **c;
+       int ret;
+       LDAPControl **clp;
+       ret = ldap_parse_page_control(ld,clp,ct,c);
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0003-BACKPORT-autofs-5.1.9-fix-crash-in-make_options_stri.patch
+++ b/app-admin/autofs/autobuild/patches/0003-BACKPORT-autofs-5.1.9-fix-crash-in-make_options_stri.patch
@@ -1,0 +1,105 @@
+From fd8396d55698cfc1234e35b7b7b13fc30eb71ec0 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 03/19] BACKPORT: autofs-5.1.9 - fix crash in
+ make_options_string()
+
+glibc reports a memory overflow when make_options_string() in snprintf()
+As described by Andreas Hasenack on the autofs mailing list this is due
+to my incorrect use of max_len in snprintf(), it should in fact be
+max_len - <length of buffer already used>.
+
+Anyway looking at the calculated maximum options string length there's
+no actual overflow possible.
+
+To fix this use strcat(3) instead of snprintf(), in this case there's
+probably less overhead anyway. While we are at it drop the useless error
+checks because we know it won't overflow.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ lib/mounts.c | 35 +++++++++--------------------------
+ 1 file changed, 9 insertions(+), 26 deletions(-)
+
+diff --git a/lib/mounts.c b/lib/mounts.c
+index 05f18db..7680c59 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -695,10 +695,11 @@ static int cacl_max_options_len(unsigned int flags)
+ 	unsigned int kver_minor = get_kver_minor();
+ 	int max_len;
+ 
+-	/* %d and %u are maximum lenght of 10 and mount type is maximum
+-	 * length of 9 (e. ",indirect").
++	/* %d and %u are maximum length of 10 and mount type is maximum
++	 * length of 9 (ie. ",indirect").
+ 	 * The base temaplate is "fd=%d,pgrp=%u,minproto=5,maxproto=%d"
+-	 * plus the length of mount type plus 1 for the NULL.
++	 * plus the length of mount type plus 1 for the NULL (and an
++	 * additional 10 characters for good measure!).
+ 	 */
+ 	max_len = 79 + 1;
+ 
+@@ -728,7 +729,7 @@ char *make_options_string(char *path, int pipefd,
+ 	unsigned int kver_major = get_kver_major();
+ 	unsigned int kver_minor = get_kver_minor();
+ 	char *options;
+-	int max_len, len, new;
++	int max_len, len;
+ 
+ 	max_len = cacl_max_options_len(flags);
+ 
+@@ -751,21 +752,13 @@ char *make_options_string(char *path, int pipefd,
+ 	if (len < 0)
+ 		goto error_out;
+ 
+-	if (len >= max_len)
+-		goto truncated;
+-
+ 	if (kver_major < 5 || (kver_major == 5 && kver_minor < 4))
+ 		goto out;
+ 
+ 	/* maybe add ",strictexpire" */
+ 	if (flags & MOUNT_FLAG_STRICTEXPIRE) {
+-		new = snprintf(options + len,
+-			       max_len, "%s", ",strictexpire");
+-		if (new < 0)
+-		       goto error_out;
+-		len += new;
+-		if (len >= max_len)
+-			goto truncated;
++		strcat(options, ",strictexpire");
++		len += 13;
+ 	}
+ 
+ 	if (kver_major == 5 && kver_minor < 5)
+@@ -773,23 +766,13 @@ char *make_options_string(char *path, int pipefd,
+ 
+ 	/* maybe add ",ignore" */
+ 	if (flags & MOUNT_FLAG_IGNORE) {
+-		new = snprintf(options + len,
+-			       max_len, "%s", ",ignore");
+-		if (new < 0)
+-		       goto error_out;
+-		len += new;
+-		if (len >= max_len)
+-			goto truncated;
++		strcat(options, ",ignore");
++		len += 7;
+ 	}
+ out:
+ 	options[len] = '\0';
+ 	return options;
+ 
+-truncated:
+-	logerr("buffer to small for options - truncated");
+-	len = max_len -1;
+-	goto out;
+-
+ error_out:
+ 	logerr("error constructing mount options string for %s", path);
+ 	free(options);
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0004-BACKPORT-autofs-5.1.9-Fix-incompatible-function-poin.patch
+++ b/app-admin/autofs/autobuild/patches/0004-BACKPORT-autofs-5.1.9-Fix-incompatible-function-poin.patch
@@ -1,0 +1,60 @@
+From 954d9564f95af96c31cd6e2f121355da4694a213 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 04/19] BACKPORT: autofs-5.1.9 - Fix incompatible function
+ pointer types in cyrus-sasl module
+
+Add casts to SASL callbacks to avoid incompatible-pointer-types
+errors.  Avoids a build failure with stricter compilers.
+
+Signed-off-by: Florian Weimer <fweimer@redhat.com>
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG            |  2 ++
+ modules/cyrus-sasl.c | 14 +++++++-------
+ 2 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 3e47daa..fd9d861 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,4 +1,6 @@
+ 
++- Fix incompatible function pointer types in cyrus-sasl module.
++
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+ - fix fedfs build flags.
+diff --git a/modules/cyrus-sasl.c b/modules/cyrus-sasl.c
+index e742eaf..78b7794 100644
+--- a/modules/cyrus-sasl.c
++++ b/modules/cyrus-sasl.c
+@@ -109,17 +109,17 @@ static int getpass_func(sasl_conn_t *, void *, int, sasl_secret_t **);
+ static int getuser_func(void *, int, const char **, unsigned *);
+ 
+ static sasl_callback_t callbacks[] = {
+-	{ SASL_CB_USER, &getuser_func, NULL },
+-	{ SASL_CB_AUTHNAME, &getuser_func, NULL },
+-	{ SASL_CB_PASS, &getpass_func, NULL },
++	{ SASL_CB_USER, (int(*)(void)) &getuser_func, NULL },
++	{ SASL_CB_AUTHNAME, (int(*)(void)) &getuser_func, NULL },
++	{ SASL_CB_PASS, (int(*)(void)) &getpass_func, NULL },
+ 	{ SASL_CB_LIST_END, NULL, NULL },
+ };
+ 
+ static sasl_callback_t debug_callbacks[] = {
+-	{ SASL_CB_LOG, &sasl_log_func, NULL },
+-	{ SASL_CB_USER, &getuser_func, NULL },
+-	{ SASL_CB_AUTHNAME, &getuser_func, NULL },
+-	{ SASL_CB_PASS, &getpass_func, NULL },
++	{ SASL_CB_LOG, (int(*)(void)) &sasl_log_func, NULL },
++	{ SASL_CB_USER, (int(*)(void)) &getuser_func, NULL },
++	{ SASL_CB_AUTHNAME, (int(*)(void)) &getuser_func, NULL },
++	{ SASL_CB_PASS, (int(*)(void)) &getpass_func, NULL },
+ 	{ SASL_CB_LIST_END, NULL, NULL },
+ };
+ 
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0005-BACKPORT-autofs-5.1.9-fix-always-recreate-credential.patch
+++ b/app-admin/autofs/autobuild/patches/0005-BACKPORT-autofs-5.1.9-fix-always-recreate-credential.patch
@@ -1,0 +1,45 @@
+From 3924d9624d8e3884b543dca7d44ae2e7fe09475c Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 05/19] BACKPORT: autofs-5.1.9 - fix always recreate credential
+ cache
+
+When I aplied the original patch from Ian Collier for this I changed
+the credential end time comparison to be against the time returned from
+monotomic_time(). But this isn't the same as the calander time returned
+from time() which Ian used in his original patch.
+
+Signed-off-by: Ian Kent < raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG            | 1 +
+ modules/cyrus-sasl.c | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index fd9d861..3fe6b63 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,5 +1,6 @@
+ 
+ - Fix incompatible function pointer types in cyrus-sasl module.
++- fix always recreate credential cache.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/cyrus-sasl.c b/modules/cyrus-sasl.c
+index 78b7794..69e613b 100644
+--- a/modules/cyrus-sasl.c
++++ b/modules/cyrus-sasl.c
+@@ -676,7 +676,7 @@ sasl_do_kinit(unsigned logopt, struct lookup_context *ctxt)
+ 	}
+ 	else {
+ 		krb5_creds match_creds, out_creds;
+-		time_t now = monotonic_time(NULL);
++		time_t now = time(NULL);
+ 
+ 		/* even if the cache is in use, we will clear it if it
+ 		 * contains an expired credential for our principal,
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0006-BACKPORT-autofs-5.1.9-fix-changelog.patch
+++ b/app-admin/autofs/autobuild/patches/0006-BACKPORT-autofs-5.1.9-fix-changelog.patch
@@ -1,0 +1,28 @@
+From 133017a396fb001b03bd375df0ad6f9e8b19a0ee Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 06/19] BACKPORT: autofs-5.1.9 - fix changelog
+
+Add missed changelog entries.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 3fe6b63..505993f 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,4 +1,7 @@
+ 
++- Update configure script.
++- fix ldap_parse_page_control() check.
++- fix crash in make_options_string().
+ - Fix incompatible function pointer types in cyrus-sasl module.
+ - fix always recreate credential cache.
+ 
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0007-BACKPORT-autofs-5.1.9-fix-amd-external-mount-error-h.patch
+++ b/app-admin/autofs/autobuild/patches/0007-BACKPORT-autofs-5.1.9-fix-amd-external-mount-error-h.patch
@@ -1,0 +1,65 @@
+From 52ccde99568558f5f0c72c07aaea2812dd94f6c4 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 07/19] BACKPORT: autofs-5.1.9 - fix amd external mount error
+ handling
+
+An amd program mount might have defined its own umount program to be used
+for external mounts.
+
+In mount failure cases where the mount needs to be umounted be sure to
+use the custom umount if there is one.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           | 1 +
+ modules/parse_amd.c | 6 +++---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 505993f..ba2fc56 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -4,6 +4,7 @@
+ - fix crash in make_options_string().
+ - Fix incompatible function pointer types in cyrus-sasl module.
+ - fix always recreate credential cache.
++- fix amd external mount error handling.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index fb6b1b7..e54c6ca 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1190,7 +1190,7 @@ static int do_generic_mount(struct autofs_point *ap, const char *name,
+ 		}
+ 		/* If we have an external mount add it to the list */
+ 		if (umount && !ext_mount_add(entry->fs, entry->umount)) {
+-			umount_ent(ap, entry->fs);
++			umount_amd_ext_mount(ap, entry->fs);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s",
+ 			      entry->fs);
+@@ -1240,7 +1240,7 @@ static int do_nfs_mount(struct autofs_point *ap, const char *name,
+ 		}
+ 		/* We might be using an external mount */
+ 		if (umount && !ext_mount_add(entry->fs, entry->umount)) {
+-			umount_ent(ap, entry->fs);
++			umount_amd_ext_mount(ap, entry->fs);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s", entry->fs);
+ 			ret = 1;
+@@ -1469,7 +1469,7 @@ static int do_program_mount(struct autofs_point *ap,
+ 				     "%s: mounted %s", entry->type, entry->fs);
+ 				goto do_free;
+ 			}
+-			umount_ent(ap, entry->fs);
++			umount_amd_ext_mount(ap, entry->fs);
+ 		}
+ 
+ 		if (!ext_mount_inuse(entry->fs))
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0008-BACKPORT-autofs-5.1.9-fix-amd-external-mount-mount-h.patch
+++ b/app-admin/autofs/autobuild/patches/0008-BACKPORT-autofs-5.1.9-fix-amd-external-mount-mount-h.patch
@@ -1,0 +1,81 @@
+From 07dee79df45cfce5ccaac656f9117b4bf6924ce8 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 08/19] BACKPORT: autofs-5.1.9 - fix amd external mount mount
+ handling
+
+Amd external mounts exist outside of the autofs file system and need
+extra effort to try and keep track of them so they are mounted and
+umounted when they should be.
+
+Cleanup cases where an external mount is already mounted.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ modules/parse_amd.c | 21 ++++++++++++---------
+ 2 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index ba2fc56..e7c78f9 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -5,6 +5,7 @@
+ - Fix incompatible function pointer types in cyrus-sasl module.
+ - fix always recreate credential cache.
+ - fix amd external mount error handling.
++- fix amd external mount mount handling.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index e54c6ca..517940c 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1189,8 +1189,9 @@ static int do_generic_mount(struct autofs_point *ap, const char *name,
+ 			umount = 1;
+ 		}
+ 		/* If we have an external mount add it to the list */
+-		if (umount && !ext_mount_add(entry->fs, entry->umount)) {
+-			umount_amd_ext_mount(ap, entry->fs);
++		if (!ext_mount_add(entry->fs, entry->umount)) {
++			if (umount)
++				umount_amd_ext_mount(ap, entry->fs);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s",
+ 			      entry->fs);
+@@ -1239,8 +1240,9 @@ static int do_nfs_mount(struct autofs_point *ap, const char *name,
+ 			umount = 1;
+ 		}
+ 		/* We might be using an external mount */
+-		if (umount && !ext_mount_add(entry->fs, entry->umount)) {
+-			umount_amd_ext_mount(ap, entry->fs);
++		if (!ext_mount_add(entry->fs, entry->umount)) {
++			if (umount)
++				umount_amd_ext_mount(ap, entry->fs);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s", entry->fs);
+ 			ret = 1;
+@@ -1442,12 +1444,13 @@ static int do_program_mount(struct autofs_point *ap,
+ 	 * before executing the mount command and removing it at
+ 	 * umount.
+ 	 */
+-	if (ext_mount_inuse(entry->fs)) {
++	if (is_mounted(entry->fs, MNTS_REAL)) {
++		if (!ext_mount_add(entry->fs, entry->umount)) {
++			error(ap->logopt, MODPREFIX
++			      "error: could not add external mount %s", entry->fs);
++			goto out;
++		}
+ 		rv = 0;
+-		/* An external mount with path entry->fs exists
+-		 * so ext_mount_add() won't fail.
+-		 */
+-		ext_mount_add(entry->fs, entry->umount);
+ 	} else {
+ 		rv = mkdir_path(entry->fs, mp_mode);
+ 		if (rv && errno != EEXIST) {
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0009-BACKPORT-autofs-5.1.9-don-t-free-ext-mount-if-mounte.patch
+++ b/app-admin/autofs/autobuild/patches/0009-BACKPORT-autofs-5.1.9-don-t-free-ext-mount-if-mounte.patch
@@ -1,0 +1,63 @@
+From b531bb32b6952f828c19719d625db9024c22b099 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 09/19] BACKPORT: autofs-5.1.9 - don't free ext mount if
+ mounted
+
+If an external mount is in use when a umount is attempted don't free
+it just let the reference count go to zero.
+
+This will leave the mount in place and it won't get umounted. But if
+another automount uses it it's reference count will become no zero
+allowing for it to be umounted as normal if it isn't in use during
+automount expire.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG    | 1 +
+ lib/mounts.c | 8 ++++----
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index e7c78f9..07d1e38 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -6,6 +6,7 @@
+ - fix always recreate credential cache.
+ - fix amd external mount error handling.
+ - fix amd external mount mount handling.
++- don't free ext mount if mounted.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/lib/mounts.c b/lib/mounts.c
+index 7680c59..9a12dbf 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -889,10 +889,10 @@ int ext_mount_remove(const char *path)
+ 	if (!em)
+ 		goto done;
+ 
+-	em->ref--;
+ 	if (em->ref)
+-		goto done;
+-	else {
++		em->ref--;
++
++	if (!em->ref && !is_mounted(path, MNTS_REAL)) {
+ 		hlist_del_init(&em->mount);
+ 		free(em->mp);
+ 		if (em->umount)
+@@ -914,7 +914,7 @@ int ext_mount_inuse(const char *path)
+ 	em = ext_mount_lookup(path);
+ 	if (!em)
+ 		goto done;
+-	ret = em->ref;
++	ret = 1;
+ done:
+ 	ext_mount_hash_mutex_unlock();
+ 	return ret;
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0010-BACKPORT-autofs-5.1.9-refactor-amd-function-do_progr.patch
+++ b/app-admin/autofs/autobuild/patches/0010-BACKPORT-autofs-5.1.9-refactor-amd-function-do_progr.patch
@@ -1,0 +1,148 @@
+From 6b6c838d8e2f6738131fc5aba0005c91d1f2a016 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 10/19] BACKPORT: autofs-5.1.9 - refactor amd function
+ do_program_mount()
+
+The amd mounts function do_program_mount() is particularly untidy.
+
+Refactor it to make it a little simpler and to take advantage of the
+coming refactoring of the funtion umount_amd_ext_mount().
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ modules/parse_amd.c | 74 +++++++++++++++++++++------------------------
+ 2 files changed, 36 insertions(+), 39 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 07d1e38..07ed247 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -7,6 +7,7 @@
+ - fix amd external mount error handling.
+ - fix amd external mount mount handling.
+ - don't free ext mount if mounted.
++- refactor amd function do_program_mount().
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index 517940c..4d98fb0 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1414,26 +1414,8 @@ out:
+ static int do_program_mount(struct autofs_point *ap,
+ 			    struct amd_entry *entry, const char *name)
+ {
+-	char *prog, *str;
+-	char **argv;
+-	int argc = -1;
+ 	int rv = 1;
+ 
+-	str = strdup(entry->mount);
+-	if (!str)
+-		goto out;
+-
+-	prog = NULL;
+-	argv = NULL;
+-
+-	argc = construct_argv(str, &prog, &argv);
+-	if (argc == -1) {
+-		error(ap->logopt, MODPREFIX
+-		      "%s: error creating mount arguments", entry->type);
+-		free(str);
+-		goto out;
+-	}
+-
+ 	/* The am-utils documentation doesn't actually say that the
+ 	 * mount (and umount, if given) command need to use ${fs} as
+ 	 * the mount point in the command.
+@@ -1452,6 +1434,25 @@ static int do_program_mount(struct autofs_point *ap,
+ 		}
+ 		rv = 0;
+ 	} else {
++		char *prog, *str;
++		char **argv;
++		int argc = -1;
++
++		str = strdup(entry->mount);
++		if (!str)
++			goto out;
++
++		prog = NULL;
++		argv = NULL;
++
++		argc = construct_argv(str, &prog, &argv);
++		if (argc == -1) {
++			error(ap->logopt, MODPREFIX
++			      "%s: error creating mount arguments", entry->type);
++			free(str);
++			goto out;
++		}
++
+ 		rv = mkdir_path(entry->fs, mp_mode);
+ 		if (rv && errno != EEXIST) {
+ 			char buf[MAX_ERR_BUF];
+@@ -1461,7 +1462,9 @@ static int do_program_mount(struct autofs_point *ap,
+ 			error(ap->logopt,
+ 			      MODPREFIX "%s: mkdir_path %s failed: %s",
+ 			      entry->type, entry->fs, estr);
+-			goto do_free;
++			free_argv(argc, (const char **) argv);
++			free(str);
++			goto out;
+ 		}
+ 
+ 		rv = spawnv(ap->logopt, prog, (const char * const *) argv);
+@@ -1470,33 +1473,26 @@ static int do_program_mount(struct autofs_point *ap,
+ 				rv = 0;
+ 				debug(ap->logopt, MODPREFIX
+ 				     "%s: mounted %s", entry->type, entry->fs);
+-				goto do_free;
++				free_argv(argc, (const char **) argv);
++				free(str);
++				goto done;
+ 			}
+ 			umount_amd_ext_mount(ap, entry->fs);
+ 		}
+-
+-		if (!ext_mount_inuse(entry->fs))
+-			rmdir_path(ap, entry->fs, ap->dev);
+ 		error(ap->logopt, MODPREFIX
+ 		   "%s: failed to mount using %s", entry->type, entry->mount);
+-	}
+-do_free:
+-	free_argv(argc, (const char **) argv);
+-	free(str);
+-
+-	if (rv)
++		free_argv(argc, (const char **) argv);
++		free(str);
+ 		goto out;
+-
++	}
++done:
+ 	rv = do_link_mount(ap, name, entry, 0);
+-	if (!rv)
+-		goto out;
+-
+-	if (umount_amd_ext_mount(ap, entry->fs)) {
+-		if (!ext_mount_inuse(entry->fs))
+-			rmdir_path(ap, entry->fs, ap->dev);
+-		debug(ap->logopt, MODPREFIX
+-		      "%s: failed to umount external mount at %s",
+-		      entry->type, entry->fs);
++	if (rv) {
++		if (umount_amd_ext_mount(ap, entry->fs)) {
++			debug(ap->logopt, MODPREFIX
++			      "%s: failed to cleanup external mount at %s",
++			      entry->type, entry->fs);
++		}
+ 	}
+ out:
+ 	return rv;
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0011-BACKPORT-autofs-5.1.9-refactor-amd-function-umount_a.patch
+++ b/app-admin/autofs/autobuild/patches/0011-BACKPORT-autofs-5.1.9-refactor-amd-function-umount_a.patch
@@ -1,0 +1,258 @@
+From b4e776f2b61b4fea6ce77512830f49f0bbaddbbd Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 11/19] BACKPORT: autofs-5.1.9 - refactor amd function
+ umount_amd_ext_mount()
+
+The amd mounts function umount_amd_ext_mount() needs some improvement.
+
+Make sure the function returns true for success and false for failure
+and add a parameter to control if the expternal mount reference should
+be decremented on successful umount.
+
+If the reference count of the external mount is greater than 1 there's
+some other mount using (symlink pointing to) it so don't try to umount
+it just return success.
+
+Also check for the case where the mount is already mounted.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ daemon/automount.c  |  4 +--
+ include/mounts.h    |  2 +-
+ lib/mounts.c        | 80 ++++++++++++++++++++++++++-------------------
+ modules/parse_amd.c | 10 +++---
+ 5 files changed, 56 insertions(+), 41 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 07ed247..bc15111 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -8,6 +8,7 @@
+ - fix amd external mount mount handling.
+ - don't free ext mount if mounted.
+ - refactor amd function do_program_mount().
++- refactor umount_amd_ext_mount().
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/daemon/automount.c b/daemon/automount.c
+index 6cb3b1b..474b29a 100644
+--- a/daemon/automount.c
++++ b/daemon/automount.c
+@@ -633,7 +633,7 @@ static int umount_subtree_mounts(struct autofs_point *ap, const char *path, unsi
+ 		/* Check for an external mount and umount if possible */
+ 		mnt = mnts_find_amdmount(path);
+ 		if (mnt) {
+-			umount_amd_ext_mount(ap, mnt->ext_mp);
++			umount_amd_ext_mount(ap, mnt->ext_mp, 1);
+ 			mnts_remove_amdmount(path);
+ 			mnts_put_mount(mnt);
+ 		}
+@@ -699,7 +699,7 @@ int umount_multi(struct autofs_point *ap, const char *path, int incl)
+ 		/* Check for an external mount and attempt umount if needed */
+ 		mnt = mnts_find_amdmount(path);
+ 		if (mnt) {
+-			umount_amd_ext_mount(ap, mnt->ext_mp);
++			umount_amd_ext_mount(ap, mnt->ext_mp, 1);
+ 			mnts_remove_amdmount(path);
+ 			mnts_put_mount(mnt);
+ 		}
+diff --git a/include/mounts.h b/include/mounts.h
+index 8e6f62a..381d120 100644
+--- a/include/mounts.h
++++ b/include/mounts.h
+@@ -199,7 +199,7 @@ int try_remount(struct autofs_point *, struct mapent *, unsigned int);
+ void set_indirect_mount_tree_catatonic(struct autofs_point *);
+ void set_direct_mount_tree_catatonic(struct autofs_point *, struct mapent *);
+ int umount_ent(struct autofs_point *, const char *);
+-int umount_amd_ext_mount(struct autofs_point *, const char *);
++int umount_amd_ext_mount(struct autofs_point *, const char *, int remove);
+ int clean_stale_multi_triggers(struct autofs_point *, struct mapent *, char *, const char *);
+ 
+ #endif
+diff --git a/lib/mounts.c b/lib/mounts.c
+index 9a12dbf..dda19a9 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -3078,37 +3078,62 @@ int umount_ent(struct autofs_point *ap, const char *path)
+ 	return mounted;
+ }
+ 
+-int umount_amd_ext_mount(struct autofs_point *ap, const char *path)
++int umount_amd_ext_mount(struct autofs_point *ap, const char *path, int remove)
+ {
+ 	struct ext_mount *em;
+ 	char *umount = NULL;
+-	char *mp;
++	char *mp = NULL;
+ 	int rv = 1;
++	int ret;
+ 
+ 	pthread_mutex_lock(&ext_mount_hash_mutex);
+-
+ 	em = ext_mount_lookup(path);
+ 	if (!em) {
+ 		pthread_mutex_unlock(&ext_mount_hash_mutex);
++		rv = 0;
+ 		goto out;
+ 	}
+ 	mp = strdup(em->mp);
+ 	if (!mp) {
+ 		pthread_mutex_unlock(&ext_mount_hash_mutex);
++		rv = 0;
+ 		goto out;
+ 	}
+ 	if (em->umount) {
+ 		umount = strdup(em->umount);
+ 		if (!umount) {
+ 			pthread_mutex_unlock(&ext_mount_hash_mutex);
+-			free(mp);
++			rv = 0;
+ 			goto out;
+ 		}
+ 	}
+-
++	/* Don't try and umount if there's more than one
++	 * user of the external mount.
++	 */
++	if (em->ref > 1) {
++		pthread_mutex_unlock(&ext_mount_hash_mutex);
++		if (!remove)
++			error(ap->logopt,
++			    "reference count mismatch, called with remove false");
++		else
++			ext_mount_remove(mp);
++		goto out;
++	}
++	/* This shouldn't happen ... */
++	if (!is_mounted(mp, MNTS_REAL)) {
++		pthread_mutex_unlock(&ext_mount_hash_mutex);
++		error(ap->logopt, "failed to umount program mount at %s", mp);
++		if (remove)
++			ext_mount_remove(mp);
++		goto out;
++	}
+ 	pthread_mutex_unlock(&ext_mount_hash_mutex);
+ 
+-	if (umount) {
++	if (!umount) {
++		ret = umount_ent(ap, mp);
++		if (ret)
++			rv = 0;
++	} else {
+ 		char *prog;
+ 		char **argv;
+ 		int argc = -1;
+@@ -3117,41 +3142,30 @@ int umount_amd_ext_mount(struct autofs_point *ap, const char *path)
+ 		argv = NULL;
+ 
+ 		argc = construct_argv(umount, &prog, &argv);
+-		if (argc == -1)
+-			goto done;
+-
+-		if (!ext_mount_remove(mp)) {
+-			rv =0;
+-			goto out_free;
+-		}
+-
+-		rv = spawnv(ap->logopt, prog, (const char * const *) argv);
+-		if (rv == -1 || (WIFEXITED(rv) && WEXITSTATUS(rv)))
++		if (argc == -1) {
+ 			error(ap->logopt,
+-			     "failed to umount program mount at %s", mp);
+-		else {
++			      "failed to allocate args for umount of %s", mp);
+ 			rv = 0;
+-			debug(ap->logopt, "umounted program mount at %s", mp);
+-			rmdir_path(ap, mp, ap->dev);
++			goto out;
+ 		}
+-out_free:
++		ret = spawnv(ap->logopt, prog, (const char * const *) argv);
++		rv = WIFEXITED(ret) && !WEXITSTATUS(ret);
+ 		free_argv(argc, (const char **) argv);
+-
+-		goto done;
+ 	}
+ 
+-	if (ext_mount_remove(mp)) {
+-		rv = umount_ent(ap, mp);
+-		if (rv)
+-			error(ap->logopt,
+-			      "failed to umount external mount %s", mp);
+-		else
+-			debug(ap->logopt, "umounted external mount %s", mp);
++	if (is_mounted(mp, MNTS_REAL))
++		error(ap->logopt,
++		      "failed to umount external mount %s", mp);
++	else {
++		info(ap->logopt, "umounted external mount %s", mp);
++		rmdir_path(ap, mp, ap->dev);
+ 	}
+-done:
++	if (remove)
++		ext_mount_remove(mp);
++out:
+ 	if (umount)
+ 		free(umount);
+-	free(mp);
+-out:
++	if (mp)
++		free(mp);
+ 	return rv;
+ }
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index 4d98fb0..41e4b2d 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1140,7 +1140,7 @@ symlink:
+ 
+ 	if (entry->sublink) {
+ 		/* failed to complete sublink mount */
+-		umount_amd_ext_mount(ap, entry->fs);
++		umount_amd_ext_mount(ap, entry->fs, 1);
+ 	}
+ out:
+ 	return ret;
+@@ -1191,7 +1191,7 @@ static int do_generic_mount(struct autofs_point *ap, const char *name,
+ 		/* If we have an external mount add it to the list */
+ 		if (!ext_mount_add(entry->fs, entry->umount)) {
+ 			if (umount)
+-				umount_amd_ext_mount(ap, entry->fs);
++				umount_amd_ext_mount(ap, entry->fs, 0);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s",
+ 			      entry->fs);
+@@ -1242,7 +1242,7 @@ static int do_nfs_mount(struct autofs_point *ap, const char *name,
+ 		/* We might be using an external mount */
+ 		if (!ext_mount_add(entry->fs, entry->umount)) {
+ 			if (umount)
+-				umount_amd_ext_mount(ap, entry->fs);
++				umount_amd_ext_mount(ap, entry->fs, 0);
+ 			error(ap->logopt, MODPREFIX
+ 			      "error: could not add external mount %s", entry->fs);
+ 			ret = 1;
+@@ -1477,7 +1477,7 @@ static int do_program_mount(struct autofs_point *ap,
+ 				free(str);
+ 				goto done;
+ 			}
+-			umount_amd_ext_mount(ap, entry->fs);
++			umount_amd_ext_mount(ap, entry->fs, 0);
+ 		}
+ 		error(ap->logopt, MODPREFIX
+ 		   "%s: failed to mount using %s", entry->type, entry->mount);
+@@ -1488,7 +1488,7 @@ static int do_program_mount(struct autofs_point *ap,
+ done:
+ 	rv = do_link_mount(ap, name, entry, 0);
+ 	if (rv) {
+-		if (umount_amd_ext_mount(ap, entry->fs)) {
++		if (!umount_amd_ext_mount(ap, entry->fs, 1)) {
+ 			debug(ap->logopt, MODPREFIX
+ 			      "%s: failed to cleanup external mount at %s",
+ 			      entry->type, entry->fs);
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0012-BACKPORT-autofs-5.1.9-add-flags-argument-to-amd-do_p.patch
+++ b/app-admin/autofs/autobuild/patches/0012-BACKPORT-autofs-5.1.9-add-flags-argument-to-amd-do_p.patch
@@ -1,0 +1,70 @@
+From 9fb84a34442ebae9b70192474b97dc10e335c2eb Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 14:52:33 +0800
+Subject: [PATCH 12/19] BACKPORT: autofs-5.1.9 - add flags argument to amd
+ do_program_mount()
+
+Most of the amd mount functions take a flags argument that allows them
+to alter their function based on configuration.
+
+For example the amd option autofs_use_lofs will use bind mounts instead
+of symlinks in some cases which might be preferred.
+
+The program mount function was not being passed this parameter but the
+design of all the amd mount functions is quite similar and adding the
+flag works as expected..
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           | 1 +
+ modules/parse_amd.c | 7 ++++---
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index bc15111..30d311e 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -9,6 +9,7 @@
+ - don't free ext mount if mounted.
+ - refactor amd function do_program_mount().
+ - refactor umount_amd_ext_mount().
++- add flags argument to amd do_program_mount().
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index 41e4b2d..d70eb16 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1412,7 +1412,8 @@ out:
+ }
+ 
+ static int do_program_mount(struct autofs_point *ap,
+-			    struct amd_entry *entry, const char *name)
++			    struct amd_entry *entry, const char *name,
++			    unsigned int flags)
+ {
+ 	int rv = 1;
+ 
+@@ -1486,7 +1487,7 @@ static int do_program_mount(struct autofs_point *ap,
+ 		goto out;
+ 	}
+ done:
+-	rv = do_link_mount(ap, name, entry, 0);
++	rv = do_link_mount(ap, name, entry, flags);
+ 	if (rv) {
+ 		if (!umount_amd_ext_mount(ap, entry->fs, 1)) {
+ 			debug(ap->logopt, MODPREFIX
+@@ -1715,7 +1716,7 @@ static int amd_mount(struct autofs_point *ap, const char *name,
+ 	case AMD_MOUNT_TYPE_PROGRAM:
+ 		if (!validate_program_options(ap->logopt, entry))
+ 			return 1;
+-		ret = do_program_mount(ap, entry, name);
++		ret = do_program_mount(ap, entry, name, flags);
+ 		break;
+ 
+ 	default:
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0013-BACKPORT-autofs-5.1.9-fix-amd-cache-options-not-copi.patch
+++ b/app-admin/autofs/autobuild/patches/0013-BACKPORT-autofs-5.1.9-fix-amd-cache-options-not-copi.patch
@@ -1,0 +1,46 @@
+From eeb3722932ba7c5c597767673e18eb1d73640f27 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Thu, 11 Jul 2024 13:56:15 +0800
+Subject: [PATCH 13/19] BACKPORT: autofs-5.1.9 - fix amd cache options not
+ copied
+
+autofs-5.1.9 - fix amd cache options not copied
+
+The cache options set when parsing the amd map entry are not copied to
+the list entry that gets processed by the caller.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           | 1 +
+ modules/amd_parse.y | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 30d311e..b337eeb 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -10,6 +10,7 @@
+ - refactor amd function do_program_mount().
+ - refactor umount_amd_ext_mount().
+ - add flags argument to amd do_program_mount().
++- fix amd cache options not copied.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/amd_parse.y b/modules/amd_parse.y
+index 17fd9b2..603ec78 100644
+--- a/modules/amd_parse.y
++++ b/modules/amd_parse.y
+@@ -888,6 +888,7 @@ static int add_location(void)
+ 		new->path = entry.path;
+ 	}
+ 	new->flags = entry.flags;
++	new->cache_opts = entry.cache_opts;
+ 	new->type = entry.type;
+ 	new->map_type = entry.map_type;
+ 	new->pref = entry.pref;
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0014-BACKPORT-autofs-5.1.9-seperate-amd-mount-and-entry-f.patch
+++ b/app-admin/autofs/autobuild/patches/0014-BACKPORT-autofs-5.1.9-seperate-amd-mount-and-entry-f.patch
@@ -1,0 +1,147 @@
+From cde4b9dd8a650b2da35e26582fad7518263d4213 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Tue, 9 Jul 2024 14:59:40 +0800
+Subject: [PATCH 14/19] BACKPORT: autofs-5.1.9 - seperate amd mount and entry
+ flags
+
+autofs-5.1.9 - seperate amd mount and entry flags
+
+We are running out of flags for amd mounts, seperate the mount flags
+from the defaults and entry flags and add a new amd entry flags field.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ include/parse_amd.h | 11 ++++++-----
+ modules/amd_parse.y |  7 ++++---
+ modules/parse_amd.c | 10 +++++-----
+ 4 files changed, 16 insertions(+), 13 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index b337eeb..635f6c9 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -11,6 +11,7 @@
+ - refactor umount_amd_ext_mount().
+ - add flags argument to amd do_program_mount().
+ - fix amd cache options not copied.
++- seperate amd mount and entry flags.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/include/parse_amd.h b/include/parse_amd.h
+index 81506cb..46f8091 100644
+--- a/include/parse_amd.h
++++ b/include/parse_amd.h
+@@ -33,12 +33,12 @@
+ #define AMD_MOUNT_TYPE_PROGRAM	0x00004000
+ #define AMD_MOUNT_TYPE_MASK	0x0000ffff
+ 
+-#define AMD_ENTRY_CUT		0x00010000
+-#define AMD_ENTRY_MASK		0x00ff0000
++#define AMD_DEFAULTS_MERGE	0x0001
++#define AMD_DEFAULTS_RESET	0x0002
++#define AMD_DEFAULTS_MASK	0x00ff
+ 
+-#define AMD_DEFAULTS_MERGE	0x01000000
+-#define AMD_DEFAULTS_RESET	0x02000000
+-#define AMD_DEFAULTS_MASK	0xff000000
++#define AMD_ENTRY_CUT		0x0100
++#define AMD_ENTRY_MASK		0xff00
+ 
+ #define AMD_CACHE_OPTION_NONE	0x0000
+ #define AMD_CACHE_OPTION_INC	0x0001
+@@ -50,6 +50,7 @@ struct amd_entry {
+ 	char *path;
+ 	unsigned long flags;
+ 	unsigned int cache_opts;
++	unsigned int entry_flags;
+ 	char *type;
+ 	char *map_type;
+ 	char *pref;
+diff --git a/modules/amd_parse.y b/modules/amd_parse.y
+index 603ec78..9ea77da 100644
+--- a/modules/amd_parse.y
++++ b/modules/amd_parse.y
+@@ -155,7 +155,7 @@ location_selection_list: location
+ 	}
+ 	| location_selection_list SPACE CUT SPACE location
+ 	{
+-		entry.flags |= AMD_ENTRY_CUT;
++		entry.entry_flags |= AMD_ENTRY_CUT;
+ 		if (!add_location()) {
+ 			amd_msg("failed to allocate new location");
+ 			YYABORT;
+@@ -168,11 +168,11 @@ location: location_entry
+ 	}
+ 	| HYPHEN location_entry
+ 	{
+-		entry.flags |= AMD_DEFAULTS_MERGE;
++		entry.entry_flags |= AMD_DEFAULTS_MERGE;
+ 	}
+ 	| HYPHEN
+ 	{
+-		entry.flags |= AMD_DEFAULTS_RESET;
++		entry.entry_flags |= AMD_DEFAULTS_RESET;
+ 	}
+ 	;
+ 
+@@ -889,6 +889,7 @@ static int add_location(void)
+ 	}
+ 	new->flags = entry.flags;
+ 	new->cache_opts = entry.cache_opts;
++	new->entry_flags = entry.entry_flags;
+ 	new->type = entry.type;
+ 	new->map_type = entry.map_type;
+ 	new->pref = entry.pref;
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index d70eb16..0fb9986 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -2029,13 +2029,13 @@ static struct amd_entry *select_default_entry(struct autofs_point *ap,
+ 
+ 		p = p->next;
+ 
+-		if (this->flags & AMD_DEFAULTS_MERGE) {
++		if (this->entry_flags & AMD_DEFAULTS_MERGE) {
+ 			if (entry_default)
+ 				free_amd_entry(entry_default);
+ 			list_del_init(&this->list);
+ 			entry_default = this;
+ 			continue;
+-		} else if (this->flags & AMD_DEFAULTS_RESET) {
++		} else if (this->entry_flags & AMD_DEFAULTS_RESET) {
+ 			struct amd_entry *new;
+ 			new = dup_defaults_entry(defaults_entry);
+ 			if (new) {
+@@ -2266,14 +2266,14 @@ int parse_mount(struct autofs_point *ap, struct map_source *map,
+ 		struct amd_entry *this = list_entry(p, struct amd_entry, list);
+ 		p = p->next;
+ 
+-		if (this->flags & AMD_DEFAULTS_MERGE) {
++		if (this->entry_flags & AMD_DEFAULTS_MERGE) {
+ 			free_amd_entry(cur_defaults);
+ 			list_del_init(&this->list);
+ 			cur_defaults = this;
+ 			update_with_defaults(defaults_entry, cur_defaults, sv);
+ 			debug(ap->logopt, "merged /defaults entry with defaults");
+ 			continue;
+-		} else if (this->flags & AMD_DEFAULTS_RESET) {
++		} else if (this->entry_flags & AMD_DEFAULTS_RESET) {
+ 			struct amd_entry *nd, *new;
+ 			struct substvar *nsv = NULL;
+ 
+@@ -2298,7 +2298,7 @@ int parse_mount(struct autofs_point *ap, struct map_source *map,
+ 		debug(ap->logopt, "expand defaults entry");
+ 		sv = expand_entry(ap, cur_defaults, flags, sv);
+ 
+-		if (this->flags & AMD_ENTRY_CUT && at_least_one) {
++		if (this->entry_flags & AMD_ENTRY_CUT && at_least_one) {
+ 			info(ap->logopt, MODPREFIX
+ 			     "at least one entry tried before cut selector, "
+ 			     "not continuing");
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0015-BACKPORT-autofs-5.1.9-make-ioctl-ops-timeout-handle-.patch
+++ b/app-admin/autofs/autobuild/patches/0015-BACKPORT-autofs-5.1.9-make-ioctl-ops-timeout-handle-.patch
@@ -1,0 +1,213 @@
+From b95fdf2c211e64988b367d8348b756295d1edf08 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Tue, 9 Jul 2024 16:18:19 +0800
+Subject: [PATCH 15/19] BACKPORT: autofs-5.1.9 - make ioctl ops ->timeout()
+ handle per-dentry expire
+
+autofs-5.1.9 - make ioctl ops ->timeout() handle per-dentry expire
+
+Update the ioctl ops ->timeout() function to handle setting of per-dentry
+expire timeout if the kernel supports it.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG               |  1 +
+ daemon/direct.c         |  6 +++---
+ daemon/indirect.c       |  2 +-
+ daemon/state.c          |  4 ++--
+ include/dev-ioctl-lib.h |  2 +-
+ lib/dev-ioctl-lib.c     | 42 ++++++++++++++++++++++++++++++-----------
+ lib/mounts.c            |  4 ++--
+ 7 files changed, 41 insertions(+), 20 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 635f6c9..b9d0b69 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -12,6 +12,7 @@
+ - add flags argument to amd do_program_mount().
+ - fix amd cache options not copied.
+ - seperate amd mount and entry flags.
++- make iocl ops ->timeout() handle per-dentry expire.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/daemon/direct.c b/daemon/direct.c
+index a9d7128..42baac8 100644
+--- a/daemon/direct.c
++++ b/daemon/direct.c
+@@ -328,7 +328,7 @@ int do_mount_autofs_direct(struct autofs_point *ap,
+ 				return 0;
+ 			}
+ 
+-			ops->timeout(ap->logopt, ioctlfd, tout);
++			ops->timeout(ap->logopt, ioctlfd, NULL, tout);
+ 
+ 			if (save_ioctlfd == -1)
+ 				ops->close(ap->logopt, ioctlfd);
+@@ -423,7 +423,7 @@ int do_mount_autofs_direct(struct autofs_point *ap,
+ 		goto out_umount;
+ 	}
+ 
+-	ops->timeout(ap->logopt, ioctlfd, timeout);
++	ops->timeout(ap->logopt, ioctlfd, NULL, timeout);
+ 	notify_mount_result(ap, me->key, timeout, str_direct);
+ 	cache_set_ino_index(me->mc, me);
+ 	ops->close(ap->logopt, ioctlfd);
+@@ -779,7 +779,7 @@ int mount_autofs_offset(struct autofs_point *ap, struct mapent *me)
+ 	if (ioctlfd < 0)
+ 		goto out_umount;
+ 
+-	ops->timeout(ap->logopt, ioctlfd, timeout);
++	ops->timeout(ap->logopt, ioctlfd, NULL, timeout);
+ 	cache_set_ino_index(me->mc, me);
+ 	notify_mount_result(ap, me->key, timeout, str_offset);
+ 	ops->close(ap->logopt, ioctlfd);
+diff --git a/daemon/indirect.c b/daemon/indirect.c
+index 6ef05c3..7d4aad7 100644
+--- a/daemon/indirect.c
++++ b/daemon/indirect.c
+@@ -136,7 +136,7 @@ static int do_mount_autofs_indirect(struct autofs_point *ap)
+ 		goto out_umount;
+ 	}
+ 
+-	ops->timeout(ap->logopt, ap->ioctlfd, timeout);
++	ops->timeout(ap->logopt, ap->ioctlfd, NULL, timeout);
+ 	notify_mount_result(ap, ap->path, timeout, str_indirect);
+ 
+ 	return 0;
+diff --git a/daemon/state.c b/daemon/state.c
+index 5fce6e3..b7dfbc6 100644
+--- a/daemon/state.c
++++ b/daemon/state.c
+@@ -370,7 +370,7 @@ static int do_readmap_mount(struct autofs_point *ap,
+ 			cache_unlock(vmc);
+ 			/* Set timeout and calculate the expire run frequency */
+ 			timeout = get_exp_timeout(ap, map);
+-			ops->timeout(ap->logopt, valid->ioctlfd, timeout);
++			ops->timeout(ap->logopt, valid->ioctlfd, NULL, timeout);
+ 			if (timeout) {
+ 				runfreq = (timeout + CHECK_RATIO - 1) / CHECK_RATIO;
+ 				if (ap->exp_runfreq)
+@@ -431,7 +431,7 @@ static void *do_readmap(void *arg)
+ 		struct ioctl_ops *ops = get_ioctl_ops();
+ 		time_t timeout = get_exp_timeout(ap, ap->entry->maps);
+ 		ap->exp_runfreq = (timeout + CHECK_RATIO - 1) / CHECK_RATIO;
+-		ops->timeout(ap->logopt, ap->ioctlfd, timeout);
++		ops->timeout(ap->logopt, ap->ioctlfd, NULL, timeout);
+ 		lookup_prune_cache(ap, now);
+ 		status = lookup_ghost(ap);
+ 	} else {
+diff --git a/include/dev-ioctl-lib.h b/include/dev-ioctl-lib.h
+index eb9075c..1d7a757 100644
+--- a/include/dev-ioctl-lib.h
++++ b/include/dev-ioctl-lib.h
+@@ -45,7 +45,7 @@ struct ioctl_ops {
+ 	int (*send_fail)(unsigned int, int, unsigned int, int);
+ 	int (*setpipefd)(unsigned int, int, int);
+ 	int (*catatonic)(unsigned int, int);
+-	int (*timeout)(unsigned int, int, time_t);
++	int (*timeout)(unsigned int, int, const char *, time_t);
+ 	int (*requester)(unsigned int, int, const char *, uid_t *, gid_t *);
+ 	int (*expire)(unsigned int, int, const char *, unsigned int);
+ 	int (*askumount)(unsigned int, int, unsigned int *);
+diff --git a/lib/dev-ioctl-lib.c b/lib/dev-ioctl-lib.c
+index 6b549d7..14e19ea 100644
+--- a/lib/dev-ioctl-lib.c
++++ b/lib/dev-ioctl-lib.c
+@@ -55,7 +55,7 @@ static int dev_ioctl_send_ready(unsigned int, int, unsigned int);
+ static int dev_ioctl_send_fail(unsigned int, int, unsigned int, int);
+ static int dev_ioctl_setpipefd(unsigned int, int, int);
+ static int dev_ioctl_catatonic(unsigned int, int);
+-static int dev_ioctl_timeout(unsigned int, int, time_t);
++static int dev_ioctl_timeout(unsigned int, int, const char *, time_t);
+ static int dev_ioctl_requester(unsigned int, int, const char *, uid_t *, gid_t *);
+ static int dev_ioctl_expire(unsigned int, int, const char *, unsigned int);
+ static int dev_ioctl_askumount(unsigned int, int, unsigned int *);
+@@ -69,7 +69,7 @@ static int ioctl_close(unsigned int, int);
+ static int ioctl_send_ready(unsigned int, int, unsigned int);
+ static int ioctl_send_fail(unsigned int, int, unsigned int, int);
+ static int ioctl_catatonic(unsigned int, int);
+-static int ioctl_timeout(unsigned int, int, time_t);
++static int ioctl_timeout(unsigned int, int, const char *, time_t);
+ static int ioctl_expire(unsigned int, int, const char *, unsigned int);
+ static int ioctl_askumount(unsigned int, int, unsigned int *);
+ 
+@@ -571,21 +571,41 @@ static int ioctl_catatonic(unsigned int logopt, int ioctlfd)
+ }
+ 
+ /* Set the autofs mount timeout */
+-static int dev_ioctl_timeout(unsigned int logopt, int ioctlfd, time_t timeout)
++static int dev_ioctl_timeout(unsigned int logopt, int ioctlfd, const char *mp, time_t timeout)
+ {
+-	struct autofs_dev_ioctl param;
+-
+-	init_autofs_dev_ioctl(&param);
+-	param.ioctlfd = ioctlfd;
+-	param.timeout.timeout = timeout;
++	if (!mp) {
++		struct autofs_dev_ioctl param;
+ 
+-	if (ioctl(ctl.devfd, AUTOFS_DEV_IOCTL_TIMEOUT, &param) == -1)
+-		return -1;
++		init_autofs_dev_ioctl(&param);
++		param.ioctlfd = ioctlfd;
++		param.timeout.timeout = timeout;
++		if (ioctl(ctl.devfd, AUTOFS_DEV_IOCTL_TIMEOUT, &param) == -1)
++			return -1;
++	} else {
++		unsigned int kver_major = get_kver_major();
++		unsigned int kver_minor = get_kver_minor();
++		struct autofs_dev_ioctl *param;
++
++		if (kver_major < 5 ||
++		   (kver_major == 5 && kver_minor < 6)) {
++			error(logopt, "per-mount expire timeout not supported by kernel.");
++			return -1;
++		}
+ 
++		param = alloc_dev_ioctl_path(ioctlfd, mp);
++		if (!param)
++			return -1;
++		param->timeout.timeout = timeout;
++		if (ioctl(ctl.devfd, AUTOFS_DEV_IOCTL_TIMEOUT, param) == -1) {
++			free_dev_ioctl_path(param);
++			return -1;
++		}
++		free_dev_ioctl_path(param);
++	}
+ 	return 0;
+ }
+ 
+-static int ioctl_timeout(unsigned int logopt, int ioctlfd, time_t timeout)
++static int ioctl_timeout(unsigned int logopt, int ioctlfd, const char *mp, time_t timeout)
+ {
+ 	time_t tout = timeout;
+ 	return ioctl(ioctlfd, AUTOFS_IOC_SETTIMEOUT, &tout);
+diff --git a/lib/mounts.c b/lib/mounts.c
+index dda19a9..656de33 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -2740,7 +2740,7 @@ static int remount_active_mount(struct autofs_point *ap,
+ 	/* Re-reading the map, set timeout and return */
+ 	if (ap->state == ST_READMAP) {
+ 		debug(ap->logopt, "already mounted, update timeout");
+-		ops->timeout(ap->logopt, fd, timeout);
++		ops->timeout(ap->logopt, fd, NULL, timeout);
+ 		ops->close(ap->logopt, fd);
+ 		return REMOUNT_READ_MAP;
+ 	}
+@@ -2762,7 +2762,7 @@ static int remount_active_mount(struct autofs_point *ap,
+ 		ops->close(ap->logopt, fd);
+ 		return REMOUNT_OPEN_FAIL;
+ 	}
+-	ops->timeout(ap->logopt, fd, timeout);
++	ops->timeout(ap->logopt, fd, NULL, timeout);
+ 	if (fstat(fd, &st) == -1) {
+ 		error(ap->logopt,
+ 		      "failed to stat %s mount %s", str_type, path);
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0016-BACKPORT-autofs-5.1.9-refactor-amd-mount-options-han.patch
+++ b/app-admin/autofs/autobuild/patches/0016-BACKPORT-autofs-5.1.9-refactor-amd-mount-options-han.patch
@@ -1,0 +1,131 @@
+From ee73ad266da13cb815fa82ccd0a02ca5631a4ff5 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Thu, 11 Jul 2024 13:35:04 +0800
+Subject: [PATCH 16/19] BACKPORT: autofs-5.1.9 - refactor amd mount options
+ handling
+
+autofs-5.1.9 - refactor amd mount options handling
+
+Refactor handling of entry options opts, addopts, remopts.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ modules/amd_parse.y | 66 ++++++++++++++++++++++++++-------------------
+ 2 files changed, 40 insertions(+), 27 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index b9d0b69..42f4349 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -13,6 +13,7 @@
+ - fix amd cache options not copied.
+ - seperate amd mount and entry flags.
+ - make iocl ops ->timeout() handle per-dentry expire.
++- refactor amd mount options handling.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/amd_parse.y b/modules/amd_parse.y
+index 9ea77da..28ec6ca 100644
+--- a/modules/amd_parse.y
++++ b/modules/amd_parse.y
+@@ -60,6 +60,7 @@ static int match_map_option_fs_type(char *map_option, char *type);
+ static int match_map_option_map_type(char *map_option, char *type);
+ static int match_map_option_cache_option(char *type);
+ static int match_mnt_option_options(char *mnt_option, char *options);
++static int match_mnt_option(char *option, char *options);
+ 
+ static struct amd_entry entry;
+ static struct list_head *entries;
+@@ -437,40 +438,18 @@ option_assignment: MAP_OPTION OPTION_ASSIGN FS_TYPE
+ 
+ options: OPTION
+ 	{
+-		if (!strcmp($1, "fullybrowsable") ||
+-		    !strcmp($1, "nounmount")) {
+-			sprintf(msg_buf, "option %s is not currently "
+-					 "implemented, ignored", $1);
+-			amd_info(msg_buf);
+-		} else if (!strncmp($1, "ping=", 5) ||
+-			   !strncmp($1, "retry=", 6) ||
+-			   !strcmp($1, "public") ||
+-			   !strcmp($1, "softlookup") ||
+-			   !strcmp($1, "xlatecookie")) {
+-			sprintf(msg_buf, "option %s is not used by "
+-					 "autofs, ignored", $1);
+-			amd_info(msg_buf);
+-		} else if (!strncmp($1, "utimeout=", 9)) {
+-			if (entry.flags & AMD_MOUNT_TYPE_AUTO) {
+-				char *opt = $1;
+-				prepend_opt(opts, ++opt);
+-			} else {
+-				sprintf(msg_buf, "umount timeout can't be "
+-						 "used for other than type "
+-						 "\"auto\" with autofs, "
+-						 "ignored");
+-				amd_info(msg_buf);
+-			}
+-		} else
++		if (match_mnt_option($1, opts))
+ 			prepend_opt(opts, $1);
+ 	}
+ 	| OPTION COMMA options
+ 	{
+-		prepend_opt(opts, $1);
++		if (match_mnt_option($1, opts))
++			prepend_opt(opts, $1);
+ 	}
+ 	| OPTION COMMA
+ 	{
+-		prepend_opt(opts, $1);
++		if (match_mnt_option($1, opts))
++			prepend_opt(opts, $1);
+ 	}
+ 	;
+ 
+@@ -664,6 +643,39 @@ static int match_mnt_option_options(char *mnt_option, char *options)
+ 	return 1;
+ }
+ 
++static int match_mnt_option(char *option, char *options)
++{
++	int ret = 0;
++
++	if (!strcmp(option, "fullybrowsable") ||
++	    !strcmp(option, "nounmount")) {
++		sprintf(msg_buf, "option %s is not currently "
++				 "implemented, ignored", option);
++		amd_info(msg_buf);
++	} else if (!strncmp(option, "ping=", 5) ||
++		   !strncmp(option, "retry=", 6) ||
++		   !strcmp(option, "public") ||
++		   !strcmp(option, "softlookup") ||
++		   !strcmp(option, "xlatecookie")) {
++		sprintf(msg_buf, "option %s is not used by "
++				 "autofs, ignored", option);
++		amd_info(msg_buf);
++	} else if (!strncmp(option, "utimeout=", 9)) {
++		if (entry.flags & AMD_MOUNT_TYPE_AUTO)
++			prepend_opt(options, ++option);
++		else {
++			sprintf(msg_buf, "umount timeout can't be "
++					 "used for other than type "
++					 "\"auto\" with autofs, "
++					 "ignored");
++			amd_info(msg_buf);
++		}
++	} else
++		ret = 1;
++
++	return ret;
++}
++
+ static void prepend_opt(char *dest, char *opt)
+ {
+ 	char new[MAX_OPTS_LEN];
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0017-BACKPORT-autofs-5.1.9-add-some-unimplemented-amd-map.patch
+++ b/app-admin/autofs/autobuild/patches/0017-BACKPORT-autofs-5.1.9-add-some-unimplemented-amd-map.patch
@@ -1,0 +1,239 @@
+From 745220a0dad43ec46af9093d61536b44ace5d6be Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Mon, 8 Jul 2024 11:04:11 +0800
+Subject: [PATCH 17/19] BACKPORT: autofs-5.1.9 - add some unimplemented amd map
+ options
+
+autofs-5.1.9 - add some unimplemented amd map options
+
+Add handling for amd per-mount options "utimeout", "unmount" and "nounmount"
+if the kernel supports it.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ include/mounts.h    |  2 ++
+ include/parse_amd.h |  6 ++++++
+ lib/mounts.c        |  4 ++++
+ modules/amd_parse.y | 38 +++++++++++++++++++++++++++-------
+ modules/parse_amd.c | 50 +++++++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 94 insertions(+), 7 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 42f4349..22b55bc 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -14,6 +14,7 @@
+ - seperate amd mount and entry flags.
+ - make iocl ops ->timeout() handle per-dentry expire.
+ - refactor amd mount options handling.
++- add some unimplemented amd map options.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/include/mounts.h b/include/mounts.h
+index 381d120..0c711ee 100644
+--- a/include/mounts.h
++++ b/include/mounts.h
+@@ -113,6 +113,8 @@ struct mnt_list {
+ 	char *amd_pref;
+ 	char *amd_type;
+ 	char *amd_opts;
++	unsigned long amd_flags;
++	unsigned int amd_utimeout;
+ 	unsigned int amd_cache_opts;
+ 	struct list_head amdmount;
+ 
+diff --git a/include/parse_amd.h b/include/parse_amd.h
+index 46f8091..5ff1931 100644
+--- a/include/parse_amd.h
++++ b/include/parse_amd.h
+@@ -33,6 +33,11 @@
+ #define AMD_MOUNT_TYPE_PROGRAM	0x00004000
+ #define AMD_MOUNT_TYPE_MASK	0x0000ffff
+ 
++#define AMD_MOUNT_OPT_UNMOUNT	0x00010000
++#define AMD_MOUNT_OPT_NOUNMOUNT	0x00020000
++#define AMD_MOUNT_OPT_UTIMEOUT	0x00040000
++#define AMD_MOUNT_OPT_MASK	0x00ff0000
++
+ #define AMD_DEFAULTS_MERGE	0x0001
+ #define AMD_DEFAULTS_RESET	0x0002
+ #define AMD_DEFAULTS_MASK	0x00ff
+@@ -49,6 +54,7 @@
+ struct amd_entry {
+ 	char *path;
+ 	unsigned long flags;
++	unsigned int utimeout;
+ 	unsigned int cache_opts;
+ 	unsigned int entry_flags;
+ 	char *type;
+diff --git a/lib/mounts.c b/lib/mounts.c
+index 656de33..bee1ae5 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -1193,6 +1193,8 @@ struct mnt_list *mnts_add_amdmount(struct autofs_point *ap, struct amd_entry *en
+ 	this->amd_pref = pref;
+ 	this->amd_type = type;
+ 	this->amd_opts = opts;
++	this->amd_flags = entry->flags;
++	this->amd_utimeout = entry->utimeout;
+ 	this->amd_cache_opts = entry->cache_opts;
+ 	this->flags |= MNTS_AMD_MOUNT;
+ 	if (list_empty(&this->amdmount))
+@@ -1237,6 +1239,8 @@ static void __mnts_remove_amdmount(const char *mp)
+ 		free(this->amd_opts);
+ 		this->amd_opts = NULL;
+ 	}
++	this->amd_flags = AMD_MOUNT_OPT_UNMOUNT;
++	this->amd_utimeout = -1;
+ 	this->amd_cache_opts = 0;
+ 	__mnts_put_mount(this);
+ }
+diff --git a/modules/amd_parse.y b/modules/amd_parse.y
+index 28ec6ca..416f228 100644
+--- a/modules/amd_parse.y
++++ b/modules/amd_parse.y
+@@ -647,8 +647,7 @@ static int match_mnt_option(char *option, char *options)
+ {
+ 	int ret = 0;
+ 
+-	if (!strcmp(option, "fullybrowsable") ||
+-	    !strcmp(option, "nounmount")) {
++	if (!strcmp(option, "fullybrowsable")) {
+ 		sprintf(msg_buf, "option %s is not currently "
+ 				 "implemented, ignored", option);
+ 		amd_info(msg_buf);
+@@ -660,15 +659,37 @@ static int match_mnt_option(char *option, char *options)
+ 		sprintf(msg_buf, "option %s is not used by "
+ 				 "autofs, ignored", option);
+ 		amd_info(msg_buf);
++	} else if (!strcmp(option, "umount")) {
++		entry.flags &= ~AMD_MOUNT_OPT_NOUNMOUNT;
++		entry.flags |= AMD_MOUNT_OPT_UNMOUNT;
++	} else if (!strcmp(option, "nounmount")) {
++		if (entry.flags & AMD_MOUNT_TYPE_AUTO)
++			prepend_opt(opts, "timeout=0");
++		else {
++			entry.flags &= ~AMD_MOUNT_OPT_UNMOUNT;
++			entry.flags |= AMD_MOUNT_OPT_NOUNMOUNT;
++			entry.utimeout = 0;
++		}
+ 	} else if (!strncmp(option, "utimeout=", 9)) {
++		/*
++		 * amd type "auto" mounts map to autofs fstype=autofs
++		 * mounts so a distinct autofs mount is present at the
++		 * the root so there's no need for special handling,
++		 * just pass the timeout=<seconds> autofs option.
++		 */
+ 		if (entry.flags & AMD_MOUNT_TYPE_AUTO)
+ 			prepend_opt(options, ++option);
+ 		else {
+-			sprintf(msg_buf, "umount timeout can't be "
+-					 "used for other than type "
+-					 "\"auto\" with autofs, "
+-					 "ignored");
+-			amd_info(msg_buf);
++			if (strchr(option, '=')) {
++				unsigned long tout;
++				int ret;
++
++				ret = sscanf(option, "utimeout=%lu", &tout);
++				if (ret) {
++					entry.flags |= AMD_MOUNT_OPT_UTIMEOUT;
++					entry.utimeout = tout;
++				}
++			}
+ 		}
+ 	} else
+ 		ret = 1;
+@@ -791,6 +812,8 @@ static void local_init_vars(void)
+ {
+ 	memset(&entry, 0, sizeof(entry));
+ 	entry.cache_opts = AMD_CACHE_OPTION_NONE;
++	entry.flags = AMD_MOUNT_OPT_UNMOUNT;
++	entry.utimeout = -1;
+ 	memset(opts, 0, sizeof(opts));
+ }
+ 
+@@ -900,6 +923,7 @@ static int add_location(void)
+ 		new->path = entry.path;
+ 	}
+ 	new->flags = entry.flags;
++	new->utimeout = entry.utimeout;
+ 	new->cache_opts = entry.cache_opts;
+ 	new->entry_flags = entry.entry_flags;
+ 	new->type = entry.type;
+diff --git a/modules/parse_amd.c b/modules/parse_amd.c
+index 0fb9986..23f5894 100644
+--- a/modules/parse_amd.c
++++ b/modules/parse_amd.c
+@@ -1654,6 +1654,7 @@ static int amd_mount(struct autofs_point *ap, const char *name,
+ 		     struct parse_context *ctxt)
+ {
+ 	unsigned long fstype = entry->flags & AMD_MOUNT_TYPE_MASK;
++	unsigned long per_mnt_flags = entry->flags & AMD_MOUNT_OPT_MASK;
+ 	int ret = 1;
+ 
+ 	switch (fstype) {
+@@ -1725,6 +1726,55 @@ static int amd_mount(struct autofs_point *ap, const char *name,
+ 		break;
+ 	}
+ 
++	if (!ret) {
++		struct ioctl_ops *ops;
++
++		if (!(per_mnt_flags & AMD_MOUNT_OPT_MASK))
++			goto done;
++
++		/* The mount succeeded, make sure there's no path component
++		 * seperator in "name" as it must be the last component of
++		 * the mount point alone for the per-mount options.
++		 */
++		if (strchr(name, '/')) {
++			warn(ap->logopt, "path component seperator not valid here");
++			goto done;
++		}
++
++		ops = get_ioctl_ops();
++
++		/* The default in autofs is to always expire mounts according to
++		 * a timeout set in the autofs mount super block information
++		 * structure. But amd allows for differing expire timeouts on a
++		 * per-mount basis. It also has (context sensitive) options "unmount"
++		 * to say expire this mount and "nounmount" to say don't expire this
++		 * mount. In amd mounts these options are set by default according
++		 * to whether a mount should expire or not, for example a cd mount
++		 * is set "nounmount". Setting defaults like this is not used in the
++		 * autofs amd implementation because there's only one, little used,
++		 * removable file system available.
++		 *
++		 * But the "nounmount" and "utimeout" options can be useful.
++		 */
++		if (per_mnt_flags & AMD_MOUNT_OPT_NOUNMOUNT) {
++			if (entry->utimeout)
++				warn(ap->logopt,
++				"non-zero timeout set, possible conflicting options");
++
++			/* "nounmount" option, don't expire this mount. */
++			if (ops)
++				ops->timeout(ap->logopt, ap->ioctlfd, name, 0);
++		} else if (per_mnt_flags & AMD_MOUNT_OPT_UTIMEOUT) {
++			if (!entry->utimeout)
++				warn(ap->logopt,
++				"zero timeout set, possible conflicting options");
++
++			/* "utimeout" option, expire this mount according to a timeout. */
++			if (ops)
++				ops->timeout(ap->logopt, ap->ioctlfd, name, entry->utimeout);
++		}
++	}
++done:
+ 	return ret;
+ }
+ 
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0018-BACKPORT-autofs-5.1.9-fix-get-parent-multi-mount-che.patch
+++ b/app-admin/autofs/autobuild/patches/0018-BACKPORT-autofs-5.1.9-fix-get-parent-multi-mount-che.patch
@@ -1,0 +1,53 @@
+From 2f9f57e986c0adbcad07974fc06c1b4e8bbdb4f0 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 15:09:34 +0800
+Subject: [PATCH 18/19] BACKPORT: autofs-5.1.9 - fix get parent multi-mount
+ check in try_remount()
+
+In commit 635b90ecc (autofs-5.1.8 - fix mount tree startup reconnect)
+when getting the parent the check for a multi-mount should include a
+check for the root of the multi-mount as well since the root does not
+set its parent (it remains NULL).
+
+We could set the root parent to itself but that may have side effects
+because the convention has always been the parent is NULL for the
+multi-mount root.
+
+Reported-by: Roberto Bergantinos Corpas <rbergant@redhat.com>
+Suggested-by: Roberto Bergantinos Corpas <rbergant@redhat.com>
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG    | 1 +
+ lib/mounts.c | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 22b55bc..f9295be 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -15,6 +15,7 @@
+ - make iocl ops ->timeout() handle per-dentry expire.
+ - refactor amd mount options handling.
+ - add some unimplemented amd map options.
++- fix get parent multi-mount check in try_remount().
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/lib/mounts.c b/lib/mounts.c
+index bee1ae5..114c7ef 100644
+--- a/lib/mounts.c
++++ b/lib/mounts.c
+@@ -2865,7 +2865,7 @@ int try_remount(struct autofs_point *ap, struct mapent *me, unsigned int type)
+ 	}
+ 
+ 	me->flags &= ~MOUNT_FLAG_DIR_CREATED;
+-	mapent = IS_MM(me) ? MM_PARENT(me) : me;
++	mapent = IS_MM(me) && !IS_MM_ROOT(me) ? MM_PARENT(me) : me;
+ 	/* Direct or offset mount, key is full path */
+ 	if (mapent->key[0] == '/') {
+ 		if (!is_mounted(mapent->key, MNTS_REAL))
+-- 
+2.51.0
+

--- a/app-admin/autofs/autobuild/patches/0019-BACKPORT-autofs-5.1.9-fix-deadlock-in-remount.patch
+++ b/app-admin/autofs/autobuild/patches/0019-BACKPORT-autofs-5.1.9-fix-deadlock-in-remount.patch
@@ -1,0 +1,77 @@
+From 099da49387c94f5aa8afb929b0a698bc897909d2 Mon Sep 17 00:00:00 2001
+From: Ian Kent <raven@themaw.net>
+Date: Wed, 17 Sep 2025 15:09:34 +0800
+Subject: [PATCH 19/19] BACKPORT: autofs-5.1.9 - fix deadlock in remount
+
+If we're starting up or trying to re-connect to an existing direct mount
+we could be iterating through the map entries with the cache readlock
+held so we can't just take the writelock for direct mounts. But when
+trying to re-connect to an existing mount at startup there won't be any
+other process updating the map entry cache.
+
+Signed-off-by: Ian Kent <raven@themaw.net>
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CHANGELOG           |  1 +
+ modules/parse_sun.c | 26 ++++++++++++++++++++++++--
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index f9295be..7f588f3 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -16,6 +16,7 @@
+ - refactor amd mount options handling.
+ - add some unimplemented amd map options.
+ - fix get parent multi-mount check in try_remount().
++- fix deadlock in remount.
+ 
+ 02/11/2023 autofs-5.1.9
+ - fix kernel mount status notification.
+diff --git a/modules/parse_sun.c b/modules/parse_sun.c
+index a5351fd..b16ebe8 100644
+--- a/modules/parse_sun.c
++++ b/modules/parse_sun.c
+@@ -889,7 +889,18 @@ update_offset_entry(struct autofs_point *ap,
+ 			strcpy(m_mapent, loc);
+ 	}
+ 
+-	cache_writelock(mc);
++	/*
++	 * If we're starting up or trying to re-connect to an existing
++	 * direct mount we could be iterating through the map entries
++	 * with the readlock held so we can't just take the writelock
++	 * for direct mounts. But at when trying to re-connect to an
++	 * existing mount at startup there won't be any other process
++	 * updating the map entry cache.
++	 */
++	if (ap->state == ST_INIT && ap->flags & MOUNT_FLAG_REMOUNT)
++		cache_readlock(mc);
++	else
++		cache_writelock(mc);
+ 	ret = cache_update_offset(mc, name, m_key, m_mapent, age);
+ 
+ 	me = cache_lookup_distinct(mc, m_key);
+@@ -1581,7 +1592,18 @@ dont_expand:
+ 			free(myoptions);
+ 		} while (*p == '/' || (*p == '"' && *(p + 1) == '/'));
+ 
+-		cache_writelock(mc);
++		/*
++		 * If we're starting up or trying to re-connect to an existing
++		 * direct mount we could be iterating through the map entries
++		 * with the readlock held so we can't just take the writelock
++		 * for direct mounts. But at when trying to re-connect to an
++		 * existing mount at startup there won't be any other process
++		 * updating the map entry cache.
++		 */
++		if (ap->state == ST_INIT && ap->flags & MOUNT_FLAG_REMOUNT)
++			cache_readlock(mc);
++		else
++			cache_writelock(mc);
+ 		me = cache_lookup_distinct(mc, name);
+ 		if (!me) {
+ 			cache_unlock(mc);
+-- 
+2.51.0
+

--- a/app-admin/autofs/spec
+++ b/app-admin/autofs/spec
@@ -1,4 +1,5 @@
 VER=5.1.9
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/linux/daemons/autofs/v${VER:0:1}/autofs-$VER.tar.xz"
 CHKSUMS="sha256::87e6af6a03794b9462ea519781e50e7d23b5f7c92cd59e1142c85d2493b3c24b"
 CHKUPDATE="anitya::id=140"


### PR DESCRIPTION
Topic Description
-----------------

- autofs: backport upstream patches to fix build error
    Fix incompatible function pointer types in cyrus-sasl module.
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- autofs: 5.1.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autofs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
