### PR TITLE
gnome-calculator: disable docs generation

### DIFF
--- a/desktop-gnome/gnome-calculator/autobuild/defines
+++ b/desktop-gnome/gnome-calculator/autobuild/defines
@@ -4,6 +4,6 @@ PKGDEP="dconf gtk-4 gtksourceview-5 libadwaita mpfr mpc"
 BUILDDEP="gnome-shell gobject-introspection intltool vala yelp-tools"
 PKGDES="GNOME scientific calculator"
 
-MESON_AFTER="-Ddisable-ui=false \
-             -Ddisable-introspection=false \
-             -Ddevelopment=false"
+MESON_AFTER=("-Ddisable-ui=false"
+             "-Ddisable-introspection=false"
+             "-Ddevelopment=false")

--- a/desktop-gnome/gnome-calculator/autobuild/patches/0001-disable-doc.patch
+++ b/desktop-gnome/gnome-calculator/autobuild/patches/0001-disable-doc.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 28149ed2..447a5888 100644
+--- a/meson.build
++++ b/meson.build
+@@ -99,7 +99,6 @@ subdir('lib')
+ subdir('src')
+ subdir('search-provider')
+ subdir('help')
+-subdir('doc')
+ subdir('po')
+ endif
+ subdir('tests')

--- a/desktop-gnome/gnome-calculator/spec
+++ b/desktop-gnome/gnome-calculator/spec
@@ -1,5 +1,5 @@
 VER=42.2
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gnome-calculator/${VER%.*}/gnome-calculator-$VER.tar.xz"
 CHKSUMS="sha256::33dab1bca43658d66520958b0f674cb0ad3185cfd30c12e459e7f69481c5c6a0"
 CHKUPDATE="anitya::id=13126"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-calculator: disable docs generation
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gnome-calculator: 42.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-calculator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
