### PR TITLE
mypaint-brushes+1: fix build with autotools!=1.16

### DIFF
--- a/runtime-creativity/mypaint-brushes+1/autobuild/patches/0001-AOSCOS-turn-autotools-to-unselected-version.patch
+++ b/runtime-creativity/mypaint-brushes+1/autobuild/patches/0001-AOSCOS-turn-autotools-to-unselected-version.patch
@@ -1,0 +1,29 @@
+From d3cc5395d217d383696a8aeb2192e36dfdd3d56d Mon Sep 17 00:00:00 2001
+From: ilikara <3435193369@qq.com>
+Date: Fri, 19 Sep 2025 20:53:38 +0800
+Subject: [PATCH] AOSCOS: turn autotools to unselected version
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ autogen.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index ce41821..e4154c8 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -7,9 +7,9 @@
+ # tools and you shouldn't use this script. Just call ./configure
+ # directly.
+ 
+-ACLOCAL=${ACLOCAL-aclocal-1.16}
++ACLOCAL=${ACLOCAL-aclocal}
+ AUTOCONF=${AUTOCONF-autoconf}
+-AUTOMAKE=${AUTOMAKE-automake-1.16}
++AUTOMAKE=${AUTOMAKE-automake}
+ 
+ AUTOCONF_REQUIRED_VERSION=2.62
+ AUTOMAKE_REQUIRED_VERSION=1.13
+-- 
+2.51.0
+

--- a/runtime-creativity/mypaint-brushes+1/spec
+++ b/runtime-creativity/mypaint-brushes+1/spec
@@ -1,3 +1,4 @@
 VER=1.3.1
+REL=1
 SRCS="tbl::https://github.com/mypaint/mypaint-brushes/archive/v$VER.tar.gz"
 CHKSUMS="sha256::e6d0f51adb2ad507c12aa40a78265638cb21c53f4eb761c274d044677afaa1ff"


### PR DESCRIPTION
Topic Description
-----------------

- mypaint-brushes+1: fix build with autotools!=1.16
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- mypaint-brushes+1: 1.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mypaint-brushes+1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
