### PR TITLE
pam-u2f: replace libu2f-* deps with libfido2

### DIFF
--- a/runtime-admin/pam-u2f/autobuild/defines
+++ b/runtime-admin/pam-u2f/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pam-u2f
 PKGSEC=admin
-PKGDEP="linux-pam libu2f-host libu2f-server"
+PKGDEP="linux-pam libfido2 openssl"
 BUILDDEP="asciidoc gettext"
 PKGDES="PAM modules for U2F"
 

--- a/runtime-admin/pam-u2f/spec
+++ b/runtime-admin/pam-u2f/spec
@@ -1,4 +1,5 @@
 VER=1.4.0
+REL=1
 SRCS="git::commit=tags/pam_u2f-$VER::https://github.com/Yubico/pam-u2f.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8511"


### PR DESCRIPTION
Topic Description
-----------------

- pam-u2f: replace libu2f-\* deps with libfido2

Package(s) Affected
-------------------

- pam-u2f: 1.4.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pam-u2f
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
