### PR TITLE
onig: update to 6.9.10

### DIFF
--- a/runtime-common/onig/autobuild/defines
+++ b/runtime-common/onig/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Oniguruma regular expressions library"
 
+ABTYPE=autotools
 ABSHADOW=no
 PKGPROV="oniguruma"
 PKGBREAK="hhvm<=3.27.0 jq<=1.5-1"

--- a/runtime-common/onig/spec
+++ b/runtime-common/onig/spec
@@ -1,4 +1,4 @@
-VER=6.9.5+rev1
+VER=6.9.10
 SRCS="tbl::https://github.com/kkos/oniguruma/releases/download/v${VER/+/_}/onig-${VER/+/_}.tar.gz"
-CHKSUMS="sha256::d33c849d1672af227944878cefe0a8fcf26fc62bedba32aa517f2f63c314a99e"
+CHKSUMS="sha256::2a5cfc5ae259e4e97f86b68dfffc152cdaffe94e2060b770cb827238d769fc05"
 CHKUPDATE="anitya::id=11184"


### PR DESCRIPTION
Topic Description
-----------------

- onig: update to 6.9.10
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- onig: 6.9.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit onig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
