### PR TITLE
 spamassassin: update to 4.0.2

### DIFF
--- a/app-network/spamassassin/autobuild/overrides/usr/lib/sysusers.d/spamassassin.conf
+++ b/app-network/spamassassin/autobuild/overrides/usr/lib/sysusers.d/spamassassin.conf
@@ -1,0 +1,2 @@
+g spamd 182
+u spamd 182 "Mail Spam Daemon" /var/lib/spamassassin /bin/false

--- a/app-network/spamassassin/autobuild/postinst
+++ b/app-network/spamassassin/autobuild/postinst
@@ -1,2 +1,4 @@
-sa-update --verbose
+echo "Creating user and group for spamassassin ..."
+systemd-sysusers spamassassin.conf
+/usr/bin/vendor_perl/sa-update --verbose
 chown 182:182 /var/lib/spamassassin

--- a/app-network/spamassassin/autobuild/usergroup
+++ b/app-network/spamassassin/autobuild/usergroup
@@ -1,2 +1,0 @@
-group spamd 182
-user spamd 182 spamd /var/lib/spamassassin "Mail Spam Daemon" /bin/false

--- a/app-network/spamassassin/spec
+++ b/app-network/spamassassin/spec
@@ -1,5 +1,4 @@
-VER=3.4.6
+VER=4.0.2
 SRCS="tbl::https://downloads.apache.org/spamassassin/source/Mail-SpamAssassin-$VER.tar.gz"
-CHKSUMS="sha256::500c7e2a7cdf3aa4dd822d97aaff2ab22235a60cf17a68ab817861d215a4e568"
+CHKSUMS="sha256::c521be978cef3d49b1e139477ca60a0bd498345fc98274796e44161fae49a17f"
 CHKUPDATE="anitya::id=4861"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- spamassassin: update to 4.0.2
    - refactor forbidden use of usergroup
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- spamassassin: 4.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit spamassassin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
