### PR TITLE
mesa: update to 25.1.9 and fix llvmpipe orcjit cache race condition

### DIFF
--- a/runtime-display/mesa/autobuild/patches/0009-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
+++ b/runtime-display/mesa/autobuild/patches/0009-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
@@ -1,0 +1,94 @@
+From d6698021878770eec059521580af32c5a592b83a Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 20 Sep 2025 22:52:30 +0800
+Subject: [PATCH 9/9] FROMLIST: gallivm: orcjit: put object cache under the
+ protect of lookup_mutex
+
+Different threads calling gallivm share the same LPJIT (and the
+underlying LLJIT) instance, which could be only bound to a single cache
+object at the same time.
+
+Pass the object cache when looking up the symbol and put it under the
+protect of lookup_mutex to prevent accessing wrong cache.
+
+This seems to fix some MissingSymbolDefinitions error when running
+Plasma Shell with llvmpipe on RISC-V.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ .../auxiliary/gallivm/lp_bld_init_orc.cpp     | 24 ++++++++++---------
+ 1 file changed, 13 insertions(+), 11 deletions(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+index f38db3a57fb..9257bcda2b9 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+@@ -236,13 +236,18 @@ public:
+ 
+    static void *lookup_in_jd(
+          const char *func_name,
+-         LLVMOrcJITDylibRef jd) {
++         LLVMOrcJITDylibRef jd,
++         llvm::ObjectCache *objcache) {
+       using llvm::orc::JITDylib;
+       using llvm::JITEvaluatedSymbol;
+       using llvm::orc::ExecutorAddr;
+       JITDylib* JD = ::unwrap(jd);
+       LPJit* jit = get_instance();
++      auto &ircl = jit->lljit->getIRCompileLayer();
++      auto &irc = ircl.getCompiler();
++      auto &sc = dynamic_cast<llvm::orc::SimpleCompiler &>(irc);
+       jit->lookup_mutex.lock();
++      sc.setObjectCache(objcache);
+       auto func = ExitOnErr(jit->lljit->lookup(*JD, func_name));
+       jit->lookup_mutex.unlock();
+ #if LLVM_VERSION_MAJOR >= 15
+@@ -259,12 +264,6 @@ public:
+       ExitOnErr(es.removeJITDylib(* ::unwrap(jd)));
+    }
+ 
+-   static void set_object_cache(llvm::ObjectCache *objcache) {
+-      auto &ircl = LPJit::get_instance()->lljit->getIRCompileLayer();
+-      auto &irc = ircl.getCompiler();
+-      auto &sc = dynamic_cast<llvm::orc::SimpleCompiler &>(irc);
+-      sc.setObjectCache(objcache);
+-   }
+    LLVMTargetMachineRef tm;
+ 
+ private:
+@@ -624,7 +623,6 @@ gallivm_free_ir(struct gallivm_state *gallivm)
+    gallivm->_ts_context=NULL;
+    gallivm->cache=NULL;
+    LPJit::deregister_gallivm_state(gallivm);
+-   LPJit::set_object_cache(NULL);
+ }
+ 
+ void
+@@ -659,8 +657,6 @@ gallivm_compile_module(struct gallivm_state *gallivm)
+          LPObjectCacheORC *objcache = new LPObjectCacheORC(gallivm->cache);
+          gallivm->cache->jit_obj_cache = (void *)objcache;
+       }
+-      auto *objcache = (LPObjectCacheORC *)gallivm->cache->jit_obj_cache;
+-      LPJit::set_object_cache(objcache);
+    }
+    /* defer compilation till first lookup by gallivm_jit_function */
+ }
+@@ -669,8 +665,14 @@ func_pointer
+ gallivm_jit_function(struct gallivm_state *gallivm,
+                      LLVMValueRef func, const char *func_name)
+ {
++   LPObjectCacheORC *objcache = NULL;
++   if (gallivm->cache) {
++      assert(gallivm->cache->jit_obj_cache);
++      objcache = (LPObjectCacheORC *)gallivm->cache->jit_obj_cache;
++   }
++
+    return pointer_to_func(
+-      LPJit::lookup_in_jd(func_name, gallivm->_per_module_jd));
++      LPJit::lookup_in_jd(func_name, gallivm->_per_module_jd, objcache));
+ }
+ 
+ void
+-- 
+2.51.0
+

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=25.1.6
+UPSTREAM_VER=25.1.9
 DXHEADERS_VER=1.616.0
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::9f2b69eb39d2d8717d30a9868fdda3e0c0d3708ba32778bbac8ddb044538ce84 \
+CHKSUMS="sha256::412df33a1bb3c785ed698555a3972118a37c458e7accf6ae53f4bb87b3db454a \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 25.1.9
    - Add a patch to fix some race condition in LLVMPipe ORCJIT when accessing
    object cache.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:25.1.9+dxheaders1.616.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
