### PR TITLE
libxml++ Survey 20250918

### DIFF
--- a/app-creativity/synfig/autobuild/defines
+++ b/app-creativity/synfig/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=synfig
 PKGSEC=graphics
 PKGDEP="boost cairo etl ffmpeg fftw fontconfig imagemagick libdv \
-        libmng libpng libsigc++ libtiff libxml++ mlt-6 openexr \
-        pango libxml++ gtkmm-3"
+        libmng libpng libsigc++ libtiff libxml++-2.6 mlt openexr \
+        pango gtkmm-3"
 BUILDDEP="intltool"
 PKGDES="Professional vector animation program (tools only)"
 

--- a/app-creativity/synfig/spec
+++ b/app-creativity/synfig/spec
@@ -1,8 +1,8 @@
-VER=1.5.1
-REL=1
+VER=1.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/synfig/synfig"
-CHKSUMS="sha256::9f68872e8db746288a0e8ca2105a9d2f98c043bd8d067902472dab97daae40dd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4924"
+ENVREQ="total_mem_per_core=1"
 
 # There is a folder called autobuild in the upstream repository, so there is
 # no choice but to set the main directory out of the source tree.

--- a/runtime-common/libxml++-2.6/autobuild/defines
+++ b/runtime-common/libxml++-2.6/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=libxml++-2.6
+PKGSEC=libs
+PKGDEP="glibmm libxml2"
+BUILDDEP="mm-common"
+PKGDES="C++ bindings for LibXML"
+
+ABTYPE=meson
+MESON_AFTER=("-Dbuild-documentation=false" "-Dbuild-examples=false")

--- a/runtime-common/libxml++-2.6/spec
+++ b/runtime-common/libxml++-2.6/spec
@@ -1,0 +1,4 @@
+VER=2.42.3
+SRCS="git::commit=tags/${VER}::https://github.com/libxmlplusplus/libxmlplusplus.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=11129"

--- a/runtime-common/libxml++/autobuild/defines
+++ b/runtime-common/libxml++/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=libxml++
 PKGSEC=libs
-PKGDEP="glibmm libxml2"
+PKGDEP="libxml2"
 BUILDDEP="mm-common"
 PKGDES="C++ bindings for LibXML"
 
-ABSHADOW=0
+ABTYPE=meson
+MESON_AFTER=("-Dbuild-documentation=false" "-Dbuild-examples=false")

--- a/runtime-common/libxml++/spec
+++ b/runtime-common/libxml++/spec
@@ -1,5 +1,4 @@
-VER=2.40.1
-REL=2
-SRCS="tbl::https://download.gnome.org/sources/libxml++/${VER:0:4}/libxml++-$VER.tar.xz"
-CHKSUMS="sha256::4ad4abdd3258874f61c2e2a41d08e9930677976d303653cd1670d3e9f35463e9"
+VER=5.4.0
+SRCS="git::commit=tags/${VER}::https://github.com/libxmlplusplus/libxmlplusplus.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11129"

--- a/runtime-multimedia/libffado/autobuild/defines
+++ b/runtime-multimedia/libffado/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libffado
 PKGSEC=libs
-PKGDEP="jack libavc1394 libconfig libiec61883 libxml++ dbus-python"
+PKGDEP="jack libavc1394 libconfig libiec61883 libxml++-2.6 dbus-python"
 BUILDDEP="doxygen scons subversion"
 PKGDES="Free firewire audio driver library"
 

--- a/runtime-multimedia/libffado/spec
+++ b/runtime-multimedia/libffado/spec
@@ -1,4 +1,4 @@
-VER=2.4.4
+VER=2.4.9
 SRCS="tbl::http://www.ffado.org/files/libffado-$VER.tgz"
-CHKSUMS="sha256::a47178cdc8c0c91e91edbaabe23d19ca12a752cbcf81c27314adb27cc00d60f0"
+CHKSUMS="sha256::c442c52fad11cafd5513bb4e846c851f101c8484f891aac545ed190e8fd4d10f"
 CHKUPDATE="anitya::id=141596"

--- a/runtime-productivity/libofx/autobuild/defines
+++ b/runtime-productivity/libofx/autobuild/defines
@@ -13,4 +13,5 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="OFX banking protocol abstraction library"
 
+ABTYPE=autotools
 NOPARALLEL=1

--- a/runtime-productivity/libofx/spec
+++ b/runtime-productivity/libofx/spec
@@ -1,4 +1,4 @@
-VER=0.10.8
-SRCS="tbl::https://github.com/libofx/libofx/archive/$VER.tar.gz"
-CHKSUMS="sha256::33a842987838b0609dd64c81cf3a26966d8c020cb1661bf71597fffc55edf2aa"
+VER=0.10.9
+SRCS="git::commit=tags/${VER}::https://github.com/libofx/libofx"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7309"


### PR DESCRIPTION
Topic Description
-----------------

- synfig: update to 1.5.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- libofx: update to 0.10.9
    Signed-off-by: stydxm <stydxm@outlook.com>
- libffado: update to 2.4.9
    Signed-off-by: stydxm <stydxm@outlook.com>
- libxml++: update to 5.4.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- libxml++-2.6: new, 2.42.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libxml++ libxml++-2.6 libffado libofx synfig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
