### PR TITLE
cargo-c: update to 0.10.15

### DIFF
--- a/lang-rust/cargo-c/spec
+++ b/lang-rust/cargo-c/spec
@@ -1,4 +1,4 @@
-VER=0.10.14
+VER=0.10.15
 SRCS="git::commit=tags/v$VER::https://github.com/lu-zero/cargo-c"
 CHKUPDATE="anitya::id=58394"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- cargo-c: update to 0.10.15
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- cargo-c: 0.10.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
