### PR TITLE
libxml++-2.6: resolve dependency problems

### DIFF
--- a/runtime-common/libxml++-2.6/autobuild/defines
+++ b/runtime-common/libxml++-2.6/autobuild/defines
@@ -3,6 +3,8 @@ PKGSEC=libs
 PKGDEP="glibmm libxml2"
 BUILDDEP="mm-common"
 PKGDES="C++ bindings for LibXML"
+PKGBREAK="libxml++<=2.40.1-2"
+PKGREP="libxml++<=2.40.1-2"
 
 ABTYPE=meson
 MESON_AFTER=("-Dbuild-documentation=false" "-Dbuild-examples=false")

--- a/runtime-common/libxml++-2.6/spec
+++ b/runtime-common/libxml++-2.6/spec
@@ -1,4 +1,5 @@
 VER=2.42.3
+REL=1
 SRCS="git::commit=tags/${VER}::https://github.com/libxmlplusplus/libxmlplusplus.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11129"


### PR DESCRIPTION
Topic Description
-----------------

- libxml++-2.6: resolve dependency problems
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libxml++-2.6: 2.42.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxml++-2.6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
