### PR TITLE
btop: update to 1.4.5

### DIFF
--- a/app-utils/btop/spec
+++ b/app-utils/btop/spec
@@ -1,4 +1,4 @@
-VER=1.4.4
+VER=1.4.5
 SRCS="git::commit=tags/v$VER::https://github.com/aristocratos/btop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=253331"


### PR DESCRIPTION
Topic Description
-----------------

- btop: update to 1.4.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- btop: 1.4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit btop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
