### PR TITLE
tracker: update to 3.10.0

### DIFF
--- a/desktop-gnome/tracker/autobuild/defines
+++ b/desktop-gnome/tracker/autobuild/defines
@@ -5,8 +5,7 @@ PKGDEP="desktop-file-utils enca exempi flac giflib gstreamer \
         libiptcdata libgrss libgsf libgxps libmediaart libosinfo libsecret \
         libsoup libunistring libvorbis networkmanager pcre poppler python-3 \
         snowball taglib tomli totem-pl-parser typogrify upower util-linux"
-BUILDDEP="asciidoc gi-docgen gtk-doc gobject-introspection hotdoc \
-          intltool vala"
+BUILDDEP="asciidoc gobject-introspection hotdoc intltool vala"
 PKGDES="All-in-one indexer, search tool and metadata database"
 
 PKGBREAK="bijiben<=40.1-3 brasero<=1:3.12.3 gnome-applets<=3.44.0 \
@@ -15,12 +14,11 @@ PKGBREAK="bijiben<=40.1-3 brasero<=1:3.12.3 gnome-applets<=3.44.0 \
           tracker-miners<=3.3.1-1"
 
 MESON_AFTER=(
-    '-Ddocs=true'
+    '-Ddocs=false'
     '-Dman=true'
     '-Dstemmer=enabled'
     '-Dunicode_support=icu'
     '-Dbash_completion=true'
     '-Dsystemd_user_services=true'
     '-Dintrospection=enabled'
-    '-Dsoup=soup2'
 )

--- a/desktop-gnome/tracker/spec
+++ b/desktop-gnome/tracker/spec
@@ -1,5 +1,4 @@
-VER=3.7.3
-REL=2
+VER=3.10.0
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/tracker.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5578"


### PR DESCRIPTION
Topic Description
-----------------

- tracker: update to 3.10.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- tracker: 3.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tracker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
