### PR TITLE
bitwarden: add loongarch64 support

### DIFF
--- a/app-utils/bitwarden/autobuild/build
+++ b/app-utils/bitwarden/autobuild/build
@@ -27,6 +27,27 @@ else
     aberr "Unsupported architecture, check `FAIL_ARCH` in defines!"
 fi
 
+abinfo "Building proxy native module ..."
+cd "$SRCDIR"/apps/desktop/desktop_native
+if ab_match_arch amd64; then
+    cargo build --bin desktop_proxy --release --target x86_64-unknown-linux-gnu
+    mkdir dist
+    # Note: Ensure the correct desktop_proxy is identified
+    mv target/x86_64-unknown-linux-gnu/release/desktop_proxy dist/desktop_proxy.linux-x64
+elif ab_match_arch arm64; then
+    cargo build --bin desktop_proxy --release --target aarch64-unknown-linux-gnu
+    mkdir dist
+    # Note: Ensure the correct desktop_proxy is identified
+    mv target/aarch64-unknown-linux-gnu/release/desktop_proxy dist/desktop_proxy.linux-arm64
+elif ab_match_arch loongarch64; then
+    cargo build --bin desktop_proxy --release --target loongarch64-unknown-linux-gnu
+    mkdir dist
+    # Note: Ensure the correct desktop_proxy is identified
+    mv target/loongarch64-unknown-linux-gnu/release/desktop_proxy dist/desktop_proxy.linux-loong64
+else
+    aberr "Unsupported architecture, check `FAIL_ARCH` in defines!"
+fi
+
 abinfo "Building Bitwarden Desktop ..."
 cd "$SRCDIR"/apps/desktop
 npm run dist:dir

--- a/app-utils/bitwarden/autobuild/build
+++ b/app-utils/bitwarden/autobuild/build
@@ -1,5 +1,17 @@
 abinfo "Installing NPM dependencies ..."
-npm clean-install
+if ab_match_arch loongarch64; then
+    # Note: Since npm7+,npm will install peerDependencies and run script by default
+    npm config set omit peer
+    export ELECTRON_MIRROR="https://github.com/darkyzhou/electron-loong64/releases/download/"
+    export electron_use_remote_checksums=1
+    # Note: Bitwarden specified Electron v36.4.0 in package.json, but loongarch64 ABI2.0 doesn't have this version, so I chose a version similar to Electron v36.4.0.
+    # FIXME: npm gets stuck at post-install when downloading Electron
+    npm install electron@37.2.5 -D --ignore-script
+    npm remove electron-builder 
+    npm install @loongdotjs/electron-builder@26.0.12 -D 
+else
+    npm clean-install 
+fi
 
 abinfo "Building native module ..."
 cd "$SRCDIR"/apps/desktop/desktop_native/napi
@@ -7,6 +19,10 @@ if ab_match_arch amd64; then
     npm run build -- --target x86_64-unknown-linux-gnu
 elif ab_match_arch arm64; then
     npm run build -- --target aarch64-unknown-linux-gnu
+elif ab_match_arch loongarch64; then
+    npm run build -- --target loongarch64-unknown-linux-gnu
+    # Note: Ensure the correct napi is identified
+    mv desktop_napi.linux-loongarch64-gnu.node desktop_napi.linux-loong64-gnu.node
 else
     aberr "Unsupported architecture, check `FAIL_ARCH` in defines!"
 fi

--- a/app-utils/bitwarden/autobuild/build
+++ b/app-utils/bitwarden/autobuild/build
@@ -16,11 +16,11 @@ fi
 abinfo "Building native module ..."
 cd "$SRCDIR"/apps/desktop/desktop_native/napi
 if ab_match_arch amd64; then
-    npm run build -- --target x86_64-unknown-linux-gnu
+    npm run build -- --release --target x86_64-unknown-linux-gnu
 elif ab_match_arch arm64; then
-    npm run build -- --target aarch64-unknown-linux-gnu
+    npm run build -- --release --target aarch64-unknown-linux-gnu
 elif ab_match_arch loongarch64; then
-    npm run build -- --target loongarch64-unknown-linux-gnu
+    npm run build -- --release --target loongarch64-unknown-linux-gnu
     # Note: Ensure the correct napi is identified
     mv desktop_napi.linux-loongarch64-gnu.node desktop_napi.linux-loong64-gnu.node
 else

--- a/app-utils/bitwarden/autobuild/defines
+++ b/app-utils/bitwarden/autobuild/defines
@@ -8,4 +8,4 @@ PKGDES="A desktop client for Bitwarden password manager"
 # /usr/bin/aarch64-aosc-linux-gnu-ld: /tmp/lto-llvm-1c53e4.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `_Z11IsValidUTF8P10napi_env__P20napi_callback_info__' which may bind externally can not be used when making a shared object; recompile with -fPIC
 # bitwarden/node_modules/utf-8-validate/build/../src/validation.cc:34:(.text._Z4InitP10napi_env__P12napi_value__+0x10): dangerous relocation: unsupported relocation
 USECLANG_AMD64=1
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="(loongarch64_nosimd|loongson3|riscv64|ppc64el)"

--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,7 +1,7 @@
-From d094d2ef861f9d6fec665b70dfc9db015308f9e9 Mon Sep 17 00:00:00 2001
+From 50fa1df35a2840c78bcfd9e1b5ece297d8ed06fd Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
-Subject: [PATCH 1/2] napi: prefer glibc instead of musl libc
+Subject: [PATCH 1/3] napi: prefer glibc instead of musl libc
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -36,5 +36,5 @@ index acfd0dffb8..bfb0e4aa69 100644
          );
          localFileExisted = existsSync(join(__dirname, "desktop_napi.linux-arm-gnueabihf.node"));
 -- 
-2.50.1
+2.51.0
 

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,7 +1,7 @@
-From ef75cd6a2bc2f968631f53baba77d8b1f658682d Mon Sep 17 00:00:00 2001
+From f844deb3c40c1d0579cadb697eb452be8bddf753 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
-Subject: [PATCH 2/2] napi: enable lto
+Subject: [PATCH 2/3] napi: enable lto
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index 669f166e74..5d9f108617 100644
+index 20b5639580..6a61587625 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -33,3 +33,9 @@ windows_plugin_authenticator = { path = "../windows_plugin_authenticator" }
+@@ -34,3 +34,9 @@ windows_plugin_authenticator = { path = "../windows_plugin_authenticator" }
  
  [build-dependencies]
  napi-build = { workspace = true }
@@ -23,5 +23,5 @@ index 669f166e74..5d9f108617 100644
 +strip = false
 +incremental = false
 -- 
-2.50.1
+2.51.0
 

--- a/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
+++ b/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
@@ -1,0 +1,57 @@
+From 544de39f9a81da11c92c61e3bd06b403f3cabbad Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Sat, 20 Sep 2025 14:59:50 +0800
+Subject: [PATCH 3/3] napi: add loongarch64 support
+
+---
+ apps/desktop/desktop_native/napi/index.js | 6 ++++++
+ apps/desktop/electron-builder.json        | 2 +-
+ apps/desktop/scripts/after-pack.js        | 2 +-
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/apps/desktop/desktop_native/napi/index.js b/apps/desktop/desktop_native/napi/index.js
+index bfb0e4aa69..03d8a4ffc5 100644
+--- a/apps/desktop/desktop_native/napi/index.js
++++ b/apps/desktop/desktop_native/napi/index.js
+@@ -98,6 +98,12 @@ switch (platform) {
+           "@bitwarden/desktop-napi-linux-arm64-musl",
+         );
+         break;
++      case "loong64":
++        nativeBinding = loadFirstAvailable(
++          ["desktop_napi.linux-loong64-gnu.node", "desktop_napi.linux-loong64-musl.node"],
++          "@bitwarden/desktop-napi-linux-loong64-musl",
++        );
++        break;
+       case "arm":
+         nativeBinding = loadFirstAvailable(
+           ["desktop_napi.linux-arm-gnu.node", "desktop_napi.linux-arm-musl.node"],
+diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
+index 800cdd848a..72a3b7232b 100644
+--- a/apps/desktop/electron-builder.json
++++ b/apps/desktop/electron-builder.json
+@@ -20,7 +20,7 @@
+     "**/node_modules/@bitwarden/desktop-napi/index.js",
+     "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
+   ],
+-  "electronVersion": "36.4.0",
++  "electronVersion": "37.2.5",
+   "generateUpdatesFilesForAllChannels": true,
+   "publish": {
+     "provider": "generic",
+diff --git a/apps/desktop/scripts/after-pack.js b/apps/desktop/scripts/after-pack.js
+index 5fc42f31ac..fc36766e02 100644
+--- a/apps/desktop/scripts/after-pack.js
++++ b/apps/desktop/scripts/after-pack.js
+@@ -4,7 +4,7 @@ const child_process = require("child_process");
+ const path = require("path");
+ 
+ const { flipFuses, FuseVersion, FuseV1Options } = require("@electron/fuses");
+-const builder = require("electron-builder");
++const builder = require("@loongdotjs/electron-builder");
+ const fse = require("fs-extra");
+ 
+ exports.default = run;
+-- 
+2.51.0
+

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,5 @@
 VER=2025.8.2
+REL=1
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: fix desktop_proxy building
- bitwarden: add release tag when building native module
- bitwarden: add loongarch64 support

Package(s) Affected
-------------------

- bitwarden: 2025.8.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
