### PR TITLE
podman: support loongarch64_nosimd

### DIFF
--- a/app-containers/podman/autobuild/defines
+++ b/app-containers/podman/autobuild/defines
@@ -6,5 +6,4 @@ PKGPRDEP="debconf"
 PKGRECOM="btrfs-progs"
 BUILDDEP="go btrfs-progs go-md2man"
 
-ABSPLITDBG=0
-FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64|loongarch64|loongarch64_nosimd)"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=5.5.2
-REL=1
+REL=2
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile


### PR DESCRIPTION
Topic Description
-----------------

- podman: support loongarch64_nosimd

Package(s) Affected
-------------------

- podman: 5.5.2+vsock0.8.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
