### PR TITLE
bitwarden: update to 2025.9.0

### DIFF
--- a/app-utils/bitwarden/autobuild/defines
+++ b/app-utils/bitwarden/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=bitwarden
 PKGSEC=utils
-PKGDEP="libsecret glib x11-lib"
+PKGDEP="libsecret glib x11-lib sqlite"
 BUILDDEP="nodejs rustc llvm-20"
 PKGDES="A desktop client for Bitwarden password manager"
 

--- a/app-utils/bitwarden/autobuild/defines
+++ b/app-utils/bitwarden/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=bitwarden
 PKGSEC=utils
 PKGDEP="libsecret glib x11-lib sqlite"
 BUILDDEP="nodejs rustc llvm-20"
-PKGDES="A desktop client for Bitwarden password manager"
+PKGDES="Desktop client for Bitwarden password manager"
 
 # FIXME: USECLANG fails on arm64 with
 # /usr/bin/aarch64-aosc-linux-gnu-ld: /tmp/lto-llvm-1c53e4.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `_Z11IsValidUTF8P10napi_env__P20napi_callback_info__' which may bind externally can not be used when making a shared object; recompile with -fPIC

--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,7 +1,7 @@
-From 50fa1df35a2840c78bcfd9e1b5ece297d8ed06fd Mon Sep 17 00:00:00 2001
+From 9c1afb7e95706e7edcaba550c4b3a05b940e1e17 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
-Subject: [PATCH 1/3] napi: prefer glibc instead of musl libc
+Subject: [PATCH 1/4] napi: prefer glibc instead of musl libc
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,7 +1,7 @@
-From f844deb3c40c1d0579cadb697eb452be8bddf753 Mon Sep 17 00:00:00 2001
+From a890235282ba1d7e78c2d3285f3857a4e38e16cf Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
-Subject: [PATCH 2/3] napi: enable lto
+Subject: [PATCH 2/4] napi: enable lto
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,13 +9,13 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index 20b5639580..6a61587625 100644
+index 9e8404ea8d..7e64c336f6 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -34,3 +34,9 @@ windows_plugin_authenticator = { path = "../windows_plugin_authenticator" }
+@@ -38,3 +38,9 @@ napi-build = { workspace = true }
  
- [build-dependencies]
- napi-build = { workspace = true }
+ [lints]
+ workspace = true
 +
 +[profile.release]
 +lto = true

--- a/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
+++ b/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
@@ -1,7 +1,7 @@
-From 544de39f9a81da11c92c61e3bd06b403f3cabbad Mon Sep 17 00:00:00 2001
+From 8a811de64f3b1fa2b4cfe53e1ccf2bdb5e426d3a Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Sat, 20 Sep 2025 14:59:50 +0800
-Subject: [PATCH 3/3] napi: add loongarch64 support
+Subject: [PATCH 3/4] napi: add loongarch64 support
 
 ---
  apps/desktop/desktop_native/napi/index.js | 6 ++++++
@@ -27,14 +27,14 @@ index bfb0e4aa69..03d8a4ffc5 100644
          nativeBinding = loadFirstAvailable(
            ["desktop_napi.linux-arm-gnu.node", "desktop_napi.linux-arm-musl.node"],
 diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
-index 800cdd848a..72a3b7232b 100644
+index 4d0dac1242..ba9cc55f58 100644
 --- a/apps/desktop/electron-builder.json
 +++ b/apps/desktop/electron-builder.json
 @@ -20,7 +20,7 @@
      "**/node_modules/@bitwarden/desktop-napi/index.js",
      "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
    ],
--  "electronVersion": "36.4.0",
+-  "electronVersion": "36.8.1",
 +  "electronVersion": "37.2.5",
    "generateUpdatesFilesForAllChannels": true,
    "publish": {

--- a/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
+++ b/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
@@ -1,0 +1,25 @@
+From 27212cd7d4b3fdd0384eb593991dbecc85e3b49c Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Mon, 22 Sep 2025 16:09:53 +0800
+Subject: [PATCH 4/4] fix: use  system libsqlite3.so
+
+---
+ .../desktop_native/bitwarden_chromium_importer/Cargo.toml       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
+index 8512ed1b31..7c9e96cab6 100644
+--- a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
++++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
+@@ -17,7 +17,7 @@ homedir = { workspace = true }
+ log = { workspace = true }
+ pbkdf2 = "=0.12.2"
+ rand = { workspace = true }
+-rusqlite = { version = "=0.35.0", features = ["bundled"] }
++rusqlite = { version = "=0.35.0" }
+ serde = { workspace = true, features = ["derive"] }
+ serde_json = { workspace = true }
+ sha1 = "=0.10.6"
+-- 
+2.51.0
+

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,5 +1,4 @@
-VER=2025.8.2
-REL=1
+VER=2025.9.0
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: add loongarch64 support
- bitwarden: update to 2025.9.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- bitwarden: 2025.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
