### PR TITLE
deno: update to 2.5.1

### DIFF
--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.5.0
+VER=2.5.1
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=140.0.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::665a61abb5c6c2527aa7c91bb43ef3f1cd9c2cb782b99e82fe6312d53b06159c \
+CHKSUMS="sha256::d039d79548930742dcd770ceaf7a5aca26c571902dd9629d91ed049865bf9ccb \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.5.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
