### PR TITLE
pavucontrol: update to 6.2

### DIFF
--- a/app-multimedia/pavucontrol/autobuild/defines
+++ b/app-multimedia/pavucontrol/autobuild/defines
@@ -2,7 +2,10 @@ PKGNAME=pavucontrol
 PKGSEC=sound
 PKGDEP="gtkmm-4 libcanberra libsigc++-3.0 pulseaudio json-glib"
 BUILDDEP="meson lynx"
-PKGDES="A GTK+ volume control for PulseAudio"
+PKGDES="GTK+ volume control for PulseAudio"
 
 ABTYPE=meson
-MESON_AFTER="-Dlynx=true"
+MESON_AFTER=(
+    '-Dlynx=enabled'
+    '-Daudio-feedback=enabled'
+)

--- a/app-multimedia/pavucontrol/spec
+++ b/app-multimedia/pavucontrol/spec
@@ -1,4 +1,4 @@
-VER=6.1
+VER=6.2
 SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/pulseaudio/pavucontrol"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8636"


### PR DESCRIPTION
Topic Description
-----------------

- pavucontrol: update to 6.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- pavucontrol: 6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pavucontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
