### PR TITLE
swww: update to 0.11.2

### DIFF
--- a/app-utils/swww/autobuild/beyond
+++ b/app-utils/swww/autobuild/beyond
@@ -1,13 +1,6 @@
 abinfo "Generating swww doc ..."
 "${SRCDIR}"/doc/gen.sh
 
-abinfo "Building swww"
-cargo build --release
-
-abinfo "Installing swww ..."
-install -Dvm755 "${SRCDIR}"/target/release/swww -t "${PKGDIR}"/usr/bin/
-install -Dvm755 "${SRCDIR}"/target/release/swww-daemon -t "${PKGDIR}"/usr/bin/
-
 abinfo "Installing swww shell completions ..."
 install -Dvm644 "${SRCDIR}"/completions/swww.bash "${PKGDIR}"/usr/share/bash-completion/completions/swww
 install -Dvm644 "${SRCDIR}"/completions/swww.fish -t "${PKGDIR}"/usr/share/fish/vendor_completions.d/

--- a/app-utils/swww/autobuild/defines
+++ b/app-utils/swww/autobuild/defines
@@ -4,7 +4,4 @@ PKGDEP="gcc-runtime glibc lz4 wayland"
 BUILDDEP="rustc llvm scdoc"
 PKGDES="Animated wallpaper daemon for Wayland"
 
-# FIXME: ld.lld is not yet available for loongson3.
-# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
-# recompile with -fPIC
-NOLTO__LOONGSON3=1
+ABTYPE=rust

--- a/app-utils/swww/spec
+++ b/app-utils/swww/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=0.11.2
 SRCS="git::commit=tags/v$VER::https://github.com/LGFae/swww"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373570"


### PR DESCRIPTION
Topic Description
-----------------

- swww: update to 0.11.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- swww: 0.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit swww
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
