### PR TITLE
iptraf-ng: update to 1.2.2

### DIFF
--- a/app-network/iptraf-ng/autobuild/alternatives
+++ b/app-network/iptraf-ng/autobuild/alternatives
@@ -1,2 +1,1 @@
 alternative /usr/bin/iptraf /usr/lib/iptraf-ng/iptraf-ng 50
-alternative /usr/bin/rvnamed /usr/lib/iptraf-ng/rvnamed-ng 50

--- a/app-network/iptraf-ng/autobuild/build
+++ b/app-network/iptraf-ng/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building iptraf-ng ..."
+make
+
+abinfo "Installing iptraf-ng ..."
+make install DESTDIR="${PKGDIR}" sbindir=/usr/lib/iptraf-ng

--- a/app-network/iptraf-ng/autobuild/defines
+++ b/app-network/iptraf-ng/autobuild/defines
@@ -2,9 +2,7 @@ PKGNAME=iptraf-ng
 PKGSEC=net
 PKGDEP="ncurses"
 BUILDDEP="check"
-PKGDES="A console-based network monitoring utility"
-
+PKGDES="Console-based network monitoring utility"
 PKGPROV="iptraf"
 
-ABSHADOW=no
-AUTOTOOLS_AFTER="--sbindir=/usr/lib/iptraf-ng"
+ABTYPE=self

--- a/app-network/iptraf-ng/spec
+++ b/app-network/iptraf-ng/spec
@@ -1,4 +1,4 @@
-VER=1.1.4
-SRCS="tbl::https://fedorahosted.org/releases/i/p/iptraf-ng/iptraf-ng-$VER.tar.gz"
-CHKSUMS="sha256::d0a5572f4e113a40f720146f68981442d4578b829fcc68c0ba621030e2ddf39b"
+VER=1.2.2
+SRCS="git::commit=tags/v${VER}::https://github.com/iptraf-ng/iptraf-ng.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7034"


### PR DESCRIPTION
Topic Description
-----------------

- iptraf-ng: update to 1.2.2

Package(s) Affected
-------------------

- iptraf-ng: 1.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit iptraf-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
