### PR TITLE
config Survey 20250919

### DIFF
--- a/app-games/assaultcube/autobuild/defines
+++ b/app-games/assaultcube/autobuild/defines
@@ -2,3 +2,4 @@ PKGNAME=assaultcube
 PKGSEC=games
 PKGDEP="curl enet gcc-runtime glu openal-soft sdl-image sdl-mixer"
 PKGDES="A realistic team oriented multiplayer FPS based on the Cube engine"
+ABTYPE=self

--- a/app-games/assaultcube/autobuild/prepare
+++ b/app-games/assaultcube/autobuild/prepare
@@ -1,7 +1,3 @@
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-    abinfo "Copying replacement $i ..."
-    # FIXME: hard-coded automake version.
-    # Adapted from redhat-rpm-config.
-    # http://pkgs.fedoraproject.org/cgit/rpms/redhat-rpm-config.git/tree/macros#n35
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+	cp -v /usr/bin/$(basename $i) $i ; \
 done

--- a/app-games/assaultcube/spec
+++ b/app-games/assaultcube/spec
@@ -1,4 +1,5 @@
 VER=1.3.0.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/assaultcube/AC"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8384"

--- a/app-network/privoxy/autobuild/prepare
+++ b/app-network/privoxy/autobuild/prepare
@@ -1,10 +1,5 @@
 abinfo "Re-generating Autotools scripts ..."
 autoreconf -fvi
-
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-    abinfo "Copying replacement $i ..."
-    # FIXME: hard-coded automake version.
-    # Adapted from redhat-rpm-config.
-    # http://pkgs.fedoraproject.org/cgit/rpms/redhat-rpm-config.git/tree/macros#n35
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+	cp -v /usr/bin/$(basename $i) $i ; \
 done

--- a/app-network/privoxy/spec
+++ b/app-network/privoxy/spec
@@ -1,4 +1,5 @@
 VER=3.0.34
+REL=1
 SRCS="tbl::http://deb.debian.org/debian/pool/main/p/privoxy/privoxy_$VER.orig.tar.gz"
 CHKSUMS="sha256::e6ccbca1656f4e616b4657f8514e33a70f6697e9d7294356577839322a3c5d2c"
 CHKUPDATE="anitya::id=3712"

--- a/app-scientific/cbc/autobuild/defines
+++ b/app-scientific/cbc/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=math
 PKGDEP="cgl"
 PKGDES="COIN-OR branch-and-cut mixed integer programming solver"
 
+ABTYPE=self
 AB_FLAGS_O3=1

--- a/app-scientific/cbc/autobuild/prepare
+++ b/app-scientific/cbc/autobuild/prepare
@@ -1,3 +1,3 @@
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-	cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+	cp -v /usr/bin/$(basename $i) $i ; \
 done

--- a/app-scientific/cbc/spec
+++ b/app-scientific/cbc/spec
@@ -1,4 +1,5 @@
 VER=2.10.5
+REL=1
 SRCS="tbl::https://www.coin-or.org/download/source/Cbc/Cbc-$VER.tgz"
 CHKSUMS="sha256::da1a945648679b21ba56b454b81e939451dc7951d9beb3c3e14f18f64dde6972"
 SUBDIR="Cbc-$VER"

--- a/app-scientific/cgl/autobuild/defines
+++ b/app-scientific/cgl/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=math
 PKGDEP="clp"
 PKGDES="COIN-OR Cut Generation Library"
 
+ABTYPE=self
 AB_FLAGS_O3=1

--- a/app-scientific/cgl/autobuild/prepare
+++ b/app-scientific/cgl/autobuild/prepare
@@ -1,3 +1,3 @@
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-	cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+	cp -v /usr/bin/$(basename $i) $i ; \
 done

--- a/app-scientific/cgl/spec
+++ b/app-scientific/cgl/spec
@@ -1,4 +1,5 @@
 VER=0.60.3
+REL=1
 SRCS="tbl::https://www.coin-or.org/download/source/Cgl/Cgl-$VER.tgz"
 CHKSUMS="sha256::cf11e3476d2182040cec412abb232d8bafa12ff5b619eca3b7b9ac1d220476c8"
 SUBDIR="Cgl-$VER"

--- a/app-scientific/coinmp/autobuild/defines
+++ b/app-scientific/coinmp/autobuild/defines
@@ -2,3 +2,4 @@ PKGNAME=coinmp
 PKGSEC=math
 PKGDEP="cbc"
 PKGDES="C-API library that supports most of the functionality of CLP (Coin LP), CBC (Coin Branch-and-Cut), and CGL (Cut Generation Library) projects"
+ABTYPE=self

--- a/app-scientific/coinmp/autobuild/prepare
+++ b/app-scientific/coinmp/autobuild/prepare
@@ -1,3 +1,3 @@
 for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-	cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
+	cp -v /usr/bin/$(basename $i) $i ; \
 done

--- a/app-scientific/coinmp/spec
+++ b/app-scientific/coinmp/spec
@@ -1,4 +1,5 @@
 VER=1.8.4
+REL=1
 SRCS="tbl::https://www.coin-or.org/download/source/CoinMP/CoinMP-$VER.tgz"
 CHKSUMS="sha256::3459fb0ccbdd39342744684338984ac4cc153fb0434f4cae8cf74bd67490a38d"
 SUBDIR="CoinMP-$VER"

--- a/app-scientific/osi/autobuild/defines
+++ b/app-scientific/osi/autobuild/defines
@@ -12,6 +12,7 @@ PKGDES="COIN-OR Open Solver Interface"
 # configure.ac:58: error: possibly undefined macro: AC_COIN_DOXYGEN
 # configure.ac:70: error: possibly undefined macro: AC_COIN_FINALIZE
 RECONF=0
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     "--with-coinutils-lib=$(pkg-config --libs coinutils)"
     '--with-coinutils-incdir=/usr/include/coin'

--- a/app-scientific/osi/spec
+++ b/app-scientific/osi/spec
@@ -1,5 +1,5 @@
 VER=0.108.6
-REL=1
+REL=2
 SRCS="tbl::https://www.coin-or.org/download/source/Osi/Osi-$VER.tgz"
 CHKSUMS="sha256::57ef3f0c97995bac647504aee0ed34d31f79033ece04cd2cb86b4645f0a552d8"
 CHKUPDATE="anitya::id=326"

--- a/runtime-desktop/libindicator/autobuild/defines
+++ b/runtime-desktop/libindicator/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=libs
 PKGDEP="gtk-2 gtk-3 ido"
 PKGDES="A set of symbols and convenience functions that all indicators would like to use"
 
+ABTYPE=self
 NOPARALLEL=1
 PKGEPOCH=1
 RECONF=0

--- a/runtime-desktop/libindicator/autobuild/patch
+++ b/runtime-desktop/libindicator/autobuild/patch
@@ -1,11 +1,3 @@
-for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
-    abinfo "Copying replacement $i ..."
-    # FIXME: hard-coded automake version.
-    # Adapted from redhat-rpm-config.
-    # http://pkgs.fedoraproject.org/cgit/rpms/redhat-rpm-config.git/tree/macros#n35
-    cp -v /usr/share/automake-1.16/$(basename $i) $i ; \
-done
-
 abinfo "Disabling -Werror in Makefile.am, Makefile.in ..."
 sed -e '/-Werror/s/$/ -Wno-deprecated-declarations/' \
     -i "$SRCDIR"/libindicator/Makefile.{am,in}

--- a/runtime-desktop/libindicator/autobuild/prepare
+++ b/runtime-desktop/libindicator/autobuild/prepare
@@ -1,0 +1,3 @@
+for i in $(find "$SRCDIR" -name config.guess -o -name config.sub); do \
+	cp -v /usr/bin/$(basename $i) $i ; \
+done

--- a/runtime-desktop/libindicator/spec
+++ b/runtime-desktop/libindicator/spec
@@ -1,5 +1,5 @@
 VER=12.10.1
-REL=4
+REL=5
 SRCS="tbl::https://launchpad.net/libindicator/${VER%.*}/$VER/+download/libindicator-$VER.tar.gz"
 CHKSUMS="sha256::b2d2e44c10313d5c9cd60db455d520f80b36dc39562df079a3f29495e8f9447f"
 CHKUPDATE="anitya::id=229577"


### PR DESCRIPTION
Topic Description
-----------------

- privoxy: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- libindicator: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- assaultcube: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- coinmp: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- osi: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- cbc: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>
- cgl: add config as builddep
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit cgl cbc osi coinmp assaultcube libindicator privoxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
