### PR TITLE
swww: update to 0.11.1

### DIFF
--- a/app-utils/swww/autobuild/build
+++ b/app-utils/swww/autobuild/build
@@ -2,6 +2,7 @@ abinfo "Generating swww doc ..."
 "${SRCDIR}"/doc/gen.sh
 
 abinfo "Building swww"
+cargo update
 cargo build --release
 
 abinfo "Installing swww ..."

--- a/app-utils/swww/autobuild/defines
+++ b/app-utils/swww/autobuild/defines
@@ -4,7 +4,4 @@ PKGDEP="gcc-runtime glibc lz4 wayland"
 BUILDDEP="rustc llvm scdoc"
 PKGDES="Animated wallpaper daemon for Wayland"
 
-# FIXME: ld.lld is not yet available for loongson3.
-# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
-# recompile with -fPIC
-NOLTO__LOONGSON3=1
+ENVREQ__ARM64="total_mem=30"

--- a/app-utils/swww/spec
+++ b/app-utils/swww/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=0.11.1
 SRCS="git::commit=tags/v$VER::https://github.com/LGFae/swww"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373570"


### PR DESCRIPTION
Topic Description
-----------------

- swww: update to 0.11.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- swww: 0.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit swww
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
