### PR TITLE
gtksourceview-3: fix build with GCC>=14

### DIFF
--- a/runtime-editors/gtksourceview-3/autobuild/defines
+++ b/runtime-editors/gtksourceview-3/autobuild/defines
@@ -4,6 +4,8 @@ PKGDEP="gtk-3 libxml2"
 BUILDDEP="gobject-introspection gtk-doc intltool vala"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 3)"
 
-AUTOTOOLS_AFTER="--disable-glade-catalog \
-                 --enable-gtk-doc"
+AUTOTOOLS_AFTER=(
+	"--disable-glade-catalog"
+	"--disable-gtk-doc"
+)
 ABSHADOW=no

--- a/runtime-editors/gtksourceview-3/autobuild/patches/0001-FEDORA-Fix-build-with-GCC-14.patch
+++ b/runtime-editors/gtksourceview-3/autobuild/patches/0001-FEDORA-Fix-build-with-GCC-14.patch
@@ -1,0 +1,28 @@
+From 42f11d6362ae7f1b84b5aa89043f7768fe6b3dbd Mon Sep 17 00:00:00 2001
+From: ilikara <3435193369@qq.com>
+Date: Fri, 19 Sep 2025 20:07:22 +0800
+Subject: [PATCH] FEDORA: Fix build with GCC 14
+
+Link: https://src.fedoraproject.org/rpms/gtksourceview3/c/ad1ac0107c6a40e4b6fb0d8bdc576ee0319dc7d0
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ gtksourceview/gtksourceview.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtksourceview/gtksourceview.c b/gtksourceview/gtksourceview.c
+index 716fcb0..26b0f52 100644
+--- a/gtksourceview/gtksourceview.c
++++ b/gtksourceview/gtksourceview.c
+@@ -1586,7 +1586,7 @@ set_source_buffer (GtkSourceView *view,
+ 	{
+ 		GtkSourceBufferInternal *buffer_internal;
+ 
+-		view->priv->source_buffer = g_object_ref (buffer);
++		view->priv->source_buffer = g_object_ref (GTK_SOURCE_BUFFER (buffer));
+ 
+ 		g_signal_connect (buffer,
+ 				  "highlight-updated",
+-- 
+2.51.0
+

--- a/runtime-editors/gtksourceview-3/spec
+++ b/runtime-editors/gtksourceview-3/spec
@@ -1,5 +1,5 @@
 VER=3.24.11
-REL=2
+REL=3
 SRCS="https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
 CHKSUMS="sha256::691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER:0:4}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- gtksourceview-3: fix build with GCC>=14
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gtksourceview-3: 3.24.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtksourceview-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
