### PR TITLE
perl-digest-nilsimsa: Add more prototypes to nilsimsa.h for C99 compatibility

### DIFF
--- a/lang-perl/perl-digest-nilsimsa/autobuild/patches/0001-FROMLIST-Digest-Nilsimsa-Add-more-prototypes-to-nils.patch
+++ b/lang-perl/perl-digest-nilsimsa/autobuild/patches/0001-FROMLIST-Digest-Nilsimsa-Add-more-prototypes-to-nils.patch
@@ -1,0 +1,31 @@
+From 2a2c4a188ff7167113b6b62d5e4df56452e34848 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 12 Jan 2023 09:43:51 +0100
+Subject: [PATCH] FROMLIST: Digest-Nilsimsa: Add more prototypes to nilsimsa.h
+ for C99 compatibility
+
+Add missing function prototypes.  This avoids implicit function
+declarations when building Nilsimsa.xs and build failures with future
+compilers.
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ nilsimsa.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/nilsimsa.h b/nilsimsa.h
+index 8ebb5f1..88f4261 100644
+--- a/nilsimsa.h
++++ b/nilsimsa.h
+@@ -47,6 +47,8 @@ int nilsimsa(struct nsrecord *a,struct nsrecord *b);
+ void aggregate(int n);
+ void codetostr(struct nsrecord *a,char *str);
+ int strtocode(char *str,struct nsrecord *a);
++void makecode(struct nsrecord *a);
++void clear(struct nsrecord *a);
+ 
+ int accbuf(unsigned char *buf,int len,struct nsrecord *a);
+ void dprint(char *msg);
+-- 
+2.51.0
+

--- a/lang-perl/perl-digest-nilsimsa/spec
+++ b/lang-perl/perl-digest-nilsimsa/spec
@@ -1,5 +1,5 @@
 VER=0.06
-REL=5
+REL=6
 SRCS="tbl::https://search.cpan.org/CPAN/authors/id/V/VI/VIPUL/Digest-Nilsimsa-$VER.tar.gz"
 CHKSUMS="sha256::cd3762cd76803729fd42022d382bc93b26f9b14aed9732eef85b44a9576d2d1e"
 CHKUPDATE="anitya::id=6448"


### PR DESCRIPTION
Topic Description
-----------------

- perl-digest-nilsimsa: Add more prototypes to nilsimsa.h for C99 compatibility
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- perl-digest-nilsimsa: 0.06-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-digest-nilsimsa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
