### PR TITLE
vscode: update to 1.104.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.104.0
+VER=1.104.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::dec5fe2e3a71a3fded60c7924a22967efc7a6ec608ad4f17e751cbc3cbde6c0a"
-CHKSUMS__ARM64="sha256::df14630c12e0cde57ac4e3e4d0b574644d95b9b5958aac21e559e8778e43341e"
+CHKSUMS__AMD64="sha256::b2671b1d820def4c72e791e714c4af83caee684eedb2c0ae1f0590861b0ee71a"
+CHKSUMS__ARM64="sha256::a02a303abf8560a861762c9b137d368040c8cb8539c273b501b8953f5400c4bb"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.104.1
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- vscode: 1.104.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
