### PR TITLE
appstream-glib: update to 0.8.3

### DIFF
--- a/app-admin/appdata-tools/autobuild/defines
+++ b/app-admin/appdata-tools/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=appdata-tools
 PKGSEC=utils
-PKGDEP="appstream-glib glib libsoup gdk-pixbuf"
-BUILDDEP="intltool"
-PKGDES="Command line program designed to validate AppData descriptions for standards compliance and to the style guide"
+PKGDEP="appstream-glib"
+PKGDES="Validation tool for software store metadata (transitional package for appstream-glib)"
 
-ABSHADOW=no
+ABTYPE=dummy
+ABHOST=noarch

--- a/app-admin/appdata-tools/spec
+++ b/app-admin/appdata-tools/spec
@@ -1,5 +1,3 @@
-VER=0.1.8
-REL=5
-SRCS="tbl::https://people.freedesktop.org/~hughsient/releases/appdata-tools-$VER.tar.xz"
-CHKSUMS="sha256::401583d27f0f91bbc03de09f53efd4bf86b20da37d6930ff7bff297d7f1e5461"
-CHKUPDATE="anitya::id=16058"
+VER=0
+EPOCH=1
+DUMMYSRC=1

--- a/app-admin/appstream-glib/autobuild/defines
+++ b/app-admin/appstream-glib/autobuild/defines
@@ -1,12 +1,20 @@
 PKGNAME=appstream-glib
 PKGSEC=libs
 PKGDEP="gcab gdk-pixbuf gtk-3 json-glib libsoup libarchive yaml"
-BUILDDEP="intltool gobject-introspection gperf gtk-doc meson"
+BUILDDEP="intltool gobject-introspection gperf gtk-doc"
 PKGDES="Provides GObjects and helper methods to make it easy to read and write AppStream metadata"
 
-PKGREP=appdata-tools
-PKGPROV=appdata-tools
 ABTYPE=meson
+MESON_AFTER=(
+    '-Ddep11=true'
+    '-Dbuilder=true'
+    '-Drpm=false'
+    '-Dalpm=false'
+    '-Dfonts=true'
+    '-Dman=true'
+    '-Dgtk-doc=false'
+    '-Dintrospection=true'
+)
 
-MESON_AFTER="-Drpm=false -Dstemmer=false -Dgtk-doc=true -Dman=true \
-             -Dfonts=true -Dbuilder=true -Ddep11=true"
+PKGBREAK="appdata-tools<=0.1.8-5"
+PKGREP="appdata-tools<=0.1.8-5"

--- a/app-admin/appstream-glib/spec
+++ b/app-admin/appstream-glib/spec
@@ -1,5 +1,4 @@
-VER=0.7.18
-REL=2
-SRCS="tbl::https://github.com/hughsie/appstream-glib/archive/appstream_glib_${VER//./_}.tar.gz"
-CHKSUMS="sha256::73b8c10273c4cdd8f6de03c2524fedad64e34ccae08ee847dba804bb15461f6e"
+VER=0.8.3
+SRCS="git::commit=tags/appstream_glib_${VER//./_}::https://github.com/hughsie/appstream-glib.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14018"


### PR DESCRIPTION
Topic Description
-----------------

- appdata-tools: transitionalise => appstream-glib
- appstream-glib: update to 0.8.3

Package(s) Affected
-------------------

- appdata-tools: 0
- appstream-glib: 0.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit appstream-glib:-pkgbreak appdata-tools appstream-glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
