### PR TITLE
 librecad: new, 2.2.1.2

### DIFF
--- a/app-creativity/librecad/autobuild/build
+++ b/app-creativity/librecad/autobuild/build
@@ -1,0 +1,40 @@
+abinfo "Configuring librecad ..."
+qmake-qt5 CONFIG+=release CONFIG+=force_debug_info PREFIX="$PKGDIR"/usr librecad.pro
+
+abinfo "Building librecad"
+make
+
+abinfo "Running postprocess script"
+sh scripts/postprocess-unix.sh
+
+abinfo "Installing librecad"
+install -Dvm755 "$SRCDIR"/unix/librecad \
+    "$PKGDIR"/usr/bin/librecad
+install -Dvm755 "$SRCDIR"/unix/ttf2lff \
+    "$PKGDIR"/usr/bin/ttf2lff
+install -Dvm755 "$SRCDIR"/unix/resources/plugins/* \
+    -t "$PKGDIR"/usr/lib/librecad/
+
+abinfo "Moving librecad data to /usr/share"
+mkdir -p "$PKGDIR"/usr/share/librecad/fonts/
+cp -a "$SRCDIR"/unix/resources/fonts/* \
+    "$PKGDIR"/usr/share/librecad/fonts/
+mkdir -p "$PKGDIR"/usr/share/librecad/library
+cp -a "$SRCDIR"/unix/resources/library/* \
+    "$PKGDIR"/usr/share/librecad/library/
+mkdir -p "$PKGDIR"/usr/share/librecad/patterns
+cp -a "$SRCDIR"/unix/resources/patterns/* \
+    "$PKGDIR"/usr/share/librecad/patterns/
+mkdir -p "$PKGDIR"/usr/share/librecad/qm
+cp -a "$SRCDIR"/unix/resources/qm/* \
+    "$PKGDIR"/usr/share/librecad/qm/
+
+abinfo "Installing desktop files ..."
+install -Dvm644 "$SRCDIR"/desktop/librecad.desktop \
+    "$PKGDIR"/usr/share/applications/librecad.desktop
+install -Dvm644 "$SRCDIR"/desktop/*.appdata.xml \
+    -t "$PKGDIR"/usr/share/metainfo/
+install -Dvm644 "$SRCDIR"/librecad/res/main/librecad.png \
+    "$PKGDIR"/usr/share/pixmaps/librecad.png
+install -Dvm644 "$SRCDIR"/desktop/librecad.sharedmimeinfo \
+    "$PKGDIR"/usr/share/mime/packages/librecad.xml

--- a/app-creativity/librecad/autobuild/defines
+++ b/app-creativity/librecad/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=librecad
+PKGDEP="gcc-runtime qt-5"
+BUILDDEP="boost"
+PKGSEC="graphics"
+PKGDES="2D CAD program"

--- a/app-creativity/librecad/spec
+++ b/app-creativity/librecad/spec
@@ -1,0 +1,4 @@
+VER=2.2.1.2
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/LibreCAD/LibreCAD"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1712"


### PR DESCRIPTION
Topic Description
-----------------

- librecad: new, 2.2.1.2
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- librecad: 2.2.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit librecad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
