### PR TITLE
lazygit: support loongarch64_nosimd

### DIFF
--- a/app-vcs/lazygit/autobuild/defines
+++ b/app-vcs/lazygit/autobuild/defines
@@ -4,8 +4,5 @@ PKGDES="Simple terminal UI for git commands"
 PKGDEP="git"
 BUILDDEP="go"
 
+ABTYPE=gomod
 GO_LDFLAGS=("-X main.version=$PKGVER" "-X main.buildSource=AOSC")
-
-# FIXME: Autobuild does not yet support splitting debug symbols out of Go
-# executables.
-ABSPLITDBG=0

--- a/app-vcs/lazygit/autobuild/prepare
+++ b/app-vcs/lazygit/autobuild/prepare
@@ -1,5 +1,6 @@
-# FIXME: This dependency supports loong64 from v1.1.17
-if ab_match_arch loongarch64; then
+# FIXME: This dependency supports loong64 from v1.1.17.
+# Ref: https://github.com/jesseduffield/lazygit/pull/3581
+if ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
     abinfo "Updating dependencies for loongarch64 ..."
     go get github.com/creack/pty@v1.1.17
     go mod vendor

--- a/app-vcs/lazygit/spec
+++ b/app-vcs/lazygit/spec
@@ -1,5 +1,5 @@
 VER=0.54.2
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/jesseduffield/lazygit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268930"


### PR DESCRIPTION
Topic Description
-----------------

- lazygit: support loongarch64_nosimd

Package(s) Affected
-------------------

- lazygit: 0.54.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lazygit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
