### PR TITLE
exim: update to 4.98.2

### DIFF
--- a/app-web/exim/autobuild/build
+++ b/app-web/exim/autobuild/build
@@ -1,52 +1,34 @@
 abinfo "Building Exim ..."
-make \
-    EXIM_RELEASE_VERSION="$PKGVER" \
-
-abinfo "Building man page ..."
-cd "$SRCDIR"/../doc/doc-docbook
-make exim.8 \
-    EXIM_VER="$PKGVER"
-cd "$SRCDIR"
-
-abinfo "Installing man page ..."
-install -Dvm0644 "$SRCDIR"/../doc/doc-docbook/exim.8 \
-    "$PKGDIR"/usr/share/man/man8/exim.8
-
-abinfo "Creating installation directories ..."
-mkdir -pv \
-    "$PKGDIR"/var/spool/exim/db \
-    "$PKGDIR"/etc/mail \
-    "$PKGDIR"/var/log/exim \
-    "$PKGDIR"/usr/lib/exim
-
-abinfo "Fixing up permissions ..."
-chmod -v 770 \
-    "$PKGDIR"/var/spool/exim{,/db} \
-    "$PKGDIR"/var/log/exim
-chown -v 0:79 \
-    "$PKGDIR"/var/spool/exim \
-    "$PKGDIR"/var/log/exim
-chown -v 79:79 \
-    "$PKGDIR"/var/spool/exim/db
+pushd "$SRCDIR"/src
+make
+popd
 
 abinfo "Installing Exim ..."
-cd "$SRCDIR"/build-Linux-*
+pushd "$SRCDIR"/src/build-Linux-*
 for i in exicyclog exim_checkaccess exim_dumpdb exim_lock exim_tidydb \
-    exipick exiqsumm exigrep exim_dbmbuild exim exim_fixdb eximstats exinext \
-    exiqgrep exiwhat; do
+    exipick exiqsumm exigrep exim_dbmbuild exim exim_fixdb eximstats \
+    exinext exiqgrep exiwhat; do
     install -Dvm0755 "$i" "$PKGDIR"/usr/bin/"$i"
 done
+popd
 
 abinfo "Creating libexec symlinks ..."
+mkdir -pv "$PKGDIR"/usr/lib/exim
 for i in mailq newaliases rmail rsmtp runq sendmail; do
     ln -sv ../../bin/exim \
         "$PKGDIR"/usr/lib/exim/"$i"
 done
-ln -sv ../bin/exim \
-    "$PKGDIR"/usr/lib/sendmail
+
+abinfo "Building man page ..."
+pushd "$SRCDIR"/doc/doc-docbook
+make exim.8 \
+    EXIM_VER="$PKGVER"
+popd
+
+abinfo "Installing man page ..."
+install -Dvm0644 "$SRCDIR"/doc/doc-docbook/exim.8 \
+    "$PKGDIR"/usr/share/man/man8/exim.8
 
 abinfo "Installing default exim.conf ..."
-cd "$SRCDIR"/src
-sed -e "s|/etc/aliases|/etc/mail/aliases|g" \
-    -e "s|SYSTEM_ALIASES_FILE|/etc/mail/aliases|g" \
-    configure.default > "$PKGDIR"/etc/mail/exim.conf
+install -Dvm0644 "$SRCDIR"/src/src/configure.default \
+    "$PKGDIR"/etc/exim/exim.conf

--- a/app-web/exim/autobuild/defines
+++ b/app-web/exim/autobuild/defines
@@ -4,9 +4,7 @@ PKGDEP="gdbm pcre2 linux-pam openssl openldap libnsl2"
 BUILDDEP="mariadb perl-file-fcntllock postgresql xfpt"
 PKGDES="A general purpose e-mail message transfer agent (MTA)"
 
+ABTYPE=self
+
 PKGCONFL="postfix<=3.0.3 opensmtpd<=5.7.3p1"
 PKGPROV="mta mail-transfer-agent"
-
-# FIXME: relocation R_X86_64_PC32 against undefined symbol `debug_selector'
-# can not be used when making a shared object; recompile with -fPIC
-AB_FLAGS_SPECS__AMD64=0

--- a/app-web/exim/autobuild/overrides/usr/lib/sysusers.d/exim.conf
+++ b/app-web/exim/autobuild/overrides/usr/lib/sysusers.d/exim.conf
@@ -1,0 +1,1 @@
+u exim 79 "Exim MTA" /var/spool/exim /usr/bin/nologin

--- a/app-web/exim/autobuild/overrides/usr/lib/tmpfiles.d/exim.conf
+++ b/app-web/exim/autobuild/overrides/usr/lib/tmpfiles.d/exim.conf
@@ -1,0 +1,3 @@
+d /var/spool/exim 0770 root exim - -
+d /var/spool/exim/db 0770 exim exim - -
+d /var/log/exim 0770 root exim - -

--- a/app-web/exim/autobuild/patches/0001-Set-exim-config.patch
+++ b/app-web/exim/autobuild/patches/0001-Set-exim-config.patch
@@ -1,7 +1,18 @@
-diff --git a/scripts/Configure-Makefile b/scripts/Configure-Makefile
-index dc5015f..07f8c23 100755
---- a/scripts/Configure-Makefile
-+++ b/scripts/Configure-Makefile
+From 38fc98870f4d320b15262af655620b2ba66f0493 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Fri, 19 Sep 2025 12:29:47 +0800
+Subject: [PATCH] Set exim config
+
+---
+ src/scripts/Configure-Makefile |   2 +-
+ src/src/EDITME                 | 103 ++++++++-------
+ src/src/configure.default      | 233 +++++++++++++++++++++++++++++----
+ 3 files changed, 260 insertions(+), 78 deletions(-)
+
+diff --git a/src/scripts/Configure-Makefile b/src/scripts/Configure-Makefile
+index dc5015f6f..07f8c2340 100755
+--- a/src/scripts/Configure-Makefile
++++ b/src/scripts/Configure-Makefile
 @@ -319,7 +319,7 @@ if [ "${EXIM_PERL}" != "" ] ; then
  
    mv $mft $mftt
@@ -11,29 +22,29 @@ index dc5015f..07f8c23 100755
    echo "PERL_LIBS=`$PERL_COMMAND -MExtUtils::Embed -e ldopts`" >>$mft
    echo "" >>$mft
    cat $mftt >> $mft
-diff --git a/src/EDITME b/src/EDITME
-index f68b3f1..a0b37b2 100644
---- a/src/EDITME
-+++ b/src/EDITME
-@@ -101,7 +101,7 @@
+diff --git a/src/src/EDITME b/src/src/EDITME
+index ebfaf640a..4d22cbc57 100644
+--- a/src/src/EDITME
++++ b/src/src/EDITME
+@@ -103,7 +103,7 @@
  # /usr/local/sbin. The installation script will try to create this directory,
  # and any superior directories, if they do not exist.
  
 -BIN_DIRECTORY=/usr/exim/bin
-+BIN_DIRECTORY=/usr/bin
++BIN_DIRECTORY=/usr/sbin
  
  
  #------------------------------------------------------------------------------
-@@ -117,7 +117,7 @@ BIN_DIRECTORY=/usr/exim/bin
+@@ -119,7 +119,7 @@ BIN_DIRECTORY=/usr/exim/bin
  # don't exist. It will also install a default runtime configuration if this
  # file does not exist.
  
 -CONFIGURE_FILE=/usr/exim/configure
-+CONFIGURE_FILE=/etc/mail/exim.conf
++CONFIGURE_FILE=/etc/exim/exim.conf
  
  # It is possible to specify a colon-separated list of files for CONFIGURE_FILE.
  # In this case, Exim will use the first of them that exists when it is run.
-@@ -134,7 +134,7 @@ CONFIGURE_FILE=/usr/exim/configure
+@@ -136,7 +136,7 @@ CONFIGURE_FILE=/usr/exim/configure
  # deliveries. (Local deliveries run as various non-root users, typically as the
  # owner of a local mailbox.) Specifying these values as root is not supported.
  
@@ -42,16 +53,7 @@ index f68b3f1..a0b37b2 100644
  
  # If you specify EXIM_USER as a name, this is looked up at build time, and the
  # uid number is built into the binary. However, you can specify that this
-@@ -155,7 +155,7 @@ EXIM_USER=
- # for EXIM_USER (e.g. EXIM_USER=exim), you don't need to set EXIM_GROUP unless
- # you want to use a group other than the default group for the given user.
- 
--# EXIM_GROUP=
-+EXIM_GROUP=ref:exim
- 
- # Many sites define a user called "exim", with an appropriate default group,
- # and use
-@@ -212,10 +212,10 @@ SPOOL_DIRECTORY=/var/spool/exim
+@@ -214,10 +214,10 @@ SPOOL_DIRECTORY=/var/spool/exim
  # If you are building with TLS, the library configuration must be done:
  
  # Uncomment this if you are using OpenSSL
@@ -64,7 +66,7 @@ index f68b3f1..a0b37b2 100644
  # TLS_LIBS=-lssl -lcrypto
  # TLS_LIBS=-L/usr/local/openssl/lib -lssl -lcrypto
  
-@@ -342,7 +342,7 @@ TRANSPORT_SMTP=yes
+@@ -344,7 +344,7 @@ TRANSPORT_SMTP=yes
  # This one is special-purpose, and commonly not required, so it is not
  # included by default.
  
@@ -73,7 +75,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -351,9 +351,9 @@ TRANSPORT_SMTP=yes
+@@ -353,9 +353,9 @@ TRANSPORT_SMTP=yes
  # MBX, is included only when requested. If you do not know what this is about,
  # leave these settings commented out.
  
@@ -86,7 +88,16 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -411,22 +411,28 @@ LOOKUP_DBM=yes
+@@ -377,7 +377,7 @@ TRANSPORT_SMTP=yes
+ # To build a module dynamically, you'll need to define CFLAGS_DYNAMIC for
+ # your platform.  Eg:
+ # CFLAGS_DYNAMIC=-shared -rdynamic
+-# CFLAGS_DYNAMIC=-shared -rdynamic -fPIC
++CFLAGS_DYNAMIC=-shared -rdynamic -fPIC
+ 
+ #------------------------------------------------------------------------------
+ # These settings determine which file and database lookup methods are included
+@@ -413,22 +413,28 @@ LOOKUP_DBM=yes
  LOOKUP_LSEARCH=yes
  LOOKUP_DNSDB=yes
  
@@ -124,7 +135,7 @@ index f68b3f1..a0b37b2 100644
  # LOOKUP_SQLITE_PC=sqlite3
  # LOOKUP_WHOSON=yes
  
-@@ -439,7 +445,7 @@ LOOKUP_DNSDB=yes
+@@ -441,7 +447,7 @@ LOOKUP_DNSDB=yes
  
  
  # Some platforms may need this for LOOKUP_NIS:
@@ -133,7 +144,7 @@ index f68b3f1..a0b37b2 100644
  
  #------------------------------------------------------------------------------
  # If you have set LOOKUP_LDAP=yes, you should set LDAP_LIB_TYPE to indicate
-@@ -513,7 +519,7 @@ SUPPORT_DANE=yes
+@@ -515,7 +521,7 @@ SUPPORT_DANE=yes
  # files are defaulted in the OS/Makefile-Default file, but can be overridden in
  # local OS-specific make files.
  
@@ -142,7 +153,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -523,7 +529,7 @@ SUPPORT_DANE=yes
+@@ -525,7 +531,7 @@ SUPPORT_DANE=yes
  # and the MIME ACL. Please read the documentation to learn more about these
  # features.
  
@@ -151,46 +162,36 @@ index f68b3f1..a0b37b2 100644
  
  # If you have content scanning you may wish to only include some of the scanner
  # interfaces.  Uncomment any of these lines to remove that code.
-@@ -604,12 +610,12 @@ DISABLE_MAL_MKS=yes
- 
- # Uncomment the following line to add DMARC checking capability, implemented
- # using libopendmarc libraries. You must have SPF and DKIM support enabled also.
--# SUPPORT_DMARC=yes
-+#SUPPORT_DMARC=yes
- # CFLAGS += -I/usr/local/include
--# LDFLAGS += -lopendmarc
-+#LDFLAGS += -lopendmarc
+@@ -614,7 +620,7 @@ DISABLE_MAL_MKS=yes
+ # LDFLAGS += -lopendmarc
  # Uncomment the following if you need to change the default. You can
  # override it at runtime (main config option dmarc_tld_file)
 -# DMARC_TLD_FILE=/etc/exim/opendmarc.tlds
-+#DMARC_TLD_FILE=/usr/share/publicsuffix/public_suffix_list.dat
++# DMARC_TLD_FILE=/usr/share/publicsuffix/public_suffix_list.dat
  #
  # Library version libopendmarc-1.4.1-1.fc33.x86_64  (on Fedora 33) is known broken;
  # 1.3.2-3 works.  It seems that the OpenDMARC project broke their API.
-@@ -740,7 +746,7 @@ FIXED_NEVER_USERS=root
+@@ -749,7 +755,7 @@ FIXED_NEVER_USERS=root
  # CONFIGURE_OWNER setting, to specify a configuration file which is listed in
  # the TRUSTED_CONFIG_LIST file, then root privileges are not dropped by Exim.
  
 -# TRUSTED_CONFIG_LIST=/usr/exim/trusted_configs
-+TRUSTED_CONFIG_LIST=/etc/mail/trusted-configs
++TRUSTED_CONFIG_LIST=/etc/exim/trusted-configs
  
  
  #------------------------------------------------------------------------------
-@@ -785,18 +791,18 @@ FIXED_NEVER_USERS=root
+@@ -794,18 +800,18 @@ FIXED_NEVER_USERS=root
  # included in the Exim binary. You will then need to set up the run time
  # configuration to make use of the mechanism(s) selected.
  
 -# AUTH_CRAM_MD5=yes
--# AUTH_CYRUS_SASL=yes
--# AUTH_DOVECOT=yes
 +AUTH_CRAM_MD5=yes
-+AUTH_CYRUS_SASL=yes
+ # AUTH_CYRUS_SASL=yes
+-# AUTH_DOVECOT=yes
 +AUTH_DOVECOT=yes
  # AUTH_EXTERNAL=yes
--# AUTH_GSASL=yes
--# AUTH_GSASL_PC=libgsasl
-+#AUTH_GSASL=yes
-+#AUTH_GSASL_PC=libgsasl
+ # AUTH_GSASL=yes
+ # AUTH_GSASL_PC=libgsasl
  # AUTH_HEIMDAL_GSSAPI=yes
  # AUTH_HEIMDAL_GSSAPI_PC=heimdal-gssapi
  # AUTH_HEIMDAL_GSSAPI_PC=heimdal-gssapi heimdal-krb5
@@ -203,7 +204,7 @@ index f68b3f1..a0b37b2 100644
  
  # Heimdal through 1.5 required pkg-config 'heimdal-gssapi'; Heimdal 7.1
  # requires multiple pkg-config files to work with Exim, so the second example
-@@ -823,7 +829,7 @@ FIXED_NEVER_USERS=root
+@@ -832,7 +838,7 @@ FIXED_NEVER_USERS=root
  # one that is set in the headers_charset option. The default setting is
  # defined by this setting:
  
@@ -212,7 +213,7 @@ index f68b3f1..a0b37b2 100644
  
  # If you are going to make use of $header_xxx expansions in your configuration
  # file, or if your users are going to use them in filter files, and the normal
-@@ -843,7 +849,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -852,7 +858,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # the Sieve filter support. For those OS where iconv() is known to be installed
  # as standard, the file in OS/Makefile-xxxx contains
  #
@@ -221,7 +222,7 @@ index f68b3f1..a0b37b2 100644
  #
  # If you are not using one of those systems, but have installed iconv(), you
  # need to uncomment that line above. In some cases, you may find that iconv()
-@@ -919,7 +925,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -928,7 +934,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # Once you have done this, "make install" will build the info files and
  # install them in the directory you have defined.
  
@@ -230,7 +231,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -932,7 +938,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -941,7 +947,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # %s. This will be replaced by one of the strings "main", "panic", or "reject"
  # to form the final file names. Some installations may want something like this:
  
@@ -239,7 +240,7 @@ index f68b3f1..a0b37b2 100644
  
  # which results in files with names /var/log/exim_mainlog, etc. The directory
  # in which the log files are placed must exist; Exim does not try to create
-@@ -1004,7 +1010,7 @@ ZCAT_COMMAND=/usr/bin/zcat
+@@ -1013,7 +1019,7 @@ ZCAT_COMMAND=/usr/bin/zcat
  # (version 5.004 or later) installed, set EXIM_PERL to perl.o. Using embedded
  # Perl costs quite a lot of resources. Only do this if you really need it.
  
@@ -248,7 +249,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1014,7 +1020,7 @@ ZCAT_COMMAND=/usr/bin/zcat
+@@ -1023,7 +1029,7 @@ ZCAT_COMMAND=/usr/bin/zcat
  # that the local_scan API is made available by the linker. You may also need
  # to add -ldl to EXTRALIBS so that dlopen() is available to Exim.
  
@@ -257,16 +258,17 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1024,7 +1030,7 @@ ZCAT_COMMAND=/usr/bin/zcat
+@@ -1033,7 +1039,8 @@ ZCAT_COMMAND=/usr/bin/zcat
  # support, which is intended for use in conjunction with the SMTP AUTH
  # facilities, is included only when requested by the following setting:
  
 -# SUPPORT_PAM=yes
 +SUPPORT_PAM=yes
++EXTRALIBS_EXIM=-export-dynamic -rdynamic -lpam
  
  # You probably need to add -lpam to EXTRALIBS, and in some releases of
  # GNU/Linux -ldl is also needed.
-@@ -1036,12 +1042,12 @@ ZCAT_COMMAND=/usr/bin/zcat
+@@ -1045,12 +1052,12 @@ ZCAT_COMMAND=/usr/bin/zcat
  # If you may want to use outbound (client-side) proxying, using Socks5,
  # uncomment the line below.
  
@@ -281,39 +283,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1065,9 +1071,9 @@ ZCAT_COMMAND=/usr/bin/zcat
- # installed on your system (www.libspf2.org). Depending on where it is installed
- # you may have to edit the CFLAGS and LDFLAGS lines.
- 
--# SUPPORT_SPF=yes
-+#SUPPORT_SPF=yes
- # CFLAGS  += -I/usr/local/include
--# LDFLAGS += -lspf2
-+#LDFLAGS += -lspf2
- 
- 
- #------------------------------------------------------------------------------
-@@ -1132,7 +1138,7 @@ ZCAT_COMMAND=/usr/bin/zcat
- # group. Once you have installed saslauthd, you should arrange for it to be
- # started by root at boot time.
- 
--# CYRUS_SASLAUTHD_SOCKET=/var/state/saslauthd/mux
-+CYRUS_SASLAUTHD_SOCKET=/run/saslauthd/mux
- 
- 
- #------------------------------------------------------------------------------
-@@ -1146,8 +1152,8 @@ ZCAT_COMMAND=/usr/bin/zcat
- # library for TCP wrappers, so you probably need something like this:
- #
- # USE_TCP_WRAPPERS=yes
--# CFLAGS=-O -I/usr/local/include
--# EXTRALIBS_EXIM=-L/usr/local/lib -lwrap
-+CFLAGS+=$(RPM_OPT_FLAGS) $(PIE)
-+EXTRALIBS_EXIM=-lpam -ldl -export-dynamic -rdynamic
- #
- # but of course there may need to be other things in CFLAGS and EXTRALIBS_EXIM
- # as well.
-@@ -1199,7 +1205,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1208,7 +1215,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  # is "yes", as well as supporting line editing, a history of input lines in the
  # current run is maintained.
  
@@ -322,7 +292,7 @@ index f68b3f1..a0b37b2 100644
  
  # You may need to add -ldl to EXTRALIBS when you set USE_READLINE=yes.
  # Note that this option adds to the size of the Exim binary, because the
-@@ -1216,7 +1222,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1225,7 +1232,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  #------------------------------------------------------------------------------
  # Uncomment this setting to include IPv6 support.
  
@@ -331,7 +301,7 @@ index f68b3f1..a0b37b2 100644
  
  ###############################################################################
  #              THINGS YOU ALMOST NEVER NEED TO MENTION                        #
-@@ -1237,13 +1243,13 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1246,13 +1253,13 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  # haven't got Perl, Exim will still build and run; you just won't be able to
  # use those utilities.
  
@@ -352,7 +322,7 @@ index f68b3f1..a0b37b2 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1445,7 +1451,7 @@ EXIM_TMPDIR="/tmp"
+@@ -1454,7 +1461,7 @@ EXIM_TMPDIR="/tmp"
  # (process id) to a file so that it can easily be identified. The path of the
  # file can be specified here. Some installations may want something like this:
  
@@ -361,10 +331,10 @@ index f68b3f1..a0b37b2 100644
  
  # If PID_FILE_PATH is not defined, Exim writes a file in its spool directory
  # using the name "exim-daemon.pid".
-diff --git a/src/configure.default b/src/configure.default
-index 633c653..6379927 100644
---- a/src/configure.default
-+++ b/src/configure.default
+diff --git a/src/src/configure.default b/src/src/configure.default
+index 633c6539e..6245a3134 100644
+--- a/src/src/configure.default
++++ b/src/src/configure.default
 @@ -67,7 +67,7 @@
  # +local_domains, +relay_to_domains, and +relay_from_hosts, respectively. They
  # are all colon-separated lists:
@@ -393,7 +363,7 @@ index 633c653..6379927 100644
  # acl_check_data access control list (see below).
  
 -# av_scanner = clamd:/tmp/clamd
-+av_scanner = clamd:/run/clamd.exim/clamd.sock
++av_scanner = clamd:/var/run/clamd.exim/clamd.sock
  
  
  # For spam scanning, there is a similar option that defines the interface to
@@ -664,7 +634,7 @@ index 633c653..6379927 100644
    accept
  
 +# To enable the greylisting, also uncomment this line:
-+# .include /etc/mail/exim-greylist.conf.inc
++# .include /etc/exim/exim-greylist.conf.inc
 +
 +acl_check_mime:
 +
@@ -679,12 +649,24 @@ index 633c653..6379927 100644
  
  
  ######################################################################
+@@ -721,9 +846,9 @@ dnslookup:
+ 
+ 
+ # This router handles aliasing using a linearly searched alias file with the
+-# name SYSTEM_ALIASES_FILE. When this configuration is installed automatically,
++# name /etc/mail/aliases. When this configuration is installed automatically,
+ # the name gets inserted into this file from whatever is set in Exim's
+-# build-time configuration. The default path is the traditional /etc/aliases.
++# build-time configuration. The default path is the traditional /etc/mail/aliases.
+ # If you install this configuration by hand, you need to specify the correct
+ # path in the "data" setting below.
+ #
 @@ -744,7 +869,7 @@ system_aliases:
    driver = redirect
    allow_fail
    allow_defer
 -  data = ${lookup{$local_part}lsearch{SYSTEM_ALIASES_FILE}}
-+  data = ${lookup{$local_part}lsearch{/etc/aliases}}
++  data = ${lookup{$local_part}lsearch{/etc/mail/aliases}}
  # user = exim
    file_transport = address_file
    pipe_transport = address_pipe
@@ -813,3 +795,6 @@ index 633c653..6379927 100644
  #  server_advertise_condition = ${if def:tls_in_cipher }
  
  
+-- 
+2.51.0
+

--- a/app-web/exim/autobuild/postinst
+++ b/app-web/exim/autobuild/postinst
@@ -1,8 +1,2 @@
-getent group exim >/dev/null 2>&1 || groupadd -g 79 exim 
-if getent passwd exim > /dev/null 2>&1; then
-    usr/sbin/usermod -d /var/spool/exim -c 'Exim MTA daemon owner' -s /sbin/nologin exim > /dev/null 2>&1
-else
-    usr/sbin/useradd -c 'Exim MTA daemon owner' -u 79 -g exim -d /var/spool/exim -s /sbin/nologin exim 
-fi
-
-passwd -l exim > /dev/null
+systemd-sysusers exim.conf
+systemd-tmpfiles --create exim.conf

--- a/app-web/exim/autobuild/prepare
+++ b/app-web/exim/autobuild/prepare
@@ -1,10 +1,12 @@
 abinfo "Installing pre-configured Makefile ..."
-install -Dvm644 "$SRCDIR"/src/EDITME \
-    "$SRCDIR"/Local/Makefile
+install -Dvm644 "$SRCDIR"/src/src/EDITME \
+    "$SRCDIR"/src/Local/Makefile
 
 abinfo "Installing pre-configured eximon configuration ..."
-install -Dvm644 "$SRCDIR"/exim_monitor/EDITME \
-    "$SRCDIR"/Local/eximon.conf
+install -Dvm644 "$SRCDIR"/src/exim_monitor/EDITME \
+    "$SRCDIR"/src/Local/eximon.conf
 
-abinfo "Appending -lsasl2 to fix build ..."
-export LDFLAGS="${LDFLAGS} -lsasl2"
+# Ref: https://github.com/AOSC-Dev/aosc-os-abbs/blob/ec21e03fae754b71ca654ec3872d20f9745702d0/app-database/postgresql/01-runtime/build#L7
+abinfo "Setting PostgreSQL headers path ..."
+PGSQL_INCLUDE="$(pkg-config --cflags libpq)"
+export CFLAGS="${CFLAGS} ${PGSQL_INCLUDE}"

--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,5 +1,4 @@
-VER=4.98
-SRCS="git::commit=exim-$VER;copy-repo=true::https://github.com/Exim/exim"
+VER=4.98.2
+SRCS="git::commit=tags/exim-$VER;copy-repo=true::https://github.com/Exim/exim"
 CHKSUMS="SKIP"
-SUBDIR="exim/src"
 CHKUPDATE="anitya::id=768"

--- a/topics/exim-4.98.2.toml
+++ b/topics/exim-4.98.2.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Exim 4.98.2"
+zh_CN = "Exim 4.98.2"
+
+[caution]
+default = "Fixes a remote SQL injection vulnerability - CVE-2025-54389 (Severity: High); Fixes a privilege escalation vulnerability - CVE-2025-54409 (Severity: High)"
+zh_CN = "修复一处远程 SQL 注入漏洞，漏洞编号 CVE-2025-26794（严重性：高）；修复一处提权漏洞，漏洞编号 CVE-2025-30232（严重性：高）"
+
+[packages]
+"exim" = "4.98.2"


### PR DESCRIPTION
Topic Description
-----------------

- exim: update to 4.98.2
    - Improve build script.

Package(s) Affected
-------------------

- exim: 4.98.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
