### PR TITLE
yubico-piv-tool: update to 2.7.2

### DIFF
--- a/app-devices/yubico-piv-tool/spec
+++ b/app-devices/yubico-piv-tool/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
-SRCS="tbl::https://github.com/Yubico/yubico-piv-tool/archive/yubico-piv-tool-$VER.tar.gz"
-CHKSUMS="sha256::11de1b708c6b917bec3da7d584f534a4314c51ccd461840fd16f15478ac2668f"
+VER=2.7.2
+SRCS="git::commit=tags/yubico-piv-tool-$VER::https://github.com/Yubico/yubico-piv-tool.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6998"


### PR DESCRIPTION
Topic Description
-----------------

- yubico-piv-tool: update to 2.7.2

Package(s) Affected
-------------------

- yubico-piv-tool: 2.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit yubico-piv-tool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
